### PR TITLE
Device file browser panel

### DIFF
--- a/src/renderer/src/components/DeviceFileTree.tsx
+++ b/src/renderer/src/components/DeviceFileTree.tsx
@@ -1,0 +1,212 @@
+import { useCallback, useEffect, useState } from 'react'
+import type { DirEntry } from '../../../preload/index.d'
+import { useDeviceStatus } from '../hooks/useDeviceStatus'
+import { useWorkspace } from '../store/workspace'
+import { Placeholder } from './Placeholder'
+
+/**
+ * Device (MicroPython board) filesystem browser for issue #7.
+ *
+ * Lists the connected board's filesystem via `window.api.device.listDir`,
+ * starting at `/`, with directories expandable on demand (children are
+ * lazy-loaded the first time a folder is opened). Clicking a file opens it in
+ * the editor through the workspace store.
+ *
+ * Gated on the live connection state from `useDeviceStatus()`: when no board is
+ * connected it falls back to a friendly hint; when a board becomes connected the
+ * tree (re)loads automatically. A Refresh action re-reads the root.
+ *
+ * File operations (create/rename/delete) are intentionally out of scope here —
+ * they are tracked separately by issue #8. This component is browse + open +
+ * refresh only. Per the local-section UX, a board/microcontroller icon marks
+ * the device section header.
+ */
+
+/** Join a device directory path and a child name into a POSIX device path. */
+function joinDevicePath(dir: string, name: string): string {
+  return dir === '/' ? `/${name}` : `${dir}/${name}`
+}
+
+interface DeviceTreeNodeProps {
+  entry: DirEntry
+  /** Full device path of this entry. */
+  path: string
+  depth: number
+  selectedPath: string | null
+  onSelect: (path: string) => void
+  onOpenFile: (path: string) => void
+}
+
+/** Recursively renders a device entry and (when expanded) its children. */
+function DeviceTreeNode({
+  entry,
+  path,
+  depth,
+  selectedPath,
+  onSelect,
+  onOpenFile
+}: DeviceTreeNodeProps): JSX.Element {
+  const [expanded, setExpanded] = useState(false)
+  const [children, setChildren] = useState<DirEntry[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const loadChildren = useCallback(async (): Promise<void> => {
+    try {
+      setChildren(await window.api.device.listDir(path))
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }, [path])
+
+  const toggle = useCallback(async (): Promise<void> => {
+    if (!expanded && children === null) await loadChildren()
+    setExpanded((v) => !v)
+  }, [expanded, children, loadChildren])
+
+  const handleClick = useCallback((): void => {
+    onSelect(path)
+    if (entry.isDir) void toggle()
+    else onOpenFile(path)
+  }, [entry.isDir, path, onOpenFile, onSelect, toggle])
+
+  const isSelected = selectedPath === path
+
+  return (
+    <div className="tree-node">
+      <div
+        className={`tree-row${isSelected ? ' is-selected' : ''}`}
+        style={{ paddingLeft: `${depth * 14 + 8}px` }}
+        onClick={handleClick}
+        role="treeitem"
+        aria-expanded={entry.isDir ? expanded : undefined}
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            handleClick()
+          }
+        }}
+      >
+        <span className="tree-row__glyph" aria-hidden>
+          {entry.isDir ? (expanded ? '▼' : '▶') : '\u{1F4C4}'}
+        </span>
+        <span className="tree-row__name">{entry.name}</span>
+      </div>
+      {error && (
+        <div className="tree-error" style={{ paddingLeft: `${depth * 14 + 22}px` }}>
+          {error}
+        </div>
+      )}
+      {entry.isDir &&
+        expanded &&
+        children?.map((child) => (
+          <DeviceTreeNode
+            key={joinDevicePath(path, child.name)}
+            entry={child}
+            path={joinDevicePath(path, child.name)}
+            depth={depth + 1}
+            selectedPath={selectedPath}
+            onSelect={onSelect}
+            onOpenFile={onOpenFile}
+          />
+        ))}
+    </div>
+  )
+}
+
+const ROOT = '/'
+
+export function DeviceFileTree(): JSX.Element {
+  const status = useDeviceStatus()
+  const connected = status.state === 'connected'
+  const { openFile } = useWorkspace()
+
+  const [entries, setEntries] = useState<DirEntry[]>([])
+  const [selectedPath, setSelectedPath] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const refresh = useCallback(async (): Promise<void> => {
+    setLoading(true)
+    try {
+      setEntries(await window.api.device.listDir(ROOT))
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  // Load (or reset) the tree as the connection comes up / goes away. Loading
+  // when `connected` flips true also covers reconnects to a different board.
+  useEffect(() => {
+    if (connected) {
+      void refresh()
+    } else {
+      setEntries([])
+      setSelectedPath(null)
+      setError(null)
+    }
+  }, [connected, refresh])
+
+  const handleOpenFile = useCallback(
+    (path: string): void => {
+      void openFile('device', path).catch((err) =>
+        setError(err instanceof Error ? err.message : String(err))
+      )
+    },
+    [openFile]
+  )
+
+  if (!connected) {
+    return (
+      <div className="devicetree">
+        <div className="devicetree__header">
+          <span className="devicetree__title">
+            <span aria-hidden>{'\u{1F50C}'}</span> Device files
+          </span>
+        </div>
+        <Placeholder label="Device files" hint="Connect a board to browse its filesystem." />
+      </div>
+    )
+  }
+
+  return (
+    <div className="devicetree">
+      <div className="devicetree__header">
+        <span className="devicetree__title">
+          <span aria-hidden>{'\u{1F50C}'}</span> Device files
+        </span>
+        <button
+          className="btn btn--ghost"
+          onClick={() => void refresh()}
+          disabled={loading}
+          title="Refresh device filesystem"
+        >
+          {loading ? '…' : '↻'} Refresh
+        </button>
+      </div>
+
+      {error && <div className="devicetree__error">{error}</div>}
+
+      <div className="devicetree__tree" role="tree" aria-label="Device file tree">
+        {entries.map((entry) => (
+          <DeviceTreeNode
+            key={joinDevicePath(ROOT, entry.name)}
+            entry={entry}
+            path={joinDevicePath(ROOT, entry.name)}
+            depth={0}
+            selectedPath={selectedPath}
+            onSelect={setSelectedPath}
+            onOpenFile={handleOpenFile}
+          />
+        ))}
+        {!loading && !error && entries.length === 0 && (
+          <div className="devicetree__empty-hint">Filesystem is empty.</div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/FilePanel.tsx
+++ b/src/renderer/src/components/FilePanel.tsx
@@ -1,6 +1,6 @@
 import { PanelHeader } from './PanelHeader'
-import { Placeholder } from './Placeholder'
 import { LocalFileTree } from './LocalFileTree'
+import { DeviceFileTree } from './DeviceFileTree'
 
 /**
  * LEFT SIDEBAR — file panels region.
@@ -19,8 +19,7 @@ export function FilePanel(): JSX.Element {
           <LocalFileTree />
         </section>
         <section className="filepanel__device">
-          {/* #7 device file browser mounts <DeviceFileTree/> here */}
-          <Placeholder label="Device files" hint="Connect a board to browse its filesystem." />
+          <DeviceFileTree />
         </section>
       </div>
     </section>

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -400,6 +400,61 @@ body {
   word-break: break-word;
 }
 
+/* Device filesystem browser (issue #7) — mirrors the local tree styling. */
+.devicetree {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+.devicetree__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.4rem;
+  padding: 0.4rem 0.6rem;
+  flex: 0 0 auto;
+}
+
+.devicetree__title {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+
+.devicetree__header .btn {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.78rem;
+  font-weight: 500;
+  flex: 0 0 auto;
+}
+
+.devicetree__tree {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  padding-bottom: 0.5rem;
+}
+
+.devicetree__error {
+  color: var(--danger);
+  font-size: 0.75rem;
+  padding: 0.25rem 0.6rem;
+  word-break: break-word;
+}
+
+.devicetree__empty-hint {
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  padding: 0.4rem 0.6rem;
+}
+
 .tree-row {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## What this does

Implements the device filesystem browser for the left sidebar's device slot.

- New `DeviceFileTree.tsx`: lists the connected board's filesystem via `window.api.device.listDir`, starting at `/`, with expandable directories (children lazy-loaded on first expand). Child paths are built by joining the parent device path with the entry name (POSIX `/`), since `DirEntry` carries only `{name,isDir,size}`.
- Clicking a file calls `useWorkspace().openFile('device', path)` to open it in the editor.
- Connection-gated via `useDeviceStatus()`: when not `connected`, renders the friendly `<Placeholder>` hint; when connected, loads and shows the tree. A `useEffect` keyed on the connection state (re)loads the root when a board connects and clears the tree when it disconnects.
- A **Refresh** button in the section header re-reads the device root.
- Board/microcontroller icon in the section header, mirroring the local section's computer icon.
- `FilePanel.tsx` device section now mounts `<DeviceFileTree/>` (placeholder removed); section label preserved.
- Minimal `devicetree` CSS in `index.css` mirroring the local-tree styling (reuses shared `tree-row`/`tree-node` classes).

File operations (create/rename/delete on device) are intentionally **not** included — those are issue #8. Browse + open + refresh only.

## Checklist
- [x] `DeviceFileTree.tsx` lists device FS from `/` with lazy-loaded expandable dirs
- [x] File click opens via `openFile('device', path)`
- [x] Gated on `useDeviceStatus()`; hint when no board, tree when connected; refreshes on connect
- [x] Refresh action in header
- [x] Board/microcontroller icon in header
- [x] `FilePanel.tsx` mounts `<DeviceFileTree/>`, label kept
- [x] No file operations (deferred to #8)
- [x] `npm install && npm run lint && npm run typecheck && npm run build` all pass

## Caveats
- Headless ARM64 Linux with no device attached, so the live tree could not be exercised end-to-end. Verified by lint/typecheck/build only.

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)