### PR TITLE
Wire macOS signing + notarization into releases (#47)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,9 +68,19 @@ jobs:
         # to its native arch to avoid cross-arch native rebuild failures.
         run: npm run dist -- ${{ matrix.platform_flag }} --publish never
         env:
-          # Code signing intentionally disabled (future work); without this,
-          # macOS builds would try to discover a signing identity and fail.
+          # macOS code signing + notarization (#47). These secrets are only set
+          # on the repo once an Apple Developer cert is configured; when empty,
+          # electron-builder skips signing (and therefore notarization), so
+          # unsigned builds keep working. See docs/macos-signing.md.
+          CSC_LINK: ${{ secrets.MAC_CSC_LINK }} # base64 of the Developer ID .p12
+          CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+          # Don't search the CI keychain; sign only with CSC_LINK when provided.
           CSC_IDENTITY_AUTO_DISCOVERY: false
+          # Notarization (Apple ID method). Skipped automatically if the app
+          # wasn't signed (no CSC_LINK).
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **macOS code signing + notarization** wired into the release workflow (#47).
+  When the Apple secrets are set (`MAC_CSC_LINK`, `MAC_CSC_KEY_PASSWORD`,
+  `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID` — see
+  `docs/macos-signing.md`), releases are signed (Developer ID, hardened runtime
+  + entitlements) and notarized — which is what lets the **in-app updater
+  install on macOS** and removes the "damaged" Gatekeeper warning. Builds stay
+  unsigned-but-working when the secrets are absent.
+
 ## [0.3.3] - 2026-06-02
 
 ### Fixed

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- Hardened-runtime entitlements required by Electron apps (JIT for V8,
+       etc.) so signing + notarization succeed. -->
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+  <true/>
+</dict>
+</plist>

--- a/docs/macos-signing.md
+++ b/docs/macos-signing.md
@@ -1,0 +1,60 @@
+# macOS code signing & notarization (#47)
+
+Snakie's release workflow signs **and** notarizes the macOS builds **when the
+secrets below are present** on the GitHub repo. With no secrets, electron-builder
+skips signing (and notarization) and produces the current unsigned builds.
+
+Why it matters:
+- **Signing** (Developer ID Application) is what lets the **in-app updater
+  install** an update on macOS — Squirrel.Mac validates the signature, so an
+  unsigned app fails with `code signature ... did not pass validation`.
+- **Notarization** clears the **"Snakie is damaged / can't be opened"**
+  Gatekeeper warning on first download (no more `xattr` workaround).
+
+## Prerequisites
+
+- An **Apple Developer Program** membership ($99/yr).
+- A **"Developer ID Application"** certificate (created in the Apple Developer
+  portal or via Xcode), exported as a **`.p12`** with a password.
+- Your **Team ID** (Apple Developer → Membership), an **Apple ID**, and an
+  **app-specific password** for that Apple ID (appleid.apple.com → Sign-In &
+  Security → App-Specific Passwords).
+
+## GitHub repo secrets to add
+
+Settings → Secrets and variables → Actions → **New repository secret**:
+
+| Secret | What it is | How to produce |
+| --- | --- | --- |
+| `MAC_CSC_LINK` | base64 of the Developer ID **.p12** | `base64 -i Certificates.p12 \| pbcopy` (macOS) and paste |
+| `MAC_CSC_KEY_PASSWORD` | the password you set when exporting the .p12 | — |
+| `APPLE_ID` | your Apple ID email | — |
+| `APPLE_APP_SPECIFIC_PASSWORD` | app-specific password for that Apple ID | appleid.apple.com → App-Specific Passwords |
+| `APPLE_TEAM_ID` | your 10-char Team ID | Apple Developer → Membership |
+
+That's it — `release.yml` passes these to electron-builder
+(`CSC_LINK`/`CSC_KEY_PASSWORD` for signing; `APPLE_ID`/
+`APPLE_APP_SPECIFIC_PASSWORD`/`APPLE_TEAM_ID` for notarization via
+`mac.notarize: true` in `electron-builder.yml`). The entitlements live in
+`build/entitlements.mac.plist`.
+
+## Verifying a release is signed & notarized
+
+After tagging a release with the secrets in place, download the dmg and:
+
+```bash
+codesign -dv --verbose=4 /Applications/Snakie.app          # shows "Authority=Developer ID Application: …"
+spctl -a -vvv -t install /Applications/Snakie.app          # "accepted … source=Notarized Developer ID"
+xcrun stapler validate /Applications/Snakie.app            # "The validate action worked!"
+```
+
+Then the in-app update flow (#74) will install/relaunch on macOS, and fresh
+downloads won't trigger the "damaged" warning.
+
+## Notes
+
+- The **App Store Connect API key** method is an alternative to the Apple ID
+  trio (`APPLE_API_KEY`/`APPLE_API_KEY_ID`/`APPLE_API_ISSUER`) — swap the env in
+  `release.yml` if you prefer it (avoids the app-specific password).
+- **Windows** signing is separate (Authenticode) and not set up here; Windows
+  auto-update works unsigned (only SmartScreen warns). **Linux** needs no signing.

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -90,11 +90,17 @@ mac:
         - arm64
         - x64
   category: public.app-category.developer-tools
-  # Code signing is intentionally disabled for now (see release.yml /
-  # CSC_IDENTITY_AUTO_DISCOVERY=false). NOTE: macOS auto-update *apply/relaunch*
-  # generally requires a signed app (Squirrel.Mac) — so unsigned builds can
-  # detect + download an update but may fail to install it. Real signing +
-  # notarization is tracked in #47.
+  # Signing + notarization (#47). Active only when the CI signing secrets are
+  # present (MAC_CSC_LINK etc. in release.yml); with no cert electron-builder
+  # skips signing AND notarization, so unsigned CI builds keep working.
+  # Signing (Developer ID) is what lets macOS auto-update *apply* (Squirrel.Mac
+  # validates the signature); notarization clears the "damaged"/Gatekeeper
+  # warning on first download. See docs/macos-signing.md.
+  hardenedRuntime: true
+  gatekeeperAssess: false
+  entitlements: build/entitlements.mac.plist
+  entitlementsInherit: build/entitlements.mac.plist
+  notarize: true
 
 # Publish installers to a GitHub Release for the pushed tag.
 publish:


### PR DESCRIPTION
Sets up macOS Developer ID signing + notarization in the release pipeline so the in-app updater can **install** on macOS (Squirrel validates the signature) and downloads no longer hit the **"damaged"** Gatekeeper warning.

- `build/entitlements.mac.plist` (hardened-runtime entitlements for Electron).
- `electron-builder.yml`: `hardenedRuntime`, `gatekeeperAssess: false`, entitlements, `notarize: true`.
- `release.yml`: passes `MAC_CSC_LINK`/`MAC_CSC_KEY_PASSWORD` (signing) + `APPLE_ID`/`APPLE_APP_SPECIFIC_PASSWORD`/`APPLE_TEAM_ID` (notarization) from repo secrets. **Empty secrets ⇒ electron-builder skips signing + notarization, so current unsigned builds still work.**
- `docs/macos-signing.md`: the exact secrets + how to obtain/verify them.

Doesn't fully close #47 until the secrets are added and a signed release is verified. lint · typecheck · build green; YAML/plist validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)