### PR TITLE
feat: run real MicroPython in the simulated device (#135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     telemetry, so the **instruments** (oscilloscope, multimeter, plotter, IMU,
     distance, encoder, button…) animate immediately, and it answers the **Board
     Viewer Live View**'s pin probe with plausible values that drift over time.
-  - A distinct **"Simulated device · offline"** status-bar badge (amber LED) so
-    it's never mistaken for real hardware, and switching between the simulator
-    and a real board is seamless (connecting to one disconnects the other).
+  - A distinct **"Simulated device · offline"** status-bar badge (amber LED) and
+    a matching **SIM** badge on the mini board viewer, so the board's pins are
+    never mistaken for real hardware. Switching between the simulator and a real
+    board is seamless (connecting to one disconnects the other).
+  - Typing in the simulated REPL now handles spaces correctly (the console
+    telemetry filter no longer absorbs a lone echoed space into the next `SNK …`
+    line).
 - **Accessibility quick wins (#188).** First pass over the renderer's
   accessibility audit:
   - The device REPL is now readable by screen readers — the xterm terminal runs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     distance, encoder, button…) animate immediately, and it answers the **Board
     Viewer Live View**'s pin probe with plausible values that drift over time.
   - A distinct **"Simulated device · offline"** status-bar badge (amber LED) and
