### PR TITLE
Add a status bar — Closes #71

### DIFF
--- a/examples/plugins/hello/__init__.py
+++ b/examples/plugins/hello/__init__.py
@@ -4,13 +4,14 @@ A minimal, dependency-free plugin demonstrating the two core action kinds:
 
 * ``hello`` returns a *message* describing the active file.
 * ``hello.upper`` returns an *edit* that uppercases the whole file.
+* ``hello.status`` posts a clickable *status*-bar message.
 
 Snakie ships this so the Plugins view works out of the box. Copy it into
 ``~/.snakie/plugins/`` to use it as a scaffold for your own plugin — see
 ``docs/writing-plugins.md``.
 """
 
-from snakie import Context, edit, message, plugin
+from snakie import Context, edit, message, plugin, status
 
 
 @plugin.command("hello", "Hello")
@@ -25,3 +26,15 @@ def hello(ctx: Context):
 def uppercase(ctx: Context):
     """Replace the active file's contents with an uppercased version."""
     return edit(ctx.file.content.upper())
+
+
+@plugin.command("hello.status", "Show status link")
+def show_status(ctx: Context):
+    """Post a clickable message to the status bar linking to the docs."""
+    lines = ctx.file.content.count("\n") + 1 if ctx.file.content else 0
+    return status(
+        f"Hello: {lines} line(s)",
+        tooltip="Open the Snakie plugin docs",
+        href="https://github.com/kevinmcaleer/Snakie",
+        priority=1,
+    )

--- a/python/snakie/__init__.py
+++ b/python/snakie/__init__.py
@@ -19,7 +19,8 @@ registers commands against the shared :data:`plugin` registry::
 
 Command handlers receive a :class:`Context` describing the active editor file
 and (optionally) the current selection, and return one of the *action* helpers
-below (or a list of them): :func:`message`, :func:`edit`, :func:`diagnostic`.
+below (or a list of them): :func:`message`, :func:`edit`, :func:`diagnostic`,
+:func:`status`.
 The Snakie host serialises those actions back to the Electron app over
 JSON-RPC; the app shows messages, applies edits and renders diagnostics.
 """
@@ -40,6 +41,7 @@ __all__ = [
     "message",
     "edit",
     "diagnostic",
+    "status",
     "fix",
 ]
 
@@ -128,6 +130,34 @@ def message(level: str, text: str) -> Action:
 def edit(new_content: str) -> Action:
     """Replace the active file's full contents with ``new_content``."""
     return {"type": "edit", "content": new_content}
