### PR TITLE
Tests for parsing logic + hardware test plan (toward #45)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,8 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+      - name: Test
+        run: npm test
+
       - name: Build
         run: npm run build

--- a/docs/hardware-test-plan.md
+++ b/docs/hardware-test-plan.md
@@ -1,0 +1,249 @@
+# Snakie — Real-Hardware Test Plan
+
+Manual, on-device validation plan for Snakie. Tracks issue
+[#45](https://github.com/kevinmcaleer/Snakie/issues/45) (real-hardware
+validation).
+
+The automated unit tests in this repo cover the pure parsing/formatting logic
+(outline, variables inspector, serial-plotter line parsing). Everything below
+requires a **physical MicroPython board** and must be run by hand — CI cannot
+exercise USB serial, firmware flashing, or the device filesystem.
+
+## How to use this document
+
+1. Build/run the app you want to validate (`npm run dev` for a dev build, or a
+   packaged artifact from `npm run dist`).
+2. Work top-to-bottom through each section for **each board** under test.
+3. Tick the checkbox and record Pass/Fail + notes in the result table at the end
+   of each section. Note the app version (`package.json` `version`) and OS.
+
+## Boards under test
+
+Run the full plan on at least one board from each MicroPython family:
+
+- [ ] **ESP32** (e.g. ESP32-DevKitC / ESP32-WROOM) — USB serial via CP210x or
+      CH340.
+- [ ] **RP2040** (Raspberry Pi Pico / Pico W) — USB CDC serial; BOOTSEL
+      mass-storage bootloader for firmware.
+- [ ] (Optional) **ESP8266** if firmware-flash parity matters.
+
+Record for each board:
+
+| Field | Value |
+| --- | --- |
+| Board / variant | |
+| MicroPython firmware version | |
+| Host OS + version | |
+| Snakie version | |
+| Serial port / driver | |
+
+---
+
+## 1. Connection & port enumeration
+
+- [ ] Board appears in the port list (correct path, manufacturer where known).
+- [ ] Connect succeeds at default baud (115200); status shows **connected** with
+      the right port + baud.
+- [ ] Disconnecting a live board (unplug USB) transitions UI back to
+      **disconnected** without a crash.
+- [ ] Reconnect after unplug works without restarting the app.
+- [ ] Connecting to a busy/occupied port surfaces a clear error (not a silent
+      hang).
+
+Expected: state transitions match (`connecting` → `connected`, and
+`error`/`disconnected` on failure). No stuck spinner.
+
+| Step | Pass/Fail | Notes |
+| --- | --- | --- |
+| Port enumeration | | |
+| Connect | | |
+| Unplug → disconnected | | |
+| Reconnect | | |
+| Busy-port error | | |
+
+## 2. Interactive REPL (terminal)
+
+- [ ] Typing in the terminal echoes and `>>>` prompt responds.
+- [ ] `print('hello')` returns `hello`.
+- [ ] Ctrl-C interrupts a running loop (e.g. `while True: pass`).
+- [ ] Ctrl-D soft-reset reboots the interpreter (banner reprints).
+- [ ] Multi-line paste / block input behaves.
+- [ ] Unicode output renders correctly.
+
+| Step | Pass/Fail | Notes |
+| --- | --- | --- |
+| Echo + prompt | | |
+| print | | |
+| Ctrl-C interrupt | | |
+| Ctrl-D soft reset | | |
+| Unicode | | |
+
+## 3. Run / Stop / Clear
+
+- [ ] **Run** the active editor file on the device; stdout appears in the
+      terminal.
+- [ ] A script with a runtime error shows the traceback.
+- [ ] **Stop** halts a long-running script (e.g. infinite loop with prints).
+- [ ] **Clear** clears the terminal buffer without disconnecting.
+- [ ] Running a second script after Stop works (raw-REPL state recovered).
+
+| Step | Pass/Fail | Notes |
+| --- | --- | --- |
+| Run script | | |
+| Traceback shown | | |
+| Stop | | |
+| Clear | | |
+| Run again after Stop | | |
+
+## 4. Local file operations
+
+- [ ] Open a local folder; tree renders.
+- [ ] Open a file into an editor tab; contents correct.
+- [ ] Edit + save a local file; change persists on disk.
+- [ ] Create / rename / delete a local file via the tree.
+- [ ] Create / rename / delete a local folder.
+
+| Step | Pass/Fail | Notes |
+| --- | --- | --- |
+| Open folder | | |
+| Open file | | |
+| Save | | |
+| File create/rename/delete | | |
+| Folder create/rename/delete | | |
+
+## 5. Device file operations
+
+- [ ] Device file tree lists the board's filesystem (root + subdirs).
+- [ ] Open a device file; contents match (incl. a file with non-ASCII bytes).
+- [ ] Save edits back to the device; re-open confirms persistence.
+- [ ] Create / rename / delete a device file.
+- [ ] Create / delete a device directory.
+- [ ] Large file (> a few KB) reads/writes intact — verify byte-for-byte
+      (hex chunking path).
+- [ ] Binary file round-trips without corruption.
+
+| Step | Pass/Fail | Notes |
+| --- | --- | --- |
+| List device FS | | |
+| Open device file | | |
+| Save to device | | |
+| Create/rename/delete file | | |
+| Create/delete dir | | |
+| Large file round-trip | | |
+| Binary round-trip | | |
+
+## 6. Upload / Download
+
+- [ ] **Upload** a local file to the device; appears in device tree with correct
+      contents.
+- [ ] **Download** a device file to local disk; contents match.
+- [ ] Upload overwrites an existing device file correctly.
+- [ ] Upload to a subdirectory path works.
+
+| Step | Pass/Fail | Notes |
+| --- | --- | --- |
+| Upload | | |
+| Download | | |
+| Overwrite on upload | | |
+| Upload to subdir | | |
+
+## 7. Serial Plotter
+
+Run a script that prints numeric data in each supported format and confirm the
+plot.
+
+- [ ] Single number per line (`print(value)`): one auto series plots.
+- [ ] CSV / space / tab multi-column (`print(a, b, c)`): multiple series, one
+      per column.
+- [ ] Labelled pairs (`temp:21.4, humidity:48` or `x=1 y=2`): named series.
+- [ ] Non-numeric lines are ignored (no spurious series, no crash).
+- [ ] Pause freezes the chart; Resume continues.
+- [ ] Clear empties the chart and legend.
+- [ ] Window-size control changes the rolling window.
+- [ ] Plotter does not disturb the terminal (both update from the same stream).
+
+| Step | Pass/Fail | Notes |
+| --- | --- | --- |
+| Single number | | |
+| Multi-column | | |
+| Labelled pairs | | |
+| Non-numeric ignored | | |
+| Pause/Resume | | |
+| Clear | | |
+| Window size | | |
+| Terminal unaffected | | |
+
+## 8. Variables inspector
+
+- [ ] With a board connected, the Variables tab lists user globals after running
+      code that defines some.
+- [ ] Types and reprs render correctly (int, str, list, dict, custom object).
+- [ ] A value whose repr is very long is truncated (no flooding).
+- [ ] **Refresh** re-reads current globals.
+- [ ] Disconnecting clears the list and shows the connect hint.
+
+| Step | Pass/Fail | Notes |
+| --- | --- | --- |
+| Lists globals | | |
+| Types/reprs correct | | |
+| Long repr truncated | | |
+| Refresh | | |
+| Clears on disconnect | | |
+
+## 9. `mip` package install
+
+- [ ] Install a known package (e.g. `mip install <pkg>`); progress/output shown.
+- [ ] Installed module is importable on the device afterward.
+- [ ] Failure (bad package name / no network) surfaces a clear error.
+
+> Note: `mip` requires the board to have network access (Wi-Fi boards: ESP32,
+> Pico W). Note connectivity in results.
+
+| Step | Pass/Fail | Notes |
+| --- | --- | --- |
+| Install package | | |
+| Import installed module | | |
+| Error on bad install | | |
+
+## 10. Firmware flashing
+
+> Destructive: erases the board. Have the correct `.bin`/`.uf2` ready and back
+> up any device files first.
+
+### ESP32 (esptool path)
+
+- [ ] Select correct port + ESP32 firmware `.bin`.
+- [ ] Erase + flash completes; progress reported.
+- [ ] Board boots into the new MicroPython (REPL banner shows new version).
+- [ ] Reconnect + run a script post-flash.
+
+### RP2040 / Pico (UF2 / BOOTSEL path)
+
+- [ ] Enter BOOTSEL (mass-storage) mode; flow detects/guides it.
+- [ ] Copy/flash the `.uf2`; board reboots into MicroPython.
+- [ ] Reconnect + run a script post-flash.
+
+| Step | Pass/Fail | Notes |
+| --- | --- | --- |
+| ESP32 select firmware | | |
+| ESP32 erase+flash | | |
+| ESP32 boots new fw | | |
+| RP2040 BOOTSEL | | |
+| RP2040 flash UF2 | | |
+| RP2040 boots new fw | | |
+
+---
+
+## Regression / stability sweep
+
+- [ ] No unhandled errors in the dev console during a full pass.
+- [ ] Switching tabs/panels mid-operation does not break the connection.
+- [ ] App quits cleanly with a board connected (port released).
+- [ ] Repeat connect/disconnect 5× — no leaked ports or zombie state.
+
+## Sign-off
+
+| Board | Tester | Date | Overall result |
+| --- | --- | --- | --- |
+| ESP32 | | | |
+| RP2040 | | | |

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,8 @@
         "eslint-plugin-react-hooks": "^4.6.2",
         "prettier": "^3.4.2",
         "typescript": "^5.6.3",
-        "vite": "^5.4.11"
+        "vite": "^5.4.11",
+        "vitest": "^2.1.9"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -2423,6 +2424,112 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.9.10",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
@@ -2861,6 +2968,15 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -3283,6 +3399,22 @@
         }
       ]
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3297,6 +3429,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chownr": {
@@ -3640,6 +3781,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -4314,6 +4464,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
@@ -4690,6 +4846,15 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4697,6 +4862,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extract-zip": {
@@ -6320,6 +6494,12 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
@@ -6876,6 +7056,21 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/pend": {
@@ -7715,6 +7910,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -7824,6 +8025,12 @@
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "optional": true
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
     "node_modules/standardwebhooks": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
