### PR TITLE
Fix preload sandbox (window.api) + UI polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,31 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **Critical: `window.api` preload bridge was never loading in the packaged/dev
+  Electron app.** `sandbox: true` prevented the CommonJS preload from
+  `require()`-ing `@electron-toolkit/preload`, so the bridge silently failed and
+  the renderer fell back to no-op stubs — making Open Folder, the package
+  search, the serial port list and all device features do nothing. Set
+  `sandbox: false` (kept `contextIsolation` + `nodeIntegration: false`). The
+  renderer fallback now also logs a loud error if the bridge is missing inside
+  Electron instead of masking it.
+- Removed the duplicated "Device files" heading in the device panel's
+  empty state (the section header already names it).
+
 ### Changed
 - **Retro 8-bit UI overhaul.** New look & feel: NES-inspired dark theme
-  (slate + blue/red/green/yellow accents), the **VT323** retro terminal font on
-  the UI chrome (toolbar, activity bar, headers, buttons) with a crisp readable
-  **JetBrains Mono** for content (editor, console, file trees, chat), square
-  corners and chunky pixel buttons. Dark is now the default theme.
+  (slate + blue/red/green/yellow accents), a single readable **JetBrains Mono**
+  font across the whole UI, square corners and chunky pixel buttons — the 8-bit
+  feel comes from the palette/buttons/borders, not the font. Dark is the default.
 - **Left activity bar + view switching.** A vertical icon strip on the far
   left switches the left sidebar between **Files**, **Source Control**,
   **Packages**, **Inspect** (Outline + Variables in a vertical split), and
   **Help**. Source Control / Packages / Outline / Variables / Help moved out of
   the right pane. The center editor is unchanged.
 - **Right pane is now Chat-only**; the toolbar toggle is relabelled
-  "Panel" → "Chat".
+  "Panel" → "Chat". Toolbar Run/Stop/Flash and the shell Clear button are
+  sized consistently with the other toolbar buttons.
 
 ## [0.2.0] - 2026-06-01
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@electron-toolkit/preload": "^3.0.1",
         "@electron-toolkit/utils": "^3.0.0",
         "@fontsource/jetbrains-mono": "^5.2.8",
-        "@fontsource/vt323": "^5.2.7",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
         "electron-updater": "^6.8.3",
@@ -1126,14 +1125,6 @@
       "version": "5.2.8",
       "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
       "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
-      "funding": {
-        "url": "https://github.com/sponsors/ayuhito"
-      }
-    },
-    "node_modules/@fontsource/vt323": {
-      "version": "5.2.7",
-      "resolved": "https://registry.npmjs.org/@fontsource/vt323/-/vt323-5.2.7.tgz",
-      "integrity": "sha512-8JTMM23vMhQxin9Cn/ijty8cNwXW4INrln0VAJ2227Rz0CVfkzM3qr3l/CqudZJ6BXCnbCGUTdf2ym3cTNex8A==",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
       }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@electron-toolkit/preload": "^3.0.1",
     "@electron-toolkit/utils": "^3.0.0",
     "@fontsource/jetbrains-mono": "^5.2.8",
-    "@fontsource/vt323": "^5.2.7",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "electron-updater": "^6.8.3",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -22,7 +22,11 @@ function createWindow(): void {
     title: 'Snakie',
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
-      sandbox: true,
+      // sandbox MUST be false: the preload uses CommonJS require() for
+      // @electron-toolkit/preload, which a sandboxed preload cannot load — that
+      // would silently break the entire window.api bridge. Security is kept via
+      // contextIsolation + nodeIntegration:false (the electron-vite default).
+      sandbox: false,
       contextIsolation: true,
       nodeIntegration: false
     }

--- a/src/renderer/src/components/DeviceFileTree.tsx
+++ b/src/renderer/src/components/DeviceFileTree.tsx
@@ -390,7 +390,7 @@ export function DeviceFileTree(): JSX.Element {
             <span aria-hidden>{'▦'}</span> Device files
           </span>
         </div>
-        <Placeholder label="Device files" hint="Connect a board to browse its filesystem." />
+        <Placeholder hint="Connect a board to browse its filesystem." />
       </div>
     )
   }

