### PR TITLE
Readability: pixel chrome + JetBrains Mono content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 - **Retro 8-bit UI overhaul.** New look & feel: NES-inspired dark theme
-  (slate + blue/red/green/yellow accents), the **Press Start 2P** pixel font
-  throughout (UI, editor, and console), square corners and chunky pixel
-  buttons. Dark is now the default theme.
+  (slate + blue/red/green/yellow accents), **Press Start 2P** pixel font on the
+  UI chrome (toolbar, activity bar, headers, buttons) with a crisp readable
+  **JetBrains Mono** for content (editor, console, file trees, chat), square
+  corners and chunky pixel buttons. Dark is now the default theme.
 - **Left activity bar + view switching.** A vertical icon strip on the far
   left switches the left sidebar between **Files**, **Source Control**,
   **Packages**, **Inspect** (Outline + Variables in a vertical split), and

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@anthropic-ai/sdk": "^0.100.1",
         "@electron-toolkit/preload": "^3.0.1",
         "@electron-toolkit/utils": "^3.0.0",
+        "@fontsource/jetbrains-mono": "^5.2.8",
         "@fontsource/press-start-2p": "^5.2.7",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
@@ -1119,6 +1120,14 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fontsource/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@fontsource/press-start-2p": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@anthropic-ai/sdk": "^0.100.1",
     "@electron-toolkit/preload": "^3.0.1",
     "@electron-toolkit/utils": "^3.0.0",
+    "@fontsource/jetbrains-mono": "^5.2.8",
     "@fontsource/press-start-2p": "^5.2.7",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",

--- a/src/renderer/src/components/MonacoEditor.tsx
+++ b/src/renderer/src/components/MonacoEditor.tsx
@@ -68,9 +68,9 @@ export function MonacoEditor(): JSX.Element {
       tabSize: 4,
       insertSpaces: true,
       detectIndentation: false,
-      fontFamily: "'Press Start 2P', monospace",
-      fontSize: 11,
-      lineHeight: 22,
+      fontFamily: "'JetBrains Mono', 'DejaVu Sans Mono', ui-monospace, monospace",
+      fontSize: 13,
+      lineHeight: 20,
       letterSpacing: 0,
       scrollBeyondLastLine: false
     })

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -76,8 +76,8 @@ export const Terminal = forwardRef<TerminalHandle>(function Terminal(_props, ref
     const term = new XTerm({
       cursorBlink: true,
       convertEol: true,
-      fontFamily: "'Press Start 2P', monospace",
-      fontSize: 12,
+      fontFamily: "'JetBrains Mono', 'DejaVu Sans Mono', ui-monospace, monospace",
+      fontSize: 13,
       scrollback: 5000,
       theme: TERMINAL_THEME,
       allowProposedApi: true

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -44,6 +44,7 @@
   --pixel-shadow: 3px 3px 0 #000;
   --pixel-shadow-active: 1px 1px 0 #000;
   --font-pixel: 'Press Start 2P', monospace;
+  --font-mono: 'JetBrains Mono', 'DejaVu Sans Mono', ui-monospace, monospace;
   --toolbar-h: 52px;
 }
 
@@ -82,12 +83,25 @@ body,
 
 body {
   margin: 0;
-  font-family: var(--font-pixel);
-  font-size: 11px;
-  line-height: 1.6;
+  /* Body text / content (editor, console, file trees, chat, lists) uses a
+   * crisp READABLE monospace. The retro pixel font is applied to chrome only
+   * (see the .pixel-chrome rule below). */
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.5;
   background: var(--bg);
   color: var(--text);
-  /* Crisp pixel rendering — no soft anti-alias smear on the retro look. */
+}
+
+/* Retro pixel font for CHROME only: toolbar, activity bar, panel/section
+ * headers, and buttons. Pixel fonts look best with anti-aliasing OFF. */
+.toolbar,
+.activitybar,
+.panel-header,
+.localtree__title,
+.devicetree__title,
+.btn {
+  font-family: var(--font-pixel);
   -webkit-font-smoothing: none;
   font-smooth: never;
 }
@@ -136,8 +150,8 @@ body {
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
-  font: inherit;
   font-family: var(--font-pixel);
+  font-size: 0.7rem;
   color: var(--text);
   background: var(--bg-sunken);
   border: var(--border-w) solid var(--border);

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 import '@fontsource/press-start-2p'
+import '@fontsource/jetbrains-mono'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(


### PR DESCRIPTION
Rebalances the retro fonts for readability (you reported Press Start 2P everywhere was too wide/large for code).

- **Chrome stays Press Start 2P** — toolbar, activity bar, panel/section headers, buttons.
- **Content switches to JetBrains Mono** (added `@fontsource/jetbrains-mono`) — the Monaco editor (13px), the xterm console (13px), file trees, chat, lists, and body text.
- Body anti-aliasing re-enabled for the mono text; pixel chrome stays crisp (un-smoothed).

NES dark palette unchanged. Verified by headless render: pixel chrome vs readable mono content.

lint · typecheck · test (39) · build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)