### PR TITLE
Python linter plugin (ruff/pyflakes) + Problems panel — Closes #65

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   quick-fixes** (a Monaco code-action provider applies the plugin's edit). Adds a
   `lint` RPC / `window.api.plugins.lint`, diagnostics with optional ranged
   `fixes`, and an example linter (flags trailing whitespace + TODOs).
+- **Python linter plugin (#65).** A bundled `python_linter` plugin runs **ruff**
+  (with autofix quick-fixes) or falls back to **pyflakes**, linting `.py` files
+  live via the reactive engine. New **Problems** tab in the shell panel (count
+  badge, click-to-jump) backed by a shared diagnostics store, and a persisted
+  **Lint on/off** toggle. Graceful when no linter is installed (`pip install ruff`).
 - **Toolbar file actions:** New File, Open Folder and Save icon buttons (left of
   Run). Save also works via Ctrl/Cmd-S, with a native **Save As** dialog for
   untitled buffers. The opened folder is now the app's shared working directory,

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -1,0 +1,86 @@
+# Python linting (issue #65)
+
+Snakie ships a real Python linter built on the [plugin system](./plugin-system.md)
+and the reactive [linter API](./writing-plugins.md#linters-reactive-analysis--quick-fixes).
+It runs automatically as you edit a `.py` file, paints squiggles in the editor,
+offers quick-fixes via the lightbulb, and lists every finding in the **Problems**
+panel.
+
+## The bundled `python_linter` plugin
+
+[`examples/plugins/python_linter/__init__.py`](../examples/plugins/python_linter/__init__.py)
+registers `@plugin.linter("python")`. It only lints files whose name ends in
+`.py` (everything else returns no diagnostics), and it auto-detects which linter
+tool is installed:
+
+| Tool | How it's run | Fixes? |
+| --- | --- | --- |
+| **ruff** (preferred) | `ruff check --output-format json --stdin-filename <name> -` with the file content on **stdin** | yes — single-edit fixes become lightbulb quick-fixes |
+| **pyflakes** (fallback) | content written to a temp file, linted, temp file removed | no |
+| neither | returns no diagnostics (the editor stays quiet) | — |
+
+Detection prefers a **PATH console script** (`ruff` / `pyflakes`); if that is not
+found it falls back to `python -m <tool>` (so a tool installed only into the
+current interpreter still works). ruff is always tried before pyflakes.
+Choosing the tool explicitly is a deliberate follow-up — for now it is
+auto-detected.
+
+### ruff diagnostics
+
+Each item in ruff's JSON array becomes a diagnostic:
+
+- `message` is `"<code>: <message>"` (e.g. `F401: \`os\` imported but unused`).
+- The range comes from ruff's `location` / `end_location` (1-based row/column).
+- Severity is `error` for codes starting `E9` (syntax) or `F` (pyflakes-class),
+  otherwise `warning`. `source` is `ruff`.
+- If the item carries a `fix` with a single edit, a ranged quick-fix is built
+  from that edit's `content` + `location`/`end_location`; the title comes from
+  the fix message (or the code).
+
+### pyflakes diagnostics
+
+pyflakes writes `path:line:col: message` (or `path:line: message`) per finding.
+The temp path is stripped back out, leaving the human-readable message;
+`severity` is `warning`, `source` is `pyflakes`, no fixes.
+
+The parsing lives in pure, importable functions — `parse_ruff_json(stdout)` and
+`parse_pyflakes_output(stdout, filename)` — unit-tested with canned input in
+[`python/tests/test_python_linter.py`](../python/tests/test_python_linter.py).
+Run them (no tool needed) with:
+
+```sh
+PYTHONPATH=python python3 -m unittest discover -s python/tests
+```
+
+The plugin is robust by design: subprocess calls are timeout-capped, never raise
+out of the linter, and empty/whitespace-only content returns nothing.
+
+## The Problems panel
+
+The bottom **Shell** region has a `Console | Plotter | Problems` toggle. The
+Problems tab shows a count badge (e.g. `Problems (3)`) and lists the active
+file's diagnostics — severity icon, `line:col`, message, and source. Clicking a
+row jumps the editor to that line.
+
+When there are no diagnostics it shows **No problems**; if no linter tool is
+installed it adds a subtle hint to install ruff (`pip install ruff`).
+
+Architecture: the editor publishes the active file's diagnostics into a shared
+store ([`src/renderer/src/store/diagnostics.ts`](../src/renderer/src/store/diagnostics.ts),
+via `<DiagnosticsProvider>` / `useDiagnostics()`) after each lint; the Problems
+panel reads from it. The Monaco markers and lightbulb quick-fixes are unchanged.
+
+## Turning linting on/off
+
+A checkbox in the Problems panel header toggles linting. The state is persisted
+in `localStorage` under `snakie.lintingEnabled` (default **on**). When off, the
+editor's lint effect no-ops and clears any existing markers and Problems rows.
+
+## Installing ruff
+
+```sh
+pip install ruff
+```
+
+Restart Snakie (or reload plugins from the Plugins view) if you install a tool
+while it is running.

--- a/docs/writing-plugins.md
+++ b/docs/writing-plugins.md
@@ -133,6 +133,9 @@ one linter are isolated (logged to stderr) and never abort the others.
 - If Python isn't found (or the plugin bridge is unavailable) linting is a
   silent no-op — the editor simply shows no plugin squiggles.
 
+Snakie ships a real Python linter built on this API (ruff / pyflakes) plus a
+**Problems** panel — see [`docs/linting.md`](./linting.md).
+
 ## Run a command
 
 1. Open the **Plugins** view from the activity bar (the puzzle-piece icon).

--- a/examples/plugins/python_linter/__init__.py
+++ b/examples/plugins/python_linter/__init__.py
@@ -1,0 +1,339 @@
+"""Bundled Snakie linter: real Python linting via ruff (or pyflakes).
+
+Registered with ``@plugin.linter("python")``, this runs reactively as you edit a
+``.py`` file and surfaces real diagnostics — squiggles in the editor and rows in
+the Problems panel — using whichever linter tool is installed:
+
+* **ruff** (preferred) — fast, rich rule set, and *quick-fixes*. Run as
+  ``ruff check --output-format json --stdin-filename <name> -`` with the file
+  content on stdin. Each JSON item becomes a :func:`~snakie.diagnostic`; an item
+  carrying a single-edit ``fix`` becomes a ranged quick-fix (editor lightbulb).
+* **pyflakes** (fallback) — found if ruff is not. No fixes; flags unused
+  imports, undefined names, etc. The content is written to a temp file, linted,
+  then the temp file is removed.
+* **neither** — the linter returns ``[]`` (no squiggles). The ``python_linter.status``
+  command reports which tool (if any) was found so the UI can hint
+  "install ruff".
+
+The tool is auto-detected (PATH console script first, else ``python -m <tool>``).
+Choosing ruff-vs-pyflakes explicitly is a follow-up.
+
+Parsing lives in pure, importable functions — :func:`parse_ruff_json` and
+:func:`parse_pyflakes_output` — so they unit-test with canned input and no tool
+installed (see ``python/tests/test_python_linter.py``).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Any, Dict, List, Optional, Tuple
+
+from snakie import Context, diagnostic, fix, plugin
+
+# How long (seconds) to wait for a linter subprocess before giving up. Linting
+# must never hang the editor, so we cap it and treat a timeout as "no results".
+_TIMEOUT_S = 10
+
+
+# ---------------------------------------------------------------------------
+# Pure parsers (unit-tested with canned input — no tool needed)
+# ---------------------------------------------------------------------------
+
+
+def _severity_for_ruff_code(code: str) -> str:
+    """Map a ruff rule code to a diagnostic severity.
+
+    Kept deliberately simple: syntax errors (``E9*``) and pyflakes-class errors
+    (``F*``) are surfaced as ``error``; everything else is a ``warning``.
+    """
+    if not code:
+        return "warning"
+    if code.startswith("E9") or code.startswith("F"):
+        return "error"
+    return "warning"
+
+
+def _ruff_fix_from(item: Dict[str, Any], code: str) -> Optional[Dict[str, Any]]:
+    """Build a quick-fix from a ruff item's ``fix`` (common single-edit case).
+
+    ruff's ``fix`` is ``{message, edits: [{content, location, end_location}]}``
+    where each location is ``{row, column}`` (1-based row, 1-based column). We
+    support the common single-edit fix; multi-edit fixes are skipped (the host
+    only needs a ranged replacement and ruff overwhelmingly emits one edit).
+    """
+    fx = item.get("fix")
+    if not isinstance(fx, dict):
+        return None
+    edits = fx.get("edits")
+    if not isinstance(edits, list) or len(edits) != 1:
+        return None
+    edit = edits[0]
+    if not isinstance(edit, dict):
+        return None
+    loc = edit.get("location") or {}
+    end = edit.get("end_location") or {}
+    title = str(fx.get("message") or f"Fix {code}".strip() or "Fix")
+    return fix(
+        title,
+        str(edit.get("content", "")),
+        line=_int_or_none(loc.get("row")),
+        column=_int_or_none(loc.get("column")),
+        end_line=_int_or_none(end.get("row")),
+        end_column=_int_or_none(end.get("column")),
+    )
+
+
+def _int_or_none(value: Any) -> Optional[int]:
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def parse_ruff_json(stdout: str) -> List[Dict[str, Any]]:
+    """Parse ``ruff check --output-format json`` output into diagnostic dicts.
+
+    ``stdout`` is a JSON array of items, each like::
+
+        {
+          "code": "F401",
+          "message": "`os` imported but unused",
+          "location": {"row": 1, "column": 8},
+          "end_location": {"row": 1, "column": 10},
+          "fix": {"message": "Remove unused import: `os`",
+                  "edits": [{"content": "", "location": {...}, "end_location": {...}}]}
+        }
+
+    Returns a list of bare Diagnostic dicts (the host normalises the
+    :func:`~snakie.diagnostic` action form too). Robust to an empty/blank body
+    (ruff prints ``[]`` when clean) and to items missing optional fields.
+    """
+    text = stdout.strip()
+    if not text:
+        return []
+    try:
+        items = json.loads(text)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(items, list):
+        return []
+
+    diagnostics: List[Dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        loc = item.get("location") or {}
+        row = _int_or_none(loc.get("row"))
+        if row is None:
+            continue
+        col = _int_or_none(loc.get("column"))
+        end = item.get("end_location") or {}
+        end_row = _int_or_none(end.get("row"))
+        end_col = _int_or_none(end.get("column"))
+        code = str(item.get("code") or "").strip()
+        raw_message = str(item.get("message") or "")
+        message = f"{code}: {raw_message}" if code else raw_message
+        fixes = None
+        built = _ruff_fix_from(item, code)
+        if built is not None:
+            fixes = [built]
+        diagnostics.append(
+            diagnostic(
+                row,
+                message,
+                severity=_severity_for_ruff_code(code),
+                column=col,
+                end_line=end_row,
+                end_column=end_col,
+                source="ruff",
+                fixes=fixes,
+            )
+        )
+    return diagnostics
+
+
+def parse_pyflakes_output(stdout: str, filename: str) -> List[Dict[str, Any]]:
+    """Parse pyflakes' ``path:line:col: message`` text into diagnostic dicts.
+
+    pyflakes writes one finding per line as ``path:line:col: message`` (the
+    column is optional on some versions: ``path:line: message``). ``filename`` is
+    the temp path we linted; it is stripped from the message so the user sees
+    only the human-readable text. Lines that do not match the pattern (banners,
+    blank lines) are ignored. No quick-fixes (pyflakes does not provide edits).
+    """
+    diagnostics: List[Dict[str, Any]] = []
+    for raw in stdout.splitlines():
+        line = raw.rstrip()
+        if not line:
+            continue
+        parsed = _parse_pyflakes_line(line, filename)
+        if parsed is None:
+            continue
+        row, col, message = parsed
+        diagnostics.append(
+            diagnostic(
+                row,
+                message,
+                severity="warning",
+                column=col,
+                source="pyflakes",
+            )
+        )
+    return diagnostics
+
+
+def _parse_pyflakes_line(
+    line: str, filename: str
+) -> Optional[Tuple[int, Optional[int], str]]:
+    """Parse one pyflakes report line -> ``(row, column?, message)`` or None.
+
+    Handles both ``<path>:<row>:<col>: <message>`` and the older
+    ``<path>:<row>: <message>``. The leading path must match the temp filename we
+    linted (so stray colons in a message body are not mistaken for fields).
+    """
+    prefix = filename + ":"
+    if not line.startswith(prefix):
+        return None
+    rest = line[len(prefix):]
+    # rest is "<row>:<col>: <message>" or "<row>: <message>"
+    head, sep, message = rest.partition(": ")
+    if not sep:
+        return None
+    parts = head.split(":")
+    row = _int_or_none(parts[0])
+    if row is None:
+        return None
+    col = _int_or_none(parts[1]) if len(parts) > 1 else None
+    return row, col, message
+
+
+# ---------------------------------------------------------------------------
+# Tool detection + invocation
+# ---------------------------------------------------------------------------
+
+
+def _console_script(name: str) -> Optional[List[str]]:
+    """Return the argv prefix for a tool on PATH, or None."""
+    path = shutil.which(name)
+    return [path] if path else None
+
+
+def _module_runnable(name: str) -> Optional[List[str]]:
+    """Return ``[python, -m, name]`` if ``python -m name`` imports, else None."""
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", f"import {name}"],
+            capture_output=True,
+            timeout=_TIMEOUT_S,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode == 0:
+        return [sys.executable, "-m", name]
+    return None
+
+
+def detect_tool() -> Optional[Tuple[str, List[str]]]:
+    """Detect an available linter, preferring ruff.
+
+    Returns ``(tool_name, argv_prefix)`` or ``None``. ruff is tried first as a
+    PATH console script, then ``python -m ruff``; then pyflakes the same way.
+    """
+    for name in ("ruff", "pyflakes"):
+        argv = _console_script(name) or _module_runnable(name)
+        if argv is not None:
+            return name, argv
+    return None
+
+
+def _run(argv: List[str], stdin_text: str) -> Optional[subprocess.CompletedProcess]:
+    """Run ``argv`` feeding ``stdin_text``; None on failure/timeout."""
+    try:
+        return subprocess.run(
+            argv,
+            input=stdin_text,
+            capture_output=True,
+            text=True,
+            timeout=_TIMEOUT_S,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def _lint_with_ruff(argv: List[str], filename: str, content: str) -> List[Dict[str, Any]]:
+    proc = _run(
+        [*argv, "check", "--output-format", "json", "--stdin-filename", filename, "-"],
+        content,
+    )
+    if proc is None:
+        return []
+    return parse_ruff_json(proc.stdout)
+
+
+def _lint_with_pyflakes(argv: List[str], content: str) -> List[Dict[str, Any]]:
+    # pyflakes has no stdin mode that reports a stable filename, so write a temp
+    # file, lint it, and clean up. Findings are keyed on the temp path, which we
+    # strip back out in the parser.
+    fd, tmp_path = tempfile.mkstemp(suffix=".py", prefix="snakie_lint_")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+        proc = _run([*argv, tmp_path], "")
+        if proc is None:
+            return []
+        # pyflakes prints findings to stdout; syntax errors go to stderr.
+        combined = (proc.stdout or "") + (proc.stderr or "")
+        return parse_pyflakes_output(combined, tmp_path)
+    finally:
+        try:
+            os.remove(tmp_path)
+        except OSError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# The linter + status command
+# ---------------------------------------------------------------------------
+
+
+def _is_python(ctx: Context) -> bool:
+    name = (ctx.file.name or "").lower()
+    return name.endswith(".py")
+
+
+@plugin.linter("python")
+def lint(ctx: Context) -> List[Dict[str, Any]]:
+    """Lint the active ``.py`` file with ruff (or pyflakes); ``[]`` otherwise."""
+    if not _is_python(ctx):
+        return []
+    content = ctx.file.content
+    if not content.strip():
+        return []
+    detected = detect_tool()
+    if detected is None:
+        return []  # no tool: stay quiet rather than spam the editor
+    tool, argv = detected
+    filename = ctx.file.name or "untitled.py"
+    if tool == "ruff":
+        return _lint_with_ruff(argv, filename, content)
+    return _lint_with_pyflakes(argv, content)
+
+
+@plugin.command("python_linter.status", "Python Linter: status")
+def status(ctx: Context):
+    """Report which linter tool was detected, for the Problems-panel hint.
+
+    Returns an ``info`` message *action* whose text is the tool name (``ruff`` /
+    ``pyflakes``) or ``none``. The renderer reads ``action.text`` to decide
+    whether to show the "Install ruff" hint.
+    """
+    detected = detect_tool()
+    tool = detected[0] if detected else "none"
+    from snakie import message
+
+    return message("info", tool)

--- a/python/tests/test_python_linter.py
+++ b/python/tests/test_python_linter.py
@@ -1,0 +1,155 @@
+"""Unit tests for the bundled ``python_linter`` plugin's pure parsers.
+
+These exercise :func:`parse_ruff_json` and :func:`parse_pyflakes_output` with
+canned input — no ruff/pyflakes installation is required. Run from the repo
+root::
+
+    PYTHONPATH=python python3 -m unittest discover -s python/tests
+
+(or ``python3 -m unittest python.tests.test_python_linter`` with ``python`` on
+the path). The plugin module is loaded from ``examples/plugins/python_linter``
+by file path so the test does not depend on that dir being importable.
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# The SDK package lives in python/; make `import snakie` work.
+sys.path.insert(0, os.path.join(_REPO_ROOT, "python"))
+
+_PLUGIN_PATH = os.path.join(
+    _REPO_ROOT, "examples", "plugins", "python_linter", "__init__.py"
+)
+_spec = importlib.util.spec_from_file_location("snakie_python_linter_under_test", _PLUGIN_PATH)
+assert _spec and _spec.loader
+pl = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(pl)
+
+
+def _item(diag):
+    """Unwrap the ``snakie.diagnostic`` action form into its bare item dict."""
+    return diag["item"] if diag.get("type") == "diagnostic" else diag
+
+
+class RuffJsonParsing(unittest.TestCase):
+    SAMPLE = """[
+      {
+        "code": "F401",
+        "message": "`os` imported but unused",
+        "location": {"row": 1, "column": 8},
+        "end_location": {"row": 1, "column": 10},
+        "fix": {
+          "message": "Remove unused import: `os`",
+          "edits": [
+            {"content": "", "location": {"row": 1, "column": 1},
+             "end_location": {"row": 2, "column": 1}}
+          ]
+        }
+      },
+      {
+        "code": "W291",
+        "message": "Trailing whitespace",
+        "location": {"row": 3, "column": 10},
+        "end_location": {"row": 3, "column": 13},
+        "fix": null
+      },
+      {
+        "code": "E999",
+        "message": "SyntaxError: unexpected EOF",
+        "location": {"row": 5, "column": 1},
+        "end_location": {"row": 5, "column": 2},
+        "fix": null
+      }
+    ]"""
+
+    def test_maps_items_to_diagnostics(self):
+        diags = [_item(d) for d in pl.parse_ruff_json(self.SAMPLE)]
+        self.assertEqual(len(diags), 3)
+
+        f401 = diags[0]
+        self.assertEqual(f401["line"], 1)
+        self.assertEqual(f401["column"], 8)
+        self.assertEqual(f401["endLine"], 1)
+        self.assertEqual(f401["endColumn"], 10)
+        self.assertEqual(f401["message"], "F401: `os` imported but unused")
+        self.assertEqual(f401["source"], "ruff")
+        # F-codes are surfaced as errors.
+        self.assertEqual(f401["severity"], "error")
+
+    def test_builds_quick_fix_from_single_edit(self):
+        f401 = _item(pl.parse_ruff_json(self.SAMPLE)[0])
+        self.assertIn("fixes", f401)
+        self.assertEqual(len(f401["fixes"]), 1)
+        fix = f401["fixes"][0]
+        self.assertEqual(fix["title"], "Remove unused import: `os`")
+        self.assertEqual(fix["edit"]["newText"], "")
+        self.assertEqual(fix["edit"]["line"], 1)
+        self.assertEqual(fix["edit"]["column"], 1)
+        self.assertEqual(fix["edit"]["endLine"], 2)
+        self.assertEqual(fix["edit"]["endColumn"], 1)
+
+    def test_no_fix_when_absent(self):
+        w291 = _item(pl.parse_ruff_json(self.SAMPLE)[1])
+        self.assertNotIn("fixes", w291)
+        self.assertEqual(w291["severity"], "warning")
+
+    def test_syntax_error_severity(self):
+        e999 = _item(pl.parse_ruff_json(self.SAMPLE)[2])
+        self.assertEqual(e999["severity"], "error")
+
+    def test_empty_and_blank_input(self):
+        self.assertEqual(pl.parse_ruff_json(""), [])
+        self.assertEqual(pl.parse_ruff_json("   \n"), [])
+        self.assertEqual(pl.parse_ruff_json("[]"), [])
+
+    def test_invalid_json_is_safe(self):
+        self.assertEqual(pl.parse_ruff_json("not json"), [])
+        self.assertEqual(pl.parse_ruff_json('{"not": "a list"}'), [])
+
+
+class PyflakesParsing(unittest.TestCase):
+    FILE = "/tmp/snakie_lint_abc.py"
+
+    def test_parses_path_line_col_message(self):
+        text = (
+            f"{self.FILE}:1:8: 'os' imported but unused\n"
+            f"{self.FILE}:3:1: undefined name 'foo'\n"
+        )
+        diags = [_item(d) for d in pl.parse_pyflakes_output(text, self.FILE)]
+        self.assertEqual(len(diags), 2)
+        self.assertEqual(diags[0]["line"], 1)
+        self.assertEqual(diags[0]["column"], 8)
+        self.assertEqual(diags[0]["message"], "'os' imported but unused")
+        self.assertEqual(diags[0]["severity"], "warning")
+        self.assertEqual(diags[0]["source"], "pyflakes")
+        self.assertNotIn("fixes", diags[0])
+        self.assertEqual(diags[1]["line"], 3)
+        self.assertEqual(diags[1]["column"], 1)
+
+    def test_parses_line_only_form(self):
+        text = f"{self.FILE}:5: invalid syntax\n"
+        diags = [_item(d) for d in pl.parse_pyflakes_output(text, self.FILE)]
+        self.assertEqual(len(diags), 1)
+        self.assertEqual(diags[0]["line"], 5)
+        self.assertNotIn("column", diags[0])
+        self.assertEqual(diags[0]["message"], "invalid syntax")
+
+    def test_ignores_unrelated_and_blank_lines(self):
+        text = (
+            "\n"
+            "some banner without the path prefix\n"
+            f"{self.FILE}:2:1: actually a finding\n"
+        )
+        diags = [_item(d) for d in pl.parse_pyflakes_output(text, self.FILE)]
+        self.assertEqual(len(diags), 1)
+        self.assertEqual(diags[0]["line"], 2)
+
+    def test_empty_input(self):
+        self.assertEqual(pl.parse_pyflakes_output("", self.FILE), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -2,13 +2,16 @@ import { AppShell } from './components/AppShell'
 import { PromptProvider } from './components/PromptModal'
 import { UpdateNotifier } from './components/UpdateNotifier'
 import { WorkspaceProvider } from './store/workspace'
+import { DiagnosticsProvider } from './store/diagnostics'
 
 function App(): JSX.Element {
   return (
     <PromptProvider>
       <WorkspaceProvider>
-        <AppShell />
-        <UpdateNotifier />
+        <DiagnosticsProvider>
+          <AppShell />
+          <UpdateNotifier />
+        </DiagnosticsProvider>
       </WorkspaceProvider>
     </PromptProvider>
   )

--- a/src/renderer/src/components/MonacoEditor.tsx
+++ b/src/renderer/src/components/MonacoEditor.tsx
@@ -8,6 +8,8 @@ import 'monaco-editor/esm/vs/basic-languages/python/python.contribution'
 import 'monaco-editor/esm/vs/basic-languages/markdown/markdown.contribution'
 import './monaco-setup'
 import { useWorkspace } from '../store/workspace'
+import { useDiagnostics } from '../store/diagnostics'
+import { useLocalStorage } from '../hooks/useLocalStorage'
 import type { Diagnostic, PluginContext } from '../../../preload/index.d'
 import { diagnosticToMarker } from './plugin-diagnostics'
 import {
@@ -93,6 +95,10 @@ function monacoTheme(theme: 'light' | 'dark'): string {
  */
 export function MonacoEditor(): JSX.Element {
   const { openFiles, activeId, revealRequest, updateContent, saveFile } = useWorkspace()
+  const { setDiagnostics, setLinterTool, clear: clearDiagnostics } = useDiagnostics()
+  // Linting on/off (issue #65), persisted. When off the lint effect no-ops and
+  // clears markers + the shared diagnostics store.
+  const [lintingEnabled] = useLocalStorage<boolean>('snakie.lintingEnabled', true)
 
   const containerRef = useRef<HTMLDivElement>(null)
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null)
@@ -103,9 +109,13 @@ export function MonacoEditor(): JSX.Element {
   const updateContentRef = useRef(updateContent)
   const saveFileRef = useRef(saveFile)
   const activeIdRef = useRef(activeId)
+  const setDiagnosticsRef = useRef(setDiagnostics)
+  const setLinterToolRef = useRef(setLinterTool)
   updateContentRef.current = updateContent
   saveFileRef.current = saveFile
   activeIdRef.current = activeId
+  setDiagnosticsRef.current = setDiagnostics
+  setLinterToolRef.current = setLinterTool
 
   // Create the editor once.
   useEffect(() => {
@@ -207,11 +217,19 @@ export function MonacoEditor(): JSX.Element {
     const editor = editorRef.current
     if (!editor || !activeFile) return undefined
 
-    const plugins = window.api?.plugins
-    if (!plugins?.lint) return undefined
-
     const model = models.current.get(activeFile.id)
     if (!model || model.isDisposed()) return undefined
+
+    // Linting turned off: clear any existing markers + shared diagnostics and
+    // skip the host round-trip entirely.
+    if (!lintingEnabled) {
+      applyDiagnostics(model, [])
+      clearDiagnostics()
+      return undefined
+    }
+
+    const plugins = window.api?.plugins
+    if (!plugins?.lint) return undefined
 
     let cancelled = false
     const file = activeFile
@@ -234,6 +252,21 @@ export function MonacoEditor(): JSX.Element {
           const m = models.current.get(file.id)
           if (!m || m.isDisposed()) return
           applyDiagnostics(m, diagnostics)
+          // Publish to the shared store so the Problems panel mirrors the
+          // squiggles painted above.
+          setDiagnosticsRef.current(diagnostics)
+          // Probe which linter tool the host found (drives the "install ruff"
+          // hint). Only meaningful for Python files; ignore failures.
+          if (/\.py$/i.test(file.name)) {
+            try {
+              const { actions } = await plugins.runCommand('python_linter.status', context)
+              if (cancelled) return
+              const msg = actions.find((a) => a.type === 'message')
+              if (msg && 'text' in msg) setLinterToolRef.current(msg.text)
+            } catch {
+              // Status is best-effort; leave the previous value.
+            }
+          }
         } catch {
           // Linting must never disrupt typing; swallow + leave prior markers.
         }
@@ -244,7 +277,13 @@ export function MonacoEditor(): JSX.Element {
       cancelled = true
       clearTimeout(timer)
     }
-  }, [activeFile, activeFile?.id, activeFile?.content])
+  }, [activeFile, activeFile?.id, activeFile?.content, lintingEnabled, clearDiagnostics])
+
+  // With no active file open there is nothing to lint, so the Problems panel
+  // should be empty (e.g. after closing the last tab).
+  useEffect(() => {
+    if (!activeFile) clearDiagnostics()
+  }, [activeFile, clearDiagnostics])
 
   // Reveal/scroll to a line on request (e.g. clicking an Outline symbol).
   // Keyed on `seq` so repeated clicks on the same symbol re-reveal it.

--- a/src/renderer/src/components/Problems.tsx
+++ b/src/renderer/src/components/Problems.tsx
@@ -1,0 +1,73 @@
+import { useDiagnostics } from '../store/diagnostics'
+import { useWorkspace } from '../store/workspace'
+import type { Diagnostic } from '../../../preload/index.d'
+
+/**
+ * Problems panel (issue #65) — lists the active file's diagnostics produced by
+ * the reactive linter, mirroring the editor squiggles. Reads the shared
+ * {@link useDiagnostics} store the editor publishes to; clicking a row jumps the
+ * editor to that line via {@link useWorkspace}.revealLine.
+ *
+ * Rendered as one of the Shell region's tabs (Console | Plotter | Problems).
+ * The linting on/off toggle lives in the header (see {@link ProblemsHeader}).
+ */
+
+/** A small severity glyph + class for a diagnostic row. */
+function severityGlyph(severity: string): { glyph: string; cls: string } {
+  switch (severity) {
+    case 'error':
+      return { glyph: '✕', cls: 'problems__sev--error' }
+    case 'info':
+      return { glyph: 'ℹ', cls: 'problems__sev--info' }
+    case 'hint':
+      return { glyph: '✦', cls: 'problems__sev--hint' }
+    case 'warning':
+    default:
+      return { glyph: '⚠', cls: 'problems__sev--warning' }
+  }
+}
+
+export function Problems(): JSX.Element {
+  const { diagnostics, linterTool } = useDiagnostics()
+  const { revealLine } = useWorkspace()
+
+  if (diagnostics.length === 0) {
+    return (
+      <div className="problems problems--empty">
+        <p className="problems__empty-text">No problems</p>
+        {linterTool === 'none' && (
+          <p className="problems__hint">
+            Install <code>ruff</code> (<code>pip install ruff</code>) for Python linting.
+          </p>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <ul className="problems" aria-label="Problems">
+      {diagnostics.map((d: Diagnostic, i: number) => {
+        const sev = severityGlyph(d.severity)
+        return (
+          <li key={`${d.line}:${d.column ?? 0}:${i}`} className="problems__item">
+            <button
+              type="button"
+              className="problems__row"
+              onClick={() => revealLine(d.line)}
+              title={`Go to line ${d.line}`}
+            >
+              <span className={`problems__sev ${sev.cls}`} aria-hidden="true">
+                {sev.glyph}
+              </span>
+              <span className="problems__loc">
+                {d.line}:{d.column ?? 1}
+              </span>
+              <span className="problems__msg">{d.message}</span>
+              <span className="problems__source">{d.source}</span>
+            </button>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/src/renderer/src/components/ShellPanel.css
+++ b/src/renderer/src/components/ShellPanel.css
@@ -50,3 +50,125 @@
 .shell-view--hidden {
   display: none;
 }
+
+/* Problems view scrolls independently of the terminal/plotter. */
+.shell-view--problems {
+  overflow: auto;
+}
+
+/* Linting on/off toggle in the Shell header (shown on the Problems tab). */
+.shell-lint-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  user-select: none;
+}
+
+.shell-lint-toggle input {
+  cursor: pointer;
+}
+
+/* --- Problems panel ----------------------------------------------------- */
+
+.problems {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.problems--empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 1rem;
+  color: var(--text-muted);
+}
+
+.problems__empty-text {
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.problems__hint {
+  margin: 0;
+  font-size: 0.78rem;
+  opacity: 0.8;
+}
+
+.problems__hint code {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 0.74rem;
+}
+
+.problems__item {
+  margin: 0;
+}
+
+.problems__row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  width: 100%;
+  text-align: left;
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  padding: 0.2rem 0.6rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.problems__row:hover {
+  background: var(--bg-sunken);
+}
+
+.problems__sev {
+  flex: 0 0 auto;
+  width: 1em;
+  text-align: center;
+}
+
+.problems__sev--error {
+  color: var(--danger, #e06c75);
+}
+
+.problems__sev--warning {
+  color: var(--warning, #e5c07b);
+}
+
+.problems__sev--info {
+  color: var(--accent, #61afef);
+}
+
+.problems__sev--hint {
+  color: var(--text-muted);
+}
+
+.problems__loc {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+}
+
+.problems__msg {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.problems__source {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  opacity: 0.7;
+  font-size: 0.72rem;
+}

--- a/src/renderer/src/components/ShellPanel.tsx
+++ b/src/renderer/src/components/ShellPanel.tsx
@@ -2,12 +2,15 @@ import { useCallback, useRef, useState } from 'react'
 import { PanelHeader } from './PanelHeader'
 import { Terminal, type TerminalHandle } from './Terminal'
 import { Plotter } from './Plotter'
+import { Problems } from './Problems'
 import { ConnectionControl } from './ConnectionControl'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
+import { useDiagnostics } from '../store/diagnostics'
+import { useLocalStorage } from '../hooks/useLocalStorage'
 import './RunControls.css'
 import './ShellPanel.css'
 
-type ShellView = 'console' | 'plotter'
+type ShellView = 'console' | 'plotter' | 'problems'
 
 /**
  * BOTTOM — shell / console (REPL) region.
@@ -27,10 +30,17 @@ export function ShellPanel(): JSX.Element {
   const status = useDeviceStatus()
   const terminalRef = useRef<TerminalHandle>(null)
   const [view, setView] = useState<ShellView>('console')
+  const { diagnostics } = useDiagnostics()
+  const [lintingEnabled, setLintingEnabled] = useLocalStorage<boolean>(
+    'snakie.lintingEnabled',
+    true
+  )
 
   const handleClear = useCallback(() => {
     terminalRef.current?.clear()
   }, [])
+
+  const problemsLabel = diagnostics.length > 0 ? `Problems (${diagnostics.length})` : 'Problems'
 
   return (
     <section className="region region--shell" aria-label="Shell">
@@ -57,7 +67,26 @@ export function ShellPanel(): JSX.Element {
               >
                 Plotter
               </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={view === 'problems'}
+                className={`shell-toggle__btn${view === 'problems' ? ' shell-toggle__btn--active' : ''}`}
+                onClick={() => setView('problems')}
+              >
+                {problemsLabel}
+              </button>
             </div>
+            {view === 'problems' && (
+              <label className="shell-lint-toggle" title="Toggle Python linting">
+                <input
+                  type="checkbox"
+                  checked={lintingEnabled}
+                  onChange={(e) => setLintingEnabled(e.target.checked)}
+                />
+                <span>Lint</span>
+              </label>
+            )}
             {view === 'console' && (
               <button
                 type="button"
@@ -88,6 +117,12 @@ export function ShellPanel(): JSX.Element {
           role="tabpanel"
         >
           <Plotter />
+        </div>
+        <div
+          className={`shell-view shell-view--problems${view === 'problems' ? '' : ' shell-view--hidden'}`}
+          role="tabpanel"
+        >
+          <Problems />
         </div>
       </div>
     </section>

--- a/src/renderer/src/store/diagnostics.ts
+++ b/src/renderer/src/store/diagnostics.ts
@@ -1,0 +1,84 @@
+/**
+ * Diagnostics store — the shared seam between the editor (which produces
+ * diagnostics by linting the active file) and the Problems panel (which lists
+ * them) for issue #65.
+ *
+ * The editor used to hold the active file's diagnostics internally. Lifting
+ * them here lets the Problems panel render the same data the squiggles are drawn
+ * from, without either component referencing the other.
+ *
+ * SHAPE (consumers depend on this):
+ *
+ *   interface DiagnosticsStore {
+ *     diagnostics: Diagnostic[]          // active file's latest diagnostics
+ *     linterTool: string | null         // 'ruff' | 'pyflakes' | 'none' | null(unknown)
+ *     setDiagnostics(diagnostics): void  // editor publishes after each lint
+ *     setLinterTool(tool): void          // editor publishes detected tool
+ *     clear(): void                      // wipe (e.g. linting turned off)
+ *   }
+ *
+ * Implemented as a React context + state (no external dep). Consume via
+ * `useDiagnostics()`; wrap the app in <DiagnosticsProvider> (alongside the
+ * workspace provider). It is intentionally "single active file" — the editor
+ * shows one file at a time, and the panel mirrors that.
+ */
+import {
+  createContext,
+  createElement,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode
+} from 'react'
+import type { Diagnostic } from '../../../preload/index.d'
+
+export interface DiagnosticsStore {
+  /** The active file's latest diagnostics (empty when clean or not linted). */
+  diagnostics: Diagnostic[]
+  /**
+   * The linter tool the host detected: `'ruff'`, `'pyflakes'`, `'none'`, or
+   * `null` when not yet probed. `'none'` drives the "install ruff" hint.
+   */
+  linterTool: string | null
+  /** Replace the published diagnostics (editor calls this after each lint). */
+  setDiagnostics: (diagnostics: Diagnostic[]) => void
+  /** Record which linter tool was detected. */
+  setLinterTool: (tool: string | null) => void
+  /** Clear diagnostics (e.g. when linting is turned off or no file is open). */
+  clear: () => void
+}
+
+const DiagnosticsContext = createContext<DiagnosticsStore | null>(null)
+
+/** Provides the diagnostics store. Wrap the app once near the root. */
+export function DiagnosticsProvider({ children }: { children: ReactNode }): JSX.Element {
+  const [diagnostics, setDiagnosticsState] = useState<Diagnostic[]>([])
+  const [linterTool, setLinterToolState] = useState<string | null>(null)
+
+  const setDiagnostics = useCallback((next: Diagnostic[]): void => {
+    setDiagnosticsState(next)
+  }, [])
+
+  const setLinterTool = useCallback((tool: string | null): void => {
+    setLinterToolState(tool)
+  }, [])
+
+  const clear = useCallback((): void => {
+    setDiagnosticsState([])
+  }, [])
+
+  const store = useMemo<DiagnosticsStore>(
+    () => ({ diagnostics, linterTool, setDiagnostics, setLinterTool, clear }),
+    [diagnostics, linterTool, setDiagnostics, setLinterTool, clear]
+  )
+
+  return createElement(DiagnosticsContext.Provider, { value: store }, children)
+}
+
+/** Access the diagnostics store. Must be used within <DiagnosticsProvider>. */
+export function useDiagnostics(): DiagnosticsStore {
+  const ctx = useContext(DiagnosticsContext)
+  if (!ctx) throw new Error('useDiagnostics must be used within a DiagnosticsProvider')
+  return ctx
+}


### PR DESCRIPTION
A real Python **linter built on the plugin system** (#65), using the reactive engine from #69.

- **`python_linter`** bundled plugin: prefers **ruff** (`--output-format json`, surfaces ruff autofixes as lightbulb quick-fixes), falls back to **pyflakes**; `.py`-only, subprocess-timeout-guarded, never throws. Pure parsers (`parse_ruff_json`, `parse_pyflakes_output`) are unit-tested (10 Python tests).
- **Problems** tab in the shell panel (`Console | Plotter | Problems (n)`): severity glyph, `line:col`, message, source; click → jump to the line. Backed by a shared `DiagnosticsProvider` store the editor publishes to.
- **Lint on/off** toggle (persisted `snakie.lintingEnabled`); off clears markers + store.
- Graceful no-tool state ("install ruff"); `docs/linting.md` added.

**Verified:** real-ruff host smoke-test (F401 unused-import → squiggle + "Remove unused import" fix) and pyflakes fallback; launched the app — python_linter loads, Problems tab shows a count, editor renders. lint · typecheck · **51** vitest · **10** Python tests · build green.

Auto-detect for now (explicit ruff-vs-pyflakes choice deferred). Closes #65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)