### PR TITLE
Update notification + status-bar update button — Closes #74

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Update notifications + status-bar update button (#74).** When a newer
+  release is available the status bar shows an **Update to vX** button (in the
+  version slot) — click to **download**, watch progress, then **Restart to
+  update** (electron-updater, `autoDownload` off so it's user-initiated); a
+  dismissible banner also offers Download. Adds `window.api.updates.download()`
+  and an hourly re-check.
 - **Python plugin system (MVP, #61).** Snakie spawns the user's `python3` running
   a host that discovers and loads Python plugins and talks to the app over
   JSON-RPC. Plugins use a stdlib-only `snakie` SDK (`@plugin.command`, `Context`,

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -10,6 +10,7 @@ const { autoUpdater } = electronUpdater
 export const UPDATE_CHANNELS = {
   status: 'updates:status',
   check: 'updates:check',
+  download: 'updates:download',
   quitAndInstall: 'updates:quitAndInstall'
 } as const
 
@@ -55,13 +56,15 @@ export function registerUpdater(getWebContents: () => WebContents | undefined): 
   // so the renderer API exists, then bail before touching `autoUpdater`.
   if (!app.isPackaged) {
     ipcMain.handle(UPDATE_CHANNELS.check, () => undefined)
+    ipcMain.handle(UPDATE_CHANNELS.download, () => undefined)
     ipcMain.handle(UPDATE_CHANNELS.quitAndInstall, () => undefined)
     return
   }
 
-  // We surface our own restart affordance in the UI, so don't auto-install on
-  // quit or auto-download silently before telling the user.
-  autoUpdater.autoDownload = true
+  // The user explicitly pulls the update from the status bar (issue #74), so
+  // don't download silently. We also surface our own restart affordance, so
+  // don't auto-install on quit.
+  autoUpdater.autoDownload = false
   autoUpdater.autoInstallOnAppQuit = false
 
   autoUpdater.on('update-available', (info) => {
@@ -85,15 +88,32 @@ export function registerUpdater(getWebContents: () => WebContents | undefined): 
     }
   })
 
+  ipcMain.handle(UPDATE_CHANNELS.download, async () => {
+    // The renderer's Update button calls this once the user opts in. With
+    // `autoDownload = false` nothing is fetched until this fires.
+    try {
+      await autoUpdater.downloadUpdate()
+    } catch (err) {
+      send({ state: 'error', message: err instanceof Error ? err.message : String(err) })
+    }
+  })
+
   ipcMain.handle(UPDATE_CHANNELS.quitAndInstall, () => {
     // `isSilent: false`, `isForceRunAfter: true` — show the installer UI where
     // applicable and relaunch the app after updating.
     autoUpdater.quitAndInstall(false, true)
   })
 
-  // Kick off an initial check shortly after startup. Swallow failures so a
+  // Kick off an initial check shortly after startup, then re-check hourly so a
+  // long-running session still learns about new releases. Swallow failures so a
   // transient network/feed error never crashes the main process.
-  void autoUpdater.checkForUpdates().catch((err) => {
-    send({ state: 'error', message: err instanceof Error ? err.message : String(err) })
-  })
+  const checkQuietly = (): void => {
+    void autoUpdater.checkForUpdates().catch((err) => {
+      send({ state: 'error', message: err instanceof Error ? err.message : String(err) })
+    })
+  }
+  checkQuietly()
+  const HOUR_MS = 60 * 60 * 1000
+  const timer = setInterval(checkQuietly, HOUR_MS)
+  app.on('before-quit', () => clearInterval(timer))
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -147,14 +147,17 @@ const fs = {
 
 /**
  * Auto-update API. Mirrors the main-process `updates:*` IPC handlers. `check`
- * triggers an update check, `quitAndInstall` restarts into a downloaded update,
- * and `onStatus` subscribes to lifecycle push events (returns an unsubscribe
- * function). In dev / unpackaged runs the main side no-ops, so nothing is ever
- * pushed.
+ * triggers an update check, `download` pulls an available update (downloads run
+ * only on explicit user request — see issue #74), `quitAndInstall` restarts into
+ * a downloaded update, and `onStatus` subscribes to lifecycle push events
+ * (returns an unsubscribe function). In dev / unpackaged runs the main side
+ * no-ops, so nothing is ever pushed.
  */
 const updates = {
   /** Trigger an update check (no-op when unpackaged). */
   check: (): Promise<void> => ipcRenderer.invoke('updates:check'),
+  /** Download an available update (the user explicitly opts in). */
+  download: (): Promise<void> => ipcRenderer.invoke('updates:download'),
   /** Restart the app and install a downloaded update. */
   quitAndInstall: (): Promise<void> => ipcRenderer.invoke('updates:quitAndInstall'),
   /** Subscribe to update lifecycle status. Returns an unsubscribe function. */

--- a/src/renderer/src/components/StatusBar.css
+++ b/src/renderer/src/components/StatusBar.css
@@ -99,6 +99,31 @@
   color: var(--accent-2);
 }
 
+/* Actionable update affordance in the version slot (issue #74) — styled as an
+ * accent button so it clearly reads as clickable, distinct from the plain
+ * version text it replaces. */
+.statusbar__update-btn {
+  background: var(--accent);
+  border: var(--border-w) solid var(--accent);
+  border-radius: var(--radius);
+  color: var(--bg);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0 0.5rem;
+  line-height: 1.3rem;
+}
+
+.statusbar__update-btn:hover {
+  background: var(--accent-2);
+  border-color: var(--accent-2);
+}
+
+.statusbar__update-btn:focus-visible {
+  outline: var(--border-w) solid var(--text);
+  outline-offset: 1px;
+}
+
 .statusbar__save--dirty {
   color: var(--accent-2);
 }

--- a/src/renderer/src/components/StatusBar.tsx
+++ b/src/renderer/src/components/StatusBar.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { useWorkspace } from '../store/workspace'
 import { FirmwareFlasher } from './FirmwareFlasher'
+import { updateButtonView } from './updateButton'
 import type { UpdateStatus } from '../../../preload/index.d'
 import './StatusBar.css'
 
@@ -13,10 +14,12 @@ import './StatusBar.css'
  * shell panel). It consolidates ambient state that previously lived in the
  * toolbar or had no home:
  *
- *   Left group  — device connection state, plugin status message(s), and a
- *                 compact "update available" notice (clickable to restart).
+ *   Left group  — device connection state and plugin status message(s).
  *   Right group — Git changed-file count, active-file line count, save status,
- *                 the app version, and a Flash-firmware button at the far right.
+ *                 the app version slot, and a Flash-firmware button at the far
+ *                 right. The version slot is update-aware (issue #74): it shows
+ *                 `v<version>` normally, but becomes an Update / Restart button
+ *                 (or a download-progress label) as an update progresses.
  *
  * Values are read from existing seams (never new global state):
  *   - connection: {@link useDeviceStatus}
@@ -137,29 +140,12 @@ export function StatusBar(): JSX.Element {
 
   const lines = activeFile ? activeFile.content.split('\n').length : null
 
-  // Compact update notice text (mirrors UpdateNotifier wording, terser).
-  let updateText: string | null = null
-  let updateAction: (() => void) | null = null
-  if (update) {
-    switch (update.state) {
-      case 'available':
-        updateText = update.version ? `Update v${update.version}…` : 'Update available…'
-        break
-      case 'downloading':
-        updateText =
-          typeof update.percent === 'number'
-            ? `Updating ${update.percent}%`
-            : 'Updating…'
-        break
-      case 'downloaded':
-        updateText = update.version ? `Restart for v${update.version}` : 'Restart to update'
-        updateAction = () => {
-          void window.api.updates.quitAndInstall()
-        }
-        break
-      default:
-        updateText = null
-    }
+  // Update-aware version slot (issue #74). The pure mapping lives in
+  // `updateButton.ts` so it can be unit-tested without rendering.
+  const updateView = updateButtonView(update, version)
+  const onUpdateClick = (): void => {
+    if (updateView.action === 'download') void window.api.updates.download()
+    else if (updateView.action === 'quitAndInstall') void window.api.updates.quitAndInstall()
   }
 
   return (
@@ -193,22 +179,6 @@ export function StatusBar(): JSX.Element {
               {pluginMsg.text}
             </span>
           ))}
-
-        {updateText &&
-          (updateAction ? (
-            <button
-              type="button"
-              className="statusbar__item statusbar__update statusbar__link"
-              title="Restart to install the downloaded update"
-              onClick={updateAction}
-            >
-              {updateText}
-            </button>
-          ) : (
-            <span className="statusbar__item statusbar__update" title="Software update">
-              {updateText}
-            </span>
-          ))}
       </div>
 
       <div className="statusbar__spacer" />
@@ -233,9 +203,24 @@ export function StatusBar(): JSX.Element {
         >
           {activeFile ? (activeFile.dirty ? 'Unsaved' : 'Saved') : '—'}
         </span>
-        <span className="statusbar__item statusbar__version" title="Snakie version">
-          {version ? `v${version}` : ''}
-        </span>
+        {updateView.label &&
+          (updateView.clickable ? (
+            <button
+              type="button"
+              className="statusbar__item statusbar__update-btn"
+              title={updateView.title}
+              onClick={onUpdateClick}
+            >
+              {updateView.label}
+            </button>
+          ) : (
+            <span
+              className={`statusbar__item ${updateView.isUpdate ? 'statusbar__update' : 'statusbar__version'}`}
+              title={updateView.title}
+            >
+              {updateView.label}
+            </span>
+          ))}
         <button
           type="button"
           className="statusbar__item statusbar__flash"

--- a/src/renderer/src/components/UpdateNotifier.tsx
+++ b/src/renderer/src/components/UpdateNotifier.tsx
@@ -7,8 +7,14 @@ import './UpdateNotifier.css'
  *
  * Subscribes to `window.api.updates.onStatus` and renders a small dismissible
  * banner describing the update lifecycle: available -> downloading -> ready.
- * When an update is downloaded it offers a Restart button that calls
- * `updates.quitAndInstall()`.
+ * Because downloads are opt-in (issue #74: `autoDownload = false`), the
+ * `available` banner offers a Download button (`updates.download()`); once
+ * downloaded it offers a Restart button (`updates.quitAndInstall()`).
+ *
+ * The status-bar version slot is the primary, persistent update control; this
+ * banner is a one-time, dismissible toast that mirrors the same actions so the
+ * user is notified the moment an update becomes available, not only when it has
+ * finished downloading.
  *
  * Nothing renders until a status arrives, so in development / unpackaged runs
  * (where the main process never pushes a status) the banner stays hidden.
@@ -36,8 +42,19 @@ export function UpdateNotifier(): JSX.Element | null {
   switch (status.state) {
     case 'available':
       message = status.version
-        ? `Update available (v${status.version}) — downloading…`
-        : 'Update available — downloading…'
+        ? `Update available (v${status.version})`
+        : 'Update available'
+      action = (
+        <button
+          type="button"
+          className="update-notifier__action"
+          onClick={() => {
+            void window.api.updates.download()
+          }}
+        >
+          Download
+        </button>
+      )
       break
     case 'downloading':
       message =

--- a/src/renderer/src/components/updateButton.ts
+++ b/src/renderer/src/components/updateButton.ts
@@ -1,0 +1,92 @@
+import type { UpdateStatus } from '../../../preload/index.d'
+
+/**
+ * Which renderer-side `window.api.updates` call an update control invokes when
+ * clicked. `null` means the control is non-interactive in that state.
+ */
+export type UpdateAction = 'download' | 'quitAndInstall' | null
+
+/**
+ * Pure mapping from an update lifecycle status (plus the resolved app version)
+ * to the status-bar version-slot view model. Kept side-effect-free and exported
+ * so it can be unit-tested without rendering React (issue #74).
+ *
+ * The version slot is *update-aware*: with no/idle update it shows `v<version>`;
+ * as the lifecycle advances it becomes an actionable button (download → restart)
+ * or a passive progress label.
+ */
+export interface UpdateButtonView {
+  /** The visible text. */
+  label: string
+  /** The `window.api.updates` method to call on click, or null if passive. */
+  action: UpdateAction
+  /** A tooltip describing the control. */
+  title: string
+  /** Whether this is the actionable "update" affordance vs the plain version. */
+  isUpdate: boolean
+  /** Whether the control should render as an enabled button. */
+  clickable: boolean
+}
+
+/**
+ * Compute the version-slot view for the status bar.
+ *
+ * @param status latest {@link UpdateStatus} push, or null if none yet.
+ * @param version resolved app version (no leading `v`), or '' if not loaded.
+ */
+export function updateButtonView(
+  status: UpdateStatus | null,
+  version: string
+): UpdateButtonView {
+  const versionLabel = version ? `v${version}` : ''
+  const plain: UpdateButtonView = {
+    label: versionLabel,
+    action: null,
+    title: 'Snakie version',
+    isUpdate: false,
+    clickable: false
+  }
+
+  if (!status) return plain
+
+  switch (status.state) {
+    case 'available':
+      return {
+        label: status.version ? `⬆ Update to v${status.version}` : '⬆ Update available',
+        action: 'download',
+        title: 'Download and install the new version',
+        isUpdate: true,
+        clickable: true
+      }
+    case 'downloading':
+      return {
+        label:
+          typeof status.percent === 'number'
+            ? `Downloading… ${status.percent}%`
+            : 'Downloading…',
+        action: null,
+        title: 'Downloading the update',
+        isUpdate: true,
+        clickable: false
+      }
+    case 'downloaded':
+      return {
+        label: status.version ? `Restart for v${status.version}` : 'Restart to update',
+        action: 'quitAndInstall',
+        title: 'Restart to install the downloaded update',
+        isUpdate: true,
+        clickable: true
+      }
+    case 'error':
+      // Subtle failure: fall back to the version text but flag it + tooltip.
+      return {
+        label: versionLabel || 'Update failed',
+        action: null,
+        title: `Update failed${status.message ? `: ${status.message}` : ''}`,
+        isUpdate: true,
+        clickable: false
+      }
+    default:
+      return plain
+  }
+}

--- a/test/updateButtonView.test.ts
+++ b/test/updateButtonView.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { updateButtonView } from '../src/renderer/src/components/updateButton'
+
+/**
+ * Unit tests for the pure `updateButtonView` helper (issue #74) that maps an
+ * update lifecycle status + app version onto the status-bar version-slot view
+ * model: label, the `window.api.updates` action to invoke, and whether it is an
+ * actionable button.
+ */
+describe('updateButtonView', () => {
+  it('shows the plain version when there is no update status', () => {
+    const v = updateButtonView(null, '1.2.3')
+    expect(v.label).toBe('v1.2.3')
+    expect(v.action).toBeNull()
+    expect(v.isUpdate).toBe(false)
+    expect(v.clickable).toBe(false)
+  })
+
+  it('shows an empty label when neither version nor status is known', () => {
+    expect(updateButtonView(null, '').label).toBe('')
+  })
+
+  it('offers a download button when an update is available', () => {
+    const v = updateButtonView({ state: 'available', version: '2.0.0' }, '1.2.3')
+    expect(v.label).toBe('⬆ Update to v2.0.0')
+    expect(v.action).toBe('download')
+    expect(v.clickable).toBe(true)
+    expect(v.isUpdate).toBe(true)
+  })
+
+  it('falls back to generic available text without a version', () => {
+    const v = updateButtonView({ state: 'available' }, '1.2.3')
+    expect(v.label).toBe('⬆ Update available')
+    expect(v.action).toBe('download')
+  })
+
+  it('shows non-clickable progress while downloading', () => {
+    const v = updateButtonView({ state: 'downloading', percent: 42 }, '1.2.3')
+    expect(v.label).toBe('Downloading… 42%')
+    expect(v.action).toBeNull()
+    expect(v.clickable).toBe(false)
+  })
+
+  it('shows a generic downloading label when percent is missing', () => {
+    expect(updateButtonView({ state: 'downloading' }, '1.2.3').label).toBe('Downloading…')
+  })
+
+  it('offers a restart button once downloaded', () => {
+    const v = updateButtonView({ state: 'downloaded', version: '2.0.0' }, '1.2.3')
+    expect(v.label).toBe('Restart for v2.0.0')
+    expect(v.action).toBe('quitAndInstall')
+    expect(v.clickable).toBe(true)
+  })
+
+  it('uses a generic restart label without a version', () => {
+    expect(updateButtonView({ state: 'downloaded' }, '1.2.3').label).toBe('Restart to update')
+  })
+
+  it('falls back to the version on error, with the message in the tooltip', () => {
+    const v = updateButtonView({ state: 'error', message: 'boom' }, '1.2.3')
+    expect(v.label).toBe('v1.2.3')
+    expect(v.action).toBeNull()
+    expect(v.clickable).toBe(false)
+    expect(v.title).toContain('boom')
+  })
+
+  it('shows "Update failed" on error when no version is loaded', () => {
+    expect(updateButtonView({ state: 'error', message: 'boom' }, '').label).toBe('Update failed')
+  })
+})


### PR DESCRIPTION
Surfaces app updates and lets the user pull + restart (issue #74), on top of #17 (electron-updater) and #71 (status bar).

- **`autoDownload = false`** — updates are user-initiated. New `window.api.updates.download()` (→ `autoUpdater.downloadUpdate()`); `check()`/`quitAndInstall()` kept; hourly re-check; still no-ops in dev.
- **Status-bar update button** (in the version slot, only when relevant): `v<version>` → **⬆ Update to v<version>** (download) → **Downloading… NN%** → **Restart for v<version>** (quitAndInstall) → falls back to version on error (message in tooltip). Driven by a pure `updateButtonView()` (10 unit tests).
- **Notification on *available*:** the dismissible banner now offers **Download** (it previously mislabelled "downloading"); status-bar button is the primary control.

Verified: lint · typecheck · **61 tests** · build green; dev no-op guard holds. (The real download/restart only runs in a packaged build against a newer GitHub Release.)

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)