### PR TITLE
File ops: in-app prompt, toolbar New/Open/Save, Save As

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Toolbar file actions:** New File, Open Folder and Save icon buttons (left of
+  Run). Save also works via Ctrl/Cmd-S, with a native **Save As** dialog for
+  untitled buffers. The opened folder is now the app's shared working directory,
+  so both the toolbar and the Files panel drive it.
+
 ### Fixed
+- **File operations did nothing in Electron.** New File / New Folder / Rename
+  (in both file trees) and the "Upload to board" path used `window.prompt`,
+  which Electron's renderer doesn't implement — replaced with an in-app prompt
+  modal so they work.
 - **Critical: `window.api` preload bridge never loaded in the real Electron
   app** (only the browser preview "worked"), so Open Folder, package search, the
   serial port list and all device features did nothing. Two causes, both fixed:

--- a/src/main/fs/ipc.ts
+++ b/src/main/fs/ipc.ts
@@ -55,6 +55,18 @@ export function registerFsIpc(getWindow: () => BrowserWindow | undefined): void 
     })
   )
 
+  ipcMain.handle('fs:saveFileDialog', (_e, defaultPath?: string) =>
+    wrap(async () => {
+      const win = getWindow()
+      const options = defaultPath ? { defaultPath } : {}
+      const result = win
+        ? await dialog.showSaveDialog(win, options)
+        : await dialog.showSaveDialog(options)
+      if (result.canceled || !result.filePath) return null
+      return result.filePath
+    })
+  )
+
   ipcMain.handle('fs:readDir', (_e, path: string) => wrap(() => readDir(path)))
 
   ipcMain.handle('fs:readFile', (_e, path: string) => wrap(() => fs.readFile(path, 'utf-8')))

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -113,6 +113,13 @@ const fs = {
   /** Show the native "open folder" dialog. Resolves to the path or null. */
   openFolderDialog: (): Promise<string | null> =>
     unwrap(ipcRenderer.invoke('fs:openFolderDialog')),
+  /**
+   * Show the native "save file" dialog (used for the untitled "Save As" flow).
+   * `defaultName` seeds the dialog's default path. Resolves to the chosen path,
+   * or null if the user cancels.
+   */
+  saveFileDialog: (defaultName?: string): Promise<string | null> =>
+    unwrap(ipcRenderer.invoke('fs:saveFileDialog', defaultName)),
   /** List a directory's entries (directories first, then alphabetical). */
   readDir: (path: string): Promise<FsEntry[]> => unwrap(ipcRenderer.invoke('fs:readDir', path)),
   /** Read a file's contents (UTF-8). */

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,13 +1,16 @@
 import { AppShell } from './components/AppShell'
+import { PromptProvider } from './components/PromptModal'
 import { UpdateNotifier } from './components/UpdateNotifier'
 import { WorkspaceProvider } from './store/workspace'
 
 function App(): JSX.Element {
   return (
-    <WorkspaceProvider>
-      <AppShell />
-      <UpdateNotifier />
-    </WorkspaceProvider>
+    <PromptProvider>
+      <WorkspaceProvider>
+        <AppShell />
+        <UpdateNotifier />
+      </WorkspaceProvider>
+    </PromptProvider>
   )
 }
 

--- a/src/renderer/src/components/DeviceFileTree.tsx
+++ b/src/renderer/src/components/DeviceFileTree.tsx
@@ -4,6 +4,7 @@ import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { useWorkspace } from '../store/workspace'
 import { ContextMenu, type ContextMenuItem, type ContextMenuPosition } from './ContextMenu'
 import { Placeholder } from './Placeholder'
+import { usePrompt } from './PromptModal'
 import './DeviceFileTree.css'
 
 /**
@@ -163,6 +164,7 @@ export function DeviceFileTree(): JSX.Element {
   const status = useDeviceStatus()
   const connected = status.state === 'connected'
   const { openFile } = useWorkspace()
+  const prompt = usePrompt()
 
   const [entries, setEntries] = useState<DirEntry[]>([])
   const [selectedPath, setSelectedPath] = useState<string | null>(null)
@@ -264,38 +266,44 @@ export function DeviceFileTree(): JSX.Element {
   const newFileIn = useCallback(
     (target: { path: string; isDir: boolean } | null): void => {
       const dir = dirFor(target)
-      const name = window.prompt('New file name (on device)', 'untitled.py')
-      if (!name) return
-      const dest = joinDevicePath(dir, name)
-      void run(() => window.api.device.writeFile(dest, ''), dir)
+      void (async (): Promise<void> => {
+        const name = await prompt('New file name (on device)', 'untitled.py')
+        if (!name) return
+        const dest = joinDevicePath(dir, name)
+        await run(() => window.api.device.writeFile(dest, ''), dir)
+      })()
     },
-    [dirFor, run]
+    [dirFor, prompt, run]
   )
 
   const newFolderIn = useCallback(
     (target: { path: string; isDir: boolean } | null): void => {
       const dir = dirFor(target)
-      const name = window.prompt('New folder name (on device)', 'new-folder')
-      if (!name) return
-      const dest = joinDevicePath(dir, name)
-      void run(() => window.api.device.mkdir(dest), dir)
+      void (async (): Promise<void> => {
+        const name = await prompt('New folder name (on device)', 'new-folder')
+        if (!name) return
+        const dest = joinDevicePath(dir, name)
+        await run(() => window.api.device.mkdir(dest), dir)
+      })()
     },
-    [dirFor, run]
+    [dirFor, prompt, run]
   )
 
   const renamePath = useCallback(
     (path: string): void => {
       const current = path.split('/').pop() ?? ''
-      const name = window.prompt('Rename to', current)
-      if (!name || name === current) return
-      const parent = parentDevicePath(path)
-      const dest = joinDevicePath(parent, name)
-      void run(async () => {
-        await window.api.device.rename(path, dest)
-        setSelectedPath(dest)
-      }, parent)
+      void (async (): Promise<void> => {
+        const name = await prompt('Rename to', current)
+        if (!name || name === current) return
+        const parent = parentDevicePath(path)
+        const dest = joinDevicePath(parent, name)
+        await run(async () => {
+          await window.api.device.rename(path, dest)
+          setSelectedPath(dest)
+        }, parent)
+      })()
     },
-    [run]
+    [prompt, run]
   )
 
   /**

--- a/src/renderer/src/components/LocalFileTree.tsx
+++ b/src/renderer/src/components/LocalFileTree.tsx
@@ -3,6 +3,7 @@ import type { FsEntry } from '../../../main/fs/types'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { useWorkspace } from '../store/workspace'
 import { ContextMenu, type ContextMenuItem, type ContextMenuPosition } from './ContextMenu'
+import { usePrompt } from './PromptModal'
 import './LocalFileTree.css'
 
 /**
@@ -118,10 +119,13 @@ interface MenuState {
 }
 
 export function LocalFileTree(): JSX.Element {
-  const { openFile } = useWorkspace()
+  const { openFile, currentFolder, openFolder } = useWorkspace()
+  const prompt = usePrompt()
   const deviceStatus = useDeviceStatus()
   const connected = deviceStatus.state === 'connected'
-  const [root, setRoot] = useState<string | null>(null)
+  // The working folder now lives in the workspace store so the toolbar and tree
+  // share one entry point; `root` is just a local alias for readability.
+  const root = currentFolder
   const [entries, setEntries] = useState<FsEntry[]>([])
   const [selectedPath, setSelectedPath] = useState<string | null>(null)
   const [selectedIsDir, setSelectedIsDir] = useState(false)
@@ -142,18 +146,20 @@ export function LocalFileTree(): JSX.Element {
     void refresh()
   }, [refresh])
 
+  // When the working folder changes (e.g. opened from the toolbar), reset the
+  // selection to the new root so create actions target it.
+  useEffect(() => {
+    setSelectedPath(root)
+    setSelectedIsDir(true)
+  }, [root])
+
   const handleOpenFolder = useCallback(async (): Promise<void> => {
     try {
-      const folder = await window.api.fs.openFolderDialog()
-      if (folder) {
-        setRoot(folder)
-        setSelectedPath(folder)
-        setSelectedIsDir(true)
-      }
+      await openFolder()
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     }
-  }, [])
+  }, [openFolder])
 
   const handleSelect = useCallback((path: string, isDir: boolean): void => {
     setSelectedPath(path)
@@ -206,34 +212,40 @@ export function LocalFileTree(): JSX.Element {
     (target: FsEntry | null): void => {
       const dir = dirFor(target)
       if (!dir) return
-      const name = window.prompt('New file name', 'untitled.py')
-      if (!name) return
-      void run(() => window.api.fs.writeFile(join(dir, name), ''))
+      void (async (): Promise<void> => {
+        const name = await prompt('New file name', 'untitled.py')
+        if (!name) return
+        await run(() => window.api.fs.writeFile(join(dir, name), ''))
+      })()
     },
-    [dirFor, run]
+    [dirFor, prompt, run]
   )
 
   const newFolderIn = useCallback(
     (target: FsEntry | null): void => {
       const dir = dirFor(target)
       if (!dir) return
-      const name = window.prompt('New folder name', 'new-folder')
-      if (!name) return
-      void run(() => window.api.fs.mkdir(join(dir, name)))
+      void (async (): Promise<void> => {
+        const name = await prompt('New folder name', 'new-folder')
+        if (!name) return
+        await run(() => window.api.fs.mkdir(join(dir, name)))
+      })()
     },
-    [dirFor, run]
+    [dirFor, prompt, run]
   )
 
   const renamePath = useCallback(
     (path: string): void => {
       if (!path || path === root) return
       const current = path.split(/[/\\]/).pop() ?? ''
-      const name = window.prompt('Rename to', current)
-      if (!name || name === current) return
-      const parent = path.replace(/[/\\][^/\\]+$/, '')
-      void run(() => window.api.fs.rename(path, join(parent || root!, name)))
+      void (async (): Promise<void> => {
+        const name = await prompt('Rename to', current)
+        if (!name || name === current) return
+        const parent = path.replace(/[/\\][^/\\]+$/, '')
+        await run(() => window.api.fs.rename(path, join(parent || root!, name)))
+      })()
     },
-    [root, run]
+    [prompt, root, run]
   )
 
   const deletePath = useCallback(

--- a/src/renderer/src/components/PromptModal.css
+++ b/src/renderer/src/components/PromptModal.css
@@ -1,0 +1,57 @@
+/*
+ * Styles for the in-app text prompt modal (PromptModal.tsx).
+ *
+ * A small centered dialog over a dimmed backdrop, matching the NES/pixel app
+ * chrome via the shared design tokens so it feels native without touching the
+ * shared index.css. Mirrors the firmware modal's overlay approach.
+ */
+
+.prompt-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+  padding: 1rem;
+}
+
+.prompt-modal {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  width: min(26rem, 100%);
+  padding: 1rem 1.1rem;
+  background: var(--bg-elevated);
+  color: var(--text);
+  border: var(--border-w) solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--pixel-shadow);
+}
+
+.prompt-modal__label {
+  font-family: var(--font-pixel);
+  font-size: 0.8rem;
+}
+
+.prompt-modal__input {
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  color: var(--text);
+  background: var(--bg-sunken);
+  border: var(--border-w) solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.5rem 0.6rem;
+}
+
+.prompt-modal__input:focus-visible {
+  outline: var(--border-w) solid var(--accent);
+  outline-offset: 2px;
+}
+
+.prompt-modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}

