### PR TITLE
Serial device connection layer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@electron-toolkit/preload": "^3.0.1",
         "@electron-toolkit/utils": "^3.0.0",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "serialport": "^13.0.0"
       },
       "devDependencies": {
         "@electron-toolkit/tsconfig": "^1.0.1",
@@ -1298,6 +1299,227 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@serialport/binding-mock": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-10.2.2.tgz",
+      "integrity": "sha512-HAFzGhk9OuFMpuor7aT5G1ChPgn5qSsklTFOTUX72Rl6p0xwcSVsRtG/xaGp6bxpN7fI9D/S8THLBWbBgS6ldw==",
+      "dependencies": {
+        "@serialport/bindings-interface": "^1.2.1",
+        "debug": "^4.3.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@serialport/bindings-cpp": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/bindings-cpp/-/bindings-cpp-13.0.0.tgz",
+      "integrity": "sha512-r25o4Bk/vaO1LyUfY/ulR6hCg/aWiN6Wo2ljVlb4Pj5bqWGcSRC4Vse4a9AcapuAu/FeBzHCbKMvRQeCuKjzIQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@serialport/bindings-interface": "1.2.2",
+        "@serialport/parser-readline": "12.0.0",
+        "debug": "4.4.0",
+        "node-addon-api": "8.3.0",
+        "node-gyp-build": "4.8.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/bindings-cpp/node_modules/@serialport/parser-delimiter": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-12.0.0.tgz",
+      "integrity": "sha512-gu26tVt5lQoybhorLTPsH2j2LnX3AOP2x/34+DUSTNaUTzu2fBXw+isVjQJpUBFWu6aeQRZw5bJol5X9Gxjblw==",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/bindings-cpp/node_modules/@serialport/parser-readline": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-12.0.0.tgz",
+      "integrity": "sha512-O7cywCWC8PiOMvo/gglEBfAkLjp/SENEML46BXDykfKP5mTPM46XMaX1L0waWU6DXJpBgjaL7+yX6VriVPbN4w==",
+      "dependencies": {
+        "@serialport/parser-delimiter": "12.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/bindings-cpp/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@serialport/bindings-interface": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@serialport/bindings-interface/-/bindings-interface-1.2.2.tgz",
+      "integrity": "sha512-CJaUd5bLvtM9c5dmO9rPBHPXTa9R2UwpkJ0wdh9JCYcbrPWsKz+ErvR0hBLeo7NPeiFdjFO4sonRljiw4d2XiA==",
+      "engines": {
+        "node": "^12.22 || ^14.13 || >=16"
+      }
+    },
+    "node_modules/@serialport/parser-byte-length": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-13.0.0.tgz",
+      "integrity": "sha512-32yvqeTAqJzAEtX5zCrN1Mej56GJ5h/cVFsCDPbF9S1ZSC9FWjOqNAgtByseHfFTSTs/4ZBQZZcZBpolt8sUng==",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-cctalk": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-13.0.0.tgz",
+      "integrity": "sha512-RErAe57g9gvnlieVYGIn1xymb1bzNXb2QtUQd14FpmbQQYlcrmuRnJwKa1BgTCujoCkhtaTtgHlbBWOxm8U2uA==",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-delimiter": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-13.0.0.tgz",
+      "integrity": "sha512-Qqyb0FX1avs3XabQqNaZSivyVbl/yl0jywImp7ePvfZKLwx7jBZjvL+Hawt9wIG6tfq6zbFM24vzCCK7REMUig==",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-inter-byte-timeout": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-13.0.0.tgz",
+      "integrity": "sha512-a0w0WecTW7bD2YHWrpTz1uyiWA2fDNym0kjmPeNSwZ2XCP+JbirZt31l43m2ey6qXItTYVuQBthm75sPVeHnGA==",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-packet-length": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-packet-length/-/parser-packet-length-13.0.0.tgz",
+      "integrity": "sha512-60ZDDIqYRi0Xs2SPZUo4Jr5LLIjtb+rvzPKMJCohrO6tAqSDponcNpcB1O4W21mKTxYjqInSz+eMrtk0LLfZIg==",
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/@serialport/parser-readline": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-13.0.0.tgz",
+      "integrity": "sha512-dov3zYoyf0dt1Sudd1q42VVYQ4WlliF0MYvAMA3MOyiU1IeG4hl0J6buBA2w4gl3DOCC05tGgLDN/3yIL81gsA==",
+      "dependencies": {
+        "@serialport/parser-delimiter": "13.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-ready": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-13.0.0.tgz",
+      "integrity": "sha512-JNUQA+y2Rfs4bU+cGYNqOPnNMAcayhhW+XJZihSLQXOHcZsFnOa2F9YtMg9VXRWIcnHldHYtisp62Etjlw24bw==",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-regex": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-13.0.0.tgz",
+      "integrity": "sha512-m7HpIf56G5XcuDdA3DB34Z0pJiwxNRakThEHjSa4mG05OnWYv0IG8l2oUyYfuGMowQWaVnQ+8r+brlPxGVH+eA==",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-slip-encoder": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-slip-encoder/-/parser-slip-encoder-13.0.0.tgz",
+      "integrity": "sha512-fUHZEExm6izJ7rg0A1yjXwu4sOzeBkPAjDZPfb+XQoqgtKAk+s+HfICiYn7N2QU9gyaeCO8VKgWwi+b/DowYOg==",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/parser-spacepacket": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/parser-spacepacket/-/parser-spacepacket-13.0.0.tgz",
+      "integrity": "sha512-DoXJ3mFYmyD8X/8931agJvrBPxqTaYDsPoly9/cwQSeh/q4EjQND9ySXBxpWz5WcpyCU4jOuusqCSAPsbB30Eg==",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/stream": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-13.0.0.tgz",
+      "integrity": "sha512-F7xLJKsjGo2WuEWMSEO1SimRcOA+WtWICsY13r0ahx8s2SecPQH06338g28OT7cW7uRXI7oEQAk62qh5gHJW3g==",
+      "dependencies": {
+        "@serialport/bindings-interface": "1.2.2",
+        "debug": "4.4.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/@serialport/stream/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
@@ -4237,6 +4459,14 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/node-addon-api": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.0.tgz",
+      "integrity": "sha512-8VOpLHFrOQlAH+qA0ZzuGRlALRA6/LVh8QJldbrC4DY0hXoMP0l4Acq8TzFC018HztWiRqyCEj2aTWY2UvnJUg==",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -4262,6 +4492,16 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-releases": {
@@ -5012,6 +5252,49 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serialport": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/serialport/-/serialport-13.0.0.tgz",
+      "integrity": "sha512-PHpnTd8isMGPfFTZNCzOZp9m4mAJSNWle9Jxu6BPTcWq7YXl5qN7tp8Sgn0h+WIGcD6JFz5QDgixC2s4VW7vzg==",
+      "dependencies": {
+        "@serialport/binding-mock": "10.2.2",
+        "@serialport/bindings-cpp": "13.0.0",
+        "@serialport/parser-byte-length": "13.0.0",
+        "@serialport/parser-cctalk": "13.0.0",
+        "@serialport/parser-delimiter": "13.0.0",
+        "@serialport/parser-inter-byte-timeout": "13.0.0",
+        "@serialport/parser-packet-length": "13.0.0",
+        "@serialport/parser-readline": "13.0.0",
+        "@serialport/parser-ready": "13.0.0",
+        "@serialport/parser-regex": "13.0.0",
+        "@serialport/parser-slip-encoder": "13.0.0",
+        "@serialport/parser-spacepacket": "13.0.0",
+        "@serialport/stream": "13.0.0",
+        "debug": "4.4.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/serialport/donate"
+      }
+    },
+    "node_modules/serialport/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/set-function-length": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "@electron-toolkit/preload": "^3.0.1",
     "@electron-toolkit/utils": "^3.0.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "serialport": "^13.0.0"
   },
   "devDependencies": {
     "@electron-toolkit/tsconfig": "^1.0.1",

--- a/src/main/device/MicroPythonDevice.ts
+++ b/src/main/device/MicroPythonDevice.ts
@@ -1,0 +1,494 @@
+import { EventEmitter } from 'events'
+import { SerialPort } from 'serialport'
+import type {
+  ConnectOptions,
+  ConnectionState,
+  DeviceStatus,
+  DirEntry,
+  ExecResult,
+  PortInfo,
+  StatResult
+} from './types'
+
+/**
+ * Control bytes used by the MicroPython REPL.
+ *
+ * The MicroPython "raw REPL" is a machine-friendly mode that lets a host run a
+ * snippet of code and reliably capture its output. The handshake is:
+ *
+ *  1. Send Ctrl-C (twice) to interrupt anything currently running.
+ *  2. Send Ctrl-A to enter raw REPL. The device replies with a banner that
+ *     ends in `raw REPL; CTRL-B to exit\r\n>`.
+ *  3. Send the code followed by Ctrl-D to execute it. The device responds with
+ *     `OK`, then stdout, then `\x04` (end of stdout), then stderr/traceback,
+ *     then another `\x04` (end of stderr), then `>` to prompt for more.
+ *  4. Send Ctrl-B to leave raw REPL and return to the friendly REPL.
+ *
+ * @see https://docs.micropython.org/en/latest/reference/repl.html
+ */
+const CTRL_A = '\x01' // enter raw REPL
+const CTRL_B = '\x02' // exit raw REPL
+const CTRL_C = '\x03' // interrupt / KeyboardInterrupt
+const CTRL_D = '\x04' // soft reset (friendly) / execute (raw)
+
+/** Map of events emitted by {@link MicroPythonDevice} to their payload types. */
+export interface MicroPythonDeviceEvents {
+  /** Raw bytes received from the device (forwarded to the renderer REPL). */
+  data: Buffer
+  /** Connection status changed. */
+  status: DeviceStatus
+}
+
+/**
+ * High-level driver for a MicroPython board over a serial connection.
+ *
+ * Responsibilities:
+ *  - own the {@link SerialPort} lifecycle (connect / disconnect / state),
+ *  - implement the raw-REPL protocol (`exec`, `eval`),
+ *  - provide filesystem helpers built on top of `exec` so that later features
+ *    (file tree, upload, file ops) can reuse them,
+ *  - stream raw serial output and status changes via events.
+ *
+ * The class is deliberately transport-agnostic about Electron: it only emits
+ * `data` / `status` events. The IPC layer (see `device/ipc.ts`) wires those to
+ * `webContents.send`.
+ */
+export class MicroPythonDevice extends EventEmitter {
+  private port: SerialPort | null = null
+  private state: ConnectionState = 'disconnected'
+  private currentPath?: string
+  private currentBaud?: number
+
+  /**
+   * Buffer of bytes received from the device. When a command is awaiting a
+   * specific marker, {@link readUntil} consumes from this buffer; otherwise
+   * incoming bytes are simply forwarded to listeners.
+   */
+  private rxBuffer = Buffer.alloc(0)
+
+  /** Resolver waiting for a particular byte sequence to appear in `rxBuffer`. */
+  private pending: {
+    marker: Buffer
+    resolve: (data: Buffer) => void
+    reject: (err: Error) => void
+    timer: NodeJS.Timeout
+  } | null = null
+
+  /**
+   * Serializes raw-REPL operations. Each `exec` chains onto this promise so two
+   * callers never interleave on the wire.
+   */
+  private opQueue: Promise<unknown> = Promise.resolve()
+
+  /** True once we have entered raw REPL and not yet exited it. */
+  private inRawRepl = false
+
+  // ---------------------------------------------------------------------------
+  // Typed event helpers (thin wrappers over EventEmitter)
+  // ---------------------------------------------------------------------------
+
+  on<E extends keyof MicroPythonDeviceEvents>(
+    event: E,
+    listener: (payload: MicroPythonDeviceEvents[E]) => void
+  ): this {
+    return super.on(event, listener as (...args: unknown[]) => void)
+  }
+
+  emit<E extends keyof MicroPythonDeviceEvents>(
+    event: E,
+    payload: MicroPythonDeviceEvents[E]
+  ): boolean {
+    return super.emit(event, payload)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Port enumeration
+  // ---------------------------------------------------------------------------
+
+  /** List the serial ports currently visible to the OS. */
+  static async listPorts(): Promise<PortInfo[]> {
+    const ports = await SerialPort.list()
+    return ports.map((p) => ({
+      path: p.path,
+      manufacturer: p.manufacturer,
+      serialNumber: p.serialNumber,
+      vendorId: p.vendorId,
+      productId: p.productId,
+      friendlyName: (p as { friendlyName?: string }).friendlyName
+    }))
+  }
+
+  // ---------------------------------------------------------------------------
+  // Connection lifecycle
+  // ---------------------------------------------------------------------------
+
+  /** Current connection status snapshot (safe to send over IPC). */
+  getStatus(): DeviceStatus {
+    return {
+      state: this.state,
+      path: this.currentPath,
+      baudRate: this.currentBaud
+    }
+  }
+
+  isConnected(): boolean {
+    return this.state === 'connected' && this.port?.isOpen === true
+  }
+
+  /** Open a serial connection to `path` at the given baud rate (default 115200). */
+  async connect(path: string, options: ConnectOptions = {}): Promise<void> {
+    if (this.port) {
+      await this.disconnect()
+    }
+    const baudRate = options.baudRate ?? 115200
+    this.currentPath = path
+    this.currentBaud = baudRate
+    this.setState('connecting')
+
+    await new Promise<void>((resolve, reject) => {
+      const port = new SerialPort({ path, baudRate, autoOpen: false })
+      port.open((err) => {
+        if (err) {
+          this.port = null
+          this.setState('error', err.message)
+          reject(new Error(err.message))
+          return
+        }
+        this.port = port
+        port.on('data', (chunk: Buffer) => this.handleData(chunk))
+        port.on('error', (e: Error) => {
+          this.setState('error', e.message)
+        })
+        port.on('close', () => {
+          // Only transition if we still think we're connected; an explicit
+          // disconnect() handles its own state change.
+          if (this.state === 'connected' || this.state === 'connecting') {
+            this.port = null
+            this.inRawRepl = false
+            this.setState('disconnected')
+          }
+        })
+        this.setState('connected')
+        resolve()
+      })
+    })
+  }
+
+  /** Close the serial connection if open. */
+  async disconnect(): Promise<void> {
+    const port = this.port
+    this.port = null
+    this.inRawRepl = false
+    this.failPending(new Error('Disconnected'))
+    if (port && port.isOpen) {
+      await new Promise<void>((resolve) => port.close(() => resolve()))
+    }
+    this.setState('disconnected')
+  }
+
+  private setState(state: ConnectionState, error?: string): void {
+    this.state = state
+    const status: DeviceStatus = {
+      state,
+      path: this.currentPath,
+      baudRate: this.currentBaud
+    }
+    if (error) status.error = error
+    this.emit('status', status)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Low-level serial IO
+  // ---------------------------------------------------------------------------
+
+  private handleData(chunk: Buffer): void {
+    // Always forward raw bytes so the renderer REPL sees everything live.
+    this.emit('data', chunk)
+    this.rxBuffer = Buffer.concat([this.rxBuffer, chunk])
+    this.tryResolvePending()
+  }
+
+  private tryResolvePending(): void {
+    if (!this.pending) return
+    const idx = this.rxBuffer.indexOf(this.pending.marker)
+    if (idx === -1) return
+    const end = idx + this.pending.marker.length
+    const data = this.rxBuffer.subarray(0, end)
+    this.rxBuffer = this.rxBuffer.subarray(end)
+    const { resolve, timer } = this.pending
+    clearTimeout(timer)
+    this.pending = null
+    resolve(data)
+  }
+
+  private failPending(err: Error): void {
+    if (!this.pending) return
+    clearTimeout(this.pending.timer)
+    const { reject } = this.pending
+    this.pending = null
+    reject(err)
+  }
+
+  /** Write raw bytes to the port, rejecting if not connected. */
+  private write(data: string | Buffer): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (!this.port || !this.port.isOpen) {
+        reject(new Error('Not connected'))
+        return
+      }
+      this.port.write(data, (err) => {
+        if (err) {
+          reject(new Error(err.message))
+          return
+        }
+        this.port?.drain(() => resolve())
+      })
+    })
+  }
+
+  /**
+   * Wait until `marker` appears in the receive buffer, returning everything up
+   * to and including it. Rejects after `timeoutMs`.
+   */
+  private readUntil(marker: string, timeoutMs = 5000): Promise<Buffer> {
+    if (this.pending) {
+      return Promise.reject(new Error('A read is already in progress'))
+    }
+    return new Promise<Buffer>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending = null
+        reject(new Error(`Timed out waiting for ${JSON.stringify(marker)}`))
+      }, timeoutMs)
+      this.pending = { marker: Buffer.from(marker, 'binary'), resolve, reject, timer }
+      // The marker may already be in the buffer from a previous read.
+      this.tryResolvePending()
+    })
+  }
+
+  // ---------------------------------------------------------------------------
+  // Raw REPL control
+  // ---------------------------------------------------------------------------
+
+  /** Send Ctrl-C to interrupt any running program. */
+  async interrupt(): Promise<void> {
+    await this.write(CTRL_C)
+  }
+
+  /** Send Ctrl-D to perform a soft reset (only meaningful in friendly REPL). */
+  async softReset(): Promise<void> {
+    await this.write(CTRL_D)
+  }
+
+  /** Enter raw REPL mode (Ctrl-A), interrupting any running program first. */
+  async enterRawRepl(): Promise<void> {
+    // Clear any stale buffered output.
+    this.rxBuffer = Buffer.alloc(0)
+    // Interrupt twice to break out of running code or input().
+    await this.write(CTRL_C)
+    await this.write(CTRL_C)
+    await this.write(CTRL_A)
+    await this.readUntil('raw REPL; CTRL-B to exit\r\n>')
+    this.inRawRepl = true
+  }
+
+  /** Leave raw REPL mode (Ctrl-B), returning to the friendly REPL. */
+  async exitRawRepl(): Promise<void> {
+    await this.write(CTRL_B)
+    this.inRawRepl = false
+  }
+
+  /**
+   * Execute `code` in the raw REPL and capture its output.
+   *
+   * Enters raw REPL if not already in it, runs the snippet, and returns the
+   * captured stdout/stderr. Operations are serialized so concurrent callers do
+   * not corrupt the protocol state.
+   */
+  exec(code: string, timeoutMs = 10000): Promise<ExecResult> {
+    const op = this.opQueue.then(() => this.execLocked(code, timeoutMs))
+    // Keep the queue alive even if this op rejects.
+    this.opQueue = op.catch(() => undefined)
+    return op
+  }
+
+  private async execLocked(code: string, timeoutMs: number): Promise<ExecResult> {
+    if (!this.isConnected()) {
+      throw new Error('Not connected')
+    }
+    const enteredHere = !this.inRawRepl
+    if (enteredHere) {
+      await this.enterRawRepl()
+    }
+    try {
+      // Send the code and execute with Ctrl-D.
+      await this.write(code)
+      await this.write(CTRL_D)
+
+      // The device acknowledges a well-formed paste with "OK".
+      const ack = await this.readUntil('OK', timeoutMs)
+      if (!ack.toString('binary').includes('OK')) {
+        throw new Error('Device did not acknowledge code (no "OK")')
+      }
+
+      // stdout is everything up to the first \x04.
+      const stdoutRaw = await this.readUntil(CTRL_D, timeoutMs)
+      const stdout = stdoutRaw.subarray(0, stdoutRaw.length - 1).toString('utf8')
+
+      // stderr/traceback is everything up to the second \x04.
+      const stderrRaw = await this.readUntil(CTRL_D, timeoutMs)
+      const stderr = stderrRaw.subarray(0, stderrRaw.length - 1).toString('utf8')
+
+      // Consume the trailing prompt so the buffer is clean for the next op.
+      await this.readUntil('>', timeoutMs)
+
+      return { stdout, stderr }
+    } finally {
+      if (enteredHere) {
+        // Best-effort return to friendly REPL.
+        await this.exitRawRepl().catch(() => undefined)
+      }
+    }
+  }
+
+  /**
+   * Run `code` and return its stdout, throwing if the device produced a
+   * traceback on stderr. Convenience wrapper around {@link exec} for small
+   * snippets whose output we care about.
+   */
+  async eval(code: string, timeoutMs = 10000): Promise<string> {
+    const { stdout, stderr } = await this.exec(code, timeoutMs)
+    if (stderr.trim().length > 0) {
+      throw new Error(stderr.trim())
+    }
+    return stdout
+  }
+
+  // ---------------------------------------------------------------------------
+  // Filesystem helpers (built on top of exec/eval)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * List a directory. Returns entries with name, type and size. Uses
+   * `os.ilistdir` when available (gives type + size in one call) and emits a
+   * compact, machine-parseable line per entry.
+   */
+  async listDir(path = '/'): Promise<DirEntry[]> {
+    const code = [
+      'import os, json',
+      `def _ls(p):`,
+      '    out=[]',
+      '    try:',
+      '        it=os.ilistdir(p)',
+      '    except AttributeError:',
+      '        it=[(n,0,0) for n in os.listdir(p)]',
+      '    for e in it:',
+      '        name=e[0]; typ=e[1] if len(e)>1 else 0',
+      '        full=(p.rstrip("/")+"/"+name) if p else name',
+      '        isdir=(typ & 0x4000)!=0',
+      '        try: size=0 if isdir else os.stat(full)[6]',
+      '        except OSError: size=0',
+      '        out.append([name,isdir,size])',
+      '    return out',
+      `print(json.dumps(_ls(${pyStr(path)})))`
+    ].join('\n')
+    const raw = (await this.eval(code)).trim()
+    const parsed = JSON.parse(raw) as [string, boolean, number][]
+    return parsed.map(([name, isDir, size]) => ({ name, isDir, size }))
+  }
+
+  /** Read a file from the device and return its contents as a string (UTF-8). */
+  async readFile(path: string): Promise<string> {
+    const buf = await this.readFileBytes(path)
+    return buf.toString('utf8')
+  }
+
+  /** Read a file from the device and return its raw bytes. */
+  async readFileBytes(path: string): Promise<Buffer> {
+    // `ubinascii` is exposed as `binascii` on some ports; import defensively.
+    const code = [
+      'import sys',
+      'try:\n import ubinascii\nexcept ImportError:\n import binascii as ubinascii',
+      `with open(${pyStr(path)},'rb') as f:`,
+      '    while True:',
+      '        b=f.read(256)',
+      '        if not b: break',
+      '        sys.stdout.write(ubinascii.hexlify(b))'
+    ].join('\n')
+    const hex = (await this.eval(code)).trim()
+    return Buffer.from(hex, 'hex')
+  }
+
+  /**
+   * Write `contents` to `path`, creating/overwriting the file. The payload is
+   * sent in hex-encoded chunks so that arbitrary binary content survives the
+   * text-oriented REPL transport.
+   */
+  async writeFile(path: string, contents: string | Buffer, chunkSize = 256): Promise<void> {
+    const data = Buffer.isBuffer(contents) ? contents : Buffer.from(contents, 'utf8')
+    // Open the file once, then stream hex chunks via repeated exec calls so we
+    // never put a multi-megabyte literal on a single line.
+    const open = [
+      'import sys',
+      'try:\n import ubinascii\nexcept ImportError:\n import binascii as ubinascii',
+      `_f=open(${pyStr(path)},'wb')`
+    ].join('\n')
+    await this.eval(open)
+    try {
+      for (let i = 0; i < data.length; i += chunkSize) {
+        const slice = data.subarray(i, i + chunkSize)
+        const hex = slice.toString('hex')
+        await this.eval(`_f.write(ubinascii.unhexlify(${pyStr(hex)}))`)
+      }
+    } finally {
+      await this.eval('_f.close()').catch(() => undefined)
+    }
+  }
+
+  /** Remove a file. */
+  async remove(path: string): Promise<void> {
+    await this.eval(`import os\nos.remove(${pyStr(path)})`)
+  }
+
+  /** Create a directory. */
+  async mkdir(path: string): Promise<void> {
+    await this.eval(`import os\nos.mkdir(${pyStr(path)})`)
+  }
+
+  /** Rename / move a path. */
+  async rename(from: string, to: string): Promise<void> {
+    await this.eval(`import os\nos.rename(${pyStr(from)}, ${pyStr(to)})`)
+  }
+
+  /** Stat a path, returning type, size and mtime when available. */
+  async stat(path: string): Promise<StatResult> {
+    const code = [
+      'import os, json',
+      `st=os.stat(${pyStr(path)})`,
+      'isdir=(st[0] & 0x4000)!=0',
+      'mtime=st[8] if len(st)>8 else None',
+      'print(json.dumps([isdir, st[6], mtime]))'
+    ].join('\n')
+    const raw = (await this.eval(code)).trim()
+    const [isDir, size, mtime] = JSON.parse(raw) as [boolean, number, number | null]
+    return { isDir, size, mtime: mtime ?? undefined }
+  }
+
+  /** Tear down resources (called on app quit). */
+  async dispose(): Promise<void> {
+    this.removeAllListeners()
+    await this.disconnect().catch(() => undefined)
+  }
+}
+
+/**
+ * Render a JS string as a Python string literal, escaping characters that would
+ * break out of the quotes. Used to inject paths/data into generated Python.
+ */
+function pyStr(value: string): string {
+  const escaped = value
+    .replace(/\\/g, '\\\\')
+    .replace(/'/g, "\\'")
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+  return `'${escaped}'`
+}

--- a/src/main/device/ipc.ts
+++ b/src/main/device/ipc.ts
@@ -1,0 +1,107 @@
+import { ipcMain, type WebContents } from 'electron'
+import { MicroPythonDevice } from './MicroPythonDevice'
+import type { ConnectOptions, DeviceStatus, IpcResult } from './types'
+
+/**
+ * IPC channel names for the device layer. Renderer-facing channels are prefixed
+ * `device:` for the push events the renderer subscribes to.
+ */
+export const DEVICE_CHANNELS = {
+  data: 'device:data',
+  status: 'device:status'
+} as const
+
+/**
+ * A single shared {@link MicroPythonDevice} instance. The app talks to one
+ * board at a time; later issues can extend this to a registry keyed by path.
+ */
+let device: MicroPythonDevice | null = null
+
+function getDevice(): MicroPythonDevice {
+  if (!device) device = new MicroPythonDevice()
+  return device
+}
+
+/**
+ * Wrap an async operation so any thrown error crosses IPC as a plain,
+ * serializable {@link IpcResult} rather than relying on Electron's lossy error
+ * propagation.
+ */
+async function wrap<T>(fn: () => Promise<T>): Promise<IpcResult<T>> {
+  try {
+    return { ok: true, value: await fn() }
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+/**
+ * Register all `device:*` IPC handlers and begin forwarding device events to
+ * the given renderer. Call once from the main process after the window exists.
+ *
+ * @param getWebContents resolver for the target renderer (so we don't capture a
+ *   destroyed window after reloads).
+ */
+export function registerDeviceIpc(getWebContents: () => WebContents | undefined): void {
+  const dev = getDevice()
+
+  // Forward raw serial output and status changes to the renderer.
+  dev.on('data', (chunk) => {
+    const wc = getWebContents()
+    if (wc && !wc.isDestroyed()) {
+      // Send as a Uint8Array; it survives structured clone across IPC.
+      wc.send(DEVICE_CHANNELS.data, new Uint8Array(chunk))
+    }
+  })
+  dev.on('status', (status: DeviceStatus) => {
+    const wc = getWebContents()
+    if (wc && !wc.isDestroyed()) {
+      wc.send(DEVICE_CHANNELS.status, status)
+    }
+  })
+
+  ipcMain.handle('device:listPorts', () => wrap(() => MicroPythonDevice.listPorts()))
+
+  ipcMain.handle('device:connect', (_e, path: string, opts?: ConnectOptions) =>
+    wrap(() => dev.connect(path, opts ?? {}))
+  )
+
+  ipcMain.handle('device:disconnect', () => wrap(() => dev.disconnect()))
+
+  ipcMain.handle('device:getStatus', () => wrap(async () => dev.getStatus()))
+
+  ipcMain.handle('device:exec', (_e, code: string) => wrap(() => dev.exec(code)))
+
+  ipcMain.handle('device:eval', (_e, code: string) => wrap(() => dev.eval(code)))
+
+  ipcMain.handle('device:interrupt', () => wrap(() => dev.interrupt()))
+
+  ipcMain.handle('device:softReset', () => wrap(() => dev.softReset()))
+
+  // Filesystem helpers.
+  ipcMain.handle('device:listDir', (_e, path?: string) => wrap(() => dev.listDir(path ?? '/')))
+
+  ipcMain.handle('device:readFile', (_e, path: string) => wrap(() => dev.readFile(path)))
+
+  ipcMain.handle('device:writeFile', (_e, path: string, contents: string) =>
+    wrap(() => dev.writeFile(path, contents))
+  )
+
+  ipcMain.handle('device:remove', (_e, path: string) => wrap(() => dev.remove(path)))
+
+  ipcMain.handle('device:mkdir', (_e, path: string) => wrap(() => dev.mkdir(path)))
+
+  ipcMain.handle('device:rename', (_e, from: string, to: string) =>
+    wrap(() => dev.rename(from, to))
+  )
+
+  ipcMain.handle('device:stat', (_e, path: string) => wrap(() => dev.stat(path)))
+}
+
+/** Dispose the shared device (call on app quit). */
+export async function disposeDevice(): Promise<void> {
+  if (device) {
+    await device.dispose()
+    device = null
+  }
+}

--- a/src/main/device/types.ts
+++ b/src/main/device/types.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared types for the serial device layer.
+ *
+ * These types are intentionally plain (no class instances, no Buffers) so they
+ * serialize cleanly across the Electron IPC boundary and can be re-used by the
+ * preload typings and the renderer.
+ */
+
+/** A serial port discovered by enumeration. */
+export interface PortInfo {
+  /** OS path / device name, e.g. `/dev/ttyACM0` or `COM3`. */
+  path: string
+  manufacturer?: string
+  serialNumber?: string
+  /** USB vendor id (hex string as reported by the OS, e.g. `2e8a`). */
+  vendorId?: string
+  /** USB product id (hex string). */
+  productId?: string
+  /** Human-friendly label, when the OS provides one. */
+  friendlyName?: string
+}
+
+/** Options for opening a connection. */
+export interface ConnectOptions {
+  /** Baud rate. Defaults to 115200 (the MicroPython convention). */
+  baudRate?: number
+}
+
+/** Connection lifecycle states. */
+export type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'error'
+
+/** Current status of the device connection, safe to send over IPC. */
+export interface DeviceStatus {
+  state: ConnectionState
+  /** Path of the currently/last targeted port, if any. */
+  path?: string
+  baudRate?: number
+  /** Populated when `state === 'error'`. */
+  error?: string
+}
+
+/** Result of running code in the raw REPL. */
+export interface ExecResult {
+  /** Decoded stdout captured between the raw-REPL output markers. */
+  stdout: string
+  /** Decoded stderr / traceback captured after the first `\x04` marker. */
+  stderr: string
+}
+
+/** A single entry returned by {@link MicroPythonDevice.listDir}. */
+export interface DirEntry {
+  name: string
+  /** True when the entry is a directory. */
+  isDir: boolean
+  /** File size in bytes (0 for directories). */
+  size: number
+}
+
+/** Result of {@link MicroPythonDevice.stat} mirroring `os.stat` essentials. */
+export interface StatResult {
+  isDir: boolean
+  size: number
+  /** st_mtime (seconds since epoch) as reported by the device, if available. */
+  mtime?: number
+}
+
+/**
+ * Generic IPC result wrapper. The IPC handlers return one of these so that
+ * errors cross the boundary as plain serializable data rather than relying on
+ * Electron's lossy error re-throwing.
+ */
+export type IpcResult<T> = { ok: true; value: T } | { ok: false; error: string }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,10 +1,14 @@
 import { app, shell, BrowserWindow, ipcMain } from 'electron'
 import { join } from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
+import { registerDeviceIpc, disposeDevice } from './device/ipc'
+
+/** The single application window, used to route device push-events. */
+let mainWindow: BrowserWindow | null = null
 
 function createWindow(): void {
   // Create the browser window with secure defaults.
-  const mainWindow = new BrowserWindow({
+  const window = new BrowserWindow({
     width: 1200,
     height: 800,
     show: false,
@@ -17,12 +21,17 @@ function createWindow(): void {
       nodeIntegration: false
     }
   })
+  mainWindow = window
 
-  mainWindow.on('ready-to-show', () => {
-    mainWindow.show()
+  window.on('ready-to-show', () => {
+    window.show()
   })
 
-  mainWindow.webContents.setWindowOpenHandler((details) => {
+  window.on('closed', () => {
+    if (mainWindow === window) mainWindow = null
+  })
+
+  window.webContents.setWindowOpenHandler((details) => {
     void shell.openExternal(details.url)
     return { action: 'deny' }
   })
@@ -30,9 +39,9 @@ function createWindow(): void {
   // HMR for renderer base on electron-vite cli.
   // Load the remote URL for development or the local html file for production.
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
-    void mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL'])
+    void window.loadURL(process.env['ELECTRON_RENDERER_URL'])
   } else {
-    void mainWindow.loadFile(join(__dirname, '../renderer/index.html'))
+    void window.loadFile(join(__dirname, '../renderer/index.html'))
   }
 }
 
@@ -50,6 +59,10 @@ app.whenReady().then(() => {
   // Example IPC handler establishing the pattern later agents will extend.
   ipcMain.handle('ping', () => 'pong')
 
+  // Register the serial device layer. Push events are routed to whichever
+  // window is currently live.
+  registerDeviceIpc(() => mainWindow?.webContents)
+
   createWindow()
 
   app.on('activate', () => {
@@ -64,4 +77,9 @@ app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
     app.quit()
   }
+})
+
+// Ensure the serial port is released before the process exits.
+app.on('before-quit', () => {
+  void disposeDevice()
 })

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -1,6 +1,19 @@
 import { ElectronAPI } from '@electron-toolkit/preload'
 import type { Api } from './index'
 
+// Re-export the device layer types so the renderer can import them from a
+// single, UI-facing module without reaching into `src/main`.
+export type {
+  PortInfo,
+  ConnectOptions,
+  ConnectionState,
+  DeviceStatus,
+  ExecResult,
+  DirEntry,
+  StatResult,
+  IpcResult
+} from '../main/device/types'
+
 declare global {
   interface Window {
     electron: ElectronAPI

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,5 +1,83 @@
-import { contextBridge, ipcRenderer } from 'electron'
+import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
+import type {
+  ConnectOptions,
+  DeviceStatus,
+  DirEntry,
+  ExecResult,
+  IpcResult,
+  PortInfo,
+  StatResult
+} from '../main/device/types'
+
+/**
+ * Unwrap an {@link IpcResult} into a resolved value or a thrown Error, so the
+ * renderer can use ordinary `try/catch` / promise rejection semantics.
+ */
+async function unwrap<T>(p: Promise<IpcResult<T>>): Promise<T> {
+  const res = await p
+  if (!res.ok) throw new Error(res.error)
+  return res.value
+}
+
+/**
+ * Serial device API. Mirrors the main-process `device:*` IPC handlers and
+ * unwraps their typed results. `onData` / `onStatus` subscribe to push events
+ * and return an unsubscribe function.
+ */
+const device = {
+  /** Enumerate available serial ports. */
+  listPorts: (): Promise<PortInfo[]> => unwrap(ipcRenderer.invoke('device:listPorts')),
+  /** Open a connection to `path` at `opts.baudRate` (default 115200). */
+  connect: (path: string, opts?: ConnectOptions): Promise<void> =>
+    unwrap(ipcRenderer.invoke('device:connect', path, opts)),
+  /** Close the active connection. */
+  disconnect: (): Promise<void> => unwrap(ipcRenderer.invoke('device:disconnect')),
+  /** Current connection status snapshot. */
+  getStatus: (): Promise<DeviceStatus> => unwrap(ipcRenderer.invoke('device:getStatus')),
+  /** Run code in the raw REPL, returning captured stdout/stderr. */
+  exec: (code: string): Promise<ExecResult> => unwrap(ipcRenderer.invoke('device:exec', code)),
+  /** Run code and return stdout, throwing on a device traceback. */
+  eval: (code: string): Promise<string> => unwrap(ipcRenderer.invoke('device:eval', code)),
+  /** Send Ctrl-C to interrupt the running program. */
+  interrupt: (): Promise<void> => unwrap(ipcRenderer.invoke('device:interrupt')),
+  /** Send Ctrl-D to soft-reset the device. */
+  softReset: (): Promise<void> => unwrap(ipcRenderer.invoke('device:softReset')),
+  /** List a directory on the device filesystem. */
+  listDir: (path?: string): Promise<DirEntry[]> =>
+    unwrap(ipcRenderer.invoke('device:listDir', path)),
+  /** Read a file's contents (UTF-8). */
+  readFile: (path: string): Promise<string> => unwrap(ipcRenderer.invoke('device:readFile', path)),
+  /** Write contents to a file (created/overwritten), chunked. */
+  writeFile: (path: string, contents: string): Promise<void> =>
+    unwrap(ipcRenderer.invoke('device:writeFile', path, contents)),
+  /** Remove a file. */
+  remove: (path: string): Promise<void> => unwrap(ipcRenderer.invoke('device:remove', path)),
+  /** Create a directory. */
+  mkdir: (path: string): Promise<void> => unwrap(ipcRenderer.invoke('device:mkdir', path)),
+  /** Rename / move a path. */
+  rename: (from: string, to: string): Promise<void> =>
+    unwrap(ipcRenderer.invoke('device:rename', from, to)),
+  /** Stat a path. */
+  stat: (path: string): Promise<StatResult> => unwrap(ipcRenderer.invoke('device:stat', path)),
+  /**
+   * Subscribe to raw serial output. The callback receives the bytes as a
+   * `Uint8Array`. Returns an unsubscribe function.
+   */
+  onData: (cb: (chunk: Uint8Array) => void): (() => void) => {
+    const listener = (_e: IpcRendererEvent, chunk: Uint8Array): void => cb(chunk)
+    ipcRenderer.on('device:data', listener)
+    return () => ipcRenderer.removeListener('device:data', listener)
+  },
+  /**
+   * Subscribe to connection status changes. Returns an unsubscribe function.
+   */
+  onStatus: (cb: (status: DeviceStatus) => void): (() => void) => {
+    const listener = (_e: IpcRendererEvent, status: DeviceStatus): void => cb(status)
+    ipcRenderer.on('device:status', listener)
+    return () => ipcRenderer.removeListener('device:status', listener)
+  }
+}
 
 // Minimal, typed API exposed to the renderer. This establishes the IPC
 // pattern that later feature work will extend.
@@ -7,7 +85,9 @@ const api = {
   /** Example round-trip channel used to prove the bridge works. */
   ping: (): Promise<string> => ipcRenderer.invoke('ping'),
   /** Snapshot of the runtime versions for display in the UI. */
-  versions: process.versions
+  versions: process.versions,
+  /** Serial device connection + MicroPython REPL/filesystem layer. */
+  device
 }
 
 // Use `contextBridge` APIs to expose Electron APIs to the renderer only if


### PR DESCRIPTION
Implements the serial device connection layer (issue #6) — the foundation for all device features (#7 device files, #8 file ops, #9 upload, #10 REPL).

## What was done
- Added `serialport@^13` as a dependency (runs in the main process; externalized by electron-vite so the native module is not bundled).
- New main-process device layer under `src/main/device/`:
  - `types.ts` — plain, IPC-serializable types (`PortInfo`, `ConnectOptions`, `DeviceStatus`, `ExecResult`, `DirEntry`, `StatResult`, `IpcResult<T>`).
  - `MicroPythonDevice.ts` — well-documented driver class.
  - `ipc.ts` — registers `device:*` IPC handlers and forwards device events to the renderer.
- Wired into `src/main/index.ts` (`registerDeviceIpc`, disposal on `before-quit`).
- Extended `window.api` with a typed `device` namespace in `src/preload/index.ts`; re-exported device types from `src/preload/index.d.ts`.

## Checklist
- [x] Add `serialport` dependency
- [x] Port enumeration (path, manufacturer, vendor/product id)
- [x] Connect/disconnect at baud (default 115200) with connection state tracking
- [x] Raw-REPL protocol: enter (Ctrl-A), exit (Ctrl-B), interrupt (Ctrl-C), soft reset (Ctrl-D)
- [x] `exec(code)` capturing stdout/stderr between `\x04` markers; `eval` helper
- [x] File helpers built on exec: `listDir`, `readFile`, `writeFile` (chunked, hex-encoded), `remove`, `mkdir`, `rename`, `stat`
- [x] Streaming: `device:data` raw output + `device:status` lifecycle events
- [x] Typed IPC surface on `window.api.device` incl. `onData`/`onStatus` subscriptions
- [x] Robust error surfacing via serializable `IpcResult` (unwrapped to thrown errors in preload)
- [x] `npm run lint`, `typecheck`, and `build` all pass

## Caveats
- ARM64 Linux, headless, no MicroPython hardware attached: protocol logic and `listPorts()` could not be exercised against a real device. Hardware/runtime testing is pending.
- Native module note: `serialport` may need rebuilding for Electron's ABI at package/run time (e.g. `electron-rebuild`). It typechecks and builds now since electron-vite externalizes it rather than bundling.
- Ownership boundary respected: no `src/renderer/**` files modified.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)