### PR TITLE
Right-click context menus for file operations

### DIFF
--- a/src/renderer/src/components/ContextMenu.css
+++ b/src/renderer/src/components/ContextMenu.css
@@ -1,0 +1,61 @@
+/*
+ * Styles co-located with ContextMenu (issue #19).
+ *
+ * A small, dependency-free popup menu shared by both file trees. Positioned via
+ * inline left/top by the component; rendered fixed so the coordinates map to
+ * the cursor's viewport position regardless of scroll containers.
+ */
+
+.context-menu {
+  position: fixed;
+  z-index: 1000;
+  min-width: 12rem;
+  padding: 0.25rem;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-surface, #1e1e1e);
+  border: 1px solid var(--color-border, #3a3a3a);
+  border-radius: 6px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+  outline: none;
+  font-size: 0.82rem;
+  user-select: none;
+}
+
+.context-menu__item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 0.4rem 0.6rem;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--color-text, #e6e6e6);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.context-menu__item:hover:not(:disabled),
+.context-menu__item.is-active:not(:disabled) {
+  background: var(--color-accent, #0e639c);
+  color: #fff;
+}
+
+.context-menu__item:disabled,
+.context-menu__item[aria-disabled='true'] {
+  color: var(--color-text-muted, #777);
+  cursor: default;
+  opacity: 0.6;
+}
+
+.context-menu__item--danger {
+  color: var(--color-danger, #e06c75);
+}
+
+.context-menu__item--danger:hover:not(:disabled),
+.context-menu__item--danger.is-active:not(:disabled) {
+  background: var(--color-danger, #c0392b);
+  color: #fff;
+}

--- a/src/renderer/src/components/ContextMenu.tsx
+++ b/src/renderer/src/components/ContextMenu.tsx
@@ -1,0 +1,184 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import './ContextMenu.css'
+
+/**
+ * Reusable right-click context menu (issue #19).
+ *
+ * Rendered at an absolute screen position (typically the cursor), it closes on
+ * outside-click, Escape, scroll, or window blur, and is keyboard-navigable
+ * (Up/Down to move between enabled items, Enter/Space to activate, Escape to
+ * dismiss). Disabled items are skipped during keyboard navigation and are not
+ * activatable. Items with `danger: true` are styled as destructive actions.
+ *
+ * Co-located styling lives in `ContextMenu.css`. The component is intentionally
+ * dependency-free so both file trees can share a single, consistent menu.
+ */
+
+/** A single actionable row in the context menu. */
+export interface ContextMenuItem {
+  /** Stable identity for the row. */
+  key: string
+  /** Visible label. */
+  label: string
+  /** Invoked when the item is activated. */
+  onSelect: () => void
+  /** When true the item is shown but cannot be activated or focused. */
+  disabled?: boolean
+  /** When true the item is rendered as a destructive (red) action. */
+  danger?: boolean
+}
+
+/** Screen coordinates (clientX/clientY) at which to anchor the menu. */
+export interface ContextMenuPosition {
+  x: number
+  y: number
+}
+
+interface ContextMenuProps {
+  position: ContextMenuPosition
+  items: ContextMenuItem[]
+  /** Request the menu be closed (outside-click, Escape, after activation). */
+  onClose: () => void
+}
+
+export function ContextMenu({ position, items, onClose }: ContextMenuProps): JSX.Element {
+  const menuRef = useRef<HTMLDivElement>(null)
+  const [coords, setCoords] = useState<ContextMenuPosition>(position)
+  // Index of the keyboard-focused item (-1 = nothing focused yet).
+  const [activeIndex, setActiveIndex] = useState<number>(-1)
+
+  const enabledIndexes = items.reduce<number[]>((acc, item, idx) => {
+    if (!item.disabled) acc.push(idx)
+    return acc
+  }, [])
+
+  // Clamp the menu inside the viewport after layout so it never overflows the
+  // window edges (e.g. when right-clicking near the bottom/right).
+  useLayoutEffect(() => {
+    const el = menuRef.current
+    if (!el) return
+    const { offsetWidth: w, offsetHeight: h } = el
+    const margin = 4
+    let { x, y } = position
+    if (x + w + margin > window.innerWidth) x = Math.max(margin, window.innerWidth - w - margin)
+    if (y + h + margin > window.innerHeight) y = Math.max(margin, window.innerHeight - h - margin)
+    setCoords({ x, y })
+  }, [position])
+
+  // Focus the menu container so it receives keyboard events immediately.
+  useEffect(() => {
+    menuRef.current?.focus()
+  }, [])
+
+  // Dismiss on outside interactions.
+  useEffect(() => {
+    const onPointerDown = (e: MouseEvent): void => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) onClose()
+    }
+    const onScroll = (): void => onClose()
+    const onBlur = (): void => onClose()
+    // `capture` so we see the event before it is potentially stopped.
+    window.addEventListener('mousedown', onPointerDown, true)
+    window.addEventListener('contextmenu', onPointerDown, true)
+    window.addEventListener('scroll', onScroll, true)
+    window.addEventListener('blur', onBlur)
+    return () => {
+      window.removeEventListener('mousedown', onPointerDown, true)
+      window.removeEventListener('contextmenu', onPointerDown, true)
+      window.removeEventListener('scroll', onScroll, true)
+      window.removeEventListener('blur', onBlur)
+    }
+  }, [onClose])
+
+  const activate = useCallback(
+    (item: ContextMenuItem): void => {
+      if (item.disabled) return
+      onClose()
+      item.onSelect()
+    },
+    [onClose]
+  )
+
+  const moveFocus = useCallback(
+    (delta: number): void => {
+      if (enabledIndexes.length === 0) return
+      setActiveIndex((current) => {
+        const pos = enabledIndexes.indexOf(current)
+        if (pos === -1) {
+          return delta > 0 ? enabledIndexes[0] : enabledIndexes[enabledIndexes.length - 1]
+        }
+        const next = (pos + delta + enabledIndexes.length) % enabledIndexes.length
+        return enabledIndexes[next]
+      })
+    },
+    [enabledIndexes]
+  )
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>): void => {
+      switch (e.key) {
+        case 'Escape':
+          e.preventDefault()
+          onClose()
+          break
+        case 'ArrowDown':
+          e.preventDefault()
+          moveFocus(1)
+          break
+        case 'ArrowUp':
+          e.preventDefault()
+          moveFocus(-1)
+          break
+        case 'Home':
+          e.preventDefault()
+          if (enabledIndexes.length) setActiveIndex(enabledIndexes[0])
+          break
+        case 'End':
+          e.preventDefault()
+          if (enabledIndexes.length) setActiveIndex(enabledIndexes[enabledIndexes.length - 1])
+          break
+        case 'Enter':
+        case ' ': {
+          e.preventDefault()
+          const item = items[activeIndex]
+          if (item) activate(item)
+          break
+        }
+        default:
+          break
+      }
+    },
+    [activate, activeIndex, enabledIndexes, items, moveFocus, onClose]
+  )
+
+  return (
+    <div
+      ref={menuRef}
+      className="context-menu"
+      style={{ left: coords.x, top: coords.y }}
+      role="menu"
+      tabIndex={-1}
+      aria-orientation="vertical"
+      onKeyDown={onKeyDown}
+      // Prevent a native context menu from appearing over our own menu.
+      onContextMenu={(e) => e.preventDefault()}
+    >
+      {items.map((item, idx) => (
+        <button
+          key={item.key}
+          type="button"
+          role="menuitem"
+          className={`context-menu__item${item.danger ? ' context-menu__item--danger' : ''}${
+            idx === activeIndex ? ' is-active' : ''
+          }`}
+          disabled={item.disabled}
+          aria-disabled={item.disabled || undefined}
+          onMouseEnter={() => !item.disabled && setActiveIndex(idx)}
+          onClick={() => activate(item)}
+        >
+          {item.label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/src/components/DeviceFileTree.css
+++ b/src/renderer/src/components/DeviceFileTree.css
@@ -20,3 +20,9 @@
   font-size: 0.78rem;
   font-weight: 500;
 }
+
+/* Give the tree some height so right-clicks in the empty area below the
+ * entries still land on the container (opening the New File / Folder menu). */
+.devicetree__tree {
+  min-height: 4rem;
+}

--- a/src/renderer/src/components/DeviceFileTree.tsx
+++ b/src/renderer/src/components/DeviceFileTree.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import type { DirEntry } from '../../../preload/index.d'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { useWorkspace } from '../store/workspace'
+import { ContextMenu, type ContextMenuItem, type ContextMenuPosition } from './ContextMenu'
 import { Placeholder } from './Placeholder'
 import './DeviceFileTree.css'
 
@@ -17,12 +18,14 @@ import './DeviceFileTree.css'
  * connected it falls back to a friendly hint; when a board becomes connected the
  * tree (re)loads automatically. A Refresh action re-reads the root.
  *
- * File operations (create folder / rename / delete) are exposed inline, mirroring
- * the `LocalFileTree` UX (action buttons + window.prompt/confirm). They run via
- * `window.api.device.mkdir/rename/remove`; after each op the affected directory
- * is re-listed so the tree reflects the change. A full right-click context menu
- * is deferred to issue #19. Per the local-section UX, a board/microcontroller
- * icon marks the device section header.
+ * File operations (new file / new folder / rename / delete / open) are exposed
+ * inline AND via a right-click context menu (issue #19), mirroring the
+ * `LocalFileTree` UX (window.prompt/confirm). The menu also offers "Download to
+ * computer": read the device file via `device.readFile`, pick a destination
+ * folder via `fs.openFolderDialog`, and write it with `fs.writeFile`. Device ops
+ * run via `window.api.device.*`; after each op the affected directory is
+ * re-listed so the tree reflects the change. Per the local-section UX, a
+ * board/microcontroller icon marks the device section header.
  */
 
 /** Join a device directory path and a child name into a POSIX device path. */
@@ -45,6 +48,7 @@ interface DeviceTreeNodeProps {
   selectedPath: string | null
   onSelect: (path: string, isDir: boolean) => void
   onOpenFile: (path: string) => void
+  onContextMenu: (e: React.MouseEvent, path: string, isDir: boolean) => void
   /**
    * Path of a directory that has changed and whose listing should be
    * re-fetched, paired with a monotonically increasing token so repeated
@@ -61,6 +65,7 @@ function DeviceTreeNode({
   selectedPath,
   onSelect,
   onOpenFile,
+  onContextMenu,
   reloadDir
 }: DeviceTreeNodeProps): JSX.Element {
   const [expanded, setExpanded] = useState(false)
@@ -104,6 +109,7 @@ function DeviceTreeNode({
         className={`tree-row${isSelected ? ' is-selected' : ''}`}
         style={{ paddingLeft: `${depth * 14 + 8}px` }}
         onClick={handleClick}
+        onContextMenu={(e) => onContextMenu(e, path, entry.isDir)}
         role="treeitem"
         aria-expanded={entry.isDir ? expanded : undefined}
         tabIndex={0}
@@ -135,6 +141,7 @@ function DeviceTreeNode({
             selectedPath={selectedPath}
             onSelect={onSelect}
             onOpenFile={onOpenFile}
+            onContextMenu={onContextMenu}
             reloadDir={reloadDir}
           />
         ))}
@@ -143,6 +150,14 @@ function DeviceTreeNode({
 }
 
 const ROOT = '/'
+
+/** State backing an open context menu: where it is and what it targets. */
+interface MenuState {
+  position: ContextMenuPosition
+  /** The right-clicked path, or null when the empty tree area was clicked. */
+  path: string | null
+  isDir: boolean
+}
 
 export function DeviceFileTree(): JSX.Element {
   const status = useDeviceStatus()
@@ -155,6 +170,7 @@ export function DeviceFileTree(): JSX.Element {
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [busy, setBusy] = useState(false)
+  const [menu, setMenu] = useState<MenuState | null>(null)
   // Signal used to tell already-expanded nodes to re-list a changed directory.
   const [reloadDir, setReloadDir] = useState<{ path: string; token: number } | null>(null)
 
@@ -231,47 +247,140 @@ export function DeviceFileTree(): JSX.Element {
   )
 
   /**
-   * Resolve the directory a new folder should be created in: the selected
-   * directory, the parent of a selected file, or the root.
+   * Resolve the directory a new file/folder should be created in for an
+   * explicit target (right-clicked) or the current selection: a directory
+   * itself, the parent of a file, or the root.
    */
-  const targetDir = useCallback((): string => {
-    if (!selectedPath) return ROOT
-    if (selectedIsDir) return selectedPath
-    return parentDevicePath(selectedPath)
-  }, [selectedIsDir, selectedPath])
+  const dirFor = useCallback(
+    (target: { path: string; isDir: boolean } | null): string => {
+      const path = target ? target.path : selectedPath
+      const isDir = target ? target.isDir : selectedIsDir
+      if (!path) return ROOT
+      return isDir ? path : parentDevicePath(path)
+    },
+    [selectedIsDir, selectedPath]
+  )
 
-  const handleNewFolder = useCallback((): void => {
-    const dir = targetDir()
-    const name = window.prompt('New folder name (on device)', 'new-folder')
-    if (!name) return
-    const target = joinDevicePath(dir, name)
-    void run(() => window.api.device.mkdir(target), dir)
-  }, [run, targetDir])
+  const newFileIn = useCallback(
+    (target: { path: string; isDir: boolean } | null): void => {
+      const dir = dirFor(target)
+      const name = window.prompt('New file name (on device)', 'untitled.py')
+      if (!name) return
+      const dest = joinDevicePath(dir, name)
+      void run(() => window.api.device.writeFile(dest, ''), dir)
+    },
+    [dirFor, run]
+  )
 
-  const handleRename = useCallback((): void => {
-    if (!selectedPath) return
-    const current = selectedPath.split('/').pop() ?? ''
-    const name = window.prompt('Rename to', current)
-    if (!name || name === current) return
-    const parent = parentDevicePath(selectedPath)
-    const dest = joinDevicePath(parent, name)
-    void run(async () => {
-      await window.api.device.rename(selectedPath, dest)
-      setSelectedPath(dest)
-    }, parent)
-  }, [run, selectedPath])
+  const newFolderIn = useCallback(
+    (target: { path: string; isDir: boolean } | null): void => {
+      const dir = dirFor(target)
+      const name = window.prompt('New folder name (on device)', 'new-folder')
+      if (!name) return
+      const dest = joinDevicePath(dir, name)
+      void run(() => window.api.device.mkdir(dest), dir)
+    },
+    [dirFor, run]
+  )
 
-  const handleDelete = useCallback((): void => {
-    if (!selectedPath) return
-    const name = selectedPath.split('/').pop()
-    if (!window.confirm(`Delete "${name}" from the device? This cannot be undone.`)) return
-    const parent = parentDevicePath(selectedPath)
-    void run(async () => {
-      await window.api.device.remove(selectedPath)
-      setSelectedPath(null)
-      setSelectedIsDir(false)
-    }, parent)
-  }, [run, selectedPath])
+  const renamePath = useCallback(
+    (path: string): void => {
+      const current = path.split('/').pop() ?? ''
+      const name = window.prompt('Rename to', current)
+      if (!name || name === current) return
+      const parent = parentDevicePath(path)
+      const dest = joinDevicePath(parent, name)
+      void run(async () => {
+        await window.api.device.rename(path, dest)
+        setSelectedPath(dest)
+      }, parent)
+    },
+    [run]
+  )
+
+  /**
+   * Download a device file to the computer: read it via `device.readFile`, ask
+   * for a destination folder via `fs.openFolderDialog`, then write it there
+   * with `fs.writeFile`.
+   */
+  const downloadToComputer = useCallback((path: string): void => {
+    const name = path.split('/').pop() ?? 'download'
+    void (async (): Promise<void> => {
+      try {
+        const contents = await window.api.device.readFile(path)
+        const folder = await window.api.fs.openFolderDialog()
+        if (!folder) return
+        const sep = folder.includes('\\') ? '\\' : '/'
+        await window.api.fs.writeFile(`${folder}${sep}${name}`, contents)
+        setError(null)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err))
+      }
+    })()
+  }, [])
+
+  const deletePath = useCallback(
+    (path: string): void => {
+      const name = path.split('/').pop()
+      if (!window.confirm(`Delete "${name}" from the device? This cannot be undone.`)) return
+      const parent = parentDevicePath(path)
+      void run(async () => {
+        await window.api.device.remove(path)
+        setSelectedPath(null)
+        setSelectedIsDir(false)
+      }, parent)
+    },
+    [run]
+  )
+
+  const closeMenu = useCallback((): void => setMenu(null), [])
+
+  const handleContextMenu = useCallback(
+    (e: React.MouseEvent, path: string | null, isDir: boolean): void => {
+      e.preventDefault()
+      e.stopPropagation()
+      if (path) handleSelect(path, isDir)
+      setMenu({ position: { x: e.clientX, y: e.clientY }, path, isDir })
+    },
+    [handleSelect]
+  )
+
+  const menuItems = useCallback(
+    (target: MenuState): ContextMenuItem[] => {
+      const { path, isDir } = target
+      const items: ContextMenuItem[] = [
+        {
+          key: 'new-file',
+          label: 'New File',
+          onSelect: () => newFileIn(path ? { path, isDir } : null)
+        },
+        {
+          key: 'new-folder',
+          label: 'New Folder',
+          onSelect: () => newFolderIn(path ? { path, isDir } : null)
+        }
+      ]
+      if (path) {
+        if (!isDir) {
+          items.push({ key: 'open', label: 'Open', onSelect: () => handleOpenFile(path) })
+          items.push({
+            key: 'download',
+            label: 'Download to computer',
+            onSelect: () => downloadToComputer(path)
+          })
+        }
+        items.push({ key: 'rename', label: 'Rename', onSelect: () => renamePath(path) })
+        items.push({
+          key: 'delete',
+          label: 'Delete',
+          danger: true,
+          onSelect: () => deletePath(path)
+        })
+      }
+      return items
+    },
+    [deletePath, downloadToComputer, handleOpenFile, newFileIn, newFolderIn, renamePath]
+  )
 
   if (!connected) {
     return (
@@ -287,6 +396,9 @@ export function DeviceFileTree(): JSX.Element {
   }
 
   const hasSelection = !!selectedPath
+  const selectedTarget: { path: string; isDir: boolean } | null = selectedPath
+    ? { path: selectedPath, isDir: selectedIsDir }
+    : null
 
   return (
     <div className="devicetree">
@@ -307,18 +419,26 @@ export function DeviceFileTree(): JSX.Element {
       <div className="devicetree__actions">
         <button
           className="btn btn--ghost"
-          onClick={handleNewFolder}
+          onClick={() => newFileIn(selectedTarget)}
+          disabled={busy}
+          title="Create a file on the device"
+        >
+          + File
+        </button>
+        <button
+          className="btn btn--ghost"
+          onClick={() => newFolderIn(selectedTarget)}
           disabled={busy}
           title="Create a folder on the device"
         >
           + Folder
         </button>
         {/* Entry-specific actions revealed only when an entry is selected. */}
-        {hasSelection && (
+        {hasSelection && selectedPath && (
           <>
             <button
               className="btn btn--ghost"
-              onClick={handleRename}
+              onClick={() => renamePath(selectedPath)}
               disabled={busy}
               title="Rename the selected item on the device"
             >
@@ -326,7 +446,7 @@ export function DeviceFileTree(): JSX.Element {
             </button>
             <button
               className="btn btn--ghost btn--danger"
-              onClick={handleDelete}
+              onClick={() => deletePath(selectedPath)}
               disabled={busy}
               title="Delete the selected item from the device"
             >
@@ -338,7 +458,12 @@ export function DeviceFileTree(): JSX.Element {
 
       {error && <div className="devicetree__error">{error}</div>}
 
-      <div className="devicetree__tree" role="tree" aria-label="Device file tree">
+      <div
+        className="devicetree__tree"
+        role="tree"
+        aria-label="Device file tree"
+        onContextMenu={(e) => handleContextMenu(e, null, true)}
+      >
         {entries.map((entry) => (
           <DeviceTreeNode
             key={joinDevicePath(ROOT, entry.name)}
@@ -348,6 +473,7 @@ export function DeviceFileTree(): JSX.Element {
             selectedPath={selectedPath}
             onSelect={handleSelect}
             onOpenFile={handleOpenFile}
+            onContextMenu={handleContextMenu}
             reloadDir={reloadDir}
           />
         ))}
@@ -355,6 +481,10 @@ export function DeviceFileTree(): JSX.Element {
           <div className="devicetree__empty-hint">Filesystem is empty.</div>
         )}
       </div>
+
+      {menu && (
+        <ContextMenu position={menu.position} items={menuItems(menu)} onClose={closeMenu} />
+      )}
     </div>
   )
 }

--- a/src/renderer/src/components/LocalFileTree.css
+++ b/src/renderer/src/components/LocalFileTree.css
@@ -1,0 +1,13 @@
+/*
+ * Styles co-located with LocalFileTree (issue #19).
+ *
+ * The base `.localtree*` and `.tree-*` rules live in
+ * `src/renderer/src/index.css` (added by earlier issues). This file only adds
+ * what the right-click context-menu work needs: making the tree area fill the
+ * available height so right-clicks in the empty space below the entries still
+ * land on the tree container (and thus open the "New File / New Folder" menu).
+ */
+
+.localtree__tree {
+  min-height: 4rem;
+}

--- a/src/renderer/src/components/LocalFileTree.tsx
+++ b/src/renderer/src/components/LocalFileTree.tsx
@@ -1,26 +1,32 @@
 import { useCallback, useEffect, useState } from 'react'
 import type { FsEntry } from '../../../main/fs/types'
+import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { useWorkspace } from '../store/workspace'
+import { ContextMenu, type ContextMenuItem, type ContextMenuPosition } from './ContextMenu'
+import './LocalFileTree.css'
 
 /**
  * Local (host) filesystem browser for issue #5.
  *
  * Offers an "Open Folder" action, an expandable tree of the chosen folder, and
- * opens files into the workspace store on click. Basic create/rename/delete
- * actions are exposed inline; a full right-click context menu is deferred to
- * issue #19.
+ * opens files into the workspace store on click. Create/rename/delete actions
+ * are available inline AND via a right-click context menu (issue #19), which
+ * also exposes "Upload to board" — reading the local file via `fs.readFile`
+ * and writing it to the connected device via `device.writeFile` (disabled when
+ * no board is connected).
  *
  * Per the feedback UX cues a computer icon marks the local section and file
- * actions are revealed contextually (on row hover / selection).
+ * actions are revealed contextually (on row hover / selection / right-click).
  */
 
 interface TreeNodeProps {
   entry: FsEntry
   depth: number
   selectedPath: string | null
-  onSelect: (path: string) => void
+  onSelect: (path: string, isDir: boolean) => void
   onOpenFile: (path: string) => void
   onChanged: () => void
+  onContextMenu: (e: React.MouseEvent, entry: FsEntry) => void
 }
 
 /** Recursively renders a directory entry and (when expanded) its children. */
@@ -30,7 +36,8 @@ function TreeNode({
   selectedPath,
   onSelect,
   onOpenFile,
-  onChanged
+  onChanged,
+  onContextMenu
 }: TreeNodeProps): JSX.Element {
   const [expanded, setExpanded] = useState(false)
   const [children, setChildren] = useState<FsEntry[] | null>(null)
@@ -51,7 +58,7 @@ function TreeNode({
   }, [expanded, children, loadChildren])
 
   const handleClick = useCallback((): void => {
-    onSelect(entry.path)
+    onSelect(entry.path, entry.isDir)
     if (entry.isDir) void toggle()
     else onOpenFile(entry.path)
   }, [entry.isDir, entry.path, onOpenFile, onSelect, toggle])
@@ -64,6 +71,7 @@ function TreeNode({
         className={`tree-row${isSelected ? ' is-selected' : ''}`}
         style={{ paddingLeft: `${depth * 14 + 8}px` }}
         onClick={handleClick}
+        onContextMenu={(e) => onContextMenu(e, entry)}
         role="treeitem"
         aria-expanded={entry.isDir ? expanded : undefined}
         tabIndex={0}
@@ -95,18 +103,30 @@ function TreeNode({
             onSelect={onSelect}
             onOpenFile={onOpenFile}
             onChanged={onChanged}
+            onContextMenu={onContextMenu}
           />
         ))}
     </div>
   )
 }
 
+/** State backing an open context menu: where it is and what it targets. */
+interface MenuState {
+  position: ContextMenuPosition
+  /** The right-clicked entry, or null when the empty tree area was clicked. */
+  entry: FsEntry | null
+}
+
 export function LocalFileTree(): JSX.Element {
   const { openFile } = useWorkspace()
+  const deviceStatus = useDeviceStatus()
+  const connected = deviceStatus.state === 'connected'
   const [root, setRoot] = useState<string | null>(null)
   const [entries, setEntries] = useState<FsEntry[]>([])
   const [selectedPath, setSelectedPath] = useState<string | null>(null)
+  const [selectedIsDir, setSelectedIsDir] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [menu, setMenu] = useState<MenuState | null>(null)
 
   const refresh = useCallback(async (): Promise<void> => {
     if (!root) return
@@ -128,10 +148,16 @@ export function LocalFileTree(): JSX.Element {
       if (folder) {
         setRoot(folder)
         setSelectedPath(folder)
+        setSelectedIsDir(true)
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     }
+  }, [])
+
+  const handleSelect = useCallback((path: string, isDir: boolean): void => {
+    setSelectedPath(path)
+    setSelectedIsDir(isDir)
   }, [])
 
   const handleOpenFile = useCallback(
@@ -145,15 +171,20 @@ export function LocalFileTree(): JSX.Element {
 
   /**
    * Resolve the directory that a new file/folder should be created in: the
-   * selected directory, the parent of the selected file, or the root.
+   * given (or selected) directory, the parent of a file, or the root.
    */
-  const targetDir = useCallback((): string | null => {
-    if (!root) return null
-    if (!selectedPath || selectedPath === root) return root
-    // If a file is selected, create alongside it (use its parent dir).
-    const parent = selectedPath.replace(/[/\\][^/\\]+$/, '')
-    return parent || root
-  }, [root, selectedPath])
+  const dirFor = useCallback(
+    (target: FsEntry | null): string | null => {
+      if (!root) return null
+      const path = target ? target.path : selectedPath
+      const isDir = target ? target.isDir : selectedIsDir
+      if (!path || path === root) return root
+      if (isDir) return path
+      const parent = path.replace(/[/\\][^/\\]+$/, '')
+      return parent || root
+    },
+    [root, selectedIsDir, selectedPath]
+  )
 
   const join = (dir: string, name: string): string =>
     dir.includes('\\') ? `${dir}\\${name}` : `${dir}/${name}`
@@ -171,38 +202,123 @@ export function LocalFileTree(): JSX.Element {
     [refresh]
   )
 
-  const handleNewFile = useCallback((): void => {
-    const dir = targetDir()
-    if (!dir) return
-    const name = window.prompt('New file name', 'untitled.py')
-    if (!name) return
-    void run(() => window.api.fs.writeFile(join(dir, name), ''))
-  }, [run, targetDir])
+  const newFileIn = useCallback(
+    (target: FsEntry | null): void => {
+      const dir = dirFor(target)
+      if (!dir) return
+      const name = window.prompt('New file name', 'untitled.py')
+      if (!name) return
+      void run(() => window.api.fs.writeFile(join(dir, name), ''))
+    },
+    [dirFor, run]
+  )
 
-  const handleNewFolder = useCallback((): void => {
-    const dir = targetDir()
-    if (!dir) return
-    const name = window.prompt('New folder name', 'new-folder')
-    if (!name) return
-    void run(() => window.api.fs.mkdir(join(dir, name)))
-  }, [run, targetDir])
+  const newFolderIn = useCallback(
+    (target: FsEntry | null): void => {
+      const dir = dirFor(target)
+      if (!dir) return
+      const name = window.prompt('New folder name', 'new-folder')
+      if (!name) return
+      void run(() => window.api.fs.mkdir(join(dir, name)))
+    },
+    [dirFor, run]
+  )
 
-  const handleRename = useCallback((): void => {
-    if (!selectedPath || selectedPath === root) return
-    const current = selectedPath.split(/[/\\]/).pop() ?? ''
-    const name = window.prompt('Rename to', current)
-    if (!name || name === current) return
-    const parent = selectedPath.replace(/[/\\][^/\\]+$/, '')
-    void run(() => window.api.fs.rename(selectedPath, join(parent || root!, name)))
-  }, [root, run, selectedPath])
+  const renamePath = useCallback(
+    (path: string): void => {
+      if (!path || path === root) return
+      const current = path.split(/[/\\]/).pop() ?? ''
+      const name = window.prompt('Rename to', current)
+      if (!name || name === current) return
+      const parent = path.replace(/[/\\][^/\\]+$/, '')
+      void run(() => window.api.fs.rename(path, join(parent || root!, name)))
+    },
+    [root, run]
+  )
 
-  const handleDelete = useCallback((): void => {
-    if (!selectedPath || selectedPath === root) return
-    if (!window.confirm(`Delete "${selectedPath.split(/[/\\]/).pop()}"?`)) return
-    void run(() => window.api.fs.remove(selectedPath))
-  }, [root, run, selectedPath])
+  const deletePath = useCallback(
+    (path: string): void => {
+      if (!path || path === root) return
+      if (!window.confirm(`Delete "${path.split(/[/\\]/).pop()}"?`)) return
+      void run(() => window.api.fs.remove(path))
+    },
+    [root, run]
+  )
+
+  /**
+   * Upload a local file to the connected board: read it via `fs.readFile` and
+   * write it to `/<name>` on the device via `device.writeFile`.
+   */
+  const uploadToBoard = useCallback(
+    (entry: FsEntry): void => {
+      if (!connected || entry.isDir) return
+      const name = entry.path.split(/[/\\]/).pop() ?? entry.name
+      void (async (): Promise<void> => {
+        try {
+          const contents = await window.api.fs.readFile(entry.path)
+          await window.api.device.writeFile(`/${name}`, contents)
+          setError(null)
+        } catch (err) {
+          setError(err instanceof Error ? err.message : String(err))
+        }
+      })()
+    },
+    [connected]
+  )
+
+  // Inline-button handlers delegate to the shared, target-aware helpers using
+  // the current selection.
+  const selectedEntry = useCallback(
+    (): FsEntry | null =>
+      selectedPath && selectedPath !== root
+        ? { name: selectedPath.split(/[/\\]/).pop() ?? '', path: selectedPath, isDir: selectedIsDir }
+        : null,
+    [root, selectedIsDir, selectedPath]
+  )
+
+  const closeMenu = useCallback((): void => setMenu(null), [])
+
+  const handleContextMenu = useCallback(
+    (e: React.MouseEvent, entry: FsEntry | null): void => {
+      e.preventDefault()
+      e.stopPropagation()
+      if (entry) handleSelect(entry.path, entry.isDir)
+      setMenu({ position: { x: e.clientX, y: e.clientY }, entry })
+    },
+    [handleSelect]
+  )
+
+  const menuItems = useCallback(
+    (target: FsEntry | null): ContextMenuItem[] => {
+      const items: ContextMenuItem[] = [
+        { key: 'new-file', label: 'New File', onSelect: () => newFileIn(target) },
+        { key: 'new-folder', label: 'New Folder', onSelect: () => newFolderIn(target) }
+      ]
+      if (target) {
+        if (!target.isDir) {
+          items.push({ key: 'open', label: 'Open', onSelect: () => handleOpenFile(target.path) })
+          items.push({
+            key: 'upload',
+            label: connected ? 'Upload to board' : 'Upload to board (not connected)',
+            disabled: !connected,
+            onSelect: () => uploadToBoard(target)
+          })
+        }
+        items.push({ key: 'rename', label: 'Rename', onSelect: () => renamePath(target.path) })
+        items.push({
+          key: 'delete',
+          label: 'Delete',
+          danger: true,
+          onSelect: () => deletePath(target.path)
+        })
+      }
+      return items
+    },
+    [connected, deletePath, handleOpenFile, newFileIn, newFolderIn, renamePath, uploadToBoard]
+  )
 
   const hasSelection = !!selectedPath && selectedPath !== root
+  const current = selectedEntry()
 
   return (
     <div className="localtree">
@@ -215,21 +331,29 @@ export function LocalFileTree(): JSX.Element {
       {root ? (
         <>
           <div className="localtree__actions">
-            <button className="btn btn--ghost" onClick={handleNewFile} title="New file">
+            <button className="btn btn--ghost" onClick={() => newFileIn(null)} title="New file">
               + File
             </button>
-            <button className="btn btn--ghost" onClick={handleNewFolder} title="New folder">
+            <button
+              className="btn btn--ghost"
+              onClick={() => newFolderIn(null)}
+              title="New folder"
+            >
               + Folder
             </button>
             {/* File-specific actions revealed only when an entry is selected. */}
             {hasSelection && (
               <>
-                <button className="btn btn--ghost" onClick={handleRename} title="Rename">
+                <button
+                  className="btn btn--ghost"
+                  onClick={() => current && renamePath(current.path)}
+                  title="Rename"
+                >
                   Rename
                 </button>
                 <button
                   className="btn btn--ghost btn--danger"
-                  onClick={handleDelete}
+                  onClick={() => current && deletePath(current.path)}
                   title="Delete"
                 >
                   Delete
@@ -247,16 +371,22 @@ export function LocalFileTree(): JSX.Element {
 
           {error && <div className="localtree__error">{error}</div>}
 
-          <div className="localtree__tree" role="tree" aria-label="Local file tree">
+          <div
+            className="localtree__tree"
+            role="tree"
+            aria-label="Local file tree"
+            onContextMenu={(e) => handleContextMenu(e, null)}
+          >
             {entries.map((entry) => (
               <TreeNode
                 key={entry.path}
                 entry={entry}
                 depth={0}
                 selectedPath={selectedPath}
-                onSelect={setSelectedPath}
+                onSelect={handleSelect}
                 onOpenFile={handleOpenFile}
                 onChanged={refresh}
+                onContextMenu={handleContextMenu}
               />
             ))}
           </div>
@@ -268,6 +398,10 @@ export function LocalFileTree(): JSX.Element {
             <span aria-hidden>{'\u{1F4C2}'}</span> Open Folder
           </button>
         </div>
+      )}
+
+      {menu && (
+        <ContextMenu position={menu.position} items={menuItems(menu.entry)} onClose={closeMenu} />
       )}
     </div>
   )


### PR DESCRIPTION
Implements issue #19 — feedback-driven right-click context menus for both file trees.

## What changed
- **`ContextMenu.tsx` / `ContextMenu.css`** (new): a small, in-house, dependency-free menu that opens at the cursor, closes on outside-click / Escape / scroll / window blur, clamps itself inside the viewport, and is keyboard-navigable (Up/Down, Home/End, Enter/Space, Escape). Supports disabled and destructive (`danger`) item styling.
- **`LocalFileTree.tsx`**: right-click on a row or empty space opens a menu with New File, New Folder, Open, Rename, Delete, and **Upload to board** (reads the local file via `fs.readFile`, writes to `/<name>` via `device.writeFile`; disabled when no board is connected). Existing inline buttons retained; create/rename/delete handlers refactored to be target-aware so the menu can act on the right-clicked entry.
- **`DeviceFileTree.tsx`**: right-click menu with New File, New Folder, Open, Rename, Delete, and **Download to computer** (reads via `device.readFile`, picks a destination via `fs.openFolderDialog`, writes via `fs.writeFile`). Adds an inline `+ File` button and makes the device op handlers target-aware.
- Menu items are context-appropriate: New File/Folder available on a folder or empty space; Open/Rename/Delete/Upload/Download only when an item is right-clicked.
- Co-located `LocalFileTree.css` / additions to `DeviceFileTree.css` only give the tree a `min-height` so empty-area right-clicks register. `index.css`, the store, main, and preload were not touched. No new dependencies.

## Checklist
- [x] Reusable `ContextMenu.tsx` (+ co-located `ContextMenu.css`): cursor-positioned, outside-click/Escape close, keyboard-navigable
- [x] LocalFileTree menu: New File, New Folder, Rename, Delete, Open, Upload to board (gated on connection)
- [x] DeviceFileTree menu: New File, New Folder, Rename, Delete, Open, Download to computer
- [x] Context-appropriate items; existing inline behavior preserved
- [x] `npm install && npm run lint && npm run typecheck && npm run build` all pass

## Notes
Built and verified on headless ARM64 with no board attached; device-connected paths (Upload/Download/device ops) were not exercised against real hardware.

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)