--- a/src/renderer/src/components/Placeholder.tsx
+++ b/src/renderer/src/components/Placeholder.tsx
@@ -1,8 +1,8 @@
 import { ReactNode } from 'react'
 
 interface PlaceholderProps {
-  /** Region label shown to the developer until real content lands. */
-  label: string
+  /** Optional region label. Omit when a surrounding header already names it. */
+  label?: string
   /** Short hint describing what will eventually live here. */
   hint?: string
   children?: ReactNode
@@ -16,7 +16,7 @@ interface PlaceholderProps {
 export function Placeholder({ label, hint, children }: PlaceholderProps): JSX.Element {
   return (
     <div className="placeholder">
-      <span className="placeholder__label">{label}</span>
+      {label && <span className="placeholder__label">{label}</span>}
       {hint && <span className="placeholder__hint">{hint}</span>}
       {children}
     </div>

--- a/src/renderer/src/components/ShellPanel.tsx
+++ b/src/renderer/src/components/ShellPanel.tsx
@@ -61,7 +61,7 @@ export function ShellPanel(): JSX.Element {
             {view === 'console' && (
               <button
                 type="button"
-                className="btn btn--ghost btn--lg shell-actions__clear"
+                className="btn btn--ghost shell-actions__clear"
                 onClick={handleClear}
                 title="Clear shell output"
                 aria-label="Clear shell output"

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -76,7 +76,7 @@ export function Toolbar({
       <div className="toolbar__group">
         <button
           type="button"
-          className="btn btn--primary btn--lg"
+          className="btn btn--primary"
           onClick={handleRun}
           disabled={!canRun}
           title={
@@ -95,7 +95,7 @@ export function Toolbar({
         </button>
         <button
           type="button"
-          className="btn btn--danger btn--lg"
+          className="btn btn--danger"
           onClick={handleStop}
           disabled={!connected}
           title={connected ? 'Interrupt the running program (Ctrl-C)' : 'Connect to a device to stop'}
@@ -108,7 +108,7 @@ export function Toolbar({
         </button>
         <button
           type="button"
-          className="btn btn--ghost btn--lg"
+          className="btn btn--ghost"
           onClick={() => setFlasherOpen(true)}
           title="Flash MicroPython firmware to the device (ESP via esptool, RP2040 via UF2)"
           aria-label="Flash MicroPython firmware"

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -43,10 +43,11 @@
   --border-w: 2px;
   --pixel-shadow: 3px 3px 0 #000;
   --pixel-shadow-active: 1px 1px 0 #000;
-  /* Retro chrome font (toolbar, headers, buttons). VT323 — a crisp, readable
-   * terminal/8-bit font, far less wide than Press Start 2P. */
-  --font-pixel: 'VT323', 'DejaVu Sans Mono', monospace;
   --font-mono: 'JetBrains Mono', 'DejaVu Sans Mono', ui-monospace, monospace;
+  /* Single UI font: chrome uses the same readable JetBrains Mono as content.
+   * The 8-bit feel comes from the NES palette, chunky buttons and square
+   * borders — not the font. (Kept as a token so chrome refs resolve here.) */
+  --font-pixel: var(--font-mono);
   --toolbar-h: 52px;
 }
 
@@ -95,17 +96,14 @@ body {
   color: var(--text);
 }
 
-/* Retro pixel font for CHROME only: toolbar, activity bar, panel/section
- * headers, and buttons. Pixel fonts look best with anti-aliasing OFF. */
+/* One readable font everywhere (JetBrains Mono), anti-aliased for crispness. */
 .toolbar,
 .activitybar,
 .panel-header,
 .localtree__title,
 .devicetree__title,
 .btn {
-  font-family: var(--font-pixel);
-  -webkit-font-smoothing: none;
-  font-smooth: never;
+  font-family: var(--font-mono);
 }
 
 /* --------------------------------------------------------------------------
@@ -153,7 +151,7 @@ body {
   align-items: center;
   gap: 0.45rem;
   font-family: var(--font-pixel);
-  font-size: 0.7rem;
+  font-size: 0.8rem;
   color: var(--text);
   background: var(--bg-sunken);
   border: var(--border-w) solid var(--border);
@@ -682,7 +680,7 @@ body {
 }
 
 .activitybar__item-label {
-  font-size: 0.42rem;
+  font-size: 0.6rem;
   letter-spacing: 0.02em;
 }
 

--- a/src/renderer/src/lib/preloadFallback.ts
+++ b/src/renderer/src/lib/preloadFallback.ts
@@ -27,10 +27,18 @@ const w = window as typeof window & {
 }
 
 if (!w.api) {
-  console.warn(
-    '[Snakie] window.api is missing — installing a no-op preload fallback. ' +
-      'Device, file, firmware, LLM, package and Git features are inert ' +
-      '(not running inside Electron?).'
+  // Inside Electron a missing bridge means the preload FAILED to load (a real
+  // bug) — log loudly so it isn't silently masked. In a plain browser it's
+  // expected (no preload), so a warning suffices. Either way we install the
+  // no-op stub to keep the UI from blank-screening.
+  const inElectron = typeof navigator !== 'undefined' && /electron/i.test(navigator.userAgent)
+  const log = inElectron ? console.error : console.warn
+  log(
+    `[Snakie] window.api is missing — installing a no-op fallback. Device, file, ` +
+      `firmware, LLM, package and Git features are inert. ` +
+      (inElectron
+        ? 'Running in Electron, so the PRELOAD FAILED TO LOAD — check the preload path / sandbox setting.'
+        : 'Not running inside Electron (e.g. a browser preview).')
   )
 
   const api = {

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -4,7 +4,6 @@ import './lib/preloadFallback'
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
-import '@fontsource/vt323'
 import '@fontsource/jetbrains-mono'
 import './index.css'
 


### PR DESCRIPTION
## Critical fix
`sandbox: true` stopped the CommonJS preload from `require()`-ing `@electron-toolkit/preload`, so **`window.api` never loaded in the real Electron app** and the renderer silently fell back to no-op stubs. That's why **Open Folder, package search, the serial port list and all device features did nothing** (the browser preview seemed fine because the fallback is expected there). Set `sandbox: false` (kept `contextIsolation` + `nodeIntegration: false` — the electron-vite default). The fallback now logs a loud error if the bridge is missing inside Electron instead of masking it.

## UI polish (your feedback)
- Single readable **JetBrains Mono** font across the whole UI (dropped VT323/Press Start 2P); the 8-bit feel now comes from the NES palette, chunky buttons and square borders.
- **Run / Stop / Flash firmware** and the shell **Clear** button sized consistently with Files/Shell/Chat.
- Removed the duplicated **"Device files"** heading in the device panel.

Verified: headless render (UI), and `lint` · `typecheck` · `test` (39) · `build` all green. Open Folder / package search require the real Electron run to confirm (this fix is exactly what unblocks them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)