### PR TITLE
Built-in version control (Git, VS Code-style)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-resizable-panels": "^2.1.9",
-        "serialport": "^13.0.0"
+        "serialport": "^13.0.0",
+        "simple-git": "^3.36.0"
       },
       "devDependencies": {
         "@electron-toolkit/tsconfig": "^1.0.1",
@@ -1316,6 +1317,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
+    },
     "node_modules/@malept/cross-spawn-promise": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
@@ -1984,6 +1998,19 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@simple-git/args-pathspec": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz",
+      "integrity": "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA=="
+    },
+    "node_modules/@simple-git/argv-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz",
+      "integrity": "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==",
+      "dependencies": {
+        "@simple-git/args-pathspec": "^1.0.3"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -7698,6 +7725,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-git": {
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.36.0.tgz",
+      "integrity": "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "@simple-git/args-pathspec": "^1.0.3",
+        "@simple-git/argv-parser": "^1.1.0",
+        "debug": "^4.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
       }
     },
     "node_modules/simple-update-notifier": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-resizable-panels": "^2.1.9",
-    "serialport": "^13.0.0"
+    "serialport": "^13.0.0",
+    "simple-git": "^3.36.0"
   },
   "devDependencies": {
     "@electron-toolkit/tsconfig": "^1.0.1",

--- a/src/main/git/GitService.ts
+++ b/src/main/git/GitService.ts
@@ -1,0 +1,281 @@
+import { simpleGit, type SimpleGit, type StatusResult } from 'simple-git'
+import type {
+  GitBranchList,
+  GitDiff,
+  GitFileStatus,
+  GitRemoteResult,
+  GitStatus
+} from './types'
+
+/**
+ * Thin wrapper around `simple-git`, scoped to a single chosen repository
+ * directory (issue #15).
+ *
+ * The renderer picks a folder (via the existing `fs.openFolderDialog`) and
+ * hands the path to {@link GitService.openRepo}. From then on every operation
+ * runs in that directory. The class never throws for the common "this folder
+ * is not a git repo" case — {@link GitService.status} returns `{ isRepo:false }`
+ * so the panel can render a clear empty state. Genuine git errors (e.g. a
+ * failed push) DO reject, and are surfaced through the IPC `IpcResult` wrapper.
+ */
+export class GitService {
+  /** The repo directory currently targeted, or null when none is open. */
+  private dir: string | null = null
+  /** Lazily-created simple-git instance bound to {@link dir}. */
+  private git: SimpleGit | null = null
+
+  /**
+   * Point the service at `path`. Does not assert that `path` is a repo — call
+   * {@link status} afterwards, which reports `isRepo` cleanly. Returns the
+   * resolved repository root when `path` is inside a repo, otherwise null.
+   */
+  async openRepo(path: string): Promise<string | null> {
+    this.dir = path
+    this.git = simpleGit({ baseDir: path })
+    return this.repoRoot()
+  }
+
+  /** The directory currently targeted (the user's chosen folder). */
+  get currentDir(): string | null {
+    return this.dir
+  }
+
+  /** Resolve the bound simple-git instance, throwing if no folder is open. */
+  private require(): SimpleGit {
+    if (!this.git) throw new Error('No folder is open. Pick a repository first.')
+    return this.git
+  }
+
+  /**
+   * Return the repository root for the open folder, or null when the folder is
+   * not inside a git working tree. Never throws for the not-a-repo case.
+   */
+  private async repoRoot(): Promise<string | null> {
+    const git = this.git
+    if (!git) return null
+    try {
+      const isRepo = await git.checkIsRepo()
+      if (!isRepo) return null
+      const root = (await git.revparse(['--show-toplevel'])).trim()
+      return root || this.dir
+    } catch {
+      return null
+    }
+  }
+
+  /**
+   * Classify a single file from a {@link StatusResult} into the UI buckets.
+   * `index`/`workingDir` are the porcelain single-letter codes simple-git
+   * surfaces per file.
+   */
+  private classify(
+    path: string,
+    index: string,
+    workingDir: string,
+    isUntracked: boolean,
+    conflicted: boolean
+  ): GitFileStatus {
+    const codes = `${index}${workingDir}`
+    let kind: GitFileStatus['kind'] = 'unknown'
+    if (conflicted) kind = 'conflicted'
+    else if (isUntracked) kind = 'untracked'
+    else if (codes.includes('A')) kind = 'added'
+    else if (codes.includes('D')) kind = 'deleted'
+    else if (codes.includes('R')) kind = 'renamed'
+    else if (codes.includes('M') || codes.includes('T')) kind = 'modified'
+
+    const isStaged = index !== ' ' && index !== '?' && index !== '' && !isUntracked
+    return { path, index, workingDir, isUntracked, isStaged, kind }
+  }
+
+  /**
+   * Read the working-tree status. Returns `{ isRepo:false }` (not an error)
+   * when the open folder is not a git repository, so the renderer can show a
+   * clear empty state.
+   */
+  async status(): Promise<GitStatus> {
+    const empty: GitStatus = {
+      isRepo: false,
+      ahead: 0,
+      behind: 0,
+      staged: [],
+      changed: [],
+      untracked: []
+    }
+    if (!this.git) return empty
+
+    const root = await this.repoRoot()
+    if (!root) return empty
+
+    let s: StatusResult
+    try {
+      s = await this.require().status()
+    } catch (err) {
+      return {
+        ...empty,
+        isRepo: true,
+        root,
+        warning: err instanceof Error ? err.message : String(err)
+      }
+    }
+
+    const conflictedSet = new Set(s.conflicted)
+    const staged: GitFileStatus[] = []
+    const changed: GitFileStatus[] = []
+    const untracked: GitFileStatus[] = []
+
+    for (const f of s.files) {
+      const isUntracked = f.index === '?' && f.working_dir === '?'
+      const conflicted = conflictedSet.has(f.path)
+      const fileStatus = this.classify(
+        f.path,
+        f.index,
+        f.working_dir,
+        isUntracked,
+        conflicted
+      )
+      if (conflicted) {
+        // Conflicts surface in the changed list so the user can resolve them.
+        changed.push(fileStatus)
+      } else if (isUntracked) {
+        untracked.push(fileStatus)
+      } else {
+        // A file can be both staged and have further working changes; show it
+        // in both lists so each part is independently stage/unstage-able.
+        if (fileStatus.index !== ' ' && fileStatus.index !== '') {
+          staged.push({ ...fileStatus, isStaged: true })
+        }
+        if (fileStatus.workingDir !== ' ' && fileStatus.workingDir !== '') {
+          changed.push({ ...fileStatus, isStaged: false })
+        }
+      }
+    }
+
+    return {
+      isRepo: true,
+      root,
+      branch: s.current ?? undefined,
+      tracking: s.tracking ?? undefined,
+      ahead: s.ahead ?? 0,
+      behind: s.behind ?? 0,
+      staged,
+      changed,
+      untracked
+    }
+  }
+
+  /** Stage a single file (git add). */
+  async stage(file: string): Promise<void> {
+    await this.require().add([file])
+  }
+
+  /** Unstage a single file (git reset HEAD -- file), tolerating no-HEAD repos. */
+  async unstage(file: string): Promise<void> {
+    const git = this.require()
+    try {
+      await git.reset(['HEAD', '--', file])
+    } catch {
+      // Fresh repo with no commits yet: unstage via `git rm --cached`.
+      await git.raw(['rm', '--cached', '--', file])
+    }
+  }
+
+  /**
+   * Discard working-tree changes for `file`. For tracked files this is a
+   * checkout from HEAD; for untracked files it removes them from disk.
+   */
+  async discard(file: string): Promise<void> {
+    const git = this.require()
+    const s = await git.status()
+    const entry = s.files.find((f) => f.path === file)
+    const isUntracked = entry?.index === '?' && entry?.working_dir === '?'
+    if (isUntracked) {
+      await git.clean('f', ['--', file])
+    } else {
+      await git.checkout(['--', file])
+    }
+  }
+
+  /**
+   * Commit with `message`. When `stageAll` is true (the default), any unstaged
+   * tracked changes are staged first so the commit captures everything the user
+   * sees; otherwise only what is already in the index is committed.
+   */
+  async commit(message: string, stageAll = true): Promise<void> {
+    const trimmed = message.trim()
+    if (!trimmed) throw new Error('Commit message must not be empty.')
+    const git = this.require()
+    if (stageAll) await git.add(['-A'])
+    await git.commit(trimmed)
+  }
+
+  /**
+   * Unified diff for `file`. When `staged` is true the diff is index-vs-HEAD;
+   * otherwise it is working-tree-vs-index. Untracked files have no diff, so we
+   * synthesize an "added" diff with `--no-index` against /dev/null.
+   */
+  async diff(file: string, staged = false): Promise<GitDiff> {
+    const git = this.require()
+    if (staged) {
+      const text = await git.diff(['--cached', '--', file])
+      return { path: file, diff: text, staged: true }
+    }
+
+    const s = await git.status()
+    const entry = s.files.find((f) => f.path === file)
+    const isUntracked = entry?.index === '?' && entry?.working_dir === '?'
+    if (isUntracked) {
+      try {
+        // --no-index exits non-zero when files differ; capture its output.
+        const text = await git.raw(['diff', '--no-index', '--', '/dev/null', file])
+        return { path: file, diff: text, staged: false }
+      } catch (err) {
+        const out = err instanceof Error ? err.message : String(err)
+        return { path: file, diff: out, staged: false }
+      }
+    }
+
+    const text = await git.diff(['--', file])
+    return { path: file, diff: text, staged: false }
+  }
+
+  /** Current branch name, or undefined when detached / no commits. */
+  async currentBranch(): Promise<string | undefined> {
+    const git = this.require()
+    const branches = await git.branchLocal()
+    return branches.current || undefined
+  }
+
+  /** List local branches plus the current one. */
+  async listBranches(): Promise<GitBranchList> {
+    const git = this.require()
+    const branches = await git.branchLocal()
+    return {
+      current: branches.current || undefined,
+      branches: branches.all
+    }
+  }
+
+  /** Check out an existing branch. */
+  async checkout(branch: string): Promise<void> {
+    await this.require().checkout(branch)
+  }
+
+  /** Push the current branch to its upstream. */
+  async push(): Promise<GitRemoteResult> {
+    const git = this.require()
+    const result = await git.push()
+    const updates = result.update ? ` (${result.update.hash.from}..${result.update.hash.to})` : ''
+    return { summary: `Pushed${updates}`.trim() }
+  }
+
+  /** Pull from the upstream of the current branch. */
+  async pull(): Promise<GitRemoteResult> {
+    const git = this.require()
+    const result = await git.pull()
+    const { changes, insertions, deletions } = result.summary
+    return {
+      summary: `Pulled: ${changes} file(s), +${insertions} -${deletions}`
+    }
+  }
+}

--- a/src/main/git/ipc.ts
+++ b/src/main/git/ipc.ts
@@ -1,0 +1,80 @@
+import { ipcMain } from 'electron'
+import type { IpcResult } from '../device/types'
+import { GitService } from './GitService'
+import type { GitBranchList, GitDiff, GitRemoteResult, GitStatus } from './types'
+
+/**
+ * IPC for the built-in version-control (Git) layer (issue #15).
+ *
+ * All git operations run here in the main process via `simple-git`, scoped to a
+ * single repository directory the user picks in the renderer (reusing the
+ * existing `fs.openFolderDialog`). The handlers mirror the device/fs/packages
+ * convention: each returns a serializable {@link IpcResult} that the preload
+ * unwraps into a value or a thrown Error.
+ *
+ * The not-a-git-repository case is NOT an error: `git:status` resolves with
+ * `{ isRepo:false }` so the panel can render a clear empty state. Only genuine
+ * git failures (push/pull/checkout) reject across the boundary.
+ */
+
+/**
+ * Wrap an async operation so any thrown error crosses IPC as a plain,
+ * serializable {@link IpcResult}. Mirrors the other layers' `wrap` helper.
+ */
+async function wrap<T>(fn: () => Promise<T>): Promise<IpcResult<T>> {
+  try {
+    return { ok: true, value: await fn() }
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+/**
+ * Register all `git:*` IPC handlers. Call once from the main process after the
+ * app is ready. A single {@link GitService} instance is kept for the lifetime
+ * of the process, retargeted whenever the user opens a different repo. There
+ * are no push events, so unlike the device layer this takes no window resolver.
+ */
+export function registerGitIpc(): void {
+  const service = new GitService()
+
+  // Point the service at a chosen folder; returns the resolved repo root or
+  // null when the folder is not inside a git working tree.
+  ipcMain.handle('git:openRepo', (_e, path: string) =>
+    wrap<string | null>(() => service.openRepo(path))
+  )
+
+  // Working-tree status (branch, ahead/behind, staged/changed/untracked).
+  ipcMain.handle('git:status', () => wrap<GitStatus>(() => service.status()))
+
+  ipcMain.handle('git:stage', (_e, file: string) =>
+    wrap<void>(() => service.stage(file))
+  )
+  ipcMain.handle('git:unstage', (_e, file: string) =>
+    wrap<void>(() => service.unstage(file))
+  )
+  ipcMain.handle('git:discard', (_e, file: string) =>
+    wrap<void>(() => service.discard(file))
+  )
+
+  ipcMain.handle('git:commit', (_e, message: string, stageAll?: boolean) =>
+    wrap<void>(() => service.commit(message, stageAll ?? true))
+  )
+
+  ipcMain.handle('git:diff', (_e, file: string, staged?: boolean) =>
+    wrap<GitDiff>(() => service.diff(file, staged ?? false))
+  )
+
+  ipcMain.handle('git:currentBranch', () =>
+    wrap<string | undefined>(() => service.currentBranch())
+  )
+  ipcMain.handle('git:listBranches', () =>
+    wrap<GitBranchList>(() => service.listBranches())
+  )
+  ipcMain.handle('git:checkout', (_e, branch: string) =>
+    wrap<void>(() => service.checkout(branch))
+  )
+
+  ipcMain.handle('git:push', () => wrap<GitRemoteResult>(() => service.push()))
+  ipcMain.handle('git:pull', () => wrap<GitRemoteResult>(() => service.pull()))
+}

--- a/src/main/git/types.ts
+++ b/src/main/git/types.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared types for the built-in Git (version control) layer (issue #15).
+ *
+ * These types are intentionally plain (no class instances, no Buffers) so they
+ * serialize cleanly across the Electron IPC boundary and can be re-used by the
+ * preload typings and the renderer's Source Control panel.
+ */
+
+/** Working-tree status of a single file, as classified for the UI. */
+export interface GitFileStatus {
+  /** Repo-relative path. */
+  path: string
+  /** Single-letter index/worktree code (git porcelain), best-effort. */
+  index: string
+  workingDir: string
+  /** True when the file is untracked (not yet known to git). */
+  isUntracked: boolean
+  /** True when the change is staged (present in the index). */
+  isStaged: boolean
+  /** Human-friendly classification used to drive the icon/colour in the UI. */
+  kind: 'modified' | 'added' | 'deleted' | 'renamed' | 'conflicted' | 'untracked' | 'unknown'
+}
+
+/**
+ * A snapshot of the repository status, safe to send over IPC. When `isRepo`
+ * is false the remaining fields are empty/zero and the renderer should render a
+ * "not a git repository" state instead of the file lists.
+ */
+export interface GitStatus {
+  /** Whether the opened folder resolved to a git repository. */
+  isRepo: boolean
+  /** Resolved repository root (the top-level working dir), when `isRepo`. */
+  root?: string
+  /** Current branch name, or a detached-HEAD marker. */
+  branch?: string
+  /** Upstream tracking branch, if any (e.g. `origin/main`). */
+  tracking?: string
+  /** Commits the local branch is ahead of its upstream. */
+  ahead: number
+  /** Commits the local branch is behind its upstream. */
+  behind: number
+  /** Files present in the index (staged changes). */
+  staged: GitFileStatus[]
+  /** Tracked files with unstaged working-tree changes. */
+  changed: GitFileStatus[]
+  /** Untracked files (not yet known to git). */
+  untracked: GitFileStatus[]
+  /** Set when the folder is a repo but status could not be read fully. */
+  warning?: string
+}
+
+/** Result of listing branches. */
+export interface GitBranchList {
+  /** Currently checked-out branch (undefined when detached). */
+  current?: string
+  /** All local branch names. */
+  branches: string[]
+}
+
+/** Unified diff text for a file, plus the side it came from. */
+export interface GitDiff {
+  /** Repo-relative path. */
+  path: string
+  /** Unified diff text (may be empty when there is no diff). */
+  diff: string
+  /** Whether the diff reflects staged (index) changes vs the working tree. */
+  staged: boolean
+}
+
+/** Result of a push/pull, surfacing a short human-readable summary. */
+export interface GitRemoteResult {
+  /** Short summary suitable for a toast/status line. */
+  summary: string
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,6 +6,7 @@ import { registerFsIpc } from './fs/ipc'
 import { registerPackagesIpc } from './packages/ipc'
 import { registerLlmIpc } from './llm/ipc'
 import { registerFirmwareIpc } from './firmware/ipc'
+import { registerGitIpc } from './git/ipc'
 import { registerUpdater } from './updater'
 
 /** The single application window, used to route device push-events. */
@@ -79,6 +80,10 @@ app.whenReady().then(() => {
   // Register the firmware-flashing layer (ESP via esptool, RP2040 via UF2 copy).
   // The file dialog is parented to the live window and progress is routed to it.
   registerFirmwareIpc(() => mainWindow ?? undefined)
+
+  // Register the built-in version-control (Git) layer (issue #15). All git
+  // operations run here via simple-git, scoped to a folder the renderer picks.
+  registerGitIpc()
 
   // Register the auto-update layer. No-ops cleanly in dev (unpackaged); when
   // packaged it checks GitHub Releases and pushes status to the live window.

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -45,6 +45,16 @@ export type {
 // from the UI-facing preload module rather than reaching into `src/main`.
 export type { LlmKeyStatus, LlmMessage, LlmSendRequest, LlmStreamEvent } from '../main/llm/types'
 
+// Re-export the Git (version-control) types (issue #15) so the Source Control
+// panel can import them from this single UI-facing module.
+export type {
+  GitFileStatus,
+  GitStatus,
+  GitBranchList,
+  GitDiff,
+  GitRemoteResult
+} from '../main/git/types'
+
 declare global {
   interface Window {
     electron: ElectronAPI

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -26,6 +26,12 @@ import type {
   PackageInfo
 } from '../main/packages/types'
 import type { LlmKeyStatus, LlmSendRequest, LlmStreamEvent } from '../main/llm/types'
+import type {
+  GitBranchList,
+  GitDiff,
+  GitRemoteResult,
+  GitStatus
+} from '../main/git/types'
 
 /**
  * Unwrap an {@link IpcResult} into a resolved value or a thrown Error, so the
@@ -270,6 +276,45 @@ const firmware = {
   }
 }
 
+/**
+ * Built-in version-control (Git) API (issue #15). Mirrors the main-process
+ * `git:*` IPC handlers and unwraps their typed results. All git work runs in
+ * the main process via simple-git, scoped to a folder the renderer picks with
+ * `fs.openFolderDialog`. The not-a-repo case is reported via `status().isRepo`
+ * rather than thrown, so the panel can show a clear empty state.
+ */
+const git = {
+  /** Point git at `path`. Resolves to the repo root, or null if not a repo. */
+  openRepo: (path: string): Promise<string | null> =>
+    unwrap(ipcRenderer.invoke('git:openRepo', path)),
+  /** Working-tree status: branch, ahead/behind, staged/changed/untracked. */
+  status: (): Promise<GitStatus> => unwrap(ipcRenderer.invoke('git:status')),
+  /** Stage a single file. */
+  stage: (file: string): Promise<void> => unwrap(ipcRenderer.invoke('git:stage', file)),
+  /** Unstage a single file. */
+  unstage: (file: string): Promise<void> => unwrap(ipcRenderer.invoke('git:unstage', file)),
+  /** Discard working-tree changes for a file (or delete it, if untracked). */
+  discard: (file: string): Promise<void> => unwrap(ipcRenderer.invoke('git:discard', file)),
+  /** Commit; stages all tracked changes first unless `stageAll` is false. */
+  commit: (message: string, stageAll?: boolean): Promise<void> =>
+    unwrap(ipcRenderer.invoke('git:commit', message, stageAll)),
+  /** Unified diff for a file; `staged` selects index-vs-HEAD over working-vs-index. */
+  diff: (file: string, staged?: boolean): Promise<GitDiff> =>
+    unwrap(ipcRenderer.invoke('git:diff', file, staged)),
+  /** Current branch name (undefined when detached / no commits). */
+  currentBranch: (): Promise<string | undefined> =>
+    unwrap(ipcRenderer.invoke('git:currentBranch')),
+  /** List local branches plus the current one. */
+  listBranches: (): Promise<GitBranchList> => unwrap(ipcRenderer.invoke('git:listBranches')),
+  /** Check out an existing branch. */
+  checkout: (branch: string): Promise<void> =>
+    unwrap(ipcRenderer.invoke('git:checkout', branch)),
+  /** Push the current branch to its upstream. */
+  push: (): Promise<GitRemoteResult> => unwrap(ipcRenderer.invoke('git:push')),
+  /** Pull from the upstream of the current branch. */
+  pull: (): Promise<GitRemoteResult> => unwrap(ipcRenderer.invoke('git:pull'))
+}
+
 // Minimal, typed API exposed to the renderer. This establishes the IPC
 // pattern that later feature work will extend.
 const api = {
@@ -288,7 +333,9 @@ const api = {
   /** Auto-update check + status + restart layer. */
   updates,
   /** LLM (Claude) chat layer. */
-  llm
+  llm,
+  /** Built-in version-control (Git) layer. */
+  git
 }
 
 // Use `contextBridge` APIs to expose Electron APIs to the renderer only if

--- a/src/renderer/src/components/GitPanel.css
+++ b/src/renderer/src/components/GitPanel.css
@@ -1,0 +1,407 @@
+/*
+ * Styles co-located with GitPanel (issue #15).
+ *
+ * A VS Code-style Source Control view: a branch/sync toolbar, a commit box,
+ * grouped file lists (staged / changes / untracked) with per-row stage,
+ * unstage and discard actions, and an inline colorized unified-diff viewer.
+ * Uses the shared design tokens from index.css so it tracks the active theme.
+ */
+
+.git {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  font-size: 13px;
+  color: var(--text);
+}
+
+/* --- Empty / non-repo states ---------------------------------------------- */
+
+.git--empty {
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.9rem 0.85rem;
+}
+
+.git__empty-note {
+  margin: 0;
+  padding: 0.6rem 0.85rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.git--empty .git__empty-note {
+  padding: 0;
+}
+
+.git__empty-actions {
+  display: flex;
+  gap: 8px;
+}
+
+/* --- Toolbar --------------------------------------------------------------- */
+
+.git__toolbar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0.5rem 0.7rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.git__branch {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.git__branch-icon {
+  color: var(--text-muted);
+}
+
+.git__sync-counts {
+  display: inline-flex;
+  gap: 6px;
+  margin-left: 6px;
+  color: var(--text-muted);
+  font-weight: 400;
+  font-size: 0.78rem;
+}
+
+.git__toolbar-spacer {
+  flex: 1 1 auto;
+}
+
+/* --- Buttons --------------------------------------------------------------- */
+
+.git__btn {
+  padding: 0.3rem 0.7rem;
+  background: var(--bg-sunken);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-family: inherit;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.git__btn:hover:not(:disabled) {
+  background: var(--bg-elevated);
+}
+
+.git__btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.git__btn--primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.git__btn--primary:hover:not(:disabled) {
+  filter: brightness(1.08);
+  background: var(--accent);
+}
+
+.git__icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+  height: 24px;
+  padding: 0 4px;
+  background: transparent;
+  color: var(--text-muted);
+  border: 1px solid transparent;
+  border-radius: var(--radius);
+  font-size: 0.95rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.git__icon-btn:hover:not(:disabled) {
+  background: var(--bg-elevated);
+  color: var(--text);
+}
+
+.git__icon-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.git__link-btn {
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-size: 0.75rem;
+  cursor: pointer;
+  padding: 0;
+}
+
+/* --- Branch switcher ------------------------------------------------------- */
+
+.git__branches {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0.4rem 0.7rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.git__branches-label {
+  color: var(--text-muted);
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.git__branch-select {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 0.25rem 0.4rem;
+  background: var(--bg-sunken);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-family: inherit;
+  font-size: 0.8rem;
+}
+
+/* --- Commit ---------------------------------------------------------------- */
+
+.git__commit {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 0.6rem 0.7rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.git__commit-msg {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.4rem 0.5rem;
+  background: var(--bg-sunken);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-family: inherit;
+  font-size: 0.82rem;
+  resize: vertical;
+}
+
+/* --- Notices --------------------------------------------------------------- */
+
+.git__error,
+.git__notice {
+  margin: 0;
+  padding: 0.5rem 0.7rem;
+  font-size: 0.8rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.git__error {
+  color: var(--danger, #c0392b);
+  background: var(--bg-sunken);
+}
+
+.git__notice {
+  color: var(--text-muted);
+}
+
+/* --- File lists ------------------------------------------------------------ */
+
+.git__lists {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+}
+
+.git__group {
+  border-bottom: 1px solid var(--border);
+}
+
+.git__group-head {
+  padding: 0.45rem 0.7rem;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.git__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.git__file {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 0.5rem 0 0.2rem;
+}
+
+.git__file:hover {
+  background: var(--bg-elevated);
+}
+
+.git__file-main {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0.3rem 0.4rem;
+  background: none;
+  border: none;
+  color: inherit;
+  font-family: inherit;
+  font-size: 0.82rem;
+  text-align: left;
+  cursor: pointer;
+}
+
+.git__mark {
+  flex: 0 0 auto;
+  width: 1.1em;
+  text-align: center;
+  font-weight: 700;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.git__mark--modified {
+  color: #d29922;
+}
+
+.git__mark--added,
+.git__mark--untracked {
+  color: #2ea043;
+}
+
+.git__mark--deleted {
+  color: #c0392b;
+}
+
+.git__mark--conflicted {
+  color: #e5534b;
+}
+
+.git__file-name {
+  flex: 0 1 auto;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.git__file-dir {
+  flex: 1 1 auto;
+  min-width: 0;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.git__file-actions {
+  flex: 0 0 auto;
+  display: inline-flex;
+  gap: 2px;
+  opacity: 0;
+}
+
+.git__file:hover .git__file-actions {
+  opacity: 1;
+}
+
+/* --- Diff viewer ----------------------------------------------------------- */
+
+.git__diff-wrap {
+  flex: 0 0 auto;
+  max-height: 45%;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  border-top: 1px solid var(--border);
+}
+
+.git__diff-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 0.4rem 0.7rem;
+  background: var(--bg-sunken);
+}
+
+.git__diff-title {
+  font-size: 0.78rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.git__diff {
+  margin: 0;
+  padding: 0.3rem 0;
+  overflow: auto;
+  background: var(--bg-sunken);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.74rem;
+  line-height: 1.45;
+}
+
+.git__diff-line {
+  padding: 0 0.7rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.git__diff-line--add {
+  background: rgba(46, 160, 67, 0.18);
+}
+
+.git__diff-line--del {
+  background: rgba(192, 57, 43, 0.18);
+}
+
+.git__diff-line--hunk {
+  color: var(--accent);
+}
+
+.git__diff-line--meta {
+  color: var(--text-muted);
+}
+
+/* --- Footer ---------------------------------------------------------------- */
+
+.git__footer {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0.4rem 0.7rem;
+  border-top: 1px solid var(--border);
+}
+
+.git__repo-path {
+  flex: 1 1 auto;
+  min-width: 0;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  direction: rtl;
+  text-align: left;
+}

--- a/src/renderer/src/components/GitPanel.tsx
+++ b/src/renderer/src/components/GitPanel.tsx
@@ -1,0 +1,427 @@
+import { useCallback, useEffect, useState } from 'react'
+import './GitPanel.css'
+import type {
+  GitBranchList,
+  GitDiff,
+  GitFileStatus,
+  GitStatus
+} from '../../../preload/index.d'
+
+/**
+ * SOURCE CONTROL TAB (issue #15)
+ * ==============================
+ *
+ * A VS Code-style Git panel. The user picks a folder (reusing the native
+ * `fs.openFolderDialog`); the main process resolves whether it is a repo and
+ * reports status through `window.api.git`. From there the panel shows the
+ * branch indicator, ahead/behind counts, staged / changed / untracked file
+ * lists with per-file stage / unstage / discard actions, a commit box + button,
+ * push/pull, and an inline unified-diff view.
+ *
+ * Everything degrades gracefully: a non-repo folder shows a clear empty state
+ * (not an error), and every async action surfaces failures inline rather than
+ * throwing. Git itself runs in the main process, so this component is purely a
+ * thin view over the IPC bridge.
+ */
+
+/** A short glyph + label for each file-status kind, for the row marker. */
+const KIND_MARK: Record<GitFileStatus['kind'], { mark: string; title: string }> = {
+  modified: { mark: 'M', title: 'Modified' },
+  added: { mark: 'A', title: 'Added' },
+  deleted: { mark: 'D', title: 'Deleted' },
+  renamed: { mark: 'R', title: 'Renamed' },
+  conflicted: { mark: '!', title: 'Conflicted' },
+  untracked: { mark: 'U', title: 'Untracked' },
+  unknown: { mark: '?', title: 'Changed' }
+}
+
+/** Render a single colorized unified diff, line by line. */
+function DiffView({ diff }: { diff: string }): JSX.Element {
+  if (!diff.trim()) {
+    return <p className="git__empty-note">No differences to show.</p>
+  }
+  const lines = diff.split(/\r?\n/)
+  return (
+    <pre className="git__diff" aria-label="File diff">
+      {lines.map((line, i) => {
+        let cls = 'git__diff-line'
+        if (line.startsWith('+') && !line.startsWith('+++')) cls += ' git__diff-line--add'
+        else if (line.startsWith('-') && !line.startsWith('---')) cls += ' git__diff-line--del'
+        else if (line.startsWith('@@')) cls += ' git__diff-line--hunk'
+        else if (
+          line.startsWith('diff ') ||
+          line.startsWith('index ') ||
+          line.startsWith('+++') ||
+          line.startsWith('---')
+        )
+          cls += ' git__diff-line--meta'
+        return (
+          <div key={i} className={cls}>
+            {line || ' '}
+          </div>
+        )
+      })}
+    </pre>
+  )
+}
+
+export function GitPanel(): JSX.Element {
+  const [repoPath, setRepoPath] = useState<string | null>(null)
+  const [status, setStatus] = useState<GitStatus | null>(null)
+  const [branches, setBranches] = useState<GitBranchList | null>(null)
+  const [message, setMessage] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [notice, setNotice] = useState<string | null>(null)
+  const [openDiff, setOpenDiff] = useState<GitDiff | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  /** Reload status (and branches) for the open repo. */
+  const refresh = useCallback(async (): Promise<void> => {
+    setLoading(true)
+    setError(null)
+    try {
+      const st = await window.api.git.status()
+      setStatus(st)
+      if (st.isRepo) {
+        try {
+          setBranches(await window.api.git.listBranches())
+        } catch {
+          setBranches(null)
+        }
+      } else {
+        setBranches(null)
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  /** Pick a folder and open it as a repository. */
+  const openFolder = useCallback(async (): Promise<void> => {
+    setError(null)
+    setNotice(null)
+    setOpenDiff(null)
+    try {
+      const picked = await window.api.fs.openFolderDialog()
+      if (!picked) return
+      await window.api.git.openRepo(picked)
+      setRepoPath(picked)
+      await refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }, [refresh])
+
+  // Re-resolve status when a repo path is set (also covers the openRepo above).
+  useEffect(() => {
+    if (repoPath) void refresh()
+  }, [repoPath, refresh])
+
+  /** Run an action with busy-state + error capture, then refresh status. */
+  const run = useCallback(
+    async (fn: () => Promise<void>, successNotice?: string): Promise<void> => {
+      setBusy(true)
+      setError(null)
+      setNotice(null)
+      try {
+        await fn()
+        if (successNotice) setNotice(successNotice)
+        await refresh()
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err))
+      } finally {
+        setBusy(false)
+      }
+    },
+    [refresh]
+  )
+
+  const showDiff = useCallback(async (file: string, staged: boolean): Promise<void> => {
+    setError(null)
+    try {
+      const d = await window.api.git.diff(file, staged)
+      setOpenDiff(d)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }, [])
+
+  const commit = useCallback(async (): Promise<void> => {
+    const msg = message.trim()
+    if (!msg) {
+      setError('Enter a commit message first.')
+      return
+    }
+    await run(async () => {
+      await window.api.git.commit(msg, true)
+      setMessage('')
+    }, 'Committed.')
+  }, [message, run])
+
+  // --- Render: no folder picked -------------------------------------------
+  if (!repoPath) {
+    return (
+      <div className="git git--empty">
+        <p className="git__empty-note">
+          Open a folder to manage it with Git. Source control runs on your
+          machine using the system <code>git</code>.
+        </p>
+        <button type="button" className="git__btn git__btn--primary" onClick={() => void openFolder()}>
+          Open Folder…
+        </button>
+      </div>
+    )
+  }
+
+  // --- Render: folder picked but not a git repo ---------------------------
+  if (status && !status.isRepo) {
+    return (
+      <div className="git git--empty">
+        <p className="git__empty-note">
+          <code>{repoPath}</code> is not a Git repository.
+        </p>
+        <div className="git__empty-actions">
+          <button type="button" className="git__btn" onClick={() => void openFolder()}>
+            Open a different folder…
+          </button>
+          <button type="button" className="git__btn" onClick={() => void refresh()}>
+            Re-check
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  const fileRow = (f: GitFileStatus, group: 'staged' | 'changed' | 'untracked'): JSX.Element => {
+    const meta = KIND_MARK[f.kind]
+    const name = f.path.split('/').pop() ?? f.path
+    const dir = f.path.slice(0, f.path.length - name.length)
+    return (
+      <li key={`${group}:${f.path}`} className="git__file">
+        <button
+          type="button"
+          className="git__file-main"
+          title={`${meta.title} — click to view diff`}
+          onClick={() => void showDiff(f.path, group === 'staged')}
+        >
+          <span className={`git__mark git__mark--${f.kind}`} aria-hidden="true">
+            {meta.mark}
+          </span>
+          <span className="git__file-name">{name}</span>
+          {dir && <span className="git__file-dir">{dir}</span>}
+        </button>
+        <span className="git__file-actions">
+          {group === 'staged' ? (
+            <button
+              type="button"
+              className="git__icon-btn"
+              title="Unstage"
+              disabled={busy}
+              onClick={() => void run(() => window.api.git.unstage(f.path))}
+            >
+              −
+            </button>
+          ) : (
+            <>
+              <button
+                type="button"
+                className="git__icon-btn"
+                title="Discard changes"
+                disabled={busy}
+                onClick={() => void run(() => window.api.git.discard(f.path))}
+              >
+                ⨯
+              </button>
+              <button
+                type="button"
+                className="git__icon-btn"
+                title="Stage"
+                disabled={busy}
+                onClick={() => void run(() => window.api.git.stage(f.path))}
+              >
+                ＋
+              </button>
+            </>
+          )}
+        </span>
+      </li>
+    )
+  }
+
+  const staged = status?.staged ?? []
+  const changed = status?.changed ?? []
+  const untracked = status?.untracked ?? []
+  const hasChanges = staged.length + changed.length + untracked.length > 0
+
+  return (
+    <div className="git">
+      {/* Toolbar: branch indicator + repo actions */}
+      <div className="git__toolbar">
+        <span className="git__branch" title={status?.tracking ?? 'No upstream'}>
+          <span className="git__branch-icon" aria-hidden="true">
+            ⎇
+          </span>
+          {status?.branch ?? 'detached'}
+          {status && (status.ahead > 0 || status.behind > 0) && (
+            <span className="git__sync-counts">
+              {status.ahead > 0 && <span title="Ahead">↑{status.ahead}</span>}
+              {status.behind > 0 && <span title="Behind">↓{status.behind}</span>}
+            </span>
+          )}
+        </span>
+        <span className="git__toolbar-spacer" />
+        <button
+          type="button"
+          className="git__icon-btn"
+          title="Refresh"
+          disabled={loading || busy}
+          onClick={() => void refresh()}
+        >
+          ⟳
+        </button>
+        <button
+          type="button"
+          className="git__icon-btn"
+          title="Pull"
+          disabled={busy}
+          onClick={() => void run(async () => void (await window.api.git.pull()), 'Pulled.')}
+        >
+          ↓
+        </button>
+        <button
+          type="button"
+          className="git__icon-btn"
+          title="Push"
+          disabled={busy}
+          onClick={() => void run(async () => void (await window.api.git.push()), 'Pushed.')}
+        >
+          ↑
+        </button>
+      </div>
+
+      {/* Branch switcher */}
+      {branches && branches.branches.length > 0 && (
+        <div className="git__branches">
+          <label className="git__branches-label" htmlFor="git-branch-select">
+            Branch
+          </label>
+          <select
+            id="git-branch-select"
+            className="git__branch-select"
+            value={branches.current ?? ''}
+            disabled={busy}
+            onChange={(e) => {
+              const next = e.target.value
+              if (next && next !== branches.current) {
+                void run(() => window.api.git.checkout(next), `Switched to ${next}`)
+              }
+            }}
+          >
+            {!branches.current && <option value="">(detached)</option>}
+            {branches.branches.map((b) => (
+              <option key={b} value={b}>
+                {b}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {/* Commit box */}
+      <div className="git__commit">
+        <textarea
+          className="git__commit-msg"
+          placeholder="Message (Ctrl+Enter to commit)"
+          value={message}
+          rows={2}
+          disabled={busy}
+          onChange={(e) => setMessage(e.target.value)}
+          onKeyDown={(e) => {
+            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+              e.preventDefault()
+              void commit()
+            }
+          }}
+        />
+        <button
+          type="button"
+          className="git__btn git__btn--primary"
+          disabled={busy || !message.trim()}
+          title="Stage all changes and commit"
+          onClick={() => void commit()}
+        >
+          Commit
+        </button>
+      </div>
+
+      {error && (
+        <p className="git__error" role="alert">
+          {error}
+        </p>
+      )}
+      {notice && (
+        <p className="git__notice" role="status">
+          {notice}
+        </p>
+      )}
+
+      {/* File lists */}
+      <div className="git__lists">
+        {staged.length > 0 && (
+          <section className="git__group">
+            <div className="git__group-head">Staged Changes ({staged.length})</div>
+            <ul className="git__list">{staged.map((f) => fileRow(f, 'staged'))}</ul>
+          </section>
+        )}
+        {changed.length > 0 && (
+          <section className="git__group">
+            <div className="git__group-head">Changes ({changed.length})</div>
+            <ul className="git__list">{changed.map((f) => fileRow(f, 'changed'))}</ul>
+          </section>
+        )}
+        {untracked.length > 0 && (
+          <section className="git__group">
+            <div className="git__group-head">Untracked ({untracked.length})</div>
+            <ul className="git__list">{untracked.map((f) => fileRow(f, 'untracked'))}</ul>
+          </section>
+        )}
+        {!hasChanges && !loading && (
+          <p className="git__empty-note">No changes. Working tree is clean.</p>
+        )}
+      </div>
+
+      {/* Diff viewer */}
+      {openDiff && (
+        <section className="git__diff-wrap">
+          <div className="git__diff-head">
+            <span className="git__diff-title">
+              {openDiff.path}
+              {openDiff.staged ? ' (staged)' : ''}
+            </span>
+            <button
+              type="button"
+              className="git__icon-btn"
+              title="Close diff"
+              onClick={() => setOpenDiff(null)}
+            >
+              ✕
+            </button>
+          </div>
+          <DiffView diff={openDiff.diff} />
+        </section>
+      )}
+
+      <div className="git__footer">
+        <span className="git__repo-path" title={status?.root ?? repoPath}>
+          {status?.root ?? repoPath}
+        </span>
+        <button type="button" className="git__link-btn" onClick={() => void openFolder()}>
+          Change…
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/RightPanel.tsx
+++ b/src/renderer/src/components/RightPanel.tsx
@@ -5,6 +5,7 @@ import { OutlinePanel } from './OutlinePanel'
 import { VariablesPanel } from './VariablesPanel'
 import { ChatPanel } from './ChatPanel'
 import { PackagesPanel } from './PackagesPanel'
+import { GitPanel } from './GitPanel'
 
 /**
  * RIGHT PANE — optional/collapsible region (collapsed by default).
@@ -32,7 +33,9 @@ export function RightPanel(): JSX.Element {
     // Claude chat assistant (issue #18):
     { id: 'chat', title: 'Chat', icon: '💬', content: <ChatPanel /> },
     // MicroPython package installer (mip/PyPI) with discovery (issue #20):
-    { id: 'packages', title: 'Packages', icon: '📦', content: <PackagesPanel /> }
+    { id: 'packages', title: 'Packages', icon: '📦', content: <PackagesPanel /> },
+    // Built-in version control / Source Control (Git, issue #15):
+    { id: 'git', title: 'Source Control', icon: '⎇', content: <GitPanel /> }
   ]
 
   return (


### PR DESCRIPTION
Adds a built-in, VS Code-style Source Control panel backed by a new main-process Git layer (`simple-git`).

## What's included
- **Main process** `src/main/git/`:
  - `GitService` — wraps `simple-git`, scoped to a chosen repo directory.
  - `registerGitIpc` — `git:*` handlers following the `IpcResult` convention, wired in `src/main/index.ts`.
  - Not-a-repo is reported via `status().isRepo` (never thrown) so the UI shows a clean empty state.
- **Preload** — new `window.api.git` namespace (localized) + type re-exports in `index.d.ts`.
- **UI** `GitPanel.tsx` (+ CSS) — Source Control tab appended to `RightPanel`:
  - Repo picker (reuses `fs.openFolderDialog`), branch indicator with ahead/behind, branch switcher.
  - Staged / Changes / Untracked lists with per-file stage / unstage / discard.
  - Commit message box + Commit button (Ctrl/Cmd+Enter), Push / Pull, Refresh.
  - Inline colorized unified-diff viewer (working + staged).
  - Clear empty and non-repo states.
- **Dependency**: `simple-git`.

## `window.api.git` shape
`openRepo(path)`, `status()`, `stage(file)`, `unstage(file)`, `discard(file)`, `commit(message, stageAll?)`, `diff(file, staged?)`, `currentBranch()`, `listBranches()`, `checkout(branch)`, `push()`, `pull()`.

## Checklist
- [x] Main process `src/main/git/` + `registerGitIpc`
- [x] `openRepo` / repo-root detection; `status()` with branch, ahead/behind, file lists
- [x] `stage` / `unstage` / `discard`
- [x] `commit(message)` (stages all tracked changes)
- [x] `diff(file)` unified diff (staged + working, incl. untracked)
- [x] `currentBranch` / `listBranches` / `checkout`
- [x] `push` / `pull`
- [x] Clean guard for non-repo folders
- [x] `GitPanel.tsx` Source Control UI with empty/non-repo states
- [ ] Inline editor gutter indicators (optional — not done; kept scope to the core panel)

## Acceptance
`npm install && npm run lint && npm run typecheck && npm run build` all pass.

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)