-    a matching **SIM** badge on the mini board viewer, so the board's pins are
-    never mistaken for real hardware. Switching between the simulator and a real
+    a matching **SIMULATION** badge on the mini board viewer, so the board's pins
+    are never mistaken for real hardware. Switching between the simulator and a real
     board is seamless (connecting to one disconnects the other).
   - Typing in the simulated REPL now handles spaces correctly (the console
     telemetry filter no longer absorbs a lone echoed space into the next `SNK …`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - Typing in the simulated REPL now handles spaces correctly (the console
     telemetry filter no longer absorbs a lone echoed space into the next `SNK …`
     line).
+  - The simulated device has a **real in-memory filesystem** (the interpreter's
+    VFS): uploaded files persist, list, read back and are **importable** — e.g.
+    you can upload `instruments.py` to `/lib` and `import instruments` from the
+    REPL (`/lib` is on `sys.path`). It's RAM-backed (not a fixed flash size) and
+    resets on disconnect.
 - **Accessibility quick wins (#188).** First pass over the renderer's
   accessibility audit:
   - The device REPL is now readable by screen readers — the xterm terminal runs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Offline mode — a simulated MicroPython device (#135).** Snakie now ships a
   built-in **Simulated device (offline)** that appears in the shell's port
   dropdown, so you can explore, learn and demo with **no hardware connected**:
-  - Connecting to it greets you with a friendly REPL banner and a live, animated
-    stream of `SNK …` telemetry, so the **instruments** (oscilloscope,
-    multimeter, plotter, IMU, distance, encoder, button…) work immediately.
-  - The **Board Viewer Live View** works too — the simulated device answers the
-    live-pin probe with plausible values that drift over time.
+  - It runs a **real MicroPython interpreter** (compiled to WebAssembly), so the
+    **REPL and the Run button work for real** — `print("Hello, World!")`, loops,
+    maths and the rest run and stream their output to the console. Hardware
+    modules (`machine`, etc.) aren't available, so importing them raises
+    `ImportError`, just like a board without that peripheral.
+  - On top of the interpreter it emits a live, animated stream of `SNK …`
+    telemetry, so the **instruments** (oscilloscope, multimeter, plotter, IMU,
+    distance, encoder, button…) animate immediately, and it answers the **Board
+    Viewer Live View**'s pin probe with plausible values that drift over time.
   - A distinct **"Simulated device · offline"** status-bar badge (amber LED) so
     it's never mistaken for real hardware, and switching between the simulator
     and a real board is seamless (connecting to one disconnects the other).

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -13,6 +13,13 @@ files:
   - out/**
   - package.json
 
+# Keep the MicroPython WebAssembly runtime (offline simulated device, #135)
+# OUTSIDE the asar so the loader can read the `.wasm` binary by file path at
+# runtime. The main bundle externalizes the package (externalizeDepsPlugin) and
+# resolves it from node_modules, so the `.wasm` must exist as a real file.
+asarUnpack:
+  - node_modules/@micropython/micropython-webassembly-pyscript/**
+
 # Ship the Python plugin SDK + host and the bundled example plugins (issue #61)
 # into the packaged app's resources/ dir. PluginHost resolves them from
 # process.resourcesPath when app.isPackaged, and from the repo root in dev.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@electron-toolkit/preload": "^3.0.1",
         "@electron-toolkit/utils": "^3.0.0",
         "@fontsource/jetbrains-mono": "^5.2.8",
+        "@micropython/micropython-webassembly-pyscript": "^1.28.0-6",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
         "electron-updater": "^6.8.3",
@@ -1413,6 +1414,11 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/@micropython/micropython-webassembly-pyscript": {
+      "version": "1.28.0-6",
+      "resolved": "https://registry.npmjs.org/@micropython/micropython-webassembly-pyscript/-/micropython-webassembly-pyscript-1.28.0-6.tgz",
+      "integrity": "sha512-eRJw+jOhFPoEClHRI8RmzIBjORpOhVdDFcdrNYHUc0U+EwchuD5cYIfmgvj3RWim7vBnjBK8mYxMBBVduOo8Lw=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@electron-toolkit/preload": "^3.0.1",
     "@electron-toolkit/utils": "^3.0.0",
     "@fontsource/jetbrains-mono": "^5.2.8",
+    "@micropython/micropython-webassembly-pyscript": "^1.28.0-6",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "electron-updater": "^6.8.3",

--- a/src/main/device/MicroPythonRuntime.ts
+++ b/src/main/device/MicroPythonRuntime.ts
@@ -24,6 +24,13 @@ export interface ReplRuntime {
   init(onOutput: (chunk: Buffer) => void): Promise<void>
   /** Feed raw input bytes (keystrokes, paste-mode payloads, control chars). */
   feed(data: string): Promise<void>
+  /**
+   * Run a snippet OUT-OF-BAND (not through the interactive REPL) and return what
+   * it printed, WITHOUT that output reaching the console — used for filesystem
+   * helpers (listdir/read/write/…) that should be invisible. Rejects if the
+   * snippet raises a Python exception.
+   */
+  runCaptured(code: string): Promise<string>
   /** Tear the runtime down. */
   dispose(): void
 }
@@ -46,6 +53,8 @@ export class MicroPythonRuntime implements ReplRuntime {
   private mp: MicroPythonInstance | null = null
   private onOutput: ((chunk: Buffer) => void) | null = null
   private pending: number[] = []
+  /** When set, interpreter output is diverted here instead of the console. */
+  private capturing: number[] | null = null
   private flushTimer: ReturnType<typeof setInterval> | null = null
   /** Serializes input so bytes are processed strictly in order. */
   private queue: Promise<unknown> = Promise.resolve()
@@ -85,6 +94,25 @@ export class MicroPythonRuntime implements ReplRuntime {
     return op
   }
 
+  runCaptured(code: string): Promise<string> {
+    const op = this.queue.then(async () => {
+      const mp = this.mp
+      if (!mp) throw new Error('MicroPython runtime is not running')
+      // Emit any console output buffered so far, then divert this snippet's
+      // output into a private buffer so it stays off the console.
+      this.flush()
+      this.capturing = []
+      try {
+        await mp.runPythonAsync(code)
+        return Buffer.from(this.capturing).toString('utf8')
+      } finally {
+        this.capturing = null
+      }
+    })
+    this.queue = op.catch(() => undefined)
+    return op
+  }
+
   dispose(): void {
     if (this.flushTimer) {
       clearInterval(this.flushTimer)
@@ -94,11 +122,14 @@ export class MicroPythonRuntime implements ReplRuntime {
     this.mp = null
     this.onOutput = null
     this.pending = []
+    this.capturing = null
   }
 
-  /** Accumulate one byte of interpreter output. */
+  /** Accumulate interpreter output — into the capture buffer if one is active
+   * (a `runCaptured` snippet), otherwise the console-bound pending buffer. */
   private collect(bytes: Uint8Array): void {
-    for (const b of bytes) this.pending.push(b)
+    const sink = this.capturing ?? this.pending
+    for (const b of bytes) sink.push(b)
   }
 
   /** Emit any buffered output as a single chunk. */

--- a/src/main/device/MicroPythonRuntime.ts
+++ b/src/main/device/MicroPythonRuntime.ts
@@ -1,0 +1,111 @@
+import { createRequire } from 'module'
+import type {
+  LoadMicroPythonOptions,
+  MicroPythonInstance
+} from '@micropython/micropython-webassembly-pyscript/micropython.mjs'
+
+// The main bundle is ESM, so reconstruct a `require` for resolving the package's
+// `.wasm` file path (works in dev, in the packaged asar, and under vitest).
+const require = createRequire(import.meta.url)
+
+/** Specifier of the MicroPython WebAssembly ESM loader + its binary. */
+const MP_MJS = '@micropython/micropython-webassembly-pyscript/micropython.mjs'
+const MP_WASM = '@micropython/micropython-webassembly-pyscript/micropython.wasm'
+
+/** How often buffered interpreter output is flushed to the consumer (ms). */
+const FLUSH_INTERVAL_MS = 16
+
+/**
+ * A REPL backend the {@link SimulatedDevice} drives. Abstracted so the device
+ * can be unit-tested against a lightweight fake without loading WebAssembly.
+ */
+export interface ReplRuntime {
+  /** Boot the runtime; `onOutput` receives REPL output as raw byte chunks. */
+  init(onOutput: (chunk: Buffer) => void): Promise<void>
+  /** Feed raw input bytes (keystrokes, paste-mode payloads, control chars). */
+  feed(data: string): Promise<void>
+  /** Tear the runtime down. */
+  dispose(): void
+}
+
+/**
+ * REAL MicroPython interpreter, compiled to WebAssembly (issue #135).
+ *
+ * Wraps the official `@micropython/micropython-webassembly-pyscript` build so the
+ * simulated device runs ACTUAL Python: `init()` boots the interpreter and prints
+ * the friendly banner + prompt, and `feed()` pushes input bytes through the
+ * genuine MicroPython REPL — so interactive typing, **paste mode** (how the Run
+ * button ships a file: Ctrl-E … Ctrl-D), Ctrl-C and Ctrl-D all work natively.
+ *
+ * Output arrives one byte at a time from Emscripten; we buffer it and flush on a
+ * short timer so a running program streams without firing an IPC message per
+ * character. Hardware modules (`machine`, etc.) don't exist in the WASM port, so
+ * importing them raises `ImportError` — exactly like a board with no such device.
+ */
+export class MicroPythonRuntime implements ReplRuntime {
+  private mp: MicroPythonInstance | null = null
+  private onOutput: ((chunk: Buffer) => void) | null = null
+  private pending: number[] = []
+  private flushTimer: ReturnType<typeof setInterval> | null = null
+  /** Serializes input so bytes are processed strictly in order. */
+  private queue: Promise<unknown> = Promise.resolve()
+
+  async init(onOutput: (chunk: Buffer) => void): Promise<void> {
+    this.onOutput = onOutput
+    const wasmPath = require.resolve(MP_WASM)
+    const { loadMicroPython } = await import(MP_MJS)
+    const options: LoadMicroPythonOptions = {
+      url: wasmPath,
+      linebuffer: false,
+      stdout: (bytes) => this.collect(bytes),
+      stderr: (bytes) => this.collect(bytes)
+    }
+    const mp = await loadMicroPython(options)
+    this.mp = mp
+    // Stream buffered output on a short cadence so long-running programs show
+    // progress instead of dumping everything when they finish.
+    this.flushTimer = setInterval(() => this.flush(), FLUSH_INTERVAL_MS)
+    this.flushTimer.unref?.()
+    // Print the banner + first prompt.
+    mp.replInit()
+    this.flush()
+  }
+
+  feed(data: string): Promise<void> {
+    const op = this.queue.then(async () => {
+      const mp = this.mp
+      if (!mp) return
+      for (const byte of Buffer.from(data, 'utf8')) {
+        await mp.replProcessCharWithAsyncify(byte)
+      }
+      this.flush()
+    })
+    // Keep the queue alive even if one feed rejects.
+    this.queue = op.catch(() => undefined)
+    return op
+  }
+
+  dispose(): void {
+    if (this.flushTimer) {
+      clearInterval(this.flushTimer)
+      this.flushTimer = null
+    }
+    this.flush()
+    this.mp = null
+    this.onOutput = null
+    this.pending = []
+  }
+
+  /** Accumulate one byte of interpreter output. */
+  private collect(bytes: Uint8Array): void {
+    for (const b of bytes) this.pending.push(b)
+  }
+
+  /** Emit any buffered output as a single chunk. */
+  private flush(): void {
+    if (this.pending.length === 0 || !this.onOutput) return
+    const chunk = Buffer.from(this.pending)
+    this.pending = []
+    this.onOutput(chunk)
+  }
+}

--- a/src/main/device/SimulatedDevice.ts
+++ b/src/main/device/SimulatedDevice.ts
@@ -174,44 +174,74 @@ export class SimulatedDevice extends EventEmitter implements SnakieDevice {
   }
 
   // ---------------------------------------------------------------------------
-  // Filesystem — a tiny, read-only simulated FS so the device tree isn't broken
+  // Filesystem — backed by the interpreter's REAL in-memory VFS (#135), so
+  // uploaded files persist and are importable (e.g. `import instruments`, since
+  // `/lib` is on sys.path). It's RAM-backed, so it resets on disconnect.
   // ---------------------------------------------------------------------------
 
+  /** Emscripten MEMFS mounts that aren't part of a "board" — hidden at root. */
+  private static readonly SYSTEM_DIRS = new Set(['dev', 'proc', 'tmp', 'home'])
+
   async listDir(path = '/'): Promise<DirEntry[]> {
-    const root = path === '' || path === '/'
-    if (root) {
-      return [
-        { name: 'boot.py', isDir: false, size: 24 },
-        { name: 'main.py', isDir: false, size: 96 },
-        { name: 'lib', isDir: true, size: 0 }
-      ]
-    }
-    if (path === '/lib' || path === 'lib') {
-      return [{ name: 'snakie_instruments.py', isDir: false, size: 0 }]
-    }
-    return []
+    const code = [
+      'import os, json',
+      'def _ls(p):',
+      '    out=[]',
+      '    try: it=os.ilistdir(p)',
+      '    except AttributeError: it=[(n,0,0) for n in os.listdir(p)]',
+      '    for e in it:',
+      '        name=e[0]; typ=e[1] if len(e)>1 else 0',
+      '        full=(p.rstrip("/")+"/"+name) if p else name',
+      '        isdir=(typ & 0x4000)!=0',
+      '        try: size=0 if isdir else os.stat(full)[6]',
+      '        except OSError: size=0',
+      '        out.append([name,isdir,size])',
+      '    return out',
+      `print(json.dumps(_ls(${pyStr(path)})))`
+    ].join('\n')
+    const raw = (await this.runtime.runCaptured(code)).trim()
+    const parsed = JSON.parse(raw) as [string, boolean, number][]
+    const isRoot = path === '' || path === '/'
+    return parsed
+      .filter(([name, isDir]) => !(isRoot && isDir && SimulatedDevice.SYSTEM_DIRS.has(name)))
+      .map(([name, isDir, size]) => ({ name, isDir, size }))
   }
 
   async readFile(path: string): Promise<string> {
-    if (path.endsWith('main.py')) {
-      return '# Simulated device — connect real hardware to edit files.\nprint("hello from the simulator")\n'
-    }
-    return ''
+    // Text read (the simulator's files are source); exact bytes via stdout.write.
+    const code = `import sys\nwith open(${pyStr(path)}) as f:\n    sys.stdout.write(f.read())`
+    return this.runtime.runCaptured(code)
   }
 
-  async writeFile(): Promise<void> {
-    // Writes are accepted but not persisted on the simulated device.
+  async writeFile(path: string, contents: string | Buffer): Promise<void> {
+    const data = Buffer.isBuffer(contents) ? contents : Buffer.from(contents, 'utf8')
+    // Hex-encode so arbitrary (incl. binary) content survives without escaping.
+    const code = `_d=bytes.fromhex(${pyStr(data.toString('hex'))})\nwith open(${pyStr(path)},'wb') as f:\n    f.write(_d)`
+    await this.runtime.runCaptured(code)
   }
 
-  async remove(): Promise<void> {}
+  async remove(path: string): Promise<void> {
+    await this.runtime.runCaptured(`import os\nos.remove(${pyStr(path)})`)
+  }
 
-  async mkdir(): Promise<void> {}
+  async mkdir(path: string): Promise<void> {
+    await this.runtime.runCaptured(`import os\nos.mkdir(${pyStr(path)})`)
+  }
 
-  async rename(): Promise<void> {}
+  async rename(from: string, to: string): Promise<void> {
+    await this.runtime.runCaptured(`import os\nos.rename(${pyStr(from)}, ${pyStr(to)})`)
+  }
 
   async stat(path: string): Promise<StatResult> {
-    const isDir = path.endsWith('/lib') || path === '/' || path === ''
-    return { isDir, size: isDir ? 0 : 96 }
+    const code = [
+      'import os, json',
+      `st=os.stat(${pyStr(path)})`,
+      'isdir=(st[0] & 0x4000)!=0',
+      'print(json.dumps([isdir, st[6], st[8] if len(st)>8 else None]))'
+    ].join('\n')
+    const raw = (await this.runtime.runCaptured(code)).trim()
+    const [isDir, size, mtime] = JSON.parse(raw) as [boolean, number, number | null]
+    return { isDir, size, mtime: mtime ?? undefined }
   }
 
   async dispose(): Promise<void> {
@@ -220,4 +250,17 @@ export class SimulatedDevice extends EventEmitter implements SnakieDevice {
     this.removeAllListeners()
     this.state = 'disconnected'
   }
+}
+
+/**
+ * Render a JS string as a Python string literal, escaping characters that would
+ * break out of the quotes. Used to inject paths/data into generated Python.
+ */
+function pyStr(value: string): string {
+  const escaped = value
+    .replace(/\\/g, '\\\\')
+    .replace(/'/g, "\\'")
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+  return `'${escaped}'`
 }

--- a/src/main/device/SimulatedDevice.ts
+++ b/src/main/device/SimulatedDevice.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events'
 import { VIRTUAL_PORT_PATH } from '../../shared/virtual-device'
+import { MicroPythonRuntime, type ReplRuntime } from './MicroPythonRuntime'
 import { isProbeCode, simulateProbeResponse, simulatedTelemetryFrame } from './simulation'
 import type {
   ConnectionState,
@@ -13,32 +14,39 @@ import type {
 /** How often the simulated board "prints" a telemetry frame (ms). */
 const TELEMETRY_INTERVAL_MS = 120
 
-/** Boot banner the simulated friendly REPL greets with. */
-const BANNER =
-  '\r\nMicroPython v1.24.0 (Snakie simulator) on rp2; Virtual board with RP2040\r\n' +
-  'Type "help()" for more information.\r\n>>> '
-
 /**
  * SIMULATED MicroPython device (issue #135).
  *
- * A drop-in {@link SnakieDevice} that needs no hardware: it fakes the friendly
- * REPL (banner + keystroke echo), continuously emits realistic `SNK …` telemetry
- * so the instruments animate, and answers the Board Viewer's `<<SNKV>>` live-pin
- * probe with plausible values — letting users explore Snakie, the instruments
- * and the Board Viewer Live View completely offline.
+ * A drop-in {@link SnakieDevice} that needs no hardware. It runs a REAL
+ * MicroPython interpreter (compiled to WebAssembly, via {@link MicroPythonRuntime})
+ * so the REPL, the Run button (paste mode) and `print()` all work — and, on top
+ * of that, continuously emits realistic `SNK …` telemetry so the instruments
+ * animate and answers the Board Viewer's `<<SNKV>>` live-pin probe with plausible
+ * values. The result: you can write and run Python, watch instruments and use the
+ * Board Viewer Live View completely offline.
  *
- * It deliberately mirrors {@link MicroPythonDevice}'s public surface (and emits
- * the same `data` / `status` events) so `device/ipc.ts` can route to it for the
- * reserved virtual port without any special-casing downstream. All the signal
- * generation lives in the pure `simulation.ts` helpers; this class only owns the
- * connection lifecycle, the telemetry timer and the fake REPL/filesystem.
+ * Hardware modules (`machine`, etc.) don't exist in the WASM port, so the
+ * synthetic telemetry/probe stand in for a board's sensors — the instruments and
+ * Live View stay useful without real pins. The REPL output and the telemetry
+ * share the `data` channel safely: the Terminal's telemetry filter drops whole
+ * `SNK …` lines wherever they fall, and the two are emitted as separate complete
+ * chunks, so they never splice into one another.
+ *
+ * The interpreter is injected as a {@link ReplRuntime} so the device can be
+ * unit-tested against a lightweight fake without loading WebAssembly.
  */
 export class SimulatedDevice extends EventEmitter implements SnakieDevice {
   private state: ConnectionState = 'disconnected'
   private timer: ReturnType<typeof setInterval> | null = null
   private tick = 0
+  private readonly runtime: ReplRuntime
   /** Latest control payload per target (for inspection / future feedback). */
   private readonly control = new Map<string, string>()
+
+  constructor(runtime: ReplRuntime = new MicroPythonRuntime()) {
+    super()
+    this.runtime = runtime
+  }
 
   on(event: 'data', listener: (chunk: Buffer) => void): this
   on(event: 'status', listener: (status: DeviceStatus) => void): this
@@ -62,15 +70,30 @@ export class SimulatedDevice extends EventEmitter implements SnakieDevice {
     if (this.state === 'connected') return
     // Mimic the real flow: a brief "connecting" then "connected".
     this.setState('connecting')
+    try {
+      // Boot the interpreter; its banner + prompt stream out via `data`.
+      await this.runtime.init((chunk) => this.emit('data', chunk))
+    } catch (err) {
+      // The REPL couldn't start — still connect so the instruments + Board
+      // Viewer work; just print a notice instead of a live Python prompt.
+      const reason = err instanceof Error ? err.message : String(err)
+      this.emit(
+        'data',
+        Buffer.from(
+          `\r\nSimulated device — Python REPL unavailable (${reason}).\r\n` +
+            'Instruments and the Board Viewer still work.\r\n>>> ',
+          'utf8'
+        )
+      )
+    }
     this.setState('connected')
-    // Greet on the friendly REPL, then start the telemetry stream.
-    this.emit('data', Buffer.from(BANNER, 'utf8'))
     this.startTelemetry()
   }
 
   async disconnect(): Promise<void> {
     this.stopTelemetry()
     this.control.clear()
+    this.runtime.dispose()
     if (this.state !== 'disconnected') this.setState('disconnected')
   }
 
@@ -111,8 +134,9 @@ export class SimulatedDevice extends EventEmitter implements SnakieDevice {
 
   /**
    * Run code in the "raw REPL". The only snippet we meaningfully answer is the
-   * Board Viewer's `<<SNKV>>` live-pin probe; anything else returns empty output
-   * (no traceback), which is enough for the offline experience.
+   * Board Viewer's `<<SNKV>>` live-pin probe (with synthetic values, since there
+   * is no hardware to read); anything else returns empty output (no traceback).
+   * Interactive code execution flows through {@link sendData} → the real REPL.
    */
   async exec(code: string): Promise<ExecResult> {
     if (this.state !== 'connected') throw new Error('Not connected')
@@ -128,22 +152,10 @@ export class SimulatedDevice extends EventEmitter implements SnakieDevice {
     return stdout
   }
 
-  /** Echo user keystrokes back to the fake REPL so typing feels alive. */
+  /** Feed user keystrokes / Run paste-mode payloads to the real MicroPython REPL. */
   async sendData(data: string): Promise<void> {
     if (this.state !== 'connected') return
-    if (data.includes('\x03')) {
-      // Ctrl-C → KeyboardInterrupt and a fresh prompt.
-      this.emit('data', Buffer.from('\r\nKeyboardInterrupt\r\n>>> ', 'utf8'))
-      return
-    }
-    if (data.includes('\x04')) {
-      // Ctrl-D → soft reset: re-print the banner.
-      this.emit('data', Buffer.from(BANNER, 'utf8'))
-      return
-    }
-    // Echo what was typed; on Enter, drop to a new prompt line.
-    const echoed = data.replace(/\r/g, '\r\n>>> ')
-    this.emit('data', Buffer.from(echoed, 'utf8'))
+    await this.runtime.feed(data)
   }
 
   /** Record an IDE→board control command (latest-wins per target). */
@@ -151,10 +163,12 @@ export class SimulatedDevice extends EventEmitter implements SnakieDevice {
     this.control.set(target, payload)
   }
 
+  /** Ctrl-C — interrupt the running program in the real REPL. */
   async interrupt(): Promise<void> {
     await this.sendData('\x03')
   }
 
+  /** Ctrl-D — soft-reset the real REPL. */
   async softReset(): Promise<void> {
     await this.sendData('\x04')
   }
@@ -202,6 +216,7 @@ export class SimulatedDevice extends EventEmitter implements SnakieDevice {
 
   async dispose(): Promise<void> {
     this.stopTelemetry()
+    this.runtime.dispose()
     this.removeAllListeners()
     this.state = 'disconnected'
   }

--- a/src/main/device/micropython-wasm.d.ts
+++ b/src/main/device/micropython-wasm.d.ts
@@ -1,0 +1,40 @@
+/**
+ * Minimal ambient types for the untyped MicroPython WebAssembly package
+ * (`@micropython/micropython-webassembly-pyscript`). Only the surface the
+ * simulated device uses (issue #135) is declared.
+ *
+ * @see https://docs.micropython.org/en/latest/reference/glossary.html#term-WebAssembly
+ */
+declare module '@micropython/micropython-webassembly-pyscript/micropython.mjs' {
+  /** A loaded MicroPython interpreter instance. */
+  export interface MicroPythonInstance {
+    /** Print the friendly REPL banner + first prompt. */
+    replInit(): void
+    /** Feed one input byte to the REPL, running code via Asyncify when needed. */
+    replProcessCharWithAsyncify(charCode: number): Promise<unknown>
+    /** Synchronous variant (no Asyncify); unused here. */
+    replProcessChar(charCode: number): number
+    /** Run a snippet, awaiting Asyncify suspensions (e.g. `time.sleep`). */
+    runPythonAsync(code: string): Promise<unknown>
+    /** Run a snippet synchronously. */
+    runPython(code: string): unknown
+  }
+
+  /** Options accepted by {@link loadMicroPython}. */
+  export interface LoadMicroPythonOptions {
+    /** Path / URL to the `.wasm` binary. */
+    url?: string
+    stdin?: () => string
+    /** Per-line (linebuffer:true) or per-byte (linebuffer:false) output sink. */
+    stdout?: (data: Uint8Array) => void
+    stderr?: (data: Uint8Array) => void
+    /** When false, stdout/stderr are called per byte; when true, per line. */
+    linebuffer?: boolean
+    heapsize?: number
+    pystack?: number
+  }
+
+  export function loadMicroPython(
+    options?: LoadMicroPythonOptions
+  ): Promise<MicroPythonInstance>
+}

--- a/src/renderer/src/components/MiniBoardView.css
+++ b/src/renderer/src/components/MiniBoardView.css
@@ -34,6 +34,22 @@
   white-space: nowrap;
 }
 
+/* Offline-mode badge (#135): connected to the simulated device, not hardware.
+   Amber to match the status-bar "Simulated device" indicator. Pushed to the
+   right (next to the expand button) so the board name keeps the left. */
+.mini-board__sim {
+  flex: 0 0 auto;
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 0.54rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--accent-contrast, #15161a);
+  background: var(--warn, #d6a23f);
+  padding: 0.05rem 0.3rem;
+  border-radius: 3px;
+}
+
 .mini-board__open {
   flex: 0 0 auto;
   display: inline-flex;

--- a/src/renderer/src/components/MiniBoardView.css
+++ b/src/renderer/src/components/MiniBoardView.css
@@ -40,6 +40,7 @@
 .mini-board__sim {
   flex: 0 0 auto;
   margin-left: auto;
+  white-space: nowrap;
   font-family: var(--font-mono);
   font-size: 0.54rem;
   font-weight: 700;

--- a/src/renderer/src/components/MiniBoardView.tsx
+++ b/src/renderer/src/components/MiniBoardView.tsx
@@ -13,6 +13,8 @@ import { PartBody } from './part-body'
 import { boardPartFor } from './part-editor.util'
 import { useBoards } from './use-boards'
 import { useConsole } from '../store/console'
+import { useDeviceStatus } from '../hooks/useDeviceStatus'
+import { isVirtualPort } from '../../../shared/virtual-device'
 import './MiniBoardView.css'
 
 /** Shared with BoardView/BoardGraph so the full viewer adopts the same board. */
@@ -147,6 +149,10 @@ function PinAnnotation({ u }: { u: UsedPad }): JSX.Element {
  */
 export function MiniBoardView({ source, isPython }: { source: string; isPython: boolean }): JSX.Element {
   const consoleStore = useConsole()
+  // Connected to the built-in simulator rather than real hardware (#135)? Surface
+  // it here so the board's pins/values are clearly understood as simulated.
+  const deviceStatus = useDeviceStatus()
+  const simulated = deviceStatus.state === 'connected' && isVirtualPort(deviceStatus.path)
   // Boards from the installed parts libraries (microcontroller parts), built-ins
   // as a fallback — the same source the full Board Viewer uses (#52).
   const boards = useBoards()
@@ -322,6 +328,14 @@ export function MiniBoardView({ source, isPython }: { source: string; isPython: 
         <span className="mini-board__name" title={`${def.name} · ${def.mcu}`}>
           {def.name}
         </span>
+        {simulated && (
+          <span
+            className="mini-board__sim"
+            title="Connected to the simulated device — no hardware connected (offline mode)"
+          >
+            SIM
+          </span>
+        )}
         <button
           type="button"
           className="mini-board__open"

--- a/src/renderer/src/components/MiniBoardView.tsx
+++ b/src/renderer/src/components/MiniBoardView.tsx
@@ -333,7 +333,7 @@ export function MiniBoardView({ source, isPython }: { source: string; isPython: 
             className="mini-board__sim"
             title="Connected to the simulated device — no hardware connected (offline mode)"
           >
-            SIM
+            SIMULATION
           </span>
         )}
         <button

--- a/src/renderer/src/components/terminal-telemetry.ts
+++ b/src/renderer/src/components/terminal-telemetry.ts
@@ -48,7 +48,11 @@ function isHidden(line: string): boolean {
  */
 function couldBecomeTelemetry(tail: string): boolean {
   const t = tail.trimStart()
-  if (t === '') return true // still only whitespace — wait and see
+  // Pure whitespace is never a telemetry line on its own — flush it immediately.
+  // Holding it would let a lone echoed space (e.g. typed at the simulated REPL,
+  // #135) be concatenated onto the NEXT `SNK …` telemetry line and dropped with
+  // it. Telemetry the device prints starts at column 0, so nothing is lost.
+  if (t === '') return false
   // `t` is a prefix of a header (e.g. "S", "SN", "SNK", "SNK ", "SNKC", "SNKCMD ").
   if (SENTINEL_PREFIXES.some((p) => p.startsWith(t))) return true
   // Already a full `SNK `/`SNKCMD ` header but no newline yet → wait for the rest.

--- a/test/micropythonRuntime.test.ts
+++ b/test/micropythonRuntime.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { MicroPythonRuntime } from '../src/main/device/MicroPythonRuntime'
+
+/**
+ * Integration test for the REAL MicroPython WebAssembly runtime (issue #135) —
+ * this actually loads + runs the interpreter, so it proves the offline device
+ * executes Python (this is what makes "hello world" print). Generous timeouts
+ * cover the one-off WASM load.
+ */
+describe('MicroPythonRuntime (real WebAssembly)', () => {
+  it('runs a hello-world program via paste mode and streams its output', async () => {
+    const rt = new MicroPythonRuntime()
+    const out: Buffer[] = []
+    await rt.init((c) => out.push(c))
+
+    // Exactly what the Run button sends: Ctrl-E (paste mode) … Ctrl-D (execute).
+    const program = 'print("Hello, World!")\nfor i in range(3):\n    print("n", i)\n'
+    await rt.feed('\x05' + program + '\x04')
+    await new Promise((r) => setTimeout(r, 50)) // let the flush timer drain
+
+    const text = Buffer.concat(out).toString('utf8')
+    expect(text).toContain('Hello, World!')
+    expect(text).toContain('n 2')
+    rt.dispose()
+  }, 30000)
+
+  it('evaluates expressions interactively', async () => {
+    const rt = new MicroPythonRuntime()
+    const out: Buffer[] = []
+    await rt.init((c) => out.push(c))
+    await rt.feed('print(6 * 7)\r')
+    await new Promise((r) => setTimeout(r, 50))
+    expect(Buffer.concat(out).toString('utf8')).toContain('42')
+    rt.dispose()
+  }, 30000)
+
+  it('raises ImportError for hardware modules (no machine in the WASM port)', async () => {
+    const rt = new MicroPythonRuntime()
+    const out: Buffer[] = []
+    await rt.init((c) => out.push(c))
+    await rt.feed('import machine\r')
+    await new Promise((r) => setTimeout(r, 50))
+    expect(Buffer.concat(out).toString('utf8')).toContain('ImportError')
+    rt.dispose()
+  }, 30000)
+})

--- a/test/simulatedDevice.test.ts
+++ b/test/simulatedDevice.test.ts
@@ -15,6 +15,9 @@ import {
  */
 class FakeRuntime implements ReplRuntime {
   feeds: string[] = []
+  capturedCalls: string[] = []
+  /** Canned response returned by the next runCaptured call. */
+  nextCaptured = ''
   private emit: ((chunk: Buffer) => void) | null = null
   async init(onOutput: (chunk: Buffer) => void): Promise<void> {
     this.emit = onOutput
@@ -23,6 +26,10 @@ class FakeRuntime implements ReplRuntime {
   async feed(data: string): Promise<void> {
     this.feeds.push(data)
     this.emit?.(Buffer.from(`echo:${data}`, 'utf8'))
+  }
+  async runCaptured(code: string): Promise<string> {
+    this.capturedCalls.push(code)
+    return this.nextCaptured
   }
   dispose(): void {}
 }
@@ -148,13 +155,23 @@ describe('SimulatedDevice lifecycle', () => {
     await dev.dispose()
   })
 
-  it('exposes a small simulated filesystem so the device tree is usable', async () => {
-    const dev = new SimulatedDevice(new FakeRuntime())
+  it('lists the interpreter VFS via runCaptured, hiding Emscripten system dirs', async () => {
+    const runtime = new FakeRuntime()
+    const dev = new SimulatedDevice(runtime)
     await dev.connect()
+    // The runtime returns the raw os.ilistdir JSON; the device hides the MEMFS
+    // system mounts (dev/proc/tmp/home) at the root so it reads like a board.
+    runtime.nextCaptured = JSON.stringify([
+      ['main.py', false, 12],
+      ['lib', true, 0],
+      ['dev', true, 0],
+      ['proc', true, 0]
+    ])
     const root = await dev.listDir('/')
-    expect(root.some((e) => e.name === 'main.py')).toBe(true)
-    expect(root.some((e) => e.isDir)).toBe(true)
-    expect(await dev.readFile('/main.py')).toContain('simulator')
+    expect(root.map((e) => e.name)).toEqual(['main.py', 'lib'])
+    // FS ops are routed out-of-band through the runtime, not the REPL.
+    expect(runtime.capturedCalls.at(-1)).toContain('ilistdir')
+    expect(runtime.feeds).toHaveLength(0)
     await dev.dispose()
   })
 })

--- a/test/simulatedDevice.test.ts
+++ b/test/simulatedDevice.test.ts
@@ -1,11 +1,31 @@
 import { describe, it, expect } from 'vitest'
 import { SimulatedDevice } from '../src/main/device/SimulatedDevice'
+import type { ReplRuntime } from '../src/main/device/MicroPythonRuntime'
 import { isTelemetry } from '../src/renderer/src/components/instrument-telemetry'
 import {
   isVirtualPort,
   VIRTUAL_PORT_PATH,
   VIRTUAL_PORT_LABEL
 } from '../src/shared/virtual-device'
+
+/**
+ * A lightweight {@link ReplRuntime} so the device tests stay fast and
+ * deterministic (no WebAssembly load). It prints a fake prompt on init and
+ * echoes whatever it's fed, and records the feeds for assertions.
+ */
+class FakeRuntime implements ReplRuntime {
+  feeds: string[] = []
+  private emit: ((chunk: Buffer) => void) | null = null
+  async init(onOutput: (chunk: Buffer) => void): Promise<void> {
+    this.emit = onOutput
+    onOutput(Buffer.from('MicroPython (fake)\r\n>>> ', 'utf8'))
+  }
+  async feed(data: string): Promise<void> {
+    this.feeds.push(data)
+    this.emit?.(Buffer.from(`echo:${data}`, 'utf8'))
+  }
+  dispose(): void {}
+}
 
 describe('virtual-device identity', () => {
   it('recognises only the reserved sentinel path', () => {
@@ -24,15 +44,15 @@ describe('virtual-device identity', () => {
 
 describe('SimulatedDevice lifecycle', () => {
   it('starts disconnected and reports the virtual path', () => {
-    const dev = new SimulatedDevice()
+    const dev = new SimulatedDevice(new FakeRuntime())
     const status = dev.getStatus()
     expect(status.state).toBe('disconnected')
     expect(status.path).toBe(VIRTUAL_PORT_PATH)
     expect(dev.isConnected()).toBe(false)
   })
 
-  it('emits connecting → connected status and a REPL banner on connect', async () => {
-    const dev = new SimulatedDevice()
+  it('emits connecting → connected status and boots the REPL on connect', async () => {
+    const dev = new SimulatedDevice(new FakeRuntime())
     const states: string[] = []
     const data: string[] = []
     dev.on('status', (s) => states.push(s.state))
@@ -41,13 +61,35 @@ describe('SimulatedDevice lifecycle', () => {
     await dev.connect()
     expect(states).toEqual(['connecting', 'connected'])
     expect(dev.isConnected()).toBe(true)
+    // The runtime's banner streamed out via the data channel.
     expect(data.join('')).toContain('MicroPython')
 
     await dev.dispose()
   })
 
+  it('feeds keystrokes / Run payloads to the REPL runtime', async () => {
+    const runtime = new FakeRuntime()
+    const dev = new SimulatedDevice(runtime)
+    const data: string[] = []
+    dev.on('data', (c) => data.push(c.toString('utf8')))
+    await dev.connect()
+
+    // The Run button sends paste mode: Ctrl-E … Ctrl-D.
+    await dev.sendData('\x05print("hi")\x04')
+    expect(runtime.feeds).toContain('\x05print("hi")\x04')
+    expect(data.join('')).toContain('echo:')
+
+    // interrupt / softReset feed the control bytes too.
+    await dev.interrupt()
+    await dev.softReset()
+    expect(runtime.feeds).toContain('\x03')
+    expect(runtime.feeds).toContain('\x04')
+
+    await dev.dispose()
+  })
+
   it('streams parseable SNK telemetry while connected', async () => {
-    const dev = new SimulatedDevice()
+    const dev = new SimulatedDevice(new FakeRuntime())
     const chunks: string[] = []
     dev.on('data', (c) => chunks.push(c.toString('utf8')))
     await dev.connect()
@@ -67,7 +109,7 @@ describe('SimulatedDevice lifecycle', () => {
   })
 
   it('stops emitting telemetry after disconnect', async () => {
-    const dev = new SimulatedDevice()
+    const dev = new SimulatedDevice(new FakeRuntime())
     await dev.connect()
     await dev.disconnect()
 
@@ -83,7 +125,7 @@ describe('SimulatedDevice lifecycle', () => {
   })
 
   it('answers the live-pin probe via exec and rejects exec when disconnected', async () => {
-    const dev = new SimulatedDevice()
+    const dev = new SimulatedDevice(new FakeRuntime())
     await expect(dev.exec('print(1)')).rejects.toThrow(/Not connected/)
 
     await dev.connect()
@@ -99,16 +141,15 @@ describe('SimulatedDevice lifecycle', () => {
   })
 
   it('records control commands (latest-wins per target)', async () => {
-    const dev = new SimulatedDevice()
+    const dev = new SimulatedDevice(new FakeRuntime())
     await dev.connect()
-    // Should not throw; the simulator accepts any control line.
     await dev.sendControl('led', 'pwm 0.5')
     await dev.sendControl('teleop', 'axes=drive:0.5')
     await dev.dispose()
   })
 
   it('exposes a small simulated filesystem so the device tree is usable', async () => {
-    const dev = new SimulatedDevice()
+    const dev = new SimulatedDevice(new FakeRuntime())
     await dev.connect()
     const root = await dev.listDir('/')
     expect(root.some((e) => e.name === 'main.py')).toBe(true)

--- a/test/simulatedDeviceFs.test.ts
+++ b/test/simulatedDeviceFs.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { SimulatedDevice } from '../src/main/device/SimulatedDevice'
+
+/**
+ * Integration test for the simulated device's REAL filesystem (#135): files
+ * written through the device API land in the interpreter's in-memory VFS, so
+ * they persist, list, read back, and are IMPORTABLE — the `import instruments`
+ * scenario (`/lib` is on MicroPython's sys.path). Uses the real WebAssembly
+ * runtime, hence the generous timeouts.
+ */
+describe('SimulatedDevice filesystem (real VFS)', () => {
+  it('writes, lists, reads and stats files in the interpreter VFS', async () => {
+    const dev = new SimulatedDevice()
+    await dev.connect()
+    try {
+      await dev.mkdir('/lib')
+      await dev.writeFile('/lib/mymod.py', 'VALUE = 7\n')
+
+      const lib = await dev.listDir('/lib')
+      expect(lib.map((e) => e.name)).toContain('mymod.py')
+
+      expect(await dev.readFile('/lib/mymod.py')).toBe('VALUE = 7\n')
+
+      const st = await dev.stat('/lib/mymod.py')
+      expect(st.isDir).toBe(false)
+      expect(st.size).toBe('VALUE = 7\n'.length)
+
+      // The root hides the Emscripten system mounts (dev/proc/tmp/home).
+      const root = await dev.listDir('/')
+      expect(root.map((e) => e.name)).not.toContain('dev')
+      expect(root.map((e) => e.name)).toContain('lib')
+    } finally {
+      await dev.dispose()
+    }
+  }, 30000)
+
+  it('makes an uploaded module importable from the REPL (import instruments style)', async () => {
+    const dev = new SimulatedDevice()
+    const out: string[] = []
+    dev.on('data', (c) => out.push(c.toString('utf8')))
+    await dev.connect()
+    try {
+      // Upload a module to /lib (on sys.path), then import + use it from the REPL.
+      await dev.mkdir('/lib')
+      await dev.writeFile('/lib/greet.py', 'def hi():\n    print("imported-ok", 6 * 7)\n')
+      await dev.sendData('import greet\r')
+      await dev.sendData('greet.hi()\r')
+      await new Promise((r) => setTimeout(r, 80))
+      const text = out.join('')
+      expect(text).toContain('imported-ok 42')
+    } finally {
+      await dev.dispose()
+    }
+  }, 30000)
+
+  it('rejects filesystem errors (e.g. removing a missing file)', async () => {
+    const dev = new SimulatedDevice()
+    await dev.connect()
+    try {
+      await expect(dev.remove('/does/not/exist.py')).rejects.toThrow()
+    } finally {
+      await dev.dispose()
+    }
+  }, 30000)
+})

--- a/test/simulatorReplEcho.test.ts
+++ b/test/simulatorReplEcho.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { MicroPythonRuntime } from '../src/main/device/MicroPythonRuntime'
+import { simulatedTelemetryFrame } from '../src/main/device/simulation'
+import { makeTelemetryFilter } from '../src/renderer/src/components/terminal-telemetry'
+
+/**
+ * Regression for the offline REPL "swallowed space" bug (#135): the simulated
+ * device streams `SNK …` telemetry continuously, and the Terminal's telemetry
+ * filter used to HOLD a lone echoed space — which then got concatenated onto the
+ * next telemetry line and dropped, so typing a space in the REPL appeared to do
+ * nothing. This drives the REAL interpreter through the REAL filter with
+ * telemetry interleaved, exactly like the renderer, and asserts the echoed space
+ * survives to the console.
+ */
+describe('simulated REPL echo survives interleaved telemetry', () => {
+  it('does not swallow a typed space', async () => {
+    const rt = new MicroPythonRuntime()
+    const filter = makeTelemetryFilter()
+    const decoder = new TextDecoder()
+    let visible = ''
+    const onChunk = (buf: Buffer): void => {
+      visible += filter.push(decoder.decode(buf))
+    }
+
+    await rt.init(onChunk)
+
+    // Type a line containing a space, char by char, with a telemetry frame
+    // interleaved after each keystroke (as the running device emits ~every 120ms).
+    let tick = 0
+    for (const ch of 'print("a b")\r') {
+      await rt.feed(ch)
+      onChunk(Buffer.from(simulatedTelemetryFrame(tick++).join('\r\n') + '\r\n', 'utf8'))
+    }
+    await new Promise((r) => setTimeout(r, 50))
+
+    // `a b")` only appears in the ECHO of the typed input (the program's stdout is
+    // just `a b`), so finding it proves the echoed space wasn't dropped.
+    expect(visible).toContain('a b")')
+    // And no telemetry leaked into the console.
+    expect(visible).not.toContain('SNK ')
+    rt.dispose()
+  }, 30000)
+})


### PR DESCRIPTION
Follow-up to #200. The offline **Simulated device** now runs an **actual MicroPython interpreter** (compiled to WebAssembly), so the REPL and the **Run** button work for real.

## Why

After #200 the simulator only faked the REPL banner and echoed keystrokes — so a hello-world program (`print("Hello, World!")`) printed **nothing**. The Run button ships a file via MicroPython *paste mode* (`\x05` … `\x04`), which the fake REPL discarded. This PR runs the real interpreter, so code actually executes.

## What changed

- **`MicroPythonRuntime`** (`src/main/device/MicroPythonRuntime.ts`) — wraps `@micropython/micropython-webassembly-pyscript`. `init()` boots the interpreter and prints the banner/prompt; `feed()` pushes input bytes through the **genuine MicroPython REPL**, so interactive typing, **paste mode** (how Run works), Ctrl-C and Ctrl-D all work natively. Output is byte-buffered and flushed on a short timer so long programs stream. Loaded lazily; the `.wasm` path resolved via `createRequire(import.meta.url)`.
- **`SimulatedDevice`** now drives an injected `ReplRuntime`: `sendData()` feeds the real REPL; `interrupt`/`softReset` feed the control bytes. The synthetic `SNK` telemetry (instruments) and `<<SNKV>>` board-probe responses are **unchanged** — hardware modules (`machine`, …) don't exist in the WASM port, so they stand in for a board's sensors. REPL output and telemetry share the `data` channel safely (the Terminal filter drops whole `SNK` lines wherever they fall).
- **Packaging** — `asarUnpack` the micropython package so the `.wasm` is a real file at runtime (the package is externalized by `externalizeDepsPlugin`).

## Behaviour now

```
>>> print('Hello, World!')
Hello, World!
>>> for i in range(3): print(i)
0
1
2
>>> import machine   # no hardware in WASM
ImportError: no module named 'machine'
```

## Tests

- Device tests inject a **fast fake runtime** (no WASM) so they stay quick.
- A new **integration test loads the REAL interpreter** and runs hello-world via the exact paste-mode payload the Run button sends (plus the `machine` ImportError).
- `npm run typecheck` ✅ · `npm run lint` ✅ · `npm test` ✅ (1099, +4) · `npm run build` ✅ (main keeps the package external).

## Verification note

Proven end-to-end through Node/vitest (the integration test runs the same `\x05…\x04` payload the Run button sends). I could **not** smoke-test inside the actual Electron GUI here (headless box, no display) — worth a quick run in `npm run dev`: connect to **Simulated device (offline)** and Run a `print(...)` program.

Part of #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)