### PR TITLE
Python plugin system (MVP) — Closes #61

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ dist-electron/
 # Claude Code worktrees / local agent state and the local preview helper
 .claude/
 vite.preview.config.mjs
+
+# Python bytecode (plugin SDK/host)
+__pycache__/
+*.pyc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Python plugin system (MVP, #61).** Snakie spawns the user's `python3` running
+  a host that discovers and loads Python plugins and talks to the app over
+  JSON-RPC. Plugins use a stdlib-only `snakie` SDK (`@plugin.command`, `Context`,
+  `message`/`edit` helpers); discovery from `~/.snakie/plugins/` (+ bundled
+  examples and entry points). New **Plugins** activity-bar view lists plugins and
+  runs their commands against the active file; graceful "Python not found" state.
+  Ships an example plugin + `docs/writing-plugins.md` (design: `docs/plugin-system.md`).
 - **Toolbar file actions:** New File, Open Folder and Save icon buttons (left of
   Run). Save also works via Ctrl/Cmd-S, with a native **Save As** dialog for
   untitled buffers. The opened folder is now the app's shared working directory,

--- a/docs/writing-plugins.md
+++ b/docs/writing-plugins.md
@@ -1,0 +1,86 @@
+# Writing Snakie plugins
+
+Snakie plugins are ordinary **Python** packages. Snakie spawns a Python host
+(`python3 -m snakie.host`) that discovers and loads your plugins and talks to
+the editor over JSON-RPC; you just write commands against the `snakie` SDK.
+
+For the full design see [`plugin-system.md`](./plugin-system.md).
+
+## Prerequisites
+
+- **Python 3** on your `PATH` (Snakie tries `python3`, then `python`). If it
+  can't find one, the **Plugins** view shows an install prompt instead.
+- The SDK: `pip install snakie`.
+
+  > Snakie also ships a bundled copy of the SDK plus an example plugin, so the
+  > Plugins view works out of the box even before you `pip install` anything.
+
+## Where plugins live
+
+Snakie discovers plugins from **`~/.snakie/plugins/`**:
+
+- a single-file plugin: `~/.snakie/plugins/my_plugin.py`
+- a package plugin: `~/.snakie/plugins/my_plugin/__init__.py`
+
+(It also discovers `snakie.plugins` entry points from installed packages, and
+loads its own bundled `examples/plugins/`.)
+
+## Scaffold a plugin
+
+Create `~/.snakie/plugins/my_plugin/__init__.py`:
+
+```python
+from snakie import plugin, Context, message, edit
+
+@plugin.command("hello", "Say hello")
+def hello(ctx: Context):
+    # ctx.file has .path, .name, .source ('local' | 'device') and .content
+    return message("info", f"Editing {ctx.file.name} ({len(ctx.file.content)} chars)")
+
+@plugin.command("upper", "Uppercase the file")
+def upper(ctx: Context):
+    return edit(ctx.file.content.upper())
+```
+
+A copy of this lives in the repo at
+[`examples/plugins/hello/__init__.py`](../examples/plugins/hello/__init__.py) —
+use it as a starting point.
+
+## The SDK
+
+Import everything from the top-level `snakie` package:
+
+- **`@plugin.command(id, title)`** — register a command. `id` is unique;
+  `title` is shown in the Plugins view.
+- **`Context`** — what your command receives:
+  - `ctx.file`: `path`, `name`, `source`, `content`
+  - `ctx.selection` (optional): `start_line`, `start_column`, `end_line`,
+    `end_column`, `text`
+- **Return helpers** (return one, or a list of them):
+  - `message(level, text)` — `level` is `"info"`, `"warning"` or `"error"`;
+    shown as a notice in the panel.
+  - `edit(new_content)` — replace the active file's contents (the buffer is
+    marked dirty; save as usual).
+  - `diagnostic(line, message, *, severity=..., column=..., source=...)` — a
+    problem marker (the linter feature that consumes these is a follow-up).
+
+Returning `None` is fine (the command simply ran with no action). A bare string
+is treated as an info message.
+
+## Run a command
+
+1. Open the **Plugins** view from the activity bar (the puzzle-piece icon).
+2. Open the file you want to act on — commands run against the **active file**.
+3. Press **Run** next to a command. `message` results appear as notices in the
+   panel; `edit` results replace the active buffer.
+
+Added a new plugin (or edited one)? Press **Reload** in the Plugins view to
+re-spawn the host and pick it up.
+
+## Notes & trust
+
+- Plugins are arbitrary Python executed as you. Only install plugins you trust.
+- Your command runs inside the host process; anything you `print` goes to
+  Snakie's stderr/log, never the JSON-RPC channel, so it won't corrupt the
+  protocol.
+- Keep commands quick and side-effect-light; long-running work blocks the host.

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -13,6 +13,21 @@ files:
   - out/**
   - package.json
 
+# Ship the Python plugin SDK + host and the bundled example plugins (issue #61)
+# into the packaged app's resources/ dir. PluginHost resolves them from
+# process.resourcesPath when app.isPackaged, and from the repo root in dev.
+extraResources:
+  - from: python
+    to: python
+    filter:
+      - '**/*.py'
+      - 'pyproject.toml'
+      - 'README.md'
+  - from: examples/plugins
+    to: examples/plugins
+    filter:
+      - '**/*.py'
+
 # Rebuild native modules (e.g. serialport) for the Electron ABI.
 # npmRebuild defaults to true; nodeGypRebuild stays false so install-app-deps
 # (run via the postinstall script / electron-builder) handles serialport.