--- a/src/renderer/src/components/PromptModal.tsx
+++ b/src/renderer/src/components/PromptModal.tsx
@@ -1,0 +1,133 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode
+} from 'react'
+import './PromptModal.css'
+
+/**
+ * In-app text prompt — a Promise-based replacement for `window.prompt`.
+ *
+ * Electron's renderer does NOT implement `window.prompt()` (it returns null and
+ * does nothing), so the file trees' New File / New Folder / Rename actions used
+ * to silently fail. This provider renders a small modal (text input + OK/Cancel)
+ * and exposes a `prompt(message, defaultValue?)` function that resolves to the
+ * entered string, or null if the user cancels.
+ *
+ * Keyboard: Enter confirms, Esc cancels; the input autofocuses (and selects its
+ * default text) so a user can immediately type a replacement name.
+ *
+ * Styling follows the NES/JetBrains-Mono app chrome via PromptModal.css; this
+ * keeps the shared index.css untouched.
+ */
+
+type PromptFn = (message: string, defaultValue?: string) => Promise<string | null>
+
+const PromptContext = createContext<PromptFn | null>(null)
+
+interface PromptRequest {
+  message: string
+  defaultValue: string
+  resolve: (value: string | null) => void
+}
+
+export function PromptProvider({ children }: { children: ReactNode }): JSX.Element {
+  const [request, setRequest] = useState<PromptRequest | null>(null)
+  const [value, setValue] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const prompt = useCallback<PromptFn>((message, defaultValue = '') => {
+    return new Promise<string | null>((resolve) => {
+      setValue(defaultValue)
+      setRequest({ message, defaultValue, resolve })
+    })
+  }, [])
+
+  // Autofocus + select the default text once the modal mounts for a request.
+  useEffect(() => {
+    if (request) {
+      const input = inputRef.current
+      if (input) {
+        input.focus()
+        input.select()
+      }
+    }
+  }, [request])
+
+  const settle = useCallback(
+    (result: string | null): void => {
+      if (request) request.resolve(result)
+      setRequest(null)
+      setValue('')
+    },
+    [request]
+  )
+
+  const onConfirm = useCallback((): void => settle(value), [settle, value])
+  const onCancel = useCallback((): void => settle(null), [settle])
+
+  return (
+    <PromptContext.Provider value={prompt}>
+      {children}
+      {request && (
+        <div
+          className="prompt-overlay"
+          onMouseDown={(e) => {
+            // Click on the backdrop (not the modal) cancels.
+            if (e.target === e.currentTarget) onCancel()
+          }}
+        >
+          <div
+            className="prompt-modal"
+            role="dialog"
+            aria-modal="true"
+            aria-label={request.message}
+          >
+            <label className="prompt-modal__label" htmlFor="prompt-modal-input">
+              {request.message}
+            </label>
+            <input
+              id="prompt-modal-input"
+              ref={inputRef}
+              className="prompt-modal__input"
+              type="text"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  onConfirm()
+                } else if (e.key === 'Escape') {
+                  e.preventDefault()
+                  onCancel()
+                }
+              }}
+            />
+            <div className="prompt-modal__actions">
+              <button type="button" className="btn btn--ghost" onClick={onCancel}>
+                Cancel
+              </button>
+              <button type="button" className="btn btn--primary" onClick={onConfirm}>
+                OK
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </PromptContext.Provider>
+  )
+}
+
+/**
+ * Access the in-app prompt. Returns a function that resolves to the entered
+ * string (or null on cancel). Must be used within <PromptProvider>.
+ */
+export function usePrompt(): PromptFn {
+  const ctx = useContext(PromptContext)
+  if (!ctx) throw new Error('usePrompt must be used within a PromptProvider')
+  return ctx
+}

