### PR TITLE
Integrated LLM chat pane (Claude)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.100.1",
         "@electron-toolkit/preload": "^3.0.1",
         "@electron-toolkit/utils": "^3.0.0",
         "@xterm/addon-fit": "^0.11.0",
@@ -39,6 +40,26 @@
         "prettier": "^3.4.2",
         "typescript": "^5.6.3",
         "vite": "^5.4.11"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.100.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.100.1.tgz",
+      "integrity": "sha512-RANcEe7LpiLczkKGOwoXOTuFdPhuubS0i4xaAKOMpcqc55YO0mukgxppV7eygx3DXNjxWT6RYOLPyOy0aIAmwg==",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -290,6 +311,14 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1967,6 +1996,11 @@
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
@@ -4713,6 +4747,11 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -6025,6 +6064,18 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -7730,6 +7781,15 @@
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "optional": true
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/stat-mode": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
@@ -8091,6 +8151,11 @@
       "dependencies": {
         "utf8-byte-length": "^1.0.1"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="
     },
     "node_modules/ts-api-utils": {
       "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dist:linux": "electron-vite build && electron-builder --linux"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.100.1",
     "@electron-toolkit/preload": "^3.0.1",
     "@electron-toolkit/utils": "^3.0.0",
     "@xterm/addon-fit": "^0.11.0",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import { registerDeviceIpc, disposeDevice } from './device/ipc'
 import { registerFsIpc } from './fs/ipc'
+import { registerLlmIpc } from './llm/ipc'
 import { registerUpdater } from './updater'
 
 /** The single application window, used to route device push-events. */
@@ -72,6 +73,10 @@ app.whenReady().then(() => {
   // Register the auto-update layer. No-ops cleanly in dev (unpackaged); when
   // packaged it checks GitHub Releases and pushes status to the live window.
   registerUpdater(() => mainWindow?.webContents)
+
+  // Register the LLM (Claude) chat layer. All Anthropic API calls happen in the
+  // main process; deltas stream back to whichever window is currently live.
+  registerLlmIpc(() => mainWindow?.webContents)
 
   createWindow()
 

--- a/src/main/llm/client.ts
+++ b/src/main/llm/client.ts
@@ -1,0 +1,101 @@
+/**
+ * Thin wrapper around the official Anthropic SDK for the in-app Claude chat.
+ *
+ * All Anthropic API calls happen HERE, in the main process — the renderer's CSP
+ * blocks direct external requests, so the renderer talks to this module over
+ * IPC and never sees the API key or the network call.
+ *
+ * Design choices (see issue #18):
+ *  - SDK: `@anthropic-ai/sdk` (preferred over hand-rolled fetch).
+ *  - Default model: `claude-sonnet-4-6`, overridable per request.
+ *  - Streaming: yes — we stream text deltas back so the UI feels responsive.
+ *  - Prompt caching: a `cache_control` breakpoint is placed on the (stable)
+ *    system prompt and, when present, on the large active-file context block,
+ *    so repeated turns in a conversation re-use the cached prefix.
+ */
+import Anthropic from '@anthropic-ai/sdk'
+import type { LlmMessage } from './types'
+
+/** Default Claude model. Configurable per request via {@link StreamArgs.model}. */
+export const DEFAULT_MODEL = 'claude-sonnet-4-6'
+
+/** Upper bound on streamed output tokens. */
+const MAX_TOKENS = 4096
+
+/** The frozen system prompt — kept byte-stable so it caches across requests. */
+const SYSTEM_PROMPT =
+  'You are a helpful coding assistant embedded in Snakie, a MicroPython editor ' +
+  'for microcontroller boards (Raspberry Pi Pico, ESP32, etc.). Help the user ' +
+  'write, debug, and understand MicroPython code. Prefer MicroPython-compatible ' +
+  'APIs (the `machine`, `time`, `network` modules and friends) over full CPython ' +
+  'libraries that are unavailable on-device. Be concise, and when you show code ' +
+  'use fenced code blocks with a language tag.'
+
+export interface StreamArgs {
+  apiKey: string
+  messages: LlmMessage[]
+  activeFile?: { name: string; content: string }
+  model?: string
+  /** Called with each text delta as it streams in. */
+  onDelta: (text: string) => void
+  /** Optional abort signal to cancel the request. */
+  signal?: AbortSignal
+}
+
+/**
+ * Build the system prompt blocks. When an active file is attached it becomes a
+ * second block after the instructions; both carry a cache breakpoint so the
+ * whole prefix is reused while the file and instructions are unchanged.
+ */
+function buildSystem(activeFile?: { name: string; content: string }): Anthropic.TextBlockParam[] {
+  const blocks: Anthropic.TextBlockParam[] = [
+    { type: 'text', text: SYSTEM_PROMPT, cache_control: { type: 'ephemeral' } }
+  ]
+  if (activeFile && activeFile.content.trim()) {
+    blocks.push({
+      type: 'text',
+      text:
+        `The user is currently editing a file named "${activeFile.name}". ` +
+        `Here are its full contents for context:\n\n` +
+        '```python\n' +
+        activeFile.content +
+        '\n```',
+      cache_control: { type: 'ephemeral' }
+    })
+  }
+  return blocks
+}
+
+/**
+ * Stream a Claude completion, invoking `onDelta` for each text chunk. Resolves
+ * with the full assembled text once the stream ends. Throws on API errors
+ * (the IPC layer translates these into a serializable error result).
+ */
+export async function streamChat(args: StreamArgs): Promise<string> {
+  const { apiKey, messages, activeFile, model, onDelta, signal } = args
+  const client = new Anthropic({ apiKey })
+
+  const apiMessages: Anthropic.MessageParam[] = messages.map((m) => ({
+    role: m.role,
+    content: m.content
+  }))
+
+  let full = ''
+  const stream = client.messages.stream(
+    {
+      model: model ?? DEFAULT_MODEL,
+      max_tokens: MAX_TOKENS,
+      system: buildSystem(activeFile),
+      messages: apiMessages
+    },
+    { signal }
+  )
+
+  stream.on('text', (delta) => {
+    full += delta
+    onDelta(delta)
+  })
+
+  await stream.finalMessage()
+  return full
+}

--- a/src/main/llm/ipc.ts
+++ b/src/main/llm/ipc.ts
@@ -1,0 +1,94 @@
+/**
+ * IPC handlers for the LLM (Claude) chat layer.
+ *
+ * Renderer-facing channels (all under `llm:`):
+ *   - `llm:getKeyStatus`  → {@link LlmKeyStatus}
+ *   - `llm:setKey`        → store/clear the Anthropic API key
+ *   - `llm:sendMessage`   → run a streaming completion; the assembled reply is
+ *                           returned, and deltas are pushed on `llm:stream`.
+ *
+ * Push channel:
+ *   - `llm:stream`        → {@link LlmStreamEvent} chunks for the active request.
+ *
+ * Errors cross IPC as the same serializable {@link IpcResult} shape used by the
+ * device/fs layers. The API key never appears in a log line or an error message.
+ */
+import { ipcMain, type WebContents } from 'electron'
+import type { IpcResult } from '../device/types'
+import { streamChat } from './client'
+import { getKey, hasKey, isEncryptionAvailable, setKey } from './keyStore'
+import type { LlmKeyStatus, LlmSendRequest, LlmStreamEvent } from './types'
+
+/** IPC channel names for the LLM layer. */
+export const LLM_CHANNELS = {
+  stream: 'llm:stream',
+  getKeyStatus: 'llm:getKeyStatus',
+  setKey: 'llm:setKey',
+  sendMessage: 'llm:sendMessage'
+} as const
+
+/** Monotonic id so the renderer can correlate stream events with a request. */
+let requestCounter = 0
+
+/**
+ * Wrap an async operation so any thrown error crosses IPC as a serializable
+ * {@link IpcResult}. Mirrors the device/fs layers.
+ */
+async function wrap<T>(fn: () => Promise<T>): Promise<IpcResult<T>> {
+  try {
+    return { ok: true, value: await fn() }
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+/**
+ * Register all `llm:*` IPC handlers. Call once from the main process after the
+ * window exists.
+ *
+ * @param getWebContents resolver for the target renderer (so we never capture a
+ *   destroyed window after a reload).
+ */
+export function registerLlmIpc(getWebContents: () => WebContents | undefined): void {
+  const push = (event: LlmStreamEvent): void => {
+    const wc = getWebContents()
+    if (wc && !wc.isDestroyed()) wc.send(LLM_CHANNELS.stream, event)
+  }
+
+  ipcMain.handle(LLM_CHANNELS.getKeyStatus, () =>
+    wrap(
+      async (): Promise<LlmKeyStatus> => ({
+        hasKey: await hasKey(),
+        secure: isEncryptionAvailable()
+      })
+    )
+  )
+
+  ipcMain.handle(LLM_CHANNELS.setKey, (_e, key: string) => wrap(() => setKey(key)))
+
+  ipcMain.handle(LLM_CHANNELS.sendMessage, (_e, req: LlmSendRequest) =>
+    wrap(async (): Promise<string> => {
+      const apiKey = await getKey()
+      if (!apiKey) {
+        throw new Error('No Anthropic API key set. Add your key in the chat settings.')
+      }
+      const requestId = `req-${++requestCounter}`
+      push({ type: 'start', requestId })
+      try {
+        const full = await streamChat({
+          apiKey,
+          messages: req.messages,
+          activeFile: req.activeFile,
+          model: req.model,
+          onDelta: (text) => push({ type: 'delta', requestId, text })
+        })
+        push({ type: 'done', requestId })
+        return full
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        push({ type: 'error', requestId, message })
+        throw err
+      }
+    })
+  )
+}

--- a/src/main/llm/keyStore.ts
+++ b/src/main/llm/keyStore.ts
@@ -1,0 +1,92 @@
+/**
+ * Secure storage for the user's Anthropic API key.
+ *
+ * The key is encrypted with Electron `safeStorage` (which uses the OS keychain /
+ * credential store where available) and persisted to a file under the app's
+ * `userData` directory. The plaintext key NEVER touches a log line, and the
+ * on-disk blob is opaque ciphertext on platforms that support encryption.
+ *
+ * On platforms where `safeStorage` reports encryption unavailable (some Linux
+ * setups with no keyring), we fall back to a base64 obfuscation so the app
+ * still works — callers learn this via {@link isEncryptionAvailable} and the UI
+ * surfaces it as a "stored, but not securely encrypted" warning.
+ */
+import { app, safeStorage } from 'electron'
+import { promises as fs } from 'fs'
+import { join } from 'path'
+
+/** Marker prepended to the stored blob to record how it was encoded. */
+const ENC_PREFIX = 'enc:'
+const PLAIN_PREFIX = 'b64:'
+
+/** Absolute path to the key file inside `userData`. */
+function keyFilePath(): string {
+  return join(app.getPath('userData'), 'anthropic-key.bin')
+}
+
+/** Whether OS-backed encryption is available on this platform. */
+export function isEncryptionAvailable(): boolean {
+  try {
+    return safeStorage.isEncryptionAvailable()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Persist `key` to disk, encrypted where possible. An empty/whitespace-only key
+ * clears any stored key instead.
+ */
+export async function setKey(key: string): Promise<void> {
+  const trimmed = key.trim()
+  if (!trimmed) {
+    await clearKey()
+    return
+  }
+  let blob: string
+  if (isEncryptionAvailable()) {
+    blob = ENC_PREFIX + safeStorage.encryptString(trimmed).toString('base64')
+  } else {
+    blob = PLAIN_PREFIX + Buffer.from(trimmed, 'utf8').toString('base64')
+  }
+  await fs.writeFile(keyFilePath(), blob, { encoding: 'utf8', mode: 0o600 })
+}
+
+/** Read and decrypt the stored key, or `null` if none is set. */
+export async function getKey(): Promise<string | null> {
+  let blob: string
+  try {
+    blob = await fs.readFile(keyFilePath(), 'utf8')
+  } catch {
+    return null
+  }
+  try {
+    if (blob.startsWith(ENC_PREFIX)) {
+      const cipher = Buffer.from(blob.slice(ENC_PREFIX.length), 'base64')
+      const value = safeStorage.decryptString(cipher).trim()
+      return value || null
+    }
+    if (blob.startsWith(PLAIN_PREFIX)) {
+      const value = Buffer.from(blob.slice(PLAIN_PREFIX.length), 'base64').toString('utf8').trim()
+      return value || null
+    }
+    return null
+  } catch {
+    // Corrupt or undecryptable (e.g. keyring changed) — treat as no key.
+    return null
+  }
+}
+
+/** True when a non-empty key is stored. */
+export async function hasKey(): Promise<boolean> {
+  return (await getKey()) !== null
+}
+
+/** Remove the stored key file (no-op if absent). */
+export async function clearKey(): Promise<void> {
+  try {
+    await fs.unlink(keyFilePath())
+  } catch {
+    // Already absent — nothing to do.
+  }
+}

--- a/src/main/llm/types.ts
+++ b/src/main/llm/types.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared types for the LLM (Claude) chat layer. These cross the IPC boundary,
+ * so they must be plain, structured-clone-safe data — no class instances.
+ *
+ * Re-exported through the preload `index.d.ts` so the renderer can import them
+ * from the UI-facing surface without reaching into `src/main`.
+ */
+
+/** A single chat turn in the conversation thread. */
+export interface LlmMessage {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+/**
+ * Whether an Anthropic API key is currently stored, plus whether this platform
+ * can encrypt it at rest. When `secure` is false the key is still persisted but
+ * (per Electron `safeStorage`) may be stored in plaintext, so the UI can warn.
+ */
+export interface LlmKeyStatus {
+  /** True when a non-empty key is persisted. */
+  hasKey: boolean
+  /** True when OS-backed encryption is available for storage. */
+  secure: boolean
+}
+
+/** Arguments for a chat completion request. */
+export interface LlmSendRequest {
+  /** The full conversation so far (oldest first). Last entry is the new user turn. */
+  messages: LlmMessage[]
+  /**
+   * When set, the active editor file is attached as cached context so Claude
+   * can reason about the code the user is editing.
+   */
+  activeFile?: { name: string; content: string }
+  /** Override the default model for this request. */
+  model?: string
+}
+
+/** A streamed chunk pushed to the renderer during a streaming completion. */
+export type LlmStreamEvent =
+  | { type: 'start'; requestId: string }
+  | { type: 'delta'; requestId: string; text: string }
+  | { type: 'done'; requestId: string }
+  | { type: 'error'; requestId: string; message: string }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -22,6 +22,10 @@ export type { FsEntry, FsStat } from '../main/fs/types'
 // from the UI-facing preload module rather than reaching into `src/main`.
 export type { UpdateStatus } from '../main/updater'
 
+// Re-export the LLM chat types so the renderer's chat panel can import them
+// from the UI-facing preload module rather than reaching into `src/main`.
+export type { LlmKeyStatus, LlmMessage, LlmSendRequest, LlmStreamEvent } from '../main/llm/types'
+
 declare global {
   interface Window {
     electron: ElectronAPI

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -11,6 +11,7 @@ import type {
 } from '../main/device/types'
 import type { FsEntry, FsStat } from '../main/fs/types'
 import type { UpdateStatus } from '../main/updater'
+import type { LlmKeyStatus, LlmSendRequest, LlmStreamEvent } from '../main/llm/types'
 
 /**
  * Unwrap an {@link IpcResult} into a resolved value or a thrown Error, so the
@@ -130,6 +131,32 @@ const updates = {
   }
 }
 
+/**
+ * LLM (Claude) chat API. Mirrors the main-process `llm:*` IPC handlers and
+ * unwraps their typed results. All Anthropic API calls run in the main process
+ * (the renderer CSP blocks external requests), so the renderer never sees the
+ * API key. `onStream` subscribes to streamed completion chunks and returns an
+ * unsubscribe function.
+ */
+const llm = {
+  /** Whether an API key is stored, and whether storage is OS-encrypted. */
+  getKeyStatus: (): Promise<LlmKeyStatus> => unwrap(ipcRenderer.invoke('llm:getKeyStatus')),
+  /** Store (or, with an empty string, clear) the Anthropic API key. */
+  setKey: (key: string): Promise<void> => unwrap(ipcRenderer.invoke('llm:setKey', key)),
+  /**
+   * Run a streaming chat completion. Deltas arrive via `onStream`; this resolves
+   * with the full assembled assistant reply once the stream ends.
+   */
+  sendMessage: (req: LlmSendRequest): Promise<string> =>
+    unwrap(ipcRenderer.invoke('llm:sendMessage', req)),
+  /** Subscribe to streamed completion chunks. Returns an unsubscribe function. */
+  onStream: (cb: (event: LlmStreamEvent) => void): (() => void) => {
+    const listener = (_e: IpcRendererEvent, event: LlmStreamEvent): void => cb(event)
+    ipcRenderer.on('llm:stream', listener)
+    return () => ipcRenderer.removeListener('llm:stream', listener)
+  }
+}
+
 // Minimal, typed API exposed to the renderer. This establishes the IPC
 // pattern that later feature work will extend.
 const api = {
@@ -142,7 +169,9 @@ const api = {
   /** Local host filesystem layer. */
   fs,
   /** Auto-update check + status + restart layer. */
-  updates
+  updates,
+  /** LLM (Claude) chat layer. */
+  llm
 }
 
 // Use `contextBridge` APIs to expose Electron APIs to the renderer only if

--- a/src/renderer/src/components/ChatPanel.css
+++ b/src/renderer/src/components/ChatPanel.css
@@ -1,0 +1,267 @@
+/*
+ * Styles co-located with ChatPanel (issue #18).
+ *
+ * An in-app Claude chat assistant for the right pane. Uses the shared design
+ * tokens from index.css so it tracks the active light/dark theme.
+ */
+
+.chat {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  font-size: 13px;
+  color: var(--text);
+}
+
+/* Toolbar -------------------------------------------------------------- */
+.chat__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 0.45rem 0.85rem;
+  border-bottom: 1px solid var(--border);
+  flex: 0 0 auto;
+}
+
+.chat__status {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.chat__toolbar-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.chat__btn {
+  padding: 0.2rem 0.6rem;
+  background: var(--bg-sunken);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-size: 0.8rem;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.chat__btn:hover:not(:disabled) {
+  background: var(--bg-elevated);
+}
+
+.chat__btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.chat__btn--primary {
+  background: var(--accent);
+  color: var(--accent-contrast);
+  border-color: var(--accent);
+}
+
+/* Settings (API key) --------------------------------------------------- */
+.chat__settings {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 0.65rem 0.85rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-sunken);
+  flex: 0 0 auto;
+}
+
+.chat__settings-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.chat__input-key {
+  padding: 0.35rem 0.5rem;
+  background: var(--bg-elevated);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.8rem;
+}
+
+.chat__settings-row {
+  display: flex;
+  gap: 6px;
+}
+
+.chat__settings-hint,
+.chat__settings-warn {
+  margin: 0;
+  font-size: 0.74rem;
+  line-height: 1.4;
+  color: var(--text-muted);
+}
+
+.chat__settings-warn {
+  color: var(--danger, #c0392b);
+}
+
+/* Message thread ------------------------------------------------------- */
+.chat__thread {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0.6rem 0.7rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.chat__empty {
+  margin: 0.5rem 0;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.chat__bubble {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.45rem 0.6rem;
+  background: var(--bg-elevated);
+}
+
+.chat__bubble--user {
+  background: var(--bg-sunken);
+}
+
+.chat__bubble-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.25rem;
+}
+
+.chat__bubble-role {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--text-muted);
+}
+
+.chat__bubble-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.chat__text {
+  margin: 0;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.chat__caret {
+  opacity: 0.6;
+  animation: chat-blink 1s steps(2, start) infinite;
+}
+
+@keyframes chat-blink {
+  to {
+    visibility: hidden;
+  }
+}
+
+/* Code blocks ---------------------------------------------------------- */
+.chat__code {
+  position: relative;
+}
+
+.chat__code-pre {
+  margin: 0;
+  padding: 0.55rem 0.65rem;
+  background: var(--bg-sunken);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  overflow-x: auto;
+  white-space: pre;
+}
+
+.chat__copy {
+  padding: 0.05rem 0.4rem;
+  background: var(--bg-sunken);
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 0.7rem;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.chat__copy:hover {
+  background: var(--bg-elevated);
+  color: var(--text);
+}
+
+.chat__code-copy {
+  position: absolute;
+  top: 0.3rem;
+  right: 0.3rem;
+  background: var(--bg-elevated);
+}
+
+/* Error + composer ----------------------------------------------------- */
+.chat__error {
+  margin: 0;
+  padding: 0.45rem 0.85rem;
+  color: var(--danger, #c0392b);
+  background: var(--bg-sunken);
+  font-size: 0.78rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  flex: 0 0 auto;
+}
+
+.chat__composer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.55rem 0.7rem 0.7rem;
+  border-top: 1px solid var(--border);
+  flex: 0 0 auto;
+}
+
+.chat__include {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.76rem;
+  color: var(--text-muted);
+}
+
+.chat__composer-row {
+  display: flex;
+  gap: 6px;
+  align-items: flex-end;
+}
+
+.chat__input {
+  flex: 1 1 auto;
+  resize: vertical;
+  min-height: 2.2rem;
+  padding: 0.4rem 0.5rem;
+  background: var(--bg-elevated);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-family: inherit;
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.chat__send {
+  flex: 0 0 auto;
+  align-self: stretch;
+}

--- a/src/renderer/src/components/ChatPanel.tsx
+++ b/src/renderer/src/components/ChatPanel.tsx
@@ -1,0 +1,362 @@
+import { FormEvent, useCallback, useEffect, useRef, useState } from 'react'
+import type { LlmKeyStatus, LlmMessage, LlmStreamEvent } from '../../../preload/index.d'
+import { useWorkspace } from '../store/workspace'
+import './ChatPanel.css'
+
+/**
+ * CHAT TAB (issue #18)
+ * ====================
+ *
+ * An in-app Claude chat assistant. The message thread, an input box, a settings
+ * affordance for the Anthropic API key, and a toggle to attach the active
+ * editor file as context.
+ *
+ * All Anthropic API calls run in the MAIN process (the renderer CSP blocks
+ * external requests), so this panel only talks to `window.api.llm`. Replies are
+ * streamed: `sendMessage` resolves with the full text, but we also subscribe to
+ * `onStream` deltas so the assistant bubble fills in live.
+ *
+ * If no API key is stored, the panel prompts for one rather than crashing.
+ */
+
+interface ChatTurn extends LlmMessage {
+  /** Stable key for React lists. */
+  id: string
+}
+
+export function ChatPanel(): JSX.Element {
+  const { openFiles, activeId } = useWorkspace()
+  const activeFile = openFiles.find((f) => f.id === activeId)
+
+  const [keyStatus, setKeyStatus] = useState<LlmKeyStatus | null>(null)
+  const [showSettings, setShowSettings] = useState(false)
+  const [keyInput, setKeyInput] = useState('')
+  const [savingKey, setSavingKey] = useState(false)
+
+  const [turns, setTurns] = useState<ChatTurn[]>([])
+  const [input, setInput] = useState('')
+  const [includeFile, setIncludeFile] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  /** Live-streaming assistant text for the in-flight reply. */
+  const [streaming, setStreaming] = useState<string | null>(null)
+
+  const threadRef = useRef<HTMLDivElement>(null)
+  const streamingRef = useRef('')
+
+  // Load whether a key is configured on mount.
+  const refreshKeyStatus = useCallback(async (): Promise<void> => {
+    try {
+      const status = await window.api.llm.getKeyStatus()
+      setKeyStatus(status)
+      // Open settings automatically the first time if no key is set.
+      if (!status.hasKey) setShowSettings(true)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }, [])
+
+  useEffect(() => {
+    void refreshKeyStatus()
+  }, [refreshKeyStatus])
+
+  // Subscribe to streamed deltas for the in-flight request.
+  useEffect(() => {
+    const unsub = window.api.llm.onStream((event: LlmStreamEvent) => {
+      if (event.type === 'start') {
+        streamingRef.current = ''
+        setStreaming('')
+      } else if (event.type === 'delta') {
+        streamingRef.current += event.text
+        setStreaming(streamingRef.current)
+      }
+      // `done` / `error` are handled by the sendMessage promise below.
+    })
+    return unsub
+  }, [])
+
+  // Keep the thread scrolled to the bottom as content grows.
+  useEffect(() => {
+    const el = threadRef.current
+    if (el) el.scrollTop = el.scrollHeight
+  }, [turns, streaming])
+
+  const saveKey = useCallback(
+    async (e: FormEvent): Promise<void> => {
+      e.preventDefault()
+      setSavingKey(true)
+      setError(null)
+      try {
+        await window.api.llm.setKey(keyInput)
+        setKeyInput('')
+        await refreshKeyStatus()
+        setShowSettings(false)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err))
+      } finally {
+        setSavingKey(false)
+      }
+    },
+    [keyInput, refreshKeyStatus]
+  )
+
+  const send = useCallback(
+    async (e: FormEvent): Promise<void> => {
+      e.preventDefault()
+      const text = input.trim()
+      if (!text || busy) return
+      setError(null)
+
+      const userTurn: ChatTurn = { id: `u-${Date.now()}`, role: 'user', content: text }
+      const history = [...turns, userTurn]
+      setTurns(history)
+      setInput('')
+      setBusy(true)
+      setStreaming('')
+      streamingRef.current = ''
+
+      try {
+        const reply = await window.api.llm.sendMessage({
+          messages: history.map((t) => ({ role: t.role, content: t.content })),
+          activeFile:
+            includeFile && activeFile
+              ? { name: activeFile.name, content: activeFile.content }
+              : undefined
+        })
+        setTurns((prev) => [...prev, { id: `a-${Date.now()}`, role: 'assistant', content: reply }])
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err))
+      } finally {
+        setBusy(false)
+        setStreaming(null)
+        streamingRef.current = ''
+      }
+    },
+    [input, busy, turns, includeFile, activeFile]
+  )
+
+  const clearThread = useCallback((): void => {
+    setTurns([])
+    setError(null)
+    setStreaming(null)
+  }, [])
+
+  return (
+    <div className="chat">
+      <div className="chat__toolbar">
+        <span className="chat__status">
+          {keyStatus?.hasKey ? 'Claude ready' : 'No API key'}
+        </span>
+        <div className="chat__toolbar-actions">
+          <button
+            type="button"
+            className="chat__btn"
+            onClick={clearThread}
+            disabled={turns.length === 0 || busy}
+          >
+            Clear
+          </button>
+          <button
+            type="button"
+            className="chat__btn"
+            onClick={() => setShowSettings((s) => !s)}
+            aria-expanded={showSettings}
+          >
+            ⚙ Key
+          </button>
+        </div>
+      </div>
+
+      {showSettings && (
+        <form className="chat__settings" onSubmit={saveKey}>
+          <label className="chat__settings-label" htmlFor="chat-key">
+            Anthropic API key
+          </label>
+          <input
+            id="chat-key"
+            type="password"
+            className="chat__input-key"
+            placeholder={keyStatus?.hasKey ? '•••••••• (stored)' : 'sk-ant-...'}
+            value={keyInput}
+            onChange={(e) => setKeyInput(e.target.value)}
+            autoComplete="off"
+          />
+          <div className="chat__settings-row">
+            <button type="submit" className="chat__btn chat__btn--primary" disabled={savingKey}>
+              {savingKey ? 'Saving…' : 'Save key'}
+            </button>
+            {keyStatus?.hasKey && (
+              <button
+                type="button"
+                className="chat__btn"
+                onClick={async () => {
+                  await window.api.llm.setKey('')
+                  await refreshKeyStatus()
+                }}
+                disabled={savingKey}
+              >
+                Remove
+              </button>
+            )}
+          </div>
+          {keyStatus && !keyStatus.secure && (
+            <p className="chat__settings-warn">
+              Secure OS encryption is unavailable on this system; the key is stored obfuscated but
+              not encrypted.
+            </p>
+          )}
+          <p className="chat__settings-hint">
+            Your key is stored locally and used only to call the Claude API from this app.
+          </p>
+        </form>
+      )}
+
+      <div className="chat__thread" ref={threadRef}>
+        {turns.length === 0 && !streaming && (
+          <p className="chat__empty">
+            Ask Claude about your MicroPython code. Toggle “Include active file” below to send the
+            current editor file as context.
+          </p>
+        )}
+        {turns.map((t) => (
+          <Bubble key={t.id} role={t.role} content={t.content} />
+        ))}
+        {streaming !== null && <Bubble role="assistant" content={streaming} streaming />}
+      </div>
+
+      {error && <p className="chat__error">{error}</p>}
+
+      <form className="chat__composer" onSubmit={send}>
+        <label className="chat__include">
+          <input
+            type="checkbox"
+            checked={includeFile}
+            onChange={(e) => setIncludeFile(e.target.checked)}
+            disabled={!activeFile}
+          />
+          Include active file{activeFile ? ` (${activeFile.name})` : ''}
+        </label>
+        <div className="chat__composer-row">
+          <textarea
+            className="chat__input"
+            placeholder={keyStatus?.hasKey ? 'Message Claude…' : 'Set an API key to start'}
+            value={input}
+            rows={2}
+            disabled={busy || !keyStatus?.hasKey}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault()
+                void send(e)
+              }
+            }}
+          />
+          <button
+            type="submit"
+            className="chat__btn chat__btn--primary chat__send"
+            disabled={busy || !input.trim() || !keyStatus?.hasKey}
+          >
+            {busy ? '…' : 'Send'}
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+/**
+ * A single chat bubble. Renders text with fenced code blocks broken out into
+ * styled `<pre>` blocks (each with a Copy button); a Copy button also covers the
+ * whole assistant message. Markdown beyond fenced code is rendered as plain text.
+ */
+function Bubble({
+  role,
+  content,
+  streaming
+}: {
+  role: 'user' | 'assistant'
+  content: string
+  streaming?: boolean
+}): JSX.Element {
+  const segments = parseSegments(content)
+  return (
+    <div className={`chat__bubble chat__bubble--${role}`}>
+      <div className="chat__bubble-head">
+        <span className="chat__bubble-role">{role === 'user' ? 'You' : 'Claude'}</span>
+        {role === 'assistant' && content && !streaming && <CopyButton text={content} label="Copy" />}
+      </div>
+      <div className="chat__bubble-body">
+        {segments.map((seg, i) =>
+          seg.type === 'code' ? (
+            <div className="chat__code" key={i}>
+              <CopyButton text={seg.text} label="Copy" className="chat__code-copy" />
+              <pre className="chat__code-pre">{seg.text}</pre>
+            </div>
+          ) : (
+            <p className="chat__text" key={i}>
+              {seg.text}
+              {streaming && i === segments.length - 1 && <span className="chat__caret">▍</span>}
+            </p>
+          )
+        )}
+      </div>
+    </div>
+  )
+}
+
+/** A button that copies `text` to the clipboard, with brief confirmation. */
+function CopyButton({
+  text,
+  label,
+  className
+}: {
+  text: string
+  label: string
+  className?: string
+}): JSX.Element {
+  const [copied, setCopied] = useState(false)
+  return (
+    <button
+      type="button"
+      className={`chat__copy${className ? ` ${className}` : ''}`}
+      onClick={async () => {
+        try {
+          await navigator.clipboard.writeText(text)
+          setCopied(true)
+          setTimeout(() => setCopied(false), 1200)
+        } catch {
+          // Clipboard unavailable — ignore.
+        }
+      }}
+    >
+      {copied ? 'Copied' : label}
+    </button>
+  )
+}
+
+type Segment = { type: 'text' | 'code'; text: string }
+
+/**
+ * Split a message into alternating text and fenced-code segments. Handles
+ * ```lang fences; the optional language tag on the opening fence is dropped.
+ * Empty text segments are omitted.
+ */
+function parseSegments(content: string): Segment[] {
+  const segments: Segment[] = []
+  const fence = /```[^\n]*\n?([\s\S]*?)```/g
+  let last = 0
+  let m: RegExpExecArray | null
+  while ((m = fence.exec(content)) !== null) {
+    if (m.index > last) {
+      const text = content.slice(last, m.index)
+      if (text.trim()) segments.push({ type: 'text', text: text.trim() })
+    }
+    segments.push({ type: 'code', text: m[1].replace(/\n$/, '') })
+    last = fence.lastIndex
+  }
+  if (last < content.length) {
+    const text = content.slice(last)
+    if (text.trim() || segments.length === 0) segments.push({ type: 'text', text: text })
+  }
+  return segments.length > 0 ? segments : [{ type: 'text', text: content }]
+}

--- a/src/renderer/src/components/RightPanel.tsx
+++ b/src/renderer/src/components/RightPanel.tsx
@@ -3,6 +3,7 @@ import { RightPanelTabs, RightPanelTab } from './RightPanelTabs'
 import { HelpPanel } from './HelpPanel'
 import { OutlinePanel } from './OutlinePanel'
 import { VariablesPanel } from './VariablesPanel'
+import { ChatPanel } from './ChatPanel'
 
 /**
  * RIGHT PANE — optional/collapsible region (collapsed by default).
@@ -26,9 +27,10 @@ export function RightPanel(): JSX.Element {
     // Code outline of the active file (issue #16):
     { id: 'outline', title: 'Outline', icon: '☰', content: <OutlinePanel /> },
     // Connected board's variables (issue #16):
-    { id: 'vars', title: 'Variables', icon: '{}', content: <VariablesPanel /> }
+    { id: 'vars', title: 'Variables', icon: '{}', content: <VariablesPanel /> },
+    // Claude chat assistant (issue #18):
+    { id: 'chat', title: 'Chat', icon: '💬', content: <ChatPanel /> }
     // Future tabs register here, e.g.:
-    // { id: 'chat', title: 'Chat', icon: '💬', content: <ChatPanel /> },
     // { id: 'packages', title: 'Packages', icon: '📦', content: <PackagePanel /> },
   ]
 


### PR DESCRIPTION
Adds an integrated Claude chat assistant as a new **Chat** tab in the right pane (issue #18).

## What's included
- [x] **Main process** (`src/main/llm/` + `registerLlmIpc`): calls the Anthropic Messages API via the official `@anthropic-ai/sdk`. Default model `claude-sonnet-4-6` (configurable per request). **Prompt caching** (`cache_control`) applied to the stable system prompt and the optional active-file context block. **Streaming** — text deltas are pushed to the renderer over an event channel.
- [x] **API key storage**: encrypted with Electron `safeStorage` and persisted to a file under `app.getPath('userData')`; base64 fallback when OS encryption is unavailable (surfaced to the UI as a warning). The key is never logged. No key set → the UI prompts for one instead of crashing.
- [x] **IPC** `window.api.llm`: `getKeyStatus()`, `setKey(key)`, `sendMessage({ messages, activeFile?, model? })`, and `onStream(cb)` for the streaming subscription. Preload edits are localized to a new `llm` namespace.
- [x] **UI** `ChatPanel.tsx` (+ co-located CSS): message thread, input box, send; a settings affordance to enter/update/remove the API key; a toggle to include the active editor file as context; live-streaming assistant replies; fenced-code rendering; **Copy** buttons on code blocks and on assistant messages.

## Notes / caveats
- SDK chosen over hand-rolled fetch (skill-preferred). All Anthropic calls run in the main process because the renderer CSP blocks external requests.
- This environment is headless ARM64 with **no API key**, so the live API path could not be exercised. The "set your API key" empty state, encryption fallback, and the full `npm install && npm run lint && npm run typecheck && npm run build` pipeline were all verified green.

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)