### PR TITLE
MicroPython package installer (mip/PyPI) with discovery

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import { registerDeviceIpc, disposeDevice } from './device/ipc'
 import { registerFsIpc } from './fs/ipc'
+import { registerPackagesIpc } from './packages/ipc'
 import { registerUpdater } from './updater'
 
 /** The single application window, used to route device push-events. */
@@ -68,6 +69,11 @@ app.whenReady().then(() => {
   // Register the local filesystem layer. The folder dialog is parented to the
   // live window when one exists.
   registerFsIpc(() => mainWindow ?? undefined)
+
+  // Register the MicroPython package installer layer (issue #20). PyPI search
+  // runs here (main) to satisfy the renderer CSP; installs run `mip` on the
+  // device via the renderer's existing device.exec channel.
+  registerPackagesIpc()
 
   // Register the auto-update layer. No-ops cleanly in dev (unpackaged); when
   // packaged it checks GitHub Releases and pushes status to the live window.

--- a/src/main/packages/install.ts
+++ b/src/main/packages/install.ts
@@ -1,0 +1,88 @@
+import type { InstallOptions } from './types'
+
+/**
+ * Install-snippet builder (issue #20).
+ *
+ * The actual install runs MicroPython's `mip` ON THE DEVICE. The device is only
+ * reachable through the serial layer, which the renderer drives via
+ * `window.api.device.exec`. So rather than reaching into the device from here,
+ * the main process is responsible for the parts that need privilege / network
+ * reasoning — composing a safe `mip` snippet and computing any non-fatal NOTES
+ * (e.g. the `.mpy` caveat) — and hands the snippet back for the renderer to run
+ * over the existing, serialized `device.exec` channel.
+ *
+ * The snippet prints sentinel markers so the renderer can tell success from a
+ * device-side traceback even though `mip` writes progress to stdout.
+ */
+
+export const INSTALL_START = '<<SNAKIE_MIP_START>>'
+export const INSTALL_OK = '<<SNAKIE_MIP_OK>>'
+export const INSTALL_ERR = '<<SNAKIE_MIP_ERR>>'
+
+/** Encode a JS string as a Python string literal (single-quoted, escaped). */
+function pyStr(value: string): string {
+  return "'" + value.replace(/\\/g, '\\\\').replace(/'/g, "\\'") + "'"
+}
+
+/**
+ * Build the keyword-argument list for `mip.install(...)` from the user options.
+ * `mip.install(name, target=None, index=None, version=None)` is the broadly
+ * supported signature; `mpy=` is NOT a parameter, so the `.mpy` request is
+ * handled as a note (see {@link installNotes}) rather than passed through.
+ */
+function buildKwargs(options: InstallOptions): string[] {
+  const kwargs: string[] = []
+  if (options.target && options.target.trim()) {
+    kwargs.push(`target=${pyStr(options.target.trim())}`)
+  }
+  if (options.index && options.index.trim()) {
+    kwargs.push(`index=${pyStr(options.index.trim())}`)
+  }
+  return kwargs
+}
+
+/**
+ * Compose the Python snippet to run on the device for installing `name`.
+ *
+ * `mip.install` itself overwrites existing files by default, so the snippet
+ * works for both the overwrite and non-overwrite cases; the distinction is
+ * carried to the user as a note (see {@link installNotes}). The whole call is
+ * wrapped in try/except so we always emit a definitive OK/ERR sentinel.
+ */
+export function buildInstallSnippet(name: string, options: InstallOptions = {}): string {
+  const args = [pyStr(name), ...buildKwargs(options)].join(', ')
+  return [
+    `print(${pyStr(INSTALL_START)})`,
+    'try:',
+    '    import mip',
+    `    mip.install(${args})`,
+    `    print(${pyStr(INSTALL_OK)})`,
+    'except Exception as __e:',
+    `    print(${pyStr(INSTALL_ERR)}, repr(__e))`
+  ].join('\n')
+}
+
+/**
+ * Non-fatal notes for an install request. These never block the install; they
+ * explain where an advanced option is best-effort or unavailable so the UI can
+ * surface it gracefully (per the feedback in docs/feedback.md).
+ */
+export function installNotes(options: InstallOptions = {}): string[] {
+  const notes: string[] = []
+  if (options.mpy) {
+    notes.push(
+      '.mpy conversion is not available in this build (no bundled mpy-cross). ' +
+        'Packages are installed as source .py; many ports compile to bytecode on import.'
+    )
+  }
+  if (options.overwrite === false) {
+    notes.push(
+      "mip.install replaces existing files by default; this firmware doesn't expose a " +
+        'no-overwrite mode, so existing files may still be replaced.'
+    )
+  }
+  if (options.index && options.index.trim()) {
+    notes.push(`Using custom package index: ${options.index.trim()}`)
+  }
+  return notes
+}

--- a/src/main/packages/ipc.ts
+++ b/src/main/packages/ipc.ts
@@ -1,0 +1,64 @@
+import { ipcMain } from 'electron'
+import type { IpcResult } from '../device/types'
+import { CURATED_PACKAGES } from './registry'
+import { searchPackages } from './search'
+import { buildInstallSnippet, installNotes } from './install'
+import type { InstallOptions, PackageInfo } from './types'
+
+/**
+ * IPC for the MicroPython package installer (issue #20).
+ *
+ * All NETWORK access (PyPI search) happens here in the main process because the
+ * renderer's CSP forbids outbound requests. The actual install runs `mip` ON
+ * THE DEVICE, which is only reachable through the serial layer the renderer
+ * drives via `window.api.device.exec`. So `packages:install` does the
+ * privileged/offline-reasoning part — composing the `mip` snippet and computing
+ * non-fatal NOTES — and returns both for the renderer to run over the existing
+ * serialized device channel. Keeping it this way means we don't reach into the
+ * device singleton from here and don't touch the device IPC module.
+ */
+
+/** Payload returned by `packages:install` for the renderer to execute. */
+export interface InstallPlan {
+  /** Python snippet to run on the device via `device.exec`. */
+  snippet: string
+  /** Non-fatal notes (e.g. the `.mpy` caveat) to surface in the UI. */
+  notes: string[]
+}
+
+/**
+ * Wrap an async operation so any thrown error crosses IPC as a plain,
+ * serializable {@link IpcResult}. Mirrors the device/fs layers' `wrap` helper.
+ */
+async function wrap<T>(fn: () => Promise<T>): Promise<IpcResult<T>> {
+  try {
+    return { ok: true, value: await fn() }
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+/**
+ * Register all `packages:*` IPC handlers. Call once from the main process after
+ * the app is ready. There are no push events to route, so unlike the device
+ * layer this takes no window resolver.
+ */
+export function registerPackagesIpc(): void {
+  // Discovery: the curated starter set (offline-safe). Returned as-is.
+  ipcMain.handle('packages:topPackages', () =>
+    wrap<PackageInfo[]>(async () => CURATED_PACKAGES)
+  )
+
+  // Search: PyPI JSON API + curated matches, brokered here past the CSP.
+  ipcMain.handle('packages:search', (_e, query: string) =>
+    wrap<PackageInfo[]>(() => searchPackages(query ?? ''))
+  )
+
+  // Install: build the device snippet + notes for the renderer to execute.
+  ipcMain.handle('packages:install', (_e, name: string, options?: InstallOptions) =>
+    wrap<InstallPlan>(async () => ({
+      snippet: buildInstallSnippet(name, options ?? {}),
+      notes: installNotes(options ?? {})
+    }))
+  )
+}

--- a/src/main/packages/registry.ts
+++ b/src/main/packages/registry.ts
@@ -1,0 +1,79 @@
+import type { PackageInfo } from './types'
+
+/**
+ * Curated "top packages" discovery list (issue #20).
+ *
+ * The first version ships a static, hand-picked set of popular MicroPython
+ * libraries so the Packages tab is useful even when the network is unavailable
+ * (CI, offline, restricted environments). Each entry uses the name that
+ * MicroPython's `mip` understands — for micropython-lib packages that is the
+ * short name (e.g. `urequests`); for PyPI-distributed libraries it is the
+ * distribution name (e.g. `microdot`).
+ *
+ * This list is intentionally conservative and easy to extend. A future version
+ * could augment/replace it with live PyPI download statistics, but that needs a
+ * network round-trip and is therefore out of scope for the offline-safe
+ * baseline.
+ */
+export const CURATED_PACKAGES: PackageInfo[] = [
+  {
+    name: 'urequests',
+    description: 'Lightweight HTTP requests client (micropython-lib).',
+    source: 'curated'
+  },
+  {
+    name: 'umqtt.simple',
+    description: 'Minimal MQTT client for IoT messaging (micropython-lib).',
+    source: 'curated'
+  },
+  {
+    name: 'umqtt.robust',
+    description: 'MQTT client with automatic reconnection (micropython-lib).',
+    source: 'curated'
+  },
+  {
+    name: 'microdot',
+    description: 'Tiny async web framework for microcontrollers.',
+    source: 'curated'
+  },
+  {
+    name: 'neopixel',
+    description: 'Driver for WS2812 / NeoPixel addressable LEDs.',
+    source: 'curated'
+  },
+  {
+    name: 'ssd1306',
+    description: 'Driver for SSD1306 OLED displays (I2C/SPI).',
+    source: 'curated'
+  },
+  {
+    name: 'bme280',
+    description: 'Driver for Bosch BME280 temperature/humidity/pressure sensors.',
+    source: 'curated'
+  },
+  {
+    name: 'dht',
+    description: 'Driver for DHT11 / DHT22 temperature & humidity sensors.',
+    source: 'curated'
+  },
+  {
+    name: 'logging',
+    description: 'CPython-style logging facility (micropython-lib).',
+    source: 'curated'
+  },
+  {
+    name: 'aioble',
+    description: 'Async Bluetooth Low Energy helper library (micropython-lib).',
+    source: 'curated'
+  },
+  {
+    name: 'datetime',
+    description: 'Subset of CPython datetime for MicroPython (micropython-lib).',
+    source: 'curated'
+  },
+  {
+    name: 'base64',
+    description: 'Base16/64 encodings (micropython-lib).',
+    source: 'curated'
+  }
+]

--- a/src/main/packages/search.ts
+++ b/src/main/packages/search.ts
@@ -1,0 +1,107 @@
+import { CURATED_PACKAGES } from './registry'
+import type { PackageInfo } from './types'
+
+/**
+ * Package search (issue #20).
+ *
+ * All network access lives in the MAIN process — the renderer's CSP forbids
+ * outbound requests, so search must be brokered here. We use PyPI's JSON API
+ * (`https://pypi.org/pypi/<name>/json`), which is a stable, key-free, CORS-free
+ * endpoint and returns a package's metadata. PyPI has no public free-text
+ * search JSON API, so the strategy is:
+ *
+ *   1. Always include matches from the offline CURATED list (substring match on
+ *      name/description) so search works with no network at all.
+ *   2. Attempt an exact-name PyPI lookup for the query and, for MicroPython,
+ *      common `micropython-<query>` / `<query>` variants. Any that resolve are
+ *      merged in with their real description + latest version.
+ *
+ * Network failures are swallowed — search degrades to the curated subset rather
+ * than throwing, so the feature is usable offline and the build never depends
+ * on the network.
+ */
+
+const PYPI_TIMEOUT_MS = 6000
+
+/** PyPI JSON shape — only the fields we read. */
+interface PypiJson {
+  info?: {
+    name?: string
+    summary?: string
+    version?: string
+  }
+}
+
+/** Fetch a single PyPI package's metadata, or null on miss/error/timeout. */
+async function fetchPypi(name: string): Promise<PackageInfo | null> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), PYPI_TIMEOUT_MS)
+  try {
+    const res = await fetch(`https://pypi.org/pypi/${encodeURIComponent(name)}/json`, {
+      signal: controller.signal,
+      headers: { Accept: 'application/json' }
+    })
+    if (!res.ok) return null
+    const json = (await res.json()) as PypiJson
+    const info = json.info
+    if (!info?.name) return null
+    return {
+      name: info.name,
+      description: info.summary ?? '',
+      version: info.version,
+      source: 'pypi'
+    }
+  } catch {
+    // Network restricted / offline / 404 / abort — degrade gracefully.
+    return null
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/**
+ * Candidate PyPI names to probe for a free-text query. MicroPython libraries
+ * are frequently published as `micropython-<thing>`, so we try a few sensible
+ * spellings without making this combinatorial.
+ */
+function candidateNames(query: string): string[] {
+  const q = query.trim()
+  const lower = q.toLowerCase()
+  const set = new Set<string>()
+  if (lower) {
+    set.add(lower)
+    if (!lower.startsWith('micropython-')) set.add(`micropython-${lower}`)
+  }
+  return [...set]
+}
+
+/**
+ * Search for packages matching `query`. Returns curated matches first, then any
+ * resolved PyPI hits, de-duplicated by lowercased name. Never throws.
+ */
+export async function searchPackages(query: string): Promise<PackageInfo[]> {
+  const q = query.trim().toLowerCase()
+  if (!q) return []
+
+  const results: PackageInfo[] = []
+  const seen = new Set<string>()
+
+  // 1) Offline curated matches.
+  for (const pkg of CURATED_PACKAGES) {
+    if (pkg.name.toLowerCase().includes(q) || pkg.description.toLowerCase().includes(q)) {
+      results.push(pkg)
+      seen.add(pkg.name.toLowerCase())
+    }
+  }
+
+  // 2) Best-effort PyPI lookups for candidate names (parallel, fault-tolerant).
+  const hits = await Promise.all(candidateNames(query).map((n) => fetchPypi(n)))
+  for (const hit of hits) {
+    if (hit && !seen.has(hit.name.toLowerCase())) {
+      results.push(hit)
+      seen.add(hit.name.toLowerCase())
+    }
+  }
+
+  return results
+}

--- a/src/main/packages/types.ts
+++ b/src/main/packages/types.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared types for the MicroPython package installer layer (issue #20).
+ *
+ * These types are intentionally plain (no class instances, no Buffers) so they
+ * serialize cleanly across the Electron IPC boundary and can be re-used by the
+ * preload typings and the renderer.
+ */
+
+/** A package surfaced by search or discovery. */
+export interface PackageInfo {
+  /** Canonical install name (what `mip.install` / `mip` receives). */
+  name: string
+  /** Short, human-readable summary. May be empty when unknown. */
+  description: string
+  /** Latest known version, when the index reports one. */
+  version?: string
+  /** Where this record came from, for UI hinting. */
+  source: 'pypi' | 'curated'
+}
+
+/** Advanced/optional toggles for an install request. */
+export interface InstallOptions {
+  /**
+   * Overwrite files that already exist on the device. Maps to `mip.install`'s
+   * keyword behaviour where supported; otherwise surfaced as a note.
+   */
+  overwrite?: boolean
+  /**
+   * Custom package index URL (advanced). Passed to `mip.install(..., index=)`.
+   * When omitted, the device's default index (micropython-lib) is used.
+   */
+  index?: string
+  /**
+   * Request `.mpy` cross-compilation to optimise size/speed. The first version
+   * cannot perform this host-side (no bundled `mpy-cross`), so when set we
+   * surface a graceful note rather than failing the install.
+   */
+  mpy?: boolean
+  /** Optional install target directory on the device (e.g. `/lib`). */
+  target?: string
+}
+
+/** A single install request. */
+export interface InstallRequest {
+  name: string
+  options?: InstallOptions
+}
+
+/**
+ * A progress / lifecycle event pushed on the `packages:progress` channel while
+ * an install runs. `state` drives the UI; `message` carries human-readable
+ * detail (log line, error text, or a graceful note such as the `.mpy` caveat).
+ */
+export interface InstallProgress {
+  /** The package this event concerns. */
+  name: string
+  state: 'started' | 'running' | 'note' | 'done' | 'error'
+  /** Human-readable detail for the current state. */
+  message?: string
+}
+
+/** Result of an install attempt, returned from the `packages:install` call. */
+export interface InstallResult {
+  name: string
+  /** True when the device reported a successful install. */
+  ok: boolean
+  /** Combined stdout/stderr or summary text for display. */
+  log: string
+  /**
+   * Non-fatal notes gathered during the install (e.g. ".mpy conversion is not
+   * available in this build", or "overwrite is best-effort on this firmware").
+   */
+  notes: string[]
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -22,6 +22,15 @@ export type { FsEntry, FsStat } from '../main/fs/types'
 // from the UI-facing preload module rather than reaching into `src/main`.
 export type { UpdateStatus } from '../main/updater'
 
+// Re-export the package-installer types (issue #20) so the Packages panel can
+// import them from this single UI-facing module.
+export type {
+  PackageInfo,
+  InstallOptions,
+  InstallProgress,
+  InstallResult
+} from '../main/packages/types'
+
 declare global {
   interface Window {
     electron: ElectronAPI

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -11,6 +11,13 @@ import type {
 } from '../main/device/types'
 import type { FsEntry, FsStat } from '../main/fs/types'
 import type { UpdateStatus } from '../main/updater'
+import type { InstallPlan } from '../main/packages/ipc'
+import type {
+  InstallOptions,
+  InstallProgress,
+  InstallResult,
+  PackageInfo
+} from '../main/packages/types'
 
 /**
  * Unwrap an {@link IpcResult} into a resolved value or a thrown Error, so the
@@ -130,6 +137,79 @@ const updates = {
   }
 }
 
+// Sentinel markers emitted by the device install snippet (kept in sync with
+// src/main/packages/install.ts). Used to classify success vs device traceback.
+const INSTALL_START = '<<SNAKIE_MIP_START>>'
+const INSTALL_OK = '<<SNAKIE_MIP_OK>>'
+const INSTALL_ERR = '<<SNAKIE_MIP_ERR>>'
+
+/**
+ * MicroPython package installer API (issue #20).
+ *
+ * `search` / `topPackages` are pure main-process calls (PyPI lives past the
+ * CSP). `install` is orchestrated here in the preload: it asks main to build
+ * the `mip` snippet + notes, then runs the snippet on the connected device via
+ * the SAME serialized `device:exec` channel the rest of the app uses, parsing
+ * the sentinel markers to decide success. Progress is reported through an
+ * optional callback (purely renderer-side; no main push channel needed).
+ */
+const packages = {
+  /** Curated discovery list of popular MicroPython libraries (offline-safe). */
+  topPackages: (): Promise<PackageInfo[]> =>
+    unwrap(ipcRenderer.invoke('packages:topPackages')),
+  /** Search PyPI + the curated set for `query`. Degrades to curated offline. */
+  search: (query: string): Promise<PackageInfo[]> =>
+    unwrap(ipcRenderer.invoke('packages:search', query)),
+  /**
+   * Install `name` onto the connected device by running `mip`. Requires an
+   * active connection (the device.exec call rejects otherwise). `onProgress`
+   * receives lifecycle events; the resolved {@link InstallResult} also carries
+   * the full log + any non-fatal notes.
+   */
+  install: async (
+    name: string,
+    options?: InstallOptions,
+    onProgress?: (p: InstallProgress) => void
+  ): Promise<InstallResult> => {
+    const emit = (p: InstallProgress): void => onProgress?.(p)
+    emit({ name, state: 'started' })
+
+    const plan = await unwrap<InstallPlan>(
+      ipcRenderer.invoke('packages:install', name, options ?? {})
+    )
+    for (const note of plan.notes) emit({ name, state: 'note', message: note })
+
+    emit({ name, state: 'running', message: `Installing ${name} with mip…` })
+    const exec = await unwrap<{ stdout: string; stderr: string }>(
+      ipcRenderer.invoke('device:exec', plan.snippet)
+    )
+
+    const out = `${exec.stdout ?? ''}\n${exec.stderr ?? ''}`.trim()
+    const failed =
+      out.includes(INSTALL_ERR) ||
+      (exec.stderr != null && exec.stderr.includes('Traceback'))
+    const ok = out.includes(INSTALL_OK) && !failed
+
+    // Strip our sentinel markers from the log shown to the user, keeping any
+    // human-readable text (e.g. the error repr printed after INSTALL_ERR).
+    const log = out
+      .split(/\r?\n/)
+      .filter((l) => !l.includes(INSTALL_START) && !l.includes(INSTALL_OK))
+      .map((l) => l.replace(INSTALL_ERR, '').trim())
+      .filter((l) => l.length > 0)
+      .join('\n')
+      .trim()
+
+    emit({
+      name,
+      state: ok ? 'done' : 'error',
+      message: ok ? `Installed ${name}` : `Failed to install ${name}`
+    })
+
+    return { name, ok, log: log || out, notes: plan.notes }
+  }
+}
+
 // Minimal, typed API exposed to the renderer. This establishes the IPC
 // pattern that later feature work will extend.
 const api = {
@@ -141,6 +221,8 @@ const api = {
   device,
   /** Local host filesystem layer. */
   fs,
+  /** MicroPython package installer (mip/PyPI) + discovery layer. */
+  packages,
   /** Auto-update check + status + restart layer. */
   updates
 }

--- a/src/renderer/src/components/PackagesPanel.css
+++ b/src/renderer/src/components/PackagesPanel.css
@@ -1,0 +1,233 @@
+/*
+ * Styles co-located with PackagesPanel (issue #20).
+ *
+ * In-app MicroPython package installer: a prominent search box, a discovery
+ * list of popular libraries, per-package install controls, and a collapsible
+ * Advanced section. Uses the shared design tokens from index.css so it tracks
+ * the active theme.
+ */
+
+.pkgs {
+  display: flex;
+  flex-direction: column;
+  font-size: 13px;
+  color: var(--text);
+}
+
+.pkgs__hint {
+  margin: 0;
+  padding: 0.7rem 0.85rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+/* --- Search ---------------------------------------------------------------- */
+
+.pkgs__search {
+  display: flex;
+  gap: 6px;
+  padding: 0.6rem 0.85rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.pkgs__search-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 0.35rem 0.55rem;
+  background: var(--bg-sunken);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-family: inherit;
+  font-size: 0.85rem;
+}
+
+.pkgs__search-btn,
+.pkgs__search-clear {
+  flex: 0 0 auto;
+  padding: 0.3rem 0.7rem;
+  background: var(--bg-sunken);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-family: inherit;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.pkgs__search-btn:hover:not(:disabled),
+.pkgs__search-clear:hover {
+  background: var(--bg-elevated);
+}
+
+.pkgs__search-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+/* --- Advanced -------------------------------------------------------------- */
+
+.pkgs__advanced {
+  padding: 0.5rem 0.85rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.pkgs__advanced-summary {
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  user-select: none;
+}
+
+.pkgs__opt {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 0.5rem;
+  font-size: 0.82rem;
+}
+
+.pkgs__opt--field {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 4px;
+}
+
+.pkgs__index-input {
+  padding: 0.3rem 0.5rem;
+  background: var(--bg-sunken);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.78rem;
+}
+
+/* --- List ------------------------------------------------------------------ */
+
+.pkgs__list-head {
+  padding: 0.45rem 0.85rem;
+  color: var(--text-muted);
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.pkgs__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.pkgs__item {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 0.55rem 0.85rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.pkgs__item-main {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.pkgs__item-head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.pkgs__name {
+  font-weight: 600;
+  word-break: break-word;
+}
+
+.pkgs__version {
+  color: var(--text-muted);
+  font-size: 0.74rem;
+}
+
+.pkgs__src {
+  padding: 0.02rem 0.3rem;
+  border-radius: 4px;
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--text-muted);
+  background: var(--bg-sunken);
+}
+
+.pkgs__src--pypi {
+  color: var(--text);
+}
+
+.pkgs__desc {
+  margin: 0.2rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+.pkgs__install-btn {
+  flex: 0 0 auto;
+  padding: 0.25rem 0.6rem;
+  background: var(--bg-sunken);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-family: inherit;
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+
+.pkgs__install-btn:hover:not(:disabled) {
+  background: var(--bg-elevated);
+}
+
+.pkgs__install-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+/* --- Result / notes / log -------------------------------------------------- */
+
+.pkgs__result {
+  margin-top: 0.4rem;
+}
+
+.pkgs__note {
+  margin: 0.25rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.76rem;
+  line-height: 1.4;
+}
+
+.pkgs__log {
+  margin: 0.3rem 0 0;
+  padding: 0.4rem 0.5rem;
+  max-height: 9rem;
+  overflow: auto;
+  background: var(--bg-sunken);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.74rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.pkgs__log--error {
+  color: var(--danger, #c0392b);
+}
+
+.pkgs__error {
+  margin: 0;
+  padding: 0.6rem 0.85rem;
+  color: var(--danger, #c0392b);
+  background: var(--bg-sunken);
+  font-size: 0.8rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/src/renderer/src/components/PackagesPanel.tsx
+++ b/src/renderer/src/components/PackagesPanel.tsx
@@ -1,0 +1,277 @@
+import { useCallback, useEffect, useState } from 'react'
+import './PackagesPanel.css'
+import { useDeviceStatus } from '../hooks/useDeviceStatus'
+import type { InstallProgress, PackageInfo } from '../../../preload/index.d'
+
+/**
+ * PACKAGES TAB (issue #20)
+ * ========================
+ *
+ * In-app MicroPython package installer, driven by the feedback in
+ * docs/feedback.md: keep search front-and-centre, offer discovery of popular
+ * libraries, expose advanced options (overwrite / custom index URL / .mpy), and
+ * NEVER kick the user out to another app.
+ *
+ * Network access (PyPI search + discovery) is brokered by the main process
+ * (`window.api.packages`) because the renderer CSP forbids outbound requests.
+ * Installs run MicroPython's `mip` on the connected board, so the install
+ * controls are gated on an active connection with a clear hint otherwise.
+ *
+ * Hardware + network can't be exercised in CI, so every async path degrades
+ * gracefully: search falls back to the curated set offline, and install surfaces
+ * device errors inline rather than throwing.
+ */
+
+/** Per-package install UI state, keyed by package name. */
+interface InstallState {
+  status: 'installing' | 'done' | 'error'
+  log: string
+  notes: string[]
+}
+
+export function PackagesPanel(): JSX.Element {
+  const status = useDeviceStatus()
+  const connected = status.state === 'connected'
+
+  // Discovery (curated top packages), loaded once on mount.
+  const [top, setTop] = useState<PackageInfo[]>([])
+
+  // Search.
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<PackageInfo[] | null>(null)
+  const [searching, setSearching] = useState(false)
+  const [searchError, setSearchError] = useState<string | null>(null)
+
+  // Advanced options.
+  const [showAdvanced, setShowAdvanced] = useState(false)
+  const [overwrite, setOverwrite] = useState(true)
+  const [convertMpy, setConvertMpy] = useState(false)
+  const [customIndex, setCustomIndex] = useState('')
+
+  // Install state per package.
+  const [installs, setInstalls] = useState<Record<string, InstallState>>({})
+
+  useEffect(() => {
+    let active = true
+    window.api.packages
+      .topPackages()
+      .then((pkgs) => {
+        if (active) setTop(pkgs)
+      })
+      .catch(() => undefined)
+    return () => {
+      active = false
+    }
+  }, [])
+
+  const runSearch = useCallback(async (): Promise<void> => {
+    const q = query.trim()
+    if (!q) {
+      setResults(null)
+      setSearchError(null)
+      return
+    }
+    setSearching(true)
+    setSearchError(null)
+    try {
+      const found = await window.api.packages.search(q)
+      setResults(found)
+      if (found.length === 0) {
+        setSearchError(`No packages found for "${q}".`)
+      }
+    } catch (err) {
+      setSearchError(err instanceof Error ? err.message : String(err))
+      setResults([])
+    } finally {
+      setSearching(false)
+    }
+  }, [query])
+
+  const install = useCallback(
+    async (name: string): Promise<void> => {
+      setInstalls((prev) => ({
+        ...prev,
+        [name]: { status: 'installing', log: '', notes: [] }
+      }))
+      const collectedNotes: string[] = []
+      const onProgress = (p: InstallProgress): void => {
+        if (p.state === 'note' && p.message) collectedNotes.push(p.message)
+      }
+      try {
+        const result = await window.api.packages.install(
+          name,
+          {
+            overwrite,
+            mpy: convertMpy,
+            index: customIndex.trim() || undefined
+          },
+          onProgress
+        )
+        setInstalls((prev) => ({
+          ...prev,
+          [name]: {
+            status: result.ok ? 'done' : 'error',
+            log: result.log,
+            notes: result.notes.length ? result.notes : collectedNotes
+          }
+        }))
+      } catch (err) {
+        setInstalls((prev) => ({
+          ...prev,
+          [name]: {
+            status: 'error',
+            log: err instanceof Error ? err.message : String(err),
+            notes: collectedNotes
+          }
+        }))
+      }
+    },
+    [overwrite, convertMpy, customIndex]
+  )
+
+  const listToShow = results ?? top
+  const listLabel = results ? 'Search results' : 'Popular packages'
+
+  return (
+    <div className="pkgs">
+      <form
+        className="pkgs__search"
+        onSubmit={(e) => {
+          e.preventDefault()
+          void runSearch()
+        }}
+      >
+        <input
+          type="search"
+          className="pkgs__search-input"
+          placeholder="Search packages (e.g. urequests, microdot)…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          aria-label="Search packages"
+        />
+        <button type="submit" className="pkgs__search-btn" disabled={searching}>
+          {searching ? '…' : 'Search'}
+        </button>
+        {results != null && (
+          <button
+            type="button"
+            className="pkgs__search-clear"
+            onClick={() => {
+              setQuery('')
+              setResults(null)
+              setSearchError(null)
+            }}
+          >
+            Clear
+          </button>
+        )}
+      </form>
+
+      {!connected && (
+        <p className="pkgs__hint" role="status">
+          Connect a board to install packages. You can still search and browse
+          popular libraries below.
+        </p>
+      )}
+
+      <details
+        className="pkgs__advanced"
+        open={showAdvanced}
+        onToggle={(e) => setShowAdvanced((e.target as HTMLDetailsElement).open)}
+      >
+        <summary className="pkgs__advanced-summary">Advanced options</summary>
+        <label className="pkgs__opt">
+          <input
+            type="checkbox"
+            checked={overwrite}
+            onChange={(e) => setOverwrite(e.target.checked)}
+          />
+          <span>Overwrite existing files</span>
+        </label>
+        <label className="pkgs__opt">
+          <input
+            type="checkbox"
+            checked={convertMpy}
+            onChange={(e) => setConvertMpy(e.target.checked)}
+          />
+          <span>
+            Convert to <code>.mpy</code> (optimise size/speed)
+          </span>
+        </label>
+        <label className="pkgs__opt pkgs__opt--field">
+          <span>Custom index URL</span>
+          <input
+            type="text"
+            className="pkgs__index-input"
+            placeholder="https://micropython.org/pi/v2"
+            value={customIndex}
+            onChange={(e) => setCustomIndex(e.target.value)}
+          />
+        </label>
+        {convertMpy && (
+          <p className="pkgs__note">
+            Note: this build has no bundled <code>mpy-cross</code>, so packages
+            install as source <code>.py</code>. Many ports still compile to
+            bytecode on import.
+          </p>
+        )}
+      </details>
+
+      {searchError != null && <p className="pkgs__error">{searchError}</p>}
+
+      <div className="pkgs__list-head">{listLabel}</div>
+      <ul className="pkgs__list" role="list">
+        {listToShow.map((pkg) => {
+          const st = installs[pkg.name]
+          return (
+            <li key={`${pkg.source}:${pkg.name}`} className="pkgs__item">
+              <div className="pkgs__item-main">
+                <div className="pkgs__item-head">
+                  <span className="pkgs__name">{pkg.name}</span>
+                  {pkg.version && <span className="pkgs__version">{pkg.version}</span>}
+                  <span className={`pkgs__src pkgs__src--${pkg.source}`}>{pkg.source}</span>
+                </div>
+                {pkg.description && <p className="pkgs__desc">{pkg.description}</p>}
+                {st && (st.notes.length > 0 || st.log) && (
+                  <div className="pkgs__result">
+                    {st.notes.map((n, i) => (
+                      <p key={i} className="pkgs__note">
+                        {n}
+                      </p>
+                    ))}
+                    {st.log && (
+                      <pre
+                        className={`pkgs__log${st.status === 'error' ? ' pkgs__log--error' : ''}`}
+                      >
+                        {st.log}
+                      </pre>
+                    )}
+                  </div>
+                )}
+              </div>
+              <button
+                type="button"
+                className="pkgs__install-btn"
+                disabled={!connected || st?.status === 'installing'}
+                title={connected ? `Install ${pkg.name}` : 'Connect a board first'}
+                onClick={() => void install(pkg.name)}
+              >
+                {st?.status === 'installing'
+                  ? 'Installing…'
+                  : st?.status === 'done'
+                    ? 'Installed ✓'
+                    : st?.status === 'error'
+                      ? 'Retry'
+                      : 'Install'}
+              </button>
+            </li>
+          )
+        })}
+      </ul>
+
+      {listToShow.length === 0 && !searching && (
+        <p className="pkgs__hint">No packages to show.</p>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/RightPanel.tsx
+++ b/src/renderer/src/components/RightPanel.tsx
@@ -3,6 +3,7 @@ import { RightPanelTabs, RightPanelTab } from './RightPanelTabs'
 import { HelpPanel } from './HelpPanel'
 import { OutlinePanel } from './OutlinePanel'
 import { VariablesPanel } from './VariablesPanel'
+import { PackagesPanel } from './PackagesPanel'
 
 /**
  * RIGHT PANE — optional/collapsible region (collapsed by default).
@@ -26,10 +27,11 @@ export function RightPanel(): JSX.Element {
     // Code outline of the active file (issue #16):
     { id: 'outline', title: 'Outline', icon: '☰', content: <OutlinePanel /> },
     // Connected board's variables (issue #16):
-    { id: 'vars', title: 'Variables', icon: '{}', content: <VariablesPanel /> }
+    { id: 'vars', title: 'Variables', icon: '{}', content: <VariablesPanel /> },
+    // MicroPython package installer (mip/PyPI) with discovery (issue #20):
+    { id: 'packages', title: 'Packages', icon: '📦', content: <PackagesPanel /> }
     // Future tabs register here, e.g.:
     // { id: 'chat', title: 'Chat', icon: '💬', content: <ChatPanel /> },
-    // { id: 'packages', title: 'Packages', icon: '📦', content: <PackagePanel /> },
   ]
 
   return (


### PR DESCRIPTION
Implements **issue #20**: an in-app MicroPython package installer in the right-pane **Packages** tab — search, discover, and install `mip`/PyPI libraries onto the connected board without ever kicking out to another app (per `docs/feedback.md`).

## What's included
- [x] **Main process** `src/main/packages/` + `registerPackagesIpc` (one-line wiring in `index.ts`), using global `fetch` (no new deps)
  - [x] **Search** — PyPI JSON API (`https://pypi.org/pypi/<name>/json`) probed for the query and `micropython-<query>`, merged with curated matches. All network is in **main** (renderer CSP). Degrades to the curated subset offline; never throws.
  - [x] **Discovery — top packages** — curated static list of popular MicroPython libraries (`urequests`, `umqtt.simple/.robust`, `microdot`, `neopixel`, `ssd1306`, `bme280`, `dht`, `aioble`, …). Offline-safe; noted as a static first version.
  - [x] **Install** — composes a `mip.install(...)` snippet in main and runs it on the device via the existing `device:exec` channel; sentinel markers classify success vs traceback. Advanced: **overwrite**, **custom index URL** (`index=`), and a **`.mpy` conversion** toggle that surfaces a graceful note (no bundled `mpy-cross`) rather than failing.
  - [x] IPC `window.api.packages`: `search(query)`, `topPackages()`, `install(name, options, onProgress)` with progress callbacks. Preload edits localized to a new `packages` namespace.
- [x] **UI** `PackagesPanel.tsx` (+ co-located CSS): prominent search box, discovery list, per-package install with progress/result + log, collapsible **Advanced** section. Install gated on a connected board with a clear hint otherwise.

## Acceptance
`npm install && npm run lint && npm run typecheck && npm run build` — all pass.

## Caveats
- PyPI search and on-device `mip` install are **untested** (headless ARM64, no board, restricted network). All async paths degrade gracefully.
- Discovery is a curated static list in this first version; live PyPI download stats would need an extra network round-trip.
- `.mpy` conversion is presented in the UI but host-side conversion is unavailable (no `mpy-cross`); surfaced as a non-fatal note.

`window.api.packages` shape:
- `topPackages(): Promise<PackageInfo[]>`
- `search(query: string): Promise<PackageInfo[]>`
- `install(name, options?, onProgress?): Promise<InstallResult>` where `options = { overwrite?, index?, mpy?, target? }`

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)
