### PR TITLE
Flash MicroPython firmware to device

### DIFF
--- a/src/main/firmware/detect.ts
+++ b/src/main/firmware/detect.ts
@@ -1,0 +1,169 @@
+/**
+ * Best-effort board/chip detection for firmware flashing (issue #14).
+ *
+ * Two independent strategies are combined:
+ *
+ *  - **Serial VID/PID** — ESP boards expose a USB-to-serial bridge whose USB
+ *    vendor/product id often identifies the chip family. We enumerate serial
+ *    ports (reusing the device layer's `listPorts`) and match against a small
+ *    table of well-known bridge chips. This is heuristic: the same bridge chip
+ *    (e.g. a CP2102) ships on both esp32 and esp8266 boards, so we default to
+ *    the more common `esp32` and let the user override in the UI.
+ *
+ *  - **UF2 boot drive** — an RP2040 held in BOOTSEL mode mounts as a small FAT
+ *    volume labelled `RPI-RP2`. We scan the platform's mount points for that
+ *    label/marker and surface it as an `rp2040` candidate.
+ *
+ * Detection never throws for the caller: failures in one strategy are swallowed
+ * so the other can still contribute candidates.
+ */
+import { promises as fs } from 'fs'
+import { homedir, platform } from 'os'
+import { join } from 'path'
+import { MicroPythonDevice } from '../device/MicroPythonDevice'
+import type { BoardCandidate, BoardType } from './types'
+
+/**
+ * Known USB-serial bridge VID/PIDs found on common ESP dev boards. Values are
+ * lowercase hex without the `0x` prefix, matching {@link PortInfo}. The mapped
+ * board is the *most likely* family; the user can change it before flashing.
+ */
+const ESP_USB_BRIDGES: Array<{ vid: string; pid?: string; board: BoardType; chip: string }> = [
+  // Silicon Labs CP210x — extremely common on ESP32 dev boards.
+  { vid: '10c4', pid: 'ea60', board: 'esp32', chip: 'CP210x' },
+  // WCH CH340 / CH341 — common on cheaper ESP8266 (NodeMCU) and some ESP32.
+  { vid: '1a86', pid: '7523', board: 'esp8266', chip: 'CH340' },
+  { vid: '1a86', pid: '5523', board: 'esp8266', chip: 'CH341' },
+  // FTDI FT232 — older ESP dev boards.
+  { vid: '0403', pid: '6001', board: 'esp32', chip: 'FT232R' },
+  // Espressif native USB CDC (ESP32-S2/S3/C3 built-in USB JTAG/serial).
+  { vid: '303a', board: 'esp32', chip: 'Espressif native USB' }
+]
+
+/** Match a serial port's VID/PID against the known ESP bridge table. */
+function matchEspBridge(
+  vendorId?: string,
+  productId?: string
+): { board: BoardType; chip: string } | undefined {
+  if (!vendorId) return undefined
+  const vid = vendorId.toLowerCase()
+  const pid = productId?.toLowerCase()
+  // Prefer an exact vid+pid match, then fall back to a vid-only entry.
+  return (
+    ESP_USB_BRIDGES.find((e) => e.vid === vid && e.pid && e.pid === pid) ??
+    ESP_USB_BRIDGES.find((e) => e.vid === vid && !e.pid)
+  )
+}
+
+/** Detect ESP candidates from the enumerated serial ports. */
+async function detectEspFromSerial(): Promise<BoardCandidate[]> {
+  const candidates: BoardCandidate[] = []
+  try {
+    const ports = await MicroPythonDevice.listPorts()
+    for (const p of ports) {
+      const match = matchEspBridge(p.vendorId, p.productId)
+      if (!match) continue
+      const detail = p.friendlyName ?? p.manufacturer ?? match.chip
+      candidates.push({
+        board: match.board,
+        source: 'serial',
+        port: p.path,
+        label: `${p.path} — ${detail} (${match.board})`,
+        vendorId: p.vendorId,
+        productId: p.productId
+      })
+    }
+  } catch {
+    // Enumeration unavailable (e.g. no serialport binding) — yield nothing.
+  }
+  return candidates
+}
+
+/**
+ * Candidate mount-point roots to scan for a UF2 boot drive, per platform. We
+ * only read directory listings (cheap, read-only) so this is safe to call
+ * repeatedly.
+ */
+function uf2SearchRoots(): string[] {
+  const os = platform()
+  if (os === 'win32') {
+    // Windows mounts removable drives as letters; scan A–Z roots.
+    return Array.from({ length: 26 }, (_, i) => `${String.fromCharCode(65 + i)}:\\`)
+  }
+  if (os === 'darwin') return ['/Volumes']
+  // Linux: media is typically auto-mounted under one of these.
+  return ['/media', join('/media', process.env.USER ?? ''), '/run/media', join(homedir())]
+}
+
+/** A directory looks like an RP2040 boot drive if it carries the UF2 markers. */
+async function looksLikeRp2040Drive(dir: string): Promise<boolean> {
+  try {
+    const entries = await fs.readdir(dir)
+    const lower = entries.map((e) => e.toLowerCase())
+    // The BOOTSEL FAT volume always contains INFO_UF2.TXT (and usually INDEX.HTM).
+    return lower.includes('info_uf2.txt') || lower.includes('index.htm')
+  } catch {
+    return false
+  }
+}
+
+/** Detect an RP2040 in BOOTSEL mode by scanning mount points for the UF2 marker. */
+async function detectRp2040Drive(): Promise<BoardCandidate[]> {
+  const candidates: BoardCandidate[] = []
+  const os = platform()
+
+  for (const root of uf2SearchRoots()) {
+    if (!root) continue
+    if (os === 'win32') {
+      // Each drive letter is itself a potential boot volume.
+      if (await looksLikeRp2040Drive(root)) {
+        candidates.push({
+          board: 'rp2040',
+          source: 'uf2-drive',
+          mountPath: root,
+          label: `${root} — RP2040 (RPI-RP2)`
+        })
+      }
+      continue
+    }
+    // POSIX: the root contains per-volume subdirectories; inspect each one.
+    let names: string[]
+    try {
+      names = await fs.readdir(root)
+    } catch {
+      continue
+    }
+    for (const name of names) {
+      const mount = join(root, name)
+      // A direct label match is a strong signal; otherwise probe the contents.
+      const labelled = name.toUpperCase().includes('RPI-RP2')
+      if (labelled || (await looksLikeRp2040Drive(mount))) {
+        candidates.push({
+          board: 'rp2040',
+          source: 'uf2-drive',
+          mountPath: mount,
+          label: `${mount} — RP2040 (RPI-RP2)`
+        })
+      }
+    }
+  }
+  return candidates
+}
+
+/**
+ * Detect all board candidates, combining serial-port and UF2-drive strategies.
+ * De-duplicates by (board, port/mountPath) and returns serial candidates first.
+ * Always resolves (never rejects) — an empty array simply means nothing was
+ * confidently recognised, which the UI presents as "choose manually".
+ */
+export async function detectBoards(): Promise<BoardCandidate[]> {
+  const [esp, rp] = await Promise.all([detectEspFromSerial(), detectRp2040Drive()])
+  const all = [...esp, ...rp]
+  const seen = new Set<string>()
+  return all.filter((c) => {
+    const key = `${c.board}:${c.port ?? c.mountPath ?? ''}`
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}

--- a/src/main/firmware/flasher.ts
+++ b/src/main/firmware/flasher.ts
@@ -1,0 +1,239 @@
+/**
+ * Firmware-flashing engine (issue #14).
+ *
+ * Two strategies, chosen by {@link FlashOptions.board}:
+ *
+ *  - **ESP (esp32 / esp8266)** — shells out to the external `esptool`
+ *    executable via `child_process.spawn`, streaming its stdout/stderr to the
+ *    renderer line-by-line. esptool is a *prerequisite the user installs*; we
+ *    never bundle it. If it is missing we fail fast with an actionable message.
+ *
+ *  - **RP2040 (UF2)** — copies the selected `.uf2` file onto the mounted
+ *    `RPI-RP2` boot drive using plain Node `fs`. The board reboots itself once
+ *    the copy completes, so there is no tool to invoke.
+ *
+ * Progress is delivered through an injected `emit` callback (the IPC layer
+ * forwards it to the renderer) so this module has no Electron dependency and is
+ * easy to reason about in isolation.
+ */
+import { spawn } from 'child_process'
+import { promises as fs, createReadStream, createWriteStream } from 'fs'
+import { basename, join } from 'path'
+import type { EsptoolInfo, FlashOptions, FlashProgress, FlashResult } from './types'
+
+/** Candidate executable names for esptool, in preference order. */
+const ESPTOOL_COMMANDS = ['esptool', 'esptool.py'] as const
+
+/** Default ESP `write_flash` offsets per family. */
+const DEFAULT_OFFSET: Record<'esp32' | 'esp8266', string> = {
+  esp32: '0x1000',
+  esp8266: '0x0'
+}
+
+/** A sink for streamed progress lines. */
+export type Emit = (p: FlashProgress) => void
+
+/**
+ * Run a command to completion, streaming combined stdout/stderr to `emit` one
+ * line at a time. Resolves with the exit code; rejects only if the process
+ * could not be spawned at all (surfaced separately so callers can detect a
+ * missing executable).
+ */
+function runStreaming(
+  command: string,
+  args: string[],
+  emit: Emit
+): Promise<{ code: number | null; spawnError?: Error }> {
+  return new Promise((resolve) => {
+    let child: ReturnType<typeof spawn>
+    try {
+      child = spawn(command, args, { windowsHide: true })
+    } catch (err) {
+      resolve({ code: null, spawnError: err instanceof Error ? err : new Error(String(err)) })
+      return
+    }
+
+    const pump =
+      (kind: 'log' | 'error') =>
+      (buf: Buffer): void => {
+        for (const line of buf.toString().split(/\r?\n/)) {
+          if (line.length > 0) emit({ kind, message: line })
+        }
+      }
+
+    child.stdout?.on('data', pump('log'))
+    child.stderr?.on('data', pump('error'))
+    child.on('error', (err) => resolve({ code: null, spawnError: err }))
+    child.on('close', (code) => resolve({ code }))
+  })
+}
+
+/**
+ * Probe for the external `esptool` prerequisite by attempting `--version`.
+ * Returns `{ available: false }` when neither candidate command runs.
+ */
+export async function detectEsptool(): Promise<EsptoolInfo> {
+  for (const command of ESPTOOL_COMMANDS) {
+    const result = await new Promise<EsptoolInfo | null>((resolve) => {
+      let stdout = ''
+      let child: ReturnType<typeof spawn>
+      try {
+        child = spawn(command, ['version'], { windowsHide: true })
+      } catch {
+        resolve(null)
+        return
+      }
+      child.stdout?.on('data', (b: Buffer) => (stdout += b.toString()))
+      child.stderr?.on('data', (b: Buffer) => (stdout += b.toString()))
+      child.on('error', () => resolve(null))
+      child.on('close', (code) => {
+        if (code === 0) {
+          const version = stdout.split(/\r?\n/).find((l) => l.trim().length > 0)?.trim()
+          resolve({ available: true, command, version })
+        } else {
+          resolve(null)
+        }
+      })
+    })
+    if (result) return result
+  }
+  return { available: false }
+}
+
+/** Validate that the firmware file exists and is a regular file. */
+async function assertFirmwareFile(path: string): Promise<void> {
+  let s: import('fs').Stats
+  try {
+    s = await fs.stat(path)
+  } catch {
+    throw new Error(`Firmware file not found: ${path}`)
+  }
+  if (!s.isFile()) throw new Error(`Firmware path is not a file: ${path}`)
+}
+
+/** Flash an ESP board by shelling out to esptool. */
+async function flashEsp(opts: FlashOptions, emit: Emit): Promise<FlashResult> {
+  if (!opts.port) {
+    return { ok: false, error: 'No serial port selected for the ESP board.' }
+  }
+
+  const tool = await detectEsptool()
+  if (!tool.available || !tool.command) {
+    const msg =
+      'esptool is not installed or not on PATH. Install it with `pip install esptool` ' +
+      '(or `pipx install esptool`) and try again. Snakie does not bundle esptool.'
+    emit({ kind: 'error', message: msg })
+    return { ok: false, error: msg }
+  }
+
+  const offset = opts.offset ?? DEFAULT_OFFSET[opts.board === 'esp8266' ? 'esp8266' : 'esp32']
+  const baud = String(opts.baud ?? 460800)
+  const args = [
+    '--port',
+    opts.port,
+    '--baud',
+    baud,
+    'write_flash',
+    offset,
+    opts.firmwarePath
+  ]
+
+  emit({ kind: 'log', message: `Using ${tool.command}${tool.version ? ` (${tool.version})` : ''}` })
+  emit({ kind: 'log', message: `> ${tool.command} ${args.join(' ')}` })
+
+  const { code, spawnError } = await runStreaming(tool.command, args, emit)
+  if (spawnError) {
+    const msg = `Failed to launch ${tool.command}: ${spawnError.message}`
+    emit({ kind: 'error', message: msg })
+    return { ok: false, error: msg }
+  }
+  if (code !== 0) {
+    const msg = `esptool exited with code ${code ?? 'null'}.`
+    emit({ kind: 'error', message: msg })
+    return { ok: false, error: msg }
+  }
+  emit({ kind: 'log', message: 'Flash complete.' })
+  return { ok: true }
+}
+
+/** Copy a `.uf2` file onto the mounted RP2040 boot drive, streaming progress. */
+async function flashRp2040(opts: FlashOptions, emit: Emit): Promise<FlashResult> {
+  const mount = opts.mountPath
+  if (!mount) {
+    return {
+      ok: false,
+      error: 'No RP2040 boot drive selected. Hold BOOTSEL while connecting so RPI-RP2 mounts.'
+    }
+  }
+
+  try {
+    const dirStat = await fs.stat(mount)
+    if (!dirStat.isDirectory()) {
+      return { ok: false, error: `Boot drive path is not a directory: ${mount}` }
+    }
+  } catch {
+    return { ok: false, error: `Boot drive not found: ${mount}` }
+  }
+
+  const dest = join(mount, basename(opts.firmwarePath))
+  emit({ kind: 'log', message: `Copying ${opts.firmwarePath}` })
+  emit({ kind: 'log', message: `     -> ${dest}` })
+
+  try {
+    const { size } = await fs.stat(opts.firmwarePath)
+    await new Promise<void>((resolve, reject) => {
+      const read = createReadStream(opts.firmwarePath)
+      const write = createWriteStream(dest)
+      let copied = 0
+      let lastPct = -1
+      read.on('data', (chunk) => {
+        copied += chunk.length
+        const pct = size > 0 ? Math.floor((copied / size) * 100) : 0
+        if (pct !== lastPct && pct % 10 === 0) {
+          lastPct = pct
+          emit({ kind: 'log', message: `Copying… ${pct}%` })
+        }
+      })
+      read.on('error', reject)
+      write.on('error', reject)
+      write.on('finish', () => resolve())
+      read.pipe(write)
+    })
+  } catch (err) {
+    // The board commonly reboots and unmounts mid-write; surface the raw error
+    // but note this may still indicate success on real hardware.
+    const msg = err instanceof Error ? err.message : String(err)
+    emit({ kind: 'error', message: `UF2 copy error: ${msg}` })
+    return { ok: false, error: msg }
+  }
+
+  emit({ kind: 'log', message: 'UF2 copied. The board will reboot into the new firmware.' })
+  return { ok: true }
+}
+
+/**
+ * Flash firmware to a device. Validates inputs, dispatches to the ESP or UF2
+ * strategy, and always emits a terminal `done` progress event reflecting the
+ * outcome.
+ */
+export async function flash(opts: FlashOptions, emit: Emit): Promise<FlashResult> {
+  let result: FlashResult
+  try {
+    await assertFirmwareFile(opts.firmwarePath)
+    if (opts.board === 'rp2040') {
+      result = await flashRp2040(opts, emit)
+    } else {
+      result = await flashEsp(opts, emit)
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    emit({ kind: 'error', message: msg })
+    result = { ok: false, error: msg }
+  }
+  emit({
+    kind: 'done',
+    ok: result.ok,
+    message: result.ok ? 'Done.' : (result.error ?? 'Flashing failed.')
+  })
+  return result
+}

--- a/src/main/firmware/ipc.ts
+++ b/src/main/firmware/ipc.ts
@@ -1,0 +1,77 @@
+/**
+ * IPC wiring for the firmware-flashing layer (issue #14).
+ *
+ * Mirrors the device / fs layers: request channels are `firmware:*` and return
+ * a serializable {@link IpcResult}; progress is delivered as `firmware:progress`
+ * push events to the live renderer. Detection and flashing live in `detect.ts`
+ * / `flasher.ts`, keeping this file to thin glue.
+ */
+import { dialog, ipcMain, BrowserWindow, type WebContents } from 'electron'
+import type { IpcResult } from '../device/types'
+import { detectBoards } from './detect'
+import { detectEsptool, flash } from './flasher'
+import type { BoardCandidate, EsptoolInfo, FlashOptions, FlashProgress, FlashResult } from './types'
+
+/** Renderer-facing channel names for the firmware layer. */
+export const FIRMWARE_CHANNELS = {
+  progress: 'firmware:progress',
+  detect: 'firmware:detect',
+  esptool: 'firmware:esptool',
+  pickFile: 'firmware:pickFile',
+  flash: 'firmware:flash'
+} as const
+
+/**
+ * Wrap an async operation so any thrown error crosses IPC as a plain,
+ * serializable {@link IpcResult}. Mirrors the device / fs layers' `wrap`.
+ */
+async function wrap<T>(fn: () => Promise<T>): Promise<IpcResult<T>> {
+  try {
+    return { ok: true, value: await fn() }
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+/**
+ * Register all `firmware:*` IPC handlers. Progress events are forwarded to
+ * whichever renderer is currently live.
+ *
+ * @param getWindow resolver for the window (used to parent the file dialog and
+ *   to route progress push-events), so we never capture a destroyed window.
+ */
+export function registerFirmwareIpc(getWindow: () => BrowserWindow | undefined): void {
+  const sendProgress = (p: FlashProgress): void => {
+    const wc: WebContents | undefined = getWindow()?.webContents
+    if (wc && !wc.isDestroyed()) wc.send(FIRMWARE_CHANNELS.progress, p)
+  }
+
+  ipcMain.handle(FIRMWARE_CHANNELS.detect, () =>
+    wrap<BoardCandidate[]>(() => detectBoards())
+  )
+
+  ipcMain.handle(FIRMWARE_CHANNELS.esptool, () => wrap<EsptoolInfo>(() => detectEsptool()))
+
+  ipcMain.handle(FIRMWARE_CHANNELS.pickFile, () =>
+    wrap<string | null>(async () => {
+      const win = getWindow()
+      const options: Electron.OpenDialogOptions = {
+        title: 'Choose firmware file',
+        properties: ['openFile'],
+        filters: [
+          { name: 'Firmware', extensions: ['bin', 'uf2'] },
+          { name: 'All files', extensions: ['*'] }
+        ]
+      }
+      const result = win
+        ? await dialog.showOpenDialog(win, options)
+        : await dialog.showOpenDialog(options)
+      if (result.canceled || result.filePaths.length === 0) return null
+      return result.filePaths[0]
+    })
+  )
+
+  ipcMain.handle(FIRMWARE_CHANNELS.flash, (_e, opts: FlashOptions) =>
+    wrap<FlashResult>(() => flash(opts, sendProgress))
+  )
+}

--- a/src/main/firmware/types.ts
+++ b/src/main/firmware/types.ts
@@ -1,0 +1,83 @@
+/**
+ * Shared types for the firmware-flashing layer (issue #14).
+ *
+ * Like the device-layer types these are intentionally plain (no class
+ * instances, no Buffers) so they serialize cleanly across the Electron IPC
+ * boundary and can be re-used by the preload typings and the renderer.
+ */
+
+/**
+ * The board families we know how to flash. `esp32` / `esp8266` shell out to
+ * `esptool`; `rp2040` copies a `.uf2` file onto the mounted boot drive.
+ */
+export type BoardType = 'esp32' | 'esp8266' | 'rp2040'
+
+/**
+ * A board candidate detected from a serial port (ESP) or a mounted UF2 boot
+ * drive (RP2040). Detection is best-effort: it ranks likely matches and lets
+ * the user confirm/override before flashing.
+ */
+export interface BoardCandidate {
+  /** Best-guess board family. */
+  board: BoardType
+  /**
+   * How the candidate was found. ESP boards are found via the serial port's
+   * USB VID/PID; RP2040 boards in BOOTSEL mode appear as a mounted UF2 volume.
+   */
+  source: 'serial' | 'uf2-drive'
+  /** Serial port path, when `source === 'serial'` (e.g. `/dev/ttyUSB0`). */
+  port?: string
+  /** Mounted UF2 boot-drive path, when `source === 'uf2-drive'`. */
+  mountPath?: string
+  /** Human-friendly description for the UI dropdown. */
+  label: string
+  /** USB vendor id (hex string), when known. */
+  vendorId?: string
+  /** USB product id (hex string), when known. */
+  productId?: string
+}
+
+/** A live progress / log line streamed to the renderer during a flash. */
+export interface FlashProgress {
+  /** Lifecycle phase the message belongs to. */
+  kind: 'log' | 'error' | 'done'
+  /** The text line (already trimmed of a trailing newline). */
+  message: string
+  /** Present on the terminal `done` event: whether the flash succeeded. */
+  ok?: boolean
+}
+
+/** Options describing a flash request from the renderer. */
+export interface FlashOptions {
+  board: BoardType
+  /** Absolute path to the firmware file (`.bin` for ESP, `.uf2` for RP2040). */
+  firmwarePath: string
+  /** Serial port path — required for ESP boards. */
+  port?: string
+  /** Mounted UF2 boot-drive path — required for RP2040; auto-detected if omitted. */
+  mountPath?: string
+  /**
+   * Flash offset for ESP `write_flash` (e.g. `0x1000` for esp32, `0x0` for
+   * esp8266). Defaults are applied per board when omitted.
+   */
+  offset?: string
+  /** esptool baud rate. Defaults to 460800. */
+  baud?: number
+}
+
+/** Result of a flash operation, returned in addition to the streamed logs. */
+export interface FlashResult {
+  ok: boolean
+  /** Failure detail when `ok === false`. */
+  error?: string
+}
+
+/** Result of probing for the external `esptool` prerequisite. */
+export interface EsptoolInfo {
+  /** True when an `esptool` / `esptool.py` executable was found on PATH. */
+  available: boolean
+  /** The command name that resolved, when available. */
+  command?: string
+  /** Version string reported by the tool, when it could be read. */
+  version?: string
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import { registerDeviceIpc, disposeDevice } from './device/ipc'
 import { registerFsIpc } from './fs/ipc'
+import { registerFirmwareIpc } from './firmware/ipc'
 import { registerUpdater } from './updater'
 
 /** The single application window, used to route device push-events. */
@@ -68,6 +69,10 @@ app.whenReady().then(() => {
   // Register the local filesystem layer. The folder dialog is parented to the
   // live window when one exists.
   registerFsIpc(() => mainWindow ?? undefined)
+
+  // Register the firmware-flashing layer (ESP via esptool, RP2040 via UF2 copy).
+  // The file dialog is parented to the live window and progress is routed to it.
+  registerFirmwareIpc(() => mainWindow ?? undefined)
 
   // Register the auto-update layer. No-ops cleanly in dev (unpackaged); when
   // packaged it checks GitHub Releases and pushes status to the live window.

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -18,6 +18,17 @@ export type {
 // single, UI-facing module without reaching into `src/main`.
 export type { FsEntry, FsStat } from '../main/fs/types'
 
+// Re-export the firmware-flashing types so the renderer's flasher UI can import
+// them from this UI-facing module rather than reaching into `src/main`.
+export type {
+  BoardType,
+  BoardCandidate,
+  FlashProgress,
+  FlashOptions,
+  FlashResult,
+  EsptoolInfo
+} from '../main/firmware/types'
+
 // Re-export the update-status type so the renderer's notifier can import it
 // from the UI-facing preload module rather than reaching into `src/main`.
 export type { UpdateStatus } from '../main/updater'

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -10,6 +10,13 @@ import type {
   StatResult
 } from '../main/device/types'
 import type { FsEntry, FsStat } from '../main/fs/types'
+import type {
+  BoardCandidate,
+  EsptoolInfo,
+  FlashOptions,
+  FlashProgress,
+  FlashResult
+} from '../main/firmware/types'
 import type { UpdateStatus } from '../main/updater'
 
 /**
@@ -130,6 +137,32 @@ const updates = {
   }
 }
 
+/**
+ * Firmware-flashing API (issue #14). Mirrors the main-process `firmware:*` IPC
+ * handlers and unwraps their typed results. `flash` shells out to esptool (ESP)
+ * or copies a `.uf2` (RP2040) in the main process; `onProgress` subscribes to
+ * the live log/progress stream and returns an unsubscribe function.
+ */
+const firmware = {
+  /** Best-effort board detection from serial VID/PID and UF2 boot drives. */
+  detectBoards: (): Promise<BoardCandidate[]> =>
+    unwrap(ipcRenderer.invoke('firmware:detect')),
+  /** Probe for the external esptool prerequisite (presence + version). */
+  checkEsptool: (): Promise<EsptoolInfo> => unwrap(ipcRenderer.invoke('firmware:esptool')),
+  /** Show the native firmware (`.bin`/`.uf2`) file picker. Resolves path or null. */
+  pickFirmwareFile: (): Promise<string | null> =>
+    unwrap(ipcRenderer.invoke('firmware:pickFile')),
+  /** Flash the given firmware; progress streams via {@link firmware.onProgress}. */
+  flash: (opts: FlashOptions): Promise<FlashResult> =>
+    unwrap(ipcRenderer.invoke('firmware:flash', opts)),
+  /** Subscribe to flash progress/log lines. Returns an unsubscribe function. */
+  onProgress: (cb: (progress: FlashProgress) => void): (() => void) => {
+    const listener = (_e: IpcRendererEvent, progress: FlashProgress): void => cb(progress)
+    ipcRenderer.on('firmware:progress', listener)
+    return () => ipcRenderer.removeListener('firmware:progress', listener)
+  }
+}
+
 // Minimal, typed API exposed to the renderer. This establishes the IPC
 // pattern that later feature work will extend.
 const api = {
@@ -141,6 +174,8 @@ const api = {
   device,
   /** Local host filesystem layer. */
   fs,
+  /** In-app MicroPython firmware flashing layer (ESP via esptool, RP2040 via UF2). */
+  firmware,
   /** Auto-update check + status + restart layer. */
   updates
 }

--- a/src/renderer/src/components/FirmwareFlasher.css
+++ b/src/renderer/src/components/FirmwareFlasher.css
@@ -1,0 +1,198 @@
+/*
+ * Styles for the firmware-flashing modal (issue #14).
+ *
+ * A centered, focus-trapping dialog over a dimmed backdrop. Colours follow the
+ * dark app chrome used by the update notifier so the modal feels native without
+ * touching the shared `index.css`.
+ */
+
+.firmware-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+  padding: 1rem;
+}
+
+.firmware-modal {
+  display: flex;
+  flex-direction: column;
+  width: min(40rem, 100%);
+  max-height: min(90vh, 48rem);
+  border-radius: 0.6rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: #1f2430;
+  color: #e6e6e6;
+  box-shadow: 0 12px 48px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+}
+
+.firmware-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.85rem 1.1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.firmware-modal__title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.firmware-modal__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  padding: 0;
+  border: none;
+  border-radius: 0.3rem;
+  background: transparent;
+  color: inherit;
+  font-size: 0.9rem;
+  cursor: pointer;
+  opacity: 0.75;
+}
+
+.firmware-modal__close:hover:not(:disabled) {
+  opacity: 1;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.firmware-modal__close:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.firmware-modal__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  padding: 1.1rem;
+  overflow-y: auto;
+}
+
+.firmware-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.firmware-field__label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  opacity: 0.85;
+}
+
+.firmware-field__row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.firmware-select,
+.firmware-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 0.45rem 0.55rem;
+  border-radius: 0.35rem;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: #161a22;
+  color: #e6e6e6;
+  font: inherit;
+  font-size: 0.85rem;
+}
+
+.firmware-input--grow {
+  flex: 1 1 auto;
+}
+
+.firmware-input:read-only {
+  opacity: 0.85;
+}
+
+.firmware-hint {
+  margin: 0;
+  font-size: 0.75rem;
+  line-height: 1.35;
+  opacity: 0.7;
+}
+
+.firmware-banner {
+  margin: 0;
+  padding: 0.55rem 0.7rem;
+  border-radius: 0.4rem;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  border: 1px solid transparent;
+}
+
+.firmware-banner code {
+  padding: 0.05rem 0.3rem;
+  border-radius: 0.2rem;
+  background: rgba(255, 255, 255, 0.12);
+  font-size: 0.78rem;
+}
+
+.firmware-banner--warn {
+  background: #3a2f1f;
+  border-color: rgba(255, 200, 120, 0.4);
+}
+
+.firmware-banner--error {
+  background: #3a2326;
+  border-color: rgba(255, 120, 120, 0.45);
+}
+
+.firmware-banner--success {
+  background: #1f3a2a;
+  border-color: rgba(120, 230, 160, 0.45);
+}
+
+.firmware-log {
+  max-height: 14rem;
+  overflow-y: auto;
+  padding: 0.55rem 0.7rem;
+  border-radius: 0.4rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: #11141b;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.78rem;
+  line-height: 1.4;
+}
+
+.firmware-log--success {
+  border-color: rgba(120, 230, 160, 0.4);
+}
+
+.firmware-log--error {
+  border-color: rgba(255, 120, 120, 0.4);
+}
+
+.firmware-log__line {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.firmware-log__line--error {
+  color: #ff9b9b;
+}
+
+.firmware-log__line--done {
+  font-weight: 600;
+}
+
+.firmware-modal__footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.6rem;
+  padding: 0.85rem 1.1rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}

--- a/src/renderer/src/components/FirmwareFlasher.tsx
+++ b/src/renderer/src/components/FirmwareFlasher.tsx
@@ -1,0 +1,376 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type {
+  BoardCandidate,
+  BoardType,
+  EsptoolInfo,
+  FlashProgress
+} from '../../../preload/index.d'
+import './FirmwareFlasher.css'
+
+interface FirmwareFlasherProps {
+  /** Close the modal (ignored while a flash is in progress). */
+  onClose: () => void
+}
+
+const BOARD_LABELS: Record<BoardType, string> = {
+  esp32: 'ESP32 (esptool)',
+  esp8266: 'ESP8266 (esptool)',
+  rp2040: 'RP2040 / Pico (UF2)'
+}
+
+/** Default ESP offsets shown in the UI; user can override per board. */
+const DEFAULT_OFFSET: Record<BoardType, string> = {
+  esp32: '0x1000',
+  esp8266: '0x0',
+  rp2040: ''
+}
+
+/**
+ * FIRMWARE FLASHER MODAL (issue #14).
+ *
+ * Lets the user flash MicroPython firmware to a device without leaving Snakie:
+ *  - auto-detects board candidates (serial VID/PID for ESP, RPI-RP2 UF2 drive),
+ *  - picks the firmware file (`.bin` for ESP, `.uf2` for RP2040),
+ *  - flashes via esptool (ESP) or a UF2 copy (RP2040), and
+ *  - streams a live log with clear success / error states.
+ *
+ * All heavy lifting happens in the main process via `window.api.firmware`; this
+ * component is purely presentational state + orchestration.
+ */
+export function FirmwareFlasher({ onClose }: FirmwareFlasherProps): JSX.Element {
+  const [candidates, setCandidates] = useState<BoardCandidate[]>([])
+  const [board, setBoard] = useState<BoardType>('esp32')
+  const [port, setPort] = useState<string>('')
+  const [mountPath, setMountPath] = useState<string>('')
+  const [offset, setOffset] = useState<string>(DEFAULT_OFFSET.esp32)
+  const [firmwarePath, setFirmwarePath] = useState<string>('')
+  const [esptool, setEsptool] = useState<EsptoolInfo | null>(null)
+  const [log, setLog] = useState<FlashProgress[]>([])
+  const [flashing, setFlashing] = useState(false)
+  const [outcome, setOutcome] = useState<'idle' | 'success' | 'error'>('idle')
+  const logRef = useRef<HTMLDivElement>(null)
+
+  const isEsp = board === 'esp32' || board === 'esp8266'
+
+  // Subscribe to streamed progress for the lifetime of the modal.
+  useEffect(() => {
+    const unsubscribe = window.api.firmware.onProgress((p) => {
+      setLog((prev) => [...prev, p])
+      if (p.kind === 'done') {
+        setFlashing(false)
+        setOutcome(p.ok ? 'success' : 'error')
+      }
+    })
+    return unsubscribe
+  }, [])
+
+  // Auto-scroll the log to the latest line.
+  useEffect(() => {
+    const el = logRef.current
+    if (el) el.scrollTop = el.scrollHeight
+  }, [log])
+
+  const refreshDetection = useCallback(async (): Promise<void> => {
+    try {
+      const [found, tool] = await Promise.all([
+        window.api.firmware.detectBoards(),
+        window.api.firmware.checkEsptool()
+      ])
+      setCandidates(found)
+      setEsptool(tool)
+      // Adopt the first detected candidate as a sensible default.
+      const first = found[0]
+      if (first) {
+        setBoard(first.board)
+        setOffset(DEFAULT_OFFSET[first.board])
+        if (first.port) setPort(first.port)
+        if (first.mountPath) setMountPath(first.mountPath)
+      }
+    } catch {
+      // Detection is best-effort; leave manual selection available.
+    }
+  }, [])
+
+  useEffect(() => {
+    void refreshDetection()
+  }, [refreshDetection])
+
+  const handleBoardChange = useCallback((next: BoardType): void => {
+    setBoard(next)
+    setOffset(DEFAULT_OFFSET[next])
+  }, [])
+
+  const handlePickFile = useCallback(async (): Promise<void> => {
+    try {
+      const picked = await window.api.firmware.pickFirmwareFile()
+      if (picked) setFirmwarePath(picked)
+    } catch {
+      // Cancelled / unavailable — keep the current selection.
+    }
+  }, [])
+
+  const serialCandidates = candidates.filter((c) => c.source === 'serial')
+  const uf2Candidates = candidates.filter((c) => c.source === 'uf2-drive')
+
+  const canFlash =
+    !flashing &&
+    firmwarePath.length > 0 &&
+    (isEsp ? port.length > 0 : mountPath.length > 0) &&
+    (!isEsp || esptool?.available === true)
+
+  const handleFlash = useCallback(async (): Promise<void> => {
+    setLog([])
+    setOutcome('idle')
+    setFlashing(true)
+    try {
+      await window.api.firmware.flash({
+        board,
+        firmwarePath,
+        port: isEsp ? port : undefined,
+        mountPath: isEsp ? undefined : mountPath,
+        offset: isEsp ? offset : undefined
+      })
+      // The terminal `done` progress event drives `flashing` / `outcome`.
+    } catch (err) {
+      setLog((prev) => [
+        ...prev,
+        { kind: 'error', message: err instanceof Error ? err.message : String(err) }
+      ])
+      setFlashing(false)
+      setOutcome('error')
+    }
+  }, [board, firmwarePath, isEsp, port, mountPath, offset])
+
+  return (
+    <div
+      className="firmware-overlay"
+      role="presentation"
+      onClick={() => {
+        if (!flashing) onClose()
+      }}
+    >
+      <div
+        className="firmware-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Flash MicroPython firmware"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="firmware-modal__header">
+          <h2 className="firmware-modal__title">Flash MicroPython firmware</h2>
+          <button
+            type="button"
+            className="firmware-modal__close"
+            aria-label="Close"
+            onClick={onClose}
+            disabled={flashing}
+          >
+            ✕
+          </button>
+        </header>
+
+        <div className="firmware-modal__body">
+          <div className="firmware-field">
+            <label className="firmware-field__label" htmlFor="firmware-board">
+              Board type
+            </label>
+            <div className="firmware-field__row">
+              <select
+                id="firmware-board"
+                className="firmware-select"
+                value={board}
+                disabled={flashing}
+                onChange={(e) => handleBoardChange(e.target.value as BoardType)}
+              >
+                {(Object.keys(BOARD_LABELS) as BoardType[]).map((b) => (
+                  <option key={b} value={b}>
+                    {BOARD_LABELS[b]}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                className="btn btn--ghost btn--sm"
+                onClick={() => void refreshDetection()}
+                disabled={flashing}
+                title="Re-scan for connected boards"
+              >
+                ⟳ Detect
+              </button>
+            </div>
+            {candidates.length > 0 && (
+              <p className="firmware-hint">
+                Detected: {candidates.map((c) => c.label).join('; ')}
+              </p>
+            )}
+          </div>
+
+          {isEsp ? (
+            <>
+              <div className="firmware-field">
+                <label className="firmware-field__label" htmlFor="firmware-port">
+                  Serial port
+                </label>
+                <select
+                  id="firmware-port"
+                  className="firmware-select"
+                  value={port}
+                  disabled={flashing}
+                  onChange={(e) => setPort(e.target.value)}
+                >
+                  <option value="">Select a port…</option>
+                  {serialCandidates.map((c) => (
+                    <option key={c.port} value={c.port}>
+                      {c.label}
+                    </option>
+                  ))}
+                  {port && !serialCandidates.some((c) => c.port === port) && (
+                    <option value={port}>{port}</option>
+                  )}
+                </select>
+              </div>
+
+              <div className="firmware-field">
+                <label className="firmware-field__label" htmlFor="firmware-offset">
+                  Flash offset
+                </label>
+                <input
+                  id="firmware-offset"
+                  className="firmware-input"
+                  type="text"
+                  value={offset}
+                  disabled={flashing}
+                  onChange={(e) => setOffset(e.target.value)}
+                  placeholder="0x1000"
+                />
+              </div>
+
+              {esptool && !esptool.available && (
+                <p className="firmware-banner firmware-banner--warn">
+                  esptool was not found on PATH. Install it with{' '}
+                  <code>pip install esptool</code> (or <code>pipx install esptool</code>) to flash
+                  ESP boards. Snakie does not bundle esptool.
+                </p>
+              )}
+              {esptool?.available && (
+                <p className="firmware-hint">
+                  esptool found{esptool.version ? `: ${esptool.version}` : ''}.
+                </p>
+              )}
+            </>
+          ) : (
+            <div className="firmware-field">
+              <label className="firmware-field__label" htmlFor="firmware-mount">
+                RP2040 boot drive (RPI-RP2)
+              </label>
+              <div className="firmware-field__row">
+                <select
+                  id="firmware-mount"
+                  className="firmware-select"
+                  value={mountPath}
+                  disabled={flashing}
+                  onChange={(e) => setMountPath(e.target.value)}
+                >
+                  <option value="">Select a boot drive…</option>
+                  {uf2Candidates.map((c) => (
+                    <option key={c.mountPath} value={c.mountPath}>
+                      {c.label}
+                    </option>
+                  ))}
+                  {mountPath && !uf2Candidates.some((c) => c.mountPath === mountPath) && (
+                    <option value={mountPath}>{mountPath}</option>
+                  )}
+                </select>
+              </div>
+              {uf2Candidates.length === 0 && (
+                <p className="firmware-hint">
+                  No RPI-RP2 drive detected. Hold BOOTSEL while plugging the board in, then press
+                  Detect.
+                </p>
+              )}
+            </div>
+          )}
+
+          <div className="firmware-field">
+            <label className="firmware-field__label">Firmware file</label>
+            <div className="firmware-field__row">
+              <input
+                className="firmware-input firmware-input--grow"
+                type="text"
+                readOnly
+                value={firmwarePath}
+                placeholder={isEsp ? 'Choose a .bin file…' : 'Choose a .uf2 file…'}
+              />
+              <button
+                type="button"
+                className="btn btn--ghost btn--sm"
+                onClick={() => void handlePickFile()}
+                disabled={flashing}
+              >
+                Browse…
+              </button>
+            </div>
+          </div>
+
+          {(log.length > 0 || flashing) && (
+            <div
+              className={`firmware-log firmware-log--${outcome}`}
+              ref={logRef}
+              role="log"
+              aria-live="polite"
+            >
+              {log.map((line, i) => (
+                <div
+                  key={i}
+                  className={`firmware-log__line firmware-log__line--${line.kind}`}
+                >
+                  {line.message}
+                </div>
+              ))}
+              {flashing && <div className="firmware-log__line">Flashing…</div>}
+            </div>
+          )}
+
+          {outcome === 'success' && (
+            <p className="firmware-banner firmware-banner--success">Firmware flashed successfully.</p>
+          )}
+          {outcome === 'error' && (
+            <p className="firmware-banner firmware-banner--error">
+              Flashing failed. Check the log above.
+            </p>
+          )}
+        </div>
+
+        <footer className="firmware-modal__footer">
+          <button
+            type="button"
+            className="btn btn--ghost"
+            onClick={onClose}
+            disabled={flashing}
+          >
+            Close
+          </button>
+          <button
+            type="button"
+            className="btn btn--primary btn--lg"
+            onClick={() => void handleFlash()}
+            disabled={!canFlash}
+            title={
+              !firmwarePath
+                ? 'Choose a firmware file first'
+                : isEsp && !port
+                  ? 'Select a serial port'
+                  : !isEsp && !mountPath
+                    ? 'Select the RP2040 boot drive'
+                    : isEsp && esptool?.available !== true
+                      ? 'esptool is required to flash ESP boards'
+                      : 'Flash the firmware to the device'
+            }
+          >
+            {flashing ? 'Flashing…' : 'Flash'}
+          </button>
+        </footer>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -1,7 +1,8 @@
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 import { Theme } from '../hooks/useTheme'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { useWorkspace } from '../store/workspace'
+import { FirmwareFlasher } from './FirmwareFlasher'
 import './RunControls.css'
 
 interface ToolbarProps {
@@ -38,6 +39,7 @@ export function Toolbar({
   onToggleRight
 }: ToolbarProps): JSX.Element {
   const status = useDeviceStatus()
+  const [flasherOpen, setFlasherOpen] = useState(false)
   const { openFiles, activeId } = useWorkspace()
   const connected = status.state === 'connected'
   const activeFile = openFiles.find((f) => f.id === activeId)
@@ -104,6 +106,18 @@ export function Toolbar({
           </span>
           <span>Stop</span>
         </button>
+        <button
+          type="button"
+          className="btn btn--ghost btn--lg"
+          onClick={() => setFlasherOpen(true)}
+          title="Flash MicroPython firmware to the device (ESP via esptool, RP2040 via UF2)"
+          aria-label="Flash MicroPython firmware"
+        >
+          <span className="btn__glyph" aria-hidden="true">
+            ⚡
+          </span>
+          <span>Flash firmware</span>
+        </button>
       </div>
 
       <div className="toolbar__group">
@@ -157,6 +171,8 @@ export function Toolbar({
           {theme === 'dark' ? '☀' : '☾'}
         </button>
       </div>
+
+      {flasherOpen && <FirmwareFlasher onClose={() => setFlasherOpen(false)} />}
     </header>
   )
 }


### PR DESCRIPTION
Implements in-app MicroPython firmware flashing (issue #14), driven by the `docs/feedback.md` request to upgrade firmware without a separate app.

## What's included

**Main process — `src/main/firmware/`**
- `detect.ts` — best-effort board detection: serial VID/PID matching for common ESP USB-serial bridges (CP210x, CH340/341, FT232, Espressif native USB) and RPI-RP2 UF2 boot-drive scanning across platform mount points. Returns ranked candidates; the user confirms/overrides.
- `flasher.ts`
  - **ESP (esp32/esp8266):** shells out to external `esptool` via `child_process.spawn` — `--port <port> --baud 460800 write_flash <offset> <firmware>` (default offset esp32 `0x1000`, esp8266 `0x0`, configurable). Probes for esptool and surfaces a clear "install esptool" message if missing. Not bundled.
  - **RP2040 (UF2):** copies the selected `.uf2` onto the mounted boot drive using Node `fs`, streaming copy progress.
  - Streams log lines via an injected `emit` callback.
- `ipc.ts` — `firmware:*` handlers (`detect`, `esptool`, `pickFile`, `flash`) returning the serializable `IpcResult`, a `firmware:progress` push channel, and an Electron `.bin`/`.uf2` file picker.

**Preload (localized)** — new `firmware` namespace: `detectBoards()`, `checkEsptool()`, `pickFirmwareFile()`, `flash(opts)`, `onProgress(cb)→unsub`; types re-exported in `index.d.ts`.

**UI** — `FirmwareFlasher.tsx` modal + co-located CSS: auto-detected board default, port / UF2-drive / offset selection, firmware file picker, live progress/log area with clear success/error states. Triggered by a big "Flash firmware" button in `Toolbar.tsx`.

## Checklist
- [x] Main-process `firmware/` module + IPC
- [x] Board/chip detection (ESP VID/PID + RPI-RP2 UF2 drive)
- [x] ESP flashing via esptool (configurable offset; missing-tool messaging; not bundled)
- [x] RP2040 UF2 copy flashing
- [x] File picker (Electron dialog) for `.bin`/`.uf2`
- [x] `firmware:progress` streaming + success/failure result
- [x] `window.api.firmware` (localized preload edit)
- [x] `FirmwareFlasher.tsx` modal + Toolbar button
- [x] `npm install && npm run lint && npm run typecheck && npm run build` all pass

## Caveats
- **Hardware untested** — built headless with no board attached and esptool absent. The code degrades gracefully (clear messaging) rather than crashing in these conditions, but the actual flash paths have not been exercised against real hardware.

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)