### PR TITLE
Broaden build targets (macOS Intel, Linux arm64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,35 @@ jobs:
   # just uploads its artifacts. This avoids the multi-job race where parallel
   # electron-builder --publish runs each create a duplicate draft release.
   build:
+    # One job per (runner, electron-builder flag) combination. Each entry maps
+    # to a specific OS/arch set of installers:
+    #   - windows-latest  -> Windows x64 nsis
+    #   - macos-latest     -> macOS arm64 + x64 dmgs (both archs build on the
+    #                         arm64 hosted runner; see electron-builder.yml)
+    #   - ubuntu-latest    -> Linux x64 AppImage + deb
+    #   - ubuntu-24.04-arm -> Linux arm64 AppImage + deb (native arm64 hosted
+    #                         runner — no QEMU/emulation; packaging tools run
+    #                         on their native arch). Falls back to needing a
+    #                         self-hosted arm64 runner if the hosted arm pool
+    #                         is ever unavailable.
+    # The per-arch arch lists live in electron-builder.yml; the platform flag
+    # below (--win/--mac/--linux) just selects which platform block applies.
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        include:
+          - os: windows-latest
+            platform_flag: --win
+            artifact: installers-windows
+          - os: macos-latest
+            platform_flag: --mac
+            artifact: installers-macos
+          - os: ubuntu-latest
+            platform_flag: --linux
+            artifact: installers-linux-x64
+          - os: ubuntu-24.04-arm
+            platform_flag: --linux
+            artifact: installers-linux-arm64
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -39,7 +64,10 @@ jobs:
         run: npm version "${GITHUB_REF_NAME#v}" --no-git-tag-version --allow-same-version
 
       - name: Build installers (no publish)
-        run: npm run dist -- --publish never
+        # The arch list per platform is defined in electron-builder.yml, so a
+        # single platform flag here builds every configured arch for that OS
+        # (e.g. --mac builds both the arm64 and x64 dmgs).
+        run: npm run dist -- ${{ matrix.platform_flag }} --publish never
         env:
           # Code signing intentionally disabled (future work); without this,
           # macOS builds would try to discover a signing identity and fail.
@@ -48,7 +76,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: installers-${{ matrix.os }}
+          name: ${{ matrix.artifact }}
           path: |
             dist/*.exe
             dist/*.dmg

--- a/README.md
+++ b/README.md
@@ -11,9 +11,15 @@ macOS and Linux, and updates easily.
 Grab the latest installer for your platform from the
 [**Releases**](https://github.com/kevinmcaleer/Snakie/releases/latest) page:
 
-- 🪟 Windows — `Snakie.Setup.<version>.exe`
+- 🪟 Windows (x64) — `Snakie.Setup.<version>.exe`
 - 🍎 macOS (Apple Silicon) — `Snakie-<version>-arm64.dmg`
-- 🐧 Linux — `Snakie-<version>.AppImage` or `snakie_<version>_amd64.deb`
+- 🍎 macOS (Intel) — `Snakie-<version>.dmg`
+- 🐧 Linux (x64) — `Snakie-<version>.AppImage` or `snakie_<version>_amd64.deb`
+- 🐧 Linux (arm64, e.g. Raspberry Pi) — `Snakie-<version>-arm64.AppImage` or
+  `snakie_<version>_arm64.deb`
+
+> Windows is x64 only for now (no arm64 build — see "Building installers"
+> below for why).
 
 ## Features
 
@@ -74,10 +80,39 @@ npm run dist:mac    # macOS dmg
 npm run dist:linux  # Linux AppImage + deb
 ```
 
-Each platform's installers are produced on that platform — cross-building is
-not supported here. On a tag push (`v*`) the
-[release workflow](.github/workflows/release.yml) builds all three on a
-CI matrix and publishes the installers to a GitHub Release.
+Each platform's installers are produced on that platform — cross-building
+across operating systems is not supported here. On a tag push (`v*`) the
+[release workflow](.github/workflows/release.yml) builds every target on a CI
+matrix and collects them into a single draft GitHub Release.
+
+### Build targets
+
+| Platform | Arch  | Artifacts                          | CI runner          |
+| -------- | ----- | ---------------------------------- | ------------------ |
+| macOS    | arm64 | `Snakie-<v>-arm64.dmg`             | `macos-latest`     |
+| macOS    | x64   | `Snakie-<v>.dmg`                   | `macos-latest`     |
+| Linux    | x64   | `.AppImage` + `_amd64.deb`         | `ubuntu-latest`    |
+| Linux    | arm64 | `-arm64.AppImage` + `_arm64.deb`   | `ubuntu-24.04-arm` |
+| Windows  | x64   | `Snakie.Setup.<v>.exe`             | `windows-latest`   |
+
+Notes on arch coverage:
+
+- **macOS** ships two per-arch dmgs (Apple Silicon + Intel) rather than one
+  universal binary. Universal merging of the native `serialport` module is more
+  fragile, and two per-arch dmgs are smaller. Both build on the arm64
+  `macos-latest` runner because `@serialport/bindings-cpp` provides a universal
+  (`darwin-x64+arm64`) prebuilt binary, so no per-arch recompilation is needed.
+- **Linux arm64** is built on GitHub's native `ubuntu-24.04-arm` hosted runner
+  (not via QEMU/emulation). `serialport` ships a `linux-arm64` prebuilt binary,
+  and the AppImage/deb packaging tools run on their native arch. If the hosted
+  arm64 runner pool is ever unavailable, this job needs a self-hosted arm64
+  runner instead — it cannot be reliably produced on the x64 `ubuntu-latest`
+  runner.
+- **Windows is x64 only.** GitHub's hosted Windows runners are x64 and there is
+  no native arm64 Windows runner in the hosted pool, so a reliable arm64 nsis
+  installer can't be produced here yet. (`serialport` does ship a `win32-arm64`
+  prebuild, so this is a CI-infrastructure limitation, not a code one — revisit
+  if/when an arm64 Windows runner becomes available.)
 
 > The app icon in `build/icon.png` is a generated placeholder — TODO: replace
 > with real artwork. Code signing is not yet configured (future work).

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -19,18 +19,38 @@ files:
 npmRebuild: true
 
 # Linux
+# Build x64 and arm64 (arm64 is valuable for Raspberry Pi). The native dep
+# (serialport / @serialport/bindings-cpp) ships prebuilt N-API binaries for
+# both linux-x64 and linux-arm64, so no cross-compilation is required — only
+# the prebuilt binary for the target arch is bundled. In CI we still build each
+# arch on a matching native runner (ubuntu-latest for x64, ubuntu-24.04-arm for
+# arm64) so the AppImage/deb packaging tools run on their native arch and there
+# are zero QEMU/emulation surprises. See .github/workflows/release.yml.
 linux:
   target:
-    - AppImage
-    - deb
+    - target: AppImage
+      arch:
+        - x64
+        - arm64
+    - target: deb
+      arch:
+        - x64
+        - arm64
   category: Development
   maintainer: Kevin McAleer <kevinmcaleer@gmail.com>
   icon: build/icon.png
 
 # Windows
+# x64 only. arm64 is intentionally NOT built: while @serialport/bindings-cpp
+# ships a win32-arm64 prebuild, GitHub-hosted Windows runners are x64 and
+# producing a reliable arm64 nsis installer there is not straightforward
+# (no native arm64 Windows runner in the hosted pool). Revisit if/when an
+# arm64 Windows runner is available. Trade-off documented in README.
 win:
   target:
-    - nsis
+    - target: nsis
+      arch:
+        - x64
 
 nsis:
   oneClick: false
@@ -38,9 +58,18 @@ nsis:
   allowToChangeInstallationDirectory: true
 
 # macOS
+# Build BOTH Apple Silicon (arm64) and Intel (x64) as two separate dmgs.
+# Chosen over a single `universal` build because universal merging of native
+# modules (serialport) is more fragile; two per-arch dmgs are smaller and the
+# more reliable option. Both archs build fine on the macos-latest (arm64)
+# hosted runner — @serialport/bindings-cpp ships a darwin universal prebuild
+# (darwin-x64+arm64), so no per-arch recompilation is needed.
 mac:
   target:
-    - dmg
+    - target: dmg
+      arch:
+        - arm64
+        - x64
   category: public.app-category.developer-tools
   # Code signing is intentionally disabled for now (see release.yml /
   # CSC_IDENTITY_AUTO_DISCOVERY=false). Future work: add real signing.


### PR DESCRIPTION
Broadens the packaged installer matrix per issue #49.

## Targets configured

| Platform | Arch  | Artifacts                        | CI runner          |
| -------- | ----- | -------------------------------- | ------------------ |
| macOS    | arm64 | `Snakie-<v>-arm64.dmg`           | `macos-latest`     |
| macOS    | x64   | `Snakie-<v>.dmg`                 | `macos-latest`     |
| Linux    | x64   | `.AppImage` + `_amd64.deb`       | `ubuntu-latest`    |
| Linux    | arm64 | `-arm64.AppImage` + `_arm64.deb` | `ubuntu-24.04-arm` |
| Windows  | x64   | `Snakie.Setup.<v>.exe`           | `windows-latest`   |

## Checklist

- [x] macOS: produce both arm64 and Intel (x64) dmgs. Chose two per-arch dmgs over a universal build (universal merging of the native serialport module is more fragile; per-arch dmgs are smaller). Both archs build on `macos-latest` since `@serialport/bindings-cpp` ships a universal `darwin-x64+arm64` prebuild.
- [x] Linux: produce both x64 and arm64 AppImage + deb. arm64 builds on GitHub's native `ubuntu-24.04-arm` hosted runner (no QEMU/emulation); `serialport` ships a `linux-arm64` prebuild so no cross-compilation. If the hosted arm64 pool is unavailable, a self-hosted arm64 runner is required — arm64 can't be reliably produced on the x64 `ubuntu-latest` runner.
- [x] Windows: kept x64. arm64 omitted — no native arm64 Windows hosted runner exists, so a reliable arm64 nsis installer can't be produced yet (a CI-infra limitation, not a code one — `serialport` does ship `win32-arm64`).
- [x] Updated `electron-builder.yml` per-arch `arch` lists.
- [x] Adjusted `release.yml` matrix to an explicit include list with a per-job platform flag + distinct artifact names; kept the single publish job (no duplicate releases) and `CSC_IDENTITY_AUTO_DISCOVERY: false`.
- [x] Updated README download list + build-targets table with honest per-arch CI-coverage notes.

## Verification

- `npm install`, `npm run lint`, `npm run typecheck`, `npm run build` all pass.
- `electron-builder.yml` and `release.yml` parse as valid YAML; `npx electron-builder --help` works and a `--dir` build is accepted by the new config (proceeds past config validation into the packaging stage).
- Full per-arch installer production is deferred to CI (this is a headless arm64 box and can't cross-build the full matrix).

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)