### PR TITLE
Issues #214–#221 + install/help polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Interactive I²C scanner (#214).** Found addresses in the I²C-detect grid are
+  clickable: an inspector names the known devices for that address and offers an
+  **ADD** button for any installed library part declaring it (new `i2cAddresses`
+  part field; BME280 + ICM20948 declare theirs) — adding the part to the project
+  and popping the breadboard.
+- **Compass in the IMU instrument (#215).** A rotating 16-wind rose card under a
+  fixed lubber line, with a `309° NW`-style readout driven by the magnetometer
+  heading (the calibrated yaw).
+- **Barometer instrument (#216).** Temperature / pressure / humidity as an
+  antique aneroid barometer — brass bezel, 950–1050 hPa scale, RAIN · CHANGE ·
+  FAIR legend — fed by `SNK ENV` telemetry; `inst.watch(weather=bme)` binds a
+  BME280-style sensor automatically (instruments library 0.9.0).
+- **Schematic buses (#217).** I²C/SPI wires in the Schematic view draw as short
+  named bus tags (»I2C0«, »SPI1«) at both ends instead of routed noodles.
+- **Animated I²C scan (#218).** Scan results play back as a cursor sweep across
+  the grid, with a water-ripple "ping" on each found address.
+- **Device-files management (#219).** Ctrl/Cmd + Shift multi-selection, drag
+  files/folders into folders (a device-side move), a hover ✕ delete on every
+  row, and "Delete N items" from the context menu. Deleting a folder now removes
+  its contents recursively (previously directories couldn't be deleted at all).
+- **Right-click context help (#221).** "Help for symbol (Snakie)" in the editor
+  context menu opens the mini help for the word under the cursor — an installed
+  part's bundled help (e.g. `bme280`) or a language-reference topic (Pin, PWM,
+  I2C, sleep, …).
+
+### Fixed
+- **Device-files Refresh refreshes folders (#220).** Refresh re-lists every
+  loaded folder — not just the root — keeping your expansion state.
+
 ## [0.22.0] - 2026-07-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Context help for standard MicroPython code.** Right-click → "Help for
+  symbol" now covers the language itself, not just hardware modules: keywords
+  (`if`/`while`/`def`/`class`/`try`/`import` …), value types (`int`, `str`,
+  `list`, `dict`, `bytes` …) and everyday built-ins (`len`, `range`,
+  `enumerate` …) open seven new mini-help reference articles — Control flow,
+  Functions, Values & types, Built-ins, Classes, Errors & exceptions, and
+  Imports & modules.
 - **Device files refresh after installs.** Installing a part driver (either
   missing-library banner), the instruments library, or a mip package now
   re-lists the connected board's file tree automatically — the new files in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **One-click install from the missing-library banner.** When the editor
+  reports the connected board is missing a library your parts need, the banner's
+  **Install** button now also covers parts that ship **bundled driver files**
+  (SG90 / BME280 / ICM20948 …) — copying them straight onto the device, exactly
+  like the instruments-library "Download & install". Previously only mip-URL
+  libraries were installable from there. (Also: importing a driver directly no
+  longer hides the missing-on-board nag just because a matching instrument looks
+  in-use, and the simulated device's `exec` now really runs code, so probes work
+  on the sim.)
 - **Interactive I²C scanner (#214).** Found addresses in the I²C-detect grid are
   clickable: an inspector names the known devices for that address and offers an
   **ADD** button for any installed library part declaring it (new `i2cAddresses`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Device files refresh after installs.** Installing a part driver (either
+  missing-library banner), the instruments library, or a mip package now
+  re-lists the connected board's file tree automatically — the new files in
+  `/lib` appear without clicking Refresh, in every window.
 - **One-click install from the missing-library banner.** When the editor
   reports the connected board is missing a library your parts need, the banner's
   **Install** button now also covers parts that ship **bundled driver files**

--- a/examples/parts/snakie-standard/bme280/bme280.py
+++ b/examples/parts/snakie-standard/bme280/bme280.py
@@ -46,12 +46,46 @@ class BME280:
 
     def __init__(self, i2c, addr=0x76):
         self.i2c = i2c
-        self.addr = addr
         self.t_fine = 0
-        chip = self._read8(_REG_ID)
-        if chip != _CHIP_ID:
+        # Probe 0x76 then 0x77 (the ADDR strap picks one) with a chip-id read,
+        # and raise a SPECIFIC error: an address that ACKs (shows in i2c.scan())
+        # but whose reads fail is a BUS/wiring fault; a readable chip with a
+        # foreign id is the wrong part; silence at both means not connected.
+        self.addr = addr
+        seen = None  # (addr, chip_id) at a readable-but-foreign address
+        fault = None  # an address that ACKed but couldn't be read
+        for a in [addr] + [x for x in (0x76, 0x77) if x != addr]:
+            self.addr = a
+            try:
+                chip = self._read8(_REG_ID)
+            except OSError:
+                try:
+                    present = a in i2c.scan()
+                except Exception:
+                    present = False
+                if present and fault is None:
+                    fault = a
+                continue
+            if chip == _CHIP_ID:
+                break
+            if seen is None:
+                seen = (a, chip)
+        else:
+            if fault is not None:
+                raise OSError(
+                    "0x%02x ACKs its address but reads fail (EIO) — a BUS/"
+                    "wiring fault: add strong SDA/SCL pull-ups (2.2k-4.7k to "
+                    "3V3), check a solid common GND, and re-seat SDA/SCL."
+                    % fault
+                )
+            if seen is not None:
+                raise OSError(
+                    "0x%02x reports chip id 0x%02x, not a BME280 (0x60). "
+                    "0x58=BMP280 (no humidity), 0x61=BME680." % seen
+                )
             raise OSError(
-                "BME280 not found at 0x%02x (id=0x%02x)" % (addr, chip)
+                "BME280 not found at 0x76/0x77 — check wiring (SDA/SCL/3V3/"
+                "GND) and run i2c.scan() to see what's on the bus"
             )
         self._load_calibration()
         # Humidity oversampling ×1 (must be written before ctrl_meas takes it).

--- a/examples/parts/snakie-standard/bme280/parts.yml
+++ b/examples/parts/snakie-standard/bme280/parts.yml
@@ -118,6 +118,9 @@ labels:
     fontSize: 9
     color: "#e6e6e6"
     z: 3
+# 7-bit I²C addresses this part answers on (0x76 default, 0x77 via ADDR) — the
+# I²C-detect instrument matches found addresses back to this part (#214).
+i2cAddresses: [118, 119]
 library:
   module: bme280
 drivers:

--- a/examples/parts/snakie-standard/icm20948/parts.yml
+++ b/examples/parts/snakie-standard/icm20948/parts.yml
@@ -123,6 +123,9 @@ labels:
     fontSize: 9
     color: "#ffffff"
     z: 4
+# 7-bit I²C addresses this part answers on (0x68 default, 0x69 via the address
+# trace) — the I²C-detect instrument matches found addresses to this part (#214).
+i2cAddresses: [104, 105]
 library:
   module: icm20948
 drivers:

--- a/micropython/instruments.py
+++ b/micropython/instruments.py
@@ -81,7 +81,7 @@ import sys
 # against the copy installed on the board and offers a one-click UPDATE when they
 # differ (a legacy copy with no __version__ reads as out-of-date). Keep the
 # `__version__ = "X.Y.Z"` literal form so the IDE can parse it without importing.
-__version__ = "0.8.0"
+__version__ = "0.9.0"
 
 # The sentinel that prefixes every telemetry line. Kept short + ASCII so it is
 # cheap to print and easy for the IDE to detect / strip.
@@ -143,6 +143,19 @@ def imu_quat(w, x, y, z, ch="imu"):
     Prints ``SNK IMUQ <ch> <w> <x> <y> <z>``.
     """
     print("%s IMUQ %s %s %s %s %s" % (SENTINEL, ch, w, x, y, z))
+
+
+def env(temp, pressure, humidity, ch="env"):
+    """Emit one environmental reading — temperature (°C), barometric pressure
+    (hPa) and relative humidity (%RH) — on channel ``ch``.
+
+    Prints ``SNK ENV <ch> <temp> <pressure> <humidity>`` for the Barometer
+    instrument (#216)::
+
+        t, p, h = bme.read()
+        inst.env(t, p, h)
+    """
+    print("%s ENV %s %s %s %s" % (SENTINEL, ch, temp, pressure, humidity))
 
 
 def distance(mm, angle=None, ch="dist"):
@@ -1572,14 +1585,27 @@ def _is_imu(obj):
     )
 
 
+def _is_env(obj):
+    """True for an environmental sensor driver exposing ``temperature`` +
+    ``pressure`` + ``humidity`` (e.g. the bundled BME280 driver)."""
+    return (
+        hasattr(obj, "temperature")
+        and hasattr(obj, "pressure")
+        and hasattr(obj, "humidity")
+    )
+
+
 def _classify(obj):
     """Best-effort object KIND by duck-typing (methods, most-specific first).
 
-    Returns ``imu``/``servo``/``pwm``/``i2c``/``adc``/``pin`` or ``None``. An IMU
-    (accel+gyro reader) is checked first; a Servo-like driver (``angle``) before a
-    bare ``Pin`` (``value``); a ``PWM`` (``duty_u16``) before an ``ADC``
+    Returns ``env``/``imu``/``servo``/``pwm``/``i2c``/``adc``/``pin`` or ``None``.
+    An environmental sensor (temperature+pressure+humidity, e.g. a BME280) and an
+    IMU (accel+gyro reader) are checked first; a Servo-like driver (``angle``)
+    before a bare ``Pin`` (``value``); a ``PWM`` (``duty_u16``) before an ``ADC``
     (``read_u16``). Never raises.
     """
+    if _is_env(obj):
+        return "env"
     if _is_imu(obj):
         return "imu"
     if hasattr(obj, "angle"):
@@ -1687,6 +1713,17 @@ def update():
             try:
                 roll, pitch, yaw = _imu_euler(obj)
                 print("%s IMU %s %s %s %s" % (SENTINEL, name, roll, pitch, yaw))
+            except Exception:
+                pass
+        elif kind == "env":
+            # An environmental sensor (#216): one burst read() when available
+            # (atomic + cheapest), else the three properties.
+            try:
+                if hasattr(obj, "read"):
+                    t, p, h = obj.read()
+                else:
+                    t, p, h = obj.temperature, obj.pressure, obj.humidity
+                print("%s ENV %s %s %s %s" % (SENTINEL, name, t, p, h))
             except Exception:
                 pass
 

--- a/python/tests/test_instruments.py
+++ b/python/tests/test_instruments.py
@@ -974,6 +974,28 @@ class _FakeServoObj:
         return self.a
 
 
+class _FakeBme:
+    """A user env-sensor driver (BME280-shaped): t/p/h properties + read()."""
+
+    def __init__(self, t=21.5, p=1013.2, h=45.0):
+        self._t, self._p, self._h = t, p, h
+
+    @property
+    def temperature(self):
+        return self._t
+
+    @property
+    def pressure(self):
+        return self._p
+
+    @property
+    def humidity(self):
+        return self._h
+
+    def read(self):
+        return (self._t, self._p, self._h)
+
+
 class _FakeIMU:
     """A user IMU driver (ICM20948-shaped): accel/gyro + optional magnetometer."""
 
@@ -1013,10 +1035,25 @@ class WatchBinding(unittest.TestCase):
         self.assertEqual(inst._classify(_FakeServoObj()), "servo")
         self.assertEqual(inst._classify(_FakeI2C([0x3C])), "i2c")
         self.assertEqual(inst._classify(_FakeIMU()), "imu")
+        self.assertEqual(inst._classify(_FakeBme()), "env")
         self.assertIsNone(inst._classify(object()))
 
     def test_watch_imu_emits_bind(self):
         self.assertEqual(_emit(inst.watch, imu=_FakeIMU()), "SNK BIND imu imu")
+
+    def test_watch_env_emits_bind_and_update_streams(self):
+        self.assertEqual(_emit(inst.watch, weather=_FakeBme()), "SNK BIND weather env")
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            inst.update()
+        line = buf.getvalue().strip()
+        self.assertEqual(line, "SNK ENV weather 21.5 1013.2 45.0")
+
+    def test_env_emit_function(self):
+        self.assertEqual(_emit(inst.env, 21.5, 1013.2, 45.0), "SNK ENV env 21.5 1013.2 45.0")
+        self.assertEqual(
+            _emit(inst.env, 20, 990, 60, ch="attic"), "SNK ENV attic 20 990 60"
+        )
 
     def test_update_imu_flat_board(self):
         # Flat, still board: accel (0, 0, 1) g → roll 0, pitch 0; no mag → yaw 0.

--- a/src/main/device/MicroPythonDevice.ts
+++ b/src/main/device/MicroPythonDevice.ts
@@ -487,9 +487,28 @@ export class MicroPythonDevice extends EventEmitter implements SnakieDevice {
     }
   }
 
-  /** Remove a file. */
+  /** Remove a file OR a directory tree. `os.remove()` can't delete directories
+   *  (and `os.rmdir()` only empty ones), so walk depth-first with an explicit
+   *  stack: children first, then the emptied folder (#219). */
   async remove(path: string): Promise<void> {
-    await this.eval(`import os\nos.remove(${pyStr(path)})`)
+    await this.eval(
+      [
+        'import os',
+        `_s = [${pyStr(path)}]`,
+        'while _s:',
+        '    _p = _s[-1]',
+        '    if (os.stat(_p)[0] & 0x4000) != 0:',
+        '        _c = os.listdir(_p)',
+        '        if _c:',
+        "            _s.extend([_p + '/' + _x for _x in _c])",
+        '        else:',
+        '            os.rmdir(_p)',
+        '            _s.pop()',
+        '    else:',
+        '        os.remove(_p)',
+        '        _s.pop()'
+      ].join('\n')
+    )
   }
 
   /** Create a directory. */

--- a/src/main/device/SimulatedDevice.ts
+++ b/src/main/device/SimulatedDevice.ts
@@ -156,7 +156,14 @@ export class SimulatedDevice extends EventEmitter implements SnakieDevice {
         stderr: ''
       }
     }
-    return { stdout: '', stderr: '' }
+    // Actually RUN the snippet on the real WASM interpreter and return what it
+    // printed (this used to be a `''` stub, which silently broke every exec-based
+    // probe on the sim — e.g. `modules.probeInstalled`, so the missing-library
+    // banner could never clear after an install). Tracebacks arrive in the
+    // captured output, matching how a raw-REPL board surfaces them well enough
+    // for the sentinel-parsing callers (they just see no sentinel line).
+    const out = await this.runtime.runCaptured(code)
+    return { stdout: out, stderr: '' }
   }
 
   async eval(code: string): Promise<string> {

--- a/src/main/device/SimulatedDevice.ts
+++ b/src/main/device/SimulatedDevice.ts
@@ -244,7 +244,26 @@ export class SimulatedDevice extends EventEmitter implements SnakieDevice {
   }
 
   async remove(path: string): Promise<void> {
-    await this.runtime.runCaptured(`import os\nos.remove(${pyStr(path)})`)
+    // Recursive, mirroring MicroPythonDevice.remove: files delete directly;
+    // directory trees walk depth-first (children, then the emptied dir) (#219).
+    await this.runtime.runCaptured(
+      [
+        'import os',
+        `_s = [${pyStr(path)}]`,
+        'while _s:',
+        '    _p = _s[-1]',
+        '    if (os.stat(_p)[0] & 0x4000) != 0:',
+        '        _c = os.listdir(_p)',
+        '        if _c:',
+        "            _s.extend([_p + '/' + _x for _x in _c])",
+        '        else:',
+        '            os.rmdir(_p)',
+        '            _s.pop()',
+        '    else:',
+        '        os.remove(_p)',
+        '        _s.pop()'
+      ].join('\n')
+    )
   }
 
   async mkdir(path: string): Promise<void> {

--- a/src/renderer/src/board-main.tsx
+++ b/src/renderer/src/board-main.tsx
@@ -242,6 +242,9 @@ function BoardWindowApp(): JSX.Element {
             .install(lib.url)
             .then((r) => {
               if (!r.ok) window.alert(`Couldn't install ${mod}.\n${r.log || 'Open the Packages panel for details.'}`)
+              // Files landed on the board — the main window's Device Files tree
+              // + library banners refresh off this broadcast.
+              else window.api.modules.notifyChanged()
             })
             .catch(() => window.alert(`Couldn't install ${mod} — is a board connected?`))
         }

--- a/src/renderer/src/board-main.tsx
+++ b/src/renderer/src/board-main.tsx
@@ -181,7 +181,11 @@ function BoardWindowApp(): JSX.Element {
   // since it started, so a slow disk read can't clobber newer edits.
   const saveSeqRef = useRef(0)
 
-  // Load the project's robot.yml when the folder becomes known / changes.
+  // Load the project's robot.yml when the folder becomes known / changes — and
+  // re-load when ANOTHER window saves it (robot:didChange), e.g. the I²C-detect
+  // scanner adding a matched part to the project (#214).
+  const [robotNonce, setRobotNonce] = useState(0)
+  useEffect(() => window.api.robot.onChanged(() => setRobotNonce((n) => n + 1)), [])
   useEffect(() => {
     let live = true
     const startSeq = saveSeqRef.current
@@ -197,7 +201,7 @@ function BoardWindowApp(): JSX.Element {
     return () => {
       live = false
     }
-  }, [folder])
+  }, [folder, robotNonce])
 
   const saveRobot = useCallback(
     (next: RobotDefinition): void => {

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -36,8 +36,10 @@ import {
   requiredPartModules,
   missingImports as computeMissingImports,
   missingOnBoard as computeMissingOnBoard,
+  parsePyImports,
   type RequiredModule
 } from './part-imports'
+import { installPartDriver } from './driver-install'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import {
   INSTRUMENTS_LIB_PATH,
@@ -635,28 +637,43 @@ export function AppShell(): JSX.Element {
       ),
     [boardIsPython, requiredModules, boardSource, inUse]
   )
-  const missBoard = useMemo(
-    () =>
-      (installedModules ? computeMissingOnBoard(requiredModules, installedModules) : []).filter(
-        (m) => !moduleCoveredByInstrument(m.module, inUse)
-      ),
-    [installedModules, requiredModules, inUse]
-  )
+  const missBoard = useMemo(() => {
+    // Instrument coverage only excuses a module the file DOESN'T import: a
+    // direct `import bme280` will fail on a board without the driver, however
+    // in-use its instrument looks (the instrument hints match the very same
+    // module name the import mentions), so that nag — and its one-click
+    // install — must stand.
+    const imported = boardIsPython ? parsePyImports(boardSource) : new Set<string>()
+    return (installedModules ? computeMissingOnBoard(requiredModules, installedModules) : []).filter(
+      (m) => imported.has(m.module) || !moduleCoveredByInstrument(m.module, inUse)
+    )
+  }, [installedModules, requiredModules, inUse, boardIsPython, boardSource])
   const showPartsBanner =
     requiredModules.length > 0 && !partsDismissed && (missImports.length > 0 || missBoard.length > 0)
 
   const installMissingLibs = useCallback((): void => {
-    const targets = missBoard.filter((m) => m.url)
+    // Installable = the module ships bundled driver file(s) (copied straight to
+    // the board — the SG90/BME280/ICM20948 model) or declares a mip source URL.
+    const targets = missBoard.filter((m) => (m.drivers?.length ?? 0) > 0 || m.url)
     if (partsInstalling || targets.length === 0) return
     setPartsInstalling(true)
     setPartsInstallError(null)
     void (async (): Promise<void> => {
       try {
         for (const t of targets) {
-          const res = await window.api.packages.install(t.url as string)
-          if (!res.ok) throw new Error(res.log || `Failed to install ${t.module}`)
+          if (t.drivers && t.drivers.length > 0 && t.libraryId && t.partId) {
+            for (const d of t.drivers) {
+              const res = await installPartDriver(t.libraryId, t.partId, d)
+              if (!res.ok) throw new Error(res.message || `Failed to install ${t.module}`)
+            }
+          } else {
+            const res = await window.api.packages.install(t.url as string)
+            if (!res.ok) throw new Error(res.log || `Failed to install ${t.module}`)
+          }
         }
         setInstalledModules(null) // re-probe → banner clears if now present
+        // Tell the OTHER windows too (the Board View's driver banner re-probes).
+        window.api.modules.notifyChanged()
       } catch (err) {
         setPartsInstallError(err instanceof Error ? err.message : String(err))
       } finally {

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -602,10 +602,18 @@ export function AppShell(): JSX.Element {
     }
   }, [boardFolder, boardFileName, connected, robotNonce])
 
+  // Modules WE successfully installed onto this board (ground truth for this
+  // connection): a re-probe that races a running program / busy REPL can read
+  // nothing back — it must never resurrect the "Install servo" button for a
+  // driver we just copied. Merged into every probe result below.
+  const selfInstalledRef = useRef<Set<string>>(new Set())
   // Probe the board (once per connection, and again on a project change) for which
   // required modules import. Including boardFolder avoids a stale probe set when you
   // switch projects while staying connected (modules change but the cache wouldn't).
-  useEffect(() => setInstalledModules(null), [deviceStatus.state, deviceStatus.path, boardFolder])
+  useEffect(() => {
+    selfInstalledRef.current = new Set()
+    setInstalledModules(null)
+  }, [deviceStatus.state, deviceStatus.path, boardFolder])
   // Re-probe when ANY window installs a driver/library (e.g. the Board View's
   // Driver Install banner copies a file to the board), so the "missing library"
   // banner clears once the module is actually present — not only after the main
@@ -616,7 +624,7 @@ export function AppShell(): JSX.Element {
     let active = true
     void (async (): Promise<void> => {
       const present = await window.api.modules.probeInstalled(requiredModules.map((m) => m.module))
-      if (active) setInstalledModules(new Set(present))
+      if (active) setInstalledModules(new Set([...present, ...selfInstalledRef.current]))
     })()
     return () => {
       active = false
@@ -674,8 +682,17 @@ export function AppShell(): JSX.Element {
             if (!res.ok) throw new Error(res.log || `Failed to install ${t.module}`)
           }
         }
-        setInstalledModules(null) // re-probe → banner clears if now present
-        // Tell the OTHER windows too (the Board View's driver banner re-probes).
+        // The installs SUCCEEDED — that's ground truth, so mark those modules
+        // present directly and the banner clears at once. (A `null` reset +
+        // re-probe here could race a running program / busy REPL, read garbage,
+        // and leave the "Install servo" button stuck on screen.) The ref keeps
+        // them present across any later re-probe this connection.
+        for (const t of targets) selfInstalledRef.current.add(t.module)
+        setInstalledModules(
+          (prev) => new Set([...(prev ?? []), ...targets.map((t) => t.module)])
+        )
+        // Tell the OTHER windows too (the Board View's driver banner re-probes,
+        // the device file tree re-lists).
         window.api.modules.notifyChanged()
       } catch (err) {
         setPartsInstallError(err instanceof Error ? err.message : String(err))

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -531,6 +531,9 @@ export function AppShell(): JSX.Element {
           await window.api.device.writeFile(INSTRUMENTS_ROOT_PATH, source)
         }
         setLibState('present')
+        // The device's files changed — tell every window so e.g. the Device
+        // Files tree re-lists and shows the fresh /lib/instruments.py.
+        window.api.modules.notifyChanged()
       } catch (err) {
         setLibError(err instanceof Error ? err.message : String(err))
       } finally {

--- a/src/renderer/src/components/DeviceFileTree.css
+++ b/src/renderer/src/components/DeviceFileTree.css
@@ -123,3 +123,42 @@
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
+
+/* --- File management (#219): hover delete, drop targets ------------------- */
+
+/* The hover ✕: hidden until the row is hovered/focused; sits at the row end. */
+.tree-row__delete {
+  display: none;
+  margin-left: auto;
+  flex: 0 0 auto;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  font-size: 10px;
+  line-height: 1;
+  color: var(--text-muted, #9aa0a8);
+  background: transparent;
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+}
+
+.tree-row:hover .tree-row__delete,
+.tree-row:focus-within .tree-row__delete {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tree-row__delete:hover {
+  color: var(--danger, #c4301f);
+  background: var(--bg-sunken);
+}
+
+/* A folder (or the tree background = root) under a dragged row. */
+.tree-row.is-drop-target,
+.devicetree__tree.is-drop-target {
+  outline: 1.5px dashed var(--accent, #4ea1ff);
+  outline-offset: -1.5px;
+  background: color-mix(in srgb, var(--accent, #4ea1ff) 10%, transparent);
+}

--- a/src/renderer/src/components/DeviceFileTree.tsx
+++ b/src/renderer/src/components/DeviceFileTree.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { DirEntry } from '../../../preload/index.d'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { useWorkspace } from '../store/workspace'
@@ -308,6 +308,23 @@ export function DeviceFileTree(): JSX.Element {
   useEffect(() => {
     if (syncStatus === 'done' && connected) void refresh()
   }, [syncStatus, connected, refresh])
+
+  // When ANY window installs something onto the board — a part driver (either
+  // missing-library banner), the instruments library, or a mip package — the
+  // modules broadcast fires; re-list so the new files show up without a manual
+  // Refresh. Subscribed once via refs (refresh's identity tracks the loaded
+  // dirs, and re-subscribing per keystroke of state would churn the bridge).
+  const refreshRef = useRef(refresh)
+  refreshRef.current = refresh
+  const connectedRef = useRef(connected)
+  connectedRef.current = connected
+  useEffect(
+    () =>
+      window.api.modules.onChanged(() => {
+        if (connectedRef.current) void refreshRef.current()
+      }),
+    []
+  )
 
   // The single sync toggle: ON pushes the tagged files now AND auto-syncs on
   // every save; OFF stops auto-syncing.

--- a/src/renderer/src/components/DeviceFileTree.tsx
+++ b/src/renderer/src/components/DeviceFileTree.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type { DirEntry } from '../../../preload/index.d'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { useWorkspace } from '../store/workspace'
@@ -128,6 +128,12 @@ interface DeviceTreeNodeProps {
    * changes to the same directory still trigger a reload.
    */
   reloadDir: { path: string; token: number } | null
+  /**
+   * Bumped by the header Refresh action (#220): EVERY node that has already
+   * loaded its children re-lists them, so refreshing updates all folders — not
+   * just the root — while keeping the user's expansion state.
+   */
+  refreshToken: number
 }
 
 /** Recursively renders a device entry and (when expanded) its children. */
@@ -139,7 +145,8 @@ function DeviceTreeNode({
   onSelect,
   onOpenFile,
   onContextMenu,
-  reloadDir
+  reloadDir,
+  refreshToken
 }: DeviceTreeNodeProps): JSX.Element {
   const [expanded, setExpanded] = useState(false)
   const [children, setChildren] = useState<DirEntry[] | null>(null)
@@ -162,6 +169,17 @@ function DeviceTreeNode({
     }
     // `reloadDir.token` changes on every signal, so identical-path reloads fire.
   }, [reloadDir, path, children, loadChildren])
+
+  // A full Refresh (#220): re-list this folder too if it was ever loaded, so the
+  // whole visible tree updates — not only the root. Skip the mount render (token
+  // 0 → nothing to do; children were just lazily loaded or are still null).
+  const lastRefresh = useRef(refreshToken)
+  useEffect(() => {
+    if (refreshToken !== lastRefresh.current) {
+      lastRefresh.current = refreshToken
+      if (children !== null) void loadChildren()
+    }
+  }, [refreshToken, children, loadChildren])
 
   const toggle = useCallback(async (): Promise<void> => {
     if (!expanded && children === null) await loadChildren()
@@ -216,6 +234,7 @@ function DeviceTreeNode({
             onOpenFile={onOpenFile}
             onContextMenu={onContextMenu}
             reloadDir={reloadDir}
+            refreshToken={refreshToken}
           />
         ))}
     </div>
@@ -256,6 +275,8 @@ export function DeviceFileTree(): JSX.Element {
   const [menu, setMenu] = useState<MenuState | null>(null)
   // Signal used to tell already-expanded nodes to re-list a changed directory.
   const [reloadDir, setReloadDir] = useState<{ path: string; token: number } | null>(null)
+  // Bumped on every full refresh so already-loaded FOLDERS re-list too (#220).
+  const [refreshToken, setRefreshToken] = useState(0)
   // Flash usage for the bottom gauge (#211); null ⇒ unavailable, so it hides.
   const [disk, setDisk] = useState<DiskUsage | null>(null)
 
@@ -271,6 +292,9 @@ export function DeviceFileTree(): JSX.Element {
       setEntries(list)
       setDisk(df)
       setError(null)
+      // Tell every loaded folder node to re-list as well (#220) — a refresh
+      // updates the WHOLE tree, not just the root, keeping expansion state.
+      setRefreshToken((t) => t + 1)
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     } finally {
@@ -618,6 +642,7 @@ export function DeviceFileTree(): JSX.Element {
             onOpenFile={handleOpenFile}
             onContextMenu={handleContextMenu}
             reloadDir={reloadDir}
+            refreshToken={refreshToken}
           />
         ))}
         {!loading && !error && entries.length === 0 && (

--- a/src/renderer/src/components/DeviceFileTree.tsx
+++ b/src/renderer/src/components/DeviceFileTree.tsx
@@ -111,6 +111,28 @@ const CheckIcon = (): JSX.Element => (
   </svg>
 )
 
+// trashcan — the per-row hover delete (#219)
+const TrashIcon = (): JSX.Element => (
+  <svg viewBox="0 0 16 16" width="12" height="12" aria-hidden="true" focusable="false">
+    <path
+      d="M3 4.5h10M6.5 4.5V3.2A1 1 0 0 1 7.5 2.2h1a1 1 0 0 1 1 1v1.3"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+    />
+    <path
+      d="M4.2 4.5 4.8 13a1 1 0 0 0 1 .9h4.4a1 1 0 0 0 1-.9l.6-8.5"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path d="M6.7 7v4.5M9.3 7v4.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+  </svg>
+)
+
 /** The drag payload type for device-file moves (#219). */
 const DEVICE_DRAG_MIME = 'application/x-snakie-device-paths'
 
@@ -185,7 +207,7 @@ function DeviceRow({
           onDeleteRow(row)
         }}
       >
-        ✕
+        <TrashIcon />
       </button>
     </div>
   )
@@ -658,7 +680,6 @@ export function DeviceFileTree(): JSX.Element {
     )
   }
 
-  const hasSelection = !!selectedPath
   const selectedTarget: { path: string; isDir: boolean } | null = selectedPath
     ? { path: selectedPath, isDir: selectedIsDir }
     : null
@@ -725,27 +746,8 @@ export function DeviceFileTree(): JSX.Element {
         </div>
       </div>
 
-      {/* Entry-specific actions revealed only when an entry is selected. */}
-      {hasSelection && selectedPath && (
-        <div className="devicetree__actions">
-          <button
-            className="btn btn--ghost"
-            onClick={() => renamePath(selectedPath)}
-            disabled={busy}
-            title="Rename the selected item on the device"
-          >
-            Rename
-          </button>
-          <button
-            className="btn btn--ghost btn--danger"
-            onClick={() => deletePath(selectedPath)}
-            disabled={busy}
-            title="Delete the selected item from the device"
-          >
-            Delete
-          </button>
-        </div>
-      )}
+      {/* No inline Rename/Delete bar: rename + delete live on the right-click
+          context menu, and every row has a hover trashcan. */}
 
       {error && <div className="devicetree__error">{error}</div>}
 

--- a/src/renderer/src/components/DeviceFileTree.tsx
+++ b/src/renderer/src/components/DeviceFileTree.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { DirEntry } from '../../../preload/index.d'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { useWorkspace } from '../store/workspace'
@@ -7,6 +7,16 @@ import { usageLabel, usedPct, type DiskUsage } from './disk-usage'
 import { ContextMenu, type ContextMenuItem, type ContextMenuPosition } from './ContextMenu'
 import { Placeholder } from './Placeholder'
 import { usePrompt } from './PromptModal'
+import {
+  DEVICE_ROOT,
+  flattenTree,
+  joinDevicePath,
+  nextSelection,
+  parentDevicePath,
+  planMove,
+  pruneNested,
+  type FlatRow
+} from './device-tree-model'
 import './DeviceFileTree.css'
 
 /**
@@ -15,20 +25,20 @@ import './DeviceFileTree.css'
  * Lists the connected board's filesystem via `window.api.device.listDir`,
  * starting at `/`, with directories expandable on demand (children are
  * lazy-loaded the first time a folder is opened). Clicking a file opens it in
- * the editor through the workspace store.
+ * the editor through the workspace store. The loaded listings live in one flat
+ * `path → entries` map (#219) so a Refresh re-lists EVERY loaded folder (#220)
+ * and range selection can see the whole visible tree.
  *
  * Gated on the live connection state from `useDeviceStatus()`: when no board is
  * connected it falls back to a friendly hint; when a board becomes connected the
- * tree (re)loads automatically. A Refresh action re-reads the root.
+ * tree (re)loads automatically.
  *
- * File operations (new file / new folder / rename / delete / open) are exposed
- * inline AND via a right-click context menu (issue #19), mirroring the
- * `LocalFileTree` UX (window.prompt/confirm). The menu also offers "Download to
- * computer": read the device file via `device.readFile`, pick a destination
- * folder via `fs.openFolderDialog`, and write it with `fs.writeFile`. Device ops
- * run via `window.api.device.*`; after each op the affected directory is
- * re-listed so the tree reflects the change. Per the local-section UX, a
- * board/microcontroller icon marks the device section header.
+ * File MANAGEMENT (#219): Ctrl/Cmd-click toggles a multi-selection, Shift-click
+ * selects a range, rows drag into folders (a device-side move/rename), a hover
+ * ✕ deletes a row (or the whole selection it belongs to), and the context menu
+ * offers "Delete N items" for a multi-selection. Plus the classic ops (new
+ * file / new folder / rename / delete / open / download) inline and via the
+ * right-click menu, mirroring the `LocalFileTree` UX.
  */
 
 /**
@@ -101,147 +111,87 @@ const CheckIcon = (): JSX.Element => (
   </svg>
 )
 
-/** Join a device directory path and a child name into a POSIX device path. */
-function joinDevicePath(dir: string, name: string): string {
-  return dir === '/' ? `/${name}` : `${dir}/${name}`
-}
+/** The drag payload type for device-file moves (#219). */
+const DEVICE_DRAG_MIME = 'application/x-snakie-device-paths'
 
-/** Return the parent directory of a POSIX device path (root maps to root). */
-function parentDevicePath(path: string): string {
-  const idx = path.lastIndexOf('/')
-  if (idx <= 0) return '/'
-  return path.slice(0, idx)
-}
-
-interface DeviceTreeNodeProps {
-  entry: DirEntry
-  /** Full device path of this entry. */
-  path: string
-  depth: number
-  selectedPath: string | null
-  onSelect: (path: string, isDir: boolean) => void
-  onOpenFile: (path: string) => void
-  onContextMenu: (e: React.MouseEvent, path: string, isDir: boolean) => void
-  /**
-   * Path of a directory that has changed and whose listing should be
-   * re-fetched, paired with a monotonically increasing token so repeated
-   * changes to the same directory still trigger a reload.
-   */
-  reloadDir: { path: string; token: number } | null
-  /**
-   * Bumped by the header Refresh action (#220): EVERY node that has already
-   * loaded its children re-lists them, so refreshing updates all folders — not
-   * just the root — while keeping the user's expansion state.
-   */
-  refreshToken: number
-}
-
-/** Recursively renders a device entry and (when expanded) its children. */
-function DeviceTreeNode({
-  entry,
-  path,
-  depth,
-  selectedPath,
-  onSelect,
+/** One flattened, selectable, draggable tree row (#219). */
+function DeviceRow({
+  row,
+  expanded,
+  selected,
+  dropTarget,
+  onRowClick,
   onOpenFile,
   onContextMenu,
-  reloadDir,
-  refreshToken
-}: DeviceTreeNodeProps): JSX.Element {
-  const [expanded, setExpanded] = useState(false)
-  const [children, setChildren] = useState<DirEntry[] | null>(null)
-  const [error, setError] = useState<string | null>(null)
-
-  const loadChildren = useCallback(async (): Promise<void> => {
-    try {
-      setChildren(await window.api.device.listDir(path))
-      setError(null)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
-    }
-  }, [path])
-
-  // When an operation reports that this directory changed, re-list it (only if
-  // it has already been opened once — otherwise the children load lazily).
-  useEffect(() => {
-    if (reloadDir && reloadDir.path === path && children !== null) {
-      void loadChildren()
-    }
-    // `reloadDir.token` changes on every signal, so identical-path reloads fire.
-  }, [reloadDir, path, children, loadChildren])
-
-  // A full Refresh (#220): re-list this folder too if it was ever loaded, so the
-  // whole visible tree updates — not only the root. Skip the mount render (token
-  // 0 → nothing to do; children were just lazily loaded or are still null).
-  const lastRefresh = useRef(refreshToken)
-  useEffect(() => {
-    if (refreshToken !== lastRefresh.current) {
-      lastRefresh.current = refreshToken
-      if (children !== null) void loadChildren()
-    }
-  }, [refreshToken, children, loadChildren])
-
-  const toggle = useCallback(async (): Promise<void> => {
-    if (!expanded && children === null) await loadChildren()
-    setExpanded((v) => !v)
-  }, [expanded, children, loadChildren])
-
-  const handleClick = useCallback((): void => {
-    onSelect(path, entry.isDir)
-    if (entry.isDir) void toggle()
-    else onOpenFile(path)
-  }, [entry.isDir, path, onOpenFile, onSelect, toggle])
-
-  const isSelected = selectedPath === path
-
+  onDeleteRow,
+  onDragStartRow,
+  onDropInto,
+  onDragOverRow,
+  onDragLeaveRow
+}: {
+  row: FlatRow
+  expanded: boolean
+  selected: boolean
+  /** This folder row is the current drag-over target (highlight it). */
+  dropTarget: boolean
+  onRowClick: (e: React.MouseEvent, row: FlatRow) => void
+  onOpenFile: (path: string) => void
+  onContextMenu: (e: React.MouseEvent, path: string, isDir: boolean) => void
+  onDeleteRow: (row: FlatRow) => void
+  onDragStartRow: (e: React.DragEvent, row: FlatRow) => void
+  onDropInto: (e: React.DragEvent, dir: string) => void
+  onDragOverRow: (e: React.DragEvent, row: FlatRow) => void
+  onDragLeaveRow: () => void
+}): JSX.Element {
+  const { path, entry, depth } = row
   return (
-    <div className="tree-node">
-      <div
-        className={`tree-row${isSelected ? ' is-selected' : ''}`}
-        style={{ paddingLeft: `${depth * 14 + 8}px` }}
-        onClick={handleClick}
-        onContextMenu={(e) => onContextMenu(e, path, entry.isDir)}
-        role="treeitem"
-        aria-expanded={entry.isDir ? expanded : undefined}
-        tabIndex={0}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault()
-            handleClick()
-          }
+    <div
+      className={`tree-row${selected ? ' is-selected' : ''}${dropTarget ? ' is-drop-target' : ''}`}
+      style={{ paddingLeft: `${depth * 14 + 8}px` }}
+      onClick={(e) => onRowClick(e, row)}
+      onDoubleClick={() => {
+        if (!entry.isDir) onOpenFile(path)
+      }}
+      onContextMenu={(e) => onContextMenu(e, path, entry.isDir)}
+      role="treeitem"
+      aria-expanded={entry.isDir ? expanded : undefined}
+      aria-selected={selected}
+      tabIndex={0}
+      draggable
+      onDragStart={(e) => onDragStartRow(e, row)}
+      onDragOver={entry.isDir ? (e) => onDragOverRow(e, row) : undefined}
+      onDragLeave={entry.isDir ? onDragLeaveRow : undefined}
+      onDrop={entry.isDir ? (e) => onDropInto(e, path) : undefined}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onRowClick(e as unknown as React.MouseEvent, row)
+        }
+      }}
+    >
+      <span className="tree-row__glyph" aria-hidden>
+        {entry.isDir ? (expanded ? '▼' : '▶') : '▤'}
+      </span>
+      <span className="tree-row__name">{entry.name}</span>
+      {/* Hover delete (#219): removes this row — or the whole selection when the
+          row is part of a multi-selection. */}
+      <button
+        type="button"
+        className="tree-row__delete"
+        title="Delete from the device"
+        aria-label={`Delete ${entry.name}`}
+        onClick={(e) => {
+          e.stopPropagation()
+          onDeleteRow(row)
         }}
       >
-        <span className="tree-row__glyph" aria-hidden>
-          {entry.isDir ? (expanded ? '▼' : '▶') : '▤'}
-        </span>
-        <span className="tree-row__name">{entry.name}</span>
-      </div>
-      {error && (
-        <div className="tree-error" style={{ paddingLeft: `${depth * 14 + 22}px` }}>
-          {error}
-        </div>
-      )}
-      {entry.isDir &&
-        expanded &&
-        children?.map((child) => (
-          <DeviceTreeNode
-            key={joinDevicePath(path, child.name)}
-            entry={child}
-            path={joinDevicePath(path, child.name)}
-            depth={depth + 1}
-            selectedPath={selectedPath}
-            onSelect={onSelect}
-            onOpenFile={onOpenFile}
-            onContextMenu={onContextMenu}
-            reloadDir={reloadDir}
-            refreshToken={refreshToken}
-          />
-        ))}
+        ✕
+      </button>
     </div>
   )
 }
 
-const ROOT = '/'
+const ROOT = DEVICE_ROOT
 
 /** State backing an open context menu: where it is and what it targets. */
 interface MenuState {
@@ -266,41 +216,75 @@ export function DeviceFileTree(): JSX.Element {
     syncNow
   } = useSync()
 
-  const [entries, setEntries] = useState<DirEntry[]>([])
-  const [selectedPath, setSelectedPath] = useState<string | null>(null)
-  const [selectedIsDir, setSelectedIsDir] = useState(false)
+  // The loaded listings, flat (#219): path → entries, always including ROOT.
+  const [dirs, setDirs] = useState<Map<string, DirEntry[]>>(new Map())
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+  // Multi-selection (#219): the selected paths + the shift-range anchor. The
+  // PRIMARY (last-clicked) entry backs the single-target actions (rename, the
+  // actions bar, new-file placement).
+  const [selection, setSelection] = useState<Set<string>>(new Set())
+  const [anchor, setAnchor] = useState<string | null>(null)
+  const [primary, setPrimary] = useState<{ path: string; isDir: boolean } | null>(null)
+  // The folder row a drag is currently over (drop-target highlight).
+  const [dropDir, setDropDir] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [busy, setBusy] = useState(false)
   const [menu, setMenu] = useState<MenuState | null>(null)
-  // Signal used to tell already-expanded nodes to re-list a changed directory.
-  const [reloadDir, setReloadDir] = useState<{ path: string; token: number } | null>(null)
-  // Bumped on every full refresh so already-loaded FOLDERS re-list too (#220).
-  const [refreshToken, setRefreshToken] = useState(0)
   // Flash usage for the bottom gauge (#211); null ⇒ unavailable, so it hides.
   const [disk, setDisk] = useState<DiskUsage | null>(null)
+
+  const selectedPath = primary?.path ?? null
+  const selectedIsDir = primary?.isDir ?? false
+  const rows = useMemo(() => flattenTree(dirs, expanded), [dirs, expanded])
+
+  /** Re-list one directory into the flat map (drop it if listing fails). */
+  const listInto = useCallback(async (dir: string): Promise<void> => {
+    try {
+      const list = await window.api.device.listDir(dir)
+      setDirs((m) => new Map(m).set(dir, list))
+    } catch {
+      setDirs((m) => {
+        const next = new Map(m)
+        next.delete(dir)
+        return next
+      })
+    }
+  }, [])
 
   const refresh = useCallback(async (): Promise<void> => {
     setLoading(true)
     try {
-      // Read the listing + the flash gauge together (the gauge is best-effort, so
-      // a board that can't `statvfs` still shows its files).
+      // Read the root + the flash gauge together (the gauge is best-effort, so a
+      // board that can't `statvfs` still shows its files).
       const [list, df] = await Promise.all([
         window.api.device.listDir(ROOT),
         window.api.device.df().catch(() => null)
       ])
-      setEntries(list)
       setDisk(df)
       setError(null)
-      // Tell every loaded folder node to re-list as well (#220) — a refresh
-      // updates the WHOLE tree, not just the root, keeping expansion state.
-      setRefreshToken((t) => t + 1)
+      // Refresh updates the WHOLE loaded tree (#220): re-list every previously
+      // loaded folder too, keeping the user's expansion state.
+      const loaded = [...dirs.keys()].filter((d) => d !== ROOT)
+      const results = await Promise.all(
+        loaded.map(async (d) => {
+          try {
+            return [d, await window.api.device.listDir(d)] as const
+          } catch {
+            return null // the folder is gone — drop it
+          }
+        })
+      )
+      const next = new Map<string, DirEntry[]>()
+      next.set(ROOT, list)
+      for (const r of results) if (r) next.set(r[0], r[1])
+      setDirs(next)
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     } finally {
       setLoading(false)
     }
-  }, [])
+  }, [dirs])
 
   // Load (or reset) the tree as the connection comes up / goes away. Loading
   // when `connected` flips true also covers reconnects to a different board.
@@ -308,13 +292,17 @@ export function DeviceFileTree(): JSX.Element {
     if (connected) {
       void refresh()
     } else {
-      setEntries([])
-      setSelectedPath(null)
-      setSelectedIsDir(false)
+      setDirs(new Map())
+      setExpanded(new Set())
+      setSelection(new Set())
+      setAnchor(null)
+      setPrimary(null)
       setError(null)
       setDisk(null)
     }
-  }, [connected, refresh])
+    // `refresh` depends on `dirs`; re-running on every dirs change would loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [connected])
 
   // When a sync finishes, re-list the root so the just-pushed files appear.
   useEffect(() => {
@@ -332,11 +320,6 @@ export function DeviceFileTree(): JSX.Element {
     }
   }, [syncOnSave, setSyncOnSave, syncNow])
 
-  const handleSelect = useCallback((path: string, isDir: boolean): void => {
-    setSelectedPath(path)
-    setSelectedIsDir(isDir)
-  }, [])
-
   const handleOpenFile = useCallback(
     (path: string): void => {
       void openFile('device', path).catch((err) =>
@@ -346,20 +329,47 @@ export function DeviceFileTree(): JSX.Element {
     [openFile]
   )
 
+  /** Toggle a folder open/closed, lazy-loading its listing on first open. */
+  const toggleDir = useCallback(
+    (path: string): void => {
+      setExpanded((s) => {
+        const next = new Set(s)
+        if (next.has(path)) next.delete(path)
+        else next.add(path)
+        return next
+      })
+      if (!dirs.has(path)) void listInto(path)
+    },
+    [dirs, listInto]
+  )
+
   /**
-   * Re-list a changed directory so the tree reflects an operation. The root is
-   * re-fetched directly; deeper directories are signalled to any expanded node
-   * via `reloadDir`.
+   * Row click (#219): plain click keeps the classic behaviour (select; open a
+   * file / toggle a folder) and resets the selection to that row; Ctrl/Cmd-click
+   * toggles the row in the multi-selection; Shift-click selects the visible
+   * range from the anchor.
    */
-  const refreshDir = useCallback(
-    async (dir: string): Promise<void> => {
-      if (dir === ROOT) {
-        await refresh()
-      } else {
-        setReloadDir({ path: dir, token: Date.now() })
+  const handleRowClick = useCallback(
+    (e: React.MouseEvent, row: FlatRow): void => {
+      const mode = e.metaKey || e.ctrlKey ? 'toggle' : e.shiftKey ? 'range' : 'single'
+      const next = nextSelection(selection, anchor, rows, row.path, mode)
+      setSelection(next.selection)
+      setAnchor(next.anchor)
+      setPrimary({ path: row.path, isDir: row.entry.isDir })
+      if (mode === 'single') {
+        if (row.entry.isDir) toggleDir(row.path)
+        else handleOpenFile(row.path)
       }
     },
-    [refresh]
+    [selection, anchor, rows, toggleDir, handleOpenFile]
+  )
+
+  /** Re-list a changed directory so the tree reflects an operation. */
+  const refreshDir = useCallback(
+    async (dir: string): Promise<void> => {
+      await listInto(dir)
+    },
+    [listInto]
   )
 
   /** Run a device op, surface errors, and re-list the affected directory. */
@@ -430,7 +440,8 @@ export function DeviceFileTree(): JSX.Element {
         const dest = joinDevicePath(parent, name)
         await run(async () => {
           await window.api.device.rename(path, dest)
-          setSelectedPath(dest)
+          setPrimary((p) => (p?.path === path ? { ...p, path: dest } : p))
+          setSelection(new Set([dest]))
         }, parent)
       })()
     },
@@ -458,18 +469,98 @@ export function DeviceFileTree(): JSX.Element {
     })()
   }, [])
 
-  const deletePath = useCallback(
-    (path: string): void => {
-      const name = path.split('/').pop()
-      if (!window.confirm(`Delete "${name}" from the device? This cannot be undone.`)) return
-      const parent = parentDevicePath(path)
-      void run(async () => {
-        await window.api.device.remove(path)
-        setSelectedPath(null)
-        setSelectedIsDir(false)
-      }, parent)
+  /** Delete a set of paths (#219): confirm once, prune nested-redundant paths
+   *  (removing a folder already removes its contents), remove each, re-list the
+   *  affected parents, and clear the selection. */
+  const deleteMany = useCallback(
+    (paths: string[]): void => {
+      const roots = pruneNested(paths)
+      if (roots.length === 0) return
+      const label =
+        roots.length === 1
+          ? `"${roots[0].split('/').pop()}"`
+          : `${roots.length} items`
+      if (!window.confirm(`Delete ${label} from the device? This cannot be undone.`)) return
+      void (async (): Promise<void> => {
+        setBusy(true)
+        try {
+          for (const p of roots) await window.api.device.remove(p)
+          setError(null)
+        } catch (err) {
+          setError(err instanceof Error ? err.message : String(err))
+        } finally {
+          setBusy(false)
+          setSelection(new Set())
+          setPrimary(null)
+          setAnchor(null)
+          const parents = [...new Set(roots.map(parentDevicePath))]
+          await Promise.all(parents.map((d) => refreshDir(d)))
+        }
+      })()
     },
-    [run]
+    [refreshDir]
+  )
+
+  const deletePath = useCallback((path: string): void => deleteMany([path]), [deleteMany])
+
+  /** The hover ✕ (#219): a selected row deletes the whole selection. */
+  const deleteRow = useCallback(
+    (row: FlatRow): void => {
+      deleteMany(selection.has(row.path) && selection.size > 1 ? [...selection] : [row.path])
+    },
+    [deleteMany, selection]
+  )
+
+  // --- drag a row (or the selection) into a folder (#219) -------------------
+  const onDragStartRow = useCallback(
+    (e: React.DragEvent, row: FlatRow): void => {
+      const paths = selection.has(row.path) && selection.size > 1 ? [...selection] : [row.path]
+      e.dataTransfer.setData(DEVICE_DRAG_MIME, JSON.stringify(paths))
+      e.dataTransfer.effectAllowed = 'move'
+    },
+    [selection]
+  )
+
+  const onDragOverRow = useCallback((e: React.DragEvent, row: FlatRow): void => {
+    if (!e.dataTransfer.types.includes(DEVICE_DRAG_MIME)) return
+    e.preventDefault()
+    e.stopPropagation()
+    e.dataTransfer.dropEffect = 'move'
+    setDropDir(row.path)
+  }, [])
+
+  const onDropInto = useCallback(
+    (e: React.DragEvent, destDir: string): void => {
+      setDropDir(null)
+      const raw = e.dataTransfer.getData(DEVICE_DRAG_MIME)
+      if (!raw) return
+      e.preventDefault()
+      e.stopPropagation()
+      let sources: string[] = []
+      try {
+        sources = JSON.parse(raw) as string[]
+      } catch {
+        return
+      }
+      const plan = planMove(sources, destDir)
+      if (plan.length === 0) return
+      void (async (): Promise<void> => {
+        setBusy(true)
+        try {
+          for (const m of plan) await window.api.device.rename(m.from, m.to)
+          setError(null)
+        } catch (err) {
+          setError(err instanceof Error ? err.message : String(err))
+        } finally {
+          setBusy(false)
+          setSelection(new Set())
+          setPrimary(null)
+          const affected = [...new Set([destDir, ...plan.map((m) => parentDevicePath(m.from))])]
+          await Promise.all(affected.map((d) => refreshDir(d)))
+        }
+      })()
+    },
+    [refreshDir]
   )
 
   const closeMenu = useCallback((): void => setMenu(null), [])
@@ -478,10 +569,16 @@ export function DeviceFileTree(): JSX.Element {
     (e: React.MouseEvent, path: string | null, isDir: boolean): void => {
       e.preventDefault()
       e.stopPropagation()
-      if (path) handleSelect(path, isDir)
+      if (path) {
+        setPrimary({ path, isDir })
+        // Right-clicking OUTSIDE the multi-selection collapses it to that row;
+        // inside it, the selection is kept so "Delete N items" can target it.
+        setSelection((s) => (s.has(path) ? s : new Set([path])))
+        setAnchor(path)
+      }
       setMenu({ position: { x: e.clientX, y: e.clientY }, path, isDir })
     },
-    [handleSelect]
+    []
   )
 
   const menuItems = useCallback(
@@ -509,16 +606,26 @@ export function DeviceFileTree(): JSX.Element {
           })
         }
         items.push({ key: 'rename', label: 'Rename', onSelect: () => renamePath(path) })
-        items.push({
-          key: 'delete',
-          label: 'Delete',
-          danger: true,
-          onSelect: () => deletePath(path)
-        })
+        // Right-clicked inside a multi-selection (#219) → delete the whole set.
+        if (selection.has(path) && selection.size > 1) {
+          items.push({
+            key: 'delete-many',
+            label: `Delete ${selection.size} items`,
+            danger: true,
+            onSelect: () => deleteMany([...selection])
+          })
+        } else {
+          items.push({
+            key: 'delete',
+            label: 'Delete',
+            danger: true,
+            onSelect: () => deletePath(path)
+          })
+        }
       }
       return items
     },
-    [deletePath, downloadToComputer, handleOpenFile, newFileIn, newFolderIn, renamePath]
+    [deleteMany, deletePath, downloadToComputer, handleOpenFile, newFileIn, newFolderIn, renamePath, selection]
   )
 
   if (!connected) {
@@ -626,26 +733,41 @@ export function DeviceFileTree(): JSX.Element {
       {error && <div className="devicetree__error">{error}</div>}
 
       <div
-        className="devicetree__tree"
+        className={`devicetree__tree${dropDir === ROOT ? ' is-drop-target' : ''}`}
         role="tree"
         aria-label="Device file tree"
+        aria-multiselectable="true"
         onContextMenu={(e) => handleContextMenu(e, null, true)}
+        // Dropping on the background moves into the ROOT (#219).
+        onDragOver={(e) => {
+          if (!e.dataTransfer.types.includes(DEVICE_DRAG_MIME)) return
+          e.preventDefault()
+          e.dataTransfer.dropEffect = 'move'
+          setDropDir(ROOT)
+        }}
+        onDragLeave={(e) => {
+          if (e.currentTarget === e.target) setDropDir(null)
+        }}
+        onDrop={(e) => onDropInto(e, ROOT)}
       >
-        {entries.map((entry) => (
-          <DeviceTreeNode
-            key={joinDevicePath(ROOT, entry.name)}
-            entry={entry}
-            path={joinDevicePath(ROOT, entry.name)}
-            depth={0}
-            selectedPath={selectedPath}
-            onSelect={handleSelect}
+        {rows.map((row) => (
+          <DeviceRow
+            key={row.path}
+            row={row}
+            expanded={expanded.has(row.path)}
+            selected={selection.has(row.path) || selectedPath === row.path}
+            dropTarget={dropDir === row.path}
+            onRowClick={handleRowClick}
             onOpenFile={handleOpenFile}
             onContextMenu={handleContextMenu}
-            reloadDir={reloadDir}
-            refreshToken={refreshToken}
+            onDeleteRow={deleteRow}
+            onDragStartRow={onDragStartRow}
+            onDropInto={onDropInto}
+            onDragOverRow={onDragOverRow}
+            onDragLeaveRow={() => setDropDir(null)}
           />
         ))}
-        {!loading && !error && entries.length === 0 && (
+        {!loading && !error && rows.length === 0 && (
           <div className="devicetree__empty-hint">Filesystem is empty.</div>
         )}
       </div>

--- a/src/renderer/src/components/DriverInstallBanner.tsx
+++ b/src/renderer/src/components/DriverInstallBanner.tsx
@@ -1,9 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
-import {
-  driverDeviceDirs,
-  driverInstallMethod,
-  type PartDriverNeed
-} from './part-editor.util'
+import { driverInstallMethod, type PartDriverNeed } from './part-editor.util'
+import { installPartDriver } from './driver-install'
 import type { DriverFile } from '../../../preload/index.d'
 import './DriverInstallBanner.css'
 
@@ -141,32 +138,10 @@ export function DriverInstallBanner({ needs }: DriverInstallBannerProps): JSX.El
   const installOne = async (need: PartDriverNeed, d: DriverFile): Promise<void> => {
     const id = driverKey(need, d)
     setStatus(id, { state: 'installing' })
-    try {
-      if (driverInstallMethod(d.source) === 'mip') {
-        const target = d.target.trim()
-        const res = await window.api.packages.install(d.source, target ? { target } : undefined)
-        setStatus(id, {
-          state: res.ok ? 'ok' : 'error',
-          message: res.ok ? undefined : res.log.split('\n').filter(Boolean).pop() || 'mip failed'
-        })
-        return
-      }
-      // copy: read the file (bundled file or URL, via main) then write to target.
-      const read = await window.api.parts.readDriverSource(need.libraryId, need.partId, d.source)
-      if (!read.ok || read.contents == null) {
-        setStatus(id, { state: 'error', message: read.error || 'Could not read driver file.' })
-        return
-      }
-      // MicroPython has no recursive mkdir — create each ancestor folder in turn
-      // (an "already exists" error is fine, so we swallow it).
-      for (const dir of driverDeviceDirs(d.target)) {
-        await window.api.device.mkdir(dir).catch(() => undefined)
-      }
-      await window.api.device.writeFile(d.target.trim(), read.contents)
-      setStatus(id, { state: 'ok' })
-    } catch (err) {
-      setStatus(id, { state: 'error', message: err instanceof Error ? err.message : String(err) })
-    }
+    // The mip/copy sequence lives in the shared installer (also used by the main
+    // editor's missing-library banner, #166) — this wrapper just maps to status.
+    const res = await installPartDriver(need.libraryId, need.partId, d)
+    setStatus(id, { state: res.ok ? 'ok' : 'error', message: res.message })
   }
 
   const installAll = async (): Promise<void> => {

--- a/src/renderer/src/components/EnvInstrument.css
+++ b/src/renderer/src/components/EnvInstrument.css
@@ -1,0 +1,144 @@
+/*
+ * BAROMETER (#216) — an antique aneroid barometer: brass bezel, warm cream
+ * face, engraved serif scale + weather legend, blued-black needle. Prefix
+ * `envbaro__` (instrument CSS is global — keep the BEM prefix unique).
+ */
+.envbaro {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.envbaro__face {
+  filter: drop-shadow(0 2px 5px rgba(0, 0, 0, 0.45));
+}
+
+.envbaro__svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+/* Polished brass bezel ring around the dial. */
+.envbaro__bezel {
+  fill: none;
+  stroke-width: 9;
+  stroke: var(--accent, #b58a3a);
+}
+
+/* Warm parchment face, faintly aged at the rim. */
+.envbaro__dial {
+  fill: #f4ecd9;
+  stroke: #d8c9a5;
+  stroke-width: 1;
+}
+
+.envbaro__tick {
+  stroke: #6b5d43;
+  stroke-width: 1;
+}
+
+.envbaro__tick--major {
+  stroke: #3c3222;
+  stroke-width: 1.6;
+}
+
+.envbaro__num {
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: 8.5px;
+  fill: #3c3222;
+}
+
+/* The engraved weather legend — small-cap serif, like the original. */
+.envbaro__word {
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  fill: #6b5d43;
+}
+
+.envbaro__maker {
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: 6.5px;
+  letter-spacing: 0.18em;
+  fill: #8a7a58;
+}
+
+.envbaro__press {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 13px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  fill: #2e2618;
+}
+
+/* Blued-steel needle with a counterweight tail; eases between readings. */
+.envbaro__needle {
+  stroke: #1d1a14;
+  stroke-width: 2.4;
+  stroke-linecap: round;
+  transition: x1 300ms ease, y1 300ms ease, x2 300ms ease, y2 300ms ease;
+}
+
+.envbaro__hub {
+  fill: var(--accent, #b58a3a);
+  stroke: #7a5c22;
+  stroke-width: 1;
+}
+
+/* Bottom row: temp / humidity / outlook cells + the source picker. */
+.envbaro__row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  background: rgba(6, 9, 11, 0.7);
+  border: 1px solid var(--accent-border);
+}
+
+.envbaro__cell {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.envbaro__cell-lbl {
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  color: #5a5f67;
+}
+
+.envbaro__cell-val {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 13px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: color-mix(in srgb, var(--accent) 72%, #cdd2d8);
+}
+
+.envbaro__src {
+  margin-left: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.envbaro__select {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px;
+  color: #cdd2d8;
+  background: #14181c;
+  border: 1px solid var(--accent-border);
+  border-radius: 4px;
+  padding: 2px 4px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .envbaro__needle {
+    transition: none;
+  }
+}

--- a/src/renderer/src/components/EnvInstrument.tsx
+++ b/src/renderer/src/components/EnvInstrument.tsx
@@ -1,0 +1,179 @@
+import { useCallback, useState, type CSSProperties } from 'react'
+import { InstrumentWindow, type FloatProps } from './InstrumentWindow'
+import { type InstrumentDef } from './instruments-registry'
+import { useTelemetryStream } from './instrument-telemetry-subscribe'
+import { dialPoint, pressureAngle, weatherWord, PRESS_MIN, PRESS_MAX } from './env-logic'
+import './EnvInstrument.css'
+
+/**
+ * BAROMETER — an antique aneroid weather instrument (#216).
+ * =============================================================================
+ *
+ * Shows temperature / barometric pressure / humidity from the passive telemetry
+ * stream (`SNK ENV <ch> <t> <p> <h>` — `inst.env(t, p, h)` or a watched BME280
+ * via `inst.watch(env=bme)` + `inst.update()`). The pressure drives a classic
+ * cream-faced, brass-bezelled barometer dial (950–1050 hPa over 270°, with the
+ * RAIN / CHANGE / FAIR legend); temperature + humidity read out beneath it.
+ * Pure dial geometry lives in {@link ./env-logic}.
+ */
+
+export interface EnvInstrumentProps {
+  def: InstrumentDef
+  onClose?: () => void
+  docked?: boolean
+  onToggleDock?: () => void
+  float?: FloatProps
+}
+
+/** One environmental reading per reporting channel. */
+interface EnvReading {
+  temp: number
+  pressure: number
+  humidity: number
+}
+
+// Dial geometry (viewBox units): pivot centre of the round face.
+const CX = 100
+const CY = 88
+const R = 74
+
+export function EnvInstrument({
+  def,
+  onClose,
+  docked = true,
+  onToggleDock,
+  float
+}: EnvInstrumentProps): JSX.Element {
+  // Latest reading per channel + the user's picked channel (same pattern as the
+  // Potentiometer: the sole/first reporting channel "just works").
+  const [readings, setReadings] = useState<Record<string, EnvReading>>({})
+  const [picked, setPicked] = useState<string>('env')
+
+  useTelemetryStream(
+    useCallback((r) => {
+      if (r.kind !== 'env') return
+      setReadings((m) => ({ ...m, [r.ch]: { temp: r.temp, pressure: r.pressure, humidity: r.humidity } }))
+    }, [])
+  )
+
+  const channels = Object.keys(readings)
+  const channel = readings[picked] !== undefined ? picked : (channels[0] ?? picked)
+  const reading = readings[channel]
+  const hasData = reading !== undefined
+  const pressure = reading?.pressure ?? PRESS_MIN
+  const angle = pressureAngle(pressure)
+  const tip = dialPoint(angle, CX, CY, R * 0.78)
+  const tail = dialPoint(angle + 180, CX, CY, R * 0.16)
+
+  // Scale furniture: minor ticks every 5 hPa, majors (numbered) every 25.
+  const ticks: JSX.Element[] = []
+  for (let p = PRESS_MIN; p <= PRESS_MAX; p += 5) {
+    const major = (p - PRESS_MIN) % 25 === 0
+    const a = pressureAngle(p)
+    const o = dialPoint(a, CX, CY, R * 0.94)
+    const i = dialPoint(a, CX, CY, R * (major ? 0.83 : 0.88))
+    ticks.push(
+      <line
+        key={p}
+        className={major ? 'envbaro__tick envbaro__tick--major' : 'envbaro__tick'}
+        x1={o.x}
+        y1={o.y}
+        x2={i.x}
+        y2={i.y}
+      />
+    )
+    if (major) {
+      const l = dialPoint(a, CX, CY, R * 0.72)
+      ticks.push(
+        <text key={`n${p}`} className="envbaro__num" x={l.x} y={l.y} textAnchor="middle" dominantBaseline="middle">
+          {p}
+        </text>
+      )
+    }
+  }
+
+  return (
+    <InstrumentWindow
+      name={def.name.toUpperCase()}
+      helpId={`inst-${def.id}`}
+      source={`${channel} · ENV`}
+      docked={docked}
+      onClose={onClose}
+      onToggleDock={onToggleDock}
+      {...float}
+    >
+      <div
+        className="envbaro"
+        style={{ '--accent': def.accent, '--accent-border': def.border } as CSSProperties}
+      >
+        {/* The aneroid dial: brass bezel, cream face, 270° pressure scale. */}
+        <div className="envbaro__face">
+          <svg
+            className="envbaro__svg"
+            viewBox="0 0 200 176"
+            role="img"
+            aria-label={hasData ? `Barometer ${pressure.toFixed(1)} hectopascal, ${weatherWord(pressure)}` : 'Barometer — no data'}
+          >
+            <circle className="envbaro__bezel" cx={CX} cy={CY} r={R + 8} />
+            <circle className="envbaro__dial" cx={CX} cy={CY} r={R} />
+            {ticks}
+            {/* The antique weather legend. */}
+            <text className="envbaro__word" x={dialPoint(-100, CX, CY, R * 0.5).x} y={dialPoint(-100, CX, CY, R * 0.5).y} textAnchor="middle">
+              RAIN
+            </text>
+            <text className="envbaro__word" x={CX} y={CY - R * 0.5} textAnchor="middle">
+              CHANGE
+            </text>
+            <text className="envbaro__word" x={dialPoint(100, CX, CY, R * 0.5).x} y={dialPoint(100, CX, CY, R * 0.5).y} textAnchor="middle">
+              FAIR
+            </text>
+            <text className="envbaro__maker" x={CX} y={CY + R * 0.36} textAnchor="middle">
+              ANEROID · hPa
+            </text>
+            {/* Pressure readout under the hub, like an inset plaque. */}
+            <text className="envbaro__press" x={CX} y={CY + R * 0.62} textAnchor="middle">
+              {hasData ? pressure.toFixed(1) : '——'}
+            </text>
+            {/* The needle (black, counterweighted) + brass hub. */}
+            <line className="envbaro__needle" x1={tail.x} y1={tail.y} x2={tip.x} y2={tip.y} />
+            <circle className="envbaro__hub" cx={CX} cy={CY} r={5.5} />
+          </svg>
+        </div>
+
+        {/* Temperature + humidity + source. */}
+        <div className="envbaro__row">
+          <div className="envbaro__cell">
+            <span className="envbaro__cell-lbl">TEMP</span>
+            <span className="envbaro__cell-val">{hasData ? `${reading.temp.toFixed(1)}°C` : '——'}</span>
+          </div>
+          <div className="envbaro__cell">
+            <span className="envbaro__cell-lbl">HUMIDITY</span>
+            <span className="envbaro__cell-val">{hasData ? `${reading.humidity.toFixed(0)}%` : '——'}</span>
+          </div>
+          <div className="envbaro__cell">
+            <span className="envbaro__cell-lbl">OUTLOOK</span>
+            <span className="envbaro__cell-val">{hasData ? weatherWord(pressure) : '—'}</span>
+          </div>
+          <label className="envbaro__src">
+            <span className="envbaro__cell-lbl">SRC</span>
+            <select
+              className="envbaro__select"
+              value={channel}
+              onChange={(e) => setPicked(e.currentTarget.value)}
+              aria-label="Environment sensor channel"
+            >
+              {(channels.length > 0 ? channels : ['env']).map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </div>
+    </InstrumentWindow>
+  )
+}
+
+// Quick sanity anchors for the render tests: the dial's printed range.
+export const ENV_DIAL_RANGE = [PRESS_MIN, PRESS_MAX] as const

--- a/src/renderer/src/components/I2cDetectInstrument.css
+++ b/src/renderer/src/components/I2cDetectInstrument.css
@@ -197,6 +197,71 @@
     inset 0 0 0 1px color-mix(in srgb, var(--accent) 60%, transparent);
 }
 
+/* --- Scan-sweep playback (#218) ---------------------------------------------
+   The cursor cell burns bright as it sweeps; cells it hasn't reached stay dim;
+   a detected address ripples like a stone dropped in water when crossed. */
+.i2cdet__cell--unswept {
+  opacity: 0.28;
+}
+
+.i2cdet__cell--cursor {
+  background: color-mix(in srgb, var(--accent) 80%, #fff);
+  box-shadow: 0 0 9px color-mix(in srgb, var(--accent) 90%, transparent);
+}
+
+.i2cdet__cell--ping {
+  position: relative;
+  animation: i2cdet-pop 360ms ease-out;
+}
+
+/* Two staggered expanding rings = the water ripple. */
+.i2cdet__cell--ping::before,
+.i2cdet__cell--ping::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 3px;
+  border: 1.5px solid color-mix(in srgb, var(--accent) 85%, #fff);
+  opacity: 0;
+  animation: i2cdet-ripple 700ms ease-out;
+  pointer-events: none;
+}
+
+.i2cdet__cell--ping::after {
+  animation-delay: 160ms;
+}
+
+@keyframes i2cdet-pop {
+  0% {
+    transform: scale(0.6);
+  }
+  55% {
+    transform: scale(1.25);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes i2cdet-ripple {
+  0% {
+    transform: scale(1);
+    opacity: 0.9;
+  }
+  100% {
+    transform: scale(2.6);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .i2cdet__cell--ping,
+  .i2cdet__cell--ping::before,
+  .i2cdet__cell--ping::after {
+    animation: none;
+  }
+}
+
 /* --- Controls --- */
 .i2cdet__controls {
   display: flex;

--- a/src/renderer/src/components/I2cDetectInstrument.css
+++ b/src/renderer/src/components/I2cDetectInstrument.css
@@ -262,6 +262,116 @@
   }
 }
 
+/* Detected cells are clickable (#214). */
+.i2cdet__cell--click {
+  border: none;
+  font-family: inherit;
+  cursor: pointer;
+  padding: 0;
+}
+
+.i2cdet__cell--click:hover {
+  outline: 1.5px solid color-mix(in srgb, var(--accent) 90%, #fff);
+}
+
+/* --- Address inspector (#214): known devices + Add-to-project offers. --- */
+.i2cdet__inspect {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  background: rgba(6, 9, 11, 0.7);
+  border: 1px solid var(--accent-border);
+}
+
+.i2cdet__inspect-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.i2cdet__inspect-addr {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.i2cdet__inspect-title {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #5a5f67;
+}
+
+.i2cdet__inspect-close {
+  margin-left: auto;
+  width: 18px;
+  height: 18px;
+  font-size: 10px;
+  line-height: 1;
+  color: #8a8f96;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.i2cdet__inspect-close:hover {
+  color: #cdd2d8;
+  border-color: #3a3d44;
+}
+
+.i2cdet__inspect-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: #aeb4bd;
+}
+
+.i2cdet__inspect-row--part {
+  color: #e6eaee;
+}
+
+.i2cdet__inspect-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.i2cdet__inspect-lib {
+  font-size: 9px;
+  color: #5a5f67;
+}
+
+.i2cdet__inspect-add {
+  margin-left: auto;
+  flex: 0 0 auto;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: #04120a;
+  background: var(--accent);
+  border: none;
+  border-radius: 4px;
+  padding: 3px 8px;
+  cursor: pointer;
+}
+
+.i2cdet__inspect-add:hover:not(:disabled) {
+  filter: brightness(1.15);
+}
+
+.i2cdet__inspect-add:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
 /* --- Controls --- */
 .i2cdet__controls {
   display: flex;

--- a/src/renderer/src/components/I2cDetectInstrument.tsx
+++ b/src/renderer/src/components/I2cDetectInstrument.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, type CSSProperties } from 'react'
+import { useCallback, useEffect, useState, type CSSProperties } from 'react'
 import { InstrumentWindow, PhosphorScreen, type FloatProps } from './InstrumentWindow'
 import { type InstrumentDef } from './instruments-registry'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
@@ -20,6 +20,9 @@ import './I2cDetectInstrument.css'
  * we parse into the grid. Works on demand — no running program needed — and the
  * address → cell maths still lives in the unit-tested {@link ./scanner-logic}.
  */
+
+/** Sweep-playback speed (#218): ms per grid cell (128 cells ≈ 1.2 s total). */
+const SWEEP_MS_PER_CELL = 9
 
 /** GPIO numbers a board exposes (for the I²C pin dropdowns). */
 function boardGpios(boards: BoardDefinition[], boardId: string | null): number[] {
@@ -90,6 +93,21 @@ export function I2cDetectInstrument({
     if (match) setSel(match)
   }
 
+  // Scan-sweep playback (#218): after the (fast, one-shot) device scan returns,
+  // a cursor sweeps the grid cell-by-cell; detected addresses "ping" with a
+  // water-ripple as the cursor crosses them. `sweep` is the cursor's flat cell
+  // index (0..127), or null when idle/complete. `scanSeq` keys the grid per scan
+  // so the ripple animations replay on a re-scan.
+  const [sweep, setSweep] = useState<number | null>(null)
+  const [scanSeq, setScanSeq] = useState(0)
+  useEffect(() => {
+    if (sweep === null) return
+    const id = window.setInterval(() => {
+      setSweep((s) => (s === null || s >= 8 * 16 ? null : s + 1))
+    }, SWEEP_MS_PER_CELL)
+    return () => window.clearInterval(id)
+  }, [sweep === null]) // eslint-disable-line react-hooks/exhaustive-deps -- restart only on idle↔sweeping flips
+
   // One-shot scan on the chosen pins (no running program needed).
   const scan = useCallback(async () => {
     if (!connected) return
@@ -108,6 +126,10 @@ export function I2cDetectInstrument({
           .filter(Boolean)
           .map((h) => parseInt(h, 16))
         setGrid(buildI2cGrid(addrs))
+        setScanSeq((n) => n + 1)
+        // Play the sweep — unless the user prefers reduced motion (show at once).
+        const reduce = window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches
+        setSweep(reduce ? null : 0)
       } else {
         setError(errLine ? errLine.slice('SNKI2CERR '.length) : 'Scan failed — check the pins/wiring.')
       }
@@ -119,7 +141,13 @@ export function I2cDetectInstrument({
   }, [connected, sel])
 
   const found = grid?.found ?? []
-  const foundText = scanning && !grid ? '··' : String(found.length)
+  // While the cursor sweeps, FOUND counts up as detected cells are crossed.
+  const foundText =
+    scanning && !grid
+      ? '··'
+      : sweep !== null
+        ? String(found.filter((a) => a < sweep).length)
+        : String(found.length)
   const noPins = opts.length === 0
 
   return (
@@ -140,7 +168,7 @@ export function I2cDetectInstrument({
             ) : error ? (
               <p className="i2cdet__hint i2cdet__error">{error}</p>
             ) : grid ? (
-              <I2cGrid grid={grid} />
+              <I2cGrid key={scanSeq} grid={grid} sweep={sweep} />
             ) : (
               <p className="i2cdet__hint">{scanning ? 'scanning…' : 'Pick the bus + pins, then SCAN'}</p>
             )}
@@ -202,8 +230,14 @@ export function I2cDetectInstrument({
   )
 }
 
-/** The 8×16 i2cdetect grid: a column-header row, then 8 labelled rows of cells. */
-function I2cGrid({ grid }: { grid: I2cGridModel }): JSX.Element {
+/**
+ * The 8×16 i2cdetect grid: a column-header row, then 8 labelled rows of cells.
+ * During the scan-sweep playback (#218) `sweep` is the cursor's flat address
+ * index: the cell AT it draws as the cursor, cells past it stay unswept (dim),
+ * and a detected cell pings a water-ripple as the cursor crosses it.
+ * Exported for the render tests.
+ */
+export function I2cGrid({ grid, sweep }: { grid: I2cGridModel; sweep: number | null }): JSX.Element {
   return (
     <div className="i2cdet__grid" role="grid" aria-label="I²C address grid">
       <div className="i2cdet__grid-head" role="row">
@@ -219,17 +253,25 @@ function I2cGrid({ grid }: { grid: I2cGridModel }): JSX.Element {
           <span className="i2cdet__rowlabel" role="rowheader">
             {(r * 16).toString(16).toUpperCase().padStart(2, '0')}
           </span>
-          {row.map((cell) => (
-            <span
-              key={cell.addr}
-              className={`i2cdet__cell${cell.detected ? ' i2cdet__cell--on' : ''}`}
-              role="gridcell"
-              title={cell.detected ? `Device at ${cell.label}` : cell.label}
-              aria-label={cell.detected ? `${cell.label} detected` : cell.label}
-            >
-              {cell.detected ? formatI2cAddr(cell.addr).slice(2) : '··'}
-            </span>
-          ))}
+          {row.map((cell) => {
+            const swept = sweep === null || cell.addr < sweep
+            const isCursor = sweep !== null && cell.addr === sweep
+            const on = cell.detected && swept
+            const cls =
+              `i2cdet__cell${on ? ' i2cdet__cell--on i2cdet__cell--ping' : ''}` +
+              `${isCursor ? ' i2cdet__cell--cursor' : ''}${!swept && !isCursor ? ' i2cdet__cell--unswept' : ''}`
+            return (
+              <span
+                key={cell.addr}
+                className={cls}
+                role="gridcell"
+                title={cell.detected ? `Device at ${cell.label}` : cell.label}
+                aria-label={cell.detected ? `${cell.label} detected` : cell.label}
+              >
+                {on ? formatI2cAddr(cell.addr).slice(2) : '··'}
+              </span>
+            )
+          })}
         </div>
       ))}
     </div>

--- a/src/renderer/src/components/I2cDetectInstrument.tsx
+++ b/src/renderer/src/components/I2cDetectInstrument.tsx
@@ -4,8 +4,10 @@ import { type InstrumentDef } from './instruments-registry'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { buildI2cGrid, formatI2cAddr, type I2cGridModel } from './scanner-logic'
 import { i2cOptions, i2cBuses, sdaOptions, sclOptions, type I2cOption } from './i2c-pins'
+import { hexAddr, knownDevicesFor, partsForAddress } from './i2c-known-devices'
 import { useBoards } from './use-boards'
 import type { BoardDefinition } from '../../../shared/board'
+import type { PartDefinition, PartLibraryWithParts } from '../../../preload/index.d'
 import './I2cDetectInstrument.css'
 
 /**
@@ -150,6 +152,61 @@ export function I2cDetectInstrument({
         : String(found.length)
   const noPins = opts.length === 0
 
+  // --- interactive addresses (#214) ----------------------------------------
+  // Clicking a found address opens an inspector: which known devices use it,
+  // and any INSTALLED library part declaring that address — with an ADD button
+  // that drops the part into the project (robot.yml) and pops the breadboard.
+  const [inspect, setInspect] = useState<number | null>(null)
+  const [libraries, setLibraries] = useState<PartLibraryWithParts[]>([])
+  const [adding, setAdding] = useState<string | null>(null)
+  const [addedId, setAddedId] = useState<string | null>(null)
+  useEffect(() => {
+    const load = (): void => {
+      void window.api.parts
+        .listLibraries()
+        .then(setLibraries)
+        .catch(() => setLibraries([]))
+    }
+    load()
+    return window.api.parts.onChanged(load)
+  }, [])
+  // A new scan invalidates the inspector (addresses may have moved).
+  useEffect(() => setInspect(null), [scanSeq])
+
+  const addToProject = useCallback(async (libraryId: string, part: PartDefinition) => {
+    setAdding(part.id)
+    setAddedId(null)
+    try {
+      // Pop the breadboard view first, then resolve the project folder from the
+      // board payload (it streams right after the window opens) so the part
+      // lands in the SAME robot.yml the Board View edits.
+      await window.api.board.open()
+      let folder: string | undefined
+      for (let i = 0; i < 10; i++) {
+        const p = await window.api.board.requestSource().catch(() => null)
+        if (p) {
+          folder = p.folder
+          break
+        }
+        await new Promise((r) => setTimeout(r, 150))
+      }
+      const robot = await window.api.robot.load(folder)
+      const ids = new Set(['board', ...robot.parts.map((x) => x.id)])
+      let id = part.id
+      let n = 2
+      while (ids.has(id)) id = `${part.id}${n++}`
+      await window.api.robot.save(folder, {
+        ...robot,
+        parts: [...robot.parts, { id, lib: libraryId, part: part.id, label: part.name }]
+      })
+      setAddedId(part.id)
+    } catch {
+      // Best-effort — the board window not opening shouldn't crash the panel.
+    } finally {
+      setAdding(null)
+    }
+  }, [])
+
   return (
     <InstrumentWindow
       name={def.name.toUpperCase()}
@@ -168,13 +225,57 @@ export function I2cDetectInstrument({
             ) : error ? (
               <p className="i2cdet__hint i2cdet__error">{error}</p>
             ) : grid ? (
-              <I2cGrid key={scanSeq} grid={grid} sweep={sweep} />
+              <I2cGrid key={scanSeq} grid={grid} sweep={sweep} onInspect={setInspect} />
             ) : (
               <p className="i2cdet__hint">{scanning ? 'scanning…' : 'Pick the bus + pins, then SCAN'}</p>
             )}
             {scanning && grid && <div className="i2cdet__scanning">scanning…</div>}
           </div>
         </PhosphorScreen>
+
+        {/* Address inspector (#214): what's at the clicked address + Add offers. */}
+        {inspect !== null && (
+          <div className="i2cdet__inspect" role="dialog" aria-label={`Devices at ${hexAddr(inspect)}`}>
+            <div className="i2cdet__inspect-head">
+              <span className="i2cdet__inspect-addr">{hexAddr(inspect)}</span>
+              <span className="i2cdet__inspect-title">what&rsquo;s here?</span>
+              <button
+                type="button"
+                className="i2cdet__inspect-close"
+                onClick={() => setInspect(null)}
+                title="Close"
+                aria-label="Close the address inspector"
+              >
+                ✕
+              </button>
+            </div>
+            {partsForAddress(inspect, libraries).map(({ libraryId, part }) => (
+              <div className="i2cdet__inspect-row i2cdet__inspect-row--part" key={`${libraryId}:${part.id}`}>
+                <span className="i2cdet__inspect-name">{part.name}</span>
+                <span className="i2cdet__inspect-lib">{libraryId}</span>
+                <button
+                  type="button"
+                  className="i2cdet__inspect-add"
+                  disabled={adding !== null}
+                  onClick={() => void addToProject(libraryId, part)}
+                  title="Add this part to the project and open the breadboard"
+                >
+                  {adding === part.id ? 'ADDING…' : addedId === part.id ? 'ADDED ✓' : 'ADD'}
+                </button>
+              </div>
+            ))}
+            {knownDevicesFor(inspect).map((name) => (
+              <div className="i2cdet__inspect-row" key={name}>
+                <span className="i2cdet__inspect-name">{name}</span>
+              </div>
+            ))}
+            {partsForAddress(inspect, libraries).length === 0 && knownDevicesFor(inspect).length === 0 && (
+              <div className="i2cdet__inspect-row">
+                <span className="i2cdet__inspect-name">No known device for this address.</span>
+              </div>
+            )}
+          </div>
+        )}
 
         <div className="i2cdet__controls">
           <label className="i2cdet__pick">
@@ -235,9 +336,18 @@ export function I2cDetectInstrument({
  * During the scan-sweep playback (#218) `sweep` is the cursor's flat address
  * index: the cell AT it draws as the cursor, cells past it stay unswept (dim),
  * and a detected cell pings a water-ripple as the cursor crosses it.
- * Exported for the render tests.
+ * Exported for the render tests. Detected cells are clickable when `onInspect`
+ * is provided (#214) — opening the address inspector.
  */
-export function I2cGrid({ grid, sweep }: { grid: I2cGridModel; sweep: number | null }): JSX.Element {
+export function I2cGrid({
+  grid,
+  sweep,
+  onInspect
+}: {
+  grid: I2cGridModel
+  sweep: number | null
+  onInspect?: (addr: number) => void
+}): JSX.Element {
   return (
     <div className="i2cdet__grid" role="grid" aria-label="I²C address grid">
       <div className="i2cdet__grid-head" role="row">
@@ -260,6 +370,22 @@ export function I2cGrid({ grid, sweep }: { grid: I2cGridModel; sweep: number | n
             const cls =
               `i2cdet__cell${on ? ' i2cdet__cell--on i2cdet__cell--ping' : ''}` +
               `${isCursor ? ' i2cdet__cell--cursor' : ''}${!swept && !isCursor ? ' i2cdet__cell--unswept' : ''}`
+            // A revealed hit is a BUTTON (#214): click → the address inspector.
+            if (on && onInspect) {
+              return (
+                <button
+                  key={cell.addr}
+                  type="button"
+                  className={`${cls} i2cdet__cell--click`}
+                  role="gridcell"
+                  title={`Device at ${cell.label} — click for known devices`}
+                  aria-label={`${cell.label} detected — inspect`}
+                  onClick={() => onInspect(cell.addr)}
+                >
+                  {formatI2cAddr(cell.addr).slice(2)}
+                </button>
+              )
+            }
             return (
               <span
                 key={cell.addr}

--- a/src/renderer/src/components/ImuInstrument.css
+++ b/src/renderer/src/components/ImuInstrument.css
@@ -310,8 +310,108 @@
   background: #1c1f22;
 }
 
+/* --- Compass (#215): rotating rose card + heading readout ----------------- */
+.imu__compass {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 10px;
+  border-radius: 4px;
+  background: rgba(6, 9, 11, 0.7);
+  border: 1px solid var(--accent-border);
+}
+
+.imu__rose {
+  width: 64px;
+  height: 64px;
+  flex: 0 0 auto;
+}
+
+.imu__rose-bezel {
+  fill: #14181c;
+  stroke: color-mix(in srgb, var(--accent) 45%, #2a2e33);
+  stroke-width: 1.5;
+}
+
+.imu__rose-face {
+  fill: #0a0e11;
+}
+
+/* The rotating card eases between headings (disabled under reduced motion). */
+.imu__rose g {
+  transition: transform 120ms linear;
+}
+
+.imu__rose-tick {
+  stroke: #3b4148;
+  stroke-width: 1;
+}
+
+.imu__rose-tick--major {
+  stroke: color-mix(in srgb, var(--accent) 60%, #8a9096);
+  stroke-width: 1.5;
+}
+
+.imu__rose-n {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 9px;
+  font-weight: 800;
+  fill: #ff6b5e; /* north reads red, like a needle tip */
+}
+
+.imu__rose-pt {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 8px;
+  font-weight: 700;
+  fill: #9aa0a8;
+}
+
+.imu__rose-lubber {
+  fill: color-mix(in srgb, var(--accent) 85%, #fff);
+}
+
+.imu__rose-hub {
+  fill: color-mix(in srgb, var(--accent) 70%, #cdd2d8);
+}
+
+.imu__compass-readout {
+  display: flex;
+  flex: 1 1 auto;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+}
+
+.imu__compass-hdg {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 20px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: color-mix(in srgb, var(--accent) 72%, #cdd2d8);
+  text-shadow: 0 0 6px color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+.imu__compass-card {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 13px;
+  font-weight: 700;
+  color: #cdd2d8;
+}
+
+.imu__compass-lbl {
+  margin-left: auto;
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  color: #5a5f67;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .imu__model {
+    transition: none;
+  }
+
+  .imu__rose g {
     transition: none;
   }
 }

--- a/src/renderer/src/components/ImuInstrument.tsx
+++ b/src/renderer/src/components/ImuInstrument.tsx
@@ -3,8 +3,11 @@ import { InstrumentWindow, PhosphorScreen, type FloatProps } from './InstrumentW
 import { type InstrumentDef } from './instruments-registry'
 import {
   applyCalibration,
+  cardinalFor,
   eulerToCssTransform,
   formatAngle,
+  formatHeading,
+  headingFromYaw,
   NEUTRAL_EULER,
   parseImu,
   readingToEuler,
@@ -212,6 +215,17 @@ export function ImuInstrument({
           </div>
         </PhosphorScreen>
 
+        {/* Compass (#215): a rotating 16-wind card under a fixed lubber line,
+            driven by the magnetometer heading (the calibrated yaw). */}
+        <div className="imu__compass" role="img" aria-label={hasData ? `Compass heading ${formatHeading(headingFromYaw(shown.yaw))} ${cardinalFor(headingFromYaw(shown.yaw))}` : 'Compass — no data'}>
+          <CompassRose heading={hasData ? headingFromYaw(shown.yaw) : 0} />
+          <div className="imu__compass-readout">
+            <span className="imu__compass-hdg">{hasData ? formatHeading(headingFromYaw(shown.yaw)) : '———'}</span>
+            <span className="imu__compass-card">{hasData ? cardinalFor(headingFromYaw(shown.yaw)) : '—'}</span>
+            <span className="imu__compass-lbl">HDG · MAG</span>
+          </div>
+        </div>
+
         {/* Numeric ROLL / PITCH / YAW readout — mirrors placeholder__readout. */}
         <div className="imu__readout">
           <Cell label="ROLL" value={hasData ? formatAngle(shown.roll) : '——'} />
@@ -222,6 +236,49 @@ export function ImuInstrument({
         </div>
       </div>
     </InstrumentWindow>
+  )
+}
+
+/**
+ * A ship-style compass: the CARD (rose) rotates by −heading so the current
+ * heading sits under the fixed top lubber line; N/E/S/W + tick marks ride the
+ * card. Pure SVG, no dependency; ~64px.
+ */
+function CompassRose({ heading }: { heading: number }): JSX.Element {
+  const ticks: JSX.Element[] = []
+  for (let d = 0; d < 360; d += 15) {
+    const major = d % 90 === 0
+    const a = (d * Math.PI) / 180
+    const r1 = major ? 20 : 23
+    const r2 = 26
+    ticks.push(
+      <line
+        key={d}
+        className={major ? 'imu__rose-tick imu__rose-tick--major' : 'imu__rose-tick'}
+        x1={32 + r1 * Math.sin(a)}
+        y1={32 - r1 * Math.cos(a)}
+        x2={32 + r2 * Math.sin(a)}
+        y2={32 - r2 * Math.cos(a)}
+      />
+    )
+  }
+  return (
+    <svg className="imu__rose" viewBox="0 0 64 64" aria-hidden="true">
+      {/* Bezel + face. */}
+      <circle className="imu__rose-bezel" cx={32} cy={32} r={30} />
+      <circle className="imu__rose-face" cx={32} cy={32} r={27} />
+      {/* The rotating card: ticks + cardinal letters. */}
+      <g style={{ transform: `rotate(${-heading}deg)`, transformOrigin: '32px 32px' }}>
+        {ticks}
+        <text className="imu__rose-n" x={32} y={13.5} textAnchor="middle">N</text>
+        <text className="imu__rose-pt" x={50.5} y={34.5} textAnchor="middle">E</text>
+        <text className="imu__rose-pt" x={32} y={53.5} textAnchor="middle">S</text>
+        <text className="imu__rose-pt" x={13.5} y={34.5} textAnchor="middle">W</text>
+      </g>
+      {/* Fixed lubber line (reads the heading) + hub. */}
+      <path className="imu__rose-lubber" d="M 32 3 L 29.4 9 L 34.6 9 Z" />
+      <circle className="imu__rose-hub" cx={32} cy={32} r={2} />
+    </svg>
   )
 }
 

--- a/src/renderer/src/components/InstrumentHost.tsx
+++ b/src/renderer/src/components/InstrumentHost.tsx
@@ -23,6 +23,7 @@ import { PlaceholderInstrument } from './PlaceholderInstrument'
 import { GamepadInstrument } from './GamepadInstrument'
 import { RangeInstrument } from './RangeInstrument'
 import { ImuInstrument } from './ImuInstrument'
+import { EnvInstrument } from './EnvInstrument'
 import { LedInstrument } from './LedInstrument'
 import { ServoInstrument } from './ServoInstrument'
 import { PotentiometerInstrument } from './PotentiometerInstrument'
@@ -933,6 +934,8 @@ export function renderSingleton(
       return <RangeInstrument {...p} />
     case 'imu':
       return <ImuInstrument {...p} />
+    case 'env':
+      return <EnvInstrument {...p} />
     case 'led':
       return <LedInstrument {...p} />
     case 'servo':

--- a/src/renderer/src/components/MonacoEditor.tsx
+++ b/src/renderer/src/components/MonacoEditor.tsx
@@ -23,7 +23,8 @@ import {
   setModelDiagnostics
 } from './plugin-code-actions'
 import { registerInlineCompletions } from './inline-completions'
-import { setActiveEditor, dispatchOpenFind } from './editorBridge'
+import { setActiveEditor, dispatchOpenFind, dispatchOpenHelp } from './editorBridge'
+import { resolveHelpTarget } from './context-help'
 import { validateFormat, formatKindForName } from './format-validate'
 import {
   clearFormatDiagnostics,
@@ -310,6 +311,26 @@ export function MonacoEditor(): JSX.Element {
     // opens. F = find-only, H = find + replace.
     editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyF, () => dispatchOpenFind(false))
     editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyH, () => dispatchOpenFind(true))
+
+    // Right-click context help (#221): "Help for <symbol>" in the editor's
+    // context menu. Resolves the word under the cursor to an installed library
+    // part's bundled help (bme280, servo, …) or a language-reference topic
+    // (Pin/PWM/I2C/sleep/…), and opens the mini help at that page. Unknown words
+    // open nothing (the resolver is the single source of what's helpable).
+    editor.addAction({
+      id: 'snakie.contextHelp',
+      label: 'Help for symbol (Snakie)',
+      contextMenuGroupId: 'navigation',
+      contextMenuOrder: 1.1,
+      run: async (ed) => {
+        const pos = ed.getPosition()
+        const word = pos ? ed.getModel()?.getWordAtPosition(pos)?.word : undefined
+        if (!word) return
+        const libs = await window.api.parts.listLibraries().catch(() => [])
+        const target = resolveHelpTarget(word, libs)
+        if (target) dispatchOpenHelp(target.articleId)
+      }
+    })
 
     const modelStore = models.current
     return () => {

--- a/src/renderer/src/components/PackagesPanel.tsx
+++ b/src/renderer/src/components/PackagesPanel.tsx
@@ -214,6 +214,9 @@ function PackagesTab(): JSX.Element {
             notes: result.notes.length ? result.notes : collectedNotes
           }
         }))
+        // A successful install wrote files to the board — tell every window so
+        // the Device Files tree (and the library banners) refresh.
+        if (result.ok) window.api.modules.notifyChanged()
       } catch (err) {
         setInstalls((prev) => ({
           ...prev,

--- a/src/renderer/src/components/PartsImportBanner.tsx
+++ b/src/renderer/src/components/PartsImportBanner.tsx
@@ -24,11 +24,12 @@ export function PartsImportBanner({
   missingOnBoard: RequiredModule[]
   installing: boolean
   error?: string | null
-  /** Install the missing board libraries (those with a source URL). */
+  /** Install the missing board libraries — bundled driver files copy straight
+   *  to the device; modules with a source URL install via mip. */
   onInstall: () => void
   onDismiss: () => void
 }): JSX.Element {
-  const installable = missingOnBoard.filter((m) => m.url)
+  const installable = missingOnBoard.filter((m) => (m.drivers?.length ?? 0) > 0 || m.url)
   const list = (ms: RequiredModule[]): string => ms.map((m) => m.module).join(', ')
   return (
     <div className="inst-lib-banner" role="status" aria-live="polite">

--- a/src/renderer/src/components/WiringCanvas.css
+++ b/src/renderer/src/components/WiringCanvas.css
@@ -733,3 +733,37 @@
   background: #c0392b;
   border-color: #a5281b;
 }
+
+/* --- Schematic bus tags (#217): named I2C/SPI stubs instead of noodles. --- */
+.wc__bus-stub {
+  stroke-width: 2;
+}
+
+.wc__bus-tag {
+  fill: rgba(20, 24, 28, 0.06);
+  stroke-width: 1.5;
+}
+
+.wc__bus-text {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+/* I²C reads amber, SPI teal — legible on both the dark mat and the light sheet. */
+.wc__bus--i2c .wc__bus-stub,
+.wc__bus--i2c .wc__bus-tag {
+  stroke: #d6a531;
+}
+.wc__bus--i2c .wc__bus-text {
+  fill: #d6a531;
+}
+
+.wc__bus--spi .wc__bus-stub,
+.wc__bus--spi .wc__bus-tag {
+  stroke: #2fb3b3;
+}
+.wc__bus--spi .wc__bus-text {
+  fill: #2fb3b3;
+}

--- a/src/renderer/src/components/WiringCanvas.tsx
+++ b/src/renderer/src/components/WiringCanvas.tsx
@@ -30,6 +30,7 @@ import { Board, BoardDefs } from './BoardGraph'
 import { McuSymbol, PartSchematicSymbol } from './SchematicSymbols'
 import { routeOrthogonal, toSvgPath, type RBox, type RSide, type RWire } from './ortho-router'
 import { PART_DRAG_MIME, decodePartDrag } from './part-drag'
+import { classifyBusWire } from './bus-wires'
 import './WiringCanvas.css'
 
 /**
@@ -137,6 +138,8 @@ interface PlacedPin {
   /** Per-capability signal designation + bus/channel (for the hover chips). */
   signals?: PartPinSignals
   buses?: PartPinBuses
+  /** The GPIO an MCU pad breaks out (drives the schematic bus-tag id, #217). */
+  gpio?: number
 }
 /** Board pads used by the parsed code, keyed by board pad index (combine view). */
 export type UsedByCode = Map<number, { color: string; label: string }>
@@ -262,7 +265,8 @@ function boardSchematicPins(def: BoardDefinition): { w: number; h: number; place
       anchors: [{ x: t.outer.x, y: t.outer.y, ox, oy }],
       label: { x: t.label.x, y: t.label.y, anchor: t.label.anchor }, // label drawn by McuSymbol
       primary: t.primary,
-      railIndices: t.railIndices
+      railIndices: t.railIndices,
+      gpio: t.pad.gpio // → the schematic bus-tag id (#217)
     }
   })
   return { w: lay.box.w, h: lay.box.h, placed }
@@ -281,7 +285,11 @@ function partSchematicPins(def: PartDefinition): { w: number; h: number; placed:
       anchors: [{ x: t.outer.x, y: t.outer.y, ox, oy }],
       label: { x: t.label.x, y: t.label.y, anchor: t.label.anchor }, // label drawn by the symbol
       primary: t.primary,
-      railIndices: t.railIndices
+      railIndices: t.railIndices,
+      // Capabilities/bus metadata → the schematic bus classifier (#217).
+      caps: t.pin.capabilities,
+      signals: t.pin.signals,
+      buses: t.pin.buses
     }
   })
   return { w: lay.box.w, h: lay.box.h, placed }
@@ -1137,6 +1145,33 @@ export function WiringCanvas({ robot, onChange, libraries, boardDef, boardPart, 
                 isn't hidden under the body (#182). Pins stay grabbable via the
                 coordinate hit-test, not element order. */}
             {robot.connections.map((c) => {
+              // SCHEMATIC buses (#217): an I²C/SPI wire draws as two short named
+              // bus tags (»I2C0«) instead of a routed point-to-point noodle —
+              // the standard notation, and far less chaotic to arrange.
+              if (renderMode === 'schematic') {
+                const f = parseEndpoint(c.from)
+                const t = parseEndpoint(c.to)
+                const fs = subjByKey.get(f.key)
+                const ts = subjByKey.get(t.key)
+                const fp = fs?.pins[f.index]
+                const tp = ts?.pins[t.index]
+                if (fs && ts && fp && tp) {
+                  const bus = classifyBusWire(
+                    { caps: fp.caps, buses: fp.buses, signals: fp.signals, gpio: fp.gpio },
+                    { caps: tp.caps, buses: tp.buses, signals: tp.signals, gpio: tp.gpio }
+                  )
+                  if (bus) {
+                    const a = anchorOf(fs, fp, ts.x, ts.y)
+                    const b = anchorOf(ts, tp, fs.x, fs.y)
+                    return (
+                      <g key={c.id} className={`wc__bus wc__bus--${bus.kind}`}>
+                        <BusTag anchor={a} label={bus.label} />
+                        <BusTag anchor={b} label={bus.label} />
+                      </g>
+                    )
+                  }
+                }
+              }
               const p = wirePath(c)
               if (!p) return null
               return (
@@ -1628,6 +1663,43 @@ function hitRegion(mode: WiringRenderMode, x: number, y: number, w: number, h: n
 /** Render one subject (MCU or part) in its own translated group. The body is the
  *  REAL renderer for its mode (Board / PartBody / McuSymbol / PartSchematicSymbol);
  *  the wiring canvas draws the connectable dots + combine labels on top. */
+/**
+ * A named schematic BUS TAG (#217): a short stub out of the pin plus a rounded
+ * label (»I2C0«). Drawn at BOTH ends of a classified bus wire in place of the
+ * routed noodle. Orientation follows the pin's outward normal.
+ */
+function BusTag({
+  anchor,
+  label
+}: {
+  anchor: { cx: number; cy: number; ox: number; oy: number }
+  label: string
+}): JSX.Element {
+  const STUB = 12
+  const ex = anchor.cx + anchor.ox * STUB
+  const ey = anchor.cy + anchor.oy * STUB
+  const w = 10 + label.length * 7.5
+  const h = 16
+  // The tag sits just past the stub end, pushed outward so it clears the pin.
+  const tx = ex + anchor.ox * (w / 2) - w / 2
+  const ty = ey + anchor.oy * (h / 2) - h / 2
+  return (
+    <g>
+      <line className="wc__bus-stub" x1={anchor.cx} y1={anchor.cy} x2={ex} y2={ey} />
+      <rect className="wc__bus-tag" x={tx} y={ty} width={w} height={h} rx={4} />
+      <text
+        className="wc__bus-text"
+        x={tx + w / 2}
+        y={ty + h / 2}
+        textAnchor="middle"
+        dominantBaseline="central"
+      >
+        {label}
+      </text>
+    </g>
+  )
+}
+
 function SubjectBody({
   subject: s,
   onHoverPin,

--- a/src/renderer/src/components/bus-wires.ts
+++ b/src/renderer/src/components/bus-wires.ts
@@ -1,0 +1,66 @@
+/**
+ * SCHEMATIC BUS WIRES (#217) — classify a wiring-canvas connection as an I²C or
+ * SPI BUS wire so the schematic view can draw short, named bus tags at both
+ * ends (»I2C0«) instead of routing a long point-to-point noodle. Buses carry
+ * many devices, so tying every SDA/SCL/SCK/… straight to the MCU is exactly
+ * what makes real schematics chaotic — named stubs are the standard notation.
+ * Pure + unit-tested.
+ */
+import type { PartPinCapability, PartPinSignals, PartPinBuses } from '../../../shared/part'
+
+/** What the classifier needs to know about ONE wire endpoint. */
+export interface BusEndInfo {
+  /** Pin capabilities (part pins carry these; MCU pads usually don't). */
+  caps?: PartPinCapability[]
+  /** Per-capability bus ids authored on the pin. */
+  buses?: PartPinBuses
+  /** Signal designations (unused for classification today, kept for labels). */
+  signals?: PartPinSignals
+  /** The GPIO number (MCU pads) — used to derive the RP-family bus id. */
+  gpio?: number
+}
+
+/** A classified bus wire: the peripheral kind + bus id (null = unknown). */
+export interface BusWire {
+  kind: 'i2c' | 'spi'
+  bus: number | null
+  label: string
+}
+
+/** RP-family I²C block for a GPIO: I2C0 ⇔ gpio%4 ∈ {0,1}, I2C1 ⇔ {2,3}. */
+export function i2cBusForGpio(gpio: number | undefined): number | null {
+  if (gpio === undefined || !Number.isInteger(gpio) || gpio < 0) return null
+  return gpio % 4 <= 1 ? 0 : 1
+}
+
+/** RP-family SPI block for a GPIO: SPI0 ⇔ 0–7 & 16–23, SPI1 ⇔ 8–15 & 24–29. */
+export function spiBusForGpio(gpio: number | undefined): number | null {
+  if (gpio === undefined || !Number.isInteger(gpio) || gpio < 0) return null
+  const m = gpio % 16
+  return m <= 7 ? 0 : 1
+}
+
+/** The tag text for a classified bus (`I2C0`, `SPI1`, or bare `I2C`). */
+export function busLabel(kind: 'i2c' | 'spi', bus: number | null): string {
+  return `${kind.toUpperCase()}${bus ?? ''}`
+}
+
+/**
+ * Classify one connection: it's a BUS wire when EITHER endpoint's pin declares
+ * the i2c/spi capability (peripheral part pins carry capabilities; MCU pads
+ * don't). The bus id prefers an authored `buses` id from either end, then the
+ * RP-family gpio derivation from either end. Non-bus wires → null.
+ */
+export function classifyBusWire(a: BusEndInfo, b: BusEndInfo): BusWire | null {
+  for (const kind of ['i2c', 'spi'] as const) {
+    if (!a.caps?.includes(kind) && !b.caps?.includes(kind)) continue
+    const authored = a.buses?.[kind] ?? b.buses?.[kind]
+    const derived =
+      kind === 'i2c'
+        ? (i2cBusForGpio(a.gpio) ?? i2cBusForGpio(b.gpio))
+        : (spiBusForGpio(a.gpio) ?? spiBusForGpio(b.gpio))
+    const bus = authored ?? derived
+    return { kind, bus, label: busLabel(kind, bus) }
+  }
+  return null
+}

--- a/src/renderer/src/components/context-help.ts
+++ b/src/renderer/src/components/context-help.ts
@@ -8,25 +8,59 @@
  */
 import type { PartDefinition } from '../../../shared/part'
 
-/** Language-reference topics by (lower-cased) symbol → help article id. */
-export const LANGUAGE_HELP: Record<string, string> = {
-  machine: 'ref-pins',
-  pin: 'ref-pins',
-  adc: 'ref-pins',
-  pwm: 'ref-pwm',
-  i2c: 'ref-i2c',
-  softi2c: 'ref-i2c',
-  spi: 'ref-spi',
-  softspi: 'ref-spi',
-  uart: 'ref-uart',
-  time: 'ref-timing',
-  sleep: 'ref-timing',
-  sleep_ms: 'ref-timing',
-  sleep_us: 'ref-timing',
-  ticks_ms: 'ref-timing',
-  ticks_diff: 'ref-timing',
-  print: 'ref-print'
+/** Fold a word list into `map` → one target article id (builder for the table). */
+function topic(map: Record<string, string>, words: string[], article: string): void {
+  for (const w of words) map[w] = article
 }
+
+/**
+ * Language-reference topics by (lower-cased) symbol → help article id. Covers
+ * the hardware modules PLUS standard Python: keywords, the common value types,
+ * and the everyday built-ins — so right-clicking `while`, `dict` or `len`
+ * lands on the matching reference page.
+ */
+export const LANGUAGE_HELP: Record<string, string> = (() => {
+  const m: Record<string, string> = {}
+  // Hardware / MicroPython modules.
+  topic(m, ['machine', 'pin', 'adc'], 'ref-pins')
+  topic(m, ['pwm'], 'ref-pwm')
+  topic(m, ['i2c', 'softi2c'], 'ref-i2c')
+  topic(m, ['spi', 'softspi'], 'ref-spi')
+  topic(m, ['uart'], 'ref-uart')
+  topic(m, ['time', 'sleep', 'sleep_ms', 'sleep_us', 'ticks_ms', 'ticks_us', 'ticks_diff'], 'ref-timing')
+  topic(m, ['print'], 'ref-print')
+  // Control flow (keywords + boolean/membership operators).
+  topic(
+    m,
+    ['if', 'elif', 'else', 'for', 'while', 'break', 'continue', 'pass', 'and', 'or', 'not', 'in', 'is'],
+    'ref-flow'
+  )
+  // Functions & scope.
+  topic(m, ['def', 'return', 'lambda', 'global', 'nonlocal', 'yield'], 'ref-functions')
+  // Classes.
+  topic(m, ['class', 'self', 'super', 'property', '__init__'], 'ref-classes')
+  // Errors & exceptions.
+  topic(
+    m,
+    ['try', 'except', 'finally', 'raise', 'assert', 'oserror', 'valueerror', 'typeerror', 'keyerror', 'exception'],
+    'ref-exceptions'
+  )
+  // Imports & modules.
+  topic(m, ['import', 'from', 'as', 'sys', 'os'], 'ref-imports')
+  // Values & types.
+  topic(
+    m,
+    ['int', 'float', 'str', 'bool', 'list', 'dict', 'tuple', 'set', 'bytes', 'bytearray', 'none', 'true', 'false', 'complex', 'frozenset'],
+    'ref-types'
+  )
+  // Everyday built-ins.
+  topic(
+    m,
+    ['len', 'range', 'enumerate', 'zip', 'min', 'max', 'sum', 'abs', 'round', 'sorted', 'reversed', 'input', 'type', 'isinstance', 'hex', 'bin', 'chr', 'ord', 'dir', 'help', 'map', 'filter', 'open'],
+    'ref-builtins'
+  )
+  return m
+})()
 
 export interface HelpTarget {
   articleId: string

--- a/src/renderer/src/components/context-help.ts
+++ b/src/renderer/src/components/context-help.ts
@@ -1,0 +1,59 @@
+/**
+ * CONTEXT-SENSITIVE HELP (#221) — resolve the word under the editor cursor to a
+ * mini-help article: an installed library PART (right-clicking `bme280` in
+ * `from bme280 import BME280` opens that part's bundled help) or a LANGUAGE
+ * reference topic (`Pin`, `PWM`, `I2C`, `sleep`, …). Pure + unit-tested; the
+ * Monaco context-menu action calls {@link resolveHelpTarget} and dispatches the
+ * shared open-help event with the result.
+ */
+import type { PartDefinition } from '../../../shared/part'
+
+/** Language-reference topics by (lower-cased) symbol → help article id. */
+export const LANGUAGE_HELP: Record<string, string> = {
+  machine: 'ref-pins',
+  pin: 'ref-pins',
+  adc: 'ref-pins',
+  pwm: 'ref-pwm',
+  i2c: 'ref-i2c',
+  softi2c: 'ref-i2c',
+  spi: 'ref-spi',
+  softspi: 'ref-spi',
+  uart: 'ref-uart',
+  time: 'ref-timing',
+  sleep: 'ref-timing',
+  sleep_ms: 'ref-timing',
+  sleep_us: 'ref-timing',
+  ticks_ms: 'ref-timing',
+  ticks_diff: 'ref-timing',
+  print: 'ref-print'
+}
+
+export interface HelpTarget {
+  articleId: string
+  title: string
+}
+
+/**
+ * Resolve a symbol to its help article. Installed PARTS win over the language
+ * table (a part named `pwm` should open ITS help); matching is case-insensitive
+ * against each part's id and import module — the same tokens the Help panel's
+ * "In This Project" detector uses. Returns null for an unknown word.
+ */
+export function resolveHelpTarget(
+  word: string | null | undefined,
+  libraries: { id: string; parts: PartDefinition[] }[]
+): HelpTarget | null {
+  const w = (word ?? '').trim().toLowerCase()
+  if (!w) return null
+  for (const lib of libraries) {
+    for (const part of lib.parts) {
+      const toks = [part.id, part.library?.module]
+        .filter(Boolean)
+        .map((s) => String(s).toLowerCase())
+      if (toks.includes(w)) return { articleId: `part-${part.id}`, title: part.name }
+    }
+  }
+  const ref = LANGUAGE_HELP[w]
+  if (ref) return { articleId: ref, title: word ?? '' }
+  return null
+}

--- a/src/renderer/src/components/device-tree-model.ts
+++ b/src/renderer/src/components/device-tree-model.ts
@@ -1,0 +1,108 @@
+/**
+ * DEVICE FILE TREE MODEL (#219) — pure helpers behind the device-files panel's
+ * multi-select + drag-to-folder file management. The tree's listings live in a
+ * flat `path → entries` map (lifted out of the row components so range
+ * selection and full refresh can see the whole visible tree); these functions
+ * flatten it into visible rows, compute click-selection transitions
+ * (single / ctrl-toggle / shift-range) and validate folder moves. DOM-free.
+ */
+import type { DirEntry } from '../../../preload/index.d'
+
+export const DEVICE_ROOT = '/'
+
+/** One visible row of the flattened tree (depth drives the indent). */
+export interface FlatRow {
+  path: string
+  entry: DirEntry
+  depth: number
+}
+
+/** Join a device dir + name (the root is `/`, never doubled). */
+export function joinDevicePath(dir: string, name: string): string {
+  return dir === DEVICE_ROOT ? `/${name}` : `${dir}/${name}`
+}
+
+/** The parent directory of a device path (`/lib/x.py` → `/lib`, `/x` → `/`). */
+export function parentDevicePath(path: string): string {
+  const idx = path.lastIndexOf('/')
+  return idx <= 0 ? DEVICE_ROOT : path.slice(0, idx)
+}
+
+/**
+ * Flatten the loaded tree into its VISIBLE rows, walking depth-first from the
+ * root: an expanded directory contributes its (loaded) children right below it.
+ */
+export function flattenTree(
+  dirs: ReadonlyMap<string, DirEntry[]>,
+  expanded: ReadonlySet<string>
+): FlatRow[] {
+  const out: FlatRow[] = []
+  const walk = (dir: string, depth: number): void => {
+    for (const entry of dirs.get(dir) ?? []) {
+      const path = joinDevicePath(dir, entry.name)
+      out.push({ path, entry, depth })
+      if (entry.isDir && expanded.has(path)) walk(path, depth + 1)
+    }
+  }
+  walk(DEVICE_ROOT, 0)
+  return out
+}
+
+/** Selection transition for a row click (#219). */
+export function nextSelection(
+  current: ReadonlySet<string>,
+  anchor: string | null,
+  rows: FlatRow[],
+  path: string,
+  mode: 'single' | 'toggle' | 'range'
+): { selection: Set<string>; anchor: string | null } {
+  if (mode === 'toggle') {
+    const selection = new Set(current)
+    if (selection.has(path)) selection.delete(path)
+    else selection.add(path)
+    return { selection, anchor: path }
+  }
+  if (mode === 'range' && anchor) {
+    const order = rows.map((r) => r.path)
+    const a = order.indexOf(anchor)
+    const b = order.indexOf(path)
+    if (a !== -1 && b !== -1) {
+      const [lo, hi] = a <= b ? [a, b] : [b, a]
+      return { selection: new Set(order.slice(lo, hi + 1)), anchor }
+    }
+  }
+  return { selection: new Set([path]), anchor: path }
+}
+
+/** Is `child` inside `parent` (or equal)? Guards moving a folder into itself. */
+export function isSameOrDescendant(parent: string, child: string): boolean {
+  return child === parent || child.startsWith(`${parent}/`)
+}
+
+/**
+ * Plan moving `sources` into `destDir`: one from→to rename per source, skipping
+ * no-ops (already in `destDir`) and ILLEGAL moves (a folder into itself or a
+ * descendant). Nested-redundant sources (a child of another selected source)
+ * are dropped — moving the parent carries them.
+ */
+export function planMove(
+  sources: string[],
+  destDir: string
+): { from: string; to: string }[] {
+  const roots = sources.filter((s) => !sources.some((o) => o !== s && isSameOrDescendant(o, s)))
+  const plan: { from: string; to: string }[] = []
+  for (const src of roots) {
+    if (parentDevicePath(src) === destDir) continue // already there
+    if (isSameOrDescendant(src, destDir)) continue // folder into itself/child
+    plan.push({ from: src, to: joinDevicePath(destDir, src.split('/').pop() ?? '') })
+  }
+  return plan
+}
+
+/**
+ * Reduce a delete selection to its top-level paths (deleting a folder already
+ * removes everything under it).
+ */
+export function pruneNested(paths: string[]): string[] {
+  return paths.filter((p) => !paths.some((o) => o !== p && isSameOrDescendant(o, p)))
+}

--- a/src/renderer/src/components/driver-install.ts
+++ b/src/renderer/src/components/driver-install.ts
@@ -1,0 +1,48 @@
+/**
+ * SHARED PART-DRIVER INSTALLER — the one sequence that puts a part's declared
+ * {@link DriverFile} onto the connected board, used by BOTH the Board View's
+ * Driver Install banner (#184) and the main editor's missing-library banner
+ * (#166): a `mip` spec installs via the package manager; anything else (a
+ * bundled filename or an http(s) URL) is read via `parts.readDriverSource` in
+ * main (past the renderer CSP) and copied to its target path, creating each
+ * ancestor folder first (MicroPython has no recursive mkdir).
+ */
+import { driverDeviceDirs, driverInstallMethod } from './part-editor.util'
+import type { DriverFile } from '../../../preload/index.d'
+
+export interface DriverInstallResult {
+  ok: boolean
+  /** A short failure reason for the banner copy (undefined on success). */
+  message?: string
+}
+
+/** Install ONE driver file onto the connected board. Never throws. */
+export async function installPartDriver(
+  libraryId: string,
+  partId: string,
+  d: DriverFile
+): Promise<DriverInstallResult> {
+  try {
+    if (driverInstallMethod(d.source) === 'mip') {
+      const target = d.target.trim()
+      const res = await window.api.packages.install(d.source, target ? { target } : undefined)
+      return res.ok
+        ? { ok: true }
+        : { ok: false, message: res.log.split('\n').filter(Boolean).pop() || 'mip failed' }
+    }
+    // copy: read the file (bundled file or URL, via main) then write to target.
+    const read = await window.api.parts.readDriverSource(libraryId, partId, d.source)
+    if (!read.ok || read.contents == null) {
+      return { ok: false, message: read.error || 'Could not read driver file.' }
+    }
+    // MicroPython has no recursive mkdir — create each ancestor folder in turn
+    // (an "already exists" error is fine, so we swallow it).
+    for (const dir of driverDeviceDirs(d.target)) {
+      await window.api.device.mkdir(dir).catch(() => undefined)
+    }
+    await window.api.device.writeFile(d.target.trim(), read.contents)
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : String(err) }
+  }
+}

--- a/src/renderer/src/components/env-logic.ts
+++ b/src/renderer/src/components/env-logic.ts
@@ -1,0 +1,50 @@
+/**
+ * BAROMETER / ENV instrument logic (#216) — pure helpers for the antique
+ * aneroid-barometer dial: pressure→needle-angle mapping over a classic 270°
+ * sweep, tip geometry, and the weather legend an old barometer prints on its
+ * face. DOM-free and unit-tested.
+ *
+ * Scale: 950…1050 hPa across 270°, needle straight DOWN-LEFT (−135° from 12
+ * o'clock) at 950 and DOWN-RIGHT (+135°) at 1050 — so 1000 hPa points straight
+ * up, like the CHANGE mark on a hallway barometer.
+ */
+
+export const PRESS_MIN = 950
+export const PRESS_MAX = 1050
+
+/** The dial sweep in degrees (a classic three-quarter circle). */
+export const SWEEP_DEG = 270
+
+/** Clamp a pressure to the dial's printed range. Non-finite → the minimum. */
+export function clampPressure(hPa: number): number {
+  if (!Number.isFinite(hPa)) return PRESS_MIN
+  return Math.min(PRESS_MAX, Math.max(PRESS_MIN, hPa))
+}
+
+/**
+ * Needle angle for a pressure, in degrees CLOCKWISE from 12 o'clock:
+ * −135° at 950 hPa … 0° at 1000 … +135° at 1050. Input clamped.
+ */
+export function pressureAngle(hPa: number): number {
+  const f = (clampPressure(hPa) - PRESS_MIN) / (PRESS_MAX - PRESS_MIN)
+  return -SWEEP_DEG / 2 + f * SWEEP_DEG
+}
+
+/** The point at `angleDeg` (clockwise from 12 o'clock) and radius `r` from (cx, cy). */
+export function dialPoint(
+  angleDeg: number,
+  cx: number,
+  cy: number,
+  r: number
+): { x: number; y: number } {
+  const a = (angleDeg * Math.PI) / 180
+  return { x: cx + r * Math.sin(a), y: cy - r * Math.cos(a) }
+}
+
+/** The face legend under the needle — what an antique barometer prints. */
+export function weatherWord(hPa: number): 'RAIN' | 'CHANGE' | 'FAIR' {
+  const p = clampPressure(hPa)
+  if (p < 985) return 'RAIN'
+  if (p < 1015) return 'CHANGE'
+  return 'FAIR'
+}

--- a/src/renderer/src/components/help-content.ts
+++ b/src/renderer/src/components/help-content.ts
@@ -79,7 +79,14 @@ export const HELP_SECTIONS: HelpNode[] = [
         children: [
           { id: 'ref-pins', kind: 'article', title: 'Pins & GPIO', accent: A.page },
           { id: 'ref-timing', kind: 'article', title: 'Timing', accent: A.page },
-          { id: 'ref-print', kind: 'article', title: 'print & the REPL', accent: A.page }
+          { id: 'ref-print', kind: 'article', title: 'print & the REPL', accent: A.page },
+          { id: 'ref-flow', kind: 'article', title: 'Control flow', accent: A.page },
+          { id: 'ref-functions', kind: 'article', title: 'Functions', accent: A.page },
+          { id: 'ref-types', kind: 'article', title: 'Values & types', accent: A.page },
+          { id: 'ref-builtins', kind: 'article', title: 'Built-in functions', accent: A.page },
+          { id: 'ref-classes', kind: 'article', title: 'Classes', accent: A.page },
+          { id: 'ref-exceptions', kind: 'article', title: 'Errors & exceptions', accent: A.page },
+          { id: 'ref-imports', kind: 'article', title: 'Imports & modules', accent: A.page }
         ]
       },
       {

--- a/src/renderer/src/components/help/inst-env.md
+++ b/src/renderer/src/components/help/inst-env.md
@@ -23,7 +23,7 @@ bme = BME280(i2c)
 inst.start()
 inst.watch(weather=bme)     # → SNK BIND weather env (lights up this barometer)
 while True:
-    inst.update()           # → SNK ENV weather <t> <p> <h>
+    inst.update()           # streams: SNK ENV weather t p h
     time.sleep(1)
 ```
 
@@ -31,7 +31,7 @@ Or emit one reading directly:
 
 ```python
 t, p, h = bme.read()
-inst.env(t, p, h)           # SNK ENV env <t> <p> <h>
+inst.env(t, p, h)           # prints: SNK ENV env t p h
 ```
 
 ## Tips

--- a/src/renderer/src/components/help/inst-env.md
+++ b/src/renderer/src/components/help/inst-env.md
@@ -1,0 +1,41 @@
+An antique **aneroid barometer** — brass bezel, cream face, blued needle —
+reading **temperature**, **barometric pressure** and **humidity** from an
+environmental sensor like the BME280.
+
+## What it shows
+- The needle sweeps a classic **950–1050 hPa** scale with the old
+  **RAIN · CHANGE · FAIR** legend; the plaque under the hub gives the exact hPa.
+- **TEMP** (°C), **HUMIDITY** (%RH) and the **OUTLOOK** word read out below.
+- **SRC** picks which reporting sensor channel to read (defaults to `env`).
+
+## Feed it
+Bind the sensor object and let the type drive the panel — or print readings
+yourself:
+
+```python
+import time
+import instruments as inst
+from machine import I2C, Pin
+from bme280 import BME280
+
+i2c = I2C(0, sda=Pin(0), scl=Pin(1))
+bme = BME280(i2c)
+inst.start()
+inst.watch(weather=bme)     # → SNK BIND weather env (lights up this barometer)
+while True:
+    inst.update()           # → SNK ENV weather <t> <p> <h>
+    time.sleep(1)
+```
+
+Or emit one reading directly:
+
+```python
+t, p, h = bme.read()
+inst.env(t, p, h)           # SNK ENV env <t> <p> <h>
+```
+
+## Tips
+- Sea-level pressure is ~**1013 hPa**; a fast fall usually means weather is
+  coming — exactly what the RAIN/CHANGE/FAIR legend is for.
+- Any driver exposing `temperature`, `pressure` and `humidity` (or a
+  `read()` returning all three) binds as an `env` sensor.

--- a/src/renderer/src/components/help/ref-builtins.md
+++ b/src/renderer/src/components/help/ref-builtins.md
@@ -1,0 +1,41 @@
+Built-in functions — always available, no import needed.
+
+## Everyday helpers
+
+```python
+len([1, 2, 3])          # 3 — items in a list/str/dict
+range(5)                # 0..4 (see the Control flow article)
+min(3, 7), max(3, 7)    # 3, 7 — also work on lists
+sum([1, 2, 3])          # 6
+abs(-5)                 # 5
+round(3.14159, 2)       # 3.14
+sorted([3, 1, 2])       # [1, 2, 3] (a new list)
+```
+
+## Looping helpers
+
+```python
+for i, name in enumerate(["red", "green"]):   # index + value
+    print(i, name)
+
+for pin, label in zip([0, 1], ["SDA", "SCL"]):  # pairwise
+    print(pin, label)
+```
+
+## Conversions
+
+```python
+int("42"), float("0.5"), str(3.3)
+hex(60)          # '0x3c' — I2C addresses
+bin(10)          # '0b1010'
+chr(65), ord("A")  # 'A', 65
+```
+
+## In the REPL
+
+```python
+help(machine)      # what a module offers
+dir(i2c)           # every attribute/method on an object
+```
+
+`dir()` is the fastest way to explore a driver you just installed.

--- a/src/renderer/src/components/help/ref-classes.md
+++ b/src/renderer/src/components/help/ref-classes.md
@@ -1,0 +1,51 @@
+Classes — bundle state + behaviour into your own types (every driver is one).
+
+## Defining & using
+
+```python
+class Blinker:
+    """An LED that remembers its own pin and count."""
+
+    def __init__(self, pin_no):
+        self.pin = Pin(pin_no, Pin.OUT)   # per-instance state
+        self.count = 0
+
+    def blink(self):
+        self.pin.toggle()
+        self.count += 1
+
+b = Blinker(25)     # __init__ runs here
+b.blink()
+print(b.count)      # 1
+```
+
+`self` is the instance — every method takes it first, and per-object data
+lives on it (`self.pin`).
+
+## Properties — computed attributes
+
+```python
+class Thermometer:
+    def __init__(self, adc):
+        self._adc = adc
+
+    @property
+    def celsius(self):
+        return 27 - ((self._adc.read_u16() * 3.3 / 65535) - 0.706) / 0.001721
+
+t = Thermometer(ADC(4))
+print(t.celsius)          # no parentheses — reads like a value
+```
+
+The BME280 driver's `.temperature` / `.pressure` / `.humidity` work this way.
+
+## Inheritance
+
+```python
+class QuietBlinker(Blinker):
+    def blink(self):
+        super().blink()     # reuse the parent, then extend
+```
+
+Duck typing matters more than hierarchies in MicroPython: Snakie's
+`inst.watch()` recognises objects purely by the methods they expose.

--- a/src/renderer/src/components/help/ref-exceptions.md
+++ b/src/renderer/src/components/help/ref-exceptions.md
@@ -1,0 +1,45 @@
+Errors & exceptions — hardware misbehaves; `try` keeps your program alive.
+
+## try / except
+
+```python
+try:
+    bme = BME280(i2c)
+except OSError as e:
+    print("sensor not responding:", e)
+    bme = None
+```
+
+`OSError` is the one you'll meet most on hardware — a missing/unwired I2C
+device, a failed file operation ([Errno 5] EIO means the bus transfer failed).
+
+## finally — always runs
+
+```python
+try:
+    f = open("log.txt", "w")
+    f.write("hello")
+finally:
+    f.close()      # runs even if write() blew up
+```
+
+## raise — signal your own errors
+
+```python
+def set_angle(deg):
+    if not 0 <= deg <= 180:
+        raise ValueError("angle must be 0-180")
+```
+
+## Be specific
+
+Catch the narrowest error you can, and keep the `try` block small:
+
+```python
+try:
+    value = int(text)
+except ValueError:
+    value = 0
+```
+
+A bare `except:` hides real bugs (including Ctrl-C!) — avoid it.

--- a/src/renderer/src/components/help/ref-flow.md
+++ b/src/renderer/src/components/help/ref-flow.md
@@ -1,0 +1,59 @@
+Control flow — deciding and repeating. MicroPython uses standard Python syntax:
+indentation (4 spaces) marks the block.
+
+## if / elif / else
+
+```python
+temp = 21.5
+if temp > 30:
+    print("hot")
+elif temp > 15:
+    print("comfortable")
+else:
+    print("cold")
+```
+
+Conditions combine with `and`, `or`, `not`; membership tests use `in`;
+identity uses `is` (mostly for `None`: `if reading is None:`).
+
+## while — repeat until told to stop
+
+```python
+from machine import Pin
+import time
+
+led = Pin("LED", Pin.OUT)
+while True:          # the classic firmware main loop
+    led.toggle()
+    time.sleep(0.5)
+```
+
+## for — repeat over a sequence
+
+```python
+for n in range(5):        # 0, 1, 2, 3, 4
+    print(n)
+
+for name in ["red", "green", "blue"]:
+    print(name)
+```
+
+## break · continue · pass
+
+```python
+while True:
+    if button.value() == 0:
+        break        # leave the loop entirely
+    if sensor_busy():
+        continue     # skip to the next iteration
+    read_sensor()
+
+def todo():
+    pass             # a do-nothing placeholder body
+```
+
+## Tips
+
+- A bare `while True:` with a small `time.sleep()` is the normal shape of a
+  MicroPython program — see the Timing article for non-blocking loops.
+- Truthiness: `0`, `""`, `[]`, `{}` and `None` all read as `False`.

--- a/src/renderer/src/components/help/ref-functions.md
+++ b/src/renderer/src/components/help/ref-functions.md
@@ -1,0 +1,53 @@
+Functions — name a block of code once, run it whenever you need it.
+
+## def & return
+
+```python
+def celsius_to_f(c):
+    return c * 9 / 5 + 32
+
+print(celsius_to_f(21.5))    # 70.7
+```
+
+`return` hands a value back (and ends the function). Without one, a function
+returns `None`.
+
+## Default + keyword arguments
+
+```python
+def blink(pin, times=3, delay=0.2):
+    for _ in range(times):
+        pin.toggle()
+        time.sleep(delay)
+
+blink(led)                    # uses the defaults
+blink(led, times=10)          # override by name
+```
+
+## Docstrings
+
+```python
+def read_average(adc, samples=8):
+    """Mean of several ADC reads (smooths a noisy pot)."""
+    return sum(adc.read_u16() for _ in range(samples)) / samples
+```
+
+## lambda — a tiny inline function
+
+```python
+by_second = sorted(pairs, key=lambda p: p[1])
+```
+
+## Scope: global & nonlocal
+
+Assigning inside a function makes a NEW local name unless you say otherwise:
+
+```python
+count = 0
+
+def tick():
+    global count      # write the module-level variable
+    count += 1
+```
+
+Prefer returning values over `global` — it keeps programs testable.

--- a/src/renderer/src/components/help/ref-imports.md
+++ b/src/renderer/src/components/help/ref-imports.md
@@ -1,0 +1,33 @@
+Imports — bring modules (built-in, or files on the board) into your program.
+
+## The forms
+
+```python
+import time                     # use as time.sleep(...)
+from machine import Pin, PWM    # pull names in directly
+import instruments as inst      # rename for brevity
+```
+
+## Where modules come from
+
+`import servo` searches, in order:
+1. built-ins compiled into the firmware (`machine`, `time`, `os`, …)
+2. the board's filesystem: `/` then `/lib`
+
+So installing a driver = copying `servo.py` to `/lib/servo.py` — exactly what
+Snakie's Install buttons do (parts banner, Driver Install, Packages).
+
+## Seeing what's available
+
+```python
+help("modules")     # every importable module on the board
+```
+
+## Gotchas
+
+- An `ImportError` means the module isn't on the board — Snakie's banner
+  offers a one-click install when a placed part needs it.
+- Naming your own file the same as a module it imports (a `time.py` that does
+  `import time`) shadows the real one — pick a different filename.
+- Modules run ONCE on first import (then they're cached in `sys.modules`);
+  a soft reset (Ctrl-D) clears the cache and re-runs them.

--- a/src/renderer/src/components/help/ref-types.md
+++ b/src/renderer/src/components/help/ref-types.md
@@ -1,0 +1,58 @@
+Values and their types — what your variables hold.
+
+## Numbers
+
+```python
+n = 42               # int (arbitrary precision)
+duty = 0.75          # float
+addr = 0x3C          # hex int (I2C addresses read naturally)
+mask = 0b1010        # binary int
+big = int("123")     # convert a string
+level = float("0.5")
+```
+
+## Strings
+
+```python
+name = "Snakie"
+msg = f"hello {name}, temp={21.5:.1f}"   # f-string formatting
+line = "gp0,gp1".split(",")              # -> ['gp0', 'gp1']
+n = int("42")                            # str -> int
+```
+
+## bool & None
+
+```python
+ready = True
+missing = None            # "no value"
+if reading is None: ...   # test with `is`
+```
+
+## Collections
+
+```python
+pins = [0, 1, 4, 5]              # list  — ordered, mutable
+pins.append(12)
+point = (3, 7)                   # tuple — ordered, IMMUTABLE (a, b = point)
+config = {"sda": 12, "scl": 13}  # dict  — key -> value
+config["freq"] = 100_000
+seen = {0x3C, 0x68}              # set   — unique members
+```
+
+## bytes & bytearray
+
+Binary data for buses and files — what `I2C.readfrom` returns:
+
+```python
+data = bytes([0x00, 0xFF])
+buf = bytearray(8)          # mutable, fixed length
+i2c.readfrom_into(0x68, buf)
+value = buf[0] << 8 | buf[1]
+```
+
+## Checking a type
+
+```python
+type(42)                 # <class 'int'>
+isinstance(x, float)     # True / False
+```

--- a/src/renderer/src/components/i2c-known-devices.ts
+++ b/src/renderer/src/components/i2c-known-devices.ts
@@ -1,0 +1,66 @@
+/**
+ * KNOWN I²C DEVICES (#214) — a curated 7-bit-address → device-name table so the
+ * I²C-detect instrument can say what a found address probably is, and match it
+ * back to installed library parts (via {@link PartDefinition.i2cAddresses}).
+ * Pure + DOM-free (unit-tested).
+ */
+import type { PartDefinition } from '../../../shared/part'
+
+/** Well-known devices per 7-bit address (the usual breakout suspects). */
+export const KNOWN_I2C_DEVICES: Record<number, string[]> = {
+  0x0c: ['AK09916 magnetometer'],
+  0x1d: ['ADXL345 accelerometer', 'LSM303 accel'],
+  0x1e: ['HMC5883L magnetometer', 'LSM303 mag'],
+  0x23: ['BH1750 light sensor'],
+  0x27: ['PCF8574 I/O expander (LCD backpack)'],
+  0x29: ['VL53L0X / VL53L1X ToF', 'TSL2591 light', 'BNO055 IMU (alt)'],
+  0x38: ['AHT10 / AHT20 temp+humidity', 'FT6206 touch'],
+  0x39: ['APDS-9960 gesture/colour', 'TSL2561 light'],
+  0x3c: ['SSD1306 / SH1106 OLED'],
+  0x3d: ['SSD1306 / SH1106 OLED (alt)'],
+  0x40: ['PCA9685 PWM driver', 'INA219 current', 'HTU21D / Si7021 humidity'],
+  0x48: ['ADS1115 / ADS1015 ADC', 'TMP102 temp', 'PCF8591'],
+  0x49: ['ADS1115 ADC (alt)', 'TSL2561 light (alt)'],
+  0x4a: ['ADS1115 ADC (alt)'],
+  0x53: ['ADXL345 accelerometer (alt)'],
+  0x57: ['MAX30102 pulse oximeter', 'AT24C32 EEPROM'],
+  0x5a: ['MLX90614 IR thermometer', 'CCS811 air quality'],
+  0x5b: ['CCS811 air quality (alt)'],
+  0x60: ['MPL3115A2 pressure', 'ATECC608 crypto', 'SI1145 UV'],
+  0x68: ['ICM-20948 / MPU-6050 / MPU-9250 IMU', 'DS1307 / DS3231 RTC'],
+  0x69: ['ICM-20948 / MPU IMU (alt)'],
+  0x70: ['TCA9548A I²C mux', 'HT16K33 LED matrix'],
+  0x76: ['BME280 / BMP280 environmental'],
+  0x77: ['BME280 / BMP280 environmental (alt)', 'BME680'],
+  0x5c: ['AM2320 temp+humidity', 'LPS25 pressure']
+}
+
+/** Human names for a found address — `[]` when we don't recognise it. */
+export function knownDevicesFor(addr: number): string[] {
+  return KNOWN_I2C_DEVICES[addr] ?? []
+}
+
+/** One matched library part for an address (the Add offer). */
+export interface AddressPartMatch {
+  libraryId: string
+  part: PartDefinition
+}
+
+/** Installed library parts declaring `i2cAddresses` that include `addr`. */
+export function partsForAddress(
+  addr: number,
+  libraries: { id: string; parts: PartDefinition[] }[]
+): AddressPartMatch[] {
+  const out: AddressPartMatch[] = []
+  for (const lib of libraries) {
+    for (const part of lib.parts) {
+      if (part.i2cAddresses?.includes(addr)) out.push({ libraryId: lib.id, part })
+    }
+  }
+  return out
+}
+
+/** Format a 7-bit address the way the grid does (`0x68`). */
+export function hexAddr(addr: number): string {
+  return `0x${addr.toString(16).toUpperCase().padStart(2, '0')}`
+}

--- a/src/renderer/src/components/imu-logic.ts
+++ b/src/renderer/src/components/imu-logic.ts
@@ -240,3 +240,34 @@ export function formatAngle(deg: number): string {
   const sign = v > 0 ? '+' : v < 0 ? '−' : ' '
   return `${sign}${Math.abs(v).toFixed(1)}°`
 }
+
+// --- Compass (#215) ---------------------------------------------------------
+
+/**
+ * Compass HEADING (0..360°, clockwise from North) from the IMU's yaw. Yaw is a
+ * right-hand rotation about Z (counter-clockwise positive, (−180, 180]); a
+ * compass heading runs the other way — so heading = (−yaw) normalised to
+ * [0, 360). Pure; non-finite → 0.
+ */
+export function headingFromYaw(yawDeg: number): number {
+  if (!Number.isFinite(yawDeg)) return 0
+  return ((-yawDeg % 360) + 360) % 360
+}
+
+/** The 16-wind compass rose, clockwise from North (22.5° per point). */
+export const CARDINALS = [
+  'N', 'NNE', 'NE', 'ENE', 'E', 'ESE', 'SE', 'SSE',
+  'S', 'SSW', 'SW', 'WSW', 'W', 'WNW', 'NW', 'NNW'
+] as const
+
+/** The 16-wind cardinal name nearest a heading (0..360, wraps). Pure. */
+export function cardinalFor(heading: number): string {
+  const h = ((heading % 360) + 360) % 360
+  return CARDINALS[Math.round(h / 22.5) % 16]
+}
+
+/** Format a heading for the compass readout: zero-padded whole degrees (`237°`). */
+export function formatHeading(heading: number): string {
+  const h = Number.isFinite(heading) ? ((heading % 360) + 360) % 360 : 0
+  return `${String(Math.round(h) % 360).padStart(3, '0')}°`
+}

--- a/src/renderer/src/components/instrument-telemetry.ts
+++ b/src/renderer/src/components/instrument-telemetry.ts
@@ -107,6 +107,17 @@ export interface ImuQuatTelemetry {
   y: number
   z: number
 }
+/** An environmental reading (#216): temperature / pressure / humidity in one. */
+export interface EnvTelemetry {
+  kind: 'env'
+  ch: string
+  /** Temperature in °C. */
+  temp: number
+  /** Barometric pressure in hPa. */
+  pressure: number
+  /** Relative humidity in %RH. */
+  humidity: number
+}
 /** A range/distance reading in mm, with an optional servo/lidar bearing (deg). */
 export interface DistanceTelemetry {
   kind: 'dist'
@@ -185,6 +196,7 @@ export type Telemetry =
   | PlotTelemetry
   | ImuTelemetry
   | ImuQuatTelemetry
+  | EnvTelemetry
   | DistanceTelemetry
   | ButtonTelemetry
   | EncoderTelemetry
@@ -216,6 +228,7 @@ export function isTelemetry(line: string): boolean {
  *   - `SNK PLOT <tok> ...`                → `{ kind:'plot', series:[…] }`
  *   - `SNK IMU <ch> <r> <p> <y>`          → `{ kind:'imu', ch, roll, pitch, yaw }`
  *   - `SNK IMUQ <ch> <w> <x> <y> <z>`     → `{ kind:'imuq', ch, w, x, y, z }`
+ *   - `SNK ENV <ch> <t> <p> <h>`          → `{ kind:'env', ch, temp, pressure, humidity }`
  *   - `SNK DIST <ch> <mm> [<angle>]`      → `{ kind:'dist', ch, mm, angle? }`
  *   - `SNK BTN <name> <0|1>`              → `{ kind:'btn', name, pressed }`
  *   - `SNK ENC <ch> <count> [<0|1>]`      → `{ kind:'enc', ch, count, pressed? }`
@@ -302,6 +315,16 @@ export function parseTelemetry(line: string): Telemetry | null {
     const z = Number(parts[6])
     if (!ch || ![w, x, y, z].every(Number.isFinite)) return null
     return { kind: 'imuq', ch, w, x, y, z }
+  }
+
+  if (kind === 'ENV') {
+    // SNK ENV <ch> <temp °C> <pressure hPa> <humidity %RH> (#216)
+    const ch = parts[2]
+    const temp = Number(parts[3])
+    const pressure = Number(parts[4])
+    const humidity = Number(parts[5])
+    if (!ch || ![temp, pressure, humidity].every(Number.isFinite)) return null
+    return { kind: 'env', ch, temp, pressure, humidity }
   }
 
   if (kind === 'DIST') {

--- a/src/renderer/src/components/instruments-registry.ts
+++ b/src/renderer/src/components/instruments-registry.ts
@@ -170,6 +170,18 @@ export const INSTRUMENTS: InstrumentDef[] = [
     hints: ['imu', 'mpu6050', 'mpu9250', 'lsm', 'icm20948', 'bno055', 'accel', 'gyro']
   },
   {
+    id: 'env',
+    name: 'Barometer',
+    accent: '#b58a3a',
+    border: 'rgba(181,138,58,.5)',
+    // an aneroid dial: circle + needle
+    icon: 'M12 4 a8 8 0 1 1 0 16 a8 8 0 1 1 0 -16 M12 12 L16 8 M12 12 v0.01',
+    group: 'input',
+    kind: 'singleton',
+    description: 'Temperature, pressure and humidity on an antique barometer.',
+    hints: ['bme280', 'bmp280', 'bme680', 'dht22', 'dht11', 'sht31', 'aht20', 'barometer', 'weather']
+  },
+  {
     id: 'led',
     name: 'LED',
     accent: '#ff6b5e',
@@ -393,7 +405,8 @@ export const BOUND_KIND_INSTRUMENTS: Record<string, string[]> = {
   adc: ['meter', 'scope', 'pot'],
   i2c: ['i2c-detect'],
   pin: ['led', 'button'],
-  imu: ['imu']
+  imu: ['imu'],
+  env: ['env']
 }
 
 /** The instrument ids to mark in-use for the currently-bound objects (`name→kind`). */

--- a/src/renderer/src/components/part-imports.ts
+++ b/src/renderer/src/components/part-imports.ts
@@ -8,7 +8,7 @@
  * what's installed on the board, and surface a banner. All DOM-free + unit-tested.
  */
 import type { RobotDefinition } from '../../../shared/robot'
-import type { PartDefinition } from '../../../shared/part'
+import type { DriverFile, PartDefinition } from '../../../shared/part'
 
 /** A library module the project's parts need, with where to get it + which parts. */
 export interface RequiredModule {
@@ -17,6 +17,12 @@ export interface RequiredModule {
   docs?: string
   /** Part labels that need this module (for the banner copy). */
   parts: string[]
+  /** The part that declares this module (drives the bundled-driver install). */
+  libraryId?: string
+  partId?: string
+  /** Bundled driver file(s) the part ships — the banner's Install copies these
+   *  to the board when there's no mip `url` (the SG90/BME280/ICM20948 model). */
+  drivers?: DriverFile[]
 }
 
 /** Top-level module names a Python source file imports (best-effort, line-based). */
@@ -62,7 +68,16 @@ export function requiredPartModules(
     if (existing) {
       if (!existing.parts.includes(label)) existing.parts.push(label)
     } else {
-      byModule.set(mod, { module: mod, url: part?.library?.url, docs: part?.library?.docs, parts: [label] })
+      byModule.set(mod, {
+        module: mod,
+        url: part?.library?.url,
+        docs: part?.library?.docs,
+        parts: [label],
+        // Where the module's bundled drivers live (for the one-click install).
+        libraryId: lib?.id,
+        partId: part?.id,
+        drivers: part?.drivers
+      })
     }
   }
   return [...byModule.values()]

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -265,6 +265,14 @@
   background: linear-gradient(180deg, #fbfbfd, #cdd1d8);
 }
 
+/* A ghost-style danger key (e.g. the Device Files panel's Delete) keeps the
+ * silver ghost body, so the domed red pill's WHITE text is unreadable on it —
+ * read dark exactly like its sibling ghost buttons instead. */
+:root[data-theme='skeuomorph'] .btn--ghost.btn--danger {
+  color: #4a4e56;
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
+}
+
 :root[data-theme='skeuomorph'] .btn--ghost.is-active {
   background: linear-gradient(180deg, #bcc0c8, #d6dae1);
   border-color: #8d9099;

--- a/src/shared/part-yaml.ts
+++ b/src/shared/part-yaml.ts
@@ -314,6 +314,7 @@ export function partToYaml(part: PartDefinition): string {
     // NB: `help` (the filename) is kept; `helpText` (the inlined markdown) is NOT.
     help: part.help,
     schematic: part.schematic,
+    i2cAddresses: part.i2cAddresses,
     library: part.library,
     drivers: part.drivers?.map(driverToObj),
     layerVisibility: part.layerVisibility
@@ -554,6 +555,14 @@ export function partFromYaml(text: string): PartDefinition {
         if (aspect !== undefined) part.schematic.aspect = aspect
       }
     }
+  }
+
+  // I²C address list (#214): accepts numbers or hex strings ("0x76"), 7-bit range.
+  if (Array.isArray(raw.i2cAddresses)) {
+    const addrs = raw.i2cAddresses
+      .map((a) => (typeof a === 'string' ? Number(a) : (a as number)))
+      .filter((a): a is number => Number.isInteger(a) && a >= 0 && a <= 0x7f)
+    if (addrs.length) part.i2cAddresses = addrs
   }
 
   if (raw.library && typeof raw.library === 'object' && !Array.isArray(raw.library)) {

--- a/src/shared/part.ts
+++ b/src/shared/part.ts
@@ -458,6 +458,15 @@ export interface PartDefinition {
   /** Optional schematic symbol (line-drawing) for the schematic view. */
   schematic?: PartSchematic
 
+  // --- I²C identity (#214) --------------------------------------------------
+  /**
+   * The I²C address(es) this part can answer on (7-bit, e.g. `[0x76, 0x77]` for
+   * a BME280 with its ADDR strap). The I²C-detect instrument uses these to match
+   * a found bus address back to library parts and offer to add them to the
+   * project. Absent ⇒ the part isn't matched by address.
+   */
+  i2cAddresses?: number[]
+
   // --- Code library (#166) -------------------------------------------------
   /** A MicroPython driver/library linked to this part. */
   library?: PartLibraryLink

--- a/test/busWires.test.ts
+++ b/test/busWires.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import {
+  busLabel,
+  classifyBusWire,
+  i2cBusForGpio,
+  spiBusForGpio
+} from '../src/renderer/src/components/bus-wires'
+
+describe('RP-family bus derivation (#217)', () => {
+  it('I2C block from the GPIO (%4 rule)', () => {
+    expect(i2cBusForGpio(0)).toBe(0) // SDA0
+    expect(i2cBusForGpio(1)).toBe(0) // SCL0
+    expect(i2cBusForGpio(2)).toBe(1) // SDA1
+    expect(i2cBusForGpio(3)).toBe(1) // SCL1
+    expect(i2cBusForGpio(20)).toBe(0)
+    expect(i2cBusForGpio(21)).toBe(0)
+    expect(i2cBusForGpio(undefined)).toBeNull()
+  })
+  it('SPI block from the GPIO (banks of 8)', () => {
+    expect(spiBusForGpio(2)).toBe(0)
+    expect(spiBusForGpio(19)).toBe(0)
+    expect(spiBusForGpio(10)).toBe(1)
+    expect(spiBusForGpio(26)).toBe(1)
+    expect(spiBusForGpio(undefined)).toBeNull()
+  })
+  it('labels', () => {
+    expect(busLabel('i2c', 0)).toBe('I2C0')
+    expect(busLabel('spi', 1)).toBe('SPI1')
+    expect(busLabel('i2c', null)).toBe('I2C')
+  })
+})
+
+describe('bus wire classification (#217)', () => {
+  it('part SDA → MCU pad = I2C, bus derived from the pad gpio', () => {
+    const wire = classifyBusWire(
+      { caps: ['i2c'], signals: { i2c: 'SDA' } }, // part pin (no gpio)
+      { gpio: 12 } // Tiny 2350 Qwiic SDA (I2C0)
+    )
+    expect(wire).toEqual({ kind: 'i2c', bus: 0, label: 'I2C0' })
+  })
+  it('an authored bus id on either end wins over the derivation', () => {
+    const wire = classifyBusWire({ caps: ['i2c'], buses: { i2c: 1 } }, { gpio: 0 })
+    expect(wire?.label).toBe('I2C1')
+  })
+  it('SPI classifies with its own derivation', () => {
+    const wire = classifyBusWire({ caps: ['spi'] }, { gpio: 10 })
+    expect(wire).toEqual({ kind: 'spi', bus: 1, label: 'SPI1' })
+  })
+  it('no i2c/spi capability anywhere → not a bus wire', () => {
+    expect(classifyBusWire({ caps: ['digital', 'pwm'] }, { gpio: 5 })).toBeNull()
+    expect(classifyBusWire({}, {})).toBeNull()
+  })
+  it('no gpio + no authored bus → bare label', () => {
+    expect(classifyBusWire({ caps: ['i2c'] }, {})).toEqual({ kind: 'i2c', bus: null, label: 'I2C' })
+  })
+})

--- a/test/contextHelp.test.ts
+++ b/test/contextHelp.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { resolveHelpTarget, LANGUAGE_HELP } from '../src/renderer/src/components/context-help'
+import type { PartDefinition } from '../src/shared/part'
+
+const bme: PartDefinition = {
+  id: 'bme280',
+  name: 'BME280 Breakout',
+  headers: [],
+  library: { module: 'bme280' }
+}
+const servo: PartDefinition = {
+  id: 'sg90',
+  name: 'SG90 Micro Servo',
+  headers: [],
+  library: { module: 'servo' }
+}
+const libs = [{ id: 'snakie-standard', parts: [bme, servo] }]
+
+describe('context help resolver (#221)', () => {
+  it('resolves an installed part by import module or id (case-insensitive)', () => {
+    expect(resolveHelpTarget('bme280', libs)).toEqual({ articleId: 'part-bme280', title: 'BME280 Breakout' })
+    expect(resolveHelpTarget('BME280', libs)?.articleId).toBe('part-bme280')
+    expect(resolveHelpTarget('servo', libs)?.articleId).toBe('part-sg90') // by module
+    expect(resolveHelpTarget('sg90', libs)?.articleId).toBe('part-sg90') // by id
+  })
+  it('resolves language-reference symbols', () => {
+    expect(resolveHelpTarget('Pin', [])?.articleId).toBe('ref-pins')
+    expect(resolveHelpTarget('PWM', [])?.articleId).toBe('ref-pwm')
+    expect(resolveHelpTarget('I2C', [])?.articleId).toBe('ref-i2c')
+    expect(resolveHelpTarget('sleep_ms', [])?.articleId).toBe('ref-timing')
+    expect(resolveHelpTarget('print', [])?.articleId).toBe('ref-print')
+  })
+  it('parts win over the language table', () => {
+    // A hypothetical part whose module collides with a language symbol.
+    const pwmPart: PartDefinition = { id: 'pca9685', name: 'PCA9685', headers: [], library: { module: 'pwm' } }
+    const r = resolveHelpTarget('pwm', [{ id: 'x', parts: [pwmPart] }])
+    expect(r?.articleId).toBe('part-pca9685')
+  })
+  it('unknown / empty → null', () => {
+    expect(resolveHelpTarget('banana', libs)).toBeNull()
+    expect(resolveHelpTarget('', libs)).toBeNull()
+    expect(resolveHelpTarget(null, libs)).toBeNull()
+  })
+  it('every language topic points at a real ref-article id', () => {
+    for (const id of Object.values(LANGUAGE_HELP)) expect(id).toMatch(/^ref-[a-z0-9]+$/)
+  })
+})

--- a/test/contextHelp.test.ts
+++ b/test/contextHelp.test.ts
@@ -30,6 +30,31 @@ describe('context help resolver (#221)', () => {
     expect(resolveHelpTarget('sleep_ms', [])?.articleId).toBe('ref-timing')
     expect(resolveHelpTarget('print', [])?.articleId).toBe('ref-print')
   })
+  it('resolves standard Python keywords, types and built-ins', () => {
+    // keywords → control flow / functions / classes / exceptions / imports
+    expect(resolveHelpTarget('while', [])?.articleId).toBe('ref-flow')
+    expect(resolveHelpTarget('elif', [])?.articleId).toBe('ref-flow')
+    expect(resolveHelpTarget('def', [])?.articleId).toBe('ref-functions')
+    expect(resolveHelpTarget('return', [])?.articleId).toBe('ref-functions')
+    expect(resolveHelpTarget('class', [])?.articleId).toBe('ref-classes')
+    expect(resolveHelpTarget('self', [])?.articleId).toBe('ref-classes')
+    expect(resolveHelpTarget('try', [])?.articleId).toBe('ref-exceptions')
+    expect(resolveHelpTarget('OSError', [])?.articleId).toBe('ref-exceptions')
+    expect(resolveHelpTarget('import', [])?.articleId).toBe('ref-imports')
+    // types + built-ins
+    expect(resolveHelpTarget('dict', [])?.articleId).toBe('ref-types')
+    expect(resolveHelpTarget('bytearray', [])?.articleId).toBe('ref-types')
+    expect(resolveHelpTarget('None', [])?.articleId).toBe('ref-types')
+    expect(resolveHelpTarget('len', [])?.articleId).toBe('ref-builtins')
+    expect(resolveHelpTarget('range', [])?.articleId).toBe('ref-builtins')
+    expect(resolveHelpTarget('enumerate', [])?.articleId).toBe('ref-builtins')
+  })
+  it('every language topic maps to a registered help article with content', async () => {
+    const { HELP_ARTICLES } = await import('../src/renderer/src/components/help-articles')
+    for (const id of new Set(Object.values(LANGUAGE_HELP))) {
+      expect((HELP_ARTICLES[id] ?? '').length, id).toBeGreaterThan(100)
+    }
+  })
   it('parts win over the language table', () => {
     // A hypothetical part whose module collides with a language symbol.
     const pwmPart: PartDefinition = { id: 'pca9685', name: 'PCA9685', headers: [], library: { module: 'pwm' } }

--- a/test/deviceTreeModel.test.ts
+++ b/test/deviceTreeModel.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import {
+  flattenTree,
+  isSameOrDescendant,
+  joinDevicePath,
+  nextSelection,
+  parentDevicePath,
+  planMove,
+  pruneNested
+} from '../src/renderer/src/components/device-tree-model'
+import type { DirEntry } from '../src/preload/index.d'
+
+const d = (name: string): DirEntry => ({ name, isDir: true })
+const f = (name: string): DirEntry => ({ name, isDir: false })
+
+const dirs = new Map<string, DirEntry[]>([
+  ['/', [d('lib'), f('main.py'), f('boot.py')]],
+  ['/lib', [f('servo.py'), f('bme280.py')]]
+])
+
+describe('device tree flatten (#219)', () => {
+  it('walks visible rows depth-first, honouring expansion', () => {
+    const collapsed = flattenTree(dirs, new Set())
+    expect(collapsed.map((r) => r.path)).toEqual(['/lib', '/main.py', '/boot.py'])
+    const open = flattenTree(dirs, new Set(['/lib']))
+    expect(open.map((r) => r.path)).toEqual(['/lib', '/lib/servo.py', '/lib/bme280.py', '/main.py', '/boot.py'])
+    expect(open[1].depth).toBe(1)
+    expect(open[3].depth).toBe(0)
+  })
+  it('an expanded but unloaded dir contributes nothing', () => {
+    expect(flattenTree(dirs, new Set(['/nope'])).length).toBe(3)
+  })
+})
+
+describe('selection transitions (#219)', () => {
+  const rows = flattenTree(dirs, new Set(['/lib']))
+  it('single click selects only that row', () => {
+    const r = nextSelection(new Set(['/main.py']), '/main.py', rows, '/boot.py', 'single')
+    expect([...r.selection]).toEqual(['/boot.py'])
+    expect(r.anchor).toBe('/boot.py')
+  })
+  it('ctrl/cmd toggles membership', () => {
+    const on = nextSelection(new Set(['/main.py']), '/main.py', rows, '/boot.py', 'toggle')
+    expect(on.selection).toEqual(new Set(['/main.py', '/boot.py']))
+    const off = nextSelection(on.selection, on.anchor, rows, '/main.py', 'toggle')
+    expect(off.selection).toEqual(new Set(['/boot.py']))
+  })
+  it('shift selects the visible range from the anchor (either direction)', () => {
+    const down = nextSelection(new Set(['/lib']), '/lib', rows, '/main.py', 'range')
+    expect(down.selection).toEqual(new Set(['/lib', '/lib/servo.py', '/lib/bme280.py', '/main.py']))
+    expect(down.anchor).toBe('/lib') // anchor sticks for further ranges
+    const up = nextSelection(new Set(['/main.py']), '/main.py', rows, '/lib/servo.py', 'range')
+    expect(up.selection).toEqual(new Set(['/lib/servo.py', '/lib/bme280.py', '/main.py']))
+  })
+  it('shift with no anchor falls back to single', () => {
+    const r = nextSelection(new Set(), null, rows, '/main.py', 'range')
+    expect([...r.selection]).toEqual(['/main.py'])
+  })
+})
+
+describe('move planning (#219)', () => {
+  it('plans a rename per source into the destination', () => {
+    expect(planMove(['/main.py', '/boot.py'], '/lib')).toEqual([
+      { from: '/main.py', to: '/lib/main.py' },
+      { from: '/boot.py', to: '/lib/boot.py' }
+    ])
+  })
+  it('skips no-ops and illegal folder-into-itself moves', () => {
+    expect(planMove(['/lib/servo.py'], '/lib')).toEqual([]) // already there
+    expect(planMove(['/lib'], '/lib')).toEqual([]) // into itself
+    expect(planMove(['/lib'], '/lib/sub')).toEqual([]) // into its own child
+  })
+  it('drops sources nested under another dragged source', () => {
+    expect(planMove(['/lib', '/lib/servo.py'], '/x')).toEqual([{ from: '/lib', to: '/x/lib' }])
+  })
+})
+
+describe('path helpers (#219)', () => {
+  it('join/parent round-trip', () => {
+    expect(joinDevicePath('/', 'a.py')).toBe('/a.py')
+    expect(joinDevicePath('/lib', 'a.py')).toBe('/lib/a.py')
+    expect(parentDevicePath('/lib/a.py')).toBe('/lib')
+    expect(parentDevicePath('/a.py')).toBe('/')
+  })
+  it('descendant + prune', () => {
+    expect(isSameOrDescendant('/lib', '/lib/x/y')).toBe(true)
+    expect(isSameOrDescendant('/lib', '/library')).toBe(false)
+    expect(pruneNested(['/lib', '/lib/servo.py', '/main.py'])).toEqual(['/lib', '/main.py'])
+  })
+})

--- a/test/envInstrument.test.ts
+++ b/test/envInstrument.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { parseTelemetry } from '../src/renderer/src/components/instrument-telemetry'
+import {
+  clampPressure,
+  dialPoint,
+  pressureAngle,
+  weatherWord,
+  PRESS_MIN,
+  PRESS_MAX
+} from '../src/renderer/src/components/env-logic'
+import { EnvInstrument } from '../src/renderer/src/components/EnvInstrument'
+import { INSTRUMENTS, instrumentById } from '../src/renderer/src/components/instruments-registry'
+
+describe('SNK ENV telemetry (#216)', () => {
+  it('parses temp / pressure / humidity with the channel', () => {
+    expect(parseTelemetry('SNK ENV env 21.5 1013.2 45.0')).toEqual({
+      kind: 'env',
+      ch: 'env',
+      temp: 21.5,
+      pressure: 1013.2,
+      humidity: 45.0
+    })
+    expect(parseTelemetry('SNK ENV attic 20 990 60')).toMatchObject({ ch: 'attic', pressure: 990 })
+  })
+  it('rejects malformed ENV lines', () => {
+    expect(parseTelemetry('SNK ENV env 21.5 1013.2')).toBeNull() // missing humidity
+    expect(parseTelemetry('SNK ENV env x y z')).toBeNull()
+  })
+})
+
+describe('barometer dial geometry (#216)', () => {
+  it('maps the printed range across the 270° sweep', () => {
+    expect(pressureAngle(PRESS_MIN)).toBe(-135)
+    expect(pressureAngle(1000)).toBe(0) // straight up = CHANGE
+    expect(pressureAngle(PRESS_MAX)).toBe(135)
+  })
+  it('clamps out-of-range + non-finite pressure', () => {
+    expect(clampPressure(0)).toBe(PRESS_MIN)
+    expect(clampPressure(2000)).toBe(PRESS_MAX)
+    expect(clampPressure(Number.NaN)).toBe(PRESS_MIN)
+    expect(pressureAngle(900)).toBe(-135)
+  })
+  it('dialPoint: 0° is straight up, 90° is right', () => {
+    const up = dialPoint(0, 100, 88, 74)
+    expect(up.x).toBeCloseTo(100)
+    expect(up.y).toBeCloseTo(14)
+    const right = dialPoint(90, 100, 88, 74)
+    expect(right.x).toBeCloseTo(174)
+    expect(right.y).toBeCloseTo(88)
+  })
+  it('prints the antique legend', () => {
+    expect(weatherWord(960)).toBe('RAIN')
+    expect(weatherWord(1000)).toBe('CHANGE')
+    expect(weatherWord(1030)).toBe('FAIR')
+  })
+})
+
+describe('EnvInstrument render (#216)', () => {
+  const def = instrumentById('env')!
+  it('registers the env singleton with BME-ish hints', () => {
+    expect(def.kind).toBe('singleton')
+    expect(def.group).toBe('input')
+    expect(def.hints).toContain('bme280')
+    expect(INSTRUMENTS.filter((d) => d.id === 'env')).toHaveLength(1)
+  })
+  it('draws the aneroid face: bezel, dial, legend, needle + no-data readouts', () => {
+    const html = renderToStaticMarkup(createElement(EnvInstrument, { def, docked: true }))
+    expect(html).toContain('envbaro__bezel')
+    expect(html).toContain('envbaro__dial')
+    expect(html).toContain('envbaro__needle')
+    expect(html).toContain('RAIN')
+    expect(html).toContain('CHANGE')
+    expect(html).toContain('FAIR')
+    // Major scale numbers 950..1050.
+    expect(html).toContain('>950<')
+    expect(html).toContain('>1050<')
+    // No data yet → dashes in the cells.
+    expect(html).toContain('TEMP')
+    expect(html).toContain('HUMIDITY')
+    expect(html).toContain('——')
+  })
+})

--- a/test/i2cKnownDevices.test.ts
+++ b/test/i2cKnownDevices.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import {
+  hexAddr,
+  knownDevicesFor,
+  partsForAddress
+} from '../src/renderer/src/components/i2c-known-devices'
+import { partFromYaml, partToYaml } from '../src/shared/part-yaml'
+import type { PartDefinition } from '../src/shared/part'
+
+describe('known I2C devices (#214)', () => {
+  it('names the usual suspects', () => {
+    expect(knownDevicesFor(0x3c).join(' ')).toContain('SSD1306')
+    expect(knownDevicesFor(0x68).join(' ')).toContain('ICM-20948')
+    expect(knownDevicesFor(0x76).join(' ')).toContain('BME280')
+  })
+  it('returns [] for an unknown address', () => {
+    expect(knownDevicesFor(0x7f)).toEqual([])
+  })
+  it('formats addresses like the grid', () => {
+    expect(hexAddr(0x68)).toBe('0x68')
+    expect(hexAddr(0x03)).toBe('0x03')
+  })
+})
+
+describe('partsForAddress (#214)', () => {
+  const bme: PartDefinition = { id: 'bme280', name: 'BME280', headers: [], i2cAddresses: [0x76, 0x77] }
+  const icm: PartDefinition = { id: 'icm20948', name: 'ICM20948', headers: [], i2cAddresses: [0x68, 0x69] }
+  const servo: PartDefinition = { id: 'sg90', name: 'SG90', headers: [] } // no addresses
+  const libs = [{ id: 'snakie-standard', parts: [bme, icm, servo] }]
+
+  it('matches installed parts by declared address', () => {
+    expect(partsForAddress(0x76, libs)).toEqual([{ libraryId: 'snakie-standard', part: bme }])
+    expect(partsForAddress(0x69, libs)).toEqual([{ libraryId: 'snakie-standard', part: icm }])
+  })
+  it('no declared address / no match → []', () => {
+    expect(partsForAddress(0x3c, libs)).toEqual([])
+  })
+})
+
+describe('parts.yml i2cAddresses codec (#214)', () => {
+  it('round-trips through YAML', () => {
+    const yml = partToYaml({ id: 'x', name: 'X', headers: [], i2cAddresses: [0x76, 0x77] })
+    expect(yml).toContain('i2cAddresses')
+    const back = partFromYaml(yml)
+    expect(back.i2cAddresses).toEqual([118, 119])
+  })
+  it('coerces hex strings and drops out-of-range values', () => {
+    const p = partFromYaml('id: y\nname: Y\ni2cAddresses: ["0x68", 300, -1, 12]\n')
+    expect(p.i2cAddresses).toEqual([0x68, 12])
+  })
+  it('absent → undefined', () => {
+    expect(partFromYaml('id: z\nname: Z\n').i2cAddresses).toBeUndefined()
+  })
+})

--- a/test/i2cSweep.test.ts
+++ b/test/i2cSweep.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { I2cGrid } from '../src/renderer/src/components/I2cDetectInstrument'
+import { buildI2cGrid } from '../src/renderer/src/components/scanner-logic'
+
+/**
+ * Scan-sweep playback (#218): the grid renders three phases as the cursor
+ * (a flat 0..127 address index) crosses it —
+ *   ahead of the cursor  → dim `--unswept` cells,
+ *   at the cursor        → one bright `--cursor` cell,
+ *   behind the cursor    → revealed cells; detected ones get `--on --ping`
+ *                          (the water-ripple runs on the ping class).
+ */
+const grid = buildI2cGrid([0x3c, 0x68])
+
+const render = (sweep: number | null): string =>
+  renderToStaticMarkup(createElement(I2cGrid, { grid, sweep }))
+
+describe('I2C scan sweep (#218)', () => {
+  it('sweep=null (idle/finished): everything revealed, both addresses ping', () => {
+    const html = render(null)
+    expect(html).not.toContain('i2cdet__cell--cursor')
+    expect(html).not.toContain('i2cdet__cell--unswept')
+    expect(html.match(/i2cdet__cell--on i2cdet__cell--ping/g)?.length).toBe(2)
+    expect(html).toContain('>3C<')
+    expect(html).toContain('>68<')
+  })
+
+  it('mid-sweep before any hit: a cursor cell, detected cells still hidden', () => {
+    const html = render(20) // cursor at 0x14, before 0x3C
+    expect(html.match(/i2cdet__cell--cursor/g)?.length).toBe(1)
+    expect(html).not.toContain('i2cdet__cell--on')
+    expect(html).not.toContain('>3C<')
+    // Everything past the cursor is dim: 128 − 20 swept − 1 cursor = 107.
+    expect(html.match(/i2cdet__cell--unswept/g)?.length).toBe(107)
+  })
+
+  it('mid-sweep after crossing 0x3C: that address pings, 0x68 still hidden', () => {
+    const html = render(0x50)
+    expect(html.match(/i2cdet__cell--on i2cdet__cell--ping/g)?.length).toBe(1)
+    expect(html).toContain('>3C<')
+    expect(html).not.toContain('>68<')
+    expect(html.match(/i2cdet__cell--cursor/g)?.length).toBe(1)
+  })
+
+  it('cursor exactly on a detected cell: cursor shows, reveal happens after crossing', () => {
+    const html = render(0x3c)
+    expect(html.match(/i2cdet__cell--cursor/g)?.length).toBe(1)
+    expect(html).not.toContain('>3C<') // revealed only once crossed (addr < sweep)
+  })
+})

--- a/test/imuLogic.test.ts
+++ b/test/imuLogic.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest'
 import {
   applyCalibration,
+  cardinalFor,
+  formatHeading,
+  headingFromYaw,
   eulerToCssTransform,
   eulerToMatrix,
   formatAngle,
@@ -294,5 +297,33 @@ describe('imu-logic formatAngle', () => {
 describe('imu-logic NEUTRAL_EULER', () => {
   it('is all-zero (the no-data / level pose)', () => {
     expect(NEUTRAL_EULER).toEqual({ roll: 0, pitch: 0, yaw: 0 })
+  })
+})
+
+describe('imu-logic compass (#215)', () => {
+  it('headingFromYaw maps CCW yaw to a CW 0..360 heading', () => {
+    expect(headingFromYaw(0)).toBe(0) // level, facing North
+    expect(headingFromYaw(-90)).toBe(90) // yaw −90 (CW quarter turn) → East
+    expect(headingFromYaw(90)).toBe(270) // yaw +90 (CCW quarter turn) → West
+    expect(headingFromYaw(180)).toBe(180)
+    expect(headingFromYaw(-450)).toBe(90) // wraps
+    expect(headingFromYaw(Number.NaN)).toBe(0)
+  })
+  it('cardinalFor names the nearest 16-wind point (wrapping)', () => {
+    expect(cardinalFor(0)).toBe('N')
+    expect(cardinalFor(90)).toBe('E')
+    expect(cardinalFor(180)).toBe('S')
+    expect(cardinalFor(270)).toBe('W')
+    expect(cardinalFor(45)).toBe('NE')
+    expect(cardinalFor(22.5)).toBe('NNE')
+    expect(cardinalFor(354)).toBe('N') // wraps back to N near 360
+    expect(cardinalFor(-90)).toBe('W') // negative wraps
+  })
+  it('formatHeading zero-pads to 3 digits with a degree sign', () => {
+    expect(formatHeading(0)).toBe('000°')
+    expect(formatHeading(7.4)).toBe('007°')
+    expect(formatHeading(237)).toBe('237°')
+    expect(formatHeading(359.6)).toBe('000°') // rounds + wraps
+    expect(formatHeading(Number.NaN)).toBe('000°')
   })
 })

--- a/test/partImports.test.ts
+++ b/test/partImports.test.ts
@@ -53,6 +53,33 @@ describe('requiredPartModules', () => {
     expect(req[0].parts).toEqual(['distance', 'distance2']) // both refs, one module
   })
 
+  it('threads the declaring part + bundled drivers for the one-click install', () => {
+    const withDrivers = [
+      {
+        id: 'snakie-standard',
+        parts: [
+          {
+            id: 'bme280',
+            name: 'BME280',
+            headers: [],
+            library: { module: 'bme280' },
+            drivers: [{ source: 'bme280.py', target: 'lib/bme280.py', label: 'BME280 driver' }]
+          } as PartDefinition
+        ]
+      }
+    ]
+    const req = requiredPartModules(
+      { board: 'pico', parts: [{ id: 'b1', lib: 'snakie-standard', part: 'bme280' }], connections: [] } as unknown as RobotDefinition,
+      withDrivers
+    )
+    expect(req).toHaveLength(1)
+    expect(req[0].module).toBe('bme280')
+    expect(req[0].libraryId).toBe('snakie-standard')
+    expect(req[0].partId).toBe('bme280')
+    expect(req[0].drivers).toEqual([{ source: 'bme280.py', target: 'lib/bme280.py', label: 'BME280 driver' }])
+    expect(req[0].url).toBeUndefined() // driver-only: no mip source needed
+  })
+
   it('ignores parts with no linked library', () => {
     const req = requiredPartModules(
       { board: 'b', parts: [{ id: 'p', lib: 'my-parts', part: 'nolib', x: 0, y: 0 }], connections: [] } as unknown as RobotDefinition,
@@ -74,5 +101,29 @@ describe('missingImports / missingOnBoard', () => {
   it('flags required modules not present on the board', () => {
     const m = missingOnBoard(req, new Set(['vl53l0x']))
     expect(m.map((r) => r.module)).toEqual(['bmp280'])
+  })
+})
+
+describe('PartsImportBanner install gating (#166 follow-up)', () => {
+  it('offers Install for a driver-only module (no mip url) and for url modules', async () => {
+    const { createElement } = await import('react')
+    const { renderToStaticMarkup } = await import('react-dom/server')
+    const { PartsImportBanner } = await import('../src/renderer/src/components/PartsImportBanner')
+    const base = { missingImports: [], installing: false, onInstall: () => {}, onDismiss: () => {} }
+    // Driver-only (the SG90/BME280/ICM20948 model) → the Install button shows.
+    const withDrivers = renderToStaticMarkup(
+      createElement(PartsImportBanner, {
+        ...base,
+        missingOnBoard: [
+          { module: 'bme280', parts: ['BME280'], libraryId: 'snakie-standard', partId: 'bme280', drivers: [{ source: 'bme280.py', target: 'lib/bme280.py' }] }
+        ]
+      })
+    )
+    expect(withDrivers).toContain('Install bme280')
+    // No install source at all → nag only, no button.
+    const bare = renderToStaticMarkup(
+      createElement(PartsImportBanner, { ...base, missingOnBoard: [{ module: 'mystery', parts: ['X'] }] })
+    )
+    expect(bare).not.toContain('Install mystery')
   })
 })


### PR DESCRIPTION
The #214–#221 batch, plus follow-on install/help polish. Each issue is its own commit with a `Closes #NNN` footer.

## Issues
- **#214** Interactive I²C scanner — click a found address → known-device inspector + **Add** the matching library part (new `i2cAddresses` part field)
- **#215** Compass in the IMU instrument (rotating rose + heading from the magnetometer)
- **#216** Barometer instrument — temperature / pressure / humidity as an antique aneroid dial (`SNK ENV`, `inst.watch(env=…)`, lib 0.9.0)
- **#217** Schematic I²C/SPI wires draw as named bus tags (»I2C0«) instead of noodles
- **#218** Animated I²C scan — cursor sweep + water-ripple pings
- **#219** Device files: multi-select, drag-to-folder move, hover delete, "Delete N items" (+ recursive folder delete)
- **#220** Refresh re-lists every loaded folder, not just root
- **#221** Right-click "Help for symbol" → mini help for parts + language reference

## Follow-on polish
- Install bundled part drivers from the missing-library banner (shared installer; banner clears reliably; auto-refreshes the device file tree)
- Context help extended to **all standard MicroPython** — keywords, types, built-ins (7 new reference articles)
- BME280 driver probes 0x76/0x77 with precise error messages
- Trashcan delete icon; dropped the redundant Rename/Delete bar; dark Delete text in light mode

## Verification
typecheck · lint (0 errors) · **1278 vitest** · **163 python** · build — all green, plus a per-issue Electron smoke for each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)