### PR TITLE
Variables & code-outline panels

### DIFF
--- a/src/renderer/src/components/MonacoEditor.tsx
+++ b/src/renderer/src/components/MonacoEditor.tsx
@@ -36,7 +36,7 @@ function monacoTheme(theme: 'light' | 'dark'): string {
  *  - the editor auto-lays-out, so it tracks panel resizes
  */
 export function MonacoEditor(): JSX.Element {
-  const { openFiles, activeId, updateContent, saveFile } = useWorkspace()
+  const { openFiles, activeId, revealRequest, updateContent, saveFile } = useWorkspace()
   const { theme } = useTheme()
 
   const containerRef = useRef<HTMLDivElement>(null)
@@ -130,6 +130,17 @@ export function MonacoEditor(): JSX.Element {
       editor.setModel(model)
     }
   }, [activeFile, activeFile?.id, activeFile?.content, activeFile?.name])
+
+  // Reveal/scroll to a line on request (e.g. clicking an Outline symbol).
+  // Keyed on `seq` so repeated clicks on the same symbol re-reveal it.
+  useEffect(() => {
+    const editor = editorRef.current
+    if (!editor || !revealRequest) return
+    const line = Math.max(1, Math.floor(revealRequest.line))
+    editor.revealLineInCenter(line)
+    editor.setPosition({ lineNumber: line, column: 1 })
+    editor.focus()
+  }, [revealRequest])
 
   // Dispose models whose files have been closed.
   useEffect(() => {

--- a/src/renderer/src/components/OutlinePanel.css
+++ b/src/renderer/src/components/OutlinePanel.css
@@ -1,0 +1,98 @@
+/*
+ * Styles co-located with OutlinePanel (issue #16).
+ *
+ * A scrollable, clickable list of top-level symbols in the active file. Uses
+ * the shared design tokens from index.css so it tracks the active theme.
+ */
+
+.outline {
+  padding: 0.4rem 0;
+  font-size: 13px;
+  color: var(--text);
+}
+
+.outline__hint {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.outline__hint code {
+  padding: 0.05rem 0.3rem;
+  background: var(--bg-sunken);
+  border-radius: 4px;
+}
+
+.outline__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.outline__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 0.3rem 0.85rem;
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 13px;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.outline__item:hover {
+  background: var(--bg-sunken);
+}
+
+.outline__glyph {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--accent-contrast, var(--text));
+  background: var(--accent);
+}
+
+.outline__glyph--class {
+  background: #b07219;
+}
+
+.outline__glyph--variable {
+  background: var(--text-muted);
+}
+
+.outline__name {
+  flex: 0 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.outline__detail {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+.outline__line {
+  flex: 0 0 auto;
+  margin-left: auto;
+  padding-left: 8px;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+}

--- a/src/renderer/src/components/OutlinePanel.tsx
+++ b/src/renderer/src/components/OutlinePanel.tsx
@@ -1,0 +1,160 @@
+import { useMemo } from 'react'
+import './OutlinePanel.css'
+import { useWorkspace } from '../store/workspace'
+
+/**
+ * OUTLINE TAB (issue #16)
+ * =======================
+ *
+ * A code outline for the ACTIVE editor file: top-level `def` functions, `class`
+ * definitions, and module-level (column-0) assignments. Clicking a symbol asks
+ * the editor to reveal its line via the workspace store's `revealLine` action
+ * (no cross-component refs — see `workspace.ts`).
+ *
+ * Parsing is a defensive line scan rather than a full Python parser: it only
+ * considers indentation-0 lines, skips comments/strings cheaply, and is
+ * tolerant of malformed input (it simply yields fewer symbols).
+ */
+
+type SymbolKind = 'function' | 'class' | 'variable'
+
+interface OutlineSymbol {
+  kind: SymbolKind
+  name: string
+  /** 1-based line number in the source. */
+  line: number
+  /** Optional signature/detail shown muted after the name. */
+  detail?: string
+}
+
+const KIND_GLYPH: Record<SymbolKind, string> = {
+  function: 'ƒ',
+  class: 'C',
+  variable: '='
+}
+
+const KIND_LABEL: Record<SymbolKind, string> = {
+  function: 'function',
+  class: 'class',
+  variable: 'variable'
+}
+
+// Matches a top-level (column-0) symbol declaration. We anchor at the start of
+// the line so indented members (methods, locals) are intentionally excluded.
+const FUNC_RE = /^(?:async\s+)?def\s+([A-Za-z_]\w*)\s*\(([^)]*)\)/
+const CLASS_RE = /^class\s+([A-Za-z_]\w*)\s*(?:\(([^)]*)\))?/
+// Module-level assignment: `NAME = ...`, `NAME: type = ...`, or multi-target
+// `A = B = ...`. Excludes `==`, `<=`, etc. by requiring a non-`=` char after.
+const ASSIGN_RE = /^([A-Za-z_]\w*)\s*(?::\s*[^=]+)?=(?!=)/
+
+/** Extract top-level outline symbols from Python source via a line scan. */
+export function parseOutline(source: string): OutlineSymbol[] {
+  const symbols: OutlineSymbol[] = []
+  if (!source) return symbols
+  const seenVars = new Set<string>()
+  const lines = source.split(/\r?\n/)
+
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i]
+    // Only top-level constructs: skip any indented or blank/comment line.
+    if (raw.length === 0 || /^\s/.test(raw)) continue
+    const line = raw
+    if (line.startsWith('#')) continue
+
+    const fn = FUNC_RE.exec(line)
+    if (fn) {
+      const params = fn[2].trim()
+      symbols.push({
+        kind: 'function',
+        name: fn[1],
+        line: i + 1,
+        detail: `(${params})`
+      })
+      continue
+    }
+
+    const cls = CLASS_RE.exec(line)
+    if (cls) {
+      const bases = (cls[2] ?? '').trim()
+      symbols.push({
+        kind: 'class',
+        name: cls[1],
+        line: i + 1,
+        detail: bases ? `(${bases})` : undefined
+      })
+      continue
+    }
+
+    const assign = ASSIGN_RE.exec(line)
+    if (assign) {
+      const name = assign[1]
+      // Keywords like `if`, `for`, `while`, `return` can never be assignment
+      // targets, but a bare identifier followed by `=` is safe to treat as one.
+      if (!seenVars.has(name)) {
+        seenVars.add(name)
+        symbols.push({ kind: 'variable', name, line: i + 1 })
+      }
+    }
+  }
+
+  return symbols
+}
+
+export function OutlinePanel(): JSX.Element {
+  const { openFiles, activeId, revealLine } = useWorkspace()
+  const activeFile = openFiles.find((f) => f.id === activeId) ?? null
+
+  const symbols = useMemo(
+    () => parseOutline(activeFile?.content ?? ''),
+    [activeFile?.content]
+  )
+
+  if (!activeFile) {
+    return (
+      <div className="outline">
+        <p className="outline__hint">Open a file to see its outline.</p>
+      </div>
+    )
+  }
+
+  if (symbols.length === 0) {
+    return (
+      <div className="outline">
+        <p className="outline__hint">
+          No top-level functions, classes, or variables found in{' '}
+          <code>{activeFile.name}</code>.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="outline">
+      <ul className="outline__list" role="list">
+        {symbols.map((sym) => (
+          <li key={`${sym.kind}:${sym.name}:${sym.line}`}>
+            <button
+              type="button"
+              className="outline__item"
+              title={`Go to line ${sym.line}`}
+              onClick={() => revealLine(sym.line)}
+            >
+              <span
+                className={`outline__glyph outline__glyph--${sym.kind}`}
+                aria-hidden="true"
+                title={KIND_LABEL[sym.kind]}
+              >
+                {KIND_GLYPH[sym.kind]}
+              </span>
+              <span className="outline__name">{sym.name}</span>
+              {sym.detail != null && (
+                <span className="outline__detail">{sym.detail}</span>
+              )}
+              <span className="outline__line">{sym.line}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/renderer/src/components/RightPanel.tsx
+++ b/src/renderer/src/components/RightPanel.tsx
@@ -1,6 +1,8 @@
 import { PanelHeader } from './PanelHeader'
 import { RightPanelTabs, RightPanelTab } from './RightPanelTabs'
 import { HelpPanel } from './HelpPanel'
+import { OutlinePanel } from './OutlinePanel'
+import { VariablesPanel } from './VariablesPanel'
 
 /**
  * RIGHT PANE — optional/collapsible region (collapsed by default).
@@ -20,11 +22,14 @@ import { HelpPanel } from './HelpPanel'
  */
 export function RightPanel(): JSX.Element {
   const tabs: RightPanelTab[] = [
-    { id: 'help', title: 'Help', icon: '?', content: <HelpPanel /> }
+    { id: 'help', title: 'Help', icon: '?', content: <HelpPanel /> },
+    // Code outline of the active file (issue #16):
+    { id: 'outline', title: 'Outline', icon: '☰', content: <OutlinePanel /> },
+    // Connected board's variables (issue #16):
+    { id: 'vars', title: 'Variables', icon: '{}', content: <VariablesPanel /> }
     // Future tabs register here, e.g.:
     // { id: 'chat', title: 'Chat', icon: '💬', content: <ChatPanel /> },
     // { id: 'packages', title: 'Packages', icon: '📦', content: <PackagePanel /> },
-    // { id: 'vars', title: 'Variables', icon: '{}', content: <VariablesPanel /> },
   ]
 
   return (

--- a/src/renderer/src/components/VariablesPanel.css
+++ b/src/renderer/src/components/VariablesPanel.css
@@ -1,0 +1,103 @@
+/*
+ * Styles co-located with VariablesPanel (issue #16).
+ *
+ * A scrollable list of the connected board's globals, plus a refresh action.
+ * Uses the shared design tokens from index.css so it tracks the active theme.
+ */
+
+.vars {
+  display: flex;
+  flex-direction: column;
+  font-size: 13px;
+  color: var(--text);
+}
+
+.vars__hint {
+  margin: 0;
+  padding: 0.85rem 1rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.vars__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 0.45rem 0.85rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.vars__count {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+.vars__refresh {
+  padding: 0.2rem 0.6rem;
+  background: var(--bg-sunken);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-size: 0.8rem;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.vars__refresh:hover:not(:disabled) {
+  background: var(--bg-elevated);
+}
+
+.vars__refresh:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.vars__error {
+  margin: 0;
+  padding: 0.6rem 0.85rem;
+  color: var(--danger, #c0392b);
+  background: var(--bg-sunken);
+  font-size: 0.8rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.vars__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.vars__item {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 0.3rem 0.85rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.vars__name {
+  flex: 0 0 auto;
+  font-weight: 600;
+}
+
+.vars__type {
+  flex: 0 0 auto;
+  padding: 0.02rem 0.3rem;
+  color: var(--text-muted);
+  background: var(--bg-sunken);
+  border-radius: 4px;
+  font-size: 0.72rem;
+}
+
+.vars__value {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.8rem;
+}

--- a/src/renderer/src/components/VariablesPanel.tsx
+++ b/src/renderer/src/components/VariablesPanel.tsx
@@ -1,0 +1,173 @@
+import { useCallback, useEffect, useState } from 'react'
+import './VariablesPanel.css'
+import { useDeviceStatus } from '../hooks/useDeviceStatus'
+
+/**
+ * VARIABLES TAB (issue #16)
+ * =========================
+ *
+ * Inspects the connected board's user globals. When a board is connected we run
+ * a small snippet over `window.api.device.exec` that prints one line per global
+ * (name, type, repr) in a delimited format, then parse it defensively. When no
+ * board is connected we show a hint instead.
+ *
+ * Hardware can't be exercised in CI, so the snippet is conservative and the
+ * parser tolerates partial/garbled output (skips lines it can't read).
+ */
+
+interface DeviceVariable {
+  name: string
+  type: string
+  value: string
+}
+
+// Field/record separators chosen to be unlikely to appear in a repr. We still
+// truncate the repr device-side to keep output bounded, and the parser splits
+// on the first two separators only so a repr containing the FS is preserved.
+const FS = '␟' // SYMBOL FOR UNIT SEPARATOR
+const START = '<<SNAKIE_VARS>>'
+const END = '<<SNAKIE_VARS_END>>'
+
+/**
+ * Python run on the board. Walks `globals()`, skips dunders and modules, and
+ * prints `name FS type FS repr` per entry between sentinel markers. Reprs are
+ * truncated so a huge object can't flood the serial link.
+ */
+const SNIPPET = `
+print('${START}')
+try:
+    for __k in list(globals().keys()):
+        if __k.startswith('__'):
+            continue
+        if __k in ('__k', '__v', '__t', '__r'):
+            continue
+        __v = globals()[__k]
+        __t = type(__v).__name__
+        if __t in ('module', 'function', 'builtin_function_or_method'):
+            continue
+        try:
+            __r = repr(__v)
+        except Exception:
+            __r = '<unreprable>'
+        if len(__r) > 200:
+            __r = __r[:200] + '...'
+        print(__k + '${FS}' + __t + '${FS}' + __r)
+except Exception as __e:
+    print('ERR' + '${FS}' + 'error' + '${FS}' + repr(__e))
+print('${END}')
+`.trim()
+
+/** Parse the snippet's stdout into variable records (defensive). */
+export function parseVariables(stdout: string): DeviceVariable[] {
+  const vars: DeviceVariable[] = []
+  if (!stdout) return vars
+  const lines = stdout.split(/\r?\n/)
+  let inBlock = false
+  for (const line of lines) {
+    if (line.includes(START)) {
+      inBlock = true
+      continue
+    }
+    if (line.includes(END)) break
+    if (!inBlock) continue
+    const first = line.indexOf(FS)
+    if (first === -1) continue
+    const second = line.indexOf(FS, first + 1)
+    if (second === -1) continue
+    const name = line.slice(0, first)
+    const type = line.slice(first + 1, second)
+    const value = line.slice(second + 1)
+    if (name.length === 0) continue
+    vars.push({ name, type, value })
+  }
+  return vars
+}
+
+export function VariablesPanel(): JSX.Element {
+  const status = useDeviceStatus()
+  const connected = status.state === 'connected'
+
+  const [vars, setVars] = useState<DeviceVariable[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [loaded, setLoaded] = useState(false)
+
+  const refresh = useCallback(async (): Promise<void> => {
+    setLoading(true)
+    setError(null)
+    try {
+      const result = await window.api.device.exec(SNIPPET)
+      if (result.stderr && result.stderr.trim().length > 0) {
+        setError(result.stderr.trim())
+      }
+      setVars(parseVariables(result.stdout ?? ''))
+      setLoaded(true)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+      setVars([])
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  // Auto-load once when a connection first appears; clear when it drops.
+  useEffect(() => {
+    if (connected && !loaded && !loading) {
+      void refresh()
+    }
+    if (!connected) {
+      setVars([])
+      setLoaded(false)
+      setError(null)
+    }
+  }, [connected, loaded, loading, refresh])
+
+  if (!connected) {
+    return (
+      <div className="vars">
+        <p className="vars__hint">
+          Connect a board to inspect its variables. Once connected, the
+          device&apos;s global variables will appear here.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="vars">
+      <div className="vars__toolbar">
+        <span className="vars__count">
+          {loading ? 'Reading…' : `${vars.length} variable${vars.length === 1 ? '' : 's'}`}
+        </span>
+        <button
+          type="button"
+          className="vars__refresh"
+          onClick={() => void refresh()}
+          disabled={loading}
+        >
+          Refresh
+        </button>
+      </div>
+
+      {error != null && <p className="vars__error">{error}</p>}
+
+      {!loading && vars.length === 0 && error == null && (
+        <p className="vars__hint">
+          No user variables defined yet. Run some code, then Refresh.
+        </p>
+      )}
+
+      <ul className="vars__list" role="list">
+        {vars.map((v) => (
+          <li key={v.name} className="vars__item">
+            <span className="vars__name">{v.name}</span>
+            <span className="vars__type">{v.type}</span>
+            <span className="vars__value" title={v.value}>
+              {v.value}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/renderer/src/store/workspace.ts
+++ b/src/renderer/src/store/workspace.ts
@@ -56,20 +56,38 @@ export interface OpenFile {
   dirty: boolean
 }
 
+/**
+ * A request to reveal (scroll to + place the cursor on) a 1-based line in the
+ * active editor. `seq` bumps on every request so the editor re-reveals the same
+ * line on repeated clicks; consumers should react to `seq` changes, not just
+ * `line`. Used by the Outline panel to navigate without cross-component refs.
+ */
+export interface RevealRequest {
+  /** 1-based line number to reveal. */
+  line: number
+  /** Monotonic counter so identical lines still trigger a fresh reveal. */
+  seq: number
+}
+
 export interface WorkspaceStore {
   openFiles: OpenFile[]
   activeId: string | null
+  /** Latest editor reveal request, or null if none has been made yet. */
+  revealRequest: RevealRequest | null
   openFile: (source: FileSource, path: string) => Promise<void>
   setActive: (id: string) => void
   closeFile: (id: string) => void
   updateContent: (id: string, content: string) => void
   saveFile: (id: string) => Promise<void>
   newFile: () => void
+  /** Ask the editor to scroll to and place the cursor on a 1-based `line`. */
+  revealLine: (line: number) => void
 }
 
 interface State {
   openFiles: OpenFile[]
   activeId: string | null
+  revealRequest: RevealRequest | null
 }
 
 type Action =
@@ -79,6 +97,7 @@ type Action =
   | { type: 'updateContent'; id: string; content: string }
   | { type: 'markSaved'; id: string }
   | { type: 'add'; file: OpenFile }
+  | { type: 'revealLine'; line: number }
 
 /** Derive a stable document id from its source and path. */
 function makeId(source: FileSource, path: string): string {
@@ -98,12 +117,14 @@ function reducer(state: State, action: Action): State {
       const existing = state.openFiles.find((f) => f.id === action.file.id)
       if (existing) return { ...state, activeId: existing.id }
       return {
+        ...state,
         openFiles: [...state.openFiles, action.file],
         activeId: action.file.id
       }
     }
     case 'add':
       return {
+        ...state,
         openFiles: [...state.openFiles, action.file],
         activeId: action.file.id
       }
@@ -119,7 +140,7 @@ function reducer(state: State, action: Action): State {
         const next = openFiles[idx] ?? openFiles[idx - 1]
         activeId = next ? next.id : null
       }
-      return { openFiles, activeId }
+      return { ...state, openFiles, activeId }
     }
     case 'updateContent':
       return {
@@ -135,6 +156,11 @@ function reducer(state: State, action: Action): State {
           f.id === action.id ? { ...f, dirty: false } : f
         )
       }
+    case 'revealLine':
+      return {
+        ...state,
+        revealRequest: { line: action.line, seq: (state.revealRequest?.seq ?? 0) + 1 }
+      }
     default:
       return state
   }
@@ -149,7 +175,11 @@ let untitledCounter = 0
  * root (e.g. in App.tsx).
  */
 export function WorkspaceProvider({ children }: { children: ReactNode }): JSX.Element {
-  const [state, dispatch] = useReducer(reducer, { openFiles: [], activeId: null })
+  const [state, dispatch] = useReducer(reducer, {
+    openFiles: [],
+    activeId: null,
+    revealRequest: null
+  })
 
   const openFile = useCallback(
     async (source: FileSource, path: string): Promise<void> => {
@@ -197,6 +227,10 @@ export function WorkspaceProvider({ children }: { children: ReactNode }): JSX.El
     [state.openFiles]
   )
 
+  const revealLine = useCallback((line: number): void => {
+    dispatch({ type: 'revealLine', line })
+  }, [])
+
   const newFile = useCallback((): void => {
     untitledCounter += 1
     const id = `local:untitled-${untitledCounter}`
@@ -217,14 +251,27 @@ export function WorkspaceProvider({ children }: { children: ReactNode }): JSX.El
     () => ({
       openFiles: state.openFiles,
       activeId: state.activeId,
+      revealRequest: state.revealRequest,
       openFile,
       setActive,
       closeFile,
       updateContent,
       saveFile,
-      newFile
+      newFile,
+      revealLine
     }),
-    [state.openFiles, state.activeId, openFile, setActive, closeFile, updateContent, saveFile, newFile]
+    [
+      state.openFiles,
+      state.activeId,
+      state.revealRequest,
+      openFile,
+      setActive,
+      closeFile,
+      updateContent,
+      saveFile,
+      newFile,
+      revealLine
+    ]
   )
 
   return createElement(WorkspaceContext.Provider, { value: store }, children)


### PR DESCRIPTION
Adds two new right-pane tabs (issue #16), both clean, collapsible/scrollable lists matching the existing right-pane styling.

## What changed
- **Outline tab** (`OutlinePanel.tsx` + CSS): line-scans the ACTIVE file's content for top-level `def` functions, `class` definitions, and module-level (column-0) assignments. Renders a clickable list; clicking a symbol reveals/scrolls to its line in the editor and places the cursor there.
- **Variables tab** (`VariablesPanel.tsx` + CSS): when a board is connected, runs a defensive snippet via `window.api.device.exec` that prints `name/type/repr` of user globals (skipping dunders, modules, functions; truncating long reprs) between sentinel markers, then parses the stdout defensively. Auto-loads on connect, clears on disconnect, and has a **Refresh** action. Shows a hint when disconnected.
- **Reveal mechanism** (`store/workspace.ts`): added `revealRequest: {line: number, seq: number} | null` plus a `revealLine(line)` action. `seq` is a monotonic counter so clicking the same symbol repeatedly still re-reveals it. `MonacoEditor.tsx` watches `revealRequest` and calls `editor.revealLineInCenter(line)` + `setPosition` + `focus`.
- Registered both tabs in `RightPanel.tsx`.

## Acceptance (headless ARM64, no board attached)
- `npm install` ok
- `npm run lint` ok
- `npm run typecheck` ok
- `npm run build` ok

Variables hardware path could not be exercised here (no board); the exec snippet and parser are deliberately conservative/defensive.

## Checklist
- [x] Outline tab: parse top-level def/class/assignments, clickable, scroll-to-line
- [x] Variables tab: query device globals when connected, refresh action, disconnected hint
- [x] Both clean, collapsible/scrollable lists in existing right-pane styling

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)