### PR TITLE
Update notifications for new versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@electron-toolkit/utils": "^3.0.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
+        "electron-updater": "^6.8.3",
         "monaco-editor": "^0.52.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -2647,8 +2648,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -4012,6 +4012,76 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.364.tgz",
       "integrity": "sha512-G/dYE3+AYhyHwzTwg8UbnXf7zqMERYh7l2jJ3QujhFsH8agSYwtnGAR2aZ7f0AakIKJXd5En/Hre4igIUrdlYw==",
       "dev": true
+    },
+    "node_modules/electron-updater": {
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.3.tgz",
+      "integrity": "sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==",
+      "dependencies": {
+        "builder-util-runtime": "9.5.1",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/builder-util-runtime": {
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
+      "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-updater/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-updater/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/electron-updater/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/electron-vite": {
       "version": "2.3.0",
@@ -5922,7 +5992,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
       "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6021,8 +6090,7 @@
     "node_modules/lazy-val": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
-      "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true
+      "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q=="
     },
     "node_modules/lazystream": {
       "version": "1.0.1",
@@ -6125,12 +6193,23 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="
+    },
     "node_modules/lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead."
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
@@ -7319,7 +7398,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
       "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-      "dev": true,
       "engines": {
         "node": ">=11.0.0"
       }
@@ -7969,6 +8047,11 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="
     },
     "node_modules/tmp": {
       "version": "0.2.7",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@electron-toolkit/utils": "^3.0.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
+    "electron-updater": "^6.8.3",
     "monaco-editor": "^0.52.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import { registerDeviceIpc, disposeDevice } from './device/ipc'
 import { registerFsIpc } from './fs/ipc'
+import { registerUpdater } from './updater'
 
 /** The single application window, used to route device push-events. */
 let mainWindow: BrowserWindow | null = null
@@ -67,6 +68,10 @@ app.whenReady().then(() => {
   // Register the local filesystem layer. The folder dialog is parented to the
   // live window when one exists.
   registerFsIpc(() => mainWindow ?? undefined)
+
+  // Register the auto-update layer. No-ops cleanly in dev (unpackaged); when
+  // packaged it checks GitHub Releases and pushes status to the live window.
+  registerUpdater(() => mainWindow?.webContents)
 
   createWindow()
 

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -1,0 +1,99 @@
+import { app, ipcMain, type WebContents } from 'electron'
+import electronUpdater from 'electron-updater'
+
+const { autoUpdater } = electronUpdater
+
+/**
+ * IPC channel names for the auto-update layer. The renderer subscribes to
+ * `updates:status` push events and invokes the `updates:*` request channels.
+ */
+export const UPDATE_CHANNELS = {
+  status: 'updates:status',
+  check: 'updates:check',
+  quitAndInstall: 'updates:quitAndInstall'
+} as const
+
+/**
+ * A single update-lifecycle status, pushed to the renderer on the
+ * `updates:status` channel. `state` drives what (if anything) the in-app
+ * notifier shows; the optional fields carry context for the matching state.
+ */
+export interface UpdateStatus {
+  state: 'available' | 'downloading' | 'downloaded' | 'error'
+  /** Version of the available/downloaded update, when known. */
+  version?: string
+  /** Download progress 0–100, present while `state === 'downloading'`. */
+  percent?: number
+  /** Human-readable message, present when `state === 'error'`. */
+  message?: string
+}
+
+/**
+ * Wire up `electron-updater` and forward its lifecycle events to the renderer
+ * as {@link UpdateStatus} pushes. Updates are distributed via GitHub Releases
+ * (see `electron-builder.yml` `publish` / the packaged `app-update.yml`), so no
+ * feed URL is configured here — the GitHub provider is read from that config.
+ *
+ * In development (or any unpackaged run) there is no `app-update.yml`, so the
+ * updater would throw on `checkForUpdates()`. We guard the whole flow on
+ * {@link Electron.App.isPackaged} and no-op cleanly otherwise: the IPC handlers
+ * are still registered (so the preload bridge never sees a missing channel),
+ * but they do nothing.
+ *
+ * @param getWebContents resolver for the target renderer, so we never capture a
+ *   destroyed window after a reload.
+ */
+export function registerUpdater(getWebContents: () => WebContents | undefined): void {
+  const send = (status: UpdateStatus): void => {
+    const wc = getWebContents()
+    if (wc && !wc.isDestroyed()) {
+      wc.send(UPDATE_CHANNELS.status, status)
+    }
+  }
+
+  // In dev / unpackaged runs there is no update feed. Register inert handlers
+  // so the renderer API exists, then bail before touching `autoUpdater`.
+  if (!app.isPackaged) {
+    ipcMain.handle(UPDATE_CHANNELS.check, () => undefined)
+    ipcMain.handle(UPDATE_CHANNELS.quitAndInstall, () => undefined)
+    return
+  }
+
+  // We surface our own restart affordance in the UI, so don't auto-install on
+  // quit or auto-download silently before telling the user.
+  autoUpdater.autoDownload = true
+  autoUpdater.autoInstallOnAppQuit = false
+
+  autoUpdater.on('update-available', (info) => {
+    send({ state: 'available', version: info?.version })
+  })
+  autoUpdater.on('download-progress', (progress) => {
+    send({ state: 'downloading', percent: Math.round(progress?.percent ?? 0) })
+  })
+  autoUpdater.on('update-downloaded', (info) => {
+    send({ state: 'downloaded', version: info?.version })
+  })
+  autoUpdater.on('error', (err) => {
+    send({ state: 'error', message: err instanceof Error ? err.message : String(err) })
+  })
+
+  ipcMain.handle(UPDATE_CHANNELS.check, async () => {
+    try {
+      await autoUpdater.checkForUpdates()
+    } catch (err) {
+      send({ state: 'error', message: err instanceof Error ? err.message : String(err) })
+    }
+  })
+
+  ipcMain.handle(UPDATE_CHANNELS.quitAndInstall, () => {
+    // `isSilent: false`, `isForceRunAfter: true` — show the installer UI where
+    // applicable and relaunch the app after updating.
+    autoUpdater.quitAndInstall(false, true)
+  })
+
+  // Kick off an initial check shortly after startup. Swallow failures so a
+  // transient network/feed error never crashes the main process.
+  void autoUpdater.checkForUpdates().catch((err) => {
+    send({ state: 'error', message: err instanceof Error ? err.message : String(err) })
+  })
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -18,6 +18,10 @@ export type {
 // single, UI-facing module without reaching into `src/main`.
 export type { FsEntry, FsStat } from '../main/fs/types'
 
+// Re-export the update-status type so the renderer's notifier can import it
+// from the UI-facing preload module rather than reaching into `src/main`.
+export type { UpdateStatus } from '../main/updater'
+
 declare global {
   interface Window {
     electron: ElectronAPI

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -10,6 +10,7 @@ import type {
   StatResult
 } from '../main/device/types'
 import type { FsEntry, FsStat } from '../main/fs/types'
+import type { UpdateStatus } from '../main/updater'
 
 /**
  * Unwrap an {@link IpcResult} into a resolved value or a thrown Error, so the
@@ -109,6 +110,26 @@ const fs = {
   stat: (path: string): Promise<FsStat> => unwrap(ipcRenderer.invoke('fs:stat', path))
 }
 
+/**
+ * Auto-update API. Mirrors the main-process `updates:*` IPC handlers. `check`
+ * triggers an update check, `quitAndInstall` restarts into a downloaded update,
+ * and `onStatus` subscribes to lifecycle push events (returns an unsubscribe
+ * function). In dev / unpackaged runs the main side no-ops, so nothing is ever
+ * pushed.
+ */
+const updates = {
+  /** Trigger an update check (no-op when unpackaged). */
+  check: (): Promise<void> => ipcRenderer.invoke('updates:check'),
+  /** Restart the app and install a downloaded update. */
+  quitAndInstall: (): Promise<void> => ipcRenderer.invoke('updates:quitAndInstall'),
+  /** Subscribe to update lifecycle status. Returns an unsubscribe function. */
+  onStatus: (cb: (status: UpdateStatus) => void): (() => void) => {
+    const listener = (_e: IpcRendererEvent, status: UpdateStatus): void => cb(status)
+    ipcRenderer.on('updates:status', listener)
+    return () => ipcRenderer.removeListener('updates:status', listener)
+  }
+}
+
 // Minimal, typed API exposed to the renderer. This establishes the IPC
 // pattern that later feature work will extend.
 const api = {
@@ -119,7 +140,9 @@ const api = {
   /** Serial device connection + MicroPython REPL/filesystem layer. */
   device,
   /** Local host filesystem layer. */
-  fs
+  fs,
+  /** Auto-update check + status + restart layer. */
+  updates
 }
 
 // Use `contextBridge` APIs to expose Electron APIs to the renderer only if

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,10 +1,12 @@
 import { AppShell } from './components/AppShell'
+import { UpdateNotifier } from './components/UpdateNotifier'
 import { WorkspaceProvider } from './store/workspace'
 
 function App(): JSX.Element {
   return (
     <WorkspaceProvider>
       <AppShell />
+      <UpdateNotifier />
     </WorkspaceProvider>
   )
 }

--- a/src/renderer/src/components/UpdateNotifier.css
+++ b/src/renderer/src/components/UpdateNotifier.css
@@ -1,0 +1,73 @@
+/*
+ * Styles for the in-app update notifier (issue #17).
+ *
+ * A small, non-intrusive toast pinned to the bottom-right corner. It floats
+ * above the app chrome and never blocks interaction with the rest of the UI.
+ */
+
+.update-notifier {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  max-width: 24rem;
+  padding: 0.625rem 0.875rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: #1f2430;
+  color: #e6e6e6;
+  font-size: 0.85rem;
+  line-height: 1.3;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.4);
+}
+
+.update-notifier--error {
+  background: #3a2326;
+  border-color: rgba(255, 120, 120, 0.4);
+}
+
+.update-notifier__message {
+  flex: 1 1 auto;
+}
+
+.update-notifier__action {
+  flex: 0 0 auto;
+  padding: 0.3rem 0.65rem;
+  border: none;
+  border-radius: 0.35rem;
+  background: #3b82f6;
+  color: #fff;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.update-notifier__action:hover {
+  background: #2f6fe0;
+}
+
+.update-notifier__dismiss {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  padding: 0;
+  border: none;
+  border-radius: 0.25rem;
+  background: transparent;
+  color: inherit;
+  font-size: 0.8rem;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0.7;
+}
+
+.update-notifier__dismiss:hover {
+  opacity: 1;
+  background: rgba(255, 255, 255, 0.1);
+}

--- a/src/renderer/src/components/UpdateNotifier.tsx
+++ b/src/renderer/src/components/UpdateNotifier.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'react'
+import type { UpdateStatus } from '../../../preload/index.d'
+import './UpdateNotifier.css'
+
+/**
+ * Non-intrusive in-app update notifier (issue #17).
+ *
+ * Subscribes to `window.api.updates.onStatus` and renders a small dismissible
+ * banner describing the update lifecycle: available -> downloading -> ready.
+ * When an update is downloaded it offers a Restart button that calls
+ * `updates.quitAndInstall()`.
+ *
+ * Nothing renders until a status arrives, so in development / unpackaged runs
+ * (where the main process never pushes a status) the banner stays hidden.
+ */
+export function UpdateNotifier(): JSX.Element | null {
+  const [status, setStatus] = useState<UpdateStatus | null>(null)
+  const [dismissed, setDismissed] = useState(false)
+
+  useEffect(() => {
+    const unsubscribe = window.api.updates.onStatus((next) => {
+      // A fresh, more advanced status re-shows a previously dismissed banner.
+      setDismissed(false)
+      setStatus(next)
+    })
+    return unsubscribe
+  }, [])
+
+  if (!status || dismissed) return null
+
+  // Errors are surfaced quietly; an update failing to check/download should not
+  // shout at the user, so we keep it as a low-key, dismissible note.
+  let message: string
+  let action: JSX.Element | null = null
+
+  switch (status.state) {
+    case 'available':
+      message = status.version
+        ? `Update available (v${status.version}) — downloading…`
+        : 'Update available — downloading…'
+      break
+    case 'downloading':
+      message =
+        typeof status.percent === 'number'
+          ? `Downloading update… ${status.percent}%`
+          : 'Downloading update…'
+      break
+    case 'downloaded':
+      message = status.version
+        ? `Update ready (v${status.version}) — restart to update`
+        : 'Update ready — restart to update'
+      action = (
+        <button
+          type="button"
+          className="update-notifier__action"
+          onClick={() => {
+            void window.api.updates.quitAndInstall()
+          }}
+        >
+          Restart
+        </button>
+      )
+      break
+    case 'error':
+      message = `Update error: ${status.message ?? 'unknown error'}`
+      break
+    default:
+      return null
+  }
+
+  return (
+    <div
+      className={`update-notifier update-notifier--${status.state}`}
+      role="status"
+      aria-live="polite"
+    >
+      <span className="update-notifier__message">{message}</span>
+      {action}
+      <button
+        type="button"
+        className="update-notifier__dismiss"
+        aria-label="Dismiss update notification"
+        onClick={() => setDismissed(true)}
+      >
+        ✕
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
Implements in-app update notifications for new releases (issue #17). Updates are distributed via GitHub Releases (the `publish` provider in `electron-builder.yml`), so `electron-updater` reads its feed from the packaged `app-update.yml`.

## Changes
- **`src/main/updater.ts`** (new): wires `electron-updater`'s `autoUpdater`, forwarding `update-available`, `download-progress`, `update-downloaded`, and `error` events to the renderer as a single `updates:status` push. The whole flow is guarded on `app.isPackaged` — in dev / unpackaged runs it registers inert IPC handlers and never touches the updater (no `app-update.yml` means a check would otherwise throw).
- **`src/main/index.ts`**: minimal wiring — `registerUpdater(() => mainWindow?.webContents)` on app ready, following the `device`/`fs` IPC pattern.
- **`src/preload/index.ts` / `index.d.ts`**: localized `window.api.updates` namespace — `check()`, `quitAndInstall()`, and `onStatus(cb)` (returns an unsubscribe fn); re-exports the `UpdateStatus` type.
- **`src/renderer/src/components/UpdateNotifier.tsx`** (+ co-located CSS, new): non-intrusive, dismissible bottom-right toast showing available / downloading… / ready states with a Restart button calling `updates.quitAndInstall()`. Renders nothing until a status arrives, so it stays hidden in dev and when there is no update.
- **`src/renderer/src/App.tsx`**: mounts `<UpdateNotifier/>` inside `<WorkspaceProvider>`.
- **`package.json` / lock**: adds `electron-updater@^6.8.3`.

## Checklist
- [x] Add `electron-updater` dependency
- [x] `src/main/updater.ts` using `autoUpdater`, guarded by `app.isPackaged`, dev no-ops cleanly
- [x] GitHub provider (read from `electron-builder.yml` publish / `app-update.yml`)
- [x] Forward `update-available`, `download-progress`, `update-downloaded`, `error` over IPC
- [x] `window.api.updates`: `check()`, `quitAndInstall()`, `onStatus(cb)`
- [x] `UpdateNotifier.tsx` banner with Restart, mounted in `App.tsx`, co-located CSS
- [x] Non-intrusive, dismissible; nothing shown with no update or in dev
- [x] `npm install && npm run lint && npm run typecheck && npm run build` all pass

## Caveats
Built on headless ARM64 and not packaged here, so the live update flow (real check/download/install against a GitHub Release) could not be exercised. Dev no-op is verified; the packaged path follows the standard electron-updater + electron-builder GitHub provider contract.

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)