### PR TITLE
feat: Raspberry Pi (Linux arm64) build + menu integration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,15 +19,14 @@ jobs:
     #   - macos-latest     -> macOS arm64 + x64 dmgs (both archs build on the
     #                         arm64 hosted runner; see electron-builder.yml)
     #   - ubuntu-latest    -> Linux x64 AppImage + deb
-    #   - ubuntu-24.04-arm -> Linux arm64 AppImage + deb (native arm64 hosted
-    #                         runner — no QEMU/emulation; packaging tools run
-    #                         on their native arch). Falls back to needing a
-    #                         self-hosted arm64 runner if the hosted arm pool
-    #                         is ever unavailable.
+    #   - ubuntu-24.04-arm -> Linux arm64 AppImage (Raspberry Pi 4/5, 64-bit Pi
+    #                         OS). Native arm64 hosted runner — no QEMU/emulation;
+    #                         the serialport rebuild uses the arm64 toolchain and
+    #                         appimagetool runs on its own arch. AppImage ONLY:
+    #                         the arm64 .deb is skipped because the bundled fpm is
+    #                         x86 (see electron-builder.yml).
     # macOS builds both arm64+x64 on the arm64 runner (serialport ships a
-    # universal darwin prebuild). Linux is x64-only for now — arm64 packaging is
-    # deferred (electron-builder's bundled fpm is x86 and the serialport rebuild
-    # emits -m64); see electron-builder.yml.
+    # universal darwin prebuild).
     strategy:
       fail-fast: false
       matrix:
@@ -41,6 +40,11 @@ jobs:
           - os: ubuntu-latest
             platform_flag: --linux --x64
             artifact: installers-linux-x64
