### PR TITLE
Tabbed editor for multiple open files

### DIFF
--- a/src/renderer/src/components/EditorArea.tsx
+++ b/src/renderer/src/components/EditorArea.tsx
@@ -1,17 +1,18 @@
 import { PanelHeader } from './PanelHeader'
 import { MonacoEditor } from './MonacoEditor'
+import { EditorTabs } from './EditorTabs'
 
 /**
  * CENTER — editor region.
  *
  * Hosts the Monaco-backed code editor bound to the workspace's active file
- * (issue #3). The tabbed tab strip is a separate issue (#4); this region simply
- * renders the active document.
+ * (issue #3), with the tabbed strip for open files mounted above it (issue #4).
  */
 export function EditorArea(): JSX.Element {
   return (
     <section className="region region--editor" aria-label="Editor">
       <PanelHeader title="Editor" />
+      <EditorTabs />
       <div className="region__body region__body--editor">
         <MonacoEditor />
       </div>

--- a/src/renderer/src/components/EditorTabs.css
+++ b/src/renderer/src/components/EditorTabs.css
@@ -1,0 +1,100 @@
+.editor-tabs {
+  display: flex;
+  align-items: stretch;
+  gap: 1px;
+  min-height: 34px;
+  background: var(--bg-sunken);
+  border-bottom: 1px solid var(--border);
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+}
+
+.editor-tabs--empty {
+  align-items: center;
+  padding: 0 4px;
+}
+
+.editor-tab {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 8px 0 12px;
+  max-width: 200px;
+  background: var(--bg-sunken);
+  color: var(--text-muted);
+  border: none;
+  border-right: 1px solid var(--border);
+  font-size: 13px;
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.editor-tab:hover {
+  background: var(--bg);
+}
+
+.editor-tab--active {
+  background: var(--bg-elevated);
+  color: var(--text);
+  box-shadow: inset 0 2px 0 var(--accent);
+}
+
+.editor-tab__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.editor-tab__dirty {
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+.editor-tab__close {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius);
+  background: transparent;
+  color: inherit;
+  font-size: 15px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.editor-tab__close:hover {
+  background: var(--border);
+  color: var(--text);
+}
+
+.editor-tabs__new {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  margin: auto 4px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.editor-tabs__new:hover {
+  background: var(--border);
+  color: var(--text);
+}

--- a/src/renderer/src/components/EditorTabs.tsx
+++ b/src/renderer/src/components/EditorTabs.tsx
@@ -1,0 +1,126 @@
+import { useEffect } from 'react'
+import { useWorkspace } from '../store/workspace'
+import './EditorTabs.css'
+
+/**
+ * Tab strip for the editor region (issue #4).
+ *
+ * Lists every open file as a tab; the active tab is highlighted and clicking a
+ * tab activates it. Each tab carries a dirty indicator and a close (×) button
+ * that confirms before discarding unsaved edits. A trailing `+` button creates
+ * a new untitled buffer (VS Code muscle memory).
+ *
+ * Keyboard:
+ *   - Ctrl/Cmd+W           closes the active tab
+ *   - Ctrl+Tab             cycles to the next tab
+ *   - Ctrl+Shift+Tab       cycles to the previous tab
+ */
+export function EditorTabs(): JSX.Element | null {
+  const { openFiles, activeId, setActive, closeFile, newFile } = useWorkspace()
+
+  // Close a tab, confirming first if it has unsaved edits.
+  function requestClose(id: string): void {
+    const file = openFiles.find((f) => f.id === id)
+    if (file?.dirty) {
+      const ok = window.confirm(`"${file.name}" has unsaved changes. Close it anyway?`)
+      if (!ok) return
+    }
+    closeFile(id)
+  }
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent): void {
+      const mod = e.ctrlKey || e.metaKey
+      if (!mod) return
+
+      // Ctrl/Cmd+W -> close the active tab.
+      if ((e.key === 'w' || e.key === 'W') && !e.shiftKey) {
+        if (!activeId) return
+        e.preventDefault()
+        requestClose(activeId)
+        return
+      }
+
+      // Ctrl+Tab / Ctrl+Shift+Tab -> cycle tabs.
+      if (e.key === 'Tab') {
+        if (openFiles.length === 0) return
+        e.preventDefault()
+        const idx = openFiles.findIndex((f) => f.id === activeId)
+        const base = idx === -1 ? 0 : idx
+        const len = openFiles.length
+        const nextIdx = e.shiftKey ? (base - 1 + len) % len : (base + 1) % len
+        setActive(openFiles[nextIdx].id)
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [openFiles, activeId, setActive, closeFile])
+
+  if (openFiles.length === 0) {
+    // Thin empty-state bar keeps the layout stable and still offers a `+`.
+    return (
+      <div className="editor-tabs editor-tabs--empty" role="tablist" aria-label="Open files">
+        <button
+          type="button"
+          className="editor-tabs__new"
+          title="New file"
+          aria-label="New file"
+          onClick={newFile}
+        >
+          +
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="editor-tabs" role="tablist" aria-label="Open files">
+      {openFiles.map((file) => {
+        const active = file.id === activeId
+        return (
+          <div
+            key={file.id}
+            role="tab"
+            aria-selected={active}
+            className={`editor-tab${active ? ' editor-tab--active' : ''}`}
+            onClick={() => setActive(file.id)}
+            onMouseDown={(e) => {
+              // Middle-click closes, matching common editor behaviour.
+              if (e.button === 1) {
+                e.preventDefault()
+                requestClose(file.id)
+              }
+            }}
+            title={file.path || file.name}
+          >
+            {file.dirty && <span className="editor-tab__dirty" aria-hidden="true" />}
+            <span className="editor-tab__label">{file.name}</span>
+            <button
+              type="button"
+              className="editor-tab__close"
+              title="Close"
+              aria-label={`Close ${file.name}`}
+              onClick={(e) => {
+                e.stopPropagation()
+                requestClose(file.id)
+              }}
+            >
+              ×
+            </button>
+          </div>
+        )
+      })}
+      <button
+        type="button"
+        className="editor-tabs__new"
+        title="New file"
+        aria-label="New file"
+        onClick={newFile}
+      >
+        +
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
Adds a VS Code-style tab strip above the Monaco editor for working with multiple open files.

## Changes
- New `EditorTabs.tsx` + co-located `EditorTabs.css`, mounted at the top of `EditorArea.tsx` (above the Monaco editor).

## Checklist
- [x] Tab bar lists `openFiles`; active tab highlighted; click → `setActive(id)`
- [x] Per-tab close (×) → `closeFile(id)`; confirms via `window.confirm` when the file is `dirty`
- [x] Dirty indicator (dot) per tab when `file.dirty`
- [x] `+` button on the tab bar → `newFile()`
- [x] Keyboard: Ctrl/Cmd+W closes the active tab; Ctrl+Tab / Ctrl+Shift+Tab cycle tabs
- [x] Mounted at the top of `EditorArea.tsx`; thin empty-state bar (with `+`) when no files are open

## Verification
`npm install && npm run lint && npm run typecheck && npm run build` all pass.

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)