### PR TITLE
Chrome font: VT323 (readable retro) + button spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 - **Retro 8-bit UI overhaul.** New look & feel: NES-inspired dark theme
-  (slate + blue/red/green/yellow accents), **Press Start 2P** pixel font on the
-  UI chrome (toolbar, activity bar, headers, buttons) with a crisp readable
+  (slate + blue/red/green/yellow accents), the **VT323** retro terminal font on
+  the UI chrome (toolbar, activity bar, headers, buttons) with a crisp readable
   **JetBrains Mono** for content (editor, console, file trees, chat), square
   corners and chunky pixel buttons. Dark is now the default theme.
 - **Left activity bar + view switching.** A vertical icon strip on the far

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@electron-toolkit/preload": "^3.0.1",
         "@electron-toolkit/utils": "^3.0.0",
         "@fontsource/jetbrains-mono": "^5.2.8",
-        "@fontsource/press-start-2p": "^5.2.7",
+        "@fontsource/vt323": "^5.2.7",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
         "electron-updater": "^6.8.3",
@@ -1130,10 +1130,10 @@
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
-    "node_modules/@fontsource/press-start-2p": {
+    "node_modules/@fontsource/vt323": {
       "version": "5.2.7",
-      "resolved": "https://registry.npmjs.org/@fontsource/press-start-2p/-/press-start-2p-5.2.7.tgz",
-      "integrity": "sha512-ezSxYRchANoteja170ZHh2Tt4oejmVEvX42VFPOVVvERSZ68pcuZFjbhHfrK/sNjYmaGg656y7B3431ojO9PCQ==",
+      "resolved": "https://registry.npmjs.org/@fontsource/vt323/-/vt323-5.2.7.tgz",
+      "integrity": "sha512-8JTMM23vMhQxin9Cn/ijty8cNwXW4INrln0VAJ2227Rz0CVfkzM3qr3l/CqudZJ6BXCnbCGUTdf2ym3cTNex8A==",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
       }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@electron-toolkit/preload": "^3.0.1",
     "@electron-toolkit/utils": "^3.0.0",
     "@fontsource/jetbrains-mono": "^5.2.8",
-    "@fontsource/press-start-2p": "^5.2.7",
+    "@fontsource/vt323": "^5.2.7",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "electron-updater": "^6.8.3",

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -43,7 +43,9 @@
   --border-w: 2px;
   --pixel-shadow: 3px 3px 0 #000;
   --pixel-shadow-active: 1px 1px 0 #000;
-  --font-pixel: 'Press Start 2P', monospace;
+  /* Retro chrome font (toolbar, headers, buttons). VT323 — a crisp, readable
+   * terminal/8-bit font, far less wide than Press Start 2P. */
+  --font-pixel: 'VT323', 'DejaVu Sans Mono', monospace;
   --font-mono: 'JetBrains Mono', 'DejaVu Sans Mono', ui-monospace, monospace;
   --toolbar-h: 52px;
 }
@@ -149,14 +151,18 @@ body {
 .btn {
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: 0.45rem;
   font-family: var(--font-pixel);
   font-size: 0.7rem;
   color: var(--text);
   background: var(--bg-sunken);
   border: var(--border-w) solid var(--border);
   border-radius: var(--radius);
-  padding: 0.45rem 0.7rem;
+  /* Roomier horizontal padding so the wide pixel font isn't cramped against
+   * the button edges; never shrink/wrap a label below its content width. */
+  padding: 0.5rem 1rem;
+  white-space: nowrap;
+  flex: 0 0 auto;
   cursor: pointer;
   line-height: 1.4;
   box-shadow: var(--pixel-shadow);

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -4,7 +4,7 @@ import './lib/preloadFallback'
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
-import '@fontsource/press-start-2p'
+import '@fontsource/vt323'
 import '@fontsource/jetbrains-mono'
 import './index.css'
 


### PR DESCRIPTION
Press Start 2P was too wide/hard to read on the chrome (your feedback). Swap it for **VT323** — a crisp, compact, readable retro terminal font — on the toolbar, activity bar, headers and buttons. Code/content stays **JetBrains Mono**. Also: roomier button padding + `white-space: nowrap` + `flex: 0 0 auto` so labels no longer overflow their buttons.

Verified via headless render: readable VT323 chrome, compact buttons, mono content, pixel sun toggle.

lint · typecheck · test (39) · build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)