### PR TITLE
Theme toggle: pixel SVG sun/moon

### DIFF
--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -165,10 +165,35 @@ export function Toolbar({
           type="button"
           className="btn btn--ghost"
           onClick={onToggleTheme}
-          title="Toggle light/dark theme"
+          title={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
           aria-label="Toggle theme"
         >
-          {theme === 'dark' ? '☀' : '☾'}
+          <svg
+            viewBox="0 0 16 16"
+            width="16"
+            height="16"
+            shapeRendering="crispEdges"
+            aria-hidden="true"
+            focusable="false"
+          >
+            {theme === 'dark' ? (
+              // sun (currently dark → switch to light)
+              <g fill="currentColor">
+                <rect x="6" y="6" width="4" height="4" />
+                <rect x="7" y="0" width="2" height="2" />
+                <rect x="7" y="14" width="2" height="2" />
+                <rect x="0" y="7" width="2" height="2" />
+                <rect x="14" y="7" width="2" height="2" />
+                <rect x="2" y="2" width="2" height="2" />
+                <rect x="12" y="2" width="2" height="2" />
+                <rect x="2" y="12" width="2" height="2" />
+                <rect x="12" y="12" width="2" height="2" />
+              </g>
+            ) : (
+              // crescent moon (currently light → switch to dark)
+              <path d="M9.5 2A6 6 0 1 0 14 11 A4.5 4.5 0 0 1 9.5 2Z" fill="currentColor" />
+            )}
+          </svg>
         </button>
       </div>
 


### PR DESCRIPTION
Replaces the theme toggle's tofu/`*` glyph (Press Start 2P has no `☀`/`☾`) with a crisp inline **pixel SVG** — sun when dark, crescent moon when light — matching the activity-bar icons. Verified by headless render.

lint · typecheck · test (39) · build all green.

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)