### PR TITLE
Interactive REPL / shell window

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.1",
         "@electron-toolkit/utils": "^3.0.0",
+        "@xterm/addon-fit": "^0.11.0",
+        "@xterm/xterm": "^6.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-resizable-panels": "^2.1.9",
@@ -1875,6 +1877,16 @@
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg=="
     },
     "node_modules/acorn": {
       "version": "8.16.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.1",
     "@electron-toolkit/utils": "^3.0.0",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-resizable-panels": "^2.1.9",

--- a/src/main/device/MicroPythonDevice.ts
+++ b/src/main/device/MicroPythonDevice.ts
@@ -269,6 +269,16 @@ export class MicroPythonDevice extends EventEmitter {
   // Raw REPL control
   // ---------------------------------------------------------------------------
 
+  /**
+   * Write raw user keystrokes to the friendly (`>>>`) REPL. Unlike {@link exec},
+   * this performs no raw-REPL handshake — the bytes are sent verbatim, which is
+   * exactly what an interactive terminal needs (including control bytes such as
+   * Ctrl-C `\x03` and Ctrl-D `\x04`).
+   */
+  async sendData(data: string): Promise<void> {
+    await this.write(data)
+  }
+
   /** Send Ctrl-C to interrupt any running program. */
   async interrupt(): Promise<void> {
     await this.write(CTRL_C)

--- a/src/main/device/ipc.ts
+++ b/src/main/device/ipc.ts
@@ -74,6 +74,8 @@ export function registerDeviceIpc(getWebContents: () => WebContents | undefined)
 
   ipcMain.handle('device:eval', (_e, code: string) => wrap(() => dev.eval(code)))
 
+  ipcMain.handle('device:sendData', (_e, data: string) => wrap(() => dev.sendData(data)))
+
   ipcMain.handle('device:interrupt', () => wrap(() => dev.interrupt()))
 
   ipcMain.handle('device:softReset', () => wrap(() => dev.softReset()))

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -39,6 +39,8 @@ const device = {
   exec: (code: string): Promise<ExecResult> => unwrap(ipcRenderer.invoke('device:exec', code)),
   /** Run code and return stdout, throwing on a device traceback. */
   eval: (code: string): Promise<string> => unwrap(ipcRenderer.invoke('device:eval', code)),
+  /** Send raw keystrokes to the friendly REPL (interactive terminal input). */
+  sendData: (data: string): Promise<void> => unwrap(ipcRenderer.invoke('device:sendData', data)),
   /** Send Ctrl-C to interrupt the running program. */
   interrupt: (): Promise<void> => unwrap(ipcRenderer.invoke('device:interrupt')),
   /** Send Ctrl-D to soft-reset the device. */

--- a/src/renderer/src/components/ConnectionControl.tsx
+++ b/src/renderer/src/components/ConnectionControl.tsx
@@ -1,0 +1,104 @@
+import { useCallback, useEffect, useState } from 'react'
+import type { DeviceStatus, PortInfo } from '../../../preload/index.d'
+
+interface ConnectionControlProps {
+  status: DeviceStatus
+}
+
+/**
+ * Compact connect / disconnect control for the shell header.
+ *
+ * Renders a port dropdown (refreshed from `device.listPorts()`), and a single
+ * toggle button whose label/action reflects the live connection state. The
+ * state itself is owned by the device layer and supplied via `status`, so this
+ * component stays stateless about connectedness and simply reacts.
+ */
+export function ConnectionControl({ status }: ConnectionControlProps): JSX.Element {
+  const [ports, setPorts] = useState<PortInfo[]>([])
+  const [selected, setSelected] = useState<string>('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const connected = status.state === 'connected'
+  const connecting = status.state === 'connecting' || busy
+
+  const refreshPorts = useCallback(async (): Promise<void> => {
+    try {
+      const list = await window.api.device.listPorts()
+      setPorts(list)
+      setSelected((prev) => {
+        if (prev && list.some((p) => p.path === prev)) return prev
+        return list[0]?.path ?? ''
+      })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }, [])
+
+  useEffect(() => {
+    void refreshPorts()
+  }, [refreshPorts])
+
+  // Keep the dropdown showing the active port while connected.
+  useEffect(() => {
+    if (connected && status.path) setSelected(status.path)
+  }, [connected, status.path])
+
+  const handleToggle = useCallback(async (): Promise<void> => {
+    setError(null)
+    setBusy(true)
+    try {
+      if (connected) {
+        await window.api.device.disconnect()
+      } else if (selected) {
+        await window.api.device.connect(selected)
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setBusy(false)
+    }
+  }, [connected, selected])
+
+  return (
+    <div className="conn-control" title={error ?? undefined}>
+      <select
+        className="conn-control__select"
+        value={selected}
+        disabled={connected || connecting}
+        onChange={(e) => setSelected(e.target.value)}
+        aria-label="Serial port"
+      >
+        {ports.length === 0 && <option value="">No ports</option>}
+        {ports.map((p) => {
+          const detail = p.friendlyName ?? p.manufacturer
+          return (
+            <option key={p.path} value={p.path}>
+              {detail ? `${p.path} — ${detail}` : p.path}
+            </option>
+          )
+        })}
+      </select>
+      {!connected && (
+        <button
+          type="button"
+          className="btn btn--ghost btn--sm"
+          onClick={() => void refreshPorts()}
+          disabled={connecting}
+          title="Refresh ports"
+          aria-label="Refresh serial ports"
+        >
+          ⟳
+        </button>
+      )}
+      <button
+        type="button"
+        className={`btn btn--sm ${connected ? 'btn--danger' : 'btn--primary'}`}
+        onClick={() => void handleToggle()}
+        disabled={connecting || (!connected && !selected)}
+      >
+        {connected ? 'Disconnect' : connecting ? 'Connecting…' : 'Connect'}
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/src/components/ShellPanel.tsx
+++ b/src/renderer/src/components/ShellPanel.tsx
@@ -1,21 +1,23 @@
 import { PanelHeader } from './PanelHeader'
-import { Placeholder } from './Placeholder'
+import { Terminal } from './Terminal'
+import { ConnectionControl } from './ConnectionControl'
+import { useDeviceStatus } from '../hooks/useDeviceStatus'
 
 /**
  * BOTTOM — shell / console (REPL) region.
  *
- * This is core to a MicroPython tool and is therefore OPEN by default. Later
- * this hosts the REPL with colour highlighting and a clear-console action
- * (the feedback specifically praised the trashcan clear button).
- *
- * Replace the <Placeholder> body with the real REPL/console.
+ * Hosts an interactive xterm.js terminal bound to the MicroPython device's
+ * friendly REPL, plus a compact connect/disconnect control in the header. This
+ * region is OPEN by default by design (the REPL is core to the tool).
  */
 export function ShellPanel(): JSX.Element {
+  const status = useDeviceStatus()
+
   return (
     <section className="region region--shell" aria-label="Shell">
-      <PanelHeader title="Shell" />
-      <div className="region__body">
-        <Placeholder label="Shell" hint="MicroPython REPL / console goes here." />
+      <PanelHeader title="Shell" actions={<ConnectionControl status={status} />} />
+      <div className="region__body region__body--terminal">
+        <Terminal />
       </div>
     </section>
   )

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useRef } from 'react'
+import { Terminal as XTerm } from '@xterm/xterm'
+import { FitAddon } from '@xterm/addon-fit'
+import '@xterm/xterm/css/xterm.css'
+
+/**
+ * Dark terminal theme used by the REPL. ANSI colours are kept vivid so device
+ * output (tracebacks, prompts, coloured logging) reads clearly — the reviewer
+ * specifically valued console colour highlighting.
+ */
+const TERMINAL_THEME = {
+  background: '#101216',
+  foreground: '#e6e8eb',
+  cursor: '#3b82f6',
+  cursorAccent: '#101216',
+  selectionBackground: '#3b82f655',
+  black: '#16181d',
+  red: '#ef4444',
+  green: '#22c55e',
+  yellow: '#eab308',
+  blue: '#3b82f6',
+  magenta: '#a855f7',
+  cyan: '#06b6d4',
+  white: '#e6e8eb',
+  brightBlack: '#6b7280',
+  brightRed: '#f87171',
+  brightGreen: '#4ade80',
+  brightYellow: '#facc15',
+  brightBlue: '#60a5fa',
+  brightMagenta: '#c084fc',
+  brightCyan: '#22d3ee',
+  brightWhite: '#ffffff'
+}
+
+const decoder = new TextDecoder()
+
+/**
+ * Interactive xterm.js REPL bound to the MicroPython device stream.
+ *
+ *  - incoming serial bytes (`device.onData`) are decoded and written to the term
+ *  - user keystrokes (`term.onData`) are forwarded raw via `device.sendData`,
+ *    so control bytes like Ctrl-C (`\x03`) and Ctrl-D (`\x04`) pass straight
+ *    through to the friendly REPL
+ *
+ * The terminal is created once and resized to its container via the fit addon.
+ */
+export function Terminal(): JSX.Element {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return undefined
+
+    const term = new XTerm({
+      cursorBlink: true,
+      convertEol: true,
+      fontFamily:
+        'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
+      fontSize: 13,
+      scrollback: 5000,
+      theme: TERMINAL_THEME,
+      allowProposedApi: true
+    })
+    const fitAddon = new FitAddon()
+    term.loadAddon(fitAddon)
+    term.open(container)
+    fitAddon.fit()
+
+    // Device -> terminal.
+    const unsubscribeData = window.api.device.onData((chunk) => {
+      term.write(decoder.decode(chunk, { stream: true }))
+    })
+
+    // Terminal -> device. Forward raw bytes (control chars included).
+    const inputDisposable = term.onData((data) => {
+      window.api.device.sendData(data).catch(() => undefined)
+    })
+
+    // Keep the terminal sized to its panel as it resizes.
+    const resizeObserver = new ResizeObserver(() => {
+      try {
+        fitAddon.fit()
+      } catch {
+        // fit() can throw if the element is momentarily detached; ignore.
+      }
+    })
+    resizeObserver.observe(container)
+
+    return () => {
+      unsubscribeData()
+      inputDisposable.dispose()
+      resizeObserver.disconnect()
+      term.dispose()
+    }
+  }, [])
+
+  return <div className="terminal" ref={containerRef} />
+}

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -1,4 +1,5 @@
 import { Theme } from '../hooks/useTheme'
+import { useDeviceStatus } from '../hooks/useDeviceStatus'
 
 interface ToolbarProps {
   theme: Theme
@@ -15,9 +16,9 @@ interface ToolbarProps {
  * TOP TOOLBAR.
  *
  * Big, easy-to-click action buttons (Run / Stop) plus a connection-status
- * indicator. Per the issue #2 ownership boundary these are VISUAL PLACEHOLDERS
- * ONLY — they are intentionally not wired to any device API. A later agent
- * replaces the handlers/state.
+ * indicator. The Run / Stop buttons remain VISUAL PLACEHOLDERS (wired in a
+ * later issue). The connection-status indicator IS live: it reflects the
+ * device layer's status via {@link useDeviceStatus}.
  *
  * Also hosts layout controls (panel show/hide toggles) and the theme toggle,
  * following progressive disclosure: complexity stays tucked away by default.
@@ -32,6 +33,17 @@ export function Toolbar({
   rightCollapsed,
   onToggleRight
 }: ToolbarProps): JSX.Element {
+  const status = useDeviceStatus()
+  const connected = status.state === 'connected'
+  const label =
+    status.state === 'connecting'
+      ? 'Connecting…'
+      : connected
+        ? `Connected${status.path ? ` · ${status.path}` : ''}`
+        : status.state === 'error'
+          ? 'Error'
+          : 'Disconnected'
+
   return (
     <header className="toolbar" role="toolbar" aria-label="Main toolbar">
       <div className="toolbar__group">
@@ -47,13 +59,13 @@ export function Toolbar({
       </div>
 
       <div className="toolbar__group">
-        {/* Placeholder connection-status indicator — purely visual. */}
+        {/* Live connection-status indicator, driven by the device layer. */}
         <span
-          className="conn-status conn-status--disconnected"
-          title="Connection status (placeholder)"
+          className={`conn-status ${connected ? 'conn-status--connected' : 'conn-status--disconnected'}`}
+          title={status.error ? `Connection error: ${status.error}` : 'Connection status'}
         >
           <span className="conn-status__dot" aria-hidden="true" />
-          <span>Disconnected</span>
+          <span>{label}</span>
         </span>
       </div>
 

--- a/src/renderer/src/hooks/useDeviceStatus.ts
+++ b/src/renderer/src/hooks/useDeviceStatus.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react'
+import type { DeviceStatus } from '../../../preload/index.d'
+
+const INITIAL: DeviceStatus = { state: 'disconnected' }
+
+/**
+ * Subscribe to live device connection status.
+ *
+ * Reads the current snapshot once on mount (`getStatus`) and then tracks every
+ * push from `onStatus`. Multiple components (the toolbar indicator and the
+ * shell connection control) each call this independently — the device layer
+ * broadcasts to all subscribers, so they stay in sync without shared state.
+ */
+export function useDeviceStatus(): DeviceStatus {
+  const [status, setStatus] = useState<DeviceStatus>(INITIAL)
+
+  useEffect(() => {
+    let active = true
+    window.api.device
+      .getStatus()
+      .then((s) => {
+        if (active) setStatus(s)
+      })
+      .catch(() => undefined)
+
+    const unsubscribe = window.api.device.onStatus((s) => setStatus(s))
+    return () => {
+      active = false
+      unsubscribe()
+    }
+  }, [])
+
+  return status
+}

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -143,6 +143,20 @@ body {
   font-size: 1rem;
 }
 
+.btn--sm {
+  padding: 0.25rem 0.55rem;
+  font-size: 0.78rem;
+}
+
+.btn--sm.btn--ghost {
+  padding: 0.25rem 0.45rem;
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .btn__glyph {
   font-size: 0.85em;
 }
@@ -226,6 +240,50 @@ body {
   flex: 1;
   min-height: 0;
   overflow: auto;
+}
+
+/* The terminal owns its own scrolling; don't double up. */
+.region__body--terminal {
+  overflow: hidden;
+  background: #101216;
+}
+
+/* --------------------------------------------------------------------------
+ * Shell terminal (xterm) + connection control
+ * ------------------------------------------------------------------------ */
+.terminal {
+  width: 100%;
+  height: 100%;
+  padding: 0.35rem 0.45rem;
+  box-sizing: border-box;
+}
+
+.terminal .xterm {
+  height: 100%;
+}
+
+.conn-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  text-transform: none;
+  letter-spacing: normal;
+}
+
+.conn-control__select {
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: var(--text);
+  background: var(--bg-sunken);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.25rem 0.4rem;
+  max-width: 14rem;
+}
+
+.conn-control__select:disabled {
+  opacity: 0.6;
 }
 
 /* --------------------------------------------------------------------------


### PR DESCRIPTION
## What this does

Implements issue #10: an interactive MicroPython REPL inside the Shell panel.

### Device layer (raw write)
- `MicroPythonDevice.sendData(data: string)` — writes raw bytes straight to the open serial port (no raw-REPL handshake), so interactive keystrokes and control bytes (Ctrl-C `\x03`, Ctrl-D `\x04`) pass through to the friendly `>>>` REPL.
- `device:sendData` IPC handler.
- `window.api.device.sendData(data: string): Promise<void>` added to the existing `device` namespace in preload (localized, non-overlapping edit). The preload `index.d.ts` derives from `typeof api`, so the type is picked up automatically.

### REPL terminal (`Terminal.tsx`)
- `@xterm/xterm` + `@xterm/addon-fit`, xterm CSS imported.
- Subscribes to `device.onData` → decodes bytes → writes to the terminal; unsubscribes on unmount.
- `term.onData` (user input) → `device.sendData(input)`; Ctrl-C / Ctrl-D pass through as raw bytes.
- Clean dark theme with vivid ANSI colours for console colour highlighting; 5000-line scrollback; auto-fit via `ResizeObserver`.

### Connection control (`ConnectionControl.tsx`)
- Port dropdown (from `device.listPorts()`), refresh button, and a Connect/Disconnect toggle, rendered in the ShellPanel `PanelHeader` actions slot.
- State reflected from a shared `useDeviceStatus` hook (`getStatus()` + `onStatus`).

### Toolbar status indicator
- The existing placeholder indicator in `Toolbar.tsx` is now wired to live device state via `useDeviceStatus` (shows Disconnected / Connecting / Connected · port / Error, with the connected dot colour). Run/Stop remain placeholders for issue #11.

## Verification
- `npm install`, `npm run lint`, `npm run typecheck`, `npm run build` all pass.
- Hardware untested: ARM64 Linux headless, no MicroPython device attached.

## Checklist
- [x] `device.sendData` (raw write) added end to end
- [x] xterm terminal wired to onData / sendData
- [x] Ctrl-C / Ctrl-D passthrough
- [x] Connection control in shell header
- [x] Toolbar status indicator wired
- [x] lint + typecheck + build green
- [ ] Hardware smoke test (not possible in this environment)

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)