+          - os: ubuntu-24.04-arm
+            # AppImage ONLY for arm64 (the arm64 .deb's fpm is x86 — see
+            # electron-builder.yml). Naming the target skips deb.
+            platform_flag: --linux AppImage --arm64
+            artifact: installers-linux-arm64
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Raspberry Pi build (Linux arm64).** Releases now include an arm64 AppImage,
+  `Snakie-<version>-arm64.AppImage`, for **Raspberry Pi 4 / 5 on 64-bit Pi OS**.
+  It's built on a native `ubuntu-24.04-arm` runner (so the `serialport` native
+  module is the correct arm64 build) and ships as an AppImage only (the arm64
+  `.deb` is skipped because electron-builder's bundled `fpm` is x86-only).
+- **Add Snakie to the Raspberry Pi / Linux menu.** A helper script
+  (`scripts/install-linux-menu.sh`) installs a desktop entry + icon for the
+  AppImage so Snakie appears in the menu under **Programming** (`Categories=
+  Development`). Re-run it after updating, or `--uninstall` to remove it.
+
 ## [0.17.0] - 2026-06-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,9 +20,26 @@ Grab the latest installer for your platform from the
 - 🍎 macOS (Apple Silicon) — `Snakie-<version>-arm64.dmg`
 - 🍎 macOS (Intel) — `Snakie-<version>.dmg`
 - 🐧 Linux (x64) — `Snakie-<version>.AppImage` or `snakie_<version>_amd64.deb`
+- 🍓 Linux (arm64 — Raspberry Pi 4 / 5, 64-bit Pi OS) — `Snakie-<version>-arm64.AppImage`
 
-> Windows and Linux are x64 only for now; Linux arm64 (Raspberry Pi) and
-> Windows arm64 are not yet built — see "Building installers" below for why.
+> Windows is x64 only for now; Windows arm64 isn't built yet — see "Building
+> installers" below for why. The Raspberry Pi build is an **AppImage** (no
+> `.deb`); make it executable (`chmod +x`) and run it.
+
+### Raspberry Pi: add Snakie to the menu
+
+An AppImage is a single file and doesn't register itself in the menu. To make
+Snakie show up under **Programming** (with its icon), run the helper once after
+downloading the AppImage:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/kevinmcaleer/Snakie/master/scripts/install-linux-menu.sh -o install-linux-menu.sh
+bash install-linux-menu.sh ~/Downloads/Snakie-<version>-arm64.AppImage
+```
+
+It installs a desktop entry + icon under `~/.local/share` with
+`Categories=Development` — which the Raspberry Pi menu lists under **Programming**.
+Re-run it after updating to a new version, or pass `--uninstall` to remove it.
 
 ## Features
 
@@ -133,6 +150,7 @@ matrix and collects them into a single draft GitHub Release.
 | macOS    | arm64 | `Snakie-<v>-arm64.dmg`             | `macos-latest`     |
 | macOS    | x64   | `Snakie-<v>.dmg`                   | `macos-latest`     |
 | Linux    | x64   | `.AppImage` + `_amd64.deb`         | `ubuntu-latest`    |
+| Linux    | arm64 | `Snakie-<v>-arm64.AppImage`        | `ubuntu-24.04-arm` |
 | Windows  | x64   | `Snakie.Setup.<v>.exe`             | `windows-latest`   |
 
 Notes on arch coverage:
@@ -142,12 +160,12 @@ Notes on arch coverage:
   fragile, and two per-arch dmgs are smaller. Both build on the arm64
   `macos-latest` runner because `@serialport/bindings-cpp` provides a universal
   (`darwin-x64+arm64`) prebuilt binary, so no per-arch recompilation is needed.
-- **Linux arm64 (Raspberry Pi) is not yet built** — deferred. Even on a native
-  `ubuntu-24.04-arm` runner, electron-builder's bundled `fpm` (for `.deb`) is an
-  x86 binary that won't execute on arm64, and the `serialport` native rebuild
-  emits the x86-only `-m64` flag that arm64 g++ rejects. Producing arm64 Linux
-  packages needs dedicated work (AppImage-only + arm64 fpm/appimagetool + a
-  clean serialport rebuild).
+- **Linux arm64 (Raspberry Pi 4 / 5)** ships as an **AppImage only**, built on
+  the native `ubuntu-24.04-arm` hosted runner so the `serialport` rebuild uses
+  the arm64 toolchain (no cross-compile `-m64` failure). The `.deb` is skipped on
+  arm64 because electron-builder's bundled `fpm` is an x86 binary that fails on
+  arm64 — the arm64 job names just the `AppImage` target so `fpm` is never
+  invoked. Targets 64-bit Raspberry Pi OS (aarch64); 32-bit Pi OS is not built.
 - **Windows is x64 only.** GitHub's hosted Windows runners are x64 and there is
   no native arm64 Windows runner in the hosted pool, so a reliable arm64 nsis
   installer can't be produced here yet. (`serialport` does ship a `win32-arm64`

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -62,21 +62,21 @@ extraResources:
 # (run via the postinstall script / electron-builder) handles serialport.
 npmRebuild: true
 
-# Linux
-# x64 only for now. Linux arm64 packaging is deferred (tracked separately):
-# even on a native ubuntu-24.04-arm runner, electron-builder's bundled `fpm`
-# (used for .deb) is an x86 binary ("Exec format error" on arm64), and the
-# serialport native rebuild emits the x86-only `-m64` flag that arm64 g++
-# rejects. Making arm64 work needs more than a runner swap (e.g. AppImage-only
-# + an arm64 fpm/appimagetool + a clean serialport rebuild).
+# Linux. The ARCH is chosen by the CLI flag per release job (NOT pinned here):
+# pinning `arch` in the target list makes electron-builder build EVERY listed
+# arch regardless of the `--x64`/`--arm64` flag, which cross-compiles and fails.
+#   - x64  job: `--linux --x64`          → AppImage + deb (both x64).
+#   - arm64 job: `--linux AppImage --arm64` → AppImage ONLY (Raspberry Pi 4/5 on
+#     64-bit Pi OS). The arm64 job names just the AppImage target so the .deb is
+#     skipped: electron-builder's bundled `fpm` is an x86 binary that fails on
+#     arm64 ("Exec format error"), whereas appimagetool ships an arm64 build.
+# Both Linux jobs run on their NATIVE arch (ubuntu-latest / ubuntu-24.04-arm), so
+# the serialport native rebuild uses the matching toolchain — no cross-compile
+# `-m64` failure.
 linux:
   target:
-    - target: AppImage
-      arch:
-        - x64
-    - target: deb
-      arch:
-        - x64
+    - AppImage
+    - deb
   category: Development
   maintainer: Kevin McAleer <kevinmcaleer@gmail.com>
   icon: build/icon.png

--- a/scripts/install-linux-menu.sh
+++ b/scripts/install-linux-menu.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# install-linux-menu.sh — add Snakie to the application menu (issue: Raspberry Pi
+# build / menu integration).
+#
+# An AppImage is a single self-contained file and does NOT register itself in the
+# desktop menu. This script installs a per-user desktop entry + icon pointing at
+# the Snakie AppImage, so it appears in the menu — on Raspberry Pi OS that's the
+# "Programming" section, because the entry's `Categories=Development` is what the
+# Pi menu maps there.
+#
+# Usage:
+#   ./install-linux-menu.sh [path/to/Snakie-<version>-arm64.AppImage]
+#
+# With no argument it looks for a single Snakie-*.AppImage next to this script,
+# in the current directory, or in ~/Downloads. Re-run it after downloading a new
+# version to point the menu entry at the new file. Run `--uninstall` to remove it.
+set -euo pipefail
+
+APP_NAME="Snakie"
+DESKTOP_ID="snakie"
+APPS_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/applications"
+ICON_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/icons"
+DESKTOP_FILE="$APPS_DIR/$DESKTOP_ID.desktop"
+ICON_FILE="$ICON_DIR/$DESKTOP_ID.png"
+
+if [ "${1:-}" = "--uninstall" ]; then
+  rm -f "$DESKTOP_FILE" "$ICON_FILE"
+  command -v update-desktop-database >/dev/null 2>&1 && update-desktop-database "$APPS_DIR" 2>/dev/null || true
+  echo "Removed Snakie from the application menu."
+  exit 0
+fi
+
+# --- Locate the AppImage ----------------------------------------------------
+find_appimage() {
+  if [ -n "${1:-}" ]; then printf '%s\n' "$1"; return; fi
+  local here; here="$(cd "$(dirname "$0")" && pwd)"
+  local candidates=()
+  for dir in "$here" "$PWD" "$HOME/Downloads"; do
+    for f in "$dir"/Snakie-*.AppImage; do
+      [ -f "$f" ] && candidates+=("$f")
+    done
+  done
+  if [ "${#candidates[@]}" -eq 0 ]; then
+    echo "error: no Snakie-*.AppImage found. Pass its path:" >&2
+    echo "  $0 ~/Downloads/Snakie-<version>-arm64.AppImage" >&2
+    exit 1
+  fi
+  # Newest by name (versions sort lexically well enough for v0.x).
+  printf '%s\n' "${candidates[@]}" | sort | tail -1
+}
+
+APPIMAGE="$(find_appimage "${1:-}")"
+if [ ! -f "$APPIMAGE" ]; then
+  echo "error: AppImage not found: $APPIMAGE" >&2
+  exit 1
+fi
+# Absolute path so the menu entry works regardless of the working directory.
+APPIMAGE="$(cd "$(dirname "$APPIMAGE")" && pwd)/$(basename "$APPIMAGE")"
+chmod +x "$APPIMAGE"
+echo "Using AppImage: $APPIMAGE"
+
+mkdir -p "$APPS_DIR" "$ICON_DIR"
+
+# --- Extract the icon from the AppImage -------------------------------------
+# The AppImage embeds the icon; pull it out so the menu entry has a real icon.
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+if ( cd "$tmp" && "$APPIMAGE" --appimage-extract 'usr/share/icons/*' >/dev/null 2>&1 ); then
+  icon_src="$(find "$tmp/squashfs-root" -name '*.png' 2>/dev/null | sort | tail -1)"
+  if [ -n "$icon_src" ]; then
+    cp "$icon_src" "$ICON_FILE"
+    echo "Installed icon: $ICON_FILE"
+  fi
+fi
+# Fall back to the named theme icon if extraction failed.
+[ -f "$ICON_FILE" ] && ICON_VALUE="$ICON_FILE" || ICON_VALUE="$DESKTOP_ID"
+
+# --- Write the desktop entry ------------------------------------------------
+cat > "$DESKTOP_FILE" <<EOF
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=$APP_NAME
+GenericName=MicroPython Editor
+Comment=A modern, cross-platform MicroPython editor
+Exec="$APPIMAGE" --no-sandbox %U
+Icon=$ICON_VALUE
+Terminal=false
+Categories=Development;
+Keywords=MicroPython;Python;Editor;Pico;microcontroller;Raspberry Pi;
+StartupWMClass=$APP_NAME
+EOF
+chmod +x "$DESKTOP_FILE"
+echo "Installed menu entry: $DESKTOP_FILE"
+
+command -v update-desktop-database >/dev/null 2>&1 && update-desktop-database "$APPS_DIR" 2>/dev/null || true
+
+echo
+echo "Done — Snakie should now appear in the menu under Programming."
+echo "(If it doesn't show immediately, log out/in or restart the panel.)"


### PR DESCRIPTION
Adds a **Raspberry Pi build** (Linux arm64) and makes it easy to add Snakie to the Pi's **Programming** menu.

## Raspberry Pi build (Linux arm64)

- Releases now include `Snakie-<version>-arm64.AppImage` for **Raspberry Pi 4 / 5 on 64-bit Pi OS**.
- Built on the **native `ubuntu-24.04-arm`** hosted runner (added to the `release.yml` matrix), so the `serialport` native module is the correct arm64 build — no cross-compile `-m64` failure that previously blocked arm64.
- **AppImage only** for arm64: the arm64 job names just the `AppImage` target so the `.deb` is skipped (electron-builder's bundled `fpm` is x86-only and errors on arm64).
- **`electron-builder.yml`:** removed the per-target `arch` lists. They caused electron-builder to build *every* listed arch regardless of the `--x64`/`--arm64` flag (cross-compiling and failing); arch is now driven entirely by the per-job CLI flag.

### Verified natively on a Pi
I built it on an actual arm64 Pi (this dev box) with the exact CI command (`--linux AppImage --arm64`):
- ✅ produces only `Snakie-0.17.0-arm64.AppImage` (no x64, no deb) — `ELF 64-bit … ARM aarch64`.
- ✅ bundles the `linux-arm64` serialport prebuild (armv8 glibc + musl) — serial works on Pi OS.
- ✅ the MicroPython `.wasm` is correctly `asarUnpack`ed (offline mode works on the Pi too).

## Menu integration (Programming section)

An AppImage doesn't register itself in the menu. The embedded desktop entry already declares `Categories=Development`, which the Pi menu maps to **Programming** — so the remaining piece is *installing* an entry. Added **`scripts/install-linux-menu.sh`**:
- extracts the icon from the AppImage and installs a per-user desktop entry under `~/.local/share`,
- `Categories=Development` → appears under **Programming** with the Snakie icon,
- re-runnable after updates; `--uninstall` to remove.

Validated with `desktop-file-validate` (VALID). README documents a one-line `curl | bash` install.

## Notes
- This is a CI/packaging change, so the app code/tests are untouched (lint/typecheck/build remain green).
- **0.17.0 was already tagged before this** — its draft release was built without the Pi AppImage. Once this merges, the *next* tagged release will include arm64 automatically. If you want 0.17.0 itself to include the Pi build, I can either attach the locally-built arm64 AppImage to the existing draft, or re-run the release for the tag — your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)