### PR TITLE
Run / Stop / Clear Shell controls

### DIFF
--- a/src/renderer/src/components/RunControls.css
+++ b/src/renderer/src/components/RunControls.css
@@ -1,0 +1,19 @@
+/*
+ * Styles for the Run / Stop / Clear shell controls (issue #11).
+ *
+ * The Run/Stop buttons and the Clear button reuse the shared `.btn` family
+ * defined in index.css; this file only adds the small layout wrapper that
+ * groups the Shell header's Clear button next to the connection control.
+ */
+
+.shell-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* Keep the trashcan glyph readable against the ghost button background. */
+.shell-actions__clear .btn__glyph {
+  font-size: 1rem;
+  line-height: 1;
+}

--- a/src/renderer/src/components/ShellPanel.tsx
+++ b/src/renderer/src/components/ShellPanel.tsx
@@ -1,23 +1,50 @@
+import { useCallback, useRef } from 'react'
 import { PanelHeader } from './PanelHeader'
-import { Terminal } from './Terminal'
+import { Terminal, type TerminalHandle } from './Terminal'
 import { ConnectionControl } from './ConnectionControl'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
+import './RunControls.css'
 
 /**
  * BOTTOM — shell / console (REPL) region.
  *
  * Hosts an interactive xterm.js terminal bound to the MicroPython device's
- * friendly REPL, plus a compact connect/disconnect control in the header. This
- * region is OPEN by default by design (the REPL is core to the tool).
+ * friendly REPL, plus a compact connect/disconnect control in the header and a
+ * big "Clear" (trashcan) button that wipes the terminal. This region is OPEN by
+ * default by design (the REPL is core to the tool).
  */
 export function ShellPanel(): JSX.Element {
   const status = useDeviceStatus()
+  const terminalRef = useRef<TerminalHandle>(null)
+
+  const handleClear = useCallback(() => {
+    terminalRef.current?.clear()
+  }, [])
 
   return (
     <section className="region region--shell" aria-label="Shell">
-      <PanelHeader title="Shell" actions={<ConnectionControl status={status} />} />
+      <PanelHeader
+        title="Shell"
+        actions={
+          <div className="shell-actions">
+            <button
+              type="button"
+              className="btn btn--ghost btn--lg shell-actions__clear"
+              onClick={handleClear}
+              title="Clear shell output"
+              aria-label="Clear shell output"
+            >
+              <span className="btn__glyph" aria-hidden="true">
+                🗑
+              </span>
+              <span>Clear</span>
+            </button>
+            <ConnectionControl status={status} />
+          </div>
+        }
+      />
       <div className="region__body region__body--terminal">
-        <Terminal />
+        <Terminal ref={terminalRef} />
       </div>
     </section>
   )

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -1,7 +1,16 @@
-import { useEffect, useRef } from 'react'
+import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react'
 import { Terminal as XTerm } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import '@xterm/xterm/css/xterm.css'
+
+/**
+ * Imperative handle exposed by {@link Terminal}, letting parents drive the
+ * underlying xterm instance without owning it. Currently this is just `clear`,
+ * used by the ShellPanel "Clear" (trashcan) control.
+ */
+export interface TerminalHandle {
+  clear: () => void
+}
 
 /**
  * Dark terminal theme used by the REPL. ANSI colours are kept vivid so device
@@ -44,8 +53,21 @@ const decoder = new TextDecoder()
  *
  * The terminal is created once and resized to its container via the fit addon.
  */
-export function Terminal(): JSX.Element {
+export const Terminal = forwardRef<TerminalHandle>(function Terminal(_props, ref): JSX.Element {
   const containerRef = useRef<HTMLDivElement>(null)
+  const termRef = useRef<XTerm | null>(null)
+
+  // Expose an imperative `clear` so the ShellPanel header trashcan can wipe the
+  // scrollback without lifting ownership of the xterm instance out of here.
+  useImperativeHandle(
+    ref,
+    () => ({
+      clear: () => {
+        termRef.current?.clear()
+      }
+    }),
+    []
+  )
 
   useEffect(() => {
     const container = containerRef.current
@@ -65,6 +87,7 @@ export function Terminal(): JSX.Element {
     term.loadAddon(fitAddon)
     term.open(container)
     fitAddon.fit()
+    termRef.current = term
 
     // Device -> terminal.
     const unsubscribeData = window.api.device.onData((chunk) => {
@@ -91,8 +114,9 @@ export function Terminal(): JSX.Element {
       inputDisposable.dispose()
       resizeObserver.disconnect()
       term.dispose()
+      termRef.current = null
     }
   }, [])
 
   return <div className="terminal" ref={containerRef} />
-}
+})

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -1,5 +1,8 @@
+import { useCallback } from 'react'
 import { Theme } from '../hooks/useTheme'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
+import { useWorkspace } from '../store/workspace'
+import './RunControls.css'
 
 interface ToolbarProps {
   theme: Theme
@@ -16,9 +19,10 @@ interface ToolbarProps {
  * TOP TOOLBAR.
  *
  * Big, easy-to-click action buttons (Run / Stop) plus a connection-status
- * indicator. The Run / Stop buttons remain VISUAL PLACEHOLDERS (wired in a
- * later issue). The connection-status indicator IS live: it reflects the
- * device layer's status via {@link useDeviceStatus}.
+ * indicator. Run executes the active editor file on the device via MicroPython
+ * paste mode (output streams to the existing Shell terminal); Stop sends an
+ * interrupt (Ctrl-C). The connection-status indicator reflects the device
+ * layer's status via {@link useDeviceStatus}.
  *
  * Also hosts layout controls (panel show/hide toggles) and the theme toggle,
  * following progressive disclosure: complexity stays tucked away by default.
@@ -34,7 +38,28 @@ export function Toolbar({
   onToggleRight
 }: ToolbarProps): JSX.Element {
   const status = useDeviceStatus()
+  const { openFiles, activeId } = useWorkspace()
   const connected = status.state === 'connected'
+  const activeFile = openFiles.find((f) => f.id === activeId)
+  const canRun = connected && activeFile != null
+
+  /**
+   * Execute the active file on the device using MicroPython paste mode:
+   *   Ctrl-E (\x05) enters paste mode, the file content is streamed verbatim,
+   *   then Ctrl-D (\x04) executes it. Device output flows back to the Shell
+   *   terminal automatically via its existing `onData` subscription — so we
+   *   never need a handle to the terminal here.
+   */
+  const handleRun = useCallback(() => {
+    if (!connected || !activeFile) return
+    const payload = `\x05${activeFile.content}\x04`
+    window.api.device.sendData(payload).catch(() => undefined)
+  }, [connected, activeFile])
+
+  const handleStop = useCallback(() => {
+    window.api.device.interrupt().catch(() => undefined)
+  }, [])
+
   const label =
     status.state === 'connecting'
       ? 'Connecting…'
@@ -47,13 +72,36 @@ export function Toolbar({
   return (
     <header className="toolbar" role="toolbar" aria-label="Main toolbar">
       <div className="toolbar__group">
-        {/* Placeholder: not wired to a device. */}
-        <button type="button" className="btn btn--primary btn--lg" aria-label="Run (placeholder)">
-          <span className="btn__glyph">▶</span>
+        <button
+          type="button"
+          className="btn btn--primary btn--lg"
+          onClick={handleRun}
+          disabled={!canRun}
+          title={
+            !connected
+              ? 'Connect to a device to run'
+              : !activeFile
+                ? 'Open a file to run'
+                : `Run ${activeFile.name} on the device`
+          }
+          aria-label="Run active file on device"
+        >
+          <span className="btn__glyph" aria-hidden="true">
+            ▶
+          </span>
           <span>Run</span>
         </button>
-        <button type="button" className="btn btn--danger btn--lg" aria-label="Stop (placeholder)">
-          <span className="btn__glyph">■</span>
+        <button
+          type="button"
+          className="btn btn--danger btn--lg"
+          onClick={handleStop}
+          disabled={!connected}
+          title={connected ? 'Interrupt the running program (Ctrl-C)' : 'Connect to a device to stop'}
+          aria-label="Stop / interrupt running program"
+        >
+          <span className="btn__glyph" aria-hidden="true">
+            ■
+          </span>
           <span>Stop</span>
         </button>
       </div>


### PR DESCRIPTION
Wires up the Run / Stop / Clear Shell controls from issue #11.

## What changed
- **Run** (Toolbar ▶): executes the active editor file's content on the device using MicroPython **paste mode** — `\x05` (Ctrl-E, enter paste mode) + file content + `\x04` (Ctrl-D, execute) sent via `window.api.device.sendData`. Device output streams to the existing Shell terminal automatically through its `onData` subscription, so no cross-component terminal access is needed. Disabled when disconnected or when no file is active.
- **Stop** (Toolbar ■): `window.api.device.interrupt()` (Ctrl-C). Disabled when disconnected.
- **Clear** (ShellPanel header 🗑): big trashcan button next to the connection control. `Terminal` now exposes an imperative `TerminalHandle` (`forwardRef` + `useImperativeHandle`) with a `clear()` method; `ShellPanel` holds a ref and calls it. The xterm instance stays owned by `Terminal`.
- Big, labelled buttons with clear glyphs (Run ▶, Stop ■, Clear 🗑), reusing the shared `.btn`/`.btn--lg` styles plus a small co-located `RunControls.css` for the shell-actions layout wrapper.

## Files
- `src/renderer/src/components/Toolbar.tsx` (Run/Stop wiring)
- `src/renderer/src/components/ShellPanel.tsx` (Clear button + Terminal ref)
- `src/renderer/src/components/Terminal.tsx` (imperative clear handle)
- `src/renderer/src/components/RunControls.css` (new)

## Checklist
- [x] Run executes active file via paste mode; disabled when disconnected / no active file
- [x] Stop sends interrupt; disabled when disconnected
- [x] Clear (trashcan) in ShellPanel header clears the xterm instance
- [x] Big, clearly-labelled buttons with icons
- [x] `npm install && npm run lint && npm run typecheck && npm run build` all pass
- [x] No new dependencies; `index.css` untouched

## Caveats
- Headless ARM64 with no device attached: the Run/Stop serial round-trip could **not** be exercised on hardware. Logic and types verified via lint/typecheck/build only.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)