### PR TITLE
Reactive plugins + editor decorations (squiggles & lightbulbs) — Closes #69

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   examples and entry points). New **Plugins** activity-bar view lists plugins and
   runs their commands against the active file; graceful "Python not found" state.
   Ships an example plugin + `docs/writing-plugins.md` (design: `docs/plugin-system.md`).
+- **Reactive plugins + editor decorations (#69).** Plugins can register a
+  `@plugin.linter` that runs automatically as you type (debounced) and on open,
+  drawing **squiggle underlines** (Monaco markers) and offering **lightbulb
+  quick-fixes** (a Monaco code-action provider applies the plugin's edit). Adds a
+  `lint` RPC / `window.api.plugins.lint`, diagnostics with optional ranged
+  `fixes`, and an example linter (flags trailing whitespace + TODOs).
 - **Toolbar file actions:** New File, Open Folder and Save icon buttons (left of
   Run). Save also works via Ctrl/Cmd-S, with a native **Save As** dialog for
   untitled buffers. The opened folder is now the app's shared working directory,

--- a/docs/plugin-system.md
+++ b/docs/plugin-system.md
@@ -79,9 +79,10 @@ def upper(ctx: Context):
 
 - `plugin.command(id, title)` — register a command (shown in the Plugins view /
   command list).
-- `plugin.linter(name)` — register a linter (returns `Diagnostic`s); consumed by
-  the linter feature (separate issue).
-- Helpers: `message(level, text)`, `edit(new_content)`, `diagnostic(...)`.
+- `plugin.linter(name)` — register a linter `(ctx) -> list[Diagnostic]`, run
+  reactively by the editor (squiggles + lightbulb quick-fixes, issue #69).
+- Helpers: `message(level, text)`, `edit(new_content)`, `diagnostic(...)`,
+  `fix(title, new_text, ...)` (a quick-fix attached to a diagnostic).
 - A plugin declares itself either via the `snakie.plugins` entry point in its
   `pyproject.toml` **or** by living in `~/.snakie/plugins/`.
 

--- a/docs/writing-plugins.md
+++ b/docs/writing-plugins.md
@@ -61,11 +61,77 @@ Import everything from the top-level `snakie` package:
     shown as a notice in the panel.
   - `edit(new_content)` — replace the active file's contents (the buffer is
     marked dirty; save as usual).
-  - `diagnostic(line, message, *, severity=..., column=..., source=...)` — a
-    problem marker (the linter feature that consumes these is a follow-up).
+  - `diagnostic(line, message, *, severity=..., column=..., end_line=...,
+    end_column=..., source=..., fixes=...)` — a problem marker (see
+    **Linters** below). When returned from a command it shows as a notice;
+    when returned from a linter it becomes an editor squiggle.
 
 Returning `None` is fine (the command simply ran with no action). A bare string
 is treated as an info message.
+
+## Linters (reactive analysis + quick-fixes)
+
+A **linter** runs automatically as you type and decorates the editor with
+squiggles (and optional lightbulb quick-fixes). Register one with
+`@plugin.linter(name)`; its handler takes a `Context` and returns a list of
+diagnostics:
+
+```python
+import re
+from snakie import plugin, Context, diagnostic, fix
+
+@plugin.linter("lint-demo")
+def lint(ctx: Context):
+    out = []
+    for i, line in enumerate(ctx.file.content.splitlines()):
+        line_no = i + 1                      # diagnostics are 1-based
+        stripped = line.rstrip()
+        if stripped != line:                 # trailing whitespace
+            start = len(stripped) + 1
+            end = len(line) + 1
+            out.append(diagnostic(
+                line_no, "Trailing whitespace",
+                severity="warning", column=start, end_column=end,
+                source="lint-demo",
+                fixes=[fix("Remove trailing whitespace", "",
+                           line=line_no, column=start,
+                           end_line=line_no, end_column=end)],
+            ))
+    return out
+```
+
+A full copy lives at
+[`examples/plugins/lint_demo/__init__.py`](../examples/plugins/lint_demo/__init__.py)
+(flags trailing whitespace and `# TODO` comments).
+
+### The diagnostic / fix API
+
+- **`diagnostic(line, message, *, severity="warning", column=None,
+  end_line=None, end_column=None, source="snakie", fixes=None)`** — one marker.
+  - `severity` is one of `"error"`, `"warning"`, `"info"`, `"hint"`.
+  - All line/column coordinates are **1-based**. If `end_column` is omitted the
+    editor extends the squiggle to the end of the word (or line).
+  - `fixes` is an optional list built with `fix(...)`.
+- **`fix(title, new_text, *, line=None, column=None, end_line=None,
+  end_column=None)`** — a quick-fix shown on the lightbulb. It replaces the
+  given **1-based** range with `new_text`. **Omit the range entirely** to mean
+  "replace the diagnostic's own range". Fixes are always ranged — there is no
+  whole-file replacement form, so target the exact span you flagged.
+
+A linter may return a single diagnostic, a list, or `None`. Errors raised inside
+one linter are isolated (logged to stderr) and never abort the others.
+
+### How reactive linting works
+
+- When the active file's content changes — and on file open / switch — Snakie
+  **debounces ~400 ms**, then runs every registered linter via the host's
+  `lint` RPC against the current `{file: {path, name, source, content}}`.
+  Stale requests are cancelled, so it never lints on every keystroke.
+- Returned diagnostics become Monaco **markers** (squiggles, severity-coloured).
+  Diagnostics that carry `fixes` are also offered as **lightbulb quick-fixes**;
+  applying one edits the buffer in place (which marks it dirty and re-lints).
+- If Python isn't found (or the plugin bridge is unavailable) linting is a
+  silent no-op — the editor simply shows no plugin squiggles.
 
 ## Run a command
 

--- a/examples/plugins/lint_demo/__init__.py
+++ b/examples/plugins/lint_demo/__init__.py
@@ -1,0 +1,74 @@
+"""Example Snakie plugin: lint demo.
+
+A dependency-free analysis plugin demonstrating the **reactive linter** API.
+Registered with ``@plugin.linter``, its handler runs automatically (debounced)
+as you edit, returning :func:`~snakie.diagnostic` results that Snakie renders as
+squiggles — with quick-fixes surfaced via the editor lightbulb.
+
+Two rules:
+
+* **Trailing whitespace** (``warning``) — flags spaces/tabs at the end of a
+  line, offering a "Remove trailing whitespace" quick-fix that strips them.
+* **TODO comments** (``info``) — flags ``# TODO`` markers so they are easy to
+  spot; informational, no fix.
+
+Copy this into ``~/.snakie/plugins/`` as a scaffold for your own linter — see
+``docs/writing-plugins.md``.
+"""
+
+import re
+
+from snakie import Context, diagnostic, fix, plugin
+
+# A TODO marker in a comment: "# TODO", "# todo:", "#TODO ..." etc.
+_TODO = re.compile(r"#\s*todo\b", re.IGNORECASE)
+
+
+@plugin.linter("lint-demo")
+def lint(ctx: Context):
+    """Flag trailing whitespace and TODO comments in the active file."""
+    diagnostics = []
+    for index, line in enumerate(ctx.file.content.splitlines()):
+        line_no = index + 1  # diagnostics are 1-based
+
+        # Rule 1: trailing whitespace -> warning + strip fix.
+        stripped = line.rstrip()
+        if stripped != line:
+            start_col = len(stripped) + 1  # 1-based column of first trailing ws
+            end_col = len(line) + 1
+            diagnostics.append(
+                diagnostic(
+                    line_no,
+                    "Trailing whitespace",
+                    severity="warning",
+                    column=start_col,
+                    end_column=end_col,
+                    source="lint-demo",
+                    fixes=[
+                        fix(
+                            "Remove trailing whitespace",
+                            "",
+                            line=line_no,
+                            column=start_col,
+                            end_line=line_no,
+                            end_column=end_col,
+                        )
+                    ],
+                )
+            )
+
+        # Rule 2: TODO comment -> info (no fix; informational marker).
+        match = _TODO.search(line)
+        if match:
+            diagnostics.append(
+                diagnostic(
+                    line_no,
+                    "TODO comment",
+                    severity="info",
+                    column=match.start() + 1,
+                    end_column=len(line) + 1,
+                    source="lint-demo",
+                )
+            )
+
+    return diagnostics

--- a/python/snakie/__init__.py
+++ b/python/snakie/__init__.py
@@ -36,9 +36,11 @@ __all__ = [
     "FileContext",
     "Selection",
     "Command",
+    "Linter",
     "message",
     "edit",
     "diagnostic",
+    "fix",
 ]
 
 __version__ = "0.1.0"
@@ -128,6 +130,38 @@ def edit(new_content: str) -> Action:
     return {"type": "edit", "content": new_content}
 
 
+def fix(
+    title: str,
+    new_text: str,
+    *,
+    line: Optional[int] = None,
+    column: Optional[int] = None,
+    end_line: Optional[int] = None,
+    end_column: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Build a quick-fix attached to a diagnostic.
+
+    A fix is ``{ title, edit: { line?, column?, endLine?, endColumn?, newText } }``.
+    When the range is omitted entirely the host/editor replaces *the diagnostic's
+    own range*. Fixes are always ranged — a ``newText``-only fix that would
+    replace the whole file is intentionally not supported (linters should target
+    the exact span they flag).
+
+    ``line``/``column``/``end_line``/``end_column`` are 1-based, matching the
+    diagnostic coordinate system.
+    """
+    edit_obj: Dict[str, Any] = {"newText": str(new_text)}
+    if line is not None:
+        edit_obj["line"] = int(line)
+    if column is not None:
+        edit_obj["column"] = int(column)
+    if end_line is not None:
+        edit_obj["endLine"] = int(end_line)
+    if end_column is not None:
+        edit_obj["endColumn"] = int(end_column)
+    return {"title": str(title), "edit": edit_obj}
+
+
 def diagnostic(
     line: int,
     message: str,
@@ -137,10 +171,18 @@ def diagnostic(
     end_line: Optional[int] = None,
     end_column: Optional[int] = None,
     source: str = "snakie",
+    fixes: Optional[List[Dict[str, Any]]] = None,
 ) -> Action:
-    """Produce a single diagnostic action (problem marker).
+    """Produce a single diagnostic action (problem marker / squiggle).
 
-    ``severity`` is one of ``error``, ``warning``, ``info``, ``hint``.
+    ``severity`` is one of ``error``, ``warning``, ``info``, ``hint``. All
+    line/column coordinates are 1-based. ``fixes`` is an optional list of
+    quick-fixes built with :func:`fix`, surfaced as editor lightbulb actions.
+
+    The returned value is an *action* (``{"type": "diagnostic", "item": {...}}``)
+    so it can be returned from a regular ``@plugin.command``. Linters
+    (``@plugin.linter``) may return the action form or the bare ``item`` dict —
+    the host normalises both.
     """
     item: Dict[str, Any] = {
         "line": int(line),
@@ -154,6 +196,8 @@ def diagnostic(
         item["endLine"] = int(end_line)
     if end_column is not None:
         item["endColumn"] = int(end_column)
+    if fixes:
+        item["fixes"] = list(fixes)
     return {"type": "diagnostic", "item": item}
 
 
@@ -172,6 +216,21 @@ class Command:
     plugin_id: str = ""
 
 
+@dataclass
+class Linter:
+    """A registered linter.
+
+    ``handler`` is ``(ctx: Context) -> list[Diagnostic]`` (or a single
+    diagnostic / the :func:`diagnostic` action form — the host normalises the
+    return value). It is run reactively by the editor whenever the active file's
+    content changes.
+    """
+
+    name: str
+    handler: Callable[[Context], Any]
+    plugin_id: str = ""
+
+
 class Plugin:
     """The shared registry that ``@plugin.command`` writes to.
 
@@ -182,6 +241,7 @@ class Plugin:
 
     def __init__(self) -> None:
         self.commands: List[Command] = []
+        self.linters: List[Linter] = []
         # The plugin id the host is currently importing; commands registered
         # while this is set are attributed to it. Set by the host around each
         # import (see snakie.host).
@@ -198,14 +258,19 @@ class Plugin:
 
         return decorator
 
-    def linter(self, name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-        """Reserved for the linter feature (separate issue).
+    def linter(self, name: str) -> Callable[[Callable[[Context], Any]], Callable[[Context], Any]]:
+        """Decorator: register ``func`` as a linter named ``name``.
 
-        Registering is a no-op in the MVP — kept so plugins that use it import
-        cleanly. Returns the function unchanged.
+        The handler is ``(ctx: Context) -> list[Diagnostic]`` and is run
+        reactively by the editor as the active file changes. Each diagnostic may
+        carry quick-fixes (see :func:`diagnostic` / :func:`fix`). Returning a
+        single diagnostic, a list, or ``None`` are all accepted.
         """
 
-        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        def decorator(func: Callable[[Context], Any]) -> Callable[[Context], Any]:
+            self.linters.append(
+                Linter(name=name, handler=func, plugin_id=self._current_plugin_id)
+            )
             return func
 
         return decorator

--- a/python/snakie/host.py
+++ b/python/snakie/host.py
@@ -11,7 +11,7 @@ stdin/stdout**. The host:
 2. Imports each, running its ``@plugin.command`` decorators. A per-plugin import
    error is reported in the plugin list, not fatal.
 3. Serves the JSON-RPC loop: ``initialize``, ``listCommands``,
-   ``runCommand``, ``shutdown``.
+   ``runCommand``, ``lint``, ``shutdown``.
 
 Protocol
 --------
@@ -206,6 +206,78 @@ def _run_command(params: Dict[str, Any]) -> Dict[str, Any]:
     return {"actions": _normalise_actions(result)}
 
 
+def _normalise_diagnostic(item: Any) -> Optional[Dict[str, Any]]:
+    """Coerce a linter's diagnostic into a bare Diagnostic dict, or None.
+
+    Accepts either the bare ``{line, message, ...}`` shape or the action form
+    ``{"type": "diagnostic", "item": {...}}`` returned by ``snakie.diagnostic``.
+    """
+    if not isinstance(item, dict):
+        return None
+    if item.get("type") == "diagnostic" and isinstance(item.get("item"), dict):
+        item = item["item"]
+    if "line" not in item or "message" not in item:
+        return None
+    # Re-serialise to a plain JSON dict, preserving only known keys + fixes.
+    out: Dict[str, Any] = {
+        "line": int(item.get("line", 1)),
+        "severity": str(item.get("severity", "warning")),
+        "message": str(item.get("message", "")),
+        "source": str(item.get("source", "snakie")),
+    }
+    for key in ("column", "endLine", "endColumn"):
+        if item.get(key) is not None:
+            out[key] = int(item[key])
+    fixes = item.get("fixes")
+    if isinstance(fixes, (list, tuple)):
+        clean_fixes = [_normalise_fix(f) for f in fixes]
+        clean_fixes = [f for f in clean_fixes if f is not None]
+        if clean_fixes:
+            out["fixes"] = clean_fixes
+    return out
+
+
+def _normalise_fix(fx: Any) -> Optional[Dict[str, Any]]:
+    """Coerce a quick-fix into a plain ``{title, edit:{...}}`` JSON dict."""
+    if not isinstance(fx, dict):
+        return None
+    edit_in = fx.get("edit")
+    if not isinstance(edit_in, dict) or "newText" not in edit_in:
+        return None
+    edit_out: Dict[str, Any] = {"newText": str(edit_in["newText"])}
+    for key in ("line", "column", "endLine", "endColumn"):
+        if edit_in.get(key) is not None:
+            edit_out[key] = int(edit_in[key])
+    return {"title": str(fx.get("title", "Fix")), "edit": edit_out}
+
+
+def _run_lint(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Run every registered linter and concatenate their diagnostics.
+
+    A failure in one linter is captured (reported to stderr) and does not abort
+    the others or the whole lint.
+    """
+    ctx = Context.from_dict(params.get("context"))
+    diagnostics: List[Dict[str, Any]] = []
+    for ln in plugin.linters:
+        try:
+            result = ln.handler(ctx)
+        except Exception as exc:  # noqa: BLE001 - per-linter isolation
+            print(
+                f"snakie.host: linter {ln.name!r} failed: {exc}",
+                file=sys.stderr,
+            )
+            continue
+        if result is None:
+            continue
+        items = result if isinstance(result, (list, tuple)) else [result]
+        for raw in items:
+            diag = _normalise_diagnostic(raw)
+            if diag is not None:
+                diagnostics.append(diag)
+    return {"diagnostics": diagnostics}
+
+
 # ---------------------------------------------------------------------------
 # JSON-RPC loop
 # ---------------------------------------------------------------------------
@@ -232,6 +304,9 @@ class Host:
         if method == "runCommand":
             self._ensure_discovered()
             return _run_command(params)
+        if method == "lint":
+            self._ensure_discovered()
+            return _run_lint(params)
         if method == "shutdown":
             return {"ok": True}
         raise ValueError(f"unknown method: {method!r}")

--- a/src/main/plugins/PluginHost.ts
+++ b/src/main/plugins/PluginHost.ts
@@ -4,6 +4,7 @@ import { join } from 'path'
 import { app } from 'electron'
 import type {
   CommandInfo,
+  LintResult,
   PluginContext,
   PluginInfo,
   PluginListing,
@@ -270,6 +271,18 @@ export class PluginHost {
       throw new Error(this.startError ?? 'Python plugin host is not available')
     }
     return this.request<RunCommandResult>('runCommand', { commandId, context })
+  }
+
+  /**
+   * Run all registered linters against the given editor context and return the
+   * concatenated diagnostics. A no-Python host yields an empty diagnostic set
+   * (the editor simply shows no squiggles) rather than throwing — reactive
+   * linting must never disrupt typing.
+   */
+  async lint(context: PluginContext): Promise<LintResult> {
+    await this.start()
+    if (!this.child) return { diagnostics: [] }
+    return this.request<LintResult>('lint', { context })
   }
 
   /** Kill and re-spawn the host (picks up newly added plugins). */

--- a/src/main/plugins/ipc.ts
+++ b/src/main/plugins/ipc.ts
@@ -1,7 +1,13 @@
 import { ipcMain } from 'electron'
 import type { IpcResult } from '../device/types'
 import { PluginHost } from './PluginHost'
-import type { PluginContext, PluginListing, PluginStatus, RunCommandResult } from './types'
+import type {
+  LintResult,
+  PluginContext,
+  PluginListing,
+  PluginStatus,
+  RunCommandResult
+} from './types'
 
 /**
  * IPC for the Python plugin system (issue #61).
@@ -45,6 +51,9 @@ export function registerPluginsIpc(): void {
   ipcMain.handle('plugins:list', () => wrap<PluginListing>(() => h.list()))
   ipcMain.handle('plugins:runCommand', (_e, commandId: string, context: PluginContext) =>
     wrap<RunCommandResult>(() => h.runCommand(commandId, context))
+  )
+  ipcMain.handle('plugins:lint', (_e, context: PluginContext) =>
+    wrap<LintResult>(() => h.lint(context))
   )
   ipcMain.handle('plugins:reload', () => wrap<PluginStatus>(() => h.reload()))
 }

--- a/src/main/plugins/types.ts
+++ b/src/main/plugins/types.ts
@@ -67,18 +67,43 @@ export interface EditAction {
   content: string
 }
 
-/** A single diagnostic (problem marker). */
-export interface DiagnosticAction {
-  type: 'diagnostic'
-  item: {
-    line: number
+/**
+ * A quick-fix attached to a diagnostic, surfaced as an editor lightbulb action.
+ * An absent range means "replace the diagnostic's own range" (fixes are always
+ * ranged — there is no whole-file replacement form).
+ */
+export interface DiagnosticFix {
+  title: string
+  edit: {
+    line?: number
     column?: number
     endLine?: number
     endColumn?: number
-    severity: string
-    message: string
-    source: string
+    newText: string
   }
+}
+
+/** A single diagnostic (problem marker / squiggle). Coordinates are 1-based. */
+export interface Diagnostic {
+  line: number
+  column?: number
+  endLine?: number
+  endColumn?: number
+  severity: string
+  message: string
+  source: string
+  fixes?: DiagnosticFix[]
+}
+
+/** A single diagnostic action (problem marker) returned from a command. */
+export interface DiagnosticAction {
+  type: 'diagnostic'
+  item: Diagnostic
+}
+
+/** Result of the `lint` RPC: all linters' diagnostics, concatenated. */
+export interface LintResult {
+  diagnostics: Diagnostic[]
 }
 
 /** Any action a command can return. */

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -67,6 +67,9 @@ export type {
   MessageAction,
   EditAction,
   DiagnosticAction,
+  Diagnostic,
+  DiagnosticFix,
+  LintResult,
   RunCommandResult,
   PluginListing,
   PluginStatus

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -33,6 +33,7 @@ import type {
   GitStatus
 } from '../main/git/types'
 import type {
+  LintResult,
   PluginContext,
   PluginListing,
   PluginStatus,
@@ -346,6 +347,13 @@ const plugins = {
   /** Run a command against the active editor context; returns its actions. */
   runCommand: (commandId: string, context: PluginContext): Promise<RunCommandResult> =>
     unwrap(ipcRenderer.invoke('plugins:runCommand', commandId, context)),
+  /**
+   * Run all registered linters against the active editor context, returning
+   * the concatenated diagnostics (with optional quick-fixes). Used by the
+   * editor for reactive squiggles + lightbulbs.
+   */
+  lint: (context: PluginContext): Promise<LintResult> =>
+    unwrap(ipcRenderer.invoke('plugins:lint', context)),
   /** Kill + re-spawn the host, picking up newly added plugins. */
   reload: (): Promise<PluginStatus> => unwrap(ipcRenderer.invoke('plugins:reload'))
 }

--- a/src/renderer/src/components/MonacoEditor.tsx
+++ b/src/renderer/src/components/MonacoEditor.tsx
@@ -8,6 +8,35 @@ import 'monaco-editor/esm/vs/basic-languages/python/python.contribution'
 import 'monaco-editor/esm/vs/basic-languages/markdown/markdown.contribution'
 import './monaco-setup'
 import { useWorkspace } from '../store/workspace'
+import type { Diagnostic, PluginContext } from '../../../preload/index.d'
+import { diagnosticToMarker } from './plugin-diagnostics'
+import {
+  clearModelDiagnostics,
+  registerPluginCodeActions,
+  setModelDiagnostics
+} from './plugin-code-actions'
+
+// Register the plugin quick-fix (lightbulb) provider exactly once at module
+// load, mirroring the completion provider. The function is idempotent and
+// guarded against HMR double-registration.
+registerPluginCodeActions(monaco)
+
+/** Monaco marker owner used for plugin-sourced diagnostics. */
+const PLUGIN_MARKER_OWNER = 'snakie-plugins'
+
+/** Debounce window (ms) before re-linting after the active file changes. */
+const LINT_DEBOUNCE_MS = 400
+
+/**
+ * Paint plugin diagnostics onto a model: set Monaco markers (squiggles) and
+ * record the diagnostics-with-fixes so the code-action provider can offer
+ * lightbulb quick-fixes. Clears both when there are no diagnostics.
+ */
+function applyDiagnostics(model: monaco.editor.ITextModel, diagnostics: Diagnostic[]): void {
+  const markers = diagnostics.map((d) => diagnosticToMarker(model, d))
+  monaco.editor.setModelMarkers(model, PLUGIN_MARKER_OWNER, markers)
+  setModelDiagnostics(model.uri.toString(), diagnostics)
+}
 
 /**
  * Map a file name to a Monaco language id. MicroPython sources are plain Python,
@@ -123,7 +152,10 @@ export function MonacoEditor(): JSX.Element {
       changeDisposable.dispose()
       editor.dispose()
       editorRef.current = null
-      modelStore.forEach((m) => m.dispose())
+      modelStore.forEach((m) => {
+        clearModelDiagnostics(m.uri.toString())
+        m.dispose()
+      })
       modelStore.clear()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -167,6 +199,53 @@ export function MonacoEditor(): JSX.Element {
     }
   }, [activeFile, activeFile?.id, activeFile?.content, activeFile?.name])
 
+  // Reactive linting: when the active file's content changes (or the active
+  // file switches), debounce then run all plugin linters and paint the results
+  // as Monaco markers (squiggles). Stale requests are dropped via a per-run
+  // token. No-ops when the plugin bridge is absent or Python wasn't found.
+  useEffect(() => {
+    const editor = editorRef.current
+    if (!editor || !activeFile) return undefined
+
+    const plugins = window.api?.plugins
+    if (!plugins?.lint) return undefined
+
+    const model = models.current.get(activeFile.id)
+    if (!model || model.isDisposed()) return undefined
+
+    let cancelled = false
+    const file = activeFile
+    const context: PluginContext = {
+      file: {
+        path: file.path,
+        name: file.name,
+        source: file.source,
+        content: file.content
+      }
+    }
+
+    const timer = setTimeout(() => {
+      void (async () => {
+        try {
+          const status = await plugins.status()
+          if (cancelled || !status.pythonFound) return
+          const { diagnostics } = await plugins.lint(context)
+          if (cancelled) return
+          const m = models.current.get(file.id)
+          if (!m || m.isDisposed()) return
+          applyDiagnostics(m, diagnostics)
+        } catch {
+          // Linting must never disrupt typing; swallow + leave prior markers.
+        }
+      })()
+    }, LINT_DEBOUNCE_MS)
+
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+    }
+  }, [activeFile, activeFile?.id, activeFile?.content])
+
   // Reveal/scroll to a line on request (e.g. clicking an Outline symbol).
   // Keyed on `seq` so repeated clicks on the same symbol re-reveal it.
   useEffect(() => {
@@ -183,6 +262,7 @@ export function MonacoEditor(): JSX.Element {
     const openIds = new Set(openFiles.map((f) => f.id))
     models.current.forEach((model, id) => {
       if (!openIds.has(id)) {
+        clearModelDiagnostics(model.uri.toString())
         model.dispose()
         models.current.delete(id)
       }

--- a/src/renderer/src/components/plugin-code-actions.ts
+++ b/src/renderer/src/components/plugin-code-actions.ts
@@ -1,0 +1,111 @@
+/**
+ * Quick-fix (lightbulb) support for Snakie plugin diagnostics.
+ *
+ * The reactive linter (see `useReactiveLint`) sets Monaco markers AND records,
+ * per model URI, the diagnostics that carry fixes. This module registers a
+ * SINGLE Monaco `CodeActionProvider` for `python` (guarded against double-
+ * registration the same way the completion provider is) which turns those
+ * recorded fixes into `quickfix` `CodeAction`s with a `WorkspaceEdit` applying
+ * the fix's resolved range/newText to the model.
+ *
+ * Applying a fix mutates the model, which fires `onDidChangeModelContent` ->
+ * `updateContent` (already wired in MonacoEditor), so the buffer + dirty state
+ * stay in sync and a re-lint is triggered automatically.
+ */
+import type * as Monaco from 'monaco-editor/esm/vs/editor/editor.api'
+import type { Diagnostic } from '../../../preload/index.d'
+import { diagnosticRange, resolveFixRange, type ModelLike } from './plugin-diagnostics'
+
+/** Diagnostics (with fixes) for a single model, keyed by `model.uri.toString()`. */
+const diagnosticsByUri = new Map<string, Diagnostic[]>()
+
+/** Record the current diagnostics for a model so the provider can offer fixes. */
+export function setModelDiagnostics(uri: string, diagnostics: Diagnostic[]): void {
+  const withFixes = diagnostics.filter((d) => d.fixes && d.fixes.length > 0)
+  if (withFixes.length > 0) diagnosticsByUri.set(uri, withFixes)
+  else diagnosticsByUri.delete(uri)
+}
+
+/** Forget a model's diagnostics (e.g. when its file is closed). */
+export function clearModelDiagnostics(uri: string): void {
+  diagnosticsByUri.delete(uri)
+}
+
+/** Marker key making double-registration idempotent across HMR. */
+const REGISTERED_KEY = '__snakiePluginCodeActionsRegistered'
+
+type GuardedGlobal = typeof globalThis & { [REGISTERED_KEY]?: boolean }
+
+/** Does a diagnostic's range intersect the requested range? (cheap overlap.) */
+function diagnosticInRange(model: ModelLike, diag: Diagnostic, range: Monaco.IRange): boolean {
+  const r = diagnosticRange(model, diag)
+  if (r.endLineNumber < range.startLineNumber || r.startLineNumber > range.endLineNumber) {
+    return false
+  }
+  return true
+}
+
+/**
+ * Register the plugin quick-fix provider for `python`. Idempotent: the first
+ * call wins, later calls (e.g. HMR re-eval) are no-ops. Returns the disposable
+ * on first registration, otherwise `undefined`.
+ */
+export function registerPluginCodeActions(
+  monaco: typeof Monaco
+): Monaco.IDisposable | undefined {
+  const g = globalThis as GuardedGlobal
+  if (g[REGISTERED_KEY]) return undefined
+  g[REGISTERED_KEY] = true
+
+  const disposable = monaco.languages.registerCodeActionProvider('python', {
+    provideCodeActions(model, range) {
+      const diags = diagnosticsByUri.get(model.uri.toString())
+      if (!diags || diags.length === 0) return { actions: [], dispose: () => {} }
+
+      const modelLike = model as unknown as ModelLike
+      const actions: Monaco.languages.CodeAction[] = []
+
+      for (const diag of diags) {
+        if (!diagnosticInRange(modelLike, diag, range)) continue
+        for (const fix of diag.fixes ?? []) {
+          const fixRange = resolveFixRange(modelLike, diag, fix)
+          actions.push({
+            title: fix.title,
+            kind: 'quickfix',
+            edit: {
+              edits: [
+                {
+                  resource: model.uri,
+                  // Monaco's WorkspaceEdit text-edit shape.
+                  textEdit: {
+                    range: {
+                      startLineNumber: fixRange.startLineNumber,
+                      startColumn: fixRange.startColumn,
+                      endLineNumber: fixRange.endLineNumber,
+                      endColumn: fixRange.endColumn
+                    },
+                    text: fix.edit.newText
+                  },
+                  versionId: model.getVersionId()
+                } as Monaco.languages.IWorkspaceTextEdit
+              ]
+            },
+            isPreferred: true
+          })
+        }
+      }
+
+      return { actions, dispose: () => {} }
+    }
+  })
+
+  if (import.meta.hot) {
+    import.meta.hot.dispose(() => {
+      disposable.dispose()
+      diagnosticsByUri.clear()
+      g[REGISTERED_KEY] = false
+    })
+  }
+
+  return disposable
+}

--- a/src/renderer/src/components/plugin-diagnostics.ts
+++ b/src/renderer/src/components/plugin-diagnostics.ts
@@ -1,0 +1,130 @@
+/**
+ * Pure helpers turning Snakie plugin diagnostics (from the Python host's `lint`
+ * RPC) into Monaco editor decorations:
+ *
+ *  - {@link diagnosticToMarker} maps a 1-based {@link Diagnostic} to a Monaco
+ *    `IMarkerData` (squiggle), defaulting an absent end to the end of the word /
+ *    line so the squiggle has a visible span.
+ *  - {@link resolveFixRange} resolves a fix's (possibly absent) range against
+ *    the diagnostic it belongs to — an absent range means "the diagnostic's own
+ *    range" (used by the code-action provider to build a WorkspaceEdit).
+ *
+ * These are deliberately free of any Monaco *instance* state so they unit-test
+ * with a small stub (see test/diagnosticToMarker.test.ts).
+ */
+import type { Diagnostic, DiagnosticFix } from '../../../preload/index.d'
+
+/** Monaco's `MarkerSeverity` enum values (kept here so this module stays pure). */
+export const MarkerSeverity = {
+  Hint: 1,
+  Info: 2,
+  Warning: 4,
+  Error: 8
+} as const
+
+export type MarkerSeverityValue = (typeof MarkerSeverity)[keyof typeof MarkerSeverity]
+
+/** A minimal Monaco model surface this module needs to default end positions. */
+export interface ModelLike {
+  getLineMaxColumn(lineNumber: number): number
+  getLineCount(): number
+  getWordAtPosition(position: { lineNumber: number; column: number }): { endColumn: number } | null
+}
+
+/** A Monaco `IMarkerData`-compatible shape (subset we set). */
+export interface MarkerData {
+  severity: MarkerSeverityValue
+  message: string
+  source: string
+  startLineNumber: number
+  startColumn: number
+  endLineNumber: number
+  endColumn: number
+}
+
+/** A resolved, fully-specified 1-based range. */
+export interface ResolvedRange {
+  startLineNumber: number
+  startColumn: number
+  endLineNumber: number
+  endColumn: number
+}
+
+/** Map a diagnostic severity string to a Monaco `MarkerSeverity` value. */
+export function severityToMarker(severity: string): MarkerSeverityValue {
+  switch (severity) {
+    case 'error':
+      return MarkerSeverity.Error
+    case 'info':
+      return MarkerSeverity.Info
+    case 'hint':
+      return MarkerSeverity.Hint
+    case 'warning':
+    default:
+      return MarkerSeverity.Warning
+  }
+}
+
+/** Clamp a 1-based line number into the model's range. */
+function clampLine(model: ModelLike, line: number): number {
+  const max = Math.max(1, model.getLineCount())
+  return Math.min(Math.max(1, Math.floor(line)), max)
+}
+
+/**
+ * Resolve a diagnostic's full 1-based start/end range against the model,
+ * defaulting an absent column to 1 and an absent end to the end of the
+ * word-at-start (if any) or the end of the line.
+ */
+export function diagnosticRange(model: ModelLike, diag: Diagnostic): ResolvedRange {
+  const startLine = clampLine(model, diag.line)
+  const startColumn = diag.column != null ? Math.max(1, Math.floor(diag.column)) : 1
+  const endLine = diag.endLine != null ? clampLine(model, diag.endLine) : startLine
+
+  let endColumn: number
+  if (diag.endColumn != null) {
+    endColumn = Math.max(startColumn + (endLine === startLine ? 0 : -startColumn + 1), Math.floor(diag.endColumn))
+  } else {
+    const word = model.getWordAtPosition({ lineNumber: startLine, column: startColumn })
+    endColumn = word && word.endColumn > startColumn ? word.endColumn : model.getLineMaxColumn(endLine)
+    // Guarantee a non-empty span on the start line so the squiggle is visible.
+    if (endLine === startLine && endColumn <= startColumn) {
+      endColumn = Math.max(startColumn + 1, model.getLineMaxColumn(startLine))
+    }
+  }
+
+  return { startLineNumber: startLine, startColumn, endLineNumber: endLine, endColumn }
+}
+
+/** Map a diagnostic to a Monaco `IMarkerData` (squiggle). */
+export function diagnosticToMarker(model: ModelLike, diag: Diagnostic): MarkerData {
+  const range = diagnosticRange(model, diag)
+  return {
+    severity: severityToMarker(diag.severity),
+    message: diag.message,
+    source: diag.source,
+    startLineNumber: range.startLineNumber,
+    startColumn: range.startColumn,
+    endLineNumber: range.endLineNumber,
+    endColumn: range.endColumn
+  }
+}
+
+/**
+ * Resolve a fix's edit range. An absent range on the fix means "replace the
+ * diagnostic's own range" — so we fall back to {@link diagnosticRange}. A
+ * partially-specified range fills missing parts from the diagnostic range.
+ */
+export function resolveFixRange(model: ModelLike, diag: Diagnostic, fix: DiagnosticFix): ResolvedRange {
+  const base = diagnosticRange(model, diag)
+  const e = fix.edit
+  const hasAny =
+    e.line != null || e.column != null || e.endLine != null || e.endColumn != null
+  if (!hasAny) return base
+  const startLineNumber = e.line != null ? clampLine(model, e.line) : base.startLineNumber
+  const startColumn = e.column != null ? Math.max(1, Math.floor(e.column)) : base.startColumn
+  const endLineNumber = e.endLine != null ? clampLine(model, e.endLine) : startLineNumber
+  const endColumn =
+    e.endColumn != null ? Math.max(1, Math.floor(e.endColumn)) : model.getLineMaxColumn(endLineNumber)
+  return { startLineNumber, startColumn, endLineNumber, endColumn }
+}

--- a/test/diagnosticToMarker.test.ts
+++ b/test/diagnosticToMarker.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MarkerSeverity,
+  diagnosticRange,
+  diagnosticToMarker,
+  resolveFixRange,
+  severityToMarker,
+  type ModelLike
+} from '../src/renderer/src/components/plugin-diagnostics'
+import type { Diagnostic } from '../src/main/plugins/types'
+
+/**
+ * Unit tests for the pure diagnostic -> Monaco-marker mapping used by the
+ * reactive linter. A tiny model stub stands in for Monaco's ITextModel so the
+ * coordinate/defaulting logic is testable without the editor.
+ */
+function model(lines: string[]): ModelLike {
+  return {
+    getLineCount: () => lines.length,
+    getLineMaxColumn: (n) => (lines[n - 1]?.length ?? 0) + 1,
+    getWordAtPosition: ({ lineNumber, column }) => {
+      const text = lines[lineNumber - 1] ?? ''
+      const re = /[A-Za-z0-9_]+/g
+      let m: RegExpExecArray | null
+      while ((m = re.exec(text))) {
+        const start = m.index + 1
+        const end = start + m[0].length
+        if (column >= start && column <= end) return { endColumn: end }
+      }
+      return null
+    }
+  }
+}
+
+const diag = (over: Partial<Diagnostic>): Diagnostic => ({
+  line: 1,
+  severity: 'warning',
+  message: 'm',
+  source: 's',
+  ...over
+})
+
+describe('severityToMarker', () => {
+  it('maps each severity, defaulting unknown to Warning', () => {
+    expect(severityToMarker('error')).toBe(MarkerSeverity.Error)
+    expect(severityToMarker('warning')).toBe(MarkerSeverity.Warning)
+    expect(severityToMarker('info')).toBe(MarkerSeverity.Info)
+    expect(severityToMarker('hint')).toBe(MarkerSeverity.Hint)
+    expect(severityToMarker('bogus')).toBe(MarkerSeverity.Warning)
+  })
+})
+
+describe('diagnosticRange', () => {
+  it('uses an explicit full range as-is', () => {
+    const r = diagnosticRange(model(['hello world']), diag({ line: 1, column: 7, endColumn: 12 }))
+    expect(r).toEqual({ startLineNumber: 1, startColumn: 7, endLineNumber: 1, endColumn: 12 })
+  })
+
+  it('defaults absent end to the end of the word at the start position', () => {
+    const r = diagnosticRange(model(['foo = bar']), diag({ line: 1, column: 1 }))
+    // word "foo" is columns 1..3, endColumn is exclusive (4)
+    expect(r.startColumn).toBe(1)
+    expect(r.endColumn).toBe(4)
+  })
+
+  it('falls back to end of line when there is no word at the position', () => {
+    const r = diagnosticRange(model(['x = 1   ']), diag({ line: 1, column: 6 }))
+    // trailing whitespace -> no word, extend to line end (len 8 + 1)
+    expect(r.endColumn).toBe(9)
+  })
+
+  it('clamps an out-of-range line to the model', () => {
+    const r = diagnosticRange(model(['only one line']), diag({ line: 99, column: 1 }))
+    expect(r.startLineNumber).toBe(1)
+  })
+})
+
+describe('diagnosticToMarker', () => {
+  it('produces a Monaco IMarkerData with mapped severity + span', () => {
+    const marker = diagnosticToMarker(
+      model(['x = 1   ']),
+      diag({ line: 1, column: 6, endColumn: 9, severity: 'warning', message: 'Trailing whitespace' })
+    )
+    expect(marker).toEqual({
+      severity: MarkerSeverity.Warning,
+      message: 'Trailing whitespace',
+      source: 's',
+      startLineNumber: 1,
+      startColumn: 6,
+      endLineNumber: 1,
+      endColumn: 9
+    })
+  })
+})
+
+describe('resolveFixRange', () => {
+  it('uses the diagnostic range when the fix omits its range', () => {
+    const d = diag({ line: 1, column: 6, endColumn: 9 })
+    const r = resolveFixRange(model(['x = 1   ']), d, { title: 'fix', edit: { newText: '' } })
+    expect(r).toEqual({ startLineNumber: 1, startColumn: 6, endLineNumber: 1, endColumn: 9 })
+  })
+
+  it('uses the fix range when fully specified', () => {
+    const d = diag({ line: 1, column: 1 })
+    const r = resolveFixRange(model(['abcdef']), d, {
+      title: 'fix',
+      edit: { newText: '', line: 1, column: 2, endLine: 1, endColumn: 5 }
+    })
+    expect(r).toEqual({ startLineNumber: 1, startColumn: 2, endLineNumber: 1, endColumn: 5 })
+  })
+})


### PR DESCRIPTION
Plugins can now run **reactively** and **decorate the editor** (issue #69) — the engine the real linter (#65) builds on.

- **`@plugin.linter`** SDK hook: `(ctx) -> list[Diagnostic]`, with optional ranged `fixes`. New `lint` RPC + `window.api.plugins.lint(context)`.
- **Reactive:** the editor lints the active file debounced (~400ms) on change + on open — no Run click. No-ops gracefully when Python is absent.
- **Squiggles:** diagnostics → Monaco `setModelMarkers` (severity-coloured, hover messages); cleared when none.
- **Lightbulb:** a guarded Monaco `CodeActionProvider` turns fix-bearing diagnostics into `quickfix` actions; applying edits the buffer (flows through the workspace store + re-lints).
- **Example** `lint_demo` plugin: trailing whitespace (warning + "Remove trailing whitespace" fix) and TODO comments (info). Docs updated.

**Verified:** host `lint` smoke-test returns the diagnostics + fix; 8 new unit tests for diagnostic→marker mapping; lint · typecheck · **51 tests** · build green. (Squiggle/lightbulb pixels are best confirmed live — open a file with trailing whitespace.)

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)