### PR TITLE
Upload current file to the connected device

### DIFF
--- a/src/renderer/src/components/FilePanel.tsx
+++ b/src/renderer/src/components/FilePanel.tsx
@@ -1,6 +1,7 @@
 import { PanelHeader } from './PanelHeader'
 import { LocalFileTree } from './LocalFileTree'
 import { DeviceFileTree } from './DeviceFileTree'
+import { UploadControls } from './UploadControls'
 
 /**
  * LEFT SIDEBAR — file panels region.
@@ -18,6 +19,9 @@ export function FilePanel(): JSX.Element {
         <section className="filepanel__local">
           <LocalFileTree />
         </section>
+        {/* Transfer bridge: sits BETWEEN the computer (above) and board (below)
+            panes so the up/down direction matches the layout (issue #9). */}
+        <UploadControls />
         <section className="filepanel__device">
           <DeviceFileTree />
         </section>

--- a/src/renderer/src/components/UploadControls.css
+++ b/src/renderer/src/components/UploadControls.css
@@ -1,0 +1,75 @@
+/*
+ * UploadControls — the transfer bridge between the computer (above) and
+ * board (below) file panes. Direction maps to layout: download points up,
+ * upload points down.
+ */
+.upload-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px;
+  border-top: 1px solid var(--border, rgba(127, 127, 127, 0.25));
+  border-bottom: 1px solid var(--border, rgba(127, 127, 127, 0.25));
+}
+
+.upload-controls__buttons {
+  display: flex;
+  gap: 8px;
+}
+
+.upload-controls__btn {
+  flex: 1 1 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+
+.upload-controls__btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.upload-controls__glyph {
+  font-weight: 700;
+  line-height: 1;
+}
+
+.upload-controls__feedback {
+  margin: 0;
+  font-size: 0.8rem;
+  line-height: 1.3;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  word-break: break-word;
+}
+
+.upload-controls__feedback--success {
+  color: var(--success, #2e8b57);
+}
+
+.upload-controls__feedback--error {
+  color: var(--danger, #c0392b);
+}
+
+.upload-controls__feedback--info {
+  color: var(--muted, #888);
+}
+
+.upload-controls__spinner {
+  width: 12px;
+  height: 12px;
+  flex: 0 0 auto;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: upload-controls-spin 0.7s linear infinite;
+}
+
+@keyframes upload-controls-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/renderer/src/components/UploadControls.tsx
+++ b/src/renderer/src/components/UploadControls.tsx
@@ -1,0 +1,145 @@
+import { useState } from 'react'
+import { useWorkspace } from '../store/workspace'
+import { useDeviceStatus } from '../hooks/useDeviceStatus'
+import './UploadControls.css'
+
+type Feedback = { kind: 'success' | 'error' | 'info'; message: string } | null
+
+/** Join a folder and a file name with a single separator (host paths). */
+function joinLocal(folder: string, name: string): string {
+  const sep = folder.includes('\\') ? '\\' : '/'
+  const trimmed = folder.replace(/[/\\]+$/, '')
+  return `${trimmed}${sep}${name}`
+}
+
+/**
+ * UploadControls — the transfer bridge that sits BETWEEN the two file panes.
+ *
+ * Layout maps to direction: the computer (local) pane is ABOVE and the board
+ * (device) pane is BELOW, so:
+ *   - Upload "to board" points DOWN (↓): write the active editor buffer to the
+ *     connected device via `window.api.device.writeFile`.
+ *   - Download "to computer" points UP (↑): take the active *device* file and
+ *     save it to a host folder via `window.api.fs.writeFile`.
+ *
+ * This addresses the issue #9 feedback: the old "up" upload icon was
+ * unintuitive, and the controls now live inline between the panes.
+ */
+export function UploadControls(): JSX.Element {
+  const { openFiles, activeId } = useWorkspace()
+  const status = useDeviceStatus()
+  const connected = status.state === 'connected'
+
+  const [busy, setBusy] = useState(false)
+  const [feedback, setFeedback] = useState<Feedback>(null)
+
+  const activeFile = openFiles.find((f) => f.id === activeId) ?? null
+
+  const canUpload = connected && !!activeFile && !busy
+  const canDownload = !!activeFile && activeFile.source === 'device' && !busy
+
+  async function handleUpload(): Promise<void> {
+    if (!activeFile || !connected) return
+    const defaultPath = `/${activeFile.name}`
+    const destPath = window.prompt('Upload to device path:', defaultPath)
+    if (destPath == null) return // cancelled
+    const dest = destPath.trim()
+    if (!dest) {
+      setFeedback({ kind: 'error', message: 'A destination path is required.' })
+      return
+    }
+    setBusy(true)
+    setFeedback({ kind: 'info', message: `Uploading ${activeFile.name}…` })
+    try {
+      await window.api.device.writeFile(dest, activeFile.content)
+      setFeedback({
+        kind: 'success',
+        message: `Uploaded to ${dest}. Refresh the board tree to see it.`
+      })
+    } catch (err) {
+      setFeedback({
+        kind: 'error',
+        message: `Upload failed: ${err instanceof Error ? err.message : String(err)}`
+      })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function handleDownload(): Promise<void> {
+    if (!activeFile || activeFile.source !== 'device') return
+    setBusy(true)
+    setFeedback(null)
+    try {
+      const folder = await window.api.fs.openFolderDialog()
+      if (!folder) {
+        setBusy(false)
+        return // cancelled
+      }
+      const dest = joinLocal(folder, activeFile.name)
+      setFeedback({ kind: 'info', message: `Saving ${activeFile.name}…` })
+      await window.api.fs.writeFile(dest, activeFile.content)
+      setFeedback({ kind: 'success', message: `Saved to ${dest}.` })
+    } catch (err) {
+      setFeedback({
+        kind: 'error',
+        message: `Download failed: ${err instanceof Error ? err.message : String(err)}`
+      })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const uploadTitle = !connected
+    ? 'Connect a device to upload'
+    : !activeFile
+      ? 'Open a file to upload'
+      : `Upload ${activeFile.name} to the board`
+
+  const downloadTitle = !activeFile
+    ? 'Open a file to download'
+    : activeFile.source !== 'device'
+      ? 'Select a device file to download to the computer'
+      : `Save ${activeFile.name} to the computer`
+
+  return (
+    <div className="upload-controls" aria-label="Transfer files between computer and board">
+      <div className="upload-controls__buttons">
+        <button
+          type="button"
+          className="btn btn--ghost upload-controls__btn"
+          onClick={() => void handleDownload()}
+          disabled={!canDownload}
+          title={downloadTitle}
+        >
+          <span className="upload-controls__glyph" aria-hidden="true">
+            ↑
+          </span>
+          <span>Download to computer</span>
+        </button>
+        <button
+          type="button"
+          className="btn btn--ghost upload-controls__btn"
+          onClick={() => void handleUpload()}
+          disabled={!canUpload}
+          title={uploadTitle}
+        >
+          <span className="upload-controls__glyph" aria-hidden="true">
+            ↓
+          </span>
+          <span>Upload to board</span>
+        </button>
+      </div>
+      {feedback && (
+        <p
+          className={`upload-controls__feedback upload-controls__feedback--${feedback.kind}`}
+          role="status"
+          aria-live="polite"
+        >
+          {busy && <span className="upload-controls__spinner" aria-hidden="true" />}
+          {feedback.message}
+        </p>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
Implements issue #9: transfer the active file between the computer and the connected board.

## Feedback addressed
The reviewer noted the old "up" upload icon was unintuitive. The transfer controls now sit **between** the two file panes, with direction matching the layout: the computer (local) pane is above and the board (device) pane is below.

- Download to computer → points **up** (↑)
- Upload to board → points **down** (↓)

## Changes
- New `UploadControls.tsx` + co-located `UploadControls.css`, rendered in `FilePanel.tsx` between the local and device sections.

## Checklist
- [x] `UploadControls.tsx` placed between the local (computer) and device (board) sections in `FilePanel.tsx`.
- [x] Upload: writes the active editor file (`content` + `name`) to the device via `window.api.device.writeFile`, prompting for a destination path (default `/<name>`). Disabled when not connected or no active file.
- [x] Download: when the active file's `source === 'device'`, saves it locally via `window.api.fs.writeFile` after picking a folder with `openFolderDialog()` (`<folder>/<name>`). Disabled when not applicable.
- [x] Busy state + clear success/error feedback; hint to refresh the board tree after upload (live auto-refresh out of scope).
- [x] `npm install && npm run lint && npm run typecheck && npm run build` all pass.

## Caveats
- Hardware untested: developed on a headless ARM64 host with no device attached. Device upload/download paths exercise the existing `window.api.device`/`window.api.fs` IPC contracts but were not run against a physical board.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)