### PR TITLE
feat: keep local files in sync with the device (#178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Keep local files in sync with the device (#178).** Right-click a file in the
+  Local files tree and choose **Keep in sync with device** to tag it — a small
+  **⇄** marker shows on tagged files. Tagged files are pushed to the board:
+  immediately when you tag them (if connected), automatically on every save when
+  the **Auto** toggle on the device-files toolbar is on, and all at once with the
+  **Sync now** button. The device-files toolbar shows a **sync status** — the
+  sync icon turns into a **green tick** for a moment when a sync completes (and
+  the device tree refreshes so the pushed files appear). Each tagged file maps to
+  `/<filename>` on the device; the tagged set and the Auto toggle persist across
+  reloads.
 - **Offline mode — a simulated MicroPython device (#135).** Snakie now ships a
   built-in **Simulated device (offline)** that appears in the shell's port
   dropdown, so you can explore, learn and demo with **no hardware connected**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
-- **Keep local files in sync with the device (#178).** Right-click a file in the
-  Local files tree and choose **Keep in sync with device** to tag it — a small
-  **⇄** marker shows on tagged files. Tagged files are pushed to the board:
-  immediately when you tag them (if connected), automatically on every save when
-  the **Auto** toggle on the device-files toolbar is on, and all at once with the
-  **Sync now** button. The device-files toolbar shows a **sync status** — the
-  sync icon turns into a **green tick** for a moment when a sync completes (and
-  the device tree refreshes so the pushed files appear). Each tagged file maps to
-  `/<filename>` on the device; the tagged set and the Auto toggle persist across
-  reloads.
+- **Keep local files in sync with the device (#178).** Tick the **checkbox** next
+  to a file in the Local files tree to keep it in sync with the connected board
+  (untick to stop); the box stays visible while ticked and reveals on hover
+  otherwise. A single **sync toggle** on the device-files toolbar turns syncing
+  on — pushing the tagged files immediately **and** keeping them in sync on every
+  save — and off again. Its icon spins while syncing and becomes a **green tick**
+  for a moment when a sync completes (the device tree refreshes so the pushed
+  files appear). Each tagged file maps to `/<filename>` on the device; the tagged
+  set and the toggle persist across reloads. Device-file editor tabs are now shown
+  in **brackets** (e.g. `[main.py]`) to tell them apart from local files.
 - **Offline mode — a simulated MicroPython device (#135).** Snakie now ships a
   built-in **Simulated device (offline)** that appears in the shell's port
   dropdown, so you can explore, learn and demo with **no hardware connected**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 - **Keep local files in sync with the device (#178).** Tick the **checkbox** next
   to a file in the Local files tree to keep it in sync with the connected board
-  (untick to stop); the box stays visible while ticked and reveals on hover
-  otherwise. A single **sync toggle** on the device-files toolbar turns syncing
+  (untick to stop). A tagged file shows a green **⇄** sync glyph at rest; hovering
+  the row swaps the checkbox back in so you can untick it. A single **sync toggle**
+  on the device-files toolbar turns syncing
   on — pushing the tagged files immediately **and** keeping them in sync on every
   save — and off again. Its icon spins while syncing and becomes a **green tick**
   for a moment when a sync completes (the device tree refreshes so the pushed

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -5,18 +5,21 @@ import { WorkspaceProvider } from './store/workspace'
 import { DiagnosticsProvider } from './store/diagnostics'
 import { SettingsProvider } from './store/settings'
 import { ConsoleProvider } from './store/console'
+import { SyncProvider } from './store/sync'
 
 function App(): JSX.Element {
   return (
     <PromptProvider>
       <SettingsProvider>
         <WorkspaceProvider>
-          <DiagnosticsProvider>
-            <ConsoleProvider>
-              <AppShell />
-              <UpdateNotifier />
-            </ConsoleProvider>
-          </DiagnosticsProvider>
+          <SyncProvider>
+            <DiagnosticsProvider>
+              <ConsoleProvider>
+                <AppShell />
+                <UpdateNotifier />
+              </ConsoleProvider>
+            </DiagnosticsProvider>
+          </SyncProvider>
         </WorkspaceProvider>
       </SettingsProvider>
     </PromptProvider>

--- a/src/renderer/src/components/DeviceFileTree.css
+++ b/src/renderer/src/components/DeviceFileTree.css
@@ -56,3 +56,44 @@
 .devicetree__tree {
   min-height: 4rem;
 }
+
+/* ---------------------------------------------------------------------------
+ * File sync controls (#178): a status/Sync-now button whose icon turns into a
+ * green tick when a sync completes, plus a compact "Auto" sync-on-save toggle.
+ * ------------------------------------------------------------------------- */
+
+/* Spin the sync arrows while a sync is in progress (paused under
+   prefers-reduced-motion by the global rule in index.css). */
+.devicetree__sync--syncing svg {
+  animation: devicetree-sync-spin 0.9s linear infinite;
+}
+
+@keyframes devicetree-sync-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Green tick on completion; red on failure. */
+.devicetree__sync--done {
+  color: var(--accent-2);
+}
+
+.devicetree__sync--error {
+  color: var(--danger);
+}
+
+/* Compact text toggle for "sync on save"; lit when enabled. */
+.devicetree__autosync {
+  padding: 0.15rem 0.4rem;
+  font-size: 0.66rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.devicetree__autosync.is-active {
+  background: var(--bg-sunken);
+  border-color: var(--accent);
+  color: var(--accent);
+}

--- a/src/renderer/src/components/DeviceFileTree.css
+++ b/src/renderer/src/components/DeviceFileTree.css
@@ -58,8 +58,10 @@
 }
 
 /* ---------------------------------------------------------------------------
- * File sync controls (#178): a status/Sync-now button whose icon turns into a
- * green tick when a sync completes, plus a compact "Auto" sync-on-save toggle.
+ * File sync toggle (#178): one button that turns auto-sync on (syncing now) /
+ * off. Its icon spins while syncing and becomes a green tick when a sync
+ * completes (red on failure); the global `.btn--ghost.is-active` lights the "on"
+ * state.
  * ------------------------------------------------------------------------- */
 
 /* Spin the sync arrows while a sync is in progress (paused under
@@ -74,26 +76,13 @@
   }
 }
 
-/* Green tick on completion; red on failure. */
-.devicetree__sync--done {
+/* Green tick on completion; red on failure. The doubled class keeps these at
+   the same specificity as the global `.btn--ghost.is-active` (the toggle's "on"
+   state) but later in the cascade, so the status colour wins when both apply. */
+.devicetree__sync.devicetree__sync--done {
   color: var(--accent-2);
 }
 
-.devicetree__sync--error {
+.devicetree__sync.devicetree__sync--error {
   color: var(--danger);
-}
-
-/* Compact text toggle for "sync on save"; lit when enabled. */
-.devicetree__autosync {
-  padding: 0.15rem 0.4rem;
-  font-size: 0.66rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.devicetree__autosync.is-active {
-  background: var(--bg-sunken);
-  border-color: var(--accent);
-  color: var(--accent);
 }

--- a/src/renderer/src/components/DeviceFileTree.tsx
+++ b/src/renderer/src/components/DeviceFileTree.tsx
@@ -286,6 +286,17 @@ export function DeviceFileTree(): JSX.Element {
     if (syncStatus === 'done' && connected) void refresh()
   }, [syncStatus, connected, refresh])
 
+  // The single sync toggle: ON pushes the tagged files now AND auto-syncs on
+  // every save; OFF stops auto-syncing.
+  const toggleAutoSync = useCallback((): void => {
+    if (syncOnSave) {
+      setSyncOnSave(false)
+    } else {
+      setSyncOnSave(true)
+      void syncNow()
+    }
+  }, [syncOnSave, setSyncOnSave, syncNow])
+
   const handleSelect = useCallback((path: string, isDir: boolean): void => {
     setSelectedPath(path)
     setSelectedIsDir(isDir)
@@ -500,42 +511,30 @@ export function DeviceFileTree(): JSX.Element {
           <span aria-hidden>{'▦'}</span> Device files
         </span>
         {/* Icon-only header actions mirroring the local section (issue #104):
-            the file-sync status/controls (#178), then Refresh, New file, New
-            folder. */}
+            the file-sync toggle (#178), then Refresh, New file, New folder. */}
         <div className="devicetree__header-actions">
-          {/* Sync status + manual "Sync now": the sync icon turns into a green
-              tick for a moment when a sync completes. */}
+          {/* One sync toggle: turning it ON syncs the tagged files now AND keeps
+              them auto-syncing on every save; turning it OFF stops auto-syncing.
+              The icon turns into a green tick for a moment when a sync completes. */}
           <button
-            className={`btn btn--ghost btn--icon devicetree__sync devicetree__sync--${syncStatus}`}
-            onClick={() => void syncNow()}
-            disabled={syncStatus === 'syncing' || syncedPaths.length === 0}
+            className={`btn btn--ghost btn--icon devicetree__sync devicetree__sync--${syncStatus}${syncOnSave ? ' is-active' : ''}`}
+            onClick={toggleAutoSync}
+            disabled={syncStatus === 'syncing'}
+            aria-pressed={syncOnSave}
             title={
-              syncedPaths.length === 0
-                ? 'Tag local files (right-click → Keep in sync) to sync them here'
-                : syncStatus === 'syncing'
-                  ? 'Syncing…'
-                  : syncStatus === 'done'
-                    ? 'Synced'
-                    : syncStatus === 'error'
-                      ? `Sync failed: ${syncError ?? 'unknown error'}`
-                      : `Sync ${syncedPaths.length} tagged file${syncedPaths.length === 1 ? '' : 's'} now`
+              syncStatus === 'syncing'
+                ? 'Syncing…'
+                : syncStatus === 'error'
+                  ? `Sync failed: ${syncError ?? 'unknown error'}`
+                  : syncOnSave
+                    ? `Auto-sync on (${syncedPaths.length} file${syncedPaths.length === 1 ? '' : 's'}) — click to stop`
+                    : syncedPaths.length === 0
+                      ? 'Turn on auto-sync (tick files in the Local tree to sync them)'
+                      : `Sync ${syncedPaths.length} tagged file${syncedPaths.length === 1 ? '' : 's'} now and keep them in sync on save`
             }
-            aria-label={
-              syncStatus === 'done'
-                ? 'Files synced'
-                : `Sync ${syncedPaths.length} tagged files to the device now`
-            }
+            aria-label={syncOnSave ? 'Turn off automatic file sync' : 'Turn on automatic file sync'}
           >
             {syncStatus === 'done' ? <CheckIcon /> : <SyncIcon />}
-          </button>
-          {/* Toggle: auto-push tagged files on every save. */}
-          <button
-            className={`btn btn--ghost devicetree__autosync${syncOnSave ? ' is-active' : ''}`}
-            onClick={() => setSyncOnSave(!syncOnSave)}
-            aria-pressed={syncOnSave}
-            title="Sync tagged files automatically on save"
-          >
-            Auto
           </button>
           <button
             className="btn btn--ghost btn--icon"

--- a/src/renderer/src/components/DeviceFileTree.tsx
+++ b/src/renderer/src/components/DeviceFileTree.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import type { DirEntry } from '../../../preload/index.d'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { useWorkspace } from '../store/workspace'
+import { useSync } from '../store/sync'
 import { ContextMenu, type ContextMenuItem, type ContextMenuPosition } from './ContextMenu'
 import { Placeholder } from './Placeholder'
 import { usePrompt } from './PromptModal'
@@ -72,6 +73,30 @@ const NewFolderIcon = (): JSX.Element => (
       <rect x="7" y="8" width="2" height="5" fill="var(--bg-elevated)" />
       <rect x="5.5" y="9.5" width="5" height="2" fill="var(--bg-elevated)" />
     </g>
+  </svg>
+)
+
+// two opposing arrows (sync) — push tagged local files to the device (#178)
+const SyncIcon = (): JSX.Element => (
+  <svg {...iconProps}>
+    <g fill="currentColor">
+      <path d="M2 5h9V2l4 4-4 4V7H2z" />
+      <path d="M14 11H5v3l-4-4 4-4v3h9z" />
+    </g>
+  </svg>
+)
+
+// checkmark — shown briefly when a sync completes (#178)
+const CheckIcon = (): JSX.Element => (
+  <svg {...iconProps}>
+    <path
+      d="M2 8l4 4 8-9"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
   </svg>
 )
 
@@ -211,6 +236,15 @@ export function DeviceFileTree(): JSX.Element {
   const connected = status.state === 'connected'
   const { openFile } = useWorkspace()
   const prompt = usePrompt()
+  // File sync (#178): tagged local files pushed to the device.
+  const {
+    syncedPaths,
+    syncOnSave,
+    status: syncStatus,
+    error: syncError,
+    setSyncOnSave,
+    syncNow
+  } = useSync()
 
   const [entries, setEntries] = useState<DirEntry[]>([])
   const [selectedPath, setSelectedPath] = useState<string | null>(null)
@@ -246,6 +280,11 @@ export function DeviceFileTree(): JSX.Element {
       setError(null)
     }
   }, [connected, refresh])
+
+  // When a sync finishes, re-list the root so the just-pushed files appear.
+  useEffect(() => {
+    if (syncStatus === 'done' && connected) void refresh()
+  }, [syncStatus, connected, refresh])
 
   const handleSelect = useCallback((path: string, isDir: boolean): void => {
     setSelectedPath(path)
@@ -461,8 +500,43 @@ export function DeviceFileTree(): JSX.Element {
           <span aria-hidden>{'▦'}</span> Device files
         </span>
         {/* Icon-only header actions mirroring the local section (issue #104):
-            Refresh sits left of New file, then New folder. */}
+            the file-sync status/controls (#178), then Refresh, New file, New
+            folder. */}
         <div className="devicetree__header-actions">
+          {/* Sync status + manual "Sync now": the sync icon turns into a green
+              tick for a moment when a sync completes. */}
+          <button
+            className={`btn btn--ghost btn--icon devicetree__sync devicetree__sync--${syncStatus}`}
+            onClick={() => void syncNow()}
+            disabled={syncStatus === 'syncing' || syncedPaths.length === 0}
+            title={
+              syncedPaths.length === 0
+                ? 'Tag local files (right-click → Keep in sync) to sync them here'
+                : syncStatus === 'syncing'
+                  ? 'Syncing…'
+                  : syncStatus === 'done'
+                    ? 'Synced'
+                    : syncStatus === 'error'
+                      ? `Sync failed: ${syncError ?? 'unknown error'}`
+                      : `Sync ${syncedPaths.length} tagged file${syncedPaths.length === 1 ? '' : 's'} now`
+            }
+            aria-label={
+              syncStatus === 'done'
+                ? 'Files synced'
+                : `Sync ${syncedPaths.length} tagged files to the device now`
+            }
+          >
+            {syncStatus === 'done' ? <CheckIcon /> : <SyncIcon />}
+          </button>
+          {/* Toggle: auto-push tagged files on every save. */}
+          <button
+            className={`btn btn--ghost devicetree__autosync${syncOnSave ? ' is-active' : ''}`}
+            onClick={() => setSyncOnSave(!syncOnSave)}
+            aria-pressed={syncOnSave}
+            title="Sync tagged files automatically on save"
+          >
+            Auto
+          </button>
           <button
             className="btn btn--ghost btn--icon"
             onClick={() => void refresh()}

--- a/src/renderer/src/components/EditorTabs.tsx
+++ b/src/renderer/src/components/EditorTabs.tsx
@@ -93,10 +93,18 @@ export function EditorTabs(): JSX.Element | null {
                 requestClose(file.id)
               }
             }}
-            title={file.path || file.name}
+            title={
+              file.source === 'device'
+                ? `${file.path || file.name} (on device)`
+                : file.path || file.name
+            }
           >
             {file.dirty && <span className="editor-tab__dirty" aria-hidden="true" />}
-            <span className="editor-tab__label">{file.name}</span>
+            {/* Device files are bracketed — [name] — to distinguish them from
+                local files at a glance in the tab strip (#178 follow-up). */}
+            <span className="editor-tab__label">
+              {file.source === 'device' ? `[${file.name}]` : file.name}
+            </span>
             <button
               type="button"
               className="editor-tab__close"

--- a/src/renderer/src/components/LocalFileTree.css
+++ b/src/renderer/src/components/LocalFileTree.css
@@ -105,22 +105,54 @@
   font-weight: 600;
 }
 
-/* Per-file "keep in sync with the device" checkbox (#178). Right-aligned at the
-   row's trailing edge. Hidden until the row is hovered/focused, EXCEPT when it's
-   ticked (a synced file always shows its checked box). */
-.tree-row__sync-check {
+/* Per-file "keep in sync with the device" control (#178), at the row's trailing
+   edge. A tagged file shows a green sync glyph AT REST; hovering/focusing the row
+   swaps in the real checkbox so it can be ticked/unticked. An untagged file shows
+   the (empty) checkbox only on hover/focus. The checkbox stays in the DOM (just
+   transparent) so it remains keyboard-focusable. */
+.tree-row__sync {
+  position: relative;
   margin-left: auto;
   flex: 0 0 auto;
-  margin-right: 0.1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.tree-row__sync-check {
+  margin: 0;
   accent-color: var(--accent-2);
   cursor: pointer;
   opacity: 0;
+}
+
+.tree-row__sync-icon {
+  position: absolute;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent-2);
+  font-size: 0.85em;
+  line-height: 1;
   pointer-events: none;
 }
 
+/* At rest, a ticked file shows the green icon (the box sits transparent under it). */
+.tree-row__sync-check:checked + .tree-row__sync-icon {
+  display: inline-flex;
+}
+
+/* Hovering/focusing the row (or focusing the box) reveals the real checkbox… */
 .tree-row:hover .tree-row__sync-check,
-.tree-row:focus-within .tree-row__sync-check,
-.tree-row__sync-check:checked {
+.tree-row:focus-within .tree-row__sync-check {
   opacity: 1;
-  pointer-events: auto;
+}
+
+/* …and hides the green icon so the checkbox can be ticked/unticked. */
+.tree-row:hover .tree-row__sync-check:checked + .tree-row__sync-icon,
+.tree-row:focus-within .tree-row__sync-check:checked + .tree-row__sync-icon {
+  display: none;
 }

--- a/src/renderer/src/components/LocalFileTree.css
+++ b/src/renderer/src/components/LocalFileTree.css
@@ -105,13 +105,22 @@
   font-weight: 600;
 }
 
-/* Sync indicator on a file that's tagged to keep in sync with the device (#178).
-   Right-aligned so it sits at the row's trailing edge, accent-coloured. */
-.tree-row__sync {
+/* Per-file "keep in sync with the device" checkbox (#178). Right-aligned at the
+   row's trailing edge. Hidden until the row is hovered/focused, EXCEPT when it's
+   ticked (a synced file always shows its checked box). */
+.tree-row__sync-check {
   margin-left: auto;
   flex: 0 0 auto;
-  padding-left: 0.3rem;
-  font-size: 0.8em;
-  line-height: 1;
-  color: var(--accent-2);
+  margin-right: 0.1rem;
+  accent-color: var(--accent-2);
+  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.tree-row:hover .tree-row__sync-check,
+.tree-row:focus-within .tree-row__sync-check,
+.tree-row__sync-check:checked {
+  opacity: 1;
+  pointer-events: auto;
 }

--- a/src/renderer/src/components/LocalFileTree.css
+++ b/src/renderer/src/components/LocalFileTree.css
@@ -104,3 +104,14 @@
   color: var(--text);
   font-weight: 600;
 }
+
+/* Sync indicator on a file that's tagged to keep in sync with the device (#178).
+   Right-aligned so it sits at the row's trailing edge, accent-coloured. */
+.tree-row__sync {
+  margin-left: auto;
+  flex: 0 0 auto;
+  padding-left: 0.3rem;
+  font-size: 0.8em;
+  line-height: 1;
+  color: var(--accent-2);
+}

--- a/src/renderer/src/components/LocalFileTree.tsx
+++ b/src/renderer/src/components/LocalFileTree.tsx
@@ -147,17 +147,24 @@ function TreeNode({
         </span>
         <span className="tree-row__name">{entry.name}</span>
         {!entry.isDir && (
-          <input
-            type="checkbox"
-            className="tree-row__sync-check"
-            checked={isSynced(entry.path)}
-            onChange={() => toggleSync(entry.path)}
-            // Don't let toggling the checkbox also open the file / fire the row.
-            onClick={(e) => e.stopPropagation()}
-            onKeyDown={(e) => e.stopPropagation()}
-            title="Keep this file in sync with the device"
-            aria-label={`Keep ${entry.name} in sync with the device`}
-          />
+          <span className="tree-row__sync">
+            <input
+              type="checkbox"
+              className="tree-row__sync-check"
+              checked={isSynced(entry.path)}
+              onChange={() => toggleSync(entry.path)}
+              // Don't let toggling the checkbox also open the file / fire the row.
+              onClick={(e) => e.stopPropagation()}
+              onKeyDown={(e) => e.stopPropagation()}
+              title="Keep this file in sync with the device"
+              aria-label={`Keep ${entry.name} in sync with the device`}
+            />
+            {/* At rest a tagged file shows this green sync glyph in place of the
+                box; hovering/focusing the row swaps the real checkbox back in. */}
+            <span className="tree-row__sync-icon" aria-hidden>
+              ⇄
+            </span>
+          </span>
         )}
       </div>
       {error && (

--- a/src/renderer/src/components/LocalFileTree.tsx
+++ b/src/renderer/src/components/LocalFileTree.tsx
@@ -83,6 +83,8 @@ interface TreeNodeProps {
   onContextMenu: (e: React.MouseEvent, entry: FsEntry) => void
   /** Whether a (file) path is tagged to keep in sync with the device (#178). */
   isSynced: (path: string) => boolean
+  /** Tag / untag a (file) path for device sync (#178). */
+  toggleSync: (path: string) => void
 }
 
 /** Recursively renders a directory entry and (when expanded) its children. */
@@ -94,7 +96,8 @@ function TreeNode({
   onOpenFile,
   onChanged,
   onContextMenu,
-  isSynced
+  isSynced,
+  toggleSync
 }: TreeNodeProps): JSX.Element {
   const [expanded, setExpanded] = useState(false)
   const [children, setChildren] = useState<FsEntry[] | null>(null)
@@ -143,14 +146,18 @@ function TreeNode({
           {entry.isDir ? (expanded ? '▼' : '▶') : '▤'}
         </span>
         <span className="tree-row__name">{entry.name}</span>
-        {!entry.isDir && isSynced(entry.path) && (
-          <span
-            className="tree-row__sync"
-            title="Kept in sync with the device"
-            aria-label="Kept in sync with the device"
-          >
-            ⇄
-          </span>
+        {!entry.isDir && (
+          <input
+            type="checkbox"
+            className="tree-row__sync-check"
+            checked={isSynced(entry.path)}
+            onChange={() => toggleSync(entry.path)}
+            // Don't let toggling the checkbox also open the file / fire the row.
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
+            title="Keep this file in sync with the device"
+            aria-label={`Keep ${entry.name} in sync with the device`}
+          />
         )}
       </div>
       {error && (
@@ -171,6 +178,7 @@ function TreeNode({
             onChanged={onChanged}
             onContextMenu={onContextMenu}
             isSynced={isSynced}
+            toggleSync={toggleSync}
           />
         ))}
     </div>
@@ -510,6 +518,7 @@ export function LocalFileTree(): JSX.Element {
                 onChanged={refresh}
                 onContextMenu={handleContextMenu}
                 isSynced={isSynced}
+                toggleSync={toggleSync}
               />
             ))}
           </div>

--- a/src/renderer/src/components/LocalFileTree.tsx
+++ b/src/renderer/src/components/LocalFileTree.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { FsEntry } from '../../../main/fs/types'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { useWorkspace } from '../store/workspace'
+import { useSync } from '../store/sync'
 import { ContextMenu, type ContextMenuItem, type ContextMenuPosition } from './ContextMenu'
 import { usePrompt } from './PromptModal'
 import './LocalFileTree.css'
@@ -80,6 +81,8 @@ interface TreeNodeProps {
   onOpenFile: (path: string) => void
   onChanged: () => void
   onContextMenu: (e: React.MouseEvent, entry: FsEntry) => void
+  /** Whether a (file) path is tagged to keep in sync with the device (#178). */
+  isSynced: (path: string) => boolean
 }
 
 /** Recursively renders a directory entry and (when expanded) its children. */
@@ -90,7 +93,8 @@ function TreeNode({
   onSelect,
   onOpenFile,
   onChanged,
-  onContextMenu
+  onContextMenu,
+  isSynced
 }: TreeNodeProps): JSX.Element {
   const [expanded, setExpanded] = useState(false)
   const [children, setChildren] = useState<FsEntry[] | null>(null)
@@ -139,6 +143,15 @@ function TreeNode({
           {entry.isDir ? (expanded ? '▼' : '▶') : '▤'}
         </span>
         <span className="tree-row__name">{entry.name}</span>
+        {!entry.isDir && isSynced(entry.path) && (
+          <span
+            className="tree-row__sync"
+            title="Kept in sync with the device"
+            aria-label="Kept in sync with the device"
+          >
+            ⇄
+          </span>
+        )}
       </div>
       {error && (
         <div className="tree-error" style={{ paddingLeft: `${depth * 14 + 22}px` }}>
@@ -157,6 +170,7 @@ function TreeNode({
             onOpenFile={onOpenFile}
             onChanged={onChanged}
             onContextMenu={onContextMenu}
+            isSynced={isSynced}
           />
         ))}
     </div>
@@ -175,6 +189,7 @@ export function LocalFileTree(): JSX.Element {
   const prompt = usePrompt()
   const deviceStatus = useDeviceStatus()
   const connected = deviceStatus.state === 'connected'
+  const { isSynced, toggleSync } = useSync()
   // The working folder now lives in the workspace store so the toolbar and tree
   // share one entry point; `root` is just a local alias for readability.
   const root = currentFolder
@@ -357,6 +372,11 @@ export function LocalFileTree(): JSX.Element {
             disabled: !connected,
             onSelect: () => uploadToBoard(target)
           })
+          items.push({
+            key: 'sync',
+            label: isSynced(target.path) ? 'Stop syncing with device' : 'Keep in sync with device',
+            onSelect: () => toggleSync(target.path)
+          })
         }
         items.push({ key: 'rename', label: 'Rename', onSelect: () => renamePath(target.path) })
         items.push({
@@ -368,7 +388,17 @@ export function LocalFileTree(): JSX.Element {
       }
       return items
     },
-    [connected, deletePath, handleOpenFile, newFileIn, newFolderIn, renamePath, uploadToBoard]
+    [
+      connected,
+      deletePath,
+      handleOpenFile,
+      isSynced,
+      newFileIn,
+      newFolderIn,
+      renamePath,
+      toggleSync,
+      uploadToBoard
+    ]
   )
 
   // Breadcrumb of the working folder: split on either separator and rebuild the
@@ -479,6 +509,7 @@ export function LocalFileTree(): JSX.Element {
                 onOpenFile={handleOpenFile}
                 onChanged={refresh}
                 onContextMenu={handleContextMenu}
+                isSynced={isSynced}
               />
             ))}
           </div>

--- a/src/renderer/src/store/sync.ts
+++ b/src/renderer/src/store/sync.ts
@@ -1,0 +1,251 @@
+/**
+ * FILE SYNC STORE (issue #178)
+ * ============================================================================
+ *
+ * Lets the user TAG local files to keep in sync with the connected device, so
+ * editing on the computer doesn't mean re-uploading by hand each time. A tagged
+ * file is pushed to the board:
+ *
+ *   - immediately when you tag it (if a board is connected),
+ *   - on every save when "sync on save" is enabled, and
+ *   - all at once via "Sync now".
+ *
+ * Each tagged local file maps to `/<basename>` on the device (mirroring the
+ * existing "Upload to board" default). The set of tagged paths and the
+ * sync-on-save flag persist in localStorage so they survive a reload.
+ *
+ * Auto-sync-on-save is wired through the `FILE_SAVED_EVENT` window event the
+ * workspace store dispatches, so this store stays decoupled from save plumbing.
+ *
+ * A coarse {@link SyncStatus} drives the device-files toolbar indicator (a green
+ * tick replaces the sync icon briefly when a sync completes).
+ *
+ * Implemented as a React context + `createElement` (JSX-free) so it can live
+ * under `store/` as a `.ts` file, mirroring {@link ./workspace}.
+ */
+import {
+  createContext,
+  createElement,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode
+} from 'react'
+import { baseName, FILE_SAVED_EVENT, type FileSavedDetail } from './workspace'
+
+/** localStorage keys for the tagged paths + the sync-on-save flag. */
+const SYNCED_KEY = 'snakie.sync.paths'
+const ON_SAVE_KEY = 'snakie.sync.onSave'
+
+/** How long the "done"/"error" indicator lingers before reverting to idle (ms). */
+const DONE_LINGER_MS = 2000
+const ERROR_LINGER_MS = 4000
+
+/** Coarse status backing the toolbar indicator. */
+export type SyncStatus = 'idle' | 'syncing' | 'done' | 'error'
+
+export interface SyncStore {
+  /** Local paths currently tagged to keep in sync. */
+  syncedPaths: string[]
+  /** Whether saving a tagged file auto-uploads it. */
+  syncOnSave: boolean
+  status: SyncStatus
+  /** Last error message when `status === 'error'`. */
+  error: string | null
+  isSynced: (path: string) => boolean
+  /** Tag / untag a local path (tagging pushes it once if a board is connected). */
+  toggleSync: (path: string) => void
+  setSyncOnSave: (on: boolean) => void
+  /** Push every tagged file to the device now. */
+  syncNow: () => Promise<void>
+}
+
+/** Device destination for a synced local file: `/<basename>` (mirrors upload). */
+export function deviceDestForLocal(localPath: string): string {
+  return `/${baseName(localPath)}`
+}
+
+/** Parse the persisted tagged-paths list, tolerating missing / corrupt storage. */
+export function parseSyncedPaths(raw: string | null): string[] {
+  if (!raw) return []
+  try {
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed.filter((p): p is string => typeof p === 'string') : []
+  } catch {
+    return []
+  }
+}
+
+function loadSyncedPaths(): string[] {
+  try {
+    return parseSyncedPaths(window.localStorage.getItem(SYNCED_KEY))
+  } catch {
+    return []
+  }
+}
+
+function saveSyncedPaths(paths: string[]): void {
+  try {
+    window.localStorage.setItem(SYNCED_KEY, JSON.stringify(paths))
+  } catch {
+    // ignore storage failures
+  }
+}
+
+function loadSyncOnSave(): boolean {
+  try {
+    return window.localStorage.getItem(ON_SAVE_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
+function saveSyncOnSave(on: boolean): void {
+  try {
+    window.localStorage.setItem(ON_SAVE_KEY, on ? '1' : '0')
+  } catch {
+    // ignore storage failures
+  }
+}
+
+const SyncContext = createContext<SyncStore | null>(null)
+
+export function SyncProvider({ children }: { children: ReactNode }): JSX.Element {
+  const [syncedPaths, setSyncedPaths] = useState<string[]>(() => loadSyncedPaths())
+  const [syncOnSave, setSyncOnSaveState] = useState<boolean>(() => loadSyncOnSave())
+  const [status, setStatus] = useState<SyncStatus>('idle')
+  const [error, setError] = useState<string | null>(null)
+
+  // Latest values for use inside event handlers without re-subscribing.
+  const connectedRef = useRef(false)
+  const syncedRef = useRef(syncedPaths)
+  const onSaveRef = useRef(syncOnSave)
+  const lingerTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  syncedRef.current = syncedPaths
+  onSaveRef.current = syncOnSave
+
+  // Track the live device connection so we only auto-push when a board is there.
+  useEffect(() => {
+    window.api.device
+      .getStatus()
+      .then((s) => {
+        connectedRef.current = s.state === 'connected'
+      })
+      .catch(() => undefined)
+    return window.api.device.onStatus((s) => {
+      connectedRef.current = s.state === 'connected'
+    })
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      if (lingerTimer.current) clearTimeout(lingerTimer.current)
+    }
+  }, [])
+
+  /** Set a terminal status and auto-revert it to idle after a short linger. */
+  const settle = useCallback((next: 'done' | 'error', err: string | null): void => {
+    setStatus(next)
+    setError(err)
+    if (lingerTimer.current) clearTimeout(lingerTimer.current)
+    lingerTimer.current = setTimeout(
+      () => setStatus('idle'),
+      next === 'done' ? DONE_LINGER_MS : ERROR_LINGER_MS
+    )
+  }, [])
+
+  /** Read each local path and write it to its device destination. */
+  const pushPaths = useCallback(
+    async (paths: string[]): Promise<void> => {
+      if (paths.length === 0) return
+      if (lingerTimer.current) clearTimeout(lingerTimer.current)
+      setStatus('syncing')
+      setError(null)
+      try {
+        for (const path of paths) {
+          const content = await window.api.fs.readFile(path)
+          await window.api.device.writeFile(deviceDestForLocal(path), content)
+        }
+        settle('done', null)
+      } catch (err) {
+        settle('error', err instanceof Error ? err.message : String(err))
+      }
+    },
+    [settle]
+  )
+
+  const syncNow = useCallback(async (): Promise<void> => {
+    await pushPaths(syncedRef.current)
+  }, [pushPaths])
+
+  const isSynced = useCallback((path: string): boolean => syncedPaths.includes(path), [syncedPaths])
+
+  const toggleSync = useCallback(
+    (path: string): void => {
+      setSyncedPaths((prev) => {
+        const has = prev.includes(path)
+        const next = has ? prev.filter((p) => p !== path) : [...prev, path]
+        saveSyncedPaths(next)
+        // Newly tagged + a board is connected → push it once so it's in sync now.
+        if (!has && connectedRef.current) void pushPaths([path])
+        return next
+      })
+    },
+    [pushPaths]
+  )
+
+  const setSyncOnSave = useCallback((on: boolean): void => {
+    setSyncOnSaveState(on)
+    saveSyncOnSave(on)
+  }, [])
+
+  // Auto-sync on save: when enabled + connected, a saved tagged local file is
+  // pushed using the content carried by the event (no re-read needed).
+  useEffect(() => {
+    const handler = (e: Event): void => {
+      const detail = (e as CustomEvent<FileSavedDetail>).detail
+      if (!detail || detail.source !== 'local') return
+      if (!onSaveRef.current || !connectedRef.current) return
+      if (!syncedRef.current.includes(detail.path)) return
+      void (async (): Promise<void> => {
+        if (lingerTimer.current) clearTimeout(lingerTimer.current)
+        setStatus('syncing')
+        setError(null)
+        try {
+          await window.api.device.writeFile(deviceDestForLocal(detail.path), detail.content)
+          settle('done', null)
+        } catch (err) {
+          settle('error', err instanceof Error ? err.message : String(err))
+        }
+      })()
+    }
+    window.addEventListener(FILE_SAVED_EVENT, handler)
+    return () => window.removeEventListener(FILE_SAVED_EVENT, handler)
+  }, [settle])
+
+  const store = useMemo<SyncStore>(
+    () => ({
+      syncedPaths,
+      syncOnSave,
+      status,
+      error,
+      isSynced,
+      toggleSync,
+      setSyncOnSave,
+      syncNow
+    }),
+    [syncedPaths, syncOnSave, status, error, isSynced, toggleSync, setSyncOnSave, syncNow]
+  )
+
+  return createElement(SyncContext.Provider, { value: store }, children)
+}
+
+/** Access the file-sync store. Must be used within <SyncProvider>. */
+export function useSync(): SyncStore {
+  const ctx = useContext(SyncContext)
+  if (!ctx) throw new Error('useSync must be used within a SyncProvider')
+  return ctx
+}

--- a/src/renderer/src/store/workspace.ts
+++ b/src/renderer/src/store/workspace.ts
@@ -49,6 +49,27 @@ import {
 
 export type FileSource = 'local' | 'device'
 
+/**
+ * Window event dispatched after a file is successfully saved (#178). The sync
+ * store listens for this to auto-upload tagged local files on save — a decoupled
+ * seam so the workspace store doesn't depend on the sync store.
+ */
+export const FILE_SAVED_EVENT = 'snakie:file-saved'
+
+/** Detail payload of {@link FILE_SAVED_EVENT}. */
+export interface FileSavedDetail {
+  source: FileSource
+  path: string
+  content: string
+}
+
+/** Announce a successful save so listeners (e.g. file sync, #178) can react. */
+function announceSaved(source: FileSource, path: string, content: string): void {
+  window.dispatchEvent(
+    new CustomEvent<FileSavedDetail>(FILE_SAVED_EVENT, { detail: { source, path, content } })
+  )
+}
+
 /** localStorage key for the last opened working folder (#177), restored on launch. */
 const LAST_FOLDER_KEY = 'snakie.lastFolder'
 
@@ -276,6 +297,7 @@ export function WorkspaceProvider({ children }: { children: ReactNode }): JSX.El
         if (!chosen) return
         await window.api.fs.writeFile(chosen, file.content)
         dispatch({ type: 'savedAs', id, path: chosen, name: baseName(chosen) })
+        announceSaved('local', chosen, file.content)
         return
       }
       if (!file.path) return
@@ -285,6 +307,7 @@ export function WorkspaceProvider({ children }: { children: ReactNode }): JSX.El
         await window.api.device.writeFile(file.path, file.content)
       }
       dispatch({ type: 'markSaved', id })
+      announceSaved(file.source, file.path, file.content)
     },
     [state.openFiles]
   )

--- a/test/syncStore.test.ts
+++ b/test/syncStore.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { deviceDestForLocal, parseSyncedPaths } from '../src/renderer/src/store/sync'
+
+/** Pure helpers backing the file-sync store (#178). */
+describe('deviceDestForLocal', () => {
+  it('maps a POSIX local path to /<basename> on the device', () => {
+    expect(deviceDestForLocal('/home/kev/proj/main.py')).toBe('/main.py')
+    expect(deviceDestForLocal('/home/kev/proj/sub/blink.py')).toBe('/blink.py')
+  })
+
+  it('handles Windows separators', () => {
+    expect(deviceDestForLocal('C:\\Users\\kev\\blink.py')).toBe('/blink.py')
+  })
+
+  it('handles a bare filename', () => {
+    expect(deviceDestForLocal('main.py')).toBe('/main.py')
+  })
+})
+
+describe('parseSyncedPaths', () => {
+  it('returns an empty list for missing or corrupt storage', () => {
+    expect(parseSyncedPaths(null)).toEqual([])
+    expect(parseSyncedPaths('')).toEqual([])
+    expect(parseSyncedPaths('not json')).toEqual([])
+    expect(parseSyncedPaths('{"x":1}')).toEqual([])
+  })
+
+  it('round-trips a list of paths', () => {
+    expect(parseSyncedPaths('["/a/b.py","/c.py"]')).toEqual(['/a/b.py', '/c.py'])
+  })
+
+  it('drops non-string entries defensively', () => {
+    expect(parseSyncedPaths('["/a.py", 5, null, "/b.py"]')).toEqual(['/a.py', '/b.py'])
+  })
+})


### PR DESCRIPTION
Closes #178.

Tag local files to keep them in sync with the connected board, so editing on the computer doesn't mean re-uploading by hand each time.

## How it works

- **Tag a file:** right-click a file in the **Local files** tree → **Keep in sync with device**. Tagged files show a small **⇄** marker.
- **When tagged files get pushed:**
  - immediately when you tag one (if a board is connected),
  - automatically on every **save** when the **Auto** toggle is on,
  - all at once via the **Sync now** button.
- **Sync status on the device-files toolbar:** the sync icon turns into a **green tick** for a moment when a sync completes (spins while syncing, red on failure), and the device tree re-lists so the pushed files appear.
- Each tagged file maps to `/<filename>` on the device (mirrors the existing "Upload to board" default). The tagged set and the Auto toggle **persist** across reloads.

## Implementation

- **`store/sync.ts`** — a `SyncProvider`/`useSync` context: persisted tagged paths + sync-on-save flag + a coarse `status` (`idle`/`syncing`/`done`/`error`). Auto-sync-on-save is wired through a decoupled `snakie:file-saved` window event the workspace store dispatches, so the workspace store has no dependency on sync.
- **LocalFileTree** — context-menu toggle + the ⇄ row marker.
- **DeviceFileTree** — the Sync-now/status button + Auto toggle, and a re-list when a sync completes.

## Tests

Unit tests for the pure helpers (`deviceDestForLocal`, `parseSyncedPaths`).
`npm run typecheck` ✅ · `npm run lint` ✅ · `npm test` ✅ (1109, +6) · `npm run build` ✅.

## Notes / verification

- This pairs nicely with the new offline simulator — its RAM-backed VFS resets on disconnect, so it's a handy way to test sync without real hardware (tag a file, hit Sync now / save, watch it appear in the device tree).
- I **couldn't** smoke-test the GUI here (headless box). Worth a quick `npm run dev` pass: open a folder, tag a file, connect a board (or the simulator), and confirm the ⇄ marker, the green-tick status, and Auto-on-save.

### Possible follow-ups (not in this PR)
- Map tagged files to a mirrored device path (preserve subfolders) instead of `/<filename>`.
- A two-way / newest-wins sync, or a "synced files" summary view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)