+
+
+def status(
+    text: str,
+    *,
+    tooltip: Optional[str] = None,
+    href: Optional[str] = None,
+    priority: int = 0,
+) -> Action:
+    """Show a message in Snakie's **status bar** (the thin bar at the bottom).
+
+    Unlike :func:`message` (which posts to the Plugins panel), a status message
+    lives persistently in the status bar's left group. When several plugins post
+    a status the one with the highest ``priority`` wins.
+
+    ``tooltip`` sets the hover title. When ``href`` is given the message becomes
+    a clickable link that opens externally in the user's browser.
+
+    Returned as an *action* (``{"type": "status", ...}``) so it can be returned
+    from a regular ``@plugin.command`` (or a linter — the host accepts it there
+    too).
+    """
+    action: Action = {"type": "status", "text": str(text), "priority": int(priority)}
+    if tooltip is not None:
+        action["tooltip"] = str(tooltip)
+    if href is not None:
+        action["href"] = str(href)
+    return action
 
 
 def fix(

--- a/python/snakie/host.py
+++ b/python/snakie/host.py
@@ -259,6 +259,7 @@ def _run_lint(params: Dict[str, Any]) -> Dict[str, Any]:
     """
     ctx = Context.from_dict(params.get("context"))
     diagnostics: List[Dict[str, Any]] = []
+    actions: List[Dict[str, Any]] = []
     for ln in plugin.linters:
         try:
             result = ln.handler(ctx)
@@ -272,10 +273,18 @@ def _run_lint(params: Dict[str, Any]) -> Dict[str, Any]:
             continue
         items = result if isinstance(result, (list, tuple)) else [result]
         for raw in items:
+            # A linter may also return a `status` action; surface it alongside
+            # the diagnostics so the status bar can render it.
+            if isinstance(raw, dict) and raw.get("type") == "status":
+                actions.append(raw)
+                continue
             diag = _normalise_diagnostic(raw)
             if diag is not None:
                 diagnostics.append(diag)
-    return {"diagnostics": diagnostics}
+    out: Dict[str, Any] = {"diagnostics": diagnostics}
+    if actions:
+        out["actions"] = actions
+    return out
 
 
 # ---------------------------------------------------------------------------

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -70,6 +70,17 @@ app.whenReady().then(() => {
   // Example IPC handler establishing the pattern later agents will extend.
   ipcMain.handle('ping', () => 'pong')
 
+  // App version, surfaced in the status bar.
+  ipcMain.handle('app:version', () => app.getVersion())
+
+  // Open an external URL in the user's default browser (used by clickable
+  // plugin status-bar links). Only http(s) URLs are honoured.
+  ipcMain.handle('app:openExternal', (_e, url: string) => {
+    if (typeof url === 'string' && /^https?:\/\//i.test(url)) {
+      void shell.openExternal(url)
+    }
+  })
+
   // Register the serial device layer. Push events are routed to whichever
   // window is currently live.
   registerDeviceIpc(() => mainWindow?.webContents)

--- a/src/main/plugins/types.ts
+++ b/src/main/plugins/types.ts
@@ -101,13 +101,27 @@ export interface DiagnosticAction {
   item: Diagnostic
 }
 
+/**
+ * Show a message in the app's status bar. The latest status message(s) are
+ * rendered in the status bar's left group; a higher `priority` wins when more
+ * than one is present. When `href` is set the message is a clickable external
+ * link (opened via {@link window.api.openExternal}).
+ */
+export interface StatusAction {
+  type: 'status'
+  text: string
+  tooltip?: string
+  href?: string
+  priority?: number
+}
+
 /** Result of the `lint` RPC: all linters' diagnostics, concatenated. */
 export interface LintResult {
   diagnostics: Diagnostic[]
 }
 
 /** Any action a command can return. */
-export type PluginAction = MessageAction | EditAction | DiagnosticAction
+export type PluginAction = MessageAction | EditAction | DiagnosticAction | StatusAction
 
 /** Result of `runCommand`. */
 export interface RunCommandResult {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -67,6 +67,7 @@ export type {
   MessageAction,
   EditAction,
   DiagnosticAction,
+  StatusAction,
   Diagnostic,
   DiagnosticFix,
   LintResult,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -363,6 +363,11 @@ const plugins = {
 const api = {
   /** Example round-trip channel used to prove the bridge works. */
   ping: (): Promise<string> => ipcRenderer.invoke('ping'),
+  /** The application version (from package.json), shown in the status bar. */
+  appVersion: (): Promise<string> => ipcRenderer.invoke('app:version'),
+  /** Open an http(s) URL externally in the default browser. */
+  openExternal: (url: string): Promise<void> =>
+    ipcRenderer.invoke('app:openExternal', url),
   /** Snapshot of the runtime versions for display in the UI. */
   versions: process.versions,
   /** Serial device connection + MicroPython REPL/filesystem layer. */

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -14,6 +14,7 @@ import { HelpPanel } from './HelpPanel'
 import { EditorArea } from './EditorArea'
 import { ShellPanel } from './ShellPanel'
 import { RightPanel } from './RightPanel'
+import { StatusBar } from './StatusBar'
 
 /** Wrap a panel that lacks its own region chrome in a titled, scrollable region. */
 function LeftRegion({ title, children }: { title: string; children: JSX.Element }): JSX.Element {
@@ -190,6 +191,8 @@ export function AppShell(): JSX.Element {
           </Panel>
         </PanelGroup>
       </div>
+
+      <StatusBar />
     </div>
   )
 }

--- a/src/renderer/src/components/PluginsPanel.tsx
+++ b/src/renderer/src/components/PluginsPanel.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import './PluginsPanel.css'
 import { useWorkspace } from '../store/workspace'
+import { PLUGIN_STATUS_EVENT } from './StatusBar'
 import type {
   CommandInfo,
   PluginAction,
@@ -109,6 +110,21 @@ export function PluginsPanel(): JSX.Element {
             'info',
             `Diagnostic (line ${action.item.line}): ${action.item.message}`
           )
+          break
+        case 'status':
+          // Route status-bar messages to the StatusBar via a window event so we
+          // don't introduce shared state just for this hop (issue #71).
+          window.dispatchEvent(
+            new CustomEvent(PLUGIN_STATUS_EVENT, {
+              detail: {
+                text: action.text,
+                tooltip: action.tooltip,
+                href: action.href,
+                priority: action.priority
+              }
+            })
+          )
+          pushNotice('info', `Status: ${action.text}`)
           break
         default:
           break

--- a/src/renderer/src/components/StatusBar.css
+++ b/src/renderer/src/components/StatusBar.css
@@ -1,0 +1,130 @@
+/* --------------------------------------------------------------------------
+ * Status bar (issue #71)
+ *
+ * Thin, persistent bar pinned at the very bottom of the shell. Matches the
+ * JetBrains-Mono / NES theme: small text, theme tokens, hard 1px-ish dividers.
+ * ------------------------------------------------------------------------ */
+.statusbar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  height: 1.6rem;
+  padding: 0 0.5rem;
+  background: var(--bg-elevated);
+  border-top: var(--border-w) solid var(--border);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  flex: 0 0 auto;
+  user-select: none;
+  overflow: hidden;
+}
+
+.statusbar__group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.statusbar__group--left {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.statusbar__spacer {
+  flex: 0 0 auto;
+}
+
+.statusbar__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0 0.4rem;
+  white-space: nowrap;
+  line-height: 1.6rem;
+  flex: 0 0 auto;
+}
+
+/* The plugin message can be long; let it shrink/ellipsize, not the right group. */
+.statusbar__plugin,
+.statusbar__link {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Connection indicator. */
+.statusbar__conn {
+  color: var(--text-muted);
+}
+
+.statusbar__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--disconnected);
+  flex: 0 0 auto;
+}
+
+.statusbar__conn--connected .statusbar__dot {
+  background: var(--success);
+}
+
+.statusbar__conn--connected {
+  color: var(--text);
+}
+
+/* Clickable items (plugin links, update restart). */
+.statusbar__link {
+  background: transparent;
+  border: none;
+  color: var(--accent);
+  font: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.statusbar__link:hover {
+  color: var(--text);
+}
+
+.statusbar__link:focus-visible {
+  outline: var(--border-w) solid var(--accent);
+  outline-offset: 1px;
+}
+
+.statusbar__update {
+  color: var(--accent-2);
+}
+
+.statusbar__save--dirty {
+  color: var(--accent-2);
+}
+
+.statusbar__version {
+  color: var(--text-muted);
+}
+
+/* Flash-firmware action — compact, sits at the far right. */
+.statusbar__flash {
+  background: transparent;
+  border: var(--border-w) solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font: inherit;
+  cursor: pointer;
+  padding: 0 0.5rem;
+  line-height: 1.3rem;
+}
+
+.statusbar__flash:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.statusbar__flash:focus-visible {
+  outline: var(--border-w) solid var(--accent);
+  outline-offset: 1px;
+}

--- a/src/renderer/src/components/StatusBar.tsx
+++ b/src/renderer/src/components/StatusBar.tsx
@@ -1,0 +1,254 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useDeviceStatus } from '../hooks/useDeviceStatus'
+import { useWorkspace } from '../store/workspace'
+import { FirmwareFlasher } from './FirmwareFlasher'
+import type { UpdateStatus } from '../../../preload/index.d'
+import './StatusBar.css'
+
+/**
+ * STATUS BAR (issue #71)
+ * ======================
+ *
+ * A thin, persistent bar pinned at the very bottom of the window (below the
+ * shell panel). It consolidates ambient state that previously lived in the
+ * toolbar or had no home:
+ *
+ *   Left group  — device connection state, plugin status message(s), and a
+ *                 compact "update available" notice (clickable to restart).
+ *   Right group — Git changed-file count, active-file line count, save status,
+ *                 the app version, and a Flash-firmware button at the far right.
+ *
+ * Values are read from existing seams (never new global state):
+ *   - connection: {@link useDeviceStatus}
+ *   - update:     window.api.updates.onStatus
+ *   - git:        window.api.git.status() for the workspace currentFolder
+ *   - lines/save: the active file in {@link useWorkspace}
+ *   - version:    window.api.appVersion()
+ *   - plugin msg: posted into this bar via the global `snakie:status` event
+ *                 (dispatched when a plugin returns a `status` action)
+ */
+
+/** A plugin-posted status message (mirrors the SDK `status` action shape). */
+export interface PluginStatusMessage {
+  text: string
+  tooltip?: string
+  href?: string
+  priority?: number
+}
+
+/** Name of the window event the renderer dispatches for plugin status actions. */
+export const PLUGIN_STATUS_EVENT = 'snakie:status'
+
+export function StatusBar(): JSX.Element {
+  const status = useDeviceStatus()
+  const { openFiles, activeId, currentFolder } = useWorkspace()
+  const activeFile = openFiles.find((f) => f.id === activeId) ?? null
+
+  const [flasherOpen, setFlasherOpen] = useState(false)
+  const [update, setUpdate] = useState<UpdateStatus | null>(null)
+  const [version, setVersion] = useState<string>('')
+  const [changedCount, setChangedCount] = useState<number | null>(null)
+  const [pluginMsg, setPluginMsg] = useState<PluginStatusMessage | null>(null)
+
+  // App version — fetched once.
+  useEffect(() => {
+    let active = true
+    window.api
+      .appVersion()
+      .then((v) => {
+        if (active) setVersion(v)
+      })
+      .catch(() => undefined)
+    return () => {
+      active = false
+    }
+  }, [])
+
+  // Update lifecycle — subscribe to push events.
+  useEffect(() => window.api.updates.onStatus((s) => setUpdate(s)), [])
+
+  // Plugin status messages — dispatched as a window event when a plugin command
+  // returns a `status` action (see PluginsPanel). The highest-priority message
+  // wins; an empty text clears the slot.
+  useEffect(() => {
+    const handler = (e: Event): void => {
+      const detail = (e as CustomEvent<PluginStatusMessage>).detail
+      if (!detail || !detail.text) {
+        setPluginMsg(null)
+        return
+      }
+      setPluginMsg((prev) =>
+        prev && (prev.priority ?? 0) > (detail.priority ?? 0) ? prev : detail
+      )
+    }
+    window.addEventListener(PLUGIN_STATUS_EVENT, handler)
+    return () => window.removeEventListener(PLUGIN_STATUS_EVENT, handler)
+  }, [])
+
+  // Git changed-file count — best-effort for the workspace folder. Debounced,
+  // and refreshed on window focus + folder change. Tolerates non-repo / no
+  // folder by showing nothing.
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const refreshGit = useCallback(() => {
+    if (!currentFolder) {
+      setChangedCount(null)
+      return
+    }
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => {
+      void (async () => {
+        try {
+          // The main-process GitService is scoped to one repo; point it at the
+          // current folder (idempotent) before reading status. The Source
+          // Control panel does the same, so this stays in sync.
+          await window.api.git.openRepo(currentFolder)
+          const st = await window.api.git.status()
+          if (!st.isRepo) {
+            setChangedCount(null)
+            return
+          }
+          setChangedCount(st.staged.length + st.changed.length + st.untracked.length)
+        } catch {
+          setChangedCount(null)
+        }
+      })()
+    }, 300)
+  }, [currentFolder])
+
+  useEffect(() => {
+    refreshGit()
+    const onFocus = (): void => refreshGit()
+    window.addEventListener('focus', onFocus)
+    return () => {
+      window.removeEventListener('focus', onFocus)
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+    }
+  }, [refreshGit])
+
+  const connected = status.state === 'connected'
+  const connLabel =
+    status.state === 'connecting'
+      ? 'Connecting…'
+      : connected
+        ? `Connected${status.path ? ` · ${status.path}` : ''}`
+        : status.state === 'error'
+          ? 'Error'
+          : 'Disconnected'
+
+  const lines = activeFile ? activeFile.content.split('\n').length : null
+
+  // Compact update notice text (mirrors UpdateNotifier wording, terser).
+  let updateText: string | null = null
+  let updateAction: (() => void) | null = null
+  if (update) {
+    switch (update.state) {
+      case 'available':
+        updateText = update.version ? `Update v${update.version}…` : 'Update available…'
+        break
+      case 'downloading':
+        updateText =
+          typeof update.percent === 'number'
+            ? `Updating ${update.percent}%`
+            : 'Updating…'
+        break
+      case 'downloaded':
+        updateText = update.version ? `Restart for v${update.version}` : 'Restart to update'
+        updateAction = () => {
+          void window.api.updates.quitAndInstall()
+        }
+        break
+      default:
+        updateText = null
+    }
+  }
+
+  return (
+    <footer className="statusbar" role="contentinfo" aria-label="Status bar">
+      <div className="statusbar__group statusbar__group--left">
+        <span
+          className={`statusbar__item statusbar__conn ${connected ? 'statusbar__conn--connected' : 'statusbar__conn--disconnected'}`}
+          title={status.error ? `Connection error: ${status.error}` : 'Device connection status'}
+        >
+          <span className="statusbar__dot" aria-hidden="true" />
+          <span>{connLabel}</span>
+        </span>
+
+        {pluginMsg &&
+          (pluginMsg.href ? (
+            <button
+              type="button"
+              className="statusbar__item statusbar__link"
+              title={pluginMsg.tooltip ?? pluginMsg.href}
+              onClick={() => {
+                if (pluginMsg.href) void window.api.openExternal(pluginMsg.href)
+              }}
+            >
+              {pluginMsg.text}
+            </button>
+          ) : (
+            <span
+              className="statusbar__item statusbar__plugin"
+              title={pluginMsg.tooltip ?? undefined}
+            >
+              {pluginMsg.text}
+            </span>
+          ))}
+
+        {updateText &&
+          (updateAction ? (
+            <button
+              type="button"
+              className="statusbar__item statusbar__update statusbar__link"
+              title="Restart to install the downloaded update"
+              onClick={updateAction}
+            >
+              {updateText}
+            </button>
+          ) : (
+            <span className="statusbar__item statusbar__update" title="Software update">
+              {updateText}
+            </span>
+          ))}
+      </div>
+
+      <div className="statusbar__spacer" />
+
+      <div className="statusbar__group statusbar__group--right">
+        {changedCount != null && (
+          <span
+            className="statusbar__item"
+            title={`${changedCount} changed file(s) in the current repository`}
+          >
+            ⎇ {changedCount}
+          </span>
+        )}
+        {lines != null && (
+          <span className="statusbar__item" title="Lines in the active file">
+            {lines} {lines === 1 ? 'line' : 'lines'}
+          </span>
+        )}
+        <span
+          className={`statusbar__item statusbar__save ${activeFile?.dirty ? 'statusbar__save--dirty' : ''}`}
+          title={activeFile ? (activeFile.dirty ? 'Unsaved changes' : 'All changes saved') : 'No active file'}
+        >
+          {activeFile ? (activeFile.dirty ? 'Unsaved' : 'Saved') : '—'}
+        </span>
+        <span className="statusbar__item statusbar__version" title="Snakie version">
+          {version ? `v${version}` : ''}
+        </span>
+        <button
+          type="button"
+          className="statusbar__item statusbar__flash"
+          onClick={() => setFlasherOpen(true)}
+          title="Flash MicroPython firmware to the device (ESP via esptool, RP2040 via UF2)"
+          aria-label="Flash MicroPython firmware"
+        >
+          <span aria-hidden="true">⚡</span>
+          <span>Flash firmware</span>
+        </button>
+      </div>
+
+      {flasherOpen && <FirmwareFlasher onClose={() => setFlasherOpen(false)} />}
+    </footer>
+  )
+}

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -1,8 +1,7 @@
-import { useCallback, useState, type ReactNode } from 'react'
+import { useCallback, type ReactNode } from 'react'
 import { Theme } from '../hooks/useTheme'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { useWorkspace } from '../store/workspace'
-import { FirmwareFlasher } from './FirmwareFlasher'
 import './RunControls.css'
 import './Toolbar.css'
 
@@ -57,11 +56,14 @@ interface ToolbarProps {
 /**
  * TOP TOOLBAR.
  *
- * Big, easy-to-click action buttons (Run / Stop) plus a connection-status
- * indicator. Run executes the active editor file on the device via MicroPython
- * paste mode (output streams to the existing Shell terminal); Stop sends an
- * interrupt (Ctrl-C). The connection-status indicator reflects the device
- * layer's status via {@link useDeviceStatus}.
+ * Big, easy-to-click action buttons (Run / Stop) plus the file actions
+ * (New / Open / Save). Run executes the active editor file on the device via
+ * MicroPython paste mode (output streams to the existing Shell terminal); Stop
+ * sends an interrupt (Ctrl-C).
+ *
+ * Connection state and the Flash-firmware action now live in the bottom
+ * {@link StatusBar} (issue #71); this toolbar still reads {@link useDeviceStatus}
+ * only to enable/disable the Run/Stop buttons.
  *
  * Also hosts layout controls (panel show/hide toggles) and the theme toggle,
  * following progressive disclosure: complexity stays tucked away by default.
@@ -77,7 +79,6 @@ export function Toolbar({
   onToggleRight
 }: ToolbarProps): JSX.Element {
   const status = useDeviceStatus()
-  const [flasherOpen, setFlasherOpen] = useState(false)
   const { openFiles, activeId, newFile, openFolder, saveFile } = useWorkspace()
   const connected = status.state === 'connected'
   const activeFile = openFiles.find((f) => f.id === activeId)
@@ -107,15 +108,6 @@ export function Toolbar({
   const handleSave = useCallback(() => {
     if (activeId) void saveFile(activeId).catch(() => undefined)
   }, [activeId, saveFile])
-
-  const label =
-    status.state === 'connecting'
-      ? 'Connecting…'
-      : connected
-        ? `Connected${status.path ? ` · ${status.path}` : ''}`
-        : status.state === 'error'
-          ? 'Error'
-          : 'Disconnected'
 
   return (
     <header className="toolbar" role="toolbar" aria-label="Main toolbar">
@@ -185,29 +177,6 @@ export function Toolbar({
           </span>
           <span>Stop</span>
         </button>
-        <button
-          type="button"
-          className="btn btn--ghost"
-          onClick={() => setFlasherOpen(true)}
-          title="Flash MicroPython firmware to the device (ESP via esptool, RP2040 via UF2)"
-          aria-label="Flash MicroPython firmware"
-        >
-          <span className="btn__glyph" aria-hidden="true">
-            ⚡
-          </span>
-          <span>Flash firmware</span>
-        </button>
-      </div>
-
-      <div className="toolbar__group">
-        {/* Live connection-status indicator, driven by the device layer. */}
-        <span
-          className={`conn-status ${connected ? 'conn-status--connected' : 'conn-status--disconnected'}`}
-          title={status.error ? `Connection error: ${status.error}` : 'Connection status'}
-        >
-          <span className="conn-status__dot" aria-hidden="true" />
-          <span>{label}</span>
-        </span>
       </div>
 
       <div className="toolbar__spacer" />
@@ -275,8 +244,6 @@ export function Toolbar({
           </svg>
         </button>
       </div>
-
-      {flasherOpen && <FirmwareFlasher onClose={() => setFlasherOpen(false)} />}
     </header>
   )
 }


### PR DESCRIPTION
Adds a bottom **status bar** (issue #71) and moves connection status + Flash firmware out of the toolbar.

**Segments:** connection state (`useDeviceStatus`), plugin **status messages** (clickable links), update notices (click to install when downloaded), Git change count (for the working folder), active-file **lines**, **save status** (dirty), app **version**, and the **Flash firmware** button at the far right.

**Plugin capability:** new `status(text, *, tooltip, href, priority)` SDK helper → `{type:'status', ...}` action; PluginsPanel routes it to the status bar; `href` opens via a new guarded `window.api.openExternal` (http/https only). App version via `window.api.appVersion()` (`app.getVersion()`). Example: `hello.status` command demos a clickable link.

**Toolbar:** removed the connection indicator + Flash button (now in the status bar); Run/Stop, New/Open/Save, Files/Shell/Chat + theme toggle retained.

Verified: clean auto-merge with the linter (#65), lint · typecheck · **51 tests** · build green; host smoke-test confirmed the `status` action serialises.

Note: lint-returned `status` actions aren't surfaced yet (the lint consumer would need to read them) — command-returned ones are fully wired; minor follow-up.

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)