### PR TITLE
Fix preload load (ERR_REQUIRE_ESM) + editor dark theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,20 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Fixed
-- **Critical: `window.api` preload bridge was never loading in the packaged/dev
-  Electron app.** `sandbox: true` prevented the CommonJS preload from
-  `require()`-ing `@electron-toolkit/preload`, so the bridge silently failed and
-  the renderer fell back to no-op stubs — making Open Folder, the package
-  search, the serial port list and all device features do nothing. Set
-  `sandbox: false` (kept `contextIsolation` + `nodeIntegration: false`). The
-  renderer fallback now also logs a loud error if the bridge is missing inside
-  Electron instead of masking it.
+- **Critical: `window.api` preload bridge never loaded in the real Electron
+  app** (only the browser preview "worked"), so Open Folder, package search, the
+  serial port list and all device features did nothing. Two causes, both fixed:
+  the preload was emitted as `index.js` but `package.json` is `"type": "module"`,
+  so Electron's `require()` failed with `ERR_REQUIRE_ESM` — now emitted/loaded as
+  `index.cjs`; and `sandbox: true` blocked the CommonJS preload from
+  `require()`-ing `@electron-toolkit/preload` — now `sandbox: false`
+  (`contextIsolation` + `nodeIntegration: false` kept). The renderer fallback
+  also now logs a loud error if the bridge is missing inside Electron rather than
+  silently masking it.
+- **Editor matched the app theme:** the Monaco editor no longer shows a light
+  background in dark mode. It reads the app's `data-theme` (via a MutationObserver,
+  so it can't desync) and uses a custom dark theme whose background matches the
+  NES palette (`#14141f`).
 - Removed the duplicated "Device files" heading in the device panel's
   empty state (the section header already names it).
 

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -21,9 +21,11 @@ export default defineConfig({
           index: resolve(__dirname, 'src/preload/index.ts')
         },
         output: {
-          // Sandboxed preload scripts must be CommonJS, not ESM.
+          // The preload must be CommonJS. package.json has "type": "module", so
+          // a `.js` file is treated as ESM and Electron's require() of it fails
+          // with ERR_REQUIRE_ESM — emit `.cjs` so Node always loads it as CJS.
           format: 'cjs',
-          entryFileNames: '[name].js'
+          entryFileNames: '[name].cjs'
         }
       }
     }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -21,7 +21,7 @@ function createWindow(): void {
     autoHideMenuBar: true,
     title: 'Snakie',
     webPreferences: {
-      preload: join(__dirname, '../preload/index.js'),
+      preload: join(__dirname, '../preload/index.cjs'),
       // sandbox MUST be false: the preload uses CommonJS require() for
       // @electron-toolkit/preload, which a sandboxed preload cannot load — that
       // would silently break the entire window.api bridge. Security is kept via

--- a/src/renderer/src/components/MonacoEditor.tsx
+++ b/src/renderer/src/components/MonacoEditor.tsx
@@ -8,7 +8,6 @@ import 'monaco-editor/esm/vs/basic-languages/python/python.contribution'
 import 'monaco-editor/esm/vs/basic-languages/markdown/markdown.contribution'
 import './monaco-setup'
 import { useWorkspace } from '../store/workspace'
-import { useTheme } from '../hooks/useTheme'
 
 /**
  * Map a file name to a Monaco language id. MicroPython sources are plain Python,
@@ -22,8 +21,36 @@ function languageForName(name: string): string {
   return 'python'
 }
 
+/** Read the app's authoritative theme from the document root (set by useTheme
+ * on every theme change). Reading this — rather than a separate useTheme()
+ * instance — guarantees the editor always matches the visible app theme. */
+function readDocTheme(): 'light' | 'dark' {
+  return document.documentElement.getAttribute('data-theme') === 'light' ? 'light' : 'dark'
+}
+
+let themesDefined = false
+/** Define Monaco themes whose backgrounds match the app's NES palette so the
+ * editor blends into the dark UI instead of showing Monaco's default colours. */
+function ensureThemes(): void {
+  if (themesDefined) return
+  themesDefined = true
+  monaco.editor.defineTheme('snakie-dark', {
+    base: 'vs-dark',
+    inherit: true,
+    rules: [],
+    colors: {
+      'editor.background': '#14141f',
+      'editorGutter.background': '#14141f',
+      'minimap.background': '#14141f',
+      'editorWidget.background': '#1f1f30',
+      'editor.lineHighlightBackground': '#1f1f30'
+    }
+  })
+  monaco.editor.defineTheme('snakie-light', { base: 'vs', inherit: true, rules: [], colors: {} })
+}
+
 function monacoTheme(theme: 'light' | 'dark'): string {
-  return theme === 'dark' ? 'vs-dark' : 'vs'
+  return theme === 'dark' ? 'snakie-dark' : 'snakie-light'
 }
 
 /**
@@ -37,7 +64,6 @@ function monacoTheme(theme: 'light' | 'dark'): string {
  */
 export function MonacoEditor(): JSX.Element {
   const { openFiles, activeId, revealRequest, updateContent, saveFile } = useWorkspace()
-  const { theme } = useTheme()
 
   const containerRef = useRef<HTMLDivElement>(null)
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null)
@@ -57,10 +83,11 @@ export function MonacoEditor(): JSX.Element {
     const container = containerRef.current
     if (!container) return undefined
 
+    ensureThemes()
     const editor = monaco.editor.create(container, {
       value: '',
       language: 'python',
-      theme: monacoTheme(theme),
+      theme: monacoTheme(readDocTheme()),
       automaticLayout: true,
       lineNumbers: 'on',
       minimap: { enabled: true },
@@ -102,10 +129,18 @@ export function MonacoEditor(): JSX.Element {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  // Follow theme changes.
+  // Follow theme changes by observing the document root's data-theme attribute
+  // (the app's single source of truth), so the editor never desyncs from the UI.
   useEffect(() => {
-    monaco.editor.setTheme(monacoTheme(theme))
-  }, [theme])
+    const apply = (): void => monaco.editor.setTheme(monacoTheme(readDocTheme()))
+    apply()
+    const observer = new MutationObserver(apply)
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme']
+    })
+    return () => observer.disconnect()
+  }, [])
 
   // Bind the active file to a per-id model and attach it to the editor.
   const activeFile = openFiles.find((f) => f.id === activeId) ?? null


### PR DESCRIPTION
## Open Folder / device features finally work
Diagnosed in the real Electron app (forwarded the renderer console): the preload failed with `Unable to load preload script … ERR_REQUIRE_ESM`. The preload was `index.js`, but `package.json` is `"type":"module"`, so Node treated it as ESM and Electron's `require()` refused it → `window.api` never loaded → the no-op fallback silently stubbed Open Folder, package search, ports, etc. **Fix: emit/load the preload as `index.cjs`** (+ the earlier `sandbox:false`). Verified post-fix: the bridge loads with no preload errors.

## Editor dark theme
The Monaco editor showed a white background in dark mode. It now reads the app's authoritative `data-theme` (via MutationObserver, so it can't desync from the UI) and uses a custom `snakie-dark` theme whose background matches the NES `#14141f`.

lint · typecheck · test (39) · build green. Preload load verified by launching the real Electron app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)