--- a/examples/plugins/hello/__init__.py
+++ b/examples/plugins/hello/__init__.py
@@ -1,0 +1,27 @@
+"""Example Snakie plugin: Hello.
+
+A minimal, dependency-free plugin demonstrating the two core action kinds:
+
+* ``hello`` returns a *message* describing the active file.
+* ``hello.upper`` returns an *edit* that uppercases the whole file.
+
+Snakie ships this so the Plugins view works out of the box. Copy it into
+``~/.snakie/plugins/`` to use it as a scaffold for your own plugin — see
+``docs/writing-plugins.md``.
+"""
+
+from snakie import Context, edit, message, plugin
+
+
+@plugin.command("hello", "Hello")
+def hello(ctx: Context):
+    """Greet the user with the active file's name and size."""
+    name = ctx.file.name or "(no file)"
+    size = len(ctx.file.content)
+    return message("info", f"Hello from Snakie! Editing {name} ({size} chars).")
+
+
+@plugin.command("hello.upper", "Uppercase file")
+def uppercase(ctx: Context):
+    """Replace the active file's contents with an uppercased version."""
+    return edit(ctx.file.content.upper())

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,25 @@
+# snakie — the Snakie plugin SDK
+
+The Python SDK for writing [Snakie](https://github.com/kevinmcaleer/Snakie)
+editor plugins. Snakie spawns a Python host (`python3 -m snakie.host`) that
+discovers and runs your plugins, talking to the Electron app over
+newline-delimited JSON-RPC.
+
+```bash
+pip install snakie
+```
+
+```python
+# ~/.snakie/plugins/my_plugin/__init__.py
+from snakie import plugin, Context, message, edit
+
+@plugin.command("hello", "Say hello")
+def hello(ctx: Context):
+    return message("info", f"Editing {ctx.file.name}")
+
+@plugin.command("upper", "Uppercase the file")
+def upper(ctx: Context):
+    return edit(ctx.file.content.upper())
+```
+
+See `docs/writing-plugins.md` in the Snakie repository for the full quickstart.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "snakie"
+version = "0.1.0"
+description = "SDK for writing Snakie editor plugins in Python"
+readme = "README.md"
+requires-python = ">=3.8"
+license = { text = "MIT" }
+authors = [{ name = "Kevin McAleer", email = "kevinmcaleer@gmail.com" }]
+keywords = ["snakie", "micropython", "editor", "plugin"]
+dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/kevinmcaleer/Snakie"
+Documentation = "https://github.com/kevinmcaleer/Snakie/blob/master/docs/writing-plugins.md"
+
+[tool.setuptools]
+packages = ["snakie"]

--- a/python/snakie/__init__.py
+++ b/python/snakie/__init__.py
@@ -1,0 +1,221 @@
+"""Snakie plugin SDK.
+
+This is the public API that plugin authors import. It is intentionally
+dependency-free (standard library only) so that ``pip install snakie`` pulls in
+nothing else and so the bundled copy Snakie ships works on any Python 3.
+
+A plugin is an ordinary Python module/package that imports this SDK and
+registers commands against the shared :data:`plugin` registry::
+
+    from snakie import plugin, Context, message, edit
+
+    @plugin.command("hello", "Say hello")
+    def hello(ctx: Context):
+        return message("info", f"Editing {ctx.file.name}")
+
+    @plugin.command("upper", "Uppercase the file")
+    def upper(ctx: Context):
+        return edit(ctx.file.content.upper())
+
+Command handlers receive a :class:`Context` describing the active editor file
+and (optionally) the current selection, and return one of the *action* helpers
+below (or a list of them): :func:`message`, :func:`edit`, :func:`diagnostic`.
+The Snakie host serialises those actions back to the Electron app over
+JSON-RPC; the app shows messages, applies edits and renders diagnostics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+__all__ = [
+    "plugin",
+    "Plugin",
+    "Context",
+    "FileContext",
+    "Selection",
+    "Command",
+    "message",
+    "edit",
+    "diagnostic",
+]
+
+__version__ = "0.1.0"
+
+
+# ---------------------------------------------------------------------------
+# Context passed to command handlers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Selection:
+    """A text selection in the active editor (1-based line/column)."""
+
+    start_line: int
+    start_column: int
+    end_line: int
+    end_column: int
+    text: str = ""
+
+    @classmethod
+    def from_dict(cls, data: Optional[Dict[str, Any]]) -> "Optional[Selection]":
+        if not data:
+            return None
+        return cls(
+            start_line=int(data.get("startLine", 1)),
+            start_column=int(data.get("startColumn", 1)),
+            end_line=int(data.get("endLine", 1)),
+            end_column=int(data.get("endColumn", 1)),
+            text=str(data.get("text", "")),
+        )
+
+
+@dataclass
+class FileContext:
+    """The active editor file a command runs against."""
+
+    path: str
+    name: str
+    source: str  # 'local' | 'device'
+    content: str
+
+    @classmethod
+    def from_dict(cls, data: Optional[Dict[str, Any]]) -> "FileContext":
+        data = data or {}
+        return cls(
+            path=str(data.get("path", "")),
+            name=str(data.get("name", "")),
+            source=str(data.get("source", "local")),
+            content=str(data.get("content", "")),
+        )
+
+
+@dataclass
+class Context:
+    """Everything a command knows about the current editor state."""
+
+    file: FileContext
+    selection: Optional[Selection] = None
+
+    @classmethod
+    def from_dict(cls, data: Optional[Dict[str, Any]]) -> "Context":
+        data = data or {}
+        return cls(
+            file=FileContext.from_dict(data.get("file")),
+            selection=Selection.from_dict(data.get("selection")),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Action helpers (what a command returns)
+# ---------------------------------------------------------------------------
+
+Action = Dict[str, Any]
+
+
+def message(level: str, text: str) -> Action:
+    """Show a message in the Plugins panel.
+
+    ``level`` is one of ``info``, ``warning`` or ``error``.
+    """
+    return {"type": "message", "level": level, "text": text}
+
+
+def edit(new_content: str) -> Action:
+    """Replace the active file's full contents with ``new_content``."""
+    return {"type": "edit", "content": new_content}
+
+
+def diagnostic(
+    line: int,
+    message: str,
+    *,
+    severity: str = "warning",
+    column: Optional[int] = None,
+    end_line: Optional[int] = None,
+    end_column: Optional[int] = None,
+    source: str = "snakie",
+) -> Action:
+    """Produce a single diagnostic action (problem marker).
+
+    ``severity`` is one of ``error``, ``warning``, ``info``, ``hint``.
+    """
+    item: Dict[str, Any] = {
+        "line": int(line),
+        "severity": severity,
+        "message": str(message),
+        "source": source,
+    }
+    if column is not None:
+        item["column"] = int(column)
+    if end_line is not None:
+        item["endLine"] = int(end_line)
+    if end_column is not None:
+        item["endColumn"] = int(end_column)
+    return {"type": "diagnostic", "item": item}
+
+
+# ---------------------------------------------------------------------------
+# The plugin registry
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Command:
+    """A registered command."""
+
+    id: str
+    title: str
+    handler: Callable[[Context], Any]
+    plugin_id: str = ""
+
+
+class Plugin:
+    """The shared registry that ``@plugin.command`` writes to.
+
+    A single module-level instance (:data:`plugin`) is shared across every
+    imported plugin. The host tags each command with the plugin module it was
+    imported from so the UI can group commands by plugin.
+    """
+
+    def __init__(self) -> None:
+        self.commands: List[Command] = []
+        # The plugin id the host is currently importing; commands registered
+        # while this is set are attributed to it. Set by the host around each
+        # import (see snakie.host).
+        self._current_plugin_id: str = ""
+
+    def command(self, id: str, title: str) -> Callable[[Callable[[Context], Any]], Callable[[Context], Any]]:
+        """Decorator: register ``func`` as the command ``id`` titled ``title``."""
+
+        def decorator(func: Callable[[Context], Any]) -> Callable[[Context], Any]:
+            self.commands.append(
+                Command(id=id, title=title, handler=func, plugin_id=self._current_plugin_id)
+            )
+            return func
+
+        return decorator
+
+    def linter(self, name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        """Reserved for the linter feature (separate issue).
+
+        Registering is a no-op in the MVP — kept so plugins that use it import
+        cleanly. Returns the function unchanged.
+        """
+
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            return func
+
+        return decorator
+
+    def find(self, command_id: str) -> Optional[Command]:
+        for cmd in self.commands:
+            if cmd.id == command_id:
+                return cmd
+        return None
+
+
+# The single shared registry imported by every plugin.
+plugin = Plugin()

--- a/python/snakie/host.py
+++ b/python/snakie/host.py
@@ -1,0 +1,299 @@
+"""Snakie plugin host.
+
+Run as ``python3 -m snakie.host`` (or directly as a script). The Electron main
+process spawns this and talks to it over **newline-delimited JSON-RPC on
+stdin/stdout**. The host:
+
+1. Discovers plugins (``~/.snakie/plugins/*.py`` and ``*/__init__.py``, plus any
+   directories passed via ``--plugin-dir`` / the ``SNAKIE_PLUGIN_DIRS`` env var —
+   Snakie uses this to add its bundled ``examples/plugins`` dir; entry points are
+   discovered too when ``importlib.metadata`` finds the ``snakie.plugins`` group).
+2. Imports each, running its ``@plugin.command`` decorators. A per-plugin import
+   error is reported in the plugin list, not fatal.
+3. Serves the JSON-RPC loop: ``initialize``, ``listCommands``,
+   ``runCommand``, ``shutdown``.
+
+Protocol
+--------
+Requests are ``{"id", "method", "params"}``; responses are
+``{"id", "result"}`` or ``{"id", "error": {"message"}}``. One JSON object per
+line. stdout carries only protocol messages — anything a plugin prints to
+stdout is redirected to stderr so it cannot corrupt the channel.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import importlib.util
+import json
+import os
+import sys
+import traceback
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# Ensure the SDK package is importable when run directly as a script (not just
+# as ``-m snakie.host``): add this file's parent dir (the one containing the
+# ``snakie`` package) to sys.path.
+_PKG_PARENT = str(Path(__file__).resolve().parent.parent)
+if _PKG_PARENT not in sys.path:
+    sys.path.insert(0, _PKG_PARENT)
+
+from snakie import Context, plugin  # noqa: E402  (after sys.path tweak)
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+
+def _default_plugin_dir() -> Path:
+    return Path.home() / ".snakie" / "plugins"
+
+
+def _candidate_dirs(extra_dirs: List[str]) -> List[Path]:
+    """Directories to scan for plugins, de-duplicated, existing first."""
+    dirs: List[Path] = [_default_plugin_dir()]
+    env = os.environ.get("SNAKIE_PLUGIN_DIRS", "")
+    if env:
+        dirs.extend(Path(p) for p in env.split(os.pathsep) if p)
+    dirs.extend(Path(p) for p in extra_dirs if p)
+    seen: set = set()
+    out: List[Path] = []
+    for d in dirs:
+        key = str(d)
+        if key not in seen:
+            seen.add(key)
+            out.append(d)
+    return out
+
+
+def _discover_paths(extra_dirs: List[str]) -> List[Path]:
+    """Find plugin entry files: ``dir/*.py`` and ``dir/*/__init__.py``."""
+    found: List[Path] = []
+    for base in _candidate_dirs(extra_dirs):
+        if not base.is_dir():
+            continue
+        for child in sorted(base.iterdir()):
+            if child.name.startswith((".", "_")):
+                continue
+            if child.is_file() and child.suffix == ".py":
+                found.append(child)
+            elif child.is_dir() and (child / "__init__.py").is_file():
+                found.append(child / "__init__.py")
+    return found
+
+
+def _plugin_id_for(path: Path) -> str:
+    """A stable, human-readable id for a discovered plugin file."""
+    if path.name == "__init__.py":
+        return path.parent.name
+    return path.stem
+
+
+def _import_from_path(plugin_id: str, path: Path) -> None:
+    """Import a plugin file under a unique module name and run its decorators."""
+    mod_name = f"snakie_plugin_{plugin_id}"
+    spec = importlib.util.spec_from_file_location(mod_name, str(path))
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load spec for {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+
+
+def _discover_entry_point_plugins() -> List[Dict[str, Any]]:
+    """Discover ``snakie.plugins`` entry points (bonus; best-effort)."""
+    infos: List[Dict[str, Any]] = []
+    try:
+        from importlib.metadata import entry_points
+    except Exception:  # pragma: no cover - very old Python
+        return infos
+    try:
+        eps = entry_points()
+        # Python 3.10+ returns a SelectableGroups; older returns a dict.
+        group = (
+            eps.select(group="snakie.plugins")
+            if hasattr(eps, "select")
+            else eps.get("snakie.plugins", [])  # type: ignore[attr-defined]
+        )
+    except Exception:
+        return infos
+    for ep in group:
+        pid = ep.name
+        info: Dict[str, Any] = {"id": pid, "name": pid, "source": "entry-point"}
+        try:
+            plugin._current_plugin_id = pid
+            ep.load()
+            info["ok"] = True
+        except Exception as exc:  # noqa: BLE001 - report per-plugin
+            info["ok"] = False
+            info["error"] = f"{type(exc).__name__}: {exc}"
+        finally:
+            plugin._current_plugin_id = ""
+        infos.append(info)
+    return infos
+
+
+def discover(extra_dirs: List[str]) -> List[Dict[str, Any]]:
+    """Discover and import every plugin. Returns per-plugin info records.
+
+    Each record is ``{id, name, path?, source, ok, error?}``. Import errors are
+    captured per-plugin and reported, never raised.
+    """
+    infos: List[Dict[str, Any]] = []
+    for path in _discover_paths(extra_dirs):
+        pid = _plugin_id_for(path)
+        info: Dict[str, Any] = {
+            "id": pid,
+            "name": pid,
+            "path": str(path),
+            "source": "directory",
+        }
+        try:
+            plugin._current_plugin_id = pid
+            _import_from_path(pid, path)
+            info["ok"] = True
+        except Exception as exc:  # noqa: BLE001 - report per-plugin, not fatal
+            info["ok"] = False
+            info["error"] = f"{type(exc).__name__}: {exc}"
+            print(
+                f"snakie.host: failed to import plugin {pid}: {exc}",
+                file=sys.stderr,
+            )
+        finally:
+            plugin._current_plugin_id = ""
+        infos.append(info)
+
+    infos.extend(_discover_entry_point_plugins())
+    return infos
+
+
+# ---------------------------------------------------------------------------
+# Command execution
+# ---------------------------------------------------------------------------
+
+
+def _commands_payload() -> List[Dict[str, str]]:
+    return [
+        {"id": c.id, "title": c.title, "pluginId": c.plugin_id}
+        for c in plugin.commands
+    ]
+
+
+def _normalise_actions(result: Any) -> List[Dict[str, Any]]:
+    """Coerce a command's return value into a list of action dicts."""
+    if result is None:
+        return []
+    if isinstance(result, dict):
+        return [result]
+    if isinstance(result, (list, tuple)):
+        return [a for a in result if isinstance(a, dict)]
+    # A bare string is treated as an info message for convenience.
+    if isinstance(result, str):
+        return [{"type": "message", "level": "info", "text": result}]
+    return []
+
+
+def _run_command(params: Dict[str, Any]) -> Dict[str, Any]:
+    command_id = params.get("commandId")
+    cmd = plugin.find(command_id) if command_id else None
+    if cmd is None:
+        raise ValueError(f"unknown command: {command_id!r}")
+    ctx = Context.from_dict(params.get("context"))
+    result = cmd.handler(ctx)
+    return {"actions": _normalise_actions(result)}
+
+
+# ---------------------------------------------------------------------------
+# JSON-RPC loop
+# ---------------------------------------------------------------------------
+
+
+class Host:
+    def __init__(self, extra_dirs: List[str]) -> None:
+        self.extra_dirs = extra_dirs
+        self.plugins: List[Dict[str, Any]] = []
+        self._discovered = False
+
+    def _ensure_discovered(self) -> None:
+        if not self._discovered:
+            self.plugins = discover(self.extra_dirs)
+            self._discovered = True
+
+    def handle(self, method: str, params: Dict[str, Any]) -> Any:
+        if method == "initialize":
+            self._ensure_discovered()
+            return {"plugins": self.plugins}
+        if method == "listCommands":
+            self._ensure_discovered()
+            return {"commands": _commands_payload()}
+        if method == "runCommand":
+            self._ensure_discovered()
+            return _run_command(params)
+        if method == "shutdown":
+            return {"ok": True}
+        raise ValueError(f"unknown method: {method!r}")
+
+    def serve(self, stdin: Any, stdout: Any) -> None:
+        for raw in stdin:
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                request = json.loads(line)
+            except json.JSONDecodeError as exc:
+                _write(stdout, {"id": None, "error": {"message": f"invalid JSON: {exc}"}})
+                continue
+
+            req_id = request.get("id")
+            method = request.get("method", "")
+            params = request.get("params") or {}
+            try:
+                result = self.handle(method, params)
+                _write(stdout, {"id": req_id, "result": result})
+            except Exception as exc:  # noqa: BLE001 - report, keep serving
+                _write(
+                    stdout,
+                    {
+                        "id": req_id,
+                        "error": {
+                            "message": f"{type(exc).__name__}: {exc}",
+                            "traceback": traceback.format_exc(),
+                        },
+                    },
+                )
+            if method == "shutdown":
+                break
+
+
+def _write(stream: Any, obj: Dict[str, Any]) -> None:
+    stream.write(json.dumps(obj) + "\n")
+    stream.flush()
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(prog="snakie.host", description="Snakie plugin host")
+    parser.add_argument(
+        "--plugin-dir",
+        action="append",
+        default=[],
+        dest="plugin_dirs",
+        help="Extra directory to scan for plugins (repeatable).",
+    )
+    args = parser.parse_args(argv)
+
+    # Protect the protocol channel: a plugin printing to stdout must not corrupt
+    # JSON-RPC, so redirect process stdout to stderr and keep the real stdout
+    # only for our own writes.
+    protocol_out = sys.stdout
+    sys.stdout = sys.stderr
+
+    host = Host(extra_dirs=list(args.plugin_dirs))
+    host.serve(sys.stdin, protocol_out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -7,6 +7,7 @@ import { registerPackagesIpc } from './packages/ipc'
 import { registerLlmIpc } from './llm/ipc'
 import { registerFirmwareIpc } from './firmware/ipc'
 import { registerGitIpc } from './git/ipc'
+import { registerPluginsIpc, disposePlugins } from './plugins/ipc'
 import { registerUpdater } from './updater'
 
 /** The single application window, used to route device push-events. */
@@ -89,6 +90,11 @@ app.whenReady().then(() => {
   // operations run here via simple-git, scoped to a folder the renderer picks.
   registerGitIpc()
 
+  // Register the Python plugin system (issue #61). Spawns the user's python3
+  // running snakie.host lazily on first use and speaks JSON-RPC over stdio.
+  // Absent Python is reported via status() rather than crashing.
+  registerPluginsIpc()
+
   // Register the auto-update layer. No-ops cleanly in dev (unpackaged); when
   // packaged it checks GitHub Releases and pushes status to the live window.
   registerUpdater(() => mainWindow?.webContents)
@@ -113,7 +119,9 @@ app.on('window-all-closed', () => {
   }
 })
 
-// Ensure the serial port is released before the process exits.
+// Ensure the serial port is released and the plugin host is killed before the
+// process exits.
 app.on('before-quit', () => {
   void disposeDevice()
+  void disposePlugins()
 })

--- a/src/main/plugins/PluginHost.ts
+++ b/src/main/plugins/PluginHost.ts
@@ -1,0 +1,299 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'child_process'
+import { existsSync } from 'fs'
+import { join } from 'path'
+import { app } from 'electron'
+import type {
+  CommandInfo,
+  PluginContext,
+  PluginInfo,
+  PluginListing,
+  PluginStatus,
+  RunCommandResult
+} from './types'
+
+/**
+ * PluginHost — spawns and supervises the Python plugin host
+ * (`python3 -m snakie.host`) and exchanges newline-delimited JSON-RPC over its
+ * stdio (issue #61).
+ *
+ * Design:
+ * - Locates a Python interpreter (`python3` then `python` on PATH for the MVP;
+ *   a configurable setting is a follow-up). If none works the host enters a
+ *   "no Python" state ({@link status} reports `pythonFound:false`) — the rest
+ *   of the app is unaffected and the Plugins panel shows a friendly install
+ *   prompt.
+ * - Runs the host with the bundled `python/` package on `PYTHONPATH` and the
+ *   bundled `examples/plugins` dir passed via `SNAKIE_PLUGIN_DIRS`, so the
+ *   feature demos out of the box. The host additionally scans
+ *   `~/.snakie/plugins/` for the user's own plugins.
+ * - Requests are correlated by a monotonically-increasing id. The host is
+ *   spawned lazily on first use; {@link reload} kills and re-spawns it (picking
+ *   up newly added plugins). {@link dispose} is called on app quit.
+ *
+ * Failures never crash the app: a spawn error, a host that exits, or a malformed
+ * line all reject the in-flight requests and flip the status flag.
+ */
+export class PluginHost {
+  private child: ChildProcessWithoutNullStreams | null = null
+  private buffer = ''
+  private nextId = 1
+  private pending = new Map<
+    number,
+    { resolve: (value: unknown) => void; reject: (err: Error) => void }
+  >()
+
+  private pythonCmd: string | null = null
+  private startError: string | null = null
+  private starting: Promise<void> | null = null
+
+  /**
+   * The interpreter candidates to try, in order. `python3` is preferred; on
+   * Windows `python` is the common name. A configurable override is a follow-up.
+   */
+  private static readonly INTERPRETERS = ['python3', 'python']
+
+  /** Resolve the bundled `python/` dir (contains the `snakie` package). */
+  private pythonPackageDir(): string {
+    // Packaged: shipped under resources via electron-builder `extraResources`.
+    // Dev: __dirname is `out/main`, so the repo root is two levels up.
+    const packaged = join(process.resourcesPath, 'python')
+    if (app.isPackaged && existsSync(packaged)) return packaged
+    return join(__dirname, '..', '..', 'python')
+  }
+
+  /** Resolve the bundled `examples/plugins` dir. */
+  private bundledPluginsDir(): string {
+    const packaged = join(process.resourcesPath, 'examples', 'plugins')
+    if (app.isPackaged && existsSync(packaged)) return packaged
+    return join(__dirname, '..', '..', 'examples', 'plugins')
+  }
+
+  /**
+   * Try each interpreter candidate until one spawns the host successfully.
+   * Resolves once a live child is connected; sets {@link startError} and leaves
+   * {@link child} null if none work.
+   */
+  private async start(): Promise<void> {
+    if (this.child) return
+    if (this.starting) return this.starting
+    this.starting = this.doStart().finally(() => {
+      this.starting = null
+    })
+    return this.starting
+  }
+
+  private async doStart(): Promise<void> {
+    this.startError = null
+    const pkgDir = this.pythonPackageDir()
+    const pluginsDir = this.bundledPluginsDir()
+    const errors: string[] = []
+
+    for (const cmd of PluginHost.INTERPRETERS) {
+      try {
+        const child = spawn(cmd, ['-u', '-m', 'snakie.host'], {
+          windowsHide: true,
+          env: {
+            ...process.env,
+            PYTHONPATH: [pkgDir, process.env.PYTHONPATH].filter(Boolean).join(
+              process.platform === 'win32' ? ';' : ':'
+            ),
+            SNAKIE_PLUGIN_DIRS: pluginsDir
+          }
+        })
+
+        // Surface a spawn failure (e.g. interpreter not on PATH) synchronously
+        // enough to try the next candidate.
+        const spawned = await new Promise<boolean>((resolve) => {
+          let settled = false
+          child.once('spawn', () => {
+            if (!settled) {
+              settled = true
+              resolve(true)
+            }
+          })
+          child.once('error', (err) => {
+            if (!settled) {
+              settled = true
+              errors.push(`${cmd}: ${err.message}`)
+              resolve(false)
+            }
+          })
+        })
+
+        if (!spawned) continue
+
+        this.attach(child)
+        // Verify the host actually answers (catches a present interpreter that
+        // can't import the SDK, e.g. a broken PYTHONPATH).
+        await this.request('initialize')
+        this.pythonCmd = cmd
+        return
+      } catch (err) {
+        errors.push(`${cmd}: ${err instanceof Error ? err.message : String(err)}`)
+        this.teardownChild()
+      }
+    }
+
+    this.startError =
+      errors.length > 0
+        ? `No working Python interpreter found (${errors.join('; ')})`
+        : 'No Python interpreter found on PATH'
+  }
+
+  /** Wire up stdout parsing + lifecycle handlers for a spawned child. */
+  private attach(child: ChildProcessWithoutNullStreams): void {
+    this.child = child
+    this.buffer = ''
+
+    child.stdout.setEncoding('utf8')
+    child.stdout.on('data', (chunk: string) => this.onData(chunk))
+
+    child.stderr.setEncoding('utf8')
+    child.stderr.on('data', (chunk: string) => {
+      // Host diagnostics + plugin stdout (redirected to stderr by the host).
+      console.error('[snakie.host]', chunk.toString().trimEnd())
+    })
+
+    const onExit = (code: number | null): void => {
+      const err = new Error(`Python plugin host exited (code ${code ?? 'null'})`)
+      this.failPending(err)
+      if (this.child === child) {
+        this.child = null
+        // Only record as a fatal status if it died after starting cleanly.
+        if (this.pythonCmd) this.startError = err.message
+      }
+    }
+    child.once('exit', onExit)
+    child.once('error', (err) => {
+      this.failPending(err)
+    })
+  }
+
+  /** Accumulate stdout and dispatch each complete JSON line. */
+  private onData(chunk: string): void {
+    this.buffer += chunk
+    let idx = this.buffer.indexOf('\n')
+    while (idx !== -1) {
+      const line = this.buffer.slice(0, idx).trim()
+      this.buffer = this.buffer.slice(idx + 1)
+      if (line) this.dispatchLine(line)
+      idx = this.buffer.indexOf('\n')
+    }
+  }
+
+  private dispatchLine(line: string): void {
+    let msg: { id?: number; result?: unknown; error?: { message?: string } }
+    try {
+      msg = JSON.parse(line)
+    } catch {
+      console.error('[snakie.host] unparseable line:', line)
+      return
+    }
+    if (typeof msg.id !== 'number') return // notification (unused in MVP)
+    const entry = this.pending.get(msg.id)
+    if (!entry) return
+    this.pending.delete(msg.id)
+    if (msg.error) {
+      entry.reject(new Error(msg.error.message ?? 'plugin host error'))
+    } else {
+      entry.resolve(msg.result)
+    }
+  }
+
+  /** Reject all in-flight requests (host died / errored). */
+  private failPending(err: Error): void {
+    for (const { reject } of this.pending.values()) reject(err)
+    this.pending.clear()
+  }
+
+  /** Send a JSON-RPC request and await its correlated response. */
+  private request<T = unknown>(method: string, params?: unknown): Promise<T> {
+    const child = this.child
+    if (!child) return Promise.reject(new Error('plugin host not running'))
+    const id = this.nextId++
+    return new Promise<T>((resolve, reject) => {
+      this.pending.set(id, {
+        resolve: resolve as (value: unknown) => void,
+        reject
+      })
+      const payload = JSON.stringify({ id, method, params: params ?? {} }) + '\n'
+      child.stdin.write(payload, (err) => {
+        if (err) {
+          this.pending.delete(id)
+          reject(err)
+        }
+      })
+    })
+  }
+
+  private teardownChild(): void {
+    if (this.child) {
+      try {
+        this.child.kill()
+      } catch {
+        // ignore
+      }
+      this.child = null
+    }
+  }
+
+  // --- Public API ----------------------------------------------------------
+
+  /** Whether a Python host is available (spawns lazily to find out). */
+  async status(): Promise<PluginStatus> {
+    await this.start()
+    if (this.child && this.pythonCmd) {
+      return { pythonFound: true, python: this.pythonCmd }
+    }
+    return {
+      pythonFound: false,
+      error: this.startError ?? 'Python interpreter not found'
+    }
+  }
+
+  /** Discovered plugins + their registered commands. */
+  async list(): Promise<PluginListing> {
+    await this.start()
+    if (!this.child) {
+      // No Python: an empty listing (the panel uses status() for the prompt).
+      return { plugins: [], commands: [] }
+    }
+    const init = await this.request<{ plugins: PluginInfo[] }>('initialize')
+    const cmds = await this.request<{ commands: CommandInfo[] }>('listCommands')
+    return { plugins: init.plugins ?? [], commands: cmds.commands ?? [] }
+  }
+
+  /** Run a command against the given editor context, returning its actions. */
+  async runCommand(commandId: string, context: PluginContext): Promise<RunCommandResult> {
+    await this.start()
+    if (!this.child) {
+      throw new Error(this.startError ?? 'Python plugin host is not available')
+    }
+    return this.request<RunCommandResult>('runCommand', { commandId, context })
+  }
+
+  /** Kill and re-spawn the host (picks up newly added plugins). */
+  async reload(): Promise<PluginStatus> {
+    await this.dispose()
+    this.pythonCmd = null
+    this.startError = null
+    return this.status()
+  }
+
+  /** Gracefully shut down the host (best-effort). Called on app quit. */
+  async dispose(): Promise<void> {
+    const child = this.child
+    if (!child) return
+    try {
+      // Ask politely; ignore failures, then ensure it's gone.
+      await Promise.race([
+        this.request('shutdown').catch(() => undefined),
+        new Promise((r) => setTimeout(r, 500))
+      ])
+    } finally {
+      this.failPending(new Error('plugin host disposed'))
+      this.teardownChild()
+      this.pythonCmd = null
+    }
+  }
+}

--- a/src/main/plugins/ipc.ts
+++ b/src/main/plugins/ipc.ts
@@ -1,0 +1,58 @@
+import { ipcMain } from 'electron'
+import type { IpcResult } from '../device/types'
+import { PluginHost } from './PluginHost'
+import type { PluginContext, PluginListing, PluginStatus, RunCommandResult } from './types'
+
+/**
+ * IPC for the Python plugin system (issue #61).
+ *
+ * A single {@link PluginHost} is kept for the process lifetime; it spawns the
+ * user's `python3` running `snakie.host` and speaks newline-delimited JSON-RPC.
+ * Handlers mirror the device/git/packages convention: each returns a
+ * serializable {@link IpcResult} the preload unwraps into a value or thrown
+ * Error.
+ *
+ * The no-Python case is NOT an error: `plugins:status` resolves with
+ * `{ pythonFound:false, error }` so the panel can render a clear install
+ * prompt. The host spawns lazily, so registering this layer never blocks app
+ * startup or fails when Python is absent.
+ */
+
+/** Wrap an async op so errors cross IPC as serializable {@link IpcResult}. */
+async function wrap<T>(fn: () => Promise<T>): Promise<IpcResult<T>> {
+  try {
+    return { ok: true, value: await fn() }
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+let host: PluginHost | null = null
+
+function getHost(): PluginHost {
+  if (!host) host = new PluginHost()
+  return host
+}
+
+/**
+ * Register all `plugins:*` IPC handlers. Call once after the app is ready. The
+ * host is created here but only spawns Python on first use.
+ */
+export function registerPluginsIpc(): void {
+  const h = getHost()
+
+  ipcMain.handle('plugins:status', () => wrap<PluginStatus>(() => h.status()))
+  ipcMain.handle('plugins:list', () => wrap<PluginListing>(() => h.list()))
+  ipcMain.handle('plugins:runCommand', (_e, commandId: string, context: PluginContext) =>
+    wrap<RunCommandResult>(() => h.runCommand(commandId, context))
+  )
+  ipcMain.handle('plugins:reload', () => wrap<PluginStatus>(() => h.reload()))
+}
+
+/** Dispose the shared plugin host (call on app quit). */
+export async function disposePlugins(): Promise<void> {
+  if (host) {
+    await host.dispose()
+    host = null
+  }
+}

--- a/src/main/plugins/types.ts
+++ b/src/main/plugins/types.ts
@@ -1,0 +1,106 @@
+/**
+ * Shared types for the Python plugin system (issue #61).
+ *
+ * These are plain, serializable shapes so they cross the Electron IPC boundary
+ * cleanly and can be re-used by the preload typings and the renderer. They
+ * mirror the JSON-RPC payloads exchanged with the Python host
+ * (`python3 -m snakie.host`).
+ */
+
+/** Per-plugin discovery record returned by the host's `initialize`. */
+export interface PluginInfo {
+  /** Stable id (directory/module name, or entry-point name). */
+  id: string
+  /** Display name (defaults to the id). */
+  name: string
+  /** Absolute path to the plugin entry file (directory-discovered plugins). */
+  path?: string
+  /** How the plugin was found: a scanned directory or an entry point. */
+  source: 'directory' | 'entry-point'
+  /** False when the plugin failed to import (see `error`). */
+  ok: boolean
+  /** Import error message, when `ok` is false. */
+  error?: string
+}
+
+/** A command a plugin registered, shown in the Plugins view. */
+export interface CommandInfo {
+  id: string
+  title: string
+  /** The id of the plugin that registered the command. */
+  pluginId: string
+}
+
+/** The active editor file a command runs against. */
+export interface PluginFileContext {
+  path: string
+  name: string
+  source: string
+  content: string
+}
+
+/** A text selection passed to a command (1-based). */
+export interface PluginSelection {
+  startLine: number
+  startColumn: number
+  endLine: number
+  endColumn: number
+  text?: string
+}
+
+/** Context handed to a command on `runCommand`. */
+export interface PluginContext {
+  file: PluginFileContext
+  selection?: PluginSelection
+}
+
+/** Show a message in the Plugins panel. */
+export interface MessageAction {
+  type: 'message'
+  level: 'info' | 'warning' | 'error'
+  text: string
+}
+
+/** Replace the active file's full contents. */
+export interface EditAction {
+  type: 'edit'
+  content: string
+}
+
+/** A single diagnostic (problem marker). */
+export interface DiagnosticAction {
+  type: 'diagnostic'
+  item: {
+    line: number
+    column?: number
+    endLine?: number
+    endColumn?: number
+    severity: string
+    message: string
+    source: string
+  }
+}
+
+/** Any action a command can return. */
+export type PluginAction = MessageAction | EditAction | DiagnosticAction
+
+/** Result of `runCommand`. */
+export interface RunCommandResult {
+  actions: PluginAction[]
+}
+
+/** Discovered plugins + their commands, returned by `list()`. */
+export interface PluginListing {
+  plugins: PluginInfo[]
+  commands: CommandInfo[]
+}
+
+/** Whether a Python interpreter + host were found. */
+export interface PluginStatus {
+  /** True when a Python interpreter was located and the host started. */
+  pythonFound: boolean
+  /** The interpreter command that was used, when found. */
+  python?: string
+  /** A human-readable reason when `pythonFound` is false (or the host died). */
+  error?: string
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -55,6 +55,23 @@ export type {
   GitRemoteResult
 } from '../main/git/types'
 
+// Re-export the Python plugin-system types (issue #61) so the Plugins panel can
+// import them from this single UI-facing module.
+export type {
+  PluginInfo,
+  CommandInfo,
+  PluginContext,
+  PluginFileContext,
+  PluginSelection,
+  PluginAction,
+  MessageAction,
+  EditAction,
+  DiagnosticAction,
+  RunCommandResult,
+  PluginListing,
+  PluginStatus
+} from '../main/plugins/types'
+
 declare global {
   interface Window {
     electron: ElectronAPI

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -32,6 +32,12 @@ import type {
   GitRemoteResult,
   GitStatus
 } from '../main/git/types'
+import type {
+  PluginContext,
+  PluginListing,
+  PluginStatus,
+  RunCommandResult
+} from '../main/plugins/types'
 
 /**
  * Unwrap an {@link IpcResult} into a resolved value or a thrown Error, so the
@@ -322,6 +328,28 @@ const git = {
   pull: (): Promise<GitRemoteResult> => unwrap(ipcRenderer.invoke('git:pull'))
 }
 
+/**
+ * Python plugin system API (issue #61). Mirrors the main-process `plugins:*`
+ * IPC handlers and unwraps their typed results. Snakie's main process spawns
+ * the user's `python3` running `snakie.host`, which discovers + loads Python
+ * plugins and speaks JSON-RPC over stdio.
+ *
+ * The no-Python case is reported via `status().pythonFound === false` (with a
+ * human-readable `error`) rather than thrown, so the Plugins panel can show a
+ * clear "install Python 3 and `pip install snakie`" empty state.
+ */
+const plugins = {
+  /** Whether a Python interpreter + host were found (and which interpreter). */
+  status: (): Promise<PluginStatus> => unwrap(ipcRenderer.invoke('plugins:status')),
+  /** Discovered plugins + their registered commands. */
+  list: (): Promise<PluginListing> => unwrap(ipcRenderer.invoke('plugins:list')),
+  /** Run a command against the active editor context; returns its actions. */
+  runCommand: (commandId: string, context: PluginContext): Promise<RunCommandResult> =>
+    unwrap(ipcRenderer.invoke('plugins:runCommand', commandId, context)),
+  /** Kill + re-spawn the host, picking up newly added plugins. */
+  reload: (): Promise<PluginStatus> => unwrap(ipcRenderer.invoke('plugins:reload'))
+}
+
 // Minimal, typed API exposed to the renderer. This establishes the IPC
 // pattern that later feature work will extend.
 const api = {
@@ -342,7 +370,9 @@ const api = {
   /** LLM (Claude) chat layer. */
   llm,
   /** Built-in version-control (Git) layer. */
-  git
+  git,
+  /** Python plugin system layer (spawns snakie.host over JSON-RPC). */
+  plugins
 }
 
 // Use `contextBridge` APIs to expose Electron APIs to the renderer only if

--- a/src/renderer/src/components/ActivityBar.tsx
+++ b/src/renderer/src/components/ActivityBar.tsx
@@ -14,7 +14,13 @@ import type { JSX, ReactNode } from 'react'
  */
 
 /** Stable, persisted view ids. Default is `files`. */
-export type ActivityView = 'files' | 'source-control' | 'packages' | 'inspect' | 'help'
+export type ActivityView =
+  | 'files'
+  | 'source-control'
+  | 'packages'
+  | 'plugins'
+  | 'inspect'
+  | 'help'
 
 const SVG = (children: ReactNode): JSX.Element => (
   <svg
@@ -48,6 +54,13 @@ const ICONS: Record<ActivityView, JSX.Element> = {
       <path d="M1.5 5 8 8.5 14.5 5M8 8.5V14.5" />
     </g>
   ),
+  // puzzle piece
+  plugins: SVG(
+    <path
+      fill="currentColor"
+      d="M6 1h4v2a1 1 0 0 0 2 0V2h3v3h-1a1 1 0 0 0 0 2h1v4h-2a1 1 0 0 1-1-1 1 1 0 0 0-2 0 1 1 0 0 1-1 1H6v-3a1 1 0 0 0-2 0v3H1V8h1a1 1 0 0 0 0-2H1V3h3a1 1 0 0 0 2 0z"
+    />
+  ),
   // magnifier
   inspect: SVG(
     <g fill="none" stroke="currentColor" strokeWidth="1.8">
@@ -73,6 +86,7 @@ const TOP_ITEMS: ActivityItem[] = [
   { id: 'files', label: 'Files' },
   { id: 'source-control', label: 'Source' },
   { id: 'packages', label: 'Packages' },
+  { id: 'plugins', label: 'Plugins' },
   { id: 'inspect', label: 'Inspect' }
 ]
 

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -8,6 +8,7 @@ import { PanelHeader } from './PanelHeader'
 import { FilePanel } from './FilePanel'
 import { GitPanel } from './GitPanel'
 import { PackagesPanel } from './PackagesPanel'
+import { PluginsPanel } from './PluginsPanel'
 import { InspectPanel } from './InspectPanel'
 import { HelpPanel } from './HelpPanel'
 import { EditorArea } from './EditorArea'
@@ -42,6 +43,12 @@ function LeftView({ view }: { view: ActivityView }): JSX.Element {
       return (
         <LeftRegion title="Packages">
           <PackagesPanel />
+        </LeftRegion>
+      )
+    case 'plugins':
+      return (
+        <LeftRegion title="Plugins">
+          <PluginsPanel />
         </LeftRegion>
       )
     case 'inspect':

--- a/src/renderer/src/components/PluginsPanel.css
+++ b/src/renderer/src/components/PluginsPanel.css
@@ -1,0 +1,244 @@
+/*
+ * Styles co-located with PluginsPanel (issue #61).
+ *
+ * The Plugins view lists discovered Python plugins + their commands with a Run
+ * button each, plus a notices area for messages / applied edits. Uses the
+ * shared design tokens from index.css so it tracks the active theme.
+ */
+
+.plugins {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  font-size: 13px;
+  color: var(--text);
+}
+
+/* --- Empty / no-Python states --------------------------------------------- */
+
+.plugins--empty {
+  align-items: flex-start;
+  gap: 0.6rem;
+  padding: 0.9rem 0.85rem;
+}
+
+.plugins__empty-note {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.plugins__empty-detail {
+  font-size: 0.78rem;
+}
+
+.plugins__code {
+  margin: 0;
+  padding: 0.45rem 0.6rem;
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--bg-sunken);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-family: inherit;
+  font-size: 0.82rem;
+  color: var(--text);
+}
+
+/* --- Toolbar --------------------------------------------------------------- */
+
+.plugins__toolbar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0.5rem 0.7rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.plugins__interpreter {
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+}
+
+.plugins__toolbar-spacer {
+  flex: 1 1 auto;
+}
+
+/* --- Trust notice ---------------------------------------------------------- */
+
+.plugins__trust {
+  margin: 0;
+  padding: 0.4rem 0.7rem;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  line-height: 1.4;
+  border-bottom: 1px solid var(--border);
+}
+
+/* --- Buttons --------------------------------------------------------------- */
+
+.plugins__btn {
+  padding: 0.25rem 0.6rem;
+  background: var(--bg-sunken);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-family: inherit;
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+
+.plugins__btn:hover:not(:disabled) {
+  background: var(--bg-elevated);
+}
+
+.plugins__btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.plugins__btn--run {
+  flex: 0 0 auto;
+}
+
+.plugins__icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+  height: 24px;
+  padding: 0 4px;
+  background: transparent;
+  color: var(--text-muted);
+  border: 1px solid transparent;
+  border-radius: var(--radius);
+  font-size: 0.95rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.plugins__icon-btn:hover:not(:disabled) {
+  background: var(--bg-elevated);
+  color: var(--text);
+}
+
+.plugins__icon-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+/* --- Plugin + command list ------------------------------------------------- */
+
+.plugins__list {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+}
+
+.plugins__list > .plugins__empty-note {
+  padding: 0.8rem 0.85rem;
+}
+
+.plugins__plugin {
+  border-bottom: 1px solid var(--border);
+}
+
+.plugins__plugin-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0.5rem 0.7rem 0.3rem;
+}
+
+.plugins__plugin-name {
+  font-weight: 600;
+}
+
+.plugins__source {
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0 4px;
+}
+
+.plugins__plugin-error {
+  margin: 0;
+  padding: 0.3rem 0.7rem 0.5rem;
+  color: var(--danger, #c0392b);
+  font-size: 0.78rem;
+}
+
+.plugins__commands {
+  margin: 0;
+  padding: 0 0 0.4rem;
+  list-style: none;
+}
+
+.plugins__command {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0.25rem 0.7rem;
+}
+
+.plugins__command:hover {
+  background: var(--bg-elevated);
+}
+
+.plugins__command-title {
+  flex: 1 1 auto;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* --- Notices --------------------------------------------------------------- */
+
+.plugins__error {
+  margin: 0;
+  padding: 0.5rem 0.7rem;
+  font-size: 0.8rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--danger, #c0392b);
+  background: var(--bg-sunken);
+}
+
+.plugins__notices {
+  flex: 0 0 auto;
+  max-height: 40%;
+  overflow: auto;
+  border-top: 1px solid var(--border);
+  background: var(--bg-sunken);
+}
+
+.plugins__notice {
+  margin: 0;
+  padding: 0.4rem 0.7rem;
+  font-size: 0.78rem;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-word;
+  border-bottom: 1px solid var(--border);
+}
+
+.plugins__notice:last-child {
+  border-bottom: none;
+}
+
+.plugins__notice--warning {
+  color: #d29922;
+}
+
+.plugins__notice--error {
+  color: var(--danger, #c0392b);
+}

--- a/src/renderer/src/components/PluginsPanel.tsx
+++ b/src/renderer/src/components/PluginsPanel.tsx
@@ -1,0 +1,264 @@
+import { useCallback, useEffect, useState } from 'react'
+import './PluginsPanel.css'
+import { useWorkspace } from '../store/workspace'
+import type {
+  CommandInfo,
+  PluginAction,
+  PluginContext,
+  PluginInfo,
+  PluginStatus
+} from '../../../preload/index.d'
+
+/**
+ * PLUGINS TAB (issue #61)
+ * =======================
+ *
+ * Lists the Python plugins Snakie discovered (via the spawned `snakie.host`)
+ * and the commands each registered. Pressing **Run** sends the active editor
+ * file as context and applies the returned actions: a `message` shows as a
+ * notice here; an `edit` replaces the active buffer's contents through the
+ * workspace store (marking it dirty).
+ *
+ * Everything degrades gracefully. When no Python interpreter is found,
+ * `status().pythonFound` is false and the panel shows a clear install prompt
+ * instead of an error. A **Reload** action re-spawns the host so newly added
+ * `~/.snakie/plugins/` files are picked up.
+ */
+
+/** A timestamped notice shown in the panel (from `message` actions / errors). */
+interface Notice {
+  id: number
+  level: 'info' | 'warning' | 'error'
+  text: string
+}
+
+let noticeSeq = 0
+
+export function PluginsPanel(): JSX.Element {
+  const { openFiles, activeId, updateContent } = useWorkspace()
+  const activeFile = openFiles.find((f) => f.id === activeId) ?? null
+
+  const [status, setStatus] = useState<PluginStatus | null>(null)
+  const [plugins, setPlugins] = useState<PluginInfo[]>([])
+  const [commands, setCommands] = useState<CommandInfo[]>([])
+  const [loading, setLoading] = useState(false)
+  const [busy, setBusy] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [notices, setNotices] = useState<Notice[]>([])
+
+  const pushNotice = useCallback((level: Notice['level'], text: string): void => {
+    setNotices((prev) => [{ id: ++noticeSeq, level, text }, ...prev].slice(0, 8))
+  }, [])
+
+  /** Load status, then (if Python was found) plugins + commands. */
+  const refresh = useCallback(async (): Promise<void> => {
+    setLoading(true)
+    setError(null)
+    try {
+      const st = await window.api.plugins.status()
+      setStatus(st)
+      if (st.pythonFound) {
+        const listing = await window.api.plugins.list()
+        setPlugins(listing.plugins)
+        setCommands(listing.commands)
+      } else {
+        setPlugins([])
+        setCommands([])
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  const reload = useCallback(async (): Promise<void> => {
+    setLoading(true)
+    setError(null)
+    try {
+      await window.api.plugins.reload()
+      await refresh()
+      pushNotice('info', 'Reloaded plugins.')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+      setLoading(false)
+    }
+  }, [refresh, pushNotice])
+
+  /** Apply a single returned action to the workspace / notices. */
+  const applyAction = useCallback(
+    (action: PluginAction): void => {
+      switch (action.type) {
+        case 'message':
+          pushNotice(action.level, action.text)
+          break
+        case 'edit':
+          if (activeId) {
+            updateContent(activeId, action.content)
+            pushNotice('info', `Applied edit to ${activeFile?.name ?? 'file'}.`)
+          } else {
+            pushNotice('warning', 'No active file to apply the edit to.')
+          }
+          break
+        case 'diagnostic':
+          pushNotice(
+            'info',
+            `Diagnostic (line ${action.item.line}): ${action.item.message}`
+          )
+          break
+        default:
+          break
+      }
+    },
+    [activeId, activeFile, updateContent, pushNotice]
+  )
+
+  const runCommand = useCallback(
+    async (command: CommandInfo): Promise<void> => {
+      if (!activeFile) {
+        pushNotice('warning', 'Open a file first — commands run against the active file.')
+        return
+      }
+      setBusy(command.id)
+      setError(null)
+      const context: PluginContext = {
+        file: {
+          path: activeFile.path,
+          name: activeFile.name,
+          source: activeFile.source,
+          content: activeFile.content
+        }
+      }
+      try {
+        const { actions } = await window.api.plugins.runCommand(command.id, context)
+        if (actions.length === 0) {
+          pushNotice('info', `${command.title} ran (no actions).`)
+        }
+        for (const action of actions) applyAction(action)
+      } catch (err) {
+        pushNotice('error', `${command.title} failed: ${err instanceof Error ? err.message : String(err)}`)
+      } finally {
+        setBusy(null)
+      }
+    },
+    [activeFile, applyAction, pushNotice]
+  )
+
+  // --- Render: Python not found -------------------------------------------
+  if (status && !status.pythonFound) {
+    return (
+      <div className="plugins plugins--empty">
+        <p className="plugins__empty-note">
+          <strong>Python not found.</strong> The plugin system runs your local
+          Python. Install Python 3 and the SDK:
+        </p>
+        <pre className="plugins__code">pip install snakie</pre>
+        <p className="plugins__empty-note plugins__empty-detail">{status.error}</p>
+        <button type="button" className="plugins__btn" onClick={() => void reload()}>
+          Reload
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="plugins">
+      <div className="plugins__toolbar">
+        <span className="plugins__interpreter" title={status?.python ?? ''}>
+          {status?.python ? `Python: ${status.python}` : 'Plugins'}
+        </span>
+        <span className="plugins__toolbar-spacer" />
+        <button
+          type="button"
+          className="plugins__icon-btn"
+          title="Reload plugins"
+          disabled={loading}
+          onClick={() => void reload()}
+        >
+          ⟳
+        </button>
+      </div>
+
+      <p className="plugins__trust" role="note">
+        Plugins run Python code on your machine. Only install plugins you trust.
+      </p>
+
+      {error && (
+        <p className="plugins__error" role="alert">
+          {error}
+        </p>
+      )}
+
+      {/* Plugin + command list */}
+      <div className="plugins__list">
+        {loading && plugins.length === 0 && (
+          <p className="plugins__empty-note">Loading plugins…</p>
+        )}
+        {!loading && plugins.length === 0 && !error && (
+          <p className="plugins__empty-note">
+            No plugins found. Drop a Python file in <code>~/.snakie/plugins/</code> and
+            press Reload. See <code>docs/writing-plugins.md</code>.
+          </p>
+        )}
+        {plugins.map((p) => {
+          const pluginCommands = commands.filter((c) => c.pluginId === p.id)
+          return (
+            <section key={p.id} className="plugins__plugin">
+              <header className="plugins__plugin-head">
+                <span className="plugins__plugin-name">{p.name}</span>
+                <span className={`plugins__source plugins__source--${p.source}`}>
+                  {p.source}
+                </span>
+              </header>
+              {!p.ok && (
+                <p className="plugins__plugin-error" role="alert">
+                  Failed to load: {p.error}
+                </p>
+              )}
+              {p.ok && pluginCommands.length === 0 && (
+                <p className="plugins__empty-note plugins__empty-detail">
+                  No commands registered.
+                </p>
+              )}
+              <ul className="plugins__commands">
+                {pluginCommands.map((c) => (
+                  <li key={c.id} className="plugins__command">
+                    <span className="plugins__command-title">{c.title}</span>
+                    <button
+                      type="button"
+                      className="plugins__btn plugins__btn--run"
+                      disabled={busy !== null}
+                      title={
+                        activeFile
+                          ? `Run against ${activeFile.name}`
+                          : 'Open a file to run against'
+                      }
+                      onClick={() => void runCommand(c)}
+                    >
+                      {busy === c.id ? 'Running…' : 'Run'}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )
+        })}
+      </div>
+
+      {/* Notices (messages / applied edits / errors) */}
+      {notices.length > 0 && (
+        <div className="plugins__notices" aria-label="Plugin output">
+          {notices.map((n) => (
+            <p key={n.id} className={`plugins__notice plugins__notice--${n.level}`}>
+              {n.text}
+            </p>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
MVP of the Python-based plugin system (issue #61), to `docs/plugin-system.md`.

**How it works:** the Electron main process spawns the user's `python3` running a host (`python -m snakie.host`) that discovers + imports Python plugins and speaks newline-delimited **JSON-RPC over stdio**. Plugins use a stdlib-only **`snakie` SDK** (`@plugin.command(id, title)`, `Context`, `message`/`edit` helpers).

- **Discovery:** `~/.snakie/plugins/*.py` (+ bundled `examples/plugins`, + `snakie.plugins` entry points).
- **UI:** new **Plugins** activity-bar view — lists plugins + commands, runs a command against the active editor file, applies `message`/`edit` actions; graceful "Python not found — `pip install snakie`" state + Reload.
- **IPC:** `window.api.plugins` = `status()`, `list()`, `runCommand(id, ctx)`, `reload()`.
- Ships an example `hello` plugin (Hello + Uppercase-file commands) and `docs/writing-plugins.md`.

**Verified end-to-end in the real Electron app** (screenshot): Python detected, the `hello` plugin and its two commands listed via the live host→IPC→UI chain; plus a direct host JSON-RPC smoke-test. lint · typecheck · **43 tests** · build green.

Follow-ups in the **v0.3.0 — Plugins** milestone: #65 (linter), #66 (marketplace + administration), #67 (authoring docs).

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)