### PR TITLE
In-app Help & MicroPython reference

### DIFF
--- a/src/renderer/src/components/HelpPanel.css
+++ b/src/renderer/src/components/HelpPanel.css
@@ -1,0 +1,120 @@
+/*
+ * Styles co-located with HelpPanel (issue #22).
+ *
+ * In-app help content for the right pane. Uses the shared design tokens from
+ * index.css (colours, radius) so it tracks light/dark themes automatically.
+ */
+
+.help {
+  padding: 0 0 1.5rem;
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--text);
+}
+
+/* Welcoming hero so Help feels prominent (the "big Help" the feedback asked
+ * for). Accent band across the top of the pane. */
+.help__hero {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 1rem 1.1rem;
+  margin-bottom: 0.5rem;
+  background: linear-gradient(135deg, var(--accent), var(--bg-elevated));
+  color: var(--accent-contrast);
+}
+
+.help__hero-mark {
+  font-size: 2rem;
+  line-height: 1;
+}
+
+.help__hero-title {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 700;
+}
+
+.help__hero-sub {
+  margin: 0.15rem 0 0;
+  font-size: 0.85rem;
+  opacity: 0.92;
+}
+
+.help__section {
+  padding: 0.25rem 1rem;
+}
+
+.help__h2 {
+  margin: 1rem 0 0.5rem;
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.help__h3 {
+  margin: 0.9rem 0 0.35rem;
+  font-size: 0.83rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.help__steps {
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.help__steps li {
+  margin-bottom: 0.5rem;
+}
+
+.help__list,
+.help__kbds {
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.help__list li,
+.help__kbds li {
+  margin-bottom: 0.4rem;
+}
+
+.help__muted {
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.help__link {
+  color: var(--accent);
+  word-break: break-all;
+}
+
+.help kbd {
+  display: inline-block;
+  padding: 0.05rem 0.35rem;
+  font-size: 0.75rem;
+  font-family: inherit;
+  color: var(--text);
+  background: var(--bg-sunken);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+
+.help code {
+  padding: 0.05rem 0.3rem;
+  font-size: 0.8rem;
+  background: var(--bg-sunken);
+  border-radius: 4px;
+}
+
+.help__snippet {
+  margin: 0;
+  padding: 0.6rem 0.75rem;
+  background: var(--bg-sunken);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-size: 0.78rem;
+  line-height: 1.5;
+  overflow-x: auto;
+  white-space: pre;
+  color: var(--text);
+}

--- a/src/renderer/src/components/HelpPanel.tsx
+++ b/src/renderer/src/components/HelpPanel.tsx
@@ -1,0 +1,177 @@
+import './HelpPanel.css'
+
+/**
+ * HELP TAB (issue #22)
+ * ====================
+ *
+ * In-app, self-contained help. This deliberately keeps users IN the app rather
+ * than punting them to GitHub (see docs/feedback.md): a welcoming overview, a
+ * "getting started" walkthrough, and a MicroPython syntax quick reference with
+ * copy-pasteable snippets.
+ *
+ * External links are rendered as plain anchors. Wiring them to open in the
+ * system browser needs preload/IPC changes that are out of scope for this
+ * issue, so they are intentionally NOT click-wired here — a later issue can add
+ * a `shell.openExternal` bridge and upgrade these into real links.
+ */
+export function HelpPanel(): JSX.Element {
+  return (
+    <div className="help">
+      <header className="help__hero">
+        <span className="help__hero-mark" aria-hidden="true">
+          🐍
+        </span>
+        <div>
+          <h1 className="help__hero-title">Welcome to Snakie</h1>
+          <p className="help__hero-sub">
+            A friendly editor for writing and running MicroPython on your board.
+          </p>
+        </div>
+      </header>
+
+      <section className="help__section" aria-labelledby="help-start">
+        <h2 id="help-start" className="help__h2">
+          Getting started
+        </h2>
+        <ol className="help__steps">
+          <li>
+            <strong>Plug in your board</strong> over USB, then click{' '}
+            <em>Connect</em> in the toolbar and pick its serial port.
+          </li>
+          <li>
+            <strong>Write some code</strong> in the editor. Open a file from the
+            left, or hit <kbd>+</kbd> on the tab strip for a fresh buffer.
+          </li>
+          <li>
+            <strong>Run it</strong> with the Run control to execute the current
+            file on the device, and watch the output in the terminal below.
+          </li>
+          <li>
+            <strong>Save &amp; upload</strong> to copy files to the board so they
+            persist (name it <code>main.py</code> to run automatically on boot).
+          </li>
+        </ol>
+      </section>
+
+      <section className="help__section" aria-labelledby="help-tips">
+        <h2 id="help-tips" className="help__h2">
+          Handy shortcuts
+        </h2>
+        <ul className="help__kbds">
+          <li>
+            <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>W</kbd> — close the active
+            editor tab
+          </li>
+          <li>
+            <kbd>Ctrl</kbd> + <kbd>Tab</kbd> — cycle between open editor tabs
+          </li>
+          <li>
+            Right-click in a file tree for New File / Folder and other actions
+          </li>
+        </ul>
+      </section>
+
+      <section className="help__section" aria-labelledby="help-ref">
+        <h2 id="help-ref" className="help__h2">
+          MicroPython quick reference
+        </h2>
+
+        <h3 className="help__h3">Common statements</h3>
+        <Snippet
+          code={`# Variables, loops, functions
+name = "Snakie"
+for i in range(3):
+    print(i, name)
+
+def add(a, b):
+    return a + b
+
+if add(1, 2) == 3:
+    print("ok")`}
+        />
+
+        <h3 className="help__h3">
+          Blink an LED — <code>machine.Pin</code>
+        </h3>
+        <Snippet
+          code={`from machine import Pin
+from time import sleep
+
+led = Pin("LED", Pin.OUT)   # or Pin(25, Pin.OUT) on a Pico
+
+while True:
+    led.toggle()
+    sleep(0.5)`}
+        />
+
+        <h3 className="help__h3">
+          Timing &amp; delays — <code>time</code>
+        </h3>
+        <Snippet
+          code={`import time
+
+time.sleep(1)          # seconds (float ok)
+time.sleep_ms(250)     # milliseconds
+start = time.ticks_ms()
+# ... do work ...
+elapsed = time.ticks_diff(time.ticks_ms(), start)
+print(elapsed, "ms")`}
+        />
+
+        <h3 className="help__h3">
+          Read an input pin &amp; analog — <code>machine</code>
+        </h3>
+        <Snippet
+          code={`from machine import Pin, ADC
+
+button = Pin(14, Pin.IN, Pin.PULL_UP)
+print("pressed" if button.value() == 0 else "released")
+
+sensor = ADC(Pin(26))           # ADC0 on a Pico
+print(sensor.read_u16())         # 0..65535`}
+        />
+
+        <h3 className="help__h3">REPL tips</h3>
+        <ul className="help__list">
+          <li>
+            The terminal below is a live MicroPython REPL — type Python and press
+            Enter to run it immediately.
+          </li>
+          <li>
+            <kbd>Ctrl</kbd> + <kbd>C</kbd> interrupts a running program (stops an
+            infinite loop).
+          </li>
+          <li>
+            <kbd>Ctrl</kbd> + <kbd>D</kbd> performs a soft reboot, re-running{' '}
+            <code>main.py</code>.
+          </li>
+          <li>
+            Paste a block of code with <kbd>Ctrl</kbd> + <kbd>E</kbd> (paste
+            mode), then <kbd>Ctrl</kbd> + <kbd>D</kbd> to execute it.
+          </li>
+          <li>
+            Call <code>help(&apos;modules&apos;)</code> to list every module
+            available on your board.
+          </li>
+        </ul>
+      </section>
+
+      <section className="help__section" aria-labelledby="help-more">
+        <h2 id="help-more" className="help__h2">
+          Learn more
+        </h2>
+        <p className="help__muted">
+          Official MicroPython docs (opens in your browser):{' '}
+          <a className="help__link" href="https://docs.micropython.org/">
+            docs.micropython.org
+          </a>
+        </p>
+      </section>
+    </div>
+  )
+}
+
+/** Read-only code block for reference snippets. */
+function Snippet({ code }: { code: string }): JSX.Element {
+  return <pre className="help__snippet">{code}</pre>
+}

--- a/src/renderer/src/components/RightPanel.tsx
+++ b/src/renderer/src/components/RightPanel.tsx
@@ -1,19 +1,37 @@
 import { PanelHeader } from './PanelHeader'
-import { Placeholder } from './Placeholder'
+import { RightPanelTabs, RightPanelTab } from './RightPanelTabs'
+import { HelpPanel } from './HelpPanel'
 
 /**
  * RIGHT PANE — optional/collapsible region (collapsed by default).
  *
- * Reserved for progressively-disclosed tooling (e.g. package installer,
- * help/docs, serial plotter, AI assistant) so the default layout stays
- * uncluttered. Replace the <Placeholder> body when a feature claims it.
+ * Now a TABBED HOST (issue #22) for progressively-disclosed tooling. The pane
+ * is just a thin wrapper: it owns the list of `tabs` and hands it to
+ * <RightPanelTabs>, which renders the strip and active panel.
+ *
+ * ADDING A TAB (for future tools — LLM chat #18, package installer #20,
+ * variables #16, serial plotter, …):
+ *   1. Build your tool as its own component under `components/` (co-locate a
+ *      `.css` you import, like HelpPanel does).
+ *   2. Append a `RightPanelTab` to the `tabs` array below:
+ *        { id: 'chat', title: 'Chat', icon: '💬', content: <ChatPanel /> }
+ *      `id` must be unique + stable; array order = strip order.
+ * See RightPanelTabs.tsx for the full contract.
  */
 export function RightPanel(): JSX.Element {
+  const tabs: RightPanelTab[] = [
+    { id: 'help', title: 'Help', icon: '?', content: <HelpPanel /> }
+    // Future tabs register here, e.g.:
+    // { id: 'chat', title: 'Chat', icon: '💬', content: <ChatPanel /> },
+    // { id: 'packages', title: 'Packages', icon: '📦', content: <PackagePanel /> },
+    // { id: 'vars', title: 'Variables', icon: '{}', content: <VariablesPanel /> },
+  ]
+
   return (
     <section className="region region--right" aria-label="Side panel">
       <PanelHeader title="Panel" />
       <div className="region__body">
-        <Placeholder label="Panel" hint="Optional tools (package installer, help, AI)." />
+        <RightPanelTabs tabs={tabs} defaultTabId="help" />
       </div>
     </section>
   )

--- a/src/renderer/src/components/RightPanelTabs.css
+++ b/src/renderer/src/components/RightPanelTabs.css
@@ -1,0 +1,64 @@
+/*
+ * Styles co-located with RightPanelTabs (issue #22).
+ *
+ * The tabbed host fills the right pane's `.region__body`. The strip mirrors the
+ * editor tab strip's look (sunken bar, accent underline on the active tab) so
+ * the two tab systems feel related, while the panel body scrolls on its own.
+ */
+
+.rptabs {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+.rptabs__strip {
+  display: flex;
+  align-items: stretch;
+  flex: 0 0 auto;
+  gap: 1px;
+  min-height: 34px;
+  background: var(--bg-sunken);
+  border-bottom: 1px solid var(--border);
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+}
+
+.rptabs__tab {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 12px;
+  background: var(--bg-sunken);
+  color: var(--text-muted);
+  border: none;
+  border-right: 1px solid var(--border);
+  font-size: 13px;
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.rptabs__tab:hover {
+  background: var(--bg);
+}
+
+.rptabs__tab--active {
+  background: var(--bg-elevated);
+  color: var(--text);
+  box-shadow: inset 0 2px 0 var(--accent);
+}
+
+.rptabs__tab-icon {
+  flex: 0 0 auto;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.rptabs__panel {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+}

--- a/src/renderer/src/components/RightPanelTabs.tsx
+++ b/src/renderer/src/components/RightPanelTabs.tsx
@@ -1,0 +1,99 @@
+import { ReactNode, useState } from 'react'
+import './RightPanelTabs.css'
+
+/**
+ * A single tab in the right-pane tabbed host (issue #22).
+ *
+ * @property id      Stable, unique key (e.g. 'help', 'chat', 'packages').
+ * @property title   Short label shown in the tab strip.
+ * @property icon    Optional leading glyph (emoji or single char) shown before
+ *                   the title. Purely decorative — keep titles self-describing.
+ * @property content The panel body, rendered when this tab is active.
+ */
+export interface RightPanelTab {
+  id: string
+  title: string
+  icon?: ReactNode
+  content: ReactNode
+}
+
+/**
+ * RIGHT PANE TABBED HOST (issue #22)
+ * ==================================
+ *
+ * A self-contained, renderer-only tab system for the right pane. It is the
+ * mounting point for progressively-disclosed tools so the default layout stays
+ * uncluttered.
+ *
+ * HOW TO ADD A TAB
+ * ----------------
+ * Tabs are plain data — there is no global registry to wire up. To add one,
+ * append a `RightPanelTab` object to the `tabs` array passed to this component
+ * from `RightPanel.tsx`:
+ *
+ *   const tabs: RightPanelTab[] = [
+ *     { id: 'help', title: 'Help', icon: '?', content: <HelpPanel /> },
+ *     // LLM chat (#18):
+ *     { id: 'chat', title: 'Chat', icon: '💬', content: <ChatPanel /> },
+ *     // Package installer (#20):
+ *     { id: 'packages', title: 'Packages', icon: '📦', content: <PackagePanel /> },
+ *     // Variables inspector (#16):
+ *     { id: 'vars', title: 'Variables', icon: '{}', content: <VariablesPanel /> },
+ *   ]
+ *
+ * Build your tool as its own component under `components/` (with a co-located
+ * CSS file) and drop it in `content`. Order in the array = order in the strip;
+ * `id` must be unique and stable. The first tab is selected by default unless
+ * `defaultTabId` is supplied.
+ */
+interface RightPanelTabsProps {
+  tabs: RightPanelTab[]
+  /** Optional id of the tab to select on first render (defaults to first). */
+  defaultTabId?: string
+}
+
+export function RightPanelTabs({ tabs, defaultTabId }: RightPanelTabsProps): JSX.Element {
+  const initial = tabs.some((t) => t.id === defaultTabId) ? defaultTabId! : tabs[0]?.id
+  const [activeId, setActiveId] = useState<string | undefined>(initial)
+
+  if (tabs.length === 0) return <></>
+
+  const active = tabs.find((t) => t.id === activeId) ?? tabs[0]
+
+  return (
+    <div className="rptabs">
+      <div className="rptabs__strip" role="tablist" aria-label="Side panel tools">
+        {tabs.map((tab) => {
+          const selected = tab.id === active.id
+          return (
+            <button
+              key={tab.id}
+              type="button"
+              role="tab"
+              id={`rptab-${tab.id}`}
+              aria-selected={selected}
+              aria-controls={`rppanel-${tab.id}`}
+              className={`rptabs__tab${selected ? ' rptabs__tab--active' : ''}`}
+              onClick={() => setActiveId(tab.id)}
+            >
+              {tab.icon != null && (
+                <span className="rptabs__tab-icon" aria-hidden="true">
+                  {tab.icon}
+                </span>
+              )}
+              <span className="rptabs__tab-label">{tab.title}</span>
+            </button>
+          )
+        })}
+      </div>
+      <div
+        className="rptabs__panel"
+        role="tabpanel"
+        id={`rppanel-${active.id}`}
+        aria-labelledby={`rptab-${active.id}`}
+      >
+        {active.content}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Turns the right pane into an extensible **tabbed host** and adds a welcoming **in-app Help** tab, keeping users IN the app rather than punting them to GitHub (per `docs/feedback.md`).

## Changes
- [x] `RightPanel.tsx` is now a tabbed host — owns a `RightPanelTab[]` and renders it via `<RightPanelTabs>`.
- [x] `RightPanelTabs.tsx` — simple, self-contained tab system (`{ id, title, icon, content }` + active tab). Documented how to add a tab so future tools (LLM chat #18, package installer #20, variables #16) just append to the array. Renderer-only, no registry.
- [x] `HelpPanel.tsx` — prominent/welcoming hero + getting-started walkthrough, handy shortcuts, and a **MicroPython quick reference** (common statements, `machine`/`time` snippets, REPL tips). Static in-app content.
- [x] External link rendered as a plain anchor only — no preload/IPC for `openExternal` added (out of scope).
- [x] Co-located CSS imported by each component. `index.css`, shell, toolbar, store, main, preload untouched. No new dependencies.

## Acceptance (headless ARM64)
`npm install && npm run lint && npm run typecheck && npm run build` — all pass.

## How to add a tab later
\`\`\`ts
const tabs: RightPanelTab[] = [
  { id: 'help', title: 'Help', icon: '?', content: <HelpPanel /> },
  { id: 'chat', title: 'Chat', icon: '💬', content: <ChatPanel /> },
]
\`\`\`
`id` unique + stable; array order = strip order; first tab selected unless `defaultTabId` given.

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)