@@ -7841,6 +8048,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -8155,6 +8368,45 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
       "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/tmp": {
       "version": "0.2.7",
@@ -8480,6 +8732,93 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -8578,6 +8917,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json --composite false",
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json --composite false",
     "typecheck": "npm run typecheck:node && npm run typecheck:web",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "eslint . --ext .ts,.tsx,.cjs",
     "format": "prettier --write \"src/**/*.{ts,tsx,css,html}\" \"*.{ts,cjs,json,md}\"",
     "postinstall": "electron-builder install-app-deps",
@@ -55,6 +57,7 @@
     "eslint-plugin-react-hooks": "^4.6.2",
     "prettier": "^3.4.2",
     "typescript": "^5.6.3",
-    "vite": "^5.4.11"
+    "vite": "^5.4.11",
+    "vitest": "^2.1.9"
   }
 }

--- a/src/renderer/src/components/Plotter.parse.ts
+++ b/src/renderer/src/components/Plotter.parse.ts
@@ -1,0 +1,33 @@
+/**
+ * Pure line parser for the Serial Plotter (issue #21), extracted from
+ * `Plotter.tsx` so it can be unit-tested without React/canvas (issue #45).
+ *
+ * The component imports {@link parseLine} from here; behaviour is unchanged.
+ *
+ * Supported line formats (the caller trims the line first):
+ *  - single number:                "12.5"
+ *  - comma / space / tab separated: "1, 2, 3"  ·  "1 2 3"  ·  "1\t2\t3"
+ *  - labelled pairs:                "temp:21.4, humidity:48"  ·  "x=1 y=2"
+ * Tokens with no parsable finite number are ignored.
+ */
+
+/** Parse one already-trimmed line into `[label|null, value]` token pairs. */
+export function parseLine(line: string): Array<{ label: string | null; value: number }> {
+  if (!line) return []
+  // Split on commas, tabs and runs of spaces — the common delimiters emitted by
+  // `print(a, b, c)` / CSV-style logging on a MicroPython board.
+  const tokens = line.split(/[,\t]|\s+/).filter((t) => t.length > 0)
+  const out: Array<{ label: string | null; value: number }> = []
+  for (const token of tokens) {
+    // "label:value" or "label=value" pairs.
+    const pair = token.match(/^(.+?)\s*[:=]\s*(-?\d.*)$/)
+    if (pair) {
+      const value = Number(pair[2])
+      if (Number.isFinite(value)) out.push({ label: pair[1].trim(), value })
+      continue
+    }
+    const value = Number(token)
+    if (Number.isFinite(value)) out.push({ label: null, value })
+  }
+  return out
+}

