### PR TITLE
Monaco editor with Python/MicroPython syntax

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@electron-toolkit/utils": "^3.0.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
+        "monaco-editor": "^0.52.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-resizable-panels": "^2.1.9",
@@ -4442,6 +4443,11 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ=="
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@electron-toolkit/utils": "^3.0.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
+    "monaco-editor": "^0.52.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-resizable-panels": "^2.1.9",

--- a/src/renderer/src/components/EditorArea.tsx
+++ b/src/renderer/src/components/EditorArea.tsx
@@ -1,21 +1,19 @@
 import { PanelHeader } from './PanelHeader'
-import { Placeholder } from './Placeholder'
+import { MonacoEditor } from './MonacoEditor'
 
 /**
- * CENTER — editor tabs region.
+ * CENTER — editor region.
  *
- * Later this hosts the tabbed code editor. Note the feedback request for a
- * `+` tab affordance for creating new files; the tab strip will live in this
- * region's header/body.
- *
- * Replace the <Placeholder> body with the real editor + tab strip.
+ * Hosts the Monaco-backed code editor bound to the workspace's active file
+ * (issue #3). The tabbed tab strip is a separate issue (#4); this region simply
+ * renders the active document.
  */
 export function EditorArea(): JSX.Element {
   return (
     <section className="region region--editor" aria-label="Editor">
       <PanelHeader title="Editor" />
-      <div className="region__body">
-        <Placeholder label="Editor" hint="Tabbed code editor goes here." />
+      <div className="region__body region__body--editor">
+        <MonacoEditor />
       </div>
     </section>
   )

--- a/src/renderer/src/components/MonacoEditor.tsx
+++ b/src/renderer/src/components/MonacoEditor.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useRef } from 'react'
+// Import only the editor core API rather than the full `monaco-editor` barrel,
+// then opt in to just the languages we render. This keeps the renderer bundle
+// small instead of pulling in all ~80 bundled languages.
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api'
+import 'monaco-editor/esm/vs/editor/editor.all'
+import 'monaco-editor/esm/vs/basic-languages/python/python.contribution'
+import 'monaco-editor/esm/vs/basic-languages/markdown/markdown.contribution'
+import 'monaco-editor/esm/vs/language/json/monaco.contribution'
+import './monaco-setup'
+import { useWorkspace } from '../store/workspace'
+import { useTheme } from '../hooks/useTheme'
+
+/**
+ * Map a file name to a Monaco language id. MicroPython sources are plain Python,
+ * so `.py` (and unknown extensions) default to `python`.
+ */
+function languageForName(name: string): string {
+  if (/\.(json)$/i.test(name)) return 'json'
+  if (/\.(md|markdown)$/i.test(name)) return 'markdown'
+  if (/\.(txt)$/i.test(name)) return 'plaintext'
+  return 'python'
+}
+
+function monacoTheme(theme: 'light' | 'dark'): string {
+  return theme === 'dark' ? 'vs-dark' : 'vs'
+}
+
+/**
+ * Monaco-backed code editor bound to the workspace's ACTIVE file.
+ *
+ *  - one Monaco model per open-file id (preserves undo history / view state
+ *    when switching between files; tabs themselves are issue #4)
+ *  - edits flow back through `updateContent` (which marks the buffer dirty)
+ *  - Ctrl/Cmd-S triggers `saveFile` and suppresses the browser default
+ *  - the editor auto-lays-out, so it tracks panel resizes
+ */
+export function MonacoEditor(): JSX.Element {
+  const { openFiles, activeId, updateContent, saveFile } = useWorkspace()
+  const { theme } = useTheme()
+
+  const containerRef = useRef<HTMLDivElement>(null)
+  const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null)
+  const models = useRef(new Map<string, monaco.editor.ITextModel>())
+
+  // Latest store callbacks, read inside Monaco event handlers without
+  // re-creating the editor on every render.
+  const updateContentRef = useRef(updateContent)
+  const saveFileRef = useRef(saveFile)
+  const activeIdRef = useRef(activeId)
+  updateContentRef.current = updateContent
+  saveFileRef.current = saveFile
+  activeIdRef.current = activeId
+
+  // Create the editor once.
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return undefined
+
+    const editor = monaco.editor.create(container, {
+      value: '',
+      language: 'python',
+      theme: monacoTheme(theme),
+      automaticLayout: true,
+      lineNumbers: 'on',
+      minimap: { enabled: true },
+      wordWrap: 'off',
+      tabSize: 4,
+      insertSpaces: true,
+      detectIndentation: false,
+      fontFamily:
+        'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
+      fontSize: 13,
+      scrollBeyondLastLine: false
+    })
+    editorRef.current = editor
+
+    // Edits -> store (marks dirty). Guarded against programmatic model swaps via
+    // the active id captured per change.
+    const changeDisposable = editor.onDidChangeModelContent(() => {
+      const id = activeIdRef.current
+      if (!id) return
+      updateContentRef.current(id, editor.getValue())
+    })
+
+    // Ctrl/Cmd-S -> save. Monaco swallows the keybinding so the browser default
+    // never fires.
+    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => {
+      const id = activeIdRef.current
+      if (id) void saveFileRef.current(id)
+    })
+
+    const modelStore = models.current
+    return () => {
+      changeDisposable.dispose()
+      editor.dispose()
+      editorRef.current = null
+      modelStore.forEach((m) => m.dispose())
+      modelStore.clear()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Follow theme changes.
+  useEffect(() => {
+    monaco.editor.setTheme(monacoTheme(theme))
+  }, [theme])
+
+  // Bind the active file to a per-id model and attach it to the editor.
+  const activeFile = openFiles.find((f) => f.id === activeId) ?? null
+
+  useEffect(() => {
+    const editor = editorRef.current
+    if (!editor || !activeFile) return
+
+    let model = models.current.get(activeFile.id)
+    if (!model || model.isDisposed()) {
+      model = monaco.editor.createModel(
+        activeFile.content,
+        languageForName(activeFile.name)
+      )
+      models.current.set(activeFile.id, model)
+    } else if (model.getValue() !== activeFile.content) {
+      // External update (e.g. reload/save round-trip) — sync without clobbering
+      // the user's cursor mid-typing. Only applies when content actually drifts.
+      model.setValue(activeFile.content)
+    }
+
+    if (editor.getModel() !== model) {
+      editor.setModel(model)
+    }
+  }, [activeFile, activeFile?.id, activeFile?.content, activeFile?.name])
+
+  // Dispose models whose files have been closed.
+  useEffect(() => {
+    const openIds = new Set(openFiles.map((f) => f.id))
+    models.current.forEach((model, id) => {
+      if (!openIds.has(id)) {
+        model.dispose()
+        models.current.delete(id)
+      }
+    })
+  }, [openFiles])
+
+  return (
+    <div className="editor-host">
+      {/* The Monaco mount point is always present so the editor instance can be
+          created on first mount regardless of whether a file is open yet. */}
+      <div className="monaco-host" ref={containerRef} hidden={!activeFile} />
+      {!activeFile && (
+        <div className="editor-empty">
+          <span className="editor-empty__text">Open a file to start editing</span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/monaco-setup.ts
+++ b/src/renderer/src/components/monaco-setup.ts
@@ -1,0 +1,26 @@
+/**
+ * Wire Monaco's web workers to the LOCALLY BUNDLED copy of `monaco-editor`.
+ *
+ * Snakie ships under a strict CSP (`script-src 'self'`) inside Electron, so
+ * Monaco must NOT pull anything from a CDN. Vite's `?worker` imports emit the
+ * worker as a same-origin chunk under `assets/`, which `'self'` permits — the
+ * worker is constructed from an app-served URL, not a blob or remote script.
+ *
+ * Python needs no language-specific worker; the base `editor.worker` is enough
+ * to drive the editor (tokenisation for `python` is synchronous/built-in).
+ *
+ * This module sets `self.MonacoEnvironment` exactly once, the first time it is
+ * imported, before any editor is instantiated.
+ */
+import EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker'
+import JsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker'
+
+self.MonacoEnvironment = {
+  getWorker(_workerId: string, label: string): Worker {
+    // Python/Markdown are basic (synchronous) languages and need no dedicated
+    // worker — the base editor worker covers them. JSON ships a language worker
+    // for validation/formatting.
+    if (label === 'json') return new JsonWorker()
+    return new EditorWorker()
+  }
+}

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -249,6 +249,39 @@ body {
 }
 
 /* --------------------------------------------------------------------------
+ * Monaco code editor (issue #3)
+ * ------------------------------------------------------------------------ */
+/* Monaco manages its own scrolling and layout; give it a clean fixed box. */
+.region__body--editor {
+  overflow: hidden;
+}
+
+.editor-host {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.monaco-host {
+  width: 100%;
+  height: 100%;
+}
+
+.editor-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: 1rem;
+  text-align: center;
+}
+
+.editor-empty__text {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+/* --------------------------------------------------------------------------
  * Shell terminal (xterm) + connection control
  * ------------------------------------------------------------------------ */
 .terminal {


### PR DESCRIPTION
## What this does

Fills the CENTER `EditorArea` region with a fully offline, bundled **Monaco editor** bound to the workspace store's active file.

### Implementation
- **`MonacoEditor.tsx`** — renders the active `OpenFile` (`openFiles.find(f => f.id === activeId)`); one Monaco model per file id (preserves undo history / view state when `activeId` switches — tabs themselves are #4). Clean empty state ("Open a file to start editing") when nothing is open.
- **Syntax** — Monaco's built-in `python` language, chosen by file extension, defaulting to `python` for `.py`. JSON/Markdown also recognized.
- **Edits** flow through `updateContent(activeId, value)` (marks dirty).
- **Ctrl/Cmd-S** wired via Monaco's own keybinding (`KeyMod.CtrlCmd | KeyCode.KeyS`) → `saveFile(activeId)`; Monaco swallows the chord so the browser's default Save never fires.
- **Theme** follows `useTheme`: dark → `vs-dark`, light → `vs`, updated live.
- **Defaults**: line numbers on, `automaticLayout` (resizes with the panel), 4-space indent (`tabSize: 4`, `insertSpaces`, `detectIndentation: false`), minimap on, word wrap off.

### Offline / no CDN (strict CSP `script-src 'self'`)
- **`monaco-setup.ts`** wires `self.MonacoEnvironment.getWorker` to the locally bundled workers via Vite `?worker` imports (`editor.worker`, plus `json.worker` for JSON). No network loader, no CDN.
- Used the **`monaco-editor` package directly** (not `@monaco-editor/react`), importing only `editor.api` + `editor.all` + the python/markdown/json contributions instead of the full barrel — trims the renderer from 80+ language chunks to three.
- `npm run build` confirmed green; `out/renderer/assets/` contains `editor.worker-*.js`, `json.worker-*.js`, and `python-*.js` chunks, all same-origin. No CDN/`importScripts(http…)` references in the bundle.
- **No changes to `electron.vite.config.ts`** were required.

### Verification
`npm install && npm run lint && npm run typecheck && npm run build` all pass.

## Checklist
- [x] Monaco integrated in `EditorArea`, bound to active file; empty state when none open
- [x] Python syntax highlighting by extension (default `.py` → python)
- [x] change → `updateContent`; Ctrl/Cmd-S → `saveFile`, browser default prevented
- [x] line numbers, automatic layout, 4-space indent, minimap on, word wrap off
- [x] theme matches app (vs-dark / vs)
- [x] honors `activeId` only (no tab bar — that's #4); per-file Monaco models
- [x] Monaco bundled locally for offline use, no CDN

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)