--- a/src/renderer/src/components/Toolbar.css
+++ b/src/renderer/src/components/Toolbar.css
@@ -1,0 +1,24 @@
+/*
+ * Toolbar.css — small additions for the file-action icon group placed to the
+ * LEFT of the Run button (New File / Open Folder / Save), plus the vertical
+ * divider separating it from the Run/Stop group. Reuses the shared `.btn`
+ * family from index.css; this only adds an icon-button sizing variant and the
+ * divider so the shared stylesheet stays untouched.
+ */
+
+.toolbar__divider {
+  align-self: stretch;
+  width: var(--border-w);
+  margin: 0.4rem 0.15rem;
+  background: var(--border);
+}
+
+/* Compact, square icon-only buttons for the file actions. */
+.btn--icon {
+  padding: 0.4rem;
+  line-height: 0;
+}
+
+.btn--icon svg {
+  display: block;
+}

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -1,9 +1,47 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useState, type ReactNode } from 'react'
 import { Theme } from '../hooks/useTheme'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { useWorkspace } from '../store/workspace'
 import { FirmwareFlasher } from './FirmwareFlasher'
 import './RunControls.css'
+import './Toolbar.css'
+
+/**
+ * Inline pixel SVG wrapper for the file-action toolbar icons, matching the
+ * crisp-edges style used by the activity bar.
+ */
+const ToolIcon = (children: ReactNode): JSX.Element => (
+  <svg
+    viewBox="0 0 16 16"
+    width="16"
+    height="16"
+    shapeRendering="crispEdges"
+    aria-hidden="true"
+    focusable="false"
+  >
+    {children}
+  </svg>
+)
+
+// page with a `+` (new file)
+const NEW_FILE_ICON = ToolIcon(
+  <g fill="currentColor">
+    <path d="M3 1h6l4 4v10H3z M9 1v4h4" />
+    <rect x="7" y="8" width="2" height="6" />
+    <rect x="5" y="10" width="6" height="2" />
+  </g>
+)
+// folder (open folder)
+const OPEN_FOLDER_ICON = ToolIcon(<path d="M1 3h5l2 2h7v8H1z" fill="currentColor" />)
+// floppy disk (save)
+const SAVE_ICON = ToolIcon(
+  <g fill="currentColor">
+    <path d="M1 1h11l3 3v11H1z" />
+    <rect x="4" y="2" width="6" height="4" fill="var(--bg-elevated)" />
+    <rect x="8" y="2.5" width="1.5" height="3" fill="currentColor" />
+    <rect x="3.5" y="9" width="9" height="5" fill="var(--bg-elevated)" />
+  </g>
+)
 
 interface ToolbarProps {
   theme: Theme
@@ -40,7 +78,7 @@ export function Toolbar({
 }: ToolbarProps): JSX.Element {
   const status = useDeviceStatus()
   const [flasherOpen, setFlasherOpen] = useState(false)
-  const { openFiles, activeId } = useWorkspace()
+  const { openFiles, activeId, newFile, openFolder, saveFile } = useWorkspace()
   const connected = status.state === 'connected'
   const activeFile = openFiles.find((f) => f.id === activeId)
   const canRun = connected && activeFile != null
@@ -62,6 +100,14 @@ export function Toolbar({
     window.api.device.interrupt().catch(() => undefined)
   }, [])
 
+  const handleOpenFolder = useCallback(() => {
+    void openFolder().catch(() => undefined)
+  }, [openFolder])
+
+  const handleSave = useCallback(() => {
+    if (activeId) void saveFile(activeId).catch(() => undefined)
+  }, [activeId, saveFile])
+
   const label =
     status.state === 'connecting'
       ? 'Connecting…'
@@ -73,6 +119,39 @@ export function Toolbar({
 
   return (
     <header className="toolbar" role="toolbar" aria-label="Main toolbar">
+      <div className="toolbar__group">
+        <button
+          type="button"
+          className="btn btn--ghost btn--icon"
+          onClick={newFile}
+          title="New file"
+          aria-label="New file"
+        >
+          {NEW_FILE_ICON}
+        </button>
+        <button
+          type="button"
+          className="btn btn--ghost btn--icon"
+          onClick={handleOpenFolder}
+          title="Open folder"
+          aria-label="Open folder"
+        >
+          {OPEN_FOLDER_ICON}
+        </button>
+        <button
+          type="button"
+          className="btn btn--ghost btn--icon"
+          onClick={handleSave}
+          disabled={!activeFile}
+          title={activeFile ? `Save ${activeFile.name}` : 'Open a file to save'}
+          aria-label="Save active file"
+        >
+          {SAVE_ICON}
+        </button>
+      </div>
+
+      <span className="toolbar__divider" aria-hidden="true" />
+
       <div className="toolbar__group">
         <button
           type="button"

--- a/src/renderer/src/components/UploadControls.tsx
+++ b/src/renderer/src/components/UploadControls.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useWorkspace } from '../store/workspace'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
+import { usePrompt } from './PromptModal'
 import './UploadControls.css'
 
 type Feedback = { kind: 'success' | 'error' | 'info'; message: string } | null
@@ -28,6 +29,7 @@ function joinLocal(folder: string, name: string): string {
 export function UploadControls(): JSX.Element {
   const { openFiles, activeId } = useWorkspace()
   const status = useDeviceStatus()
+  const prompt = usePrompt()
   const connected = status.state === 'connected'
 
   const [busy, setBusy] = useState(false)
@@ -41,7 +43,7 @@ export function UploadControls(): JSX.Element {
   async function handleUpload(): Promise<void> {
     if (!activeFile || !connected) return
     const defaultPath = `/${activeFile.name}`
-    const destPath = window.prompt('Upload to device path:', defaultPath)
+    const destPath = await prompt('Upload to device path:', defaultPath)
     if (destPath == null) return // cancelled
     const dest = destPath.trim()
     if (!dest) {

--- a/src/renderer/src/store/workspace.ts
+++ b/src/renderer/src/store/workspace.ts
@@ -15,6 +15,7 @@
  *
  *   openFiles: OpenFile[]
  *   activeId: string | null
+ *   currentFolder: string | null            // working folder for the local tree
  *
  *   openFile(source, path): Promise<void>   // reads via window.api.fs (local)
  *                                           // or window.api.device (device);
@@ -22,8 +23,10 @@
  *   setActive(id): void
  *   closeFile(id): void
  *   updateContent(id, content): void        // marks dirty=true
- *   saveFile(id): Promise<void>             // writes back (fs/device); clears dirty
+ *   saveFile(id): Promise<void>             // writes back (fs/device); clears dirty.
+ *                                           // untitled local buffer -> Save As dialog
  *   newFile(): void                          // untitled local buffer
+ *   openFolder(): Promise<void>              // native folder picker -> currentFolder
  *
  * Implemented as a React context + reducer (no external state dep). Consume via
  * the `useWorkspace()` hook below; wrap the app in <WorkspaceProvider>.
@@ -74,12 +77,19 @@ export interface WorkspaceStore {
   activeId: string | null
   /** Latest editor reveal request, or null if none has been made yet. */
   revealRequest: RevealRequest | null
+  /** The current working folder for the local file browser, or null. */
+  currentFolder: string | null
   openFile: (source: FileSource, path: string) => Promise<void>
   setActive: (id: string) => void
   closeFile: (id: string) => void
   updateContent: (id: string, content: string) => void
   saveFile: (id: string) => Promise<void>
   newFile: () => void
+  /**
+   * Open the native folder picker and, on a non-null result, set it as the
+   * current working folder (the local file browser lists it).
+   */
+  openFolder: () => Promise<void>
   /** Ask the editor to scroll to and place the cursor on a 1-based `line`. */
   revealLine: (line: number) => void
 }
@@ -88,6 +98,7 @@ interface State {
   openFiles: OpenFile[]
   activeId: string | null
   revealRequest: RevealRequest | null
+  currentFolder: string | null
 }
 
 type Action =
@@ -96,8 +107,10 @@ type Action =
   | { type: 'close'; id: string }
   | { type: 'updateContent'; id: string; content: string }
   | { type: 'markSaved'; id: string }
+  | { type: 'savedAs'; id: string; path: string; name: string }
   | { type: 'add'; file: OpenFile }
   | { type: 'revealLine'; line: number }
+  | { type: 'setFolder'; folder: string | null }
 
 /** Derive a stable document id from its source and path. */
 function makeId(source: FileSource, path: string): string {
@@ -105,7 +118,7 @@ function makeId(source: FileSource, path: string): string {
 }
 
 /** Base name of a path, handling both `/` and `\` separators. */
-function baseName(path: string): string {
+export function baseName(path: string): string {
   const parts = path.split(/[/\\]/).filter(Boolean)
   return parts.length > 0 ? parts[parts.length - 1] : path
 }
@@ -156,6 +169,19 @@ function reducer(state: State, action: Action): State {
           f.id === action.id ? { ...f, dirty: false } : f
         )
       }
+    case 'savedAs':
+      // An untitled buffer was saved to a real path: it becomes a saved file.
+      // Keep the buffer's stable id so its open tab/editor stays mounted.
+      return {
+        ...state,
+        openFiles: state.openFiles.map((f) =>
+          f.id === action.id
+            ? { ...f, path: action.path, name: action.name, dirty: false }
+            : f
+        )
+      }
+    case 'setFolder':
+      return { ...state, currentFolder: action.folder }
     case 'revealLine':
       return {
         ...state,
@@ -178,7 +204,8 @@ export function WorkspaceProvider({ children }: { children: ReactNode }): JSX.El
   const [state, dispatch] = useReducer(reducer, {
     openFiles: [],
     activeId: null,
-    revealRequest: null
+    revealRequest: null,
+    currentFolder: null
   })
 
   const openFile = useCallback(
@@ -214,8 +241,16 @@ export function WorkspaceProvider({ children }: { children: ReactNode }): JSX.El
     async (id: string): Promise<void> => {
       const file = state.openFiles.find((f) => f.id === id)
       if (!file) return
-      // Untitled buffers have no path yet; a "save as" flow (separate issue)
-      // will assign one. For now, skip persisting pathless buffers.
+      if (file.source === 'local' && !file.path) {
+        // Untitled local buffer: "Save As" — pick a destination, write it, and
+        // promote the buffer to a real saved file (path/name updated, dirty
+        // cleared). Cancelling the dialog leaves the buffer untouched.
+        const chosen = await window.api.fs.saveFileDialog(file.name)
+        if (!chosen) return
+        await window.api.fs.writeFile(chosen, file.content)
+        dispatch({ type: 'savedAs', id, path: chosen, name: baseName(chosen) })
+        return
+      }
       if (!file.path) return
       if (file.source === 'local') {
         await window.api.fs.writeFile(file.path, file.content)
@@ -226,6 +261,11 @@ export function WorkspaceProvider({ children }: { children: ReactNode }): JSX.El
     },
     [state.openFiles]
   )
+
+  const openFolder = useCallback(async (): Promise<void> => {
+    const folder = await window.api.fs.openFolderDialog()
+    if (folder) dispatch({ type: 'setFolder', folder })
+  }, [])
 
   const revealLine = useCallback((line: number): void => {
     dispatch({ type: 'revealLine', line })
@@ -252,24 +292,28 @@ export function WorkspaceProvider({ children }: { children: ReactNode }): JSX.El
       openFiles: state.openFiles,
       activeId: state.activeId,
       revealRequest: state.revealRequest,
+      currentFolder: state.currentFolder,
       openFile,
       setActive,
       closeFile,
       updateContent,
       saveFile,
       newFile,
+      openFolder,
       revealLine
     }),
     [
       state.openFiles,
       state.activeId,
       state.revealRequest,
+      state.currentFolder,
       openFile,
       setActive,
       closeFile,
       updateContent,
       saveFile,
       newFile,
+      openFolder,
       revealLine
     ]
   )

--- a/test/baseName.test.ts
+++ b/test/baseName.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { baseName } from '../src/renderer/src/store/workspace'
+
+/**
+ * Unit tests for the pure `baseName` helper used by the workspace store's
+ * "Save As" flow to derive an OpenFile's display name from a chosen path.
+ */
+describe('baseName', () => {
+  it('returns the final segment of a POSIX path', () => {
+    expect(baseName('/home/kev/projects/main.py')).toBe('main.py')
+  })
+
+  it('returns the final segment of a Windows path', () => {
+    expect(baseName('C:\\Users\\kev\\main.py')).toBe('main.py')
+  })
+
+  it('ignores a trailing separator', () => {
+    expect(baseName('/home/kev/folder/')).toBe('folder')
+  })
+
+  it('returns the input when there is no separator', () => {
+    expect(baseName('untitled.py')).toBe('untitled.py')
+  })
+})


### PR DESCRIPTION
Fixes the file-management cluster (all confirmed in the real Electron app):

- **+ File / + Folder / Rename now work.** They used `window.prompt`, which Electron's renderer doesn't support (silently null) — replaced with an in-app **prompt modal** (`usePrompt`). Also fixed the same bug in Upload-to-board.
- **Toolbar New File / Open Folder / Save** icon buttons added left of Run (pixel SVGs). Save also via Ctrl/Cmd-S.
- **Open Folder is now the shared working directory** (lifted into the workspace store), so the toolbar button and the Files panel both drive it.
- **Save As**: untitled buffers get a native save dialog (`fs.saveFileDialog` → `dialog.showSaveDialog`), then the buffer is promoted to a real file.

Verified by launching the real app: toolbar icons present, bridge healthy (real `/dev/ttyAMA10` now listed). lint · typecheck · **43 tests** · build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)