--- a/src/renderer/src/components/Plotter.tsx
+++ b/src/renderer/src/components/Plotter.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import './Plotter.css'
+import { parseLine } from './Plotter.parse'
 
 /**
  * Serial Plotter (issue #21) — Arduino-IDE-style live chart of numeric console
@@ -48,27 +49,6 @@ interface Series {
 }
 
 const decoder = new TextDecoder()
-
-/** Parse one already-trimmed line into `[label|null, value]` token pairs. */
-function parseLine(line: string): Array<{ label: string | null; value: number }> {
-  if (!line) return []
-  // Split on commas, tabs and runs of spaces — the common delimiters emitted by
-  // `print(a, b, c)` / CSV-style logging on a MicroPython board.
-  const tokens = line.split(/[,\t]|\s+/).filter((t) => t.length > 0)
-  const out: Array<{ label: string | null; value: number }> = []
-  for (const token of tokens) {
-    // "label:value" or "label=value" pairs.
-    const pair = token.match(/^(.+?)\s*[:=]\s*(-?\d.*)$/)
-    if (pair) {
-      const value = Number(pair[2])
-      if (Number.isFinite(value)) out.push({ label: pair[1].trim(), value })
-      continue
-    }
-    const value = Number(token)
-    if (Number.isFinite(value)) out.push({ label: null, value })
-  }
-  return out
-}
 
 export function Plotter(): JSX.Element {
   const canvasRef = useRef<HTMLCanvasElement>(null)

--- a/test/parseOutline.test.ts
+++ b/test/parseOutline.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest'
+import { parseOutline } from '../src/renderer/src/components/OutlinePanel'
+
+describe('parseOutline', () => {
+  it('returns no symbols for empty / whitespace-only input', () => {
+    expect(parseOutline('')).toEqual([])
+    expect(parseOutline('\n\n   \n')).toEqual([])
+  })
+
+  it('extracts a top-level function with its signature and 1-based line', () => {
+    const out = parseOutline('def foo(a, b):\n    return a + b\n')
+    expect(out).toEqual([{ kind: 'function', name: 'foo', line: 1, detail: '(a, b)' }])
+  })
+
+  it('extracts async functions', () => {
+    const out = parseOutline('async def main():\n    pass\n')
+    expect(out).toEqual([{ kind: 'function', name: 'main', line: 1, detail: '()' }])
+  })
+
+  it('extracts a class with base classes as detail', () => {
+    const out = parseOutline('class Foo(Bar, Baz):\n    pass\n')
+    expect(out).toEqual([{ kind: 'class', name: 'Foo', line: 1, detail: '(Bar, Baz)' }])
+  })
+
+  it('omits detail for a class with no bases', () => {
+    const out = parseOutline('class Foo:\n    pass\n')
+    expect(out).toEqual([{ kind: 'class', name: 'Foo', line: 1, detail: undefined }])
+  })
+
+  it('extracts module-level assignments', () => {
+    const out = parseOutline('X = 1\nY: int = 2\n')
+    expect(out).toEqual([
+      { kind: 'variable', name: 'X', line: 1 },
+      { kind: 'variable', name: 'Y', line: 2 }
+    ])
+  })
+
+  it('ignores comparison operators (== and <=) as assignments', () => {
+    // These start at column 0 but are not assignments.
+    const out = parseOutline('x == 1\ny <= 2\n')
+    expect(out).toEqual([])
+  })
+
+  it('ignores indented members (methods, locals)', () => {
+    const src = ['class Foo:', '    def method(self):', '        local = 1', 'TOP = 2'].join('\n')
+    const out = parseOutline(src)
+    expect(out).toEqual([
+      { kind: 'class', name: 'Foo', line: 1, detail: undefined },
+      { kind: 'variable', name: 'TOP', line: 4 }
+    ])
+  })
+
+  it('ignores comment lines', () => {
+    expect(parseOutline('# def notreal():\nA = 1')).toEqual([
+      { kind: 'variable', name: 'A', line: 2 }
+    ])
+  })
+
+  it('dedupes repeated variable assignments, keeping the first line', () => {
+    const out = parseOutline('count = 0\ncount = 1\ncount = 2\n')
+    expect(out).toEqual([{ kind: 'variable', name: 'count', line: 1 }])
+  })
+
+  it('handles CRLF line endings', () => {
+    const out = parseOutline('def a():\r\n    pass\r\nB = 1\r\n')
+    expect(out).toEqual([
+      { kind: 'function', name: 'a', line: 1, detail: '()' },
+      { kind: 'variable', name: 'B', line: 3 }
+    ])
+  })
+
+  it('handles a mixed module in order', () => {
+    const src = ['import os', 'CONFIG = {}', 'def setup():', '    pass', 'class App:', '    pass'].join(
+      '\n'
+    )
+    const out = parseOutline(src)
+    expect(out).toEqual([
+      { kind: 'variable', name: 'CONFIG', line: 2 },
+      { kind: 'function', name: 'setup', line: 3, detail: '()' },
+      { kind: 'class', name: 'App', line: 5, detail: undefined }
+    ])
+  })
+
+  it('treats multi-target assignment by recording the first target', () => {
+    const out = parseOutline('a = b = 0\n')
+    expect(out).toEqual([{ kind: 'variable', name: 'a', line: 1 }])
+  })
+})

--- a/test/parseVariables.test.ts
+++ b/test/parseVariables.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { parseVariables } from '../src/renderer/src/components/VariablesPanel'
+
+const FS = '␟' // SYMBOL FOR UNIT SEPARATOR (␟)
+const START = '<<SNAKIE_VARS>>'
+const END = '<<SNAKIE_VARS_END>>'
+
+/** Helper to build a record line with the sentinel field separator. */
+function rec(name: string, type: string, repr: string): string {
+  return `${name}${FS}${type}${FS}${repr}`
+}
+
+describe('parseVariables', () => {
+  it('returns nothing for empty input', () => {
+    expect(parseVariables('')).toEqual([])
+  })
+
+  it('parses name/type/repr records between sentinels', () => {
+    const stdout = [START, rec('x', 'int', '42'), rec('s', 'str', "'hi'"), END].join('\n')
+    expect(parseVariables(stdout)).toEqual([
+      { name: 'x', type: 'int', value: '42' },
+      { name: 's', type: 'str', value: "'hi'" }
+    ])
+  })
+
+  it('ignores anything before the start sentinel', () => {
+    const stdout = ['noise', rec('pre', 'int', '0'), START, rec('x', 'int', '1'), END].join('\n')
+    expect(parseVariables(stdout)).toEqual([{ name: 'x', type: 'int', value: '1' }])
+  })
+
+  it('stops at the end sentinel', () => {
+    const stdout = [START, rec('x', 'int', '1'), END, rec('after', 'int', '2')].join('\n')
+    expect(parseVariables(stdout)).toEqual([{ name: 'x', type: 'int', value: '1' }])
+  })
+
+  it('preserves a repr that itself contains the field separator', () => {
+    // Only the first two separators delimit name/type; the rest is the repr.
+    const value = `['a${FS}b', 'c${FS}d']`
+    const stdout = [START, rec('lst', 'list', value), END].join('\n')
+    expect(parseVariables(stdout)).toEqual([{ name: 'lst', type: 'list', value }])
+  })
+
+  it('skips lines with fewer than two separators', () => {
+    const stdout = [START, 'garbage-no-sep', `onlyone${FS}field`, rec('ok', 'int', '5'), END].join(
+      '\n'
+    )
+    expect(parseVariables(stdout)).toEqual([{ name: 'ok', type: 'int', value: '5' }])
+  })
+
+  it('skips records with an empty name', () => {
+    const stdout = [START, rec('', 'int', '0'), rec('ok', 'int', '1'), END].join('\n')
+    expect(parseVariables(stdout)).toEqual([{ name: 'ok', type: 'int', value: '1' }])
+  })
+
+  it('allows an empty type and empty repr', () => {
+    const stdout = [START, rec('e', '', ''), END].join('\n')
+    expect(parseVariables(stdout)).toEqual([{ name: 'e', type: '', value: '' }])
+  })
+
+  it('ignores records emitted before any start sentinel even with separators', () => {
+    const stdout = [rec('x', 'int', '1')].join('\n')
+    expect(parseVariables(stdout)).toEqual([])
+  })
+
+  it('handles CRLF line endings', () => {
+    const stdout = [START, rec('x', 'int', '1'), END].join('\r\n')
+    expect(parseVariables(stdout)).toEqual([{ name: 'x', type: 'int', value: '1' }])
+  })
+
+  it('reads the device error sentinel record as a normal variable row', () => {
+    const stdout = [START, rec('ERR', 'error', "Exception('boom')"), END].join('\n')
+    expect(parseVariables(stdout)).toEqual([
+      { name: 'ERR', type: 'error', value: "Exception('boom')" }
+    ])
+  })
+})

--- a/test/plotterParseLine.test.ts
+++ b/test/plotterParseLine.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { parseLine } from '../src/renderer/src/components/Plotter.parse'
+
+describe('Plotter parseLine', () => {
+  it('returns nothing for an empty string', () => {
+    expect(parseLine('')).toEqual([])
+  })
+
+  it('parses a single number', () => {
+    expect(parseLine('12.5')).toEqual([{ label: null, value: 12.5 }])
+  })
+
+  it('parses negative and decimal numbers', () => {
+    expect(parseLine('-3.14')).toEqual([{ label: null, value: -3.14 }])
+  })
+
+  it('parses comma-separated values', () => {
+    expect(parseLine('1, 2, 3')).toEqual([
+      { label: null, value: 1 },
+      { label: null, value: 2 },
+      { label: null, value: 3 }
+    ])
+  })
+
+  it('parses space-separated values', () => {
+    expect(parseLine('1 2 3')).toEqual([
+      { label: null, value: 1 },
+      { label: null, value: 2 },
+      { label: null, value: 3 }
+    ])
+  })
+
+  it('parses tab-separated values', () => {
+    expect(parseLine('1\t2\t3')).toEqual([
+      { label: null, value: 1 },
+      { label: null, value: 2 },
+      { label: null, value: 3 }
+    ])
+  })
+
+  it('parses label:value pairs', () => {
+    expect(parseLine('temp:21.4, humidity:48')).toEqual([
+      { label: 'temp', value: 21.4 },
+      { label: 'humidity', value: 48 }
+    ])
+  })
+
+  it('parses label=value pairs', () => {
+    expect(parseLine('x=1 y=2')).toEqual([
+      { label: 'x', value: 1 },
+      { label: 'y', value: 2 }
+    ])
+  })
+
+  it('ignores non-numeric tokens', () => {
+    expect(parseLine('hello world')).toEqual([])
+  })
+
+  it('ignores tokens whose value side is non-numeric', () => {
+    // `temp:` requires a value starting with -?digit; "abc" has no leading digit.
+    expect(parseLine('temp:abc')).toEqual([])
+  })
+
+  it('mixes labelled and unlabelled tokens', () => {
+    expect(parseLine('1 x=2 3')).toEqual([
+      { label: null, value: 1 },
+      { label: 'x', value: 2 },
+      { label: null, value: 3 }
+    ])
+  })
+
+  it('drops NaN / non-finite tokens but keeps valid neighbours', () => {
+    // "1e9999" parses to Infinity (not finite) and is dropped.
+    expect(parseLine('5 1e9999 6')).toEqual([
+      { label: null, value: 5 },
+      { label: null, value: 6 }
+    ])
+  })
+
+  it('treats a bare numeric string with units as a non-number', () => {
+    // "12px" -> Number('12px') is NaN, dropped.
+    expect(parseLine('12px')).toEqual([])
+  })
+
+  it('parses exponent notation', () => {
+    expect(parseLine('1.5e3')).toEqual([{ label: null, value: 1500 }])
+  })
+
+  it('collapses runs of spaces between values', () => {
+    expect(parseLine('7    8')).toEqual([
+      { label: null, value: 7 },
+      { label: null, value: 8 }
+    ])
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config'
+
+/**
+ * Vitest configuration for Snakie's pure-logic unit tests (issue #45).
+ *
+ * These tests exercise the parsing/formatting helpers that back device
+ * features (outline, variables inspector, serial plotter) without any
+ * Electron, serialport, monaco, React or DOM dependency — so a plain `node`
+ * environment is sufficient and fast. We import test APIs explicitly
+ * (`globals: false`) so ESLint sees real bindings and no extra global types
+ * are needed.
+ */
+export default defineConfig({
+  test: {
+    globals: false,
+    environment: 'node',
+    include: ['test/**/*.test.ts']
+  }
+})


### PR DESCRIPTION
## What this does

Real on-device validation for #45 needs a physical board, so this PR delivers the **headless-testable** and **documentation** parts.

### Automated (runs in CI)
- Added **vitest** as a devDependency with `test` (`vitest run`) and `test:watch` scripts, plus `vitest.config.ts` (node environment; explicit test imports so lint/typecheck stay clean). Existing scripts untouched.
- Unit tests for the pure data-parsing helpers where real device bugs hide:
  - `parseOutline` (OutlinePanel) — functions/classes/assignments, async defs, class bases, ignores `==`/`<=`, dedupe, CRLF, indented members. (13 tests)
  - `parseVariables` (VariablesPanel) — `name␟type␟repr` sentinel parsing, reprs containing the separator, bad-line skipping, empty name, start/end sentinels, CRLF. (11 tests)
  - Serial-plotter line parser — CSV / space / tab / `label:value` / `x=y`, non-numeric and non-finite rejection, mixed labelled/unlabelled, exponents. (15 tests)
- Extracted the plotter's `parseLine` into `src/renderer/src/components/Plotter.parse.ts` (behaviour unchanged) and imported it from both `Plotter.tsx` and the test.
- Wired `npm test` into `.github/workflows/ci.yml` after typecheck.

**Result:** 39 tests pass; `lint`, `typecheck`, `test`, `build` all green.

### Not unit-tested (noted, not skipped silently)
- `micropython-completions.ts` exposes only `registerMicropythonCompletions`, which requires a live `monaco` instance — no monaco-free pure helper to test.
- `MicroPythonDevice.ts` imports `serialport` at module load and its only pure helper (`pyStr`) is module-private. Testing would require extracting it or mocking serialport; left for a future change to keep this PR focused.

### Manual (needs a real board)
- `docs/hardware-test-plan.md`: a checkbox manual test plan covering every device path — connect/REPL, run/stop/clear, local + device file ops, upload/download, serial plotter, variables inspector, `mip` install, and firmware flashing for **ESP32** and **RP2040** — with setup notes and pass/fail tables.

## Still requires real hardware
Everything in the hardware test plan: serial connect/enumeration, REPL, run/stop, on-device filesystem, upload/download, live plotter + variables against a board, `mip` install, and firmware flashing. None of this can run in CI.

## Checklist
- [x] vitest + scripts + config
- [x] Tests for parseOutline / parseVariables / plotter parseLine
- [x] Plotter parser extracted to its own module
- [x] `npm test` added to ci.yml
- [x] Hardware test plan doc
- [x] lint / typecheck / test / build all pass

Refs #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)
