### PR TITLE
feat: offline mode — simulated MicroPython device (#135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Offline mode — a simulated MicroPython device (#135).** Snakie now ships a
+  built-in **Simulated device (offline)** that appears in the shell's port
+  dropdown, so you can explore, learn and demo with **no hardware connected**:
+  - Connecting to it greets you with a friendly REPL banner and a live, animated
+    stream of `SNK …` telemetry, so the **instruments** (oscilloscope,
+    multimeter, plotter, IMU, distance, encoder, button…) work immediately.
+  - The **Board Viewer Live View** works too — the simulated device answers the
+    live-pin probe with plausible values that drift over time.
+  - A distinct **"Simulated device · offline"** status-bar badge (amber LED) so
+    it's never mistaken for real hardware, and switching between the simulator
+    and a real board is seamless (connecting to one disconnects the other).
 - **Accessibility quick wins (#188).** First pass over the renderer's
   accessibility audit:
   - The device REPL is now readable by screen readers — the xterm terminal runs

--- a/src/main/device/MicroPythonDevice.ts
+++ b/src/main/device/MicroPythonDevice.ts
@@ -8,6 +8,7 @@ import type {
   DirEntry,
   ExecResult,
   PortInfo,
+  SnakieDevice,
   StatResult
 } from './types'
 
@@ -54,7 +55,7 @@ export interface MicroPythonDeviceEvents {
  * `data` / `status` events. The IPC layer (see `device/ipc.ts`) wires those to
  * `webContents.send`.
  */
-export class MicroPythonDevice extends EventEmitter {
+export class MicroPythonDevice extends EventEmitter implements SnakieDevice {
   private port: SerialPort | null = null
   private state: ConnectionState = 'disconnected'
   private currentPath?: string

--- a/src/main/device/SimulatedDevice.ts
+++ b/src/main/device/SimulatedDevice.ts
@@ -1,0 +1,208 @@
+import { EventEmitter } from 'events'
+import { VIRTUAL_PORT_PATH } from '../../shared/virtual-device'
+import { isProbeCode, simulateProbeResponse, simulatedTelemetryFrame } from './simulation'
+import type {
+  ConnectionState,
+  DeviceStatus,
+  DirEntry,
+  ExecResult,
+  SnakieDevice,
+  StatResult
+} from './types'
+
+/** How often the simulated board "prints" a telemetry frame (ms). */
+const TELEMETRY_INTERVAL_MS = 120
+
+/** Boot banner the simulated friendly REPL greets with. */
+const BANNER =
+  '\r\nMicroPython v1.24.0 (Snakie simulator) on rp2; Virtual board with RP2040\r\n' +
+  'Type "help()" for more information.\r\n>>> '
+
+/**
+ * SIMULATED MicroPython device (issue #135).
+ *
+ * A drop-in {@link SnakieDevice} that needs no hardware: it fakes the friendly
+ * REPL (banner + keystroke echo), continuously emits realistic `SNK …` telemetry
+ * so the instruments animate, and answers the Board Viewer's `<<SNKV>>` live-pin
+ * probe with plausible values — letting users explore Snakie, the instruments
+ * and the Board Viewer Live View completely offline.
+ *
+ * It deliberately mirrors {@link MicroPythonDevice}'s public surface (and emits
+ * the same `data` / `status` events) so `device/ipc.ts` can route to it for the
+ * reserved virtual port without any special-casing downstream. All the signal
+ * generation lives in the pure `simulation.ts` helpers; this class only owns the
+ * connection lifecycle, the telemetry timer and the fake REPL/filesystem.
+ */
+export class SimulatedDevice extends EventEmitter implements SnakieDevice {
+  private state: ConnectionState = 'disconnected'
+  private timer: ReturnType<typeof setInterval> | null = null
+  private tick = 0
+  /** Latest control payload per target (for inspection / future feedback). */
+  private readonly control = new Map<string, string>()
+
+  on(event: 'data', listener: (chunk: Buffer) => void): this
+  on(event: 'status', listener: (status: DeviceStatus) => void): this
+  on(event: string, listener: (...args: never[]) => void): this {
+    return super.on(event, listener as (...args: unknown[]) => void)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Connection lifecycle
+  // ---------------------------------------------------------------------------
+
+  getStatus(): DeviceStatus {
+    return { state: this.state, path: VIRTUAL_PORT_PATH, baudRate: 115200 }
+  }
+
+  isConnected(): boolean {
+    return this.state === 'connected'
+  }
+
+  async connect(): Promise<void> {
+    if (this.state === 'connected') return
+    // Mimic the real flow: a brief "connecting" then "connected".
+    this.setState('connecting')
+    this.setState('connected')
+    // Greet on the friendly REPL, then start the telemetry stream.
+    this.emit('data', Buffer.from(BANNER, 'utf8'))
+    this.startTelemetry()
+  }
+
+  async disconnect(): Promise<void> {
+    this.stopTelemetry()
+    this.control.clear()
+    if (this.state !== 'disconnected') this.setState('disconnected')
+  }
+
+  private setState(state: ConnectionState): void {
+    this.state = state
+    this.emit('status', { state, path: VIRTUAL_PORT_PATH, baudRate: 115200 })
+  }
+
+  // ---------------------------------------------------------------------------
+  // Telemetry stream (board → IDE)
+  // ---------------------------------------------------------------------------
+
+  private startTelemetry(): void {
+    if (this.timer) return
+    this.timer = setInterval(() => this.emitTelemetryFrame(), TELEMETRY_INTERVAL_MS)
+    // Guard against the interval keeping the app alive on quit (Node only).
+    this.timer.unref?.()
+  }
+
+  private stopTelemetry(): void {
+    if (this.timer) {
+      clearInterval(this.timer)
+      this.timer = null
+    }
+  }
+
+  /** Emit one frame of `SNK …` telemetry as a single `data` chunk. */
+  private emitTelemetryFrame(): void {
+    if (this.state !== 'connected') return
+    const frame = simulatedTelemetryFrame(this.tick++)
+    if (frame.length === 0) return
+    this.emit('data', Buffer.from(frame.join('\r\n') + '\r\n', 'utf8'))
+  }
+
+  // ---------------------------------------------------------------------------
+  // REPL / exec
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Run code in the "raw REPL". The only snippet we meaningfully answer is the
+   * Board Viewer's `<<SNKV>>` live-pin probe; anything else returns empty output
+   * (no traceback), which is enough for the offline experience.
+   */
+  async exec(code: string): Promise<ExecResult> {
+    if (this.state !== 'connected') throw new Error('Not connected')
+    if (isProbeCode(code)) {
+      return { stdout: simulateProbeResponse(code, this.tick), stderr: '' }
+    }
+    return { stdout: '', stderr: '' }
+  }
+
+  async eval(code: string): Promise<string> {
+    const { stdout, stderr } = await this.exec(code)
+    if (stderr.trim().length > 0) throw new Error(stderr.trim())
+    return stdout
+  }
+
+  /** Echo user keystrokes back to the fake REPL so typing feels alive. */
+  async sendData(data: string): Promise<void> {
+    if (this.state !== 'connected') return
+    if (data.includes('\x03')) {
+      // Ctrl-C → KeyboardInterrupt and a fresh prompt.
+      this.emit('data', Buffer.from('\r\nKeyboardInterrupt\r\n>>> ', 'utf8'))
+      return
+    }
+    if (data.includes('\x04')) {
+      // Ctrl-D → soft reset: re-print the banner.
+      this.emit('data', Buffer.from(BANNER, 'utf8'))
+      return
+    }
+    // Echo what was typed; on Enter, drop to a new prompt line.
+    const echoed = data.replace(/\r/g, '\r\n>>> ')
+    this.emit('data', Buffer.from(echoed, 'utf8'))
+  }
+
+  /** Record an IDE→board control command (latest-wins per target). */
+  async sendControl(target: string, payload = ''): Promise<void> {
+    this.control.set(target, payload)
+  }
+
+  async interrupt(): Promise<void> {
+    await this.sendData('\x03')
+  }
+
+  async softReset(): Promise<void> {
+    await this.sendData('\x04')
+  }
+
+  // ---------------------------------------------------------------------------
+  // Filesystem — a tiny, read-only simulated FS so the device tree isn't broken
+  // ---------------------------------------------------------------------------
+
+  async listDir(path = '/'): Promise<DirEntry[]> {
+    const root = path === '' || path === '/'
+    if (root) {
+      return [
+        { name: 'boot.py', isDir: false, size: 24 },
+        { name: 'main.py', isDir: false, size: 96 },
+        { name: 'lib', isDir: true, size: 0 }
+      ]
+    }
+    if (path === '/lib' || path === 'lib') {
+      return [{ name: 'snakie_instruments.py', isDir: false, size: 0 }]
+    }
+    return []
+  }
+
+  async readFile(path: string): Promise<string> {
+    if (path.endsWith('main.py')) {
+      return '# Simulated device — connect real hardware to edit files.\nprint("hello from the simulator")\n'
+    }
+    return ''
+  }
+
+  async writeFile(): Promise<void> {
+    // Writes are accepted but not persisted on the simulated device.
+  }
+
+  async remove(): Promise<void> {}
+
+  async mkdir(): Promise<void> {}
+
+  async rename(): Promise<void> {}
+
+  async stat(path: string): Promise<StatResult> {
+    const isDir = path.endsWith('/lib') || path === '/' || path === ''
+    return { isDir, size: isDir ? 0 : 96 }
+  }
+
+  async dispose(): Promise<void> {
+    this.stopTelemetry()
+    this.removeAllListeners()
+    this.state = 'disconnected'
+  }
+}

--- a/src/main/device/ipc.ts
+++ b/src/main/device/ipc.ts
@@ -1,6 +1,8 @@
 import { ipcMain, type WebContents } from 'electron'
+import { isVirtualPort, VIRTUAL_PORT_PATH, VIRTUAL_PORT_LABEL } from '../../shared/virtual-device'
 import { MicroPythonDevice } from './MicroPythonDevice'
-import type { ConnectOptions, DeviceStatus, IpcResult } from './types'
+import { SimulatedDevice } from './SimulatedDevice'
+import type { ConnectOptions, DeviceStatus, IpcResult, PortInfo, SnakieDevice } from './types'
 
 /**
  * IPC channel names for the device layer. Renderer-facing channels are prefixed
@@ -12,14 +14,34 @@ export const DEVICE_CHANNELS = {
 } as const
 
 /**
- * A single shared {@link MicroPythonDevice} instance. The app talks to one
- * board at a time; later issues can extend this to a registry keyed by path.
+ * The device layer routes between two backends (issue #135):
+ *  - {@link MicroPythonDevice} — a real board over serial,
+ *  - {@link SimulatedDevice}   — the offline/virtual board.
+ *
+ * Both implement {@link SnakieDevice} and emit the same `data` / `status`
+ * events. `active` is whichever the user last connected to (default: the real
+ * device, so a fresh launch behaves exactly as before). `device:connect` picks
+ * the backend from the selected port and disconnects the other first, so the two
+ * never run at once.
  */
-let device: MicroPythonDevice | null = null
+let real: MicroPythonDevice | null = null
+let sim: SimulatedDevice | null = null
+let active: SnakieDevice | null = null
 
-function getDevice(): MicroPythonDevice {
-  if (!device) device = new MicroPythonDevice()
-  return device
+function getReal(): MicroPythonDevice {
+  if (!real) real = new MicroPythonDevice()
+  return real
+}
+
+function getSim(): SimulatedDevice {
+  if (!sim) sim = new SimulatedDevice()
+  return sim
+}
+
+/** The currently-targeted backend (defaults to the real serial device). */
+function getActive(): SnakieDevice {
+  if (!active) active = getReal()
+  return active
 }
 
 /**
@@ -43,72 +65,103 @@ async function wrap<T>(fn: () => Promise<T>): Promise<IpcResult<T>> {
  *   destroyed window after reloads).
  */
 export function registerDeviceIpc(getWebContents: () => WebContents | undefined): void {
-  const dev = getDevice()
+  const realDev = getReal()
+  const simDev = getSim()
 
-  // Forward raw serial output and status changes to the renderer.
-  dev.on('data', (chunk) => {
-    const wc = getWebContents()
-    if (wc && !wc.isDestroyed()) {
-      // Send as a Uint8Array; it survives structured clone across IPC.
-      wc.send(DEVICE_CHANNELS.data, new Uint8Array(chunk))
-    }
-  })
-  dev.on('status', (status: DeviceStatus) => {
-    const wc = getWebContents()
-    if (wc && !wc.isDestroyed()) {
-      wc.send(DEVICE_CHANNELS.status, status)
-    }
-  })
+  // Forward raw output and status from BOTH backends; only the connected one
+  // ever emits, so there is no cross-talk between real and simulated devices.
+  const forward = (dev: SnakieDevice): void => {
+    dev.on('data', (chunk) => {
+      const wc = getWebContents()
+      if (wc && !wc.isDestroyed()) {
+        // Send as a Uint8Array; it survives structured clone across IPC.
+        wc.send(DEVICE_CHANNELS.data, new Uint8Array(chunk))
+      }
+    })
+    dev.on('status', (status: DeviceStatus) => {
+      const wc = getWebContents()
+      if (wc && !wc.isDestroyed()) {
+        wc.send(DEVICE_CHANNELS.status, status)
+      }
+    })
+  }
+  forward(realDev)
+  forward(simDev)
 
-  ipcMain.handle('device:listPorts', () => wrap(() => MicroPythonDevice.listPorts()))
-
-  ipcMain.handle('device:connect', (_e, path: string, opts?: ConnectOptions) =>
-    wrap(() => dev.connect(path, opts ?? {}))
+  // Real serial ports, plus the built-in simulated device so users can work
+  // offline (#135). The virtual port is appended so real hardware lists first.
+  ipcMain.handle('device:listPorts', () =>
+    wrap(async () => {
+      const ports = await MicroPythonDevice.listPorts()
+      const virtual: PortInfo = { path: VIRTUAL_PORT_PATH, friendlyName: VIRTUAL_PORT_LABEL }
+      return [...ports, virtual]
+    })
   )
 
-  ipcMain.handle('device:disconnect', () => wrap(() => dev.disconnect()))
+  ipcMain.handle('device:connect', (_e, path: string, opts?: ConnectOptions) =>
+    wrap(async () => {
+      if (isVirtualPort(path)) {
+        // Switch to the simulated board, disconnecting any real one first.
+        if (realDev.isConnected()) await realDev.disconnect()
+        active = simDev
+        await simDev.connect()
+      } else {
+        // Switch to the real board, stopping the simulator first.
+        if (simDev.isConnected()) await simDev.disconnect()
+        active = realDev
+        await realDev.connect(path, opts ?? {})
+      }
+    })
+  )
 
-  ipcMain.handle('device:getStatus', () => wrap(async () => dev.getStatus()))
+  ipcMain.handle('device:disconnect', () => wrap(() => getActive().disconnect()))
 
-  ipcMain.handle('device:exec', (_e, code: string) => wrap(() => dev.exec(code)))
+  ipcMain.handle('device:getStatus', () => wrap(async () => getActive().getStatus()))
 
-  ipcMain.handle('device:eval', (_e, code: string) => wrap(() => dev.eval(code)))
+  ipcMain.handle('device:exec', (_e, code: string) => wrap(() => getActive().exec(code)))
 
-  ipcMain.handle('device:sendData', (_e, data: string) => wrap(() => dev.sendData(data)))
+  ipcMain.handle('device:eval', (_e, code: string) => wrap(() => getActive().eval(code)))
+
+  ipcMain.handle('device:sendData', (_e, data: string) => wrap(() => getActive().sendData(data)))
 
   // IDE→board control line (issue #115): `SNKCMD <target> <payload>\n`.
   ipcMain.handle('device:sendControl', (_e, target: string, payload?: string) =>
-    wrap(() => dev.sendControl(target, payload ?? ''))
+    wrap(() => getActive().sendControl(target, payload ?? ''))
   )
 
-  ipcMain.handle('device:interrupt', () => wrap(() => dev.interrupt()))
+  ipcMain.handle('device:interrupt', () => wrap(() => getActive().interrupt()))
 
-  ipcMain.handle('device:softReset', () => wrap(() => dev.softReset()))
+  ipcMain.handle('device:softReset', () => wrap(() => getActive().softReset()))
 
   // Filesystem helpers.
-  ipcMain.handle('device:listDir', (_e, path?: string) => wrap(() => dev.listDir(path ?? '/')))
+  ipcMain.handle('device:listDir', (_e, path?: string) => wrap(() => getActive().listDir(path ?? '/')))
 
-  ipcMain.handle('device:readFile', (_e, path: string) => wrap(() => dev.readFile(path)))
+  ipcMain.handle('device:readFile', (_e, path: string) => wrap(() => getActive().readFile(path)))
 
   ipcMain.handle('device:writeFile', (_e, path: string, contents: string) =>
-    wrap(() => dev.writeFile(path, contents))
+    wrap(() => getActive().writeFile(path, contents))
   )
 
-  ipcMain.handle('device:remove', (_e, path: string) => wrap(() => dev.remove(path)))
+  ipcMain.handle('device:remove', (_e, path: string) => wrap(() => getActive().remove(path)))
 
-  ipcMain.handle('device:mkdir', (_e, path: string) => wrap(() => dev.mkdir(path)))
+  ipcMain.handle('device:mkdir', (_e, path: string) => wrap(() => getActive().mkdir(path)))
 
   ipcMain.handle('device:rename', (_e, from: string, to: string) =>
-    wrap(() => dev.rename(from, to))
+    wrap(() => getActive().rename(from, to))
   )
 
-  ipcMain.handle('device:stat', (_e, path: string) => wrap(() => dev.stat(path)))
+  ipcMain.handle('device:stat', (_e, path: string) => wrap(() => getActive().stat(path)))
 }
 
-/** Dispose the shared device (call on app quit). */
+/** Dispose both device backends (call on app quit). */
 export async function disposeDevice(): Promise<void> {
-  if (device) {
-    await device.dispose()
-    device = null
+  if (real) {
+    await real.dispose()
+    real = null
   }
+  if (sim) {
+    await sim.dispose()
+    sim = null
+  }
+  active = null
 }

--- a/src/main/device/simulation.ts
+++ b/src/main/device/simulation.ts
@@ -1,0 +1,108 @@
+/**
+ * SIMULATION CORE — pure signal/protocol helpers for the simulated device (#135).
+ * =============================================================================
+ *
+ * Kept dependency-free (no Electron, no serialport, no Node APIs) so it is fast
+ * to unit-test and so {@link SimulatedDevice} stays a thin wrapper around these
+ * deterministic functions. Everything here is driven by an integer `tick` rather
+ * than the wall clock, so a frame is fully reproducible in tests.
+ *
+ *  - {@link simulatedTelemetryFrame} produces the `SNK …` telemetry lines a real
+ *    board would PRINT (board→IDE), matching the wire format the renderer parser
+ *    expects (see `instrument-telemetry.ts` / `micropython/instruments.py`).
+ *  - {@link simulateProbeResponse} answers the Board Viewer's `<<SNKV>>` live-pin
+ *    probe (see `board-values.ts`) with plausible per-pin values.
+ */
+
+/** Telemetry sentinel — mirrors `TELEMETRY_SENTINEL` in instrument-telemetry.ts. */
+const SNK = 'SNK'
+
+/**
+ * Live-value probe marker — mirrors `PROBE_MARK` in `board-values.ts`. The Board
+ * Viewer execs a snippet whose `print()`s emit `<<SNKV>><index>:<value>` lines;
+ * we recognise those indices and answer with simulated values.
+ */
+export const PROBE_MARK = '<<SNKV>>'
+
+/** Round to `places` decimals and return a compact string (no trailing zeros). */
+function fixed(value: number, places = 3): string {
+  return Number(value.toFixed(places)).toString()
+}
+
+/**
+ * The `SNK …` telemetry lines for one simulated frame at integer `tick`.
+ *
+ * A believable mix is emitted every frame so that whichever instruments the user
+ * opens animate immediately: an oscilloscope trace, a multimeter voltage, a
+ * two-series plot, a gently tumbling IMU, a ranging sensor and an encoder, plus
+ * an occasional button event and a `READY` heartbeat. Each entry is ONE complete
+ * line WITHOUT a trailing newline (the caller joins + terminates them).
+ */
+export function simulatedTelemetryFrame(tick: number): string[] {
+  // ~0.12 s per tick → a slow, readable phase for the periodic signals.
+  const phase = tick * 0.12
+  const lines: string[] = []
+
+  // Oscilloscope: a clean sine on ch1 plus a slower PWM-style 0..1 ramp.
+  lines.push(`${SNK} SCOPE ch1 ${fixed(Math.sin(phase * 2), 4)}`)
+  lines.push(`${SNK} SCOPE pwm ${fixed(0.5 + 0.5 * Math.sin(phase), 4)}`)
+
+  // Multimeter: a voltage wobbling around the 3.3 V rail's midpoint.
+  lines.push(`${SNK} METER adc0 ${fixed(1.65 + 0.4 * Math.sin(phase * 0.7))} V`)
+
+  // Plotter: two named series.
+  const temp = 22 + 2 * Math.sin(phase * 0.3)
+  const light = Math.round(50 + 40 * Math.sin(phase * 0.5 + 1))
+  lines.push(`${SNK} PLOT temp=${fixed(temp, 1)} light=${light}`)
+
+  // IMU: a gentle tumble in roll / pitch / yaw (degrees).
+  lines.push(
+    `${SNK} IMU imu ${fixed(20 * Math.sin(phase))} ${fixed(15 * Math.sin(phase * 0.8 + 1))} ${fixed(
+      (tick * 3) % 360
+    )}`
+  )
+
+  // Distance: a sensor sweeping ~30–270 mm.
+  lines.push(`${SNK} DIST dist ${Math.round(150 + 120 * Math.sin(phase * 0.6))}`)
+
+  // Encoder: a monotonically rising count.
+  lines.push(`${SNK} ENC enc ${tick}`)
+
+  // Button "a": a brief press every ~5 s so the Button instrument blinks.
+  lines.push(`${SNK} BTN a ${tick % 40 < 3 ? 1 : 0}`)
+
+  // Heartbeat every ~2 s advertising the simulated capabilities.
+  if (tick % 16 === 0) {
+    lines.push(`${SNK} READY scope meter plot imu dist enc btn`)
+  }
+
+  return lines
+}
+
+/**
+ * Answer the Board Viewer live-pin probe. The probe code prints one
+ * `<<SNKV>><index>:<value>` line per wired pin; we extract those indices and
+ * return a value for each so the Live View animates. Values span 0..65535 (a
+ * believable `read_u16()` / `duty_u16()` range) and drift with `tick`. Returns
+ * the stdout the renderer's `parseProbeOutput` expects (lines joined by `\n`).
+ */
+export function simulateProbeResponse(code: string, tick: number): string {
+  const indices: number[] = []
+  const re = new RegExp(`${PROBE_MARK.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(\\d+):`, 'g')
+  let m: RegExpExecArray | null
+  while ((m = re.exec(code)) !== null) {
+    const idx = Number.parseInt(m[1], 10)
+    if (Number.isInteger(idx) && !indices.includes(idx)) indices.push(idx)
+  }
+  return indices
+    .map((idx) => {
+      const v = Math.round(32768 * (1 + Math.sin(tick * 0.4 + idx)))
+      return `${PROBE_MARK}${idx}:${v}`
+    })
+    .join('\n')
+}
+
+/** Does this exec snippet look like a Board Viewer live-pin probe? */
+export function isProbeCode(code: string): boolean {
+  return code.includes(PROBE_MARK)
+}

--- a/src/main/device/types.ts
+++ b/src/main/device/types.ts
@@ -70,3 +70,33 @@ export interface StatResult {
  * Electron's lossy error re-throwing.
  */
 export type IpcResult<T> = { ok: true; value: T } | { ok: false; error: string }
+
+/**
+ * The common device surface the IPC layer talks to. Both the real
+ * `MicroPythonDevice` (serial) and the `SimulatedDevice` (offline mode, #135)
+ * implement this, so `device/ipc.ts` can route to whichever backend is active
+ * without caring which is which. The `data` / `status` events carry the same
+ * payloads from both backends.
+ */
+export interface SnakieDevice {
+  connect(path: string, options?: ConnectOptions): Promise<void>
+  disconnect(): Promise<void>
+  getStatus(): DeviceStatus
+  isConnected(): boolean
+  exec(code: string, timeoutMs?: number): Promise<ExecResult>
+  eval(code: string, timeoutMs?: number): Promise<string>
+  sendData(data: string): Promise<void>
+  sendControl(target: string, payload?: string): Promise<void>
+  interrupt(): Promise<void>
+  softReset(): Promise<void>
+  listDir(path?: string): Promise<DirEntry[]>
+  readFile(path: string): Promise<string>
+  writeFile(path: string, contents: string | Buffer): Promise<void>
+  remove(path: string): Promise<void>
+  mkdir(path: string): Promise<void>
+  rename(from: string, to: string): Promise<void>
+  stat(path: string): Promise<StatResult>
+  dispose(): Promise<void>
+  on(event: 'data', listener: (chunk: Buffer) => void): this
+  on(event: 'status', listener: (status: DeviceStatus) => void): this
+}

--- a/src/renderer/src/components/ConnectionControl.tsx
+++ b/src/renderer/src/components/ConnectionControl.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
+import { isVirtualPort, VIRTUAL_PORT_LABEL } from '../../../shared/virtual-device'
 import type { DeviceStatus, PortInfo } from '../../../preload/index.d'
 
 interface ConnectionControlProps {
@@ -71,6 +72,15 @@ export function ConnectionControl({ status }: ConnectionControlProps): JSX.Eleme
       >
         {ports.length === 0 && <option value="">No ports</option>}
         {ports.map((p) => {
+          // The simulated device shows just its friendly label (its sentinel
+          // path, `snakie://virtual`, is an implementation detail).
+          if (isVirtualPort(p.path)) {
+            return (
+              <option key={p.path} value={p.path}>
+                {VIRTUAL_PORT_LABEL}
+              </option>
+            )
+          }
           const detail = p.friendlyName ?? p.manufacturer
           return (
             <option key={p.path} value={p.path}>

--- a/src/renderer/src/components/StatusBar.css
+++ b/src/renderer/src/components/StatusBar.css
@@ -108,6 +108,18 @@
   color: var(--text);
 }
 
+/* Simulated / offline device (#135): an amber "hollow" LED + accented text so
+   it reads as "alive but not real hardware" — clearly distinct from a green
+   connected board and a grey disconnected one. */
+.statusbar__conn--sim .statusbar__dot {
+  background: var(--warn);
+  box-shadow: inset 0 0 0 2px var(--bg-elevated);
+}
+
+.statusbar__conn--sim {
+  color: var(--text);
+}
+
 /* Clickable items (plugin links, update restart). */
 .statusbar__link {
   background: transparent;

--- a/src/renderer/src/components/StatusBar.tsx
+++ b/src/renderer/src/components/StatusBar.tsx
@@ -13,6 +13,7 @@ import {
   firmwareFamilyFromBanner,
   firmwareUpdateFromConsole
 } from './firmware-version'
+import { isVirtualPort, VIRTUAL_PORT_SHORT } from '../../../shared/virtual-device'
 import type { FirmwareCatalog, UpdateStatus } from '../../../preload/index.d'
 import './StatusBar.css'
 
@@ -161,14 +162,20 @@ export function StatusBar({
   }, [refreshGit])
 
   const connected = status.state === 'connected'
+  // Offline mode (#135): connected to the built-in simulated device, not real
+  // hardware — surfaced with a distinct label + badge so it's never mistaken
+  // for a physical board.
+  const simulated = connected && isVirtualPort(status.path)
   const connLabel =
     status.state === 'connecting'
       ? 'Connecting…'
-      : connected
-        ? `Connected${status.path ? ` · ${status.path}` : ''}`
-        : status.state === 'error'
-          ? 'Error'
-          : 'Disconnected'
+      : simulated
+        ? `${VIRTUAL_PORT_SHORT} · offline`
+        : connected
+          ? `Connected${status.path ? ` · ${status.path}` : ''}`
+          : status.state === 'error'
+            ? 'Error'
+            : 'Disconnected'
 
   // Detect a newer MicroPython for the connected device (#173): read its running
   // version from the REPL boot banner and compare against the firmware catalog's
@@ -251,8 +258,20 @@ export function StatusBar({
     <footer className="statusbar" role="contentinfo" aria-label="Status bar">
       <div className="statusbar__group statusbar__group--left">
         <span
-          className={`statusbar__item statusbar__conn ${connected ? 'statusbar__conn--connected' : 'statusbar__conn--disconnected'}`}
-          title={status.error ? `Connection error: ${status.error}` : 'Device connection status'}
+          className={`statusbar__item statusbar__conn ${
+            simulated
+              ? 'statusbar__conn--sim'
+              : connected
+                ? 'statusbar__conn--connected'
+                : 'statusbar__conn--disconnected'
+          }`}
+          title={
+            status.error
+              ? `Connection error: ${status.error}`
+              : simulated
+                ? 'Simulated device — no hardware connected (offline mode)'
+                : 'Device connection status'
+          }
         >
           <span className="statusbar__dot" aria-hidden="true" />
           <span>{connLabel}</span>

--- a/src/shared/virtual-device.ts
+++ b/src/shared/virtual-device.ts
@@ -1,0 +1,30 @@
+/**
+ * VIRTUAL (SIMULATED) DEVICE — shared identity for Snakie's offline mode (#135).
+ * =============================================================================
+ *
+ * Snakie can target a SIMULATED MicroPython device when no hardware is plugged
+ * in, so the instruments and the Board Viewer Live View work offline (for
+ * learning, demos and development). The simulated device is presented in the
+ * shell's port dropdown like any other port, identified by a reserved sentinel
+ * "path" that can never collide with a real OS serial path (`/dev/…`, `COM3`,
+ * etc.) because of the `snakie://` scheme.
+ *
+ * This module is dependency-free so every layer can agree on the identity:
+ *  - the MAIN process routes `device:connect` to the simulator for this path,
+ *  - `device:listPorts` injects it as a selectable port,
+ *  - the RENDERER labels it cleanly and shows an "offline / simulated" badge.
+ */
+
+/** Reserved sentinel "port path" for the built-in simulated device. */
+export const VIRTUAL_PORT_PATH = 'snakie://virtual'
+
+/** Friendly label shown for the simulated device in the port dropdown. */
+export const VIRTUAL_PORT_LABEL = 'Simulated device (offline)'
+
+/** Short label for compact UI (status bar badge, etc.). */
+export const VIRTUAL_PORT_SHORT = 'Simulated device'
+
+/** Is `path` the reserved simulated-device sentinel? */
+export function isVirtualPort(path: string | undefined | null): boolean {
+  return path === VIRTUAL_PORT_PATH
+}

--- a/test/simulatedDevice.test.ts
+++ b/test/simulatedDevice.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest'
+import { SimulatedDevice } from '../src/main/device/SimulatedDevice'
+import { isTelemetry } from '../src/renderer/src/components/instrument-telemetry'
+import {
+  isVirtualPort,
+  VIRTUAL_PORT_PATH,
+  VIRTUAL_PORT_LABEL
+} from '../src/shared/virtual-device'
+
+describe('virtual-device identity', () => {
+  it('recognises only the reserved sentinel path', () => {
+    expect(isVirtualPort(VIRTUAL_PORT_PATH)).toBe(true)
+    expect(isVirtualPort('/dev/ttyACM0')).toBe(false)
+    expect(isVirtualPort('COM3')).toBe(false)
+    expect(isVirtualPort(undefined)).toBe(false)
+    expect(isVirtualPort(null)).toBe(false)
+  })
+
+  it('uses a scheme that cannot collide with an OS serial path', () => {
+    expect(VIRTUAL_PORT_PATH.startsWith('snakie://')).toBe(true)
+    expect(VIRTUAL_PORT_LABEL.length).toBeGreaterThan(0)
+  })
+})
+
+describe('SimulatedDevice lifecycle', () => {
+  it('starts disconnected and reports the virtual path', () => {
+    const dev = new SimulatedDevice()
+    const status = dev.getStatus()
+    expect(status.state).toBe('disconnected')
+    expect(status.path).toBe(VIRTUAL_PORT_PATH)
+    expect(dev.isConnected()).toBe(false)
+  })
+
+  it('emits connecting → connected status and a REPL banner on connect', async () => {
+    const dev = new SimulatedDevice()
+    const states: string[] = []
+    const data: string[] = []
+    dev.on('status', (s) => states.push(s.state))
+    dev.on('data', (c) => data.push(c.toString('utf8')))
+
+    await dev.connect()
+    expect(states).toEqual(['connecting', 'connected'])
+    expect(dev.isConnected()).toBe(true)
+    expect(data.join('')).toContain('MicroPython')
+
+    await dev.dispose()
+  })
+
+  it('streams parseable SNK telemetry while connected', async () => {
+    const dev = new SimulatedDevice()
+    const chunks: string[] = []
+    dev.on('data', (c) => chunks.push(c.toString('utf8')))
+    await dev.connect()
+
+    // Wait for a couple of telemetry frames (interval ~120ms).
+    await new Promise((r) => setTimeout(r, 300))
+    await dev.disconnect()
+
+    const lines = chunks
+      .join('')
+      .split(/\r?\n/)
+      .filter((l) => l.startsWith('SNK'))
+    expect(lines.length).toBeGreaterThan(0)
+    for (const line of lines) expect(isTelemetry(line)).toBe(true)
+
+    await dev.dispose()
+  })
+
+  it('stops emitting telemetry after disconnect', async () => {
+    const dev = new SimulatedDevice()
+    await dev.connect()
+    await dev.disconnect()
+
+    let emitted = false
+    dev.on('data', () => {
+      emitted = true
+    })
+    await new Promise((r) => setTimeout(r, 250))
+    expect(emitted).toBe(false)
+    expect(dev.getStatus().state).toBe('disconnected')
+
+    await dev.dispose()
+  })
+
+  it('answers the live-pin probe via exec and rejects exec when disconnected', async () => {
+    const dev = new SimulatedDevice()
+    await expect(dev.exec('print(1)')).rejects.toThrow(/Not connected/)
+
+    await dev.connect()
+    const probe = `print('<<SNKV>>0:'+str(x))`
+    const { stdout, stderr } = await dev.exec(probe)
+    expect(stderr).toBe('')
+    expect(stdout).toContain('<<SNKV>>0:')
+
+    // A non-probe exec returns empty output (no traceback).
+    expect((await dev.exec('1+1')).stdout).toBe('')
+
+    await dev.dispose()
+  })
+
+  it('records control commands (latest-wins per target)', async () => {
+    const dev = new SimulatedDevice()
+    await dev.connect()
+    // Should not throw; the simulator accepts any control line.
+    await dev.sendControl('led', 'pwm 0.5')
+    await dev.sendControl('teleop', 'axes=drive:0.5')
+    await dev.dispose()
+  })
+
+  it('exposes a small simulated filesystem so the device tree is usable', async () => {
+    const dev = new SimulatedDevice()
+    await dev.connect()
+    const root = await dev.listDir('/')
+    expect(root.some((e) => e.name === 'main.py')).toBe(true)
+    expect(root.some((e) => e.isDir)).toBe(true)
+    expect(await dev.readFile('/main.py')).toContain('simulator')
+    await dev.dispose()
+  })
+})

--- a/test/simulation.test.ts
+++ b/test/simulation.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isProbeCode,
+  PROBE_MARK,
+  simulatedTelemetryFrame,
+  simulateProbeResponse
+} from '../src/main/device/simulation'
+import {
+  isTelemetry,
+  parseTelemetry
+} from '../src/renderer/src/components/instrument-telemetry'
+import { buildValueProbe, parseProbeOutput } from '../src/renderer/src/components/board-values'
+import type { UsedPins } from '../src/renderer/src/components/parse-pins'
+
+/**
+ * The simulator (issue #135) must speak the EXACT telemetry + probe dialect the
+ * renderer already parses. Rather than re-assert the wire format here, we feed
+ * the simulator's output through the real consumer parsers — so these tests
+ * fail if either side of the contract drifts.
+ */
+describe('simulatedTelemetryFrame', () => {
+  it('emits only well-formed SNK telemetry lines the renderer can parse', () => {
+    for (let tick = 0; tick < 64; tick++) {
+      const lines = simulatedTelemetryFrame(tick)
+      expect(lines.length).toBeGreaterThan(0)
+      for (const line of lines) {
+        expect(isTelemetry(line)).toBe(true)
+        // Every line either parses to a reading or is the READY heartbeat
+        // (which isTelemetry accepts but parseTelemetry intentionally ignores).
+        const reading = parseTelemetry(line)
+        if (!line.includes('READY')) {
+          expect(reading).not.toBeNull()
+        }
+      }
+    }
+  })
+
+  it('covers the core instrument kinds in a single frame', () => {
+    const readings = simulatedTelemetryFrame(0)
+      .map((l) => parseTelemetry(l))
+      .filter((r): r is NonNullable<typeof r> => r !== null)
+    const kinds = new Set(readings.map((r) => r.kind))
+    for (const kind of ['scope', 'meter', 'plot', 'imu', 'dist', 'enc', 'btn']) {
+      expect(kinds.has(kind as never)).toBe(true)
+    }
+  })
+
+  it('produces a moving scope signal across frames (animates)', () => {
+    const scopeAt = (tick: number): number => {
+      const r = parseTelemetry(simulatedTelemetryFrame(tick)[0])
+      if (!r || r.kind !== 'scope') throw new Error('expected scope reading first')
+      return r.value
+    }
+    // Two ticks a quarter-period apart should differ.
+    expect(scopeAt(0)).not.toBe(scopeAt(3))
+  })
+
+  it('emits a READY heartbeat on the first frame', () => {
+    expect(simulatedTelemetryFrame(0).some((l) => l.includes('READY'))).toBe(true)
+    expect(simulatedTelemetryFrame(1).some((l) => l.includes('READY'))).toBe(false)
+  })
+})
+
+describe('simulateProbeResponse', () => {
+  function conn(partial: Partial<UsedPins> & Pick<UsedPins, 'type'>): UsedPins {
+    return {
+      pins: ['0'],
+      variable: 'x',
+      constructor: 'Pin(0)',
+      ...partial
+    }
+  }
+
+  it('answers every index in a real probe, and the renderer parses the values', () => {
+    const conns: UsedPins[] = [
+      conn({ type: 'output', variable: 'led' }),
+      conn({ type: 'adc', variable: 'pot' }),
+      conn({ type: 'pwm', variable: 'servo' })
+    ]
+    const probe = buildValueProbe(conns)
+    expect(isProbeCode(probe)).toBe(true)
+
+    const stdout = simulateProbeResponse(probe, 5)
+    const values = parseProbeOutput(stdout)
+    // One live value per probeable connection.
+    expect(values.size).toBe(conns.length)
+    for (let i = 0; i < conns.length; i++) {
+      const v = values.get(i)
+      expect(v).toBeDefined()
+      expect(typeof v?.value).toBe('number')
+      expect(v?.value).toBeGreaterThanOrEqual(0)
+      expect(v?.value).toBeLessThanOrEqual(65535)
+    }
+  })
+
+  it('returns empty output for a non-probe snippet', () => {
+    expect(simulateProbeResponse('print("hi")', 0)).toBe('')
+    expect(isProbeCode('print("hi")')).toBe(false)
+  })
+
+  it('animates probe values across ticks', () => {
+    const probe = `print('${PROBE_MARK}0:'+str(x))`
+    const a = parseProbeOutput(simulateProbeResponse(probe, 0)).get(0)?.value
+    const b = parseProbeOutput(simulateProbeResponse(probe, 4)).get(0)?.value
+    expect(a).not.toBe(b)
+  })
+})


### PR DESCRIPTION
Closes #135.

Adds a built-in **Simulated device (offline)** so Snakie's instruments and the **Board Viewer Live View** work with **no hardware connected** — for learning, demos and development.

## How it works

- **`SimulatedDevice`** (`src/main/device/SimulatedDevice.ts`) — a drop-in backend that:
  - fakes the friendly REPL (boot banner + keystroke echo),
  - streams realistic `SNK …` telemetry (scope / meter / plot / IMU / distance / encoder / button + a `READY` heartbeat) so whichever instruments you open **animate immediately**,
  - answers the Board Viewer's `<<SNKV>>` **live-pin probe** with plausible values that drift over time, so the **Live View** works,
  - exposes a tiny simulated filesystem so the device tree isn't broken,
  - accepts `SNKCMD` control lines.
- **Routing** — a shared `SnakieDevice` interface is implemented by both the real `MicroPythonDevice` and the simulator. `device/ipc.ts` routes `device:connect` to the backend chosen by the selected port (and disconnects the other first, so switching is seamless), and `device:listPorts` injects the reserved virtual port (`snakie://virtual`).
- **UI** — the simulator appears in the shell port dropdown as **"Simulated device (offline)"**, and the status bar shows a distinct **"Simulated device · offline"** amber badge so it's never mistaken for real hardware.

## Requirements (all met)

- [x] Simulated MicroPython device the app can target
- [x] Instruments work against it
- [x] Board Viewer + Live View work against it
- [x] Clear UI indication of simulated / offline mode
- [x] Graceful switch between real device and simulation
- [x] Presented as a virtual device in the shell's port dropdown

## Design note

The issue's research pointer suggested looking at Damien George's web MicroPython (WASM) simulator. This PR ships a **behavioural** simulator instead of compiling/bundling `micropython.wasm`: it's far lighter, needs no native toolchain (builds/runs on the headless ARM dev box), and fully satisfies the stated requirements because it speaks the exact `SNK`/`<<SNKV>>` wire formats the renderer already consumes. A real WASM runtime that executes user code could be a future enhancement.

## Tests

New unit tests **round-trip the simulator's telemetry + probe output through the REAL renderer parsers** (`instrument-telemetry.ts`, `board-values.ts`), so the contract can't drift silently, plus `SimulatedDevice` lifecycle tests (connect/banner/telemetry/disconnect/exec/FS).

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test` ✅ (1095 passing, +16 new)
- `npm run build` ✅

No visual smoke-test (headless build environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)