### PR TITLE
Editor, board view & instrument improvements (#137, #146, #147, #148, #149)

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -48,7 +48,9 @@ export default defineConfig({
         input: {
           index: resolve(__dirname, 'src/renderer/index.html'),
           // Second entry: the floating Board View window (issue: Board View v2).
-          board: resolve(__dirname, 'src/renderer/board.html')
+          board: resolve(__dirname, 'src/renderer/board.html'),
+          // Third entry: the floating Find & Replace window (issue #146).
+          find: resolve(__dirname, 'src/renderer/find.html')
         },
         output: {
           manualChunks(id: string) {

--- a/examples/bt_scan_demo.py
+++ b/examples/bt_scan_demo.py
@@ -1,0 +1,25 @@
+"""Bluetooth scanner demo for Snakie.
+
+Open & Run this, then press SCAN in the Bluetooth instrument: each press runs a
+BLE scan on the SECOND CORE and lists nearby devices — without blocking this
+loop. Needs a BLE-capable board (Pico W / ESP32).
+
+Kept in sync with the in-app copy at
+src/renderer/src/components/bt-scan-demo.ts.
+"""
+import time
+import instruments as inst
+
+inst.start(background=False)  # register scan triggers (incl. scan:bt)
+inst.bt_scan()               # one scan now so the panel fills immediately
+
+_beat = time.ticks_ms()
+try:
+    while True:
+        inst.control.poll()  # service SCAN commands from the IDE
+        if time.ticks_diff(time.ticks_ms(), _beat) >= 1500:
+            _beat = time.ticks_ms()
+            inst.ready()  # tell the IDE we're live (works on any library version)
+        time.sleep_ms(20)
+except KeyboardInterrupt:
+    inst.stop()  # Stop pressed (Ctrl-C) -> silence + clear

--- a/examples/i2c_detect_demo.py
+++ b/examples/i2c_detect_demo.py
@@ -1,0 +1,28 @@
+"""I2C detect demo for Snakie.
+
+Open & Run this, then press SCAN in the I2C instrument: each press scans the
+bus and lights every responding address — without blocking this loop. Edit the
+sda/scl pins below to match your wiring (these are RP2040 I2C0 defaults).
+
+Kept in sync with the in-app copy at
+src/renderer/src/components/i2c-detect-demo.ts.
+"""
+import time
+from machine import I2C, Pin
+import instruments as inst
+
+i2c = I2C(0, sda=Pin(4), scl=Pin(5))   # your I2C bus (SDA=GP4, SCL=GP5)
+
+inst.start(background=False, i2c=i2c)   # registers the scan:i2c trigger for this bus
+inst.i2c_scan(i2c)                      # one scan now so the grid fills immediately
+
+_beat = time.ticks_ms()
+try:
+    while True:
+        inst.control.poll()  # service SCAN commands from the IDE
+        if time.ticks_diff(time.ticks_ms(), _beat) >= 1500:
+            _beat = time.ticks_ms()
+            inst.ready()  # tell the IDE we're live (works on any library version)
+        time.sleep_ms(20)
+except KeyboardInterrupt:
+    inst.stop()  # Stop pressed (Ctrl-C) -> silence + clear

--- a/src/main/find.ts
+++ b/src/main/find.ts
@@ -1,0 +1,98 @@
+import { BrowserWindow, ipcMain } from 'electron'
+import { join } from 'path'
+import { is } from '@electron-toolkit/utils'
+
+/**
+ * Find & Replace window + IPC layer (issue #146).
+ *
+ * Find & Replace is a separate frameless, always-on-top OS `BrowserWindow` (not
+ * an in-editor panel). It cannot reach the Monaco editor — that lives in the
+ * MAIN window's renderer — so it drives find/replace over IPC, and the main
+ * window replies with the match status:
+ *
+ *   find:open     (renderer → main, invoke)      open/focus the window
+ *   find:close    (renderer → main, send)        close the window
+ *   find:closed   (main → main window, send)      window was closed
+ *   find:command  (find window → main → MAIN)     a find/replace request, relayed
+ *   find:status   (MAIN → main → find window)     {matchIndex, matchCount}, relayed
+ *
+ * Mirrors the Board View window precedent (`src/main/board.ts`): a `send` from one
+ * window is relayed by the main process to the OTHER window's webContents.
+ */
+
+/** The live Find & Replace window, or null when closed. One at a time. */
+let findWindow: BrowserWindow | null = null
+
+/** Create (or focus) the floating Find & Replace window. */
+function openFindWindow(getMainWindow: () => BrowserWindow | null): void {
+  if (findWindow && !findWindow.isDestroyed()) {
+    findWindow.focus()
+    return
+  }
+
+  const window = new BrowserWindow({
+    width: 520,
+    height: 188,
+    show: false,
+    frame: false,
+    alwaysOnTop: true,
+    resizable: true,
+    title: 'Find & Replace',
+    webPreferences: {
+      preload: join(__dirname, '../preload/index.cjs'),
+      // Same rationale as the main window: the preload uses CommonJS require(),
+      // which a sandboxed preload cannot load.
+      sandbox: false,
+      contextIsolation: true,
+      nodeIntegration: false
+    }
+  })
+  findWindow = window
+
+  window.on('ready-to-show', () => window.show())
+
+  window.on('closed', () => {
+    if (findWindow === window) findWindow = null
+    // Tell the main renderer so it can reset its "find open" state.
+    getMainWindow()?.webContents.send('find:closed')
+  })
+
+  if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
+    void window.loadURL(`${process.env['ELECTRON_RENDERER_URL']}/find.html`)
+  } else {
+    void window.loadFile(join(__dirname, '../renderer/find.html'))
+  }
+}
+
+/**
+ * Register the Find & Replace IPC handlers. `getMainWindow` resolves the live
+ * editor window — both the relay target for find commands and the recipient of
+ * the close notification.
+ */
+export function registerFindIpc(getMainWindow: () => BrowserWindow | null): void {
+  ipcMain.handle('find:open', () => {
+    openFindWindow(getMainWindow)
+  })
+
+  ipcMain.on('find:close', () => {
+    if (findWindow && !findWindow.isDestroyed()) findWindow.close()
+  })
+
+  // find window → MAIN window: relay a find/replace command to the editor.
+  ipcMain.on('find:command', (_e, payload) => {
+    getMainWindow()?.webContents.send('find:command', payload)
+  })
+
+  // MAIN window → find window: relay the resulting match status.
+  ipcMain.on('find:status', (_e, payload) => {
+    if (findWindow && !findWindow.isDestroyed()) {
+      findWindow.webContents.send('find:status', payload)
+    }
+  })
+}
+
+/** Close the Find & Replace window (called on quit). */
+export function disposeFind(): void {
+  if (findWindow && !findWindow.isDestroyed()) findWindow.close()
+  findWindow = null
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -12,6 +12,7 @@ import { registerGitIpc } from './git/ipc'
 import { registerPluginsIpc, disposePlugins } from './plugins/ipc'
 import { registerUpdater, checkForUpdatesManual } from './updater'
 import { registerBoardIpc, disposeBoard } from './board'
+import { registerFindIpc, disposeFind } from './find'
 import { setupAppMenu } from './menu'
 
 /** The single application window, used to route device push-events. */
@@ -164,6 +165,10 @@ app.whenReady().then(() => {
   // resolver lets it notify the main window when it closes.
   registerBoardIpc(() => mainWindow)
 
+  // Register the Find & Replace layer (issue #146): a separate frameless,
+  // always-on-top window that drives the main editor's find/replace over IPC.
+  registerFindIpc(() => mainWindow)
+
   createWindow()
 
   app.on('activate', () => {
@@ -186,4 +191,5 @@ app.on('before-quit', () => {
   void disposeDevice()
   void disposePlugins()
   disposeBoard()
+  disposeFind()
 })

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -4,6 +4,7 @@ import type { Api } from './index'
 // Re-export the Board View payload + shared board-definition types so the
 // renderer can import them from this single UI-facing module.
 export type { BoardSourcePayload, InstrumentOpenPayload, InstrumentConn } from './index'
+export type { FindCommandPayload, FindStatusPayload } from './index'
 export type {
   BoardDefinition,
   BoardPad,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -109,6 +109,29 @@ export interface InstrumentOpenPayload {
 }
 
 /**
+ * A find/replace request sent from the Find & Replace window to the MAIN editor
+ * window (issue #146). The find window has no editor access, so it ships the full
+ * query + options; the main window runs it against Monaco. `action` is the
+ * renderer's `FindAction` union, left as a string so the preload needn't restate it.
+ */
+export interface FindCommandPayload {
+  /** 'count' | 'next' | 'prev' | 'replace' | 'replaceFind' | 'replaceAll'. */
+  action: string
+  query: string
+  replacement: string
+  matchCase: boolean
+  wholeWord: boolean
+}
+
+/** The match status the MAIN window pushes back to the find window (#146). */
+export interface FindStatusPayload {
+  /** 1-based index of the current selection among the matches, or 0. */
+  matchIndex: number
+  /** Total matches in the active model. */
+  matchCount: number
+}
+
+/**
  * Unwrap an {@link IpcResult} into a resolved value or a thrown Error, so the
  * renderer can use ordinary `try/catch` / promise rejection semantics.
  */
@@ -700,6 +723,42 @@ const instruments = {
   librarySource: (): Promise<string> => ipcRenderer.invoke('instruments:librarySource')
 }
 
+/**
+ * Find & Replace API (issue #146). The dialog is HOSTED in its own native window
+ * (`find.html`), which can't reach the Monaco editor (a main-window singleton).
+ * So the find window `sendCommand`s; the main process relays it to the MAIN
+ * window, which runs it and `sendStatus`es the result back (relayed here as
+ * `onStatus`). Mirrors the `board`/`instruments` relay pattern.
+ */
+const find = {
+  /** Open (or focus) the Find & Replace window. */
+  open: (): Promise<void> => ipcRenderer.invoke('find:open'),
+  /** Close the Find & Replace window (no-op if not open). Fire-and-forget. */
+  close: (): void => ipcRenderer.send('find:close'),
+  /** Subscribe (in the MAIN window) to the find window closing. Returns unsubscribe. */
+  onClosed: (cb: () => void): (() => void) => {
+    const listener = (): void => cb()
+    ipcRenderer.on('find:closed', listener)
+    return () => ipcRenderer.removeListener('find:closed', listener)
+  },
+  /** Send a find/replace command (from the find window) to the editor. */
+  sendCommand: (payload: FindCommandPayload): void => ipcRenderer.send('find:command', payload),
+  /** Subscribe (in the MAIN window) to relayed find/replace commands. Returns unsubscribe. */
+  onCommand: (cb: (payload: FindCommandPayload) => void): (() => void) => {
+    const listener = (_e: IpcRendererEvent, payload: FindCommandPayload): void => cb(payload)
+    ipcRenderer.on('find:command', listener)
+    return () => ipcRenderer.removeListener('find:command', listener)
+  },
+  /** Push the match status (from the MAIN window) back to the find window. */
+  sendStatus: (payload: FindStatusPayload): void => ipcRenderer.send('find:status', payload),
+  /** Subscribe (in the find window) to the relayed match status. Returns unsubscribe. */
+  onStatus: (cb: (payload: FindStatusPayload) => void): (() => void) => {
+    const listener = (_e: IpcRendererEvent, payload: FindStatusPayload): void => cb(payload)
+    ipcRenderer.on('find:status', listener)
+    return () => ipcRenderer.removeListener('find:status', listener)
+  }
+}
+
 // Minimal, typed API exposed to the renderer. This establishes the IPC
 // pattern that later feature work will extend.
 const api = {
@@ -733,7 +792,9 @@ const api = {
   /** Board View layer: floating window + live active-file relay + user boards. */
   board,
   /** Instrument launch relay: board window → main window scope/meter hosting. */
-  instruments
+  instruments,
+  /** Find & Replace window: native window ↔ main editor find/replace relay. */
+  find
 }
 
 // Use `contextBridge` APIs to expose Electron APIs to the renderer only if

--- a/src/renderer/find.html
+++ b/src/renderer/find.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Content-Security-Policy keeps the renderer locked down. -->
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'"
+    />
+    <title>Find &amp; Replace</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/find-main.tsx"></script>
+  </body>
+</html>

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -22,6 +22,7 @@ import {
 } from './InstrumentHost'
 import { defaultVisibility, deriveInUse } from './instruments-registry'
 import { parsePins, type UsedPins } from './parse-pins'
+import { runFindCommand } from './findController'
 import { ShellPanel } from './ShellPanel'
 import { RightPanel } from './RightPanel'
 import { StatusBar } from './StatusBar'
@@ -529,6 +530,17 @@ export function AppShell(): JSX.Element {
     // so we cast at the IPC boundary.
     const off = window.api.instruments.onOpen((payload) => {
       revealForOpenRef.current(payload.kind, payload.conn as UsedPins)
+    })
+    return off
+  }, [])
+
+  // Drive the Find & Replace window (issue #146): it has no editor access, so it
+  // relays find/replace commands here; we run them against the live Monaco editor
+  // (`findController`) and push the match status back to the window.
+  useEffect(() => {
+    const off = window.api.find.onCommand((cmd) => {
+      const status = runFindCommand(cmd as Parameters<typeof runFindCommand>[0])
+      window.api.find.sendStatus(status)
     })
     return off
   }, [])

--- a/src/renderer/src/components/BluetoothInstrument.css
+++ b/src/renderer/src/components/BluetoothInstrument.css
@@ -73,6 +73,75 @@
   }
 }
 
+/* --- "Not ready" prompt: offer to run the BLE demo (#149) --- */
+.bscan__prompt {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 9px;
+  margin: auto;
+  max-width: 230px;
+  text-align: center;
+}
+
+.bscan__prompt-msg {
+  margin: 0;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: color-mix(in srgb, var(--accent) 78%, #cfd3d8);
+  text-shadow: 0 0 6px color-mix(in srgb, var(--accent) 35%, transparent);
+}
+
+.bscan__prompt-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.bscan__demo,
+.bscan__dismiss {
+  height: 26px;
+  padding: 0 11px;
+  border-radius: 6px;
+  font-family: inherit;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  cursor: pointer;
+}
+
+.bscan__demo {
+  color: #04120a;
+  background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 88%, #fff), var(--accent));
+  border: 1px solid var(--accent-border);
+}
+
+.bscan__demo:hover:not(:disabled) {
+  filter: brightness(1.06);
+}
+
+.bscan__dismiss {
+  color: color-mix(in srgb, var(--accent) 55%, #9aa0a8);
+  background: rgba(0, 0, 0, 0.4);
+  border: 1px solid #1c1f22;
+}
+
+.bscan__demo:disabled,
+.bscan__dismiss:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.bscan__prompt-hint {
+  margin: 0;
+  font-size: 9px;
+  line-height: 1.5;
+  color: #6b7079;
+}
+
+.bscan__prompt-hint code {
+  color: color-mix(in srgb, var(--accent) 60%, #9aa0a8);
+}
+
 /* --- The device list --- */
 .bscan__list {
   list-style: none;

--- a/src/renderer/src/components/BluetoothInstrument.tsx
+++ b/src/renderer/src/components/BluetoothInstrument.tsx
@@ -2,6 +2,10 @@ import { useCallback, useState, type CSSProperties } from 'react'
 import { InstrumentWindow, PhosphorScreen, type FloatProps } from './InstrumentWindow'
 import { type InstrumentDef } from './instruments-registry'
 import { useTelemetryStream } from './instrument-telemetry-subscribe'
+import { useSnakiePresence } from './snakie-presence'
+import { useDeviceStatus } from '../hooks/useDeviceStatus'
+import { useWorkspace } from '../store/workspace'
+import { BT_SCAN_DEMO, BT_SCAN_DEMO_NAME } from './bt-scan-demo'
 import {
   MAX_SIGNAL_BARS,
   addBt,
@@ -53,9 +57,19 @@ export function BluetoothInstrument({
   onToggleDock,
   float
 }: BluetoothInstrumentProps): JSX.Element {
+  const status = useDeviceStatus()
+  const connected = status.state === 'connected'
+  const { present } = useSnakiePresence()
+  const { openBuffer } = useWorkspace()
+
   const [devices, setDevices] = useState<BluetoothTelemetry[]>([])
   const [scanning, setScanning] = useState(false)
   const [scanned, setScanned] = useState(false)
+  // Shown when SCAN can't drive a scan — no board, or no Snakie program running
+  // to service the trigger (then we offer to run the BLE demo). #149.
+  const [prompt, setPrompt] = useState(false)
+  // True while opening + running the demo (disables the prompt buttons).
+  const [busy, setBusy] = useState(false)
 
   // One device per reading: accumulate (dedupe by MAC), and the first result
   // clears the scanning flag.
@@ -67,7 +81,15 @@ export function BluetoothInstrument({
     }, [])
   )
 
+  // Kick a scan only when a Snakie program is live to service the `scan:bt`
+  // trigger; otherwise surface a prompt offering to run the BLE demo (#149)
+  // rather than spinning on "scanning…" that never resolves.
   const scan = useCallback(async () => {
+    if (!connected || !present) {
+      setPrompt(true)
+      return
+    }
+    setPrompt(false)
     setDevices([]) // RESET on SCAN press — a fresh sweep.
     setScanning(true)
     setScanned(true)
@@ -76,7 +98,28 @@ export function BluetoothInstrument({
     } catch {
       setScanning(false)
     }
-  }, [])
+  }, [connected, present])
+
+  // Open the BLE demo in a new tab and run it: interrupt any running program,
+  // drop the demo in the editor, then paste-run it. Its `inst.start()` brings the
+  // background service up (→ READY → present) and the initial scan fills the list.
+  const runDemo = useCallback(async () => {
+    setBusy(true)
+    try {
+      await window.api.device.interrupt().catch(() => undefined)
+      openBuffer(BT_SCAN_DEMO_NAME, BT_SCAN_DEMO)
+      await new Promise((resolve) => setTimeout(resolve, 200))
+      await window.api.device.sendData(`\x05${BT_SCAN_DEMO}\x04`)
+      setPrompt(false)
+      setDevices([])
+      setScanning(true)
+      setScanned(true)
+    } catch {
+      setScanning(false)
+    } finally {
+      setBusy(false)
+    }
+  }, [openBuffer])
 
   const sorted = sortBtByStrength(devices)
   const nearest = nearestBt(devices)
@@ -96,7 +139,52 @@ export function BluetoothInstrument({
       >
         <PhosphorScreen className="instr__screen--accent">
           <div className="bscan__screen">
-            {sorted.length > 0 ? (
+            {prompt ? (
+              <div className="bscan__prompt">
+                {connected ? (
+                  <>
+                    <p className="bscan__prompt-msg">
+                      No Snakie program is running to service the scan.
+                    </p>
+                    <div className="bscan__prompt-actions">
+                      <button
+                        type="button"
+                        className="bscan__demo"
+                        onClick={() => void runDemo()}
+                        disabled={busy}
+                      >
+                        {busy ? 'STARTING…' : '▶ Run BLE demo'}
+                      </button>
+                      <button
+                        type="button"
+                        className="bscan__dismiss"
+                        onClick={() => setPrompt(false)}
+                        disabled={busy}
+                      >
+                        Dismiss
+                      </button>
+                    </div>
+                    <p className="bscan__prompt-hint">
+                      Opens a demo that scans on the 2nd core — or run your own program that calls{' '}
+                      <code>inst.start()</code>.
+                    </p>
+                  </>
+                ) : (
+                  <>
+                    <p className="bscan__prompt-msg">Connect a board to scan for BLE devices.</p>
+                    <div className="bscan__prompt-actions">
+                      <button
+                        type="button"
+                        className="bscan__dismiss"
+                        onClick={() => setPrompt(false)}
+                      >
+                        Dismiss
+                      </button>
+                    </div>
+                  </>
+                )}
+              </div>
+            ) : sorted.length > 0 ? (
               <ul className="bscan__list" aria-label="Bluetooth devices">
                 {sorted.map((d, i) => (
                   <BtRow key={`${d.mac}-${i}`} dev={d} />

--- a/src/renderer/src/components/BoardGraph.css
+++ b/src/renderer/src/components/BoardGraph.css
@@ -378,6 +378,23 @@
   font-weight: 700;
 }
 
+/* Bus group (#147): tag chip text + per-pin role labels. */
+.boardgraph__bus-tag {
+  font-family: var(--font-mono), 'JetBrains Mono', monospace;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  fill: #0c0e10;
+}
+
+.boardgraph__bus-role {
+  font-family: var(--font-mono), 'JetBrains Mono', monospace;
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  opacity: 0.9;
+}
+
 .boardgraph__svg-sub {
   font-family: var(--font-mono), 'JetBrains Mono', monospace;
   font-size: 9px;

--- a/src/renderer/src/components/BoardGraph.css
+++ b/src/renderer/src/components/BoardGraph.css
@@ -444,6 +444,22 @@
   color: #43c46a;
 }
 
+/* Right-column cards (#148) mirror the left ones: the dot/wire leave the card's
+   LEFT edge (toward the board), so the content is row-reversed — tag on the far
+   (right) edge, the value pushed to the inner (left) edge, label right-aligned. */
+.boardgraph__node--right .boardgraph__node-inner {
+  flex-direction: row-reverse;
+}
+
+.boardgraph__node--right .boardgraph__node-var {
+  text-align: right;
+}
+
+.boardgraph__node--right .boardgraph__node-val {
+  margin-left: 0;
+  margin-right: auto;
+}
+
 .boardgraph__node-dot {
   width: 7px;
   height: 7px;

--- a/src/renderer/src/components/BoardGraph.tsx
+++ b/src/renderer/src/components/BoardGraph.tsx
@@ -19,6 +19,7 @@ import {
   boardBox,
   layoutPads,
   ledPoint,
+  nodeSide,
   padForToken,
   padLabelPlacement,
   type BoardBox,
@@ -134,6 +135,15 @@ const CANVAS_W = BOARD_REGION_X + BOARD_REGION_W + 90 // canvas / SVG width (920
 const PAD_R = 7 // drawn pad radius
 const STAGE_PAD = 48 // vertical breathing room above/below the content
 
+// Right column (#148): connections whose pad sits on the board's RIGHT/BOTTOM
+// edge dock to the RIGHT of the board, MIRRORED — the solder dot sits on the
+// card's LEFT edge (toward the board) and the wire leaves leftward. Cards extend
+// rightward from RIGHT_NODE_LEFT. The canvas only widens to RIGHT_CANVAS_W when
+// such a row exists, so the common all-left layout stays byte-for-byte CANVAS_W.
+const RIGHT_DOT_X = BOARD_REGION_X + BOARD_REGION_W + 4 // right card's left-edge dot (just past the board area)
+const RIGHT_NODE_LEFT = RIGHT_DOT_X + 12 // right card left inset (extends rightward)
+const RIGHT_CANVAS_W = RIGHT_NODE_LEFT + NODE_W + 36 // canvas width WHEN right rows exist
+
 /** Centre Y of node row `i`. */
 function rowY(i: number): number {
   return FIRST_Y + i * PITCH
@@ -164,7 +174,9 @@ interface GraphRow {
   conn: UsedPins
   /** Source index (for live-value merge). */
   index: number
-  /** Node row centre Y. */
+  /** Which column the card docks in — `right` mirrors toward the board (#148). */
+  side: 'left' | 'right'
+  /** Node row centre Y (per-column slot). */
   y: number
   color: string
   /** The resolved real pad coordinate for the connection's FIRST pin. */
@@ -353,24 +365,27 @@ export function BoardGraph({
 
   // One row per connection: its node card + its FIRST pin's REAL pad coordinate
   // (which may be on any edge). A bus's remaining pins become faint extra pads.
-  const rows = useMemo<GraphRow[]>(
-    () =>
-      conns.map((conn, i) => {
-        const pad = padForToken(conn.pins[0] ?? '', def, pads, box)
-        const extraPads = conn.pins
-          .slice(1)
-          .map((tok) => padForToken(tok, def, pads, box))
-        return {
-          conn,
-          index: i,
-          y: rowY(i),
-          color: PIN_TYPE_COLOR[conn.type],
-          pad,
-          extraPads
-        }
-      }),
-    [conns, def, pads, box]
-  )
+  const rows = useMemo<GraphRow[]>(() => {
+    // Each column stacks independently from FIRST_Y; a connection docks right
+    // when its first pin's pad is on the board's right/bottom edge (#148).
+    let leftN = 0
+    let rightN = 0
+    return conns.map((conn, i) => {
+      const pad = padForToken(conn.pins[0] ?? '', def, pads, box)
+      const extraPads = conn.pins.slice(1).map((tok) => padForToken(tok, def, pads, box))
+      const side = nodeSide(pad.edge)
+      const slot = side === 'left' ? leftN++ : rightN++
+      return {
+        conn,
+        index: i,
+        side,
+        y: rowY(slot),
+        color: PIN_TYPE_COLOR[conn.type],
+        pad,
+        extraPads
+      }
+    })
+  }, [conns, def, pads, box])
 
   // The set of drawn pad coordinates that a connection resolves to → "used".
   const usedPadKeys = useMemo(() => {
@@ -387,9 +402,18 @@ export function BoardGraph({
   // edge labels + USB nub), so zoom-to-fit always frames the whole drawing.
   // Derived from geometry, NOT the connection count — so large N grows the node
   // column and the board stays put, and an empty board still has a sane size.
+  // The node column now splits into two; the TALLER column drives the extent so
+  // nothing clips (for the all-left case this equals the old single-column
+  // height, keeping that layout identical). #148.
+  const leftCount = rows.reduce((n, r) => (r.side === 'left' ? n + 1 : n), 0)
+  const rightCount = rows.length - leftCount
+  const colCount = Math.max(leftCount, rightCount)
+  const colBottom = colCount > 0 ? rowY(colCount - 1) + NODE_H / 2 : FIRST_Y
   const contentTop = Math.min(FIRST_Y - NODE_H / 2, box.y - 24)
-  const contentBottom = Math.max(nodeBottom, box.y + box.h + 28)
+  const contentBottom = Math.max(colBottom, box.y + box.h + 28)
   const stageH = Math.max(680, contentBottom - Math.min(0, contentTop) + STAGE_PAD)
+  // Widen the canvas only when a right column exists; otherwise stay at CANVAS_W.
+  const stageW = rightCount > 0 ? RIGHT_CANVAS_W : CANVAS_W
 
   const hasRows = rows.length > 0
 
@@ -424,9 +448,9 @@ export function BoardGraph({
   useEffect(() => {
     if (touchedRef.current) return
     if (!hasRows || vp.w === 0 || vp.h === 0) return
-    setView(fitTransform(CANVAS_W, stageH, vp.w, vp.h, rotation))
+    setView(fitTransform(stageW, stageH, vp.w, vp.h, rotation))
     setIsOneToOne(false)
-  }, [hasRows, vp.w, vp.h, stageH, rotation, def.id])
+  }, [hasRows, vp.w, vp.h, stageW, stageH, rotation, def.id])
 
   const onZoomIn = useCallback((): void => {
     touchedRef.current = true
@@ -443,22 +467,22 @@ export function BoardGraph({
   const onFit = useCallback((): void => {
     touchedRef.current = true
     if (vp.w === 0 || vp.h === 0) return
-    setView(fitTransform(CANVAS_W, stageH, vp.w, vp.h, rotation))
+    setView(fitTransform(stageW, stageH, vp.w, vp.h, rotation))
     setIsOneToOne(false)
-  }, [vp.w, vp.h, stageH, rotation])
+  }, [vp.w, vp.h, stageW, stageH, rotation])
 
   // 100% button: toggles between a centred 1:1 view and zoom-to-fit.
   const onToggleOneToOne = useCallback((): void => {
     touchedRef.current = true
     if (vp.w === 0 || vp.h === 0) return
     if (isOneToOne) {
-      setView(fitTransform(CANVAS_W, stageH, vp.w, vp.h, rotation))
+      setView(fitTransform(stageW, stageH, vp.w, vp.h, rotation))
       setIsOneToOne(false)
     } else {
-      setView(oneToOneTransform(CANVAS_W, stageH, vp.w, vp.h, rotation))
+      setView(oneToOneTransform(stageW, stageH, vp.w, vp.h, rotation))
       setIsOneToOne(true)
     }
-  }, [isOneToOne, vp.w, vp.h, stageH, rotation])
+  }, [isOneToOne, vp.w, vp.h, stageW, stageH, rotation])
 
   const onRotate = useCallback((): void => {
     touchedRef.current = true
@@ -466,10 +490,10 @@ export function BoardGraph({
     setRotation(next)
     // Re-fit for the new rotation so the rotated board stays fully framed.
     if (vp.w !== 0 && vp.h !== 0) {
-      setView(fitTransform(CANVAS_W, stageH, vp.w, vp.h, next))
+      setView(fitTransform(stageW, stageH, vp.w, vp.h, next))
       setIsOneToOne(false)
     }
-  }, [rotation, vp.w, vp.h, stageH])
+  }, [rotation, vp.w, vp.h, stageW, stageH])
 
   // Wheel-zoom (inside the fixed viewport) — a nice-to-have on top of the buttons.
   const onWheel = useCallback((e: React.WheelEvent): void => {
@@ -510,8 +534,8 @@ export function BoardGraph({
   // A <select> picks the format; the button triggers a download in that format.
   const [exportFmt, setExportFmt] = useState<ExportFmt>('svg')
   const onExport = useCallback((): void => {
-    void exportView(exportFmt, { rows, def, box, pads, usedPadKeys, ledLit, stageH, rotation })
-  }, [exportFmt, rows, def, box, pads, usedPadKeys, ledLit, stageH, rotation])
+    void exportView(exportFmt, { rows, def, box, pads, usedPadKeys, ledLit, stageW, stageH, rotation })
+  }, [exportFmt, rows, def, box, pads, usedPadKeys, ledLit, stageW, stageH, rotation])
 
   return (
     <div className={`boardgraph ${asWindow ? 'boardgraph--window' : ''}`} aria-label="Board View">
@@ -655,7 +679,7 @@ export function BoardGraph({
             <div
               className="boardgraph__stage"
               style={{
-                width: CANVAS_W,
+                width: stageW,
                 height: stageH,
                 transform: `translate(${view.panX}px, ${view.panY}px) scale(${view.zoom}) rotate(${rotation}deg)`,
                 transformOrigin: '0 0'
@@ -664,9 +688,9 @@ export function BoardGraph({
               <svg
                 className="boardgraph__svg"
                 xmlns="http://www.w3.org/2000/svg"
-                width={CANVAS_W}
+                width={stageW}
                 height={stageH}
-                viewBox={`0 0 ${CANVAS_W} ${stageH}`}
+                viewBox={`0 0 ${stageW} ${stageH}`}
                 role="img"
                 aria-label={`${def.name}: ${rows.length} pin connection${
                   rows.length === 1 ? '' : 's'
@@ -691,7 +715,7 @@ export function BoardGraph({
                     r.extraPads.map((p, j) => (
                       <path
                         key={`bus-${i}-${j}`}
-                        d={noodlePath(NODE_DOT_X, r.y, p)}
+                        d={wirePathFor(r.side, r.y, p)}
                         stroke={r.color}
                         strokeWidth="1.4"
                         strokeDasharray="3 4"
@@ -705,7 +729,7 @@ export function BoardGraph({
                   {rows.map((r, i) => (
                     <path
                       key={`wire-${i}`}
-                      d={noodlePath(NODE_DOT_X, r.y, r.pad)}
+                      d={wirePathFor(r.side, r.y, r.pad)}
                       stroke={r.color}
                       strokeWidth="2.6"
                     />
@@ -714,7 +738,7 @@ export function BoardGraph({
                 {/* Node-side solder dots. */}
                 <g>
                   {rows.map((r, i) => (
-                    <circle key={`dot-${i}`} cx={NODE_DOT_X} cy={r.y} r="4.5" fill={r.color} />
+                    <circle key={`dot-${i}`} cx={dotXFor(r.side)} cy={r.y} r="4.5" fill={r.color} />
                   ))}
                 </g>
               </svg>
@@ -905,6 +929,46 @@ function noodlePath(sx: number, sy: number, pad: PadPoint): string {
       break
   }
   return `M${sx} ${sy} C ${c1x} ${c1y} ${c2x} ${c2y} ${pad.x} ${pad.y}`
+}
+
+/**
+ * Mirror of {@link noodlePath} for a RIGHT-column node (#148): the solder dot
+ * `(sx, sy)` sits to the RIGHT of the board, so the wire leaves horizontally to
+ * the LEFT and docks into the pad's edge. Right-column cards only target right-
+ * or bottom-edge pads.
+ */
+function noodlePathRight(sx: number, sy: number, pad: PadPoint): string {
+  const dx = pad.x - sx // negative: the pad is to the LEFT of the dot
+  const c1x = sx + Math.min(-54, dx * 0.45)
+  const c1y = sy + SAG
+  let c2x: number
+  let c2y: number
+  switch (pad.edge) {
+    case 'bottom':
+      c2x = pad.x
+      c2y = pad.y + 56
+      break
+    case 'top':
+      c2x = pad.x
+      c2y = pad.y - 56
+      break
+    default:
+      // right (and any fallback): approach from just outside the right edge.
+      c2x = pad.x + Math.max(54, -dx * 0.45)
+      c2y = pad.y + SAG
+      break
+  }
+  return `M${sx} ${sy} C ${c1x} ${c1y} ${c2x} ${c2y} ${pad.x} ${pad.y}`
+}
+
+/** The node's solder-dot X (wire start) for its column (#148). */
+function dotXFor(side: 'left' | 'right'): number {
+  return side === 'right' ? RIGHT_DOT_X : NODE_DOT_X
+}
+
+/** The drooping wire from a node's dot to `pad`, routed for the node's column. */
+function wirePathFor(side: 'left' | 'right', sy: number, pad: PadPoint): string {
+  return side === 'right' ? noodlePathRight(RIGHT_DOT_X, sy, pad) : noodlePath(NODE_DOT_X, sy, pad)
 }
 
 /**
@@ -1184,11 +1248,14 @@ function NodeCard({
   // Counter-rotate the card's TEXT so it's never upside-down: at 180°/270° the
   // inner content flips 180° back to an upright (0°/90° net) reading.
   const { counter } = labelCounterRotation(rotation)
+  // Right-column cards dock to the RIGHT of the board and mirror their content
+  // (dot/wire on their LEFT edge, toward the board) via the `--right` modifier.
+  const right = row.side === 'right'
   return (
     <div
-      className="boardgraph__node"
+      className={`boardgraph__node${right ? ' boardgraph__node--right' : ''}`}
       style={{
-        left: NODE_LEFT,
+        left: right ? RIGHT_NODE_LEFT : NODE_LEFT,
         top: row.y - NODE_H / 2,
         width: NODE_W,
         height: NODE_H,
@@ -1346,6 +1413,7 @@ interface ExportArgs {
   pads: PadPoint[]
   usedPadKeys: Set<string>
   ledLit: boolean
+  stageW: number
   stageH: number
   rotation: 0 | 90 | 180 | 270
 }
@@ -1363,8 +1431,8 @@ interface ExportArgs {
  * drawing: the full pinout from `pads`, used pads highlighted, plus the wires.
  */
 export function buildExportSvg(args: ExportArgs): string {
-  const { rows, def, box, pads, usedPadKeys, ledLit, stageH, rotation } = args
-  const W = CANVAS_W
+  const { rows, def, box, pads, usedPadKeys, ledLit, stageW, stageH, rotation } = args
+  const W = stageW
   const H = stageH
   // Rotated canvas dimensions (90/270 swap W/H).
   const swap = rotation === 90 || rotation === 270
@@ -1386,18 +1454,18 @@ export function buildExportSvg(args: ExportArgs): string {
     .flatMap((r) =>
       r.extraPads.map(
         (p) =>
-          `<path d="${noodlePath(NODE_DOT_X, r.y, p)}" stroke="${r.color}" stroke-width="1.4" stroke-dasharray="3 4" fill="none" opacity="0.5"/>`
+          `<path d="${wirePathFor(r.side, r.y, p)}" stroke="${r.color}" stroke-width="1.4" stroke-dasharray="3 4" fill="none" opacity="0.5"/>`
       )
     )
     .join('')
   const wires = rows
     .map(
       (r) =>
-        `<path d="${noodlePath(NODE_DOT_X, r.y, r.pad)}" stroke="${r.color}" stroke-width="2.6" fill="none"/>`
+        `<path d="${wirePathFor(r.side, r.y, r.pad)}" stroke="${r.color}" stroke-width="2.6" fill="none"/>`
     )
     .join('')
   const dots = rows
-    .map((r) => `<circle cx="${NODE_DOT_X}" cy="${r.y}" r="4.5" fill="${r.color}"/>`)
+    .map((r) => `<circle cx="${dotXFor(r.side)}" cy="${r.y}" r="4.5" fill="${r.color}"/>`)
     .join('')
 
   // Board pieces (mirrors <Board/> but as a string): PCB, USB, features, LED,
@@ -1462,14 +1530,20 @@ export function buildExportSvg(args: ExportArgs): string {
       const tag = PIN_TYPE_TAG[r.conn.type]
       const label = esc(r.conn.variable || r.conn.constructor)
       const val = r.conn.type === 'input' || r.conn.type === 'output' ? '1' : '—'
+      // Right-column cards mirror: row-reversed, value pushed to the OUTER edge,
+      // label right-aligned — matching the live `.boardgraph__node--right` (#148).
+      const right = r.side === 'right'
+      const dir = right ? 'row-reverse' : 'row'
+      const valMargin = right ? 'margin-right:auto' : 'margin-left:auto'
+      const varAlign = right ? 'text-align:right;' : ''
       const inner =
-        `<div style="display:flex;align-items:center;gap:9px;width:100%;height:100%;box-sizing:border-box;padding:0 12px;transform:rotate(${counter}deg)">` +
+        `<div style="display:flex;flex-direction:${dir};align-items:center;gap:9px;width:100%;height:100%;box-sizing:border-box;padding:0 12px;transform:rotate(${counter}deg)">` +
         `<span style="font-size:9.5px;font-weight:700;color:#0e2233;border-radius:4px;padding:2px 6px;background:${c}">${esc(tag)}</span>` +
-        `<span style="font-size:12.5px;color:#d6dade;overflow:hidden;white-space:nowrap;text-overflow:ellipsis">${label}</span>` +
-        `<span style="margin-left:auto;display:flex;align-items:center;gap:6px;font-size:11px;font-weight:600;color:#6a7079"><span style="width:7px;height:7px;border-radius:50%;background:#3a3f47"></span>${val}</span>` +
+        `<span style="font-size:12.5px;color:#d6dade;overflow:hidden;white-space:nowrap;text-overflow:ellipsis;${varAlign}">${label}</span>` +
+        `<span style="${valMargin};display:flex;align-items:center;gap:6px;font-size:11px;font-weight:600;color:#6a7079"><span style="width:7px;height:7px;border-radius:50%;background:#3a3f47"></span>${val}</span>` +
         `</div>`
       return (
-        `<foreignObject x="${NODE_LEFT}" y="${r.y - NODE_H / 2}" width="${NODE_W}" height="${NODE_H}">` +
+        `<foreignObject x="${right ? RIGHT_NODE_LEFT : NODE_LEFT}" y="${r.y - NODE_H / 2}" width="${NODE_W}" height="${NODE_H}">` +
         `<div xmlns="http://www.w3.org/1999/xhtml" style="box-sizing:border-box;width:${NODE_W}px;height:${NODE_H}px;border-radius:9px;background:#1e2127;border:1px solid ${c};font-family:monospace">${inner}</div>` +
         `</foreignObject>`
       )
@@ -1613,11 +1687,11 @@ function buildImagePdf(jpeg: Uint8Array, outW: number, outH: number): Blob {
 
 /** Export the current board view in `fmt`, triggering a download. */
 async function exportView(fmt: ExportFmt, args: ExportArgs): Promise<void> {
-  const { stageH, rotation } = args
+  const { stageW, stageH, rotation } = args
   const svg = buildExportSvg(args)
   const swap = rotation === 90 || rotation === 270
-  const outW = swap ? stageH : CANVAS_W
-  const outH = swap ? CANVAS_W : stageH
+  const outW = swap ? stageH : stageW
+  const outH = swap ? stageW : stageH
   try {
     if (fmt === 'svg') {
       downloadBlob(new Blob([svg], { type: 'image/svg+xml;charset=utf-8' }), 'board-view.svg')

--- a/src/renderer/src/components/BoardGraph.tsx
+++ b/src/renderer/src/components/BoardGraph.tsx
@@ -17,11 +17,13 @@ import {
 } from './board-defs'
 import {
   boardBox,
+  busLabel,
   layoutPads,
   ledPoint,
   nodeSide,
   padForToken,
   padLabelPlacement,
+  padsBounds,
   type BoardBox,
   type PadPoint
 } from './board-layout'
@@ -709,6 +711,13 @@ export function BoardGraph({
                   rotation={rotation}
                 />
 
+                {/* Bus groups (#147): outline + bus tag + per-pin roles. */}
+                <g className="boardgraph__bus">
+                  {rows.map((r, i) => (
+                    <BusGroup key={`busg-${i}`} row={r} />
+                  ))}
+                </g>
+
                 {/* Faint bus links (a multi-pin connection's other pins). */}
                 <g fill="none" strokeLinecap="round" opacity="0.5">
                   {rows.flatMap((r, i) =>
@@ -1227,6 +1236,65 @@ function Feature({
   )
 }
 
+/**
+ * Bus group (#147): frame an i2c/spi connection's pads with a dashed rounded
+ * rect in the bus colour, tag it with the bus label (I2C0…), and label each pad
+ * with its role (SDA/SCL) above the silk label. Nothing for non-bus / single-pad
+ * connections. Kept in parity with the SVG export (`busGroupSvg`).
+ */
+function BusGroup({ row }: { row: GraphRow }): JSX.Element | null {
+  const { conn, color } = row
+  if (conn.type !== 'i2c' && conn.type !== 'spi') return null
+  const groupPads = [row.pad, ...row.extraPads]
+  const bounds = padsBounds(groupPads, 12)
+  if (!bounds) return null
+  const tag = busLabel(conn.type, conn.bus)
+  const tagW = 12 + tag.length * 7
+  return (
+    <g aria-hidden="true">
+      <rect
+        x={bounds.x}
+        y={bounds.y}
+        width={bounds.w}
+        height={bounds.h}
+        rx="9"
+        fill={color}
+        fillOpacity="0.07"
+        stroke={color}
+        strokeWidth="1.4"
+        strokeDasharray="4 3"
+        opacity="0.85"
+      />
+      <rect x={bounds.x + 6} y={bounds.y - 9} width={tagW} height="16" rx="5" fill={color} />
+      <text
+        x={bounds.x + 6 + tagW / 2}
+        y={bounds.y + 2}
+        className="boardgraph__bus-tag"
+        textAnchor="middle"
+      >
+        {tag}
+      </text>
+      {groupPads.map((p, i) => {
+        const role = conn.roles?.[i]
+        if (!role) return null
+        const place = padLabelPlacement(p.edge)
+        return (
+          <text
+            key={`role-${i}`}
+            x={p.x + place.dx}
+            y={p.y + place.dy - 9}
+            className="boardgraph__bus-role"
+            textAnchor={place.anchor}
+            style={{ fill: color }}
+          >
+            {role}
+          </text>
+        )
+      })}
+    </g>
+  )
+}
+
 /** One node card: type tag inline beside the variable + its value readout. */
 function NodeCard({
   row,
@@ -1268,6 +1336,7 @@ function NodeCard({
       >
         <span className="boardgraph__node-tag" style={{ background: color }}>
           {PIN_TYPE_TAG[conn.type]}
+          {(conn.type === 'i2c' || conn.type === 'spi') && conn.bus !== undefined ? conn.bus : ''}
         </span>
         <span className="boardgraph__node-var">{conn.variable || conn.constructor}</span>
         {conn.instrument && (
@@ -1468,6 +1537,39 @@ export function buildExportSvg(args: ExportArgs): string {
     .map((r) => `<circle cx="${dotXFor(r.side)}" cy="${r.y}" r="4.5" fill="${r.color}"/>`)
     .join('')
 
+  // Bus groups (#147): outline + bus tag + per-pin roles — mirrors <BusGroup/>.
+  const busGroups = rows
+    .map((r) => {
+      if (r.conn.type !== 'i2c' && r.conn.type !== 'spi') return ''
+      const groupPads = [r.pad, ...r.extraPads]
+      const bounds = padsBounds(groupPads, 12)
+      if (!bounds) return ''
+      const tag = busLabel(r.conn.type, r.conn.bus)
+      const tagW = 12 + tag.length * 7
+      const tagX = bounds.x + 6
+      const tagCx = tagX + tagW / 2
+      const tagTextY = bounds.y + 2
+      const roleTexts = groupPads
+        .map((p, i) => {
+          const role = r.conn.roles?.[i]
+          if (!role) return ''
+          const place = padLabelPlacement(p.edge)
+          const rx = p.x + place.dx
+          const ry = p.y + place.dy - 9
+          return `<text x="${rx}" y="${ry}" text-anchor="${place.anchor}" font-family="monospace" font-size="8" font-weight="700" fill="${r.color}"${lt(rx, ry)}>${esc(role)}</text>`
+        })
+        .join('')
+      return (
+        `<g>` +
+        `<rect x="${bounds.x}" y="${bounds.y}" width="${bounds.w}" height="${bounds.h}" rx="9" fill="${r.color}" fill-opacity="0.07" stroke="${r.color}" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.85"/>` +
+        `<rect x="${tagX}" y="${bounds.y - 9}" width="${tagW}" height="16" rx="5" fill="${r.color}"/>` +
+        `<text x="${tagCx}" y="${tagTextY}" text-anchor="middle" font-family="monospace" font-size="9" font-weight="700" fill="#0c0e10"${lt(tagCx, tagTextY)}>${esc(tag)}</text>` +
+        roleTexts +
+        `</g>`
+      )
+    })
+    .join('')
+
   // Board pieces (mirrors <Board/> but as a string): PCB, USB, features, LED,
   // then EVERY pad of the physical pinout at its real edge position.
   const cx = box.x + box.w / 2
@@ -1527,7 +1629,11 @@ export function buildExportSvg(args: ExportArgs): string {
   const nodes = rows
     .map((r) => {
       const c = r.color
-      const tag = PIN_TYPE_TAG[r.conn.type]
+      const tag =
+        PIN_TYPE_TAG[r.conn.type] +
+        ((r.conn.type === 'i2c' || r.conn.type === 'spi') && r.conn.bus !== undefined
+          ? String(r.conn.bus)
+          : '')
       const label = esc(r.conn.variable || r.conn.constructor)
       const val = r.conn.type === 'input' || r.conn.type === 'output' ? '1' : '—'
       // Right-column cards mirror: row-reversed, value pushed to the OUTER edge,
@@ -1563,6 +1669,7 @@ export function buildExportSvg(args: ExportArgs): string {
     `<rect x="0" y="0" width="${outW}" height="${outH}" fill="#161719"/>` +
     `<g${groupTransform ? ` transform="${groupTransform}"` : ''}>` +
     `<g>${board}</g>` +
+    `<g>${busGroups}</g>` +
     `<g fill="none" stroke-linecap="round">${buses}</g>` +
     `<g fill="none" stroke-linecap="round" opacity="0.92">${wires}</g>` +
     `<g>${dots}</g>` +

--- a/src/renderer/src/components/BoardView.css
+++ b/src/renderer/src/components/BoardView.css
@@ -320,6 +320,23 @@
   fill: #c8ccd3;
 }
 
+/* Bus group (#147): tag chip text + per-pin role labels. */
+.boardview__bus-tag {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  fill: #0c0e10;
+}
+
+.boardview__bus-role {
+  font-family: var(--font-mono);
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  opacity: 0.9;
+}
+
 .boardview__empty {
   max-width: 28rem;
   padding: 2rem;

--- a/src/renderer/src/components/BoardView.tsx
+++ b/src/renderer/src/components/BoardView.tsx
@@ -17,10 +17,12 @@ import {
 } from './board-defs'
 import {
   boardBox,
+  busLabel,
   layoutPads,
   ledPoint,
   padForToken,
   padLabelPlacement,
+  padsBounds,
   type BoardBox,
   type PadPoint
 } from './board-layout'
@@ -300,7 +302,12 @@ export function BoardView({
           >
             <BoardOutline def={def} box={box} pads={pads} usedPads={usedPads} ledLit={ledLit} />
 
-            {/* Wires first (under the badges). */}
+            {/* Bus groups (#147): outline + bus tag + per-pin roles, under wires. */}
+            {wires.map((w, i) => (
+              <BusGroup key={`bus-${i}`} wire={w} />
+            ))}
+
+            {/* Wires (under the badges). */}
             {wires.map((w, i) =>
               w.pads.map((pad, j) => (
                 <path
@@ -317,6 +324,7 @@ export function BoardView({
               <TypeNode
                 key={`node-${i}`}
                 type={w.conn.type}
+                bus={w.conn.bus}
                 variable={w.conn.variable}
                 x={w.px}
                 y={w.py}
@@ -567,12 +575,15 @@ function Feature({ feature, box }: { feature: BoardFeature; box: BoardBox }): JS
 /** A connection-type badge: a coloured rounded rect + UPPERCASE type + variable. */
 function TypeNode({
   type,
+  bus,
   variable,
   x,
   y,
   color
 }: {
   type: PinType
+  /** Hardware bus number for i2c/spi — appended to the label (I2C0, SPI1). */
+  bus?: number
   variable: string
   x: number
   y: number
@@ -580,6 +591,8 @@ function TypeNode({
 }): JSX.Element {
   const w = 96
   const h = 38
+  // i2c/spi show the bus number (I2C0/I2C1); everything else its plain type.
+  const label = type === 'i2c' || type === 'spi' ? busLabel(type, bus) : PIN_TYPE_LABEL[type]
   return (
     <g>
       <rect
@@ -594,13 +607,74 @@ function TypeNode({
       />
       <rect x={x - w / 2} y={y - h / 2} width={w} height="9" rx="8" fill={color} opacity="0.9" />
       <text x={x} y={y + 1} className="boardview__node-type" textAnchor="middle" style={{ fill: color }}>
-        {PIN_TYPE_LABEL[type]}
+        {label}
       </text>
       {variable && (
         <text x={x} y={y + 14} className="boardview__node-var" textAnchor="middle">
           {variable}
         </text>
       )}
+    </g>
+  )
+}
+
+/**
+ * Bus group (#147): for an i2c/spi connection with ≥2 pads, frame the bus's pads
+ * with a dashed rounded rect in the bus colour, tag it with the bus label
+ * (I2C0…), and label each pad with its role (SDA/SCL) just OUTSIDE the board,
+ * stacked above the silk GPIO label — so the pair reads as one bus. Non-bus (or
+ * single-pad) connections draw nothing.
+ */
+function BusGroup({ wire }: { wire: DrawnWire }): JSX.Element | null {
+  const { conn, color, pads } = wire
+  if ((conn.type !== 'i2c' && conn.type !== 'spi') || pads.length < 2) return null
+  const bounds = padsBounds(pads, 13)
+  if (!bounds) return null
+  const tag = busLabel(conn.type, conn.bus)
+  const tagW = 13 + tag.length * 7
+  return (
+    <g className="boardview__bus" aria-hidden="true">
+      <rect
+        x={bounds.x}
+        y={bounds.y}
+        width={bounds.w}
+        height={bounds.h}
+        rx="9"
+        fill={color}
+        fillOpacity="0.06"
+        stroke={color}
+        strokeWidth="1.5"
+        strokeDasharray="4 3"
+        opacity="0.85"
+      />
+      {/* Bus tag, pinned to the group's top-left with a solid chip for contrast. */}
+      <rect x={bounds.x + 6} y={bounds.y - 9} width={tagW} height="16" rx="5" fill={color} />
+      <text
+        x={bounds.x + 6 + tagW / 2}
+        y={bounds.y + 2}
+        className="boardview__bus-tag"
+        textAnchor="middle"
+      >
+        {tag}
+      </text>
+      {/* Per-pin role labels (SDA/SCL …), stacked above each pad's silk label. */}
+      {pads.map((pad, i) => {
+        const role = conn.roles?.[i]
+        if (!role) return null
+        const place = padLabelPlacement(pad.edge, 13)
+        return (
+          <text
+            key={`role-${i}`}
+            x={pad.x + place.dx}
+            y={pad.y + place.dy - 9}
+            className="boardview__bus-role"
+            textAnchor={place.anchor}
+            style={{ fill: color }}
+          >
+            {role}
+          </text>
+        )
+      })}
     </g>
   )
 }

--- a/src/renderer/src/components/EditorArea.tsx
+++ b/src/renderer/src/components/EditorArea.tsx
@@ -1,9 +1,7 @@
-import { lazy, Suspense, useCallback, useEffect, useState } from 'react'
+import { lazy, Suspense, useCallback, useEffect } from 'react'
 import { EditorTabs } from './EditorTabs'
-import { FindReplace } from './FindReplace'
-import { getActiveEditor, FIND_EVENT, type FindEventDetail } from './editorBridge'
+import { FIND_EVENT } from './editorBridge'
 import { useWorkspace } from '../store/workspace'
-import './FindReplace.css'
 
 // Code-split Monaco: the editor (multi-MB chunk) is only loaded once a file is
 // open, keeping it out of the initial renderer bundle. Until then EditorArea
@@ -14,8 +12,9 @@ const MonacoEditor = lazy(() => import('./MonacoEditor'))
  * CENTER — editor region.
  *
  * Hosts the Monaco-backed code editor bound to the workspace's active file
- * (issue #3), with the tabbed strip for open files mounted above it (issue #4)
- * and a custom Find & Replace bar (issue #92) over the editor.
+ * (issue #3), with the tabbed strip for open files mounted above it (issue #4).
+ * Find & Replace opens in its own native window (issue #146) — the "Find" button
+ * in the tab header and Cmd/Ctrl-F / Cmd/Ctrl-H both just open that window.
  *
  * Monaco is loaded lazily (issue #48): when no file is open we show a small
  * placeholder and never fetch the editor chunk; opening a file triggers the
@@ -25,55 +24,33 @@ export function EditorArea(): JSX.Element {
   const { openFiles } = useWorkspace()
   const hasFiles = openFiles.length > 0
 
-  // Find & Replace panel state (issue #92). `withReplace` distinguishes the
-  // Cmd/Ctrl-F (find-only) and Cmd/Ctrl-H (find + replace) entry points.
-  const [findOpen, setFindOpen] = useState(false)
-  const [findWithReplace, setFindWithReplace] = useState(false)
-
-  const openFind = useCallback((withReplace: boolean): void => {
-    setFindWithReplace(withReplace)
-    setFindOpen(true)
-  }, [])
-
-  const closeFind = useCallback((): void => {
-    setFindOpen(false)
-    getActiveEditor()?.focus()
-  }, [])
-
-  // Close the panel automatically once every file is closed (nothing to search).
-  useEffect(() => {
-    if (!hasFiles) setFindOpen(false)
+  // Open the Find & Replace window. The window itself drives the editor over IPC
+  // (issue #146); we only need to open/focus it.
+  const openFind = useCallback((): void => {
+    if (!hasFiles) return
+    void window.api.find.open()
   }, [hasFiles])
 
-  // Open the panel when the editor fires the find shortcut (Cmd/Ctrl-F or -H).
-  // The editor rebinds those keys to FIND_EVENT (overriding Monaco's own find
+  // Open the window when the editor fires the find shortcut (Cmd/Ctrl-F or -H).
+  // MonacoEditor rebinds those keys to FIND_EVENT (overriding Monaco's own find
   // widget), so this is the primary open path when focus is in the editor.
   useEffect(() => {
-    const handler = (e: Event): void => {
-      if (!hasFiles) return
-      openFind((e as CustomEvent<FindEventDetail>).detail.withReplace)
-    }
+    const handler = (): void => openFind()
     window.addEventListener(FIND_EVENT, handler)
     return () => window.removeEventListener(FIND_EVENT, handler)
-  }, [hasFiles, openFind])
+  }, [openFind])
 
-  // Cmd/Ctrl-F opens Find, Cmd/Ctrl-H opens Find + Replace. Handled in the
-  // capture phase so this fires before Monaco's built-in find widget, and the
-  // default is suppressed so OUR panel is the one that opens. Only active when a
-  // file is open.
+  // Cmd/Ctrl-F / Cmd/Ctrl-H also open the window when focus is outside Monaco
+  // (e.g. in the tab strip). Captured so the default is suppressed first.
   const onKeyDownCapture = useCallback(
     (e: React.KeyboardEvent): void => {
       if (!hasFiles) return
       if (!(e.metaKey || e.ctrlKey) || e.altKey) return
       const key = e.key.toLowerCase()
-      if (key === 'f') {
+      if (key === 'f' || key === 'h') {
         e.preventDefault()
         e.stopPropagation()
-        openFind(false)
-      } else if (key === 'h') {
-        e.preventDefault()
-        e.stopPropagation()
-        openFind(true)
+        openFind()
       }
     },
     [hasFiles, openFind]
@@ -92,8 +69,7 @@ export function EditorArea(): JSX.Element {
             <button
               type="button"
               className="btn btn--sm btn--ghost"
-              onClick={() => (findOpen ? closeFind() : openFind(findWithReplace))}
-              aria-pressed={findOpen}
+              onClick={openFind}
               title="Find & Replace (Ctrl/Cmd-F, Ctrl/Cmd-H)"
             >
               Find
@@ -101,9 +77,6 @@ export function EditorArea(): JSX.Element {
           </div>
         )}
       </div>
-      {hasFiles && (
-        <FindReplace open={findOpen} withReplace={findWithReplace} onClose={closeFind} />
-      )}
       <div className="region__body region__body--editor">
         {hasFiles ? (
           <Suspense fallback={<EditorPlaceholder text="Loading editor…" />}>

--- a/src/renderer/src/components/EditorArea.tsx
+++ b/src/renderer/src/components/EditorArea.tsx
@@ -85,20 +85,22 @@ export function EditorArea(): JSX.Element {
       aria-label="Editor"
       onKeyDownCapture={onKeyDownCapture}
     >
-      <EditorTabs />
-      {hasFiles && (
-        <div className="region__editor-toolbar">
-          <button
-            type="button"
-            className="btn btn--sm btn--ghost"
-            onClick={() => (findOpen ? closeFind() : openFind(findWithReplace))}
-            aria-pressed={findOpen}
-            title="Find & Replace (Ctrl/Cmd-F, Ctrl/Cmd-H)"
-          >
-            Find
-          </button>
-        </div>
-      )}
+      <div className="editor-header">
+        <EditorTabs />
+        {hasFiles && (
+          <div className="editor-header__actions">
+            <button
+              type="button"
+              className="btn btn--sm btn--ghost"
+              onClick={() => (findOpen ? closeFind() : openFind(findWithReplace))}
+              aria-pressed={findOpen}
+              title="Find & Replace (Ctrl/Cmd-F, Ctrl/Cmd-H)"
+            >
+              Find
+            </button>
+          </div>
+        )}
+      </div>
       {hasFiles && (
         <FindReplace open={findOpen} withReplace={findWithReplace} onClose={closeFind} />
       )}

--- a/src/renderer/src/components/EditorTabs.css
+++ b/src/renderer/src/components/EditorTabs.css
@@ -1,10 +1,30 @@
+/* Header row: the tab strip shares one line with the right-aligned editor
+   actions (e.g. the Find button, issue #137). The tabs grow and scroll; the
+   actions stay pinned to the right. The bottom border lives here so it spans
+   the whole row, not just the tabs. */
+.editor-header {
+  display: flex;
+  align-items: stretch;
+  background: var(--bg-sunken);
+  border-bottom: 1px solid var(--border);
+}
+
+.editor-header__actions {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 8px;
+}
+
 .editor-tabs {
+  flex: 1 1 auto;
+  min-width: 0;
   display: flex;
   align-items: stretch;
   gap: 1px;
   min-height: 34px;
   background: var(--bg-sunken);
-  border-bottom: 1px solid var(--border);
   overflow-x: auto;
   overflow-y: hidden;
   scrollbar-width: thin;

--- a/src/renderer/src/components/EditorTabs.css
+++ b/src/renderer/src/components/EditorTabs.css
@@ -17,6 +17,24 @@
   padding: 0 8px;
 }
 
+/* The Find button reads as part of the tab bar (issue #137): no pill
+   background, border or shadow of its own — it shows the shared header surface
+   behind it. Theme-specific colours live in index.css. */
+.editor-header__actions .btn {
+  background: transparent;
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.editor-header__actions .btn:hover {
+  border-color: var(--accent);
+}
+
+.editor-header__actions .btn[aria-pressed='true'] {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
 .editor-tabs {
   flex: 1 1 auto;
   min-width: 0;
@@ -24,7 +42,9 @@
   align-items: stretch;
   gap: 1px;
   min-height: 34px;
-  background: var(--bg-sunken);
+  /* Transparent so the whole row shows the single `.editor-header` surface —
+     the tab strip and the Find button then share the same background. */
+  background: transparent;
   overflow-x: auto;
   overflow-y: hidden;
   scrollbar-width: thin;

--- a/src/renderer/src/components/FindReplace.css
+++ b/src/renderer/src/components/FindReplace.css
@@ -1,38 +1,25 @@
 /*
- * Find & Replace dialog (FindReplace.tsx, issue #92 + skeuomorph polish).
+ * Find & Replace window (FindReplace.tsx, issue #92 + skeuomorph polish).
  *
- * A floating, draggable panel docked top-right over the editor. It is
- * non-blocking — the editor stays interactive underneath. The base look uses
+ * Since issue #146 this is its OWN frameless OS window (`find.html`), so the
+ * panel FILLS the window instead of docking over the editor. The base look uses
  * the shared design tokens (so it reads on the dark theme); the
  * `:root[data-theme='skeuomorph']` block layers on the brushed-aluminium frame,
  * metal keys and gold Replace-all key from the handoff.
+ *
+ * The Find affordance that opens this window lives in the editor tab header —
+ * see `.editor-header__actions` in EditorTabs.css (issue #137).
  */
 
-/* The editor section is the positioning context for the floating panel. The
-   base `.region` is overflow:hidden, so the panel stays docked just inside the
-   top-right corner. */
-.region--editor {
-  position: relative;
-}
-
-/* The Find affordance (a visible way to open this panel without the keyboard
-   shortcut) lives in the editor tab header — see `.editor-header__actions` in
-   EditorTabs.css (issue #137). */
-
 .find-replace {
-  position: absolute;
-  top: 8px;
-  right: 12px;
-  z-index: 20;
-  width: 380px;
-  max-width: calc(100% - 24px);
   display: flex;
   flex-direction: column;
+  width: 100vw;
+  height: 100vh;
   color: var(--text);
   background: var(--bg-elevated);
-  border: var(--border-w) solid var(--border);
-  border-radius: 9px;
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
+  /* No fixed width / clip any more (#146): the window sizes the panel, so every
+     button — including the gold "Replace all" — is fully visible. */
   overflow: hidden;
 }
 
@@ -45,18 +32,15 @@
   padding: 5px 8px;
   background: var(--bg-sunken);
   border-bottom: var(--border-w) solid var(--border);
-  cursor: grab;
-  touch-action: none;
   user-select: none;
+  /* The title bar is the native window drag region (frameless window, #146). */
+  -webkit-app-region: drag;
 }
 
-.find-replace__titlebar:active {
-  cursor: grabbing;
-}
-
-/* The close button stays a normal pointer (and its own click still fires). */
+/* The close button stays clickable (and its own click still fires). */
 .find-replace__titlebar .find-replace__close {
   cursor: pointer;
+  -webkit-app-region: no-drag;
 }
 
 .find-replace__grip {
@@ -167,7 +151,6 @@
 
 .find-replace__key,
 .find-replace__arrow,
-.find-replace__expand,
 .find-replace__btn {
   font-family: var(--font-mono);
   color: var(--text);
@@ -178,8 +161,7 @@
 }
 
 .find-replace__key,
-.find-replace__arrow,
-.find-replace__expand {
+.find-replace__arrow {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -187,18 +169,6 @@
   height: 26px;
   padding: 0 5px;
   font-size: 0.75rem;
-}
-
-/* The Replace-row reveal chevron sits at the very left of the find row. */
-.find-replace__expand {
-  flex: 0 0 auto;
-  min-width: 22px;
-  padding: 0;
-  color: var(--text-muted);
-}
-
-.find-replace__expand:hover {
-  color: var(--text);
 }
 
 .find-replace__btn {
@@ -295,9 +265,6 @@
  * ===================================================================== */
 :root[data-theme='skeuomorph'] .find-replace {
   background: linear-gradient(180deg, #f3f4f7, #d3d7de 55%, #c2c6ce);
-  border: 1px solid #8d9099;
-  border-radius: 9px;
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
   color: #34373d;
 }
 

--- a/src/renderer/src/components/FindReplace.css
+++ b/src/renderer/src/components/FindReplace.css
@@ -15,17 +15,9 @@
   position: relative;
 }
 
-/* Slim toolbar above the editor that hosts the Find affordance (a visible way
-   to open the panel without the keyboard shortcut). */
-.region__editor-toolbar {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 6px;
-  padding: 3px 8px;
-  background: var(--bg-sunken);
-  border-bottom: var(--border-w) solid var(--border);
-}
+/* The Find affordance (a visible way to open this panel without the keyboard
+   shortcut) lives in the editor tab header — see `.editor-header__actions` in
+   EditorTabs.css (issue #137). */
 
 .find-replace {
   position: absolute;

--- a/src/renderer/src/components/FindReplace.tsx
+++ b/src/renderer/src/components/FindReplace.tsx
@@ -1,374 +1,96 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type KeyboardEvent,
-  type PointerEvent as ReactPointerEvent
-} from 'react'
-import type * as monaco from 'monaco-editor/esm/vs/editor/editor.api'
-import { getActiveEditor, subscribeActiveEditor } from './editorBridge'
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react'
+import type { FindStatusPayload } from '../../../preload/index.d'
 import './FindReplace.css'
 
 /**
- * Find & Replace dialog (issue #92, skeuomorph polish).
+ * Find & Replace panel (issue #92, rehoused as a native window in #146).
  *
- * A floating, draggable panel docked top-right over the editor (non-blocking —
- * the editor stays interactive) with a Find box, prev/next arrows (↑ = previous,
- * ↓ = next), three search-option keys (case `Aa`, whole-word `|ab|`, regex `.*`),
- * a chevron that reveals/hides the Replace-with row (so Replace is reachable even
- * from find-only mode), and Replace / Replace+Find / Replace all buttons, plus a
- * live `N of M matches` status line.
+ * This now renders inside its OWN frameless OS window (`find.html` /
+ * `find-main.tsx`) — NOT over the editor. It has no Monaco access; it ships the
+ * query + options to the MAIN window over IPC (`window.api.find.sendCommand`) and
+ * shows the match count it gets back (`onStatus`). The actual search/replace runs
+ * in the main window via `findController`.
  *
- * It does NOT reimplement search: it drives the live Monaco editor (exposed via
- * `editorBridge`) through `model.findMatches`, `editor.setSelection` and
- * `editor.executeEdits`. Because edits flow through the editor, Monaco's
- * `onDidChangeModelContent` handler pushes the new content to the workspace
- * store (marking the buffer dirty) for free.
- *
- *  - Find: next match relative to the cursor in the chosen direction (Down =
- *    forward, Up = backward), wrapping at the ends.
- *  - Replace: if the selection already equals a match, replace it; else Find.
- *  - Replace+Find: replace the current match, then Find the next.
- *  - Replace all: replace every match in a single edit (one undo stop).
- *
- * The case / whole-word / regex keys feed Monaco's `matchCase`, `wordSeparators`
- * and `isRegex` args; an invalid regex is caught (no throw) and surfaces as a
- * subtle error state. Enter finds the next match (Shift+Enter the previous).
- * Opening/closing + keyboard wiring lives in EditorArea.
+ * #146 changes vs. the old in-editor panel:
+ *  - native window (above), so Enter can never leak into and edit the document;
+ *  - the Replace row is ALWAYS shown (no chevron / find-only mode);
+ *  - the regex toggle is gone — find is plain-text (Match-case + Whole-word stay);
+ *  - Enter = find next, Shift+Enter = previous, Esc = close — wired at the window
+ *    root so they work whatever control has focus;
+ *  - no fixed-width clip, so every button (incl. the gold Replace all) is visible.
  */
 
-export interface FindReplaceProps {
-  /** Whether the panel is shown. */
-  open: boolean
-  /** Start with the Replace row revealed (Cmd/Ctrl-H) vs. find-only (Cmd/Ctrl-F). */
-  withReplace: boolean
-  /** Close the panel (Esc / the × button) and return focus to the editor. */
-  onClose: () => void
-}
-
-/**
- * Monaco's default word separators (the value its find widget uses for
- * whole-word matching). Passed as `wordSeparators` to `findMatches` when the
- * whole-word toggle is on; `null` otherwise. Kept inline to avoid importing a
- * non-public constant from the monaco bundle.
- */
-const USUAL_WORD_SEPARATORS = '`~!@#$%^&*()-=+[{]}\\|;:\'",.<>/?'
-
-/** A Monaco range, compared field-by-field (no reference identity available). */
-function rangesEqual(a: monaco.IRange, b: monaco.IRange): boolean {
-  return (
-    a.startLineNumber === b.startLineNumber &&
-    a.startColumn === b.startColumn &&
-    a.endLineNumber === b.endLineNumber &&
-    a.endColumn === b.endColumn
-  )
-}
-
-export function FindReplace({ open, withReplace, onClose }: FindReplaceProps): JSX.Element | null {
+export function FindReplace(): JSX.Element {
   const [query, setQuery] = useState('')
   const [replacement, setReplacement] = useState('')
   const [matchCase, setMatchCase] = useState(false)
   const [wholeWord, setWholeWord] = useState(false)
-  const [useRegex, setUseRegex] = useState(false)
-  // Whether the Replace row is revealed. Seeded from `withReplace` (Cmd/Ctrl-H
-  // opens it shown, Cmd/Ctrl-F hidden) but toggleable in-dialog via the chevron,
-  // so Replace is always reachable from find-only mode.
-  const [showReplace, setShowReplace] = useState(withReplace)
-  // Live match count + current index for the `N of M matches` status. Recomputed
-  // on query/option/content changes and after every navigation/replace.
-  const [matchCount, setMatchCount] = useState(0)
-  const [matchIndex, setMatchIndex] = useState(0)
-  // True when the regex toggle is on but the query doesn't compile — surfaced as
-  // a subtle error state instead of throwing.
-  const [regexError, setRegexError] = useState(false)
-  // Bumps whenever the bridge reports a new editor, forcing the count effect to
-  // re-run once Monaco's lazy chunk has mounted.
-  const [editorTick, setEditorTick] = useState(0)
-  // Drag offset applied to the floating panel (from its top-right dock).
-  const [offset, setOffset] = useState<{ x: number; y: number }>({ x: 0, y: 0 })
+  const [status, setStatus] = useState<FindStatusPayload>({ matchIndex: 0, matchCount: 0 })
 
   const findInputRef = useRef<HTMLInputElement>(null)
-  // Live drag bookkeeping kept in a ref so pointer move handlers don't re-bind.
-  const dragRef = useRef<{ startX: number; startY: number; baseX: number; baseY: number } | null>(
-    null
+
+  /** Ship an action to the editor with the current query + options. */
+  const send = useCallback(
+    (action: 'next' | 'prev' | 'replace' | 'replaceFind' | 'replaceAll' | 'count'): void => {
+      window.api.find.sendCommand({ action, query, replacement, matchCase, wholeWord })
+    },
+    [query, replacement, matchCase, wholeWord]
   )
 
-  // Track editor availability so the match-count effect re-runs when the lazy
-  // Monaco instance appears/disappears.
-  useEffect(() => subscribeActiveEditor(() => setEditorTick((t) => t + 1)), [])
+  /** Close the window. */
+  const close = useCallback((): void => window.api.find.close(), [])
 
-  /** All matches for the current query/options in the active model (empty if none). */
-  const findAllMatches = useCallback((): monaco.editor.FindMatch[] => {
-    const editor = getActiveEditor()
-    const model = editor?.getModel()
-    if (!editor || !model || query.length === 0) return []
-    // findMatches(searchString, searchOnlyEditableRange, isRegex, matchCase,
-    //   wordSeparators, captureMatches)
-    return model.findMatches(
-      query,
-      false,
-      useRegex,
-      matchCase,
-      wholeWord ? USUAL_WORD_SEPARATORS : null,
-      false
-    )
-  }, [query, matchCase, wholeWord, useRegex])
+  // Subscribe to the match status pushed back from the editor window.
+  useEffect(() => window.api.find.onStatus(setStatus), [])
 
-  /**
-   * Like `findAllMatches` but swallows the invalid-regex throw: when the regex
-   * toggle is on and the pattern doesn't compile, Monaco throws — we return no
-   * matches and flag the error so the UI can show it instead of crashing.
-   */
-  const safeFindAllMatches = useCallback((): monaco.editor.FindMatch[] => {
-    try {
-      const matches = findAllMatches()
-      setRegexError(false)
-      return matches
-    } catch {
-      setRegexError(true)
-      return []
-    }
-  }, [findAllMatches])
-
-  /** Index (1-based) of the current selection among `matches`, or 0 if none. */
-  const indexOfSelection = useCallback((matches: monaco.editor.FindMatch[]): number => {
-    const editor = getActiveEditor()
-    const selection = editor?.getSelection()
-    if (!selection) return 0
-    const i = matches.findIndex((m) => rangesEqual(m.range, selection))
-    return i < 0 ? 0 : i + 1
-  }, [])
-
-  // Keep the `N of M matches` status in sync. Re-runs on query/option changes and
-  // when the editor instance changes; the cheap recompute is fine for a status.
+  // Refresh the count whenever the query or the case/whole-word options change
+  // (the replacement text doesn't affect the count).
   useEffect(() => {
-    if (!open) return
-    const matches = safeFindAllMatches()
-    setMatchCount(matches.length)
-    setMatchIndex(indexOfSelection(matches))
-  }, [open, safeFindAllMatches, indexOfSelection, editorTick])
+    window.api.find.sendCommand({ action: 'count', query, replacement, matchCase, wholeWord })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query, matchCase, wholeWord])
 
-  // Focus the Find box whenever the panel opens (or flips between find/replace).
+  // Focus the Find box on mount.
   useEffect(() => {
-    if (!open) return
     const input = findInputRef.current
-    if (input) {
-      input.focus()
-      input.select()
-    }
-  }, [open, withReplace])
-
-  // Reveal/hide the Replace row to match the entry point each time the panel
-  // opens (Cmd/Ctrl-F hidden, Cmd/Ctrl-H shown); the chevron can override after.
-  useEffect(() => {
-    if (open) setShowReplace(withReplace)
-  }, [open, withReplace])
-
-  // Reset the drag offset when the panel closes so it re-docks top-right next time.
-  useEffect(() => {
-    if (!open) setOffset({ x: 0, y: 0 })
-  }, [open])
-
-  /** Recompute count + current index after a navigation/replace. */
-  const syncStatus = useCallback((): void => {
-    const matches = safeFindAllMatches()
-    setMatchCount(matches.length)
-    setMatchIndex(indexOfSelection(matches))
-  }, [safeFindAllMatches, indexOfSelection])
-
-  /**
-   * Select the next match in `dir` relative to the current selection, wrapping.
-   * Returns true if a match was selected.
-   */
-  const findNext = useCallback(
-    (dir: 'up' | 'down'): boolean => {
-      const editor = getActiveEditor()
-      if (!editor) return false
-      const matches = safeFindAllMatches()
-      if (matches.length === 0) return false
-
-      const selection = editor.getSelection()
-      let target: monaco.editor.FindMatch
-      if (!selection) {
-        target = dir === 'down' ? matches[0] : matches[matches.length - 1]
-      } else if (dir === 'down') {
-        // First match that starts strictly after the current selection's start;
-        // wrap to the first match.
-        target =
-          matches.find((m) =>
-            m.range.startLineNumber > selection.startLineNumber ||
-            (m.range.startLineNumber === selection.startLineNumber &&
-              m.range.startColumn > selection.startColumn)
-          ) ?? matches[0]
-      } else {
-        // Last match that starts strictly before the current selection's start;
-        // wrap to the last match.
-        const prior = matches.filter((m) =>
-          m.range.startLineNumber < selection.startLineNumber ||
-          (m.range.startLineNumber === selection.startLineNumber &&
-            m.range.startColumn < selection.startColumn)
-        )
-        target = prior.length > 0 ? prior[prior.length - 1] : matches[matches.length - 1]
-      }
-
-      editor.setSelection(target.range)
-      editor.revealRangeInCenterIfOutsideViewport(target.range)
-      return true
-    },
-    [safeFindAllMatches]
-  )
-
-  const handleFind = useCallback(
-    (dir: 'up' | 'down' = 'down'): void => {
-      findNext(dir)
-      syncStatus()
-      getActiveEditor()?.focus()
-    },
-    [findNext, syncStatus]
-  )
-
-  /**
-   * If the current selection exactly matches a found range, replace it in place
-   * (through the editor so the store updates) and return true; otherwise false.
-   */
-  const replaceCurrent = useCallback((): boolean => {
-    const editor = getActiveEditor()
-    if (!editor) return false
-    const selection = editor.getSelection()
-    if (!selection) return false
-    const matches = safeFindAllMatches()
-    const hit = matches.find((m) => rangesEqual(m.range, selection))
-    if (!hit) return false
-    editor.executeEdits('snakie-find-replace', [
-      { range: hit.range, text: replacement, forceMoveMarkers: true }
-    ])
-    return true
-  }, [safeFindAllMatches, replacement])
-
-  const handleReplace = useCallback((): void => {
-    // Replace the current match if the selection is on one; else find first so a
-    // subsequent Replace lands on a match.
-    if (!replaceCurrent()) findNext('down')
-    syncStatus()
-    getActiveEditor()?.focus()
-  }, [replaceCurrent, findNext, syncStatus])
-
-  const handleReplaceFind = useCallback((): void => {
-    replaceCurrent()
-    findNext('down')
-    syncStatus()
-    getActiveEditor()?.focus()
-  }, [replaceCurrent, findNext, syncStatus])
-
-  const handleReplaceAll = useCallback((): void => {
-    const editor = getActiveEditor()
-    if (!editor) return
-    const matches = safeFindAllMatches()
-    if (matches.length === 0) return
-    // One executeEdits call = one undo stop for the whole replace-all.
-    editor.executeEdits(
-      'snakie-find-replace-all',
-      matches.map((m) => ({ range: m.range, text: replacement, forceMoveMarkers: true }))
-    )
-    editor.focus()
-    syncStatus()
-  }, [safeFindAllMatches, replacement, syncStatus])
-
-  // Enter in the Find box = Find (Shift+Enter = previous); Enter in Replace =
-  // Replace+Find; Esc closes either.
-  const onFindKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLInputElement>): void => {
-      if (e.key === 'Enter') {
-        e.preventDefault()
-        handleFind(e.shiftKey ? 'up' : 'down')
-      } else if (e.key === 'Escape') {
-        e.preventDefault()
-        onClose()
-      }
-    },
-    [handleFind, onClose]
-  )
-
-  const onReplaceKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLInputElement>): void => {
-      if (e.key === 'Enter') {
-        e.preventDefault()
-        handleReplaceFind()
-      } else if (e.key === 'Escape') {
-        e.preventDefault()
-        onClose()
-      }
-    },
-    [handleReplaceFind, onClose]
-  )
-
-  // --- Drag the panel by its whole title bar (#98) ------------------------
-  const onBarPointerDown = useCallback(
-    (e: ReactPointerEvent<HTMLDivElement>): void => {
-      // Don't start a drag from the close button — let its click through.
-      if ((e.target as HTMLElement).closest('.find-replace__close')) return
-      e.preventDefault()
-      e.currentTarget.setPointerCapture(e.pointerId)
-      dragRef.current = { startX: e.clientX, startY: e.clientY, baseX: offset.x, baseY: offset.y }
-    },
-    [offset]
-  )
-
-  const onBarPointerMove = useCallback((e: ReactPointerEvent<HTMLDivElement>): void => {
-    const drag = dragRef.current
-    if (!drag) return
-    setOffset({
-      x: drag.baseX + (e.clientX - drag.startX),
-      y: drag.baseY + (e.clientY - drag.startY)
-    })
+    input?.focus()
+    input?.select()
   }, [])
 
-  const onBarPointerUp = useCallback((e: ReactPointerEvent<HTMLDivElement>): void => {
-    dragRef.current = null
-    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
-      e.currentTarget.releasePointerCapture(e.pointerId)
-    }
-  }, [])
+  // Window-level shortcuts so they work regardless of which control has focus:
+  // Enter = next, Shift+Enter = previous, Esc = close.
+  const onRootKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>): void => {
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        send(e.shiftKey ? 'prev' : 'next')
+      } else if (e.key === 'Escape') {
+        e.preventDefault()
+        close()
+      }
+    },
+    [send, close]
+  )
 
-  const status = useMemo(() => {
+  const statusIsEmpty = query.length > 0 && status.matchCount === 0
+
+  const statusText = useMemo(() => {
     if (query.length === 0) return ''
-    if (regexError) return 'Invalid regex'
-    if (matchCount === 0) return 'No results'
-    if (matchIndex === 0) return `${matchCount} match${matchCount === 1 ? '' : 'es'}`
-    return `${matchIndex} of ${matchCount} matches`
-  }, [query, regexError, matchCount, matchIndex])
-
-  const statusIsEmpty = query.length > 0 && (regexError || matchCount === 0)
-
-  if (!open) return null
-
-  // Drag offset is applied as a translate from the CSS top-right dock so the
-  // panel re-docks cleanly when reopened (offset reset on close).
-  const style =
-    offset.x !== 0 || offset.y !== 0
-      ? { transform: `translate(${offset.x}px, ${offset.y}px)` }
-      : undefined
+    if (status.matchCount === 0) return 'No results'
+    if (status.matchIndex === 0) {
+      return `${status.matchCount} match${status.matchCount === 1 ? '' : 'es'}`
+    }
+    return `${status.matchIndex} of ${status.matchCount} matches`
+  }, [query, status])
 
   return (
     <div
-      className="find-replace"
+      className="find-replace find-replace--window"
       role="search"
       aria-label="Find and replace"
-      style={style}
-      // Stop the editor's Cmd/Ctrl-F capture handler (in EditorArea) from acting
-      // while the user is typing in this panel.
-      onKeyDownCapture={(e) => e.stopPropagation()}
+      onKeyDown={onRootKeyDown}
     >
-      <div
-        className="find-replace__titlebar"
-        title="Drag to move"
-        onPointerDown={onBarPointerDown}
-        onPointerMove={onBarPointerMove}
-        onPointerUp={onBarPointerUp}
-        onPointerCancel={onBarPointerUp}
-      >
+      <div className="find-replace__titlebar" title="Drag to move">
         <span className="find-replace__grip" aria-hidden="true">
           <span className="find-replace__grip-dots" aria-hidden="true">
             <i />
@@ -383,7 +105,7 @@ export function FindReplace({ open, withReplace, onClose }: FindReplaceProps): J
         <button
           type="button"
           className="find-replace__close"
-          onClick={onClose}
+          onClick={close}
           aria-label="Close find and replace"
           title="Close (Esc)"
         >
@@ -393,16 +115,6 @@ export function FindReplace({ open, withReplace, onClose }: FindReplaceProps): J
 
       <div className="find-replace__body">
         <div className="find-replace__row">
-          <button
-            type="button"
-            className="find-replace__expand"
-            aria-label={showReplace ? 'Hide replace' : 'Show replace'}
-            aria-expanded={showReplace}
-            title={showReplace ? 'Hide replace' : 'Show replace'}
-            onClick={() => setShowReplace((v) => !v)}
-          >
-            {showReplace ? '▾' : '▸'}
-          </button>
           <input
             ref={findInputRef}
             className={`find-replace__input${statusIsEmpty ? ' find-replace__input--error' : ''}`}
@@ -411,7 +123,6 @@ export function FindReplace({ open, withReplace, onClose }: FindReplaceProps): J
             aria-label="Find"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            onKeyDown={onFindKeyDown}
           />
           <div className="find-replace__keys" role="group" aria-label="Search options">
             <button
@@ -432,21 +143,12 @@ export function FindReplace({ open, withReplace, onClose }: FindReplaceProps): J
             >
               |ab|
             </button>
-            <button
-              type="button"
-              className={`find-replace__key${useRegex ? ' is-active' : ''}`}
-              aria-pressed={useRegex}
-              onClick={() => setUseRegex((v) => !v)}
-              title="Use regular expression"
-            >
-              .*
-            </button>
           </div>
           <div className="find-replace__nav" role="group" aria-label="Navigate matches">
             <button
               type="button"
               className="find-replace__arrow"
-              onClick={() => handleFind('up')}
+              onClick={() => send('prev')}
               disabled={query.length === 0}
               aria-label="Previous match"
               title="Previous match"
@@ -456,7 +158,7 @@ export function FindReplace({ open, withReplace, onClose }: FindReplaceProps): J
             <button
               type="button"
               className="find-replace__arrow"
-              onClick={() => handleFind('down')}
+              onClick={() => send('next')}
               disabled={query.length === 0}
               aria-label="Next match"
               title="Next match"
@@ -466,50 +168,47 @@ export function FindReplace({ open, withReplace, onClose }: FindReplaceProps): J
           </div>
         </div>
 
-        {showReplace && (
-          <div className="find-replace__row">
-            <input
-              className="find-replace__input"
-              type="text"
-              placeholder="Replace with"
-              aria-label="Replace with"
-              value={replacement}
-              onChange={(e) => setReplacement(e.target.value)}
-              onKeyDown={onReplaceKeyDown}
-            />
-            <button
-              type="button"
-              className="find-replace__btn"
-              onClick={handleReplace}
-              disabled={query.length === 0}
-            >
-              Replace
-            </button>
-            <button
-              type="button"
-              className="find-replace__btn"
-              onClick={handleReplaceFind}
-              disabled={query.length === 0}
-              title="Replace then find next"
-            >
-              Replace+Find
-            </button>
-            <button
-              type="button"
-              className="find-replace__btn find-replace__btn--gold"
-              onClick={handleReplaceAll}
-              disabled={query.length === 0}
-            >
-              Replace all
-            </button>
-          </div>
-        )}
+        <div className="find-replace__row">
+          <input
+            className="find-replace__input"
+            type="text"
+            placeholder="Replace with"
+            aria-label="Replace with"
+            value={replacement}
+            onChange={(e) => setReplacement(e.target.value)}
+          />
+          <button
+            type="button"
+            className="find-replace__btn"
+            onClick={() => send('replace')}
+            disabled={query.length === 0}
+          >
+            Replace
+          </button>
+          <button
+            type="button"
+            className="find-replace__btn"
+            onClick={() => send('replaceFind')}
+            disabled={query.length === 0}
+            title="Replace then find next"
+          >
+            Replace+Find
+          </button>
+          <button
+            type="button"
+            className="find-replace__btn find-replace__btn--gold"
+            onClick={() => send('replaceAll')}
+            disabled={query.length === 0}
+          >
+            Replace all
+          </button>
+        </div>
 
         <div className="find-replace__status">
           <span
             className={`find-replace__count${statusIsEmpty ? ' find-replace__count--empty' : ''}`}
           >
-            {status}
+            {statusText}
           </span>
           <span className="find-replace__keyhint">↵ next · ⇧↵ prev · Esc close</span>
         </div>

--- a/src/renderer/src/components/I2cDetectInstrument.css
+++ b/src/renderer/src/components/I2cDetectInstrument.css
@@ -75,6 +75,74 @@
   }
 }
 
+/* --- "Not ready" prompt: offer to run the I²C demo (#149) --- */
+.i2cdet__prompt {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 9px;
+  max-width: 230px;
+  text-align: center;
+}
+
+.i2cdet__prompt-msg {
+  margin: 0;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: color-mix(in srgb, var(--accent) 78%, #cfd3d8);
+  text-shadow: 0 0 6px color-mix(in srgb, var(--accent) 35%, transparent);
+}
+
+.i2cdet__prompt-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.i2cdet__demo,
+.i2cdet__dismiss {
+  height: 26px;
+  padding: 0 11px;
+  border-radius: 6px;
+  font-family: inherit;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  cursor: pointer;
+}
+
+.i2cdet__demo {
+  color: #04120a;
+  background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 88%, #fff), var(--accent));
+  border: 1px solid var(--accent-border);
+}
+
+.i2cdet__demo:hover:not(:disabled) {
+  filter: brightness(1.06);
+}
+
+.i2cdet__dismiss {
+  color: color-mix(in srgb, var(--accent) 55%, #9aa0a8);
+  background: rgba(0, 0, 0, 0.4);
+  border: 1px solid #1c1f22;
+}
+
+.i2cdet__demo:disabled,
+.i2cdet__dismiss:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.i2cdet__prompt-hint {
+  margin: 0;
+  font-size: 9px;
+  line-height: 1.5;
+  color: #6b7079;
+}
+
+.i2cdet__prompt-hint code {
+  color: color-mix(in srgb, var(--accent) 60%, #9aa0a8);
+}
+
 /* --- The 8×16 address grid --- */
 .i2cdet__grid {
   display: flex;

--- a/src/renderer/src/components/I2cDetectInstrument.tsx
+++ b/src/renderer/src/components/I2cDetectInstrument.tsx
@@ -2,6 +2,10 @@ import { useCallback, useState, type CSSProperties } from 'react'
 import { InstrumentWindow, PhosphorScreen, type FloatProps } from './InstrumentWindow'
 import { type InstrumentDef } from './instruments-registry'
 import { useTelemetryStream } from './instrument-telemetry-subscribe'
+import { useSnakiePresence } from './snakie-presence'
+import { useDeviceStatus } from '../hooks/useDeviceStatus'
+import { useWorkspace } from '../store/workspace'
+import { I2C_DETECT_DEMO, I2C_DETECT_DEMO_NAME } from './i2c-detect-demo'
 import { buildI2cGrid, formatI2cAddr, type I2cGridModel } from './scanner-logic'
 import './I2cDetectInstrument.css'
 
@@ -47,10 +51,20 @@ export function I2cDetectInstrument({
   onToggleDock,
   float
 }: I2cDetectInstrumentProps): JSX.Element {
+  const status = useDeviceStatus()
+  const connected = status.state === 'connected'
+  const { present } = useSnakiePresence()
+  const { openBuffer } = useWorkspace()
+
   // `grid` is undefined until the first result lands; `scanning` lights the
   // "scanning…" state on SCAN and clears on the first reading.
   const [grid, setGrid] = useState<I2cGridModel | undefined>(undefined)
   const [scanning, setScanning] = useState(false)
+  // Shown when SCAN can't reach the bus — no board, or no Snakie program running
+  // an I²C bus to service the trigger (then we offer to run the demo). #149.
+  const [prompt, setPrompt] = useState(false)
+  // True while opening + running the demo (disables the prompt buttons).
+  const [busy, setBusy] = useState(false)
 
   // The whole address set arrives in ONE `kind:'i2c'` reading, so we just rebuild
   // the grid from it and drop the scanning flag.
@@ -62,7 +76,16 @@ export function I2cDetectInstrument({
     }, [])
   )
 
+  // Kick a scan. The on-device `scan:i2c` trigger only exists when a Snakie
+  // program called `inst.start(i2c=…)`; without a live program the SCAN can't
+  // reach the bus, so — instead of a misleading "scanning…" that never resolves
+  // (#149) — surface a prompt offering to run the I²C demo.
   const scan = useCallback(async () => {
+    if (!connected || !present) {
+      setPrompt(true)
+      return
+    }
+    setPrompt(false)
     setScanning(true)
     try {
       await window.api.device.sendControl(SCAN_TRIGGER)
@@ -71,7 +94,27 @@ export function I2cDetectInstrument({
       // panel doesn't hang on "scanning…". The grid keeps its last result.
       setScanning(false)
     }
-  }, [])
+  }, [connected, present])
+
+  // Open the I²C demo in a new tab and run it: interrupt any running program,
+  // drop the demo in the editor, then paste-run it. Its `inst.start(i2c=…)`
+  // registers the scan trigger (→ READY → present) and the initial scan fills the
+  // grid. Mirrors the Wi-Fi scanner's demo flow.
+  const runDemo = useCallback(async () => {
+    setBusy(true)
+    try {
+      await window.api.device.interrupt().catch(() => undefined)
+      openBuffer(I2C_DETECT_DEMO_NAME, I2C_DETECT_DEMO)
+      await new Promise((resolve) => setTimeout(resolve, 200))
+      await window.api.device.sendData(`\x05${I2C_DETECT_DEMO}\x04`)
+      setPrompt(false)
+      setScanning(true)
+    } catch {
+      setScanning(false)
+    } finally {
+      setBusy(false)
+    }
+  }, [openBuffer])
 
   const found = grid?.found ?? []
   const foundText = scanning && !grid ? '··' : String(found.length)
@@ -91,7 +134,52 @@ export function I2cDetectInstrument({
       >
         <PhosphorScreen className="instr__screen--accent">
           <div className="i2cdet__screen">
-            {grid ? (
+            {prompt ? (
+              <div className="i2cdet__prompt">
+                {connected ? (
+                  <>
+                    <p className="i2cdet__prompt-msg">
+                      No Snakie program is running an I²C bus to scan.
+                    </p>
+                    <div className="i2cdet__prompt-actions">
+                      <button
+                        type="button"
+                        className="i2cdet__demo"
+                        onClick={() => void runDemo()}
+                        disabled={busy}
+                      >
+                        {busy ? 'STARTING…' : '▶ Run I²C demo'}
+                      </button>
+                      <button
+                        type="button"
+                        className="i2cdet__dismiss"
+                        onClick={() => setPrompt(false)}
+                        disabled={busy}
+                      >
+                        Dismiss
+                      </button>
+                    </div>
+                    <p className="i2cdet__prompt-hint">
+                      Opens a demo that sets up an I²C bus and scans on the 2nd core — or run your
+                      own program that calls <code>inst.start(i2c=…)</code>.
+                    </p>
+                  </>
+                ) : (
+                  <>
+                    <p className="i2cdet__prompt-msg">Connect a board to scan the I²C bus.</p>
+                    <div className="i2cdet__prompt-actions">
+                      <button
+                        type="button"
+                        className="i2cdet__dismiss"
+                        onClick={() => setPrompt(false)}
+                      >
+                        Dismiss
+                      </button>
+                    </div>
+                  </>
+                )}
+              </div>
+            ) : grid ? (
               <I2cGrid grid={grid} />
             ) : (
               <p className="i2cdet__hint">

--- a/src/renderer/src/components/board-layout.ts
+++ b/src/renderer/src/components/board-layout.ts
@@ -145,6 +145,42 @@ export function nodeSide(edge: PadPoint['edge']): 'left' | 'right' {
   return edge === 'right' || edge === 'bottom' ? 'right' : 'left'
 }
 
+/** An axis-aligned box `{x, y, w, h}` in SVG coordinates. */
+export interface Bounds {
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+/**
+ * The bounding box around a set of pad coordinates, grown by `pad` px on every
+ * side — used to draw the group outline that frames a bus's pins (#147) so a
+ * `sda`/`scl` (or `sck`/`mosi`/…) set reads as one connection. Returns `null`
+ * for fewer than two points (nothing to group). Pure + DOM-free for unit tests.
+ */
+export function padsBounds(points: { x: number; y: number }[], pad = 14): Bounds | null {
+  if (points.length < 2) return null
+  const xs = points.map((p) => p.x)
+  const ys = points.map((p) => p.y)
+  const minX = Math.min(...xs)
+  const minY = Math.min(...ys)
+  const maxX = Math.max(...xs)
+  const maxY = Math.max(...ys)
+  return { x: minX - pad, y: minY - pad, w: maxX - minX + pad * 2, h: maxY - minY + pad * 2 }
+}
+
+/**
+ * The label for a bus connection — the type word plus its hardware bus number
+ * when known: `I2C0`, `I2C1`, `SPI0`… For a non-bus type (or no `bus`) it's just
+ * the uppercase type. Shared by both Board Views + the SVG export so the badge,
+ * the group tag and the export all read the same.
+ */
+export function busLabel(type: string, bus: number | undefined): string {
+  const base = type.toUpperCase()
+  return bus === undefined ? base : `${base}${bus}`
+}
+
 /**
  * Resolve a parsed pin token to a drawn pad coordinate.
  * Matching: numeric token vs `pad.gpio`; else token vs `pad.label`

--- a/src/renderer/src/components/board-layout.ts
+++ b/src/renderer/src/components/board-layout.ts
@@ -136,6 +136,16 @@ export function padLabelPlacement(
 }
 
 /**
+ * Which column a connection's node card docks in for the node-graph Board View
+ * (#148): a pad on the board's RIGHT or BOTTOM edge docks on the RIGHT (mirrors
+ * BoardView's badge `docksLeft` rule), everything else (left / top / led) on the
+ * LEFT. Pure so the live node-graph and its SVG export share one rule.
+ */
+export function nodeSide(edge: PadPoint['edge']): 'left' | 'right' {
+  return edge === 'right' || edge === 'bottom' ? 'right' : 'left'
+}
+
+/**
  * Resolve a parsed pin token to a drawn pad coordinate.
  * Matching: numeric token vs `pad.gpio`; else token vs `pad.label`
  * (case-insensitive, treating `GP12` and `12` as equivalent). The board's

--- a/src/renderer/src/components/bt-scan-demo.ts
+++ b/src/renderer/src/components/bt-scan-demo.ts
@@ -1,0 +1,35 @@
+/**
+ * The Bluetooth scan demo program the IDE opens + runs when SCAN is pressed and
+ * no Snakie program is detected on the board. Kept in sync with the reference
+ * copy at `examples/bt_scan_demo.py`.
+ *
+ * `inst.start()` registers the `scan:bt` trigger by default (no bus needed,
+ * unlike I²C), so this just starts the service and runs one scan up front so the
+ * list fills immediately; pressing SCAN afterwards drives a fresh scan on the
+ * board's second core without blocking this loop.
+ */
+export const BT_SCAN_DEMO_NAME = 'bt_scan_demo.py'
+
+export const BT_SCAN_DEMO = `"""Bluetooth scanner demo for Snakie.
+
+Open & Run this, then press SCAN in the Bluetooth instrument: each press runs a
+BLE scan on the SECOND CORE and lists nearby devices — without blocking this
+loop. Needs a BLE-capable board (Pico W / ESP32).
+"""
+import time
+import instruments as inst
+
+inst.start(background=False)  # register scan triggers (incl. scan:bt)
+inst.bt_scan()               # one scan now so the panel fills immediately
+
+_beat = time.ticks_ms()
+try:
+    while True:
+        inst.control.poll()  # service SCAN commands from the IDE
+        if time.ticks_diff(time.ticks_ms(), _beat) >= 1500:
+            _beat = time.ticks_ms()
+            inst.ready()  # tell the IDE we're live (works on any library version)
+        time.sleep_ms(20)
+except KeyboardInterrupt:
+    inst.stop()  # Stop pressed (Ctrl-C) -> silence + clear
+`

--- a/src/renderer/src/components/findController.ts
+++ b/src/renderer/src/components/findController.ts
@@ -1,0 +1,174 @@
+import type * as monaco from 'monaco-editor/esm/vs/editor/editor.api'
+import { getActiveEditor } from './editorBridge'
+
+/**
+ * Find & Replace controller (issue #146).
+ *
+ * The Find & Replace UI now lives in its OWN native OS window (a separate
+ * renderer process — see `find-main.tsx` / `src/main/find.ts`), which cannot
+ * touch the Monaco editor: the editor instance is a module-level singleton local
+ * to the MAIN window's renderer (`editorBridge`). So the find window sends
+ * {@link FindCommand}s over IPC and THIS module — run in the main window — drives
+ * Monaco and replies with a {@link FindStatus}.
+ *
+ * Extracted from the old in-editor `FindReplace` panel; same `findMatches` /
+ * `setSelection` / `executeEdits` mechanics, minus the regex option (removed in
+ * #146) and minus the focus hand-off (focus must stay in the find window).
+ */
+
+/** What the find window is asking the editor to do. */
+export type FindAction = 'count' | 'next' | 'prev' | 'replace' | 'replaceFind' | 'replaceAll'
+
+/** A find/replace request from the find window. */
+export interface FindCommand {
+  action: FindAction
+  query: string
+  replacement: string
+  matchCase: boolean
+  wholeWord: boolean
+}
+
+/** The result pushed back to the find window for its `N of M matches` line. */
+export interface FindStatus {
+  /** 1-based index of the current selection among the matches, or 0 if none. */
+  matchIndex: number
+  /** Total matches for the query in the active model. */
+  matchCount: number
+}
+
+/**
+ * Monaco's default word separators (the value its find widget uses for
+ * whole-word matching). Passed as `wordSeparators` to `findMatches` when the
+ * whole-word toggle is on; `null` otherwise.
+ */
+const USUAL_WORD_SEPARATORS = '`~!@#$%^&*()-=+[{]}\\|;:\'",.<>/?'
+
+/** A Monaco range, compared field-by-field (no reference identity available). */
+function rangesEqual(a: monaco.IRange, b: monaco.IRange): boolean {
+  return (
+    a.startLineNumber === b.startLineNumber &&
+    a.startColumn === b.startColumn &&
+    a.endLineNumber === b.endLineNumber &&
+    a.endColumn === b.endColumn
+  )
+}
+
+/** All matches for the command's query/options in the active model (empty if none). */
+function allMatches(cmd: FindCommand): monaco.editor.FindMatch[] {
+  const editor = getActiveEditor()
+  const model = editor?.getModel()
+  if (!editor || !model || cmd.query.length === 0) return []
+  // findMatches(searchString, searchOnlyEditableRange, isRegex, matchCase,
+  //   wordSeparators, captureMatches). Regex is always false (#146 dropped it).
+  return model.findMatches(
+    cmd.query,
+    false,
+    false,
+    cmd.matchCase,
+    cmd.wholeWord ? USUAL_WORD_SEPARATORS : null,
+    false
+  )
+}
+
+/** Index (1-based) of the current selection among `matches`, or 0 if none. */
+function indexOfSelection(matches: monaco.editor.FindMatch[]): number {
+  const selection = getActiveEditor()?.getSelection()
+  if (!selection) return 0
+  const i = matches.findIndex((m) => rangesEqual(m.range, selection))
+  return i < 0 ? 0 : i + 1
+}
+
+/**
+ * Select the next match in `dir` relative to the current selection, wrapping.
+ * Does NOT focus the editor — focus must stay in the find window.
+ */
+function findNext(dir: 'up' | 'down', matches: monaco.editor.FindMatch[]): void {
+  const editor = getActiveEditor()
+  if (!editor || matches.length === 0) return
+
+  const selection = editor.getSelection()
+  let target: monaco.editor.FindMatch
+  if (!selection) {
+    target = dir === 'down' ? matches[0] : matches[matches.length - 1]
+  } else if (dir === 'down') {
+    target =
+      matches.find(
+        (m) =>
+          m.range.startLineNumber > selection.startLineNumber ||
+          (m.range.startLineNumber === selection.startLineNumber &&
+            m.range.startColumn > selection.startColumn)
+      ) ?? matches[0]
+  } else {
+    const prior = matches.filter(
+      (m) =>
+        m.range.startLineNumber < selection.startLineNumber ||
+        (m.range.startLineNumber === selection.startLineNumber &&
+          m.range.startColumn < selection.startColumn)
+    )
+    target = prior.length > 0 ? prior[prior.length - 1] : matches[matches.length - 1]
+  }
+
+  editor.setSelection(target.range)
+  editor.revealRangeInCenterIfOutsideViewport(target.range)
+}
+
+/**
+ * If the current selection exactly matches a found range, replace it in place
+ * (through the editor so the workspace store updates) and return true.
+ */
+function replaceCurrent(cmd: FindCommand): boolean {
+  const editor = getActiveEditor()
+  const selection = editor?.getSelection()
+  if (!editor || !selection) return false
+  const hit = allMatches(cmd).find((m) => rangesEqual(m.range, selection))
+  if (!hit) return false
+  editor.executeEdits('snakie-find-replace', [
+    { range: hit.range, text: cmd.replacement, forceMoveMarkers: true }
+  ])
+  return true
+}
+
+/** Replace every match in a single edit (one undo stop). */
+function replaceAll(cmd: FindCommand): void {
+  const editor = getActiveEditor()
+  if (!editor) return
+  const matches = allMatches(cmd)
+  if (matches.length === 0) return
+  editor.executeEdits(
+    'snakie-find-replace-all',
+    matches.map((m) => ({ range: m.range, text: cmd.replacement, forceMoveMarkers: true }))
+  )
+}
+
+/**
+ * Run a find/replace command against the active editor and return the resulting
+ * status. Called in the MAIN window from the `find:command` IPC handler.
+ */
+export function runFindCommand(cmd: FindCommand): FindStatus {
+  switch (cmd.action) {
+    case 'next':
+      findNext('down', allMatches(cmd))
+      break
+    case 'prev':
+      findNext('up', allMatches(cmd))
+      break
+    case 'replace':
+      // Replace the current match if the selection is on one; else find first so
+      // a subsequent Replace lands on a match.
+      if (!replaceCurrent(cmd)) findNext('down', allMatches(cmd))
+      break
+    case 'replaceFind':
+      replaceCurrent(cmd)
+      findNext('down', allMatches(cmd))
+      break
+    case 'replaceAll':
+      replaceAll(cmd)
+      break
+    case 'count':
+    default:
+      break
+  }
+  // Recompute against the (possibly mutated) model for an accurate status.
+  const after = allMatches(cmd)
+  return { matchCount: after.length, matchIndex: indexOfSelection(after) }
+}

--- a/src/renderer/src/components/i2c-detect-demo.ts
+++ b/src/renderer/src/components/i2c-detect-demo.ts
@@ -1,0 +1,39 @@
+/**
+ * The I²C-detect demo program the IDE opens + runs when SCAN is pressed and no
+ * Snakie program is detected on the board. Kept in sync with the reference copy
+ * at `examples/i2c_detect_demo.py`.
+ *
+ * Unlike Wi-Fi, the on-device `scan:i2c` trigger is only registered when a bus
+ * is handed to `inst.start(i2c=…)` (see python/tests `test_start_with_i2c_…`), so
+ * the demo creates an I²C bus, starts the service WITH it, and runs one scan up
+ * front so the grid fills immediately. Pressing SCAN afterwards drives a fresh
+ * scan on the board's second core without blocking this loop.
+ */
+export const I2C_DETECT_DEMO_NAME = 'i2c_detect_demo.py'
+
+export const I2C_DETECT_DEMO = `"""I²C detect demo for Snakie.
+
+Open & Run this, then press SCAN in the I²C instrument: each press scans the
+bus and lights every responding address — without blocking this loop. Edit the
+sda/scl pins below to match your wiring (these are RP2040 I2C0 defaults).
+"""
+import time
+from machine import I2C, Pin
+import instruments as inst
+
+i2c = I2C(0, sda=Pin(4), scl=Pin(5))   # your I2C bus (SDA=GP4, SCL=GP5)
+
+inst.start(background=False, i2c=i2c)   # registers the scan:i2c trigger for this bus
+inst.i2c_scan(i2c)                      # one scan now so the grid fills immediately
+
+_beat = time.ticks_ms()
+try:
+    while True:
+        inst.control.poll()  # service SCAN commands from the IDE
+        if time.ticks_diff(time.ticks_ms(), _beat) >= 1500:
+            _beat = time.ticks_ms()
+            inst.ready()  # tell the IDE we're live (works on any library version)
+        time.sleep_ms(20)
+except KeyboardInterrupt:
+    inst.stop()  # Stop pressed (Ctrl-C) -> silence + clear
+`

--- a/src/renderer/src/components/parse-pins.ts
+++ b/src/renderer/src/components/parse-pins.ts
@@ -62,6 +62,19 @@ export interface UsedPins {
    * Absent for ordinary `machine`-module connections.
    */
   instrument?: string
+  /**
+   * For a bus connection (`i2c`/`spi`), the per-pin ROLE label parallel to
+   * {@link pins} — e.g. `['SDA', 'SCL']` or `['SCK', 'MOSI', 'MISO']`. Lets the
+   * Board View label each pad with what it does in the bus. Absent for non-bus
+   * connections (and may be shorter than `pins` if a role couldn't be named).
+   */
+  roles?: string[]
+  /**
+   * For a bus connection (`i2c`/`spi`), the BUS NUMBER from the constructor `id`
+   * — `0` from `I2C(id=0, …)` or `I2C(0, …)` (Pico I2C0 vs I2C1). Lets the Board
+   * View show which hardware bus the pins belong to. Absent when not given.
+   */
+  bus?: number
 }
 
 /** Connection type → wire/badge colour (matches the skeuomorph palette). */
@@ -122,27 +135,58 @@ function extractPins(fragment: string): string[] {
   return pins
 }
 
+/** Canonical pin roles per bus type, in the order they're labelled/grouped. */
+const I2C_ROLES = ['sda', 'scl']
+const SPI_ROLES = ['sck', 'mosi', 'miso', 'cs', 'dc']
+
+/** Strip surrounding quotes from a `Pin("LED")`-style string arg. */
+function unquote(s: string): string {
+  const m = s.match(/^(?:"([^"]*)"|'([^']*)')$/)
+  return (m ? (m[1] ?? m[2]) : s).trim()
+}
+
 /**
- * Extract bus pins given as BARE kwargs — `sda=4, scl=5` (I²C) or
- * `sck=2, mosi=3, ...` (SPI) — rather than wrapped in `Pin(...)`. Many
- * MicroPython ports accept a raw pin number for these keywords, and the demos
- * use that form
- * (see `examples/board_view_test.py`). Returns one pin per named `role` present,
- * in `roles` order, so the bus's pins stay grouped under their one connection.
+ * Extract a bus's pins WITH their roles. For each canonical `roleNames` role
+ * (e.g. `sda`/`scl`), find `role=Pin(x)` OR the bare `role=x` form and record
+ * (ROLE, pin) in canonical order — so `I2C(id=0, sda=4, scl=5)` and
+ * `I2C(0, sda=Pin(0), scl=Pin(1))` both yield pins+roles, and an absent role
+ * (e.g. a 3-wire SPI with no `miso`) is simply skipped.
  *
- * Only used as a fallback when {@link extractPins} found no `Pin(...)` form, so a
- * `sda=Pin(0)` line is still read by the (richer) Pin scanner and never double
- * counted. `id=`/`freq=`/`baudrate=` and other non-pin kwargs are ignored
- * because they aren't in `roles`.
+ * Falls back to POSITIONAL `Pin(...)` args (no keyword names) when no role kwarg
+ * is present — assigning the canonical roles by position — so `I2C(0, Pin(0),
+ * Pin(1))` still labels SDA/SCL. Non-pin kwargs (`id`/`freq`/`baudrate`) are
+ * never in `roleNames`, so they're ignored.
  */
-function extractKwargPins(fragment: string, roles: string[]): string[] {
+function extractBusPins(fragment: string, roleNames: string[]): { pins: string[]; roles: string[] } {
   const pins: string[] = []
-  for (const role of roles) {
-    const re = new RegExp(`\\b${role}\\s*=\\s*("([^"]*)"|'([^']*)'|\\d+)`, 'i')
+  const roles: string[] = []
+  const VAL = `"[^"]*"|'[^']*'|[^,)\\s]+`
+  for (const role of roleNames) {
+    const re = new RegExp(`\\b${role}\\s*=\\s*(?:(?:machine\\.)?Pin\\(\\s*(${VAL})\\s*\\)|(${VAL}))`, 'i')
     const m = re.exec(fragment)
-    if (m) pins.push((m[2] ?? m[3] ?? m[1]).trim())
+    if (m) {
+      pins.push(unquote(m[1] ?? m[2]))
+      roles.push(role.toUpperCase())
+    }
   }
-  return pins
+  if (pins.length > 0) return { pins, roles }
+  // No keyword roles → positional Pin() args, roles assigned by position.
+  const positional = extractPins(fragment)
+  return {
+    pins: positional,
+    roles: positional.map((_, i) => (roleNames[i] ?? '').toUpperCase())
+  }
+}
+
+/**
+ * The hardware BUS NUMBER from a bus constructor's `id` — `id=0` (kwarg) or the
+ * first bare positional integer (`I2C(0, …)`). Returns `undefined` when absent.
+ */
+function extractBusId(args: string): number | undefined {
+  const kw = args.match(/\bid\s*=\s*(\d+)/i)
+  if (kw) return Number(kw[1])
+  const pos = args.match(/^\s*(\d+)\s*(?:,|\)|$)/)
+  return pos ? Number(pos[1]) : undefined
 }
 
 /** Find the matched closing `)` for the `(` immediately after `openIdx`. */
@@ -280,23 +324,28 @@ export function parsePins(source: string): UsedPins[] {
 
     let type: PinType
     let pins: string[]
+    // Bus-only extras (i2c/spi): per-pin role labels + the hardware bus number.
+    let roles: string[] | undefined
+    let bus: number | undefined
 
     switch (name) {
-      case 'I2C':
+      case 'I2C': {
         type = 'i2c'
-        // `sda=Pin(a)/scl=Pin(b)` first; else the bare `sda=4, scl=5` form.
-        pins = extractPins(args)
-        if (pins.length === 0) pins = extractKwargPins(args, ['sda', 'scl'])
+        const bp = extractBusPins(args, I2C_ROLES)
+        pins = bp.pins
+        roles = bp.roles
+        bus = extractBusId(args)
         break
-      case 'SPI':
+      }
+      case 'SPI': {
         type = 'spi'
-        // SPI plus any trailing cs=Pin(..)/dc=Pin(..) on the same line; else the
-        // bare `sck=2, mosi=3, ...` form.
-        pins = extractPins(rhs.slice(openIdx))
-        if (pins.length === 0) {
-          pins = extractKwargPins(rhs.slice(openIdx), ['sck', 'mosi', 'miso', 'cs', 'dc'])
-        }
+        // Scan the whole RHS so trailing `cs=Pin(..)/dc=Pin(..)` are caught too.
+        const bp = extractBusPins(rhs.slice(openIdx), SPI_ROLES)
+        pins = bp.pins
+        roles = bp.roles
+        bus = extractBusId(args)
         break
+      }
       case 'PWM':
         type = 'pwm'
         pins = extractPins(args)
@@ -330,7 +379,12 @@ export function parsePins(source: string): UsedPins[] {
     }
 
     if (pins.length === 0) continue
-    out.push({ type, pins, variable, constructor: ctorSrc })
+    const entry: UsedPins = { type, pins, variable, constructor: ctorSrc }
+    // Only attach bus extras when meaningful, so non-bus connections keep their
+    // exact shape (and any role couldn't-be-named entries are dropped).
+    if (roles && roles.some((r) => r)) entry.roles = roles
+    if (bus !== undefined) entry.bus = bus
+    out.push(entry)
   }
 
   // Append pins the program hands to the `instruments` library (e.g.

--- a/src/renderer/src/components/parse-pins.ts
+++ b/src/renderer/src/components/parse-pins.ts
@@ -14,7 +14,9 @@
  *
  * Detected forms (per logical line):
  *   - `X = I2C(id, sda=Pin(a), scl=Pin(b))`             → i2c   (pins a, b)
+ *   - `X = I2C(id, sda=a, scl=b)`  (bare pin numbers)   → i2c   (pins a, b)
  *   - `X = SPI(id, sck=Pin(..), mosi=Pin(..), ...)`     → spi   (+ cs/dc Pins)
+ *   - `X = SPI(id, sck=a, mosi=b, miso=c, ...)`  (bare) → spi
  *   - `X = PWM(Pin(n), ...)`                            → pwm
  *   - `X = ADC(Pin(n))` / `ADC(n)` / `machine.ADC(...)` → adc   (analog input)
  *   - `X = StateMachine(n, prog, ...Pin(..))`           → pio
@@ -116,6 +118,29 @@ function extractPins(fragment: string): string[] {
     // Prefer the captured (unquoted) string body; else the raw first token.
     const label = m[2] ?? m[3] ?? m[1]
     pins.push(label.trim())
+  }
+  return pins
+}
+
+/**
+ * Extract bus pins given as BARE kwargs — `sda=4, scl=5` (I²C) or
+ * `sck=2, mosi=3, ...` (SPI) — rather than wrapped in `Pin(...)`. Many
+ * MicroPython ports accept a raw pin number for these keywords, and the demos
+ * use that form
+ * (see `examples/board_view_test.py`). Returns one pin per named `role` present,
+ * in `roles` order, so the bus's pins stay grouped under their one connection.
+ *
+ * Only used as a fallback when {@link extractPins} found no `Pin(...)` form, so a
+ * `sda=Pin(0)` line is still read by the (richer) Pin scanner and never double
+ * counted. `id=`/`freq=`/`baudrate=` and other non-pin kwargs are ignored
+ * because they aren't in `roles`.
+ */
+function extractKwargPins(fragment: string, roles: string[]): string[] {
+  const pins: string[] = []
+  for (const role of roles) {
+    const re = new RegExp(`\\b${role}\\s*=\\s*("([^"]*)"|'([^']*)'|\\d+)`, 'i')
+    const m = re.exec(fragment)
+    if (m) pins.push((m[2] ?? m[3] ?? m[1]).trim())
   }
   return pins
 }
@@ -259,12 +284,18 @@ export function parsePins(source: string): UsedPins[] {
     switch (name) {
       case 'I2C':
         type = 'i2c'
+        // `sda=Pin(a)/scl=Pin(b)` first; else the bare `sda=4, scl=5` form.
         pins = extractPins(args)
+        if (pins.length === 0) pins = extractKwargPins(args, ['sda', 'scl'])
         break
       case 'SPI':
         type = 'spi'
-        // SPI plus any trailing cs=Pin(..)/dc=Pin(..) on the same line.
+        // SPI plus any trailing cs=Pin(..)/dc=Pin(..) on the same line; else the
+        // bare `sck=2, mosi=3, ...` form.
         pins = extractPins(rhs.slice(openIdx))
+        if (pins.length === 0) {
+          pins = extractKwargPins(rhs.slice(openIdx), ['sck', 'mosi', 'miso', 'cs', 'dc'])
+        }
         break
       case 'PWM':
         type = 'pwm'

--- a/src/renderer/src/find-main.tsx
+++ b/src/renderer/src/find-main.tsx
@@ -1,0 +1,43 @@
+/**
+ * Entry point for the floating Find & Replace window (`find.html`, issue #146).
+ *
+ * A THIRD renderer entry (see `electron.vite.config.ts`), mounting the
+ * {@link FindReplace} panel. The window has no editor access — it drives the main
+ * window's Monaco over IPC (`window.api.find`) — so this entry is tiny: it just
+ * applies the shared editor theme so the dialog matches the app, then renders the
+ * panel which fills the frameless OS window.
+ */
+
+// Install the preload-bridge fallback BEFORE anything renders (mirrors main.tsx).
+import './lib/preloadFallback'
+import { useEffect } from 'react'
+import ReactDOM from 'react-dom/client'
+import { FindReplace } from './components/FindReplace'
+import '@fontsource/jetbrains-mono'
+import './index.css'
+
+/** Theme key shared with the editor window's `useTheme`. */
+const THEME_KEY = 'snakie.theme.v2'
+
+function applyTheme(theme: string): void {
+  document.documentElement.setAttribute('data-theme', theme)
+}
+
+function FindWindowApp(): JSX.Element {
+  // Apply the persisted theme immediately so the first paint matches the app
+  // (localStorage is shared per-origin with the main window).
+  useEffect(() => {
+    let initial = 'skeuomorph'
+    try {
+      const raw = window.localStorage.getItem(THEME_KEY)
+      if (raw) initial = JSON.parse(raw) as string
+    } catch {
+      // Ignore — fall back to the default.
+    }
+    applyTheme(initial)
+  }, [])
+
+  return <FindReplace />
+}
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(<FindWindowApp />)

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -635,9 +635,39 @@
 }
 
 /* --- Editor: cream paper tabs ------------------------------------------- */
-:root[data-theme='skeuomorph'] .editor-tabs {
+/* The cream surface is painted on the whole header row so the tab strip and
+   the Find button share one continuous background (issue #137). */
+:root[data-theme='skeuomorph'] .editor-header {
   background: linear-gradient(180deg, #d6cfba, #cabfa3);
   border-bottom: 1px solid #b3a888;
+}
+
+:root[data-theme='skeuomorph'] .editor-tabs {
+  background: transparent;
+  border-bottom: none;
+}
+
+/* Find button: flat on the cream paper, with the tab's text colour and
+   hover/active treatment so it reads as part of the tab bar. (Higher
+   specificity than the themed `.btn`/`.btn--ghost` pill so it strips the
+   gradient, border and shadow.) */
+:root[data-theme='skeuomorph'] .editor-header__actions .btn {
+  background: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  color: #6a6450;
+  text-shadow: none;
+}
+
+:root[data-theme='skeuomorph'] .editor-header__actions .btn:hover {
+  background: rgba(255, 255, 255, 0.25);
+  border-color: transparent;
+}
+
+:root[data-theme='skeuomorph'] .editor-header__actions .btn[aria-pressed='true'] {
+  background: #f6f1e3;
+  border-color: transparent;
+  color: #4a4636;
 }
 
 :root[data-theme='skeuomorph'] .editor-tab {
@@ -1305,9 +1335,33 @@
 }
 
 /* --- Editor: dark "paper" tabs ------------------------------------------- */
-:root[data-theme='dark'] .editor-tabs {
+/* Surface painted on the header row so tabs + Find button share it (issue #137). */
+:root[data-theme='dark'] .editor-header {
   background: linear-gradient(180deg, #26282e, #1d1f24);
   border-bottom: 1px solid #131418;
+}
+
+:root[data-theme='dark'] .editor-tabs {
+  background: transparent;
+  border-bottom: none;
+}
+
+:root[data-theme='dark'] .editor-header__actions .btn {
+  background: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  color: #9398a1;
+}
+
+:root[data-theme='dark'] .editor-header__actions .btn:hover {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: transparent;
+}
+
+:root[data-theme='dark'] .editor-header__actions .btn[aria-pressed='true'] {
+  background: var(--editor-paper-band);
+  border-color: transparent;
+  color: #d8dce3;
 }
 
 :root[data-theme='dark'] .editor-tab {

--- a/test/boardLayout.test.ts
+++ b/test/boardLayout.test.ts
@@ -3,6 +3,7 @@ import {
   boardBox,
   layoutPads,
   ledPoint,
+  nodeSide,
   padForToken,
   padLabelPlacement,
   type BoardBox
@@ -218,6 +219,19 @@ describe('padLabelPlacement (#109 side-correct labels)', () => {
   it('honours a custom horizontal gap', () => {
     expect(padLabelPlacement('left', 13).dx).toBe(-13)
     expect(padLabelPlacement('right', 13).dx).toBe(13)
+  })
+})
+
+describe('nodeSide (#148 mirrored right-column cards)', () => {
+  it('docks right-edge and bottom-edge connections on the RIGHT', () => {
+    expect(nodeSide('right')).toBe('right')
+    expect(nodeSide('bottom')).toBe('right')
+  })
+
+  it('keeps left / top / led connections on the LEFT', () => {
+    expect(nodeSide('left')).toBe('left')
+    expect(nodeSide('top')).toBe('left')
+    expect(nodeSide('led')).toBe('left')
   })
 })
 

--- a/test/boardLayout.test.ts
+++ b/test/boardLayout.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect } from 'vitest'
 import {
   boardBox,
+  busLabel,
   layoutPads,
   ledPoint,
   nodeSide,
   padForToken,
   padLabelPlacement,
+  padsBounds,
   type BoardBox
 } from '../src/renderer/src/components/board-layout'
 import type { BoardDefinition } from '../src/renderer/src/components/board-defs'
@@ -263,5 +265,34 @@ describe('vertical-edge layout (#109 Tiny boards)', () => {
     // …and each runs top→bottom (vertical pins).
     expect(left[0].y).toBeLessThan(left[1].y)
     expect(right[0].y).toBeLessThan(right[1].y)
+  })
+})
+
+describe('padsBounds (bus group outline, #147)', () => {
+  it('returns null for fewer than two points', () => {
+    expect(padsBounds([])).toBeNull()
+    expect(padsBounds([{ x: 10, y: 10 }])).toBeNull()
+  })
+
+  it('frames the points padded on every side', () => {
+    const b = padsBounds([{ x: 20, y: 30 }, { x: 50, y: 30 }], 10)
+    expect(b).toEqual({ x: 10, y: 20, w: 50, h: 20 })
+  })
+
+  it('spans the min/max across more than two points', () => {
+    const b = padsBounds([{ x: 20, y: 30 }, { x: 50, y: 80 }, { x: 35, y: 10 }], 5)
+    expect(b).toEqual({ x: 15, y: 5, w: 40, h: 80 })
+  })
+})
+
+describe('busLabel (#147)', () => {
+  it('appends the bus number when known', () => {
+    expect(busLabel('i2c', 0)).toBe('I2C0')
+    expect(busLabel('i2c', 1)).toBe('I2C1')
+    expect(busLabel('spi', 0)).toBe('SPI0')
+  })
+
+  it('falls back to the bare type when the bus is unknown', () => {
+    expect(busLabel('i2c', undefined)).toBe('I2C')
   })
 })

--- a/test/parsePins.test.ts
+++ b/test/parsePins.test.ts
@@ -68,10 +68,12 @@ describe('parsePins', () => {
     ])
   })
 
-  it('parses an I2C bus with sda/scl pins', () => {
+  it('parses an I2C bus with sda/scl pins, roles and bus id', () => {
     const [conn] = parsePins('i2c = I2C(0, sda=Pin(0), scl=Pin(1))')
     expect(conn.type).toBe('i2c')
     expect(conn.pins).toEqual(['0', '1'])
+    expect(conn.roles).toEqual(['SDA', 'SCL'])
+    expect(conn.bus).toBe(0)
     expect(conn.variable).toBe('i2c')
     expect(conn.constructor).toBe('I2C(0, sda=Pin(0), scl=Pin(1))')
   })
@@ -83,22 +85,32 @@ describe('parsePins', () => {
     const [conn] = parsePins('i2c = I2C(id=0, sda=4, scl=5)')
     expect(conn.type).toBe('i2c')
     expect(conn.pins).toEqual(['4', '5'])
-    expect(conn.variable).toBe('i2c')
+    expect(conn.roles).toEqual(['SDA', 'SCL'])
+    expect(conn.bus).toBe(0)
     expect(conn.constructor).toBe('I2C(id=0, sda=4, scl=5)')
   })
 
-  it('does not mistake the I2C id for a pin', () => {
-    // `id=0` is the bus id, not a pad — only sda/scl are pins.
+  it('reads the I2C bus number from id= (bus 1) without mistaking it for a pin', () => {
+    // `id=1` is the hardware bus (Pico I2C1), not a pad — only sda/scl are pins.
     const [conn] = parsePins('i2c = I2C(id=1, sda=2, scl=3)')
     expect(conn.pins).toEqual(['2', '3'])
+    expect(conn.bus).toBe(1)
   })
 
-  it('parses an SPI bus including trailing cs/dc pins', () => {
+  it('reads the I2C bus number from the first positional arg', () => {
+    const [conn] = parsePins('i2c = I2C(1, sda=Pin(2), scl=Pin(3))')
+    expect(conn.bus).toBe(1)
+  })
+
+  it('parses an SPI bus including trailing cs/dc pins, with roles and bus id', () => {
     const [conn] = parsePins(
       'tft = SPI(1, sck=Pin(10), mosi=Pin(11), cs=Pin(13), dc=Pin(8))'
     )
     expect(conn.type).toBe('spi')
     expect(conn.pins).toEqual(['10', '11', '13', '8'])
+    // miso is absent → its role is skipped, roles stay parallel to pins.
+    expect(conn.roles).toEqual(['SCK', 'MOSI', 'CS', 'DC'])
+    expect(conn.bus).toBe(1)
     expect(conn.variable).toBe('tft')
   })
 
@@ -106,7 +118,20 @@ describe('parsePins', () => {
     const [conn] = parsePins('spi = SPI(0, sck=2, mosi=3, miso=4)')
     expect(conn.type).toBe('spi')
     expect(conn.pins).toEqual(['2', '3', '4'])
-    expect(conn.variable).toBe('spi')
+    expect(conn.roles).toEqual(['SCK', 'MOSI', 'MISO'])
+    expect(conn.bus).toBe(0)
+  })
+
+  it('labels positional I2C Pin() args by role', () => {
+    const [conn] = parsePins('i2c = I2C(0, Pin(0), Pin(1))')
+    expect(conn.pins).toEqual(['0', '1'])
+    expect(conn.roles).toEqual(['SDA', 'SCL'])
+  })
+
+  it('leaves non-bus connections without roles/bus', () => {
+    const [conn] = parsePins('led = Pin(15, Pin.OUT)')
+    expect(conn.roles).toBeUndefined()
+    expect(conn.bus).toBeUndefined()
   })
 
   it('parses an ADC wrapping a Pin', () => {

--- a/test/parsePins.test.ts
+++ b/test/parsePins.test.ts
@@ -76,6 +76,23 @@ describe('parsePins', () => {
     expect(conn.constructor).toBe('I2C(0, sda=Pin(0), scl=Pin(1))')
   })
 
+  it('parses an I2C bus given bare pin numbers (sda=4, scl=5)', () => {
+    // The `sda=Pin(..)` form is common but ports also accept raw numbers — and
+    // the demos use that (examples/board_view_test.py). Both pins must surface
+    // so the bus shows up grouped on the board (#147).
+    const [conn] = parsePins('i2c = I2C(id=0, sda=4, scl=5)')
+    expect(conn.type).toBe('i2c')
+    expect(conn.pins).toEqual(['4', '5'])
+    expect(conn.variable).toBe('i2c')
+    expect(conn.constructor).toBe('I2C(id=0, sda=4, scl=5)')
+  })
+
+  it('does not mistake the I2C id for a pin', () => {
+    // `id=0` is the bus id, not a pad — only sda/scl are pins.
+    const [conn] = parsePins('i2c = I2C(id=1, sda=2, scl=3)')
+    expect(conn.pins).toEqual(['2', '3'])
+  })
+
   it('parses an SPI bus including trailing cs/dc pins', () => {
     const [conn] = parsePins(
       'tft = SPI(1, sck=Pin(10), mosi=Pin(11), cs=Pin(13), dc=Pin(8))'
@@ -83,6 +100,13 @@ describe('parsePins', () => {
     expect(conn.type).toBe('spi')
     expect(conn.pins).toEqual(['10', '11', '13', '8'])
     expect(conn.variable).toBe('tft')
+  })
+
+  it('parses an SPI bus given bare pin numbers (sck=2, mosi=3, miso=4)', () => {
+    const [conn] = parsePins('spi = SPI(0, sck=2, mosi=3, miso=4)')
+    expect(conn.type).toBe('spi')
+    expect(conn.pins).toEqual(['2', '3', '4'])
+    expect(conn.variable).toBe('spi')
   })
 
   it('parses an ADC wrapping a Pin', () => {


### PR DESCRIPTION
Batch of editor / board-view / instrument fixes. All five issues below are implemented; `typecheck`, `lint`, `test` (871), and `build` are green.

## What's in here

### #137 — Move the Find button onto the tab row
The Find affordance moved from its own slim toolbar (a wasted strip above the editor) onto the **editor tab row**, right-aligned, and restyled flat so its background and the area behind it match the tab bar across the skeuomorph + dark themes. *(Issue closed.)*

### #146 — Find & Replace dialog overhaul → native OS window
Closes #146. Rebuilt Find & Replace as its **own native frameless window** (`find.html` / `find-main.tsx` / `src/main/find.ts`), driving the editor over IPC (`find:command` → `findController` → `find:status`), mirroring the Board View window pattern. Also: buttons no longer clipped, the gold **Replace all** is fully visible, the **Replace** row is always shown, **Enter / Shift+Enter / Esc** are wired at the window root (no doc-edit leak — it's a separate renderer), and the **regex toggle was removed** (Match-case + Whole-word kept).

### #147 — Board view I2C/SPI grouping
Closes #147. Two parts:
- **Parsing:** the parser only read `sda=Pin(a)` forms, so a bus written with **bare pin numbers** — `I2C(id=0, sda=4, scl=5)`, as in `examples/board_view_test.py` — extracted zero pins and was dropped. Now it reads the bare form too, and each I2C/SPI connection also carries its **bus number** (from `id=` / first positional → Pico I2C0 vs I2C1) and **per-pin roles** (`['SDA','SCL']`, `['SCK','MOSI','MISO']`).
- **Rendering:** in both the breadboard and node-graph views (and the SVG export), a bus is now drawn as **one labelled group** — a group outline around the bus's pads tagged with the bus id (e.g. `I2C0`), each pad labelled with its role (SDA/SCL), and the connection badge/card showing the bus number. So a pair of pins reads clearly as one bus.

### #148 — Mirror right-edge connection cards (node-graph)
Closes #148. In the node-graph board view, connection cards were all stacked in the **left** column even when their pad was on the board's right edge. Right-edge (and bottom-edge) connections now dock in a **mirrored right column** (content reversed, solder dot + wire leave toward the board). New `nodeSide(edge)` helper, a mirrored `noodlePathRight`, a computed `stageW`, and matching SVG-export parity. All-left boards are byte-identical.

### #149 — Instruments guide you when not ready
Closes #149. The I2C-detect panel "scanned" forever with no board / no live program (the on-device `scan:i2c` trigger only exists once a program calls `inst.start(i2c=…)`); Bluetooth had the same dead-end. Both now mirror the Wi-Fi scanner's presence-aware pattern: when nothing services the trigger, SCAN surfaces a prompt explaining what's needed and offers a one-click **Run demo** (bundled `i2c_detect_demo.py` / `bt_scan_demo.py`). Display/Buzzer/Range/Wi-Fi already had this; the two scanners were the gap.

## ⚠️ Manual smoke tests needed
Electron couldn't be driven in CI/agent, so please verify in `npm run dev`:
1. **#146** — click Find / Cmd-F → window opens; live match count; Enter/Shift+Enter cycle; Replace / Replace+Find / Replace all; Esc closes; drag by the title bar; theme matches.
2. **#147** — open `examples/board_view_test.py` (`I2C(id=0, sda=4, scl=5)`): expect an **I2C0** group framing pins 4 & 5 with **SDA/SCL** labels, in both views and in an SVG/PNG export.
3. **#148** — node-graph board view with a board that has right-edge headers (e.g. a Pico) wired on the right: those cards sit on the right, mirrored, short non-crossing wires; SVG/PNG export matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)