### PR TITLE
feat(parts): add Pimoroni Motor 2040 + Servo 2040 to the Standard library

### DIFF
--- a/examples/parts/snakie-standard/library.yml
+++ b/examples/parts/snakie-standard/library.yml
@@ -3,4 +3,4 @@ name: Standard Parts
 description: The canonical Snakie parts — microcontrollers, sensors, ICs, power and more — kept up to date from github.com/kevinmcaleer/snakie-parts.
 author: Snakie
 homepage: https://github.com/kevinmcaleer/snakie-parts
-version: 1.1.0
+version: 1.2.0

--- a/examples/parts/snakie-standard/motor2040/help.md
+++ b/examples/parts/snakie-standard/motor2040/help.md
@@ -1,0 +1,49 @@
+# Pimoroni Motor 2040 (RP2040)
+
+An **RP2040** board that drives **4 DC motors** (up to ~10 V / 0.5 A each) with
+per-motor **current sensing**, **4 quadrature encoder** inputs, 2 analog sensor
+inputs, a WS2812 RGB LED and a Qw/ST (Qwiic / STEMMA QT) **I²C** connector.
+
+## Motors & encoders → GPIO
+
+| Motor | +  | −  | Encoder | A | B |
+|:------|:---|:---|:--------|:--|:--|
+| A | GP4 | GP5 | A | GP0 | GP1 |
+| B | GP6 | GP7 | B | GP2 | GP3 |
+| C | GP8 | GP9 | C | GP12 | GP13 |
+| D | GP10 | GP11 | D | GP14 | GP15 |
+
+Other pins: TX/TRIG **GP16**, RX/ECHO **GP17**, WS2812 LED **GP18**, I²C **INT
+GP19 · SDA GP20 · SCL GP21**, user button **GP23**, and a shared sense ADC on
+**GP29** (per-motor current, board voltage, driver fault + 2 sensors via a mux).
+
+## Powering motors
+
+Feed motor power (up to ~10 V) into the board's **screw terminal**. Each motor
+output is a **+ / −** pair driven as a complementary PWM H-bridge — don't wire a
+motor pin to logic.
+
+## MicroPython
+
+The `motor` / `motor2040` (and `encoder`) modules are built into **Pimoroni's
+MicroPython firmware** — flash the Pico-family Pimoroni build (link below), then:
+
+```python
+import time
+from motor import Motor, motor2040
+
+m = Motor(motor2040.MOTOR_A)   # motor A = GP4 / GP5
+m.enable()
+m.full_positive();  time.sleep(2)   # full speed one way
+m.stop();           time.sleep(1)
+m.full_negative();  time.sleep(2)   # full speed the other way
+m.coast()
+```
+
+Read an encoder with the `encoder` module (`Encoder(0, motor2040.ENCODER_A)`),
+or drive all four motors together with `MotorCluster`. See the examples below.
+
+## Links
+- [Pimoroni Motor 2040 product page](https://shop.pimoroni.com/products/motor-2040) (PIM618)
+- [MicroPython examples](https://github.com/pimoroni/pimoroni-pico/tree/main/micropython/examples/motor2040)
+- [Pimoroni MicroPython firmware releases](https://github.com/pimoroni/pimoroni-pico/releases)

--- a/examples/parts/snakie-standard/motor2040/parts.yml
+++ b/examples/parts/snakie-standard/motor2040/parts.yml
@@ -1,0 +1,81 @@
+id: motor2040
+name: Pimoroni Motor 2040
+description: RP2040 quad DC-motor controller with encoder inputs, current sensing and a Qw/ST connector
+manufacturer: Pimoroni
+family: Microcontroller
+mcu: RP2040
+partNumber: PIM618
+package: Board
+pinSpacing: 2.54
+voltage: 3.3V
+version: 0.1.0
+pcbColor: "#12181f"
+# Board is 52 x 38 mm. Authored with the 4 encoder inputs down the left rail and
+# the 4 motor outputs down the right rail; the spare / I2C pins along the bottom.
+aspect: 1.368
+dimensions:
+  width: 52
+  height: 38
+shape:
+  kind: rect
+  cornerRadius: 0.06
+# GPIO map verified against Pimoroni's firmware header
+# (pimoroni-pico/libraries/motor2040/motor2040.hpp):
+#   Motors  A/B/C/D (P,N) = GP4/5, GP6/7, GP8/9, GP10/11
+#   Encoders A/B/C/D (A,B) = GP0/1, GP2/3, GP12/13, GP14/15
+#   TX_TRIG=GP16, RX_ECHO=GP17, LED_DATA(WS2812 x1)=GP18,
+#   I2C_INT=GP19, I2C_SDA=GP20, I2C_SCL=GP21, USER_SW=GP23,
+#   ADC_ADDR_0/1/2=GP22/24/25 (internal mux), ADC0/1/2=GP26/27/28,
+#   SHARED_ADC=GP29 (per-motor current, voltage, fault + 2 sensors via mux).
+# Motor P/N pins are PWM (channel A for even GPIO, B for odd).
+headers:
+  - edge: left
+    pins:
+      - { number: 1, name: EA A, type: io, gpio: 0, capabilities: [digital], shape: header, rotation: 180 }
+      - { number: 2, name: EA B, type: io, gpio: 1, capabilities: [digital], shape: header, rotation: 180 }
+      - { number: 3, name: EB A, type: io, gpio: 2, capabilities: [digital], shape: header, rotation: 180 }
+      - { number: 4, name: EB B, type: io, gpio: 3, capabilities: [digital], shape: header, rotation: 180 }
+      - { number: 5, name: EC A, type: io, gpio: 12, capabilities: [digital], shape: header, rotation: 180 }
+      - { number: 6, name: EC B, type: io, gpio: 13, capabilities: [digital], shape: header, rotation: 180 }
+      - { number: 7, name: ED A, type: io, gpio: 14, capabilities: [digital], shape: header, rotation: 180 }
+      - { number: 8, name: ED B, type: io, gpio: 15, capabilities: [digital], shape: header, rotation: 180 }
+  - edge: right
+    pins:
+      - { number: 9, name: MA+, type: io, gpio: 4, capabilities: [digital, pwm], signals: { pwm: A }, shape: header, rotation: 0 }
+      - { number: 10, name: MA-, type: io, gpio: 5, capabilities: [digital, pwm], signals: { pwm: B }, shape: header, rotation: 0 }
+      - { number: 11, name: MB+, type: io, gpio: 6, capabilities: [digital, pwm], signals: { pwm: A }, shape: header, rotation: 0 }
+      - { number: 12, name: MB-, type: io, gpio: 7, capabilities: [digital, pwm], signals: { pwm: B }, shape: header, rotation: 0 }
+      - { number: 13, name: MC+, type: io, gpio: 8, capabilities: [digital, pwm], signals: { pwm: A }, shape: header, rotation: 0 }
+      - { number: 14, name: MC-, type: io, gpio: 9, capabilities: [digital, pwm], signals: { pwm: B }, shape: header, rotation: 0 }
+      - { number: 15, name: MD+, type: io, gpio: 10, capabilities: [digital, pwm], signals: { pwm: A }, shape: header, rotation: 0 }
+      - { number: 16, name: MD-, type: io, gpio: 11, capabilities: [digital, pwm], signals: { pwm: B }, shape: header, rotation: 0 }
+  - edge: bottom
+    pins:
+      - { number: 17, name: TX, type: io, gpio: 16, capabilities: [digital, uart], signals: { uart: TX }, buses: { uart: 0 }, shape: header, rotation: 90 }
+      - { number: 18, name: RX, type: io, gpio: 17, capabilities: [digital, uart], signals: { uart: RX }, buses: { uart: 0 }, shape: header, rotation: 90 }
+      - { number: 19, name: INT, type: io, gpio: 19, capabilities: [digital], shape: header, rotation: 90 }
+      - { number: 20, name: USER, type: io, gpio: 23, capabilities: [digital], shape: header, rotation: 90 }
+# Qw/ST (Qwiic / STEMMA QT) I2C0 socket: SDA=GP20, SCL=GP21.
+connectors:
+  - kind: qwiic
+    label: QW/ST
+    x: 0.5
+    y: 0.92
+    pins:
+      - { name: GND, type: gnd }
+      - { name: "3V3", type: pwr }
+      - { name: SDA, type: io, gpio: 20, capabilities: [i2c], signals: { i2c: SDA }, buses: { i2c: 0 } }
+      - { name: SCL, type: io, gpio: 21, capabilities: [i2c], signals: { i2c: SCL }, buses: { i2c: 0 } }
+# One addressable RGB LED (WS2812) on GP18; onboard user button on GP23.
+onboardLeds:
+  - { kind: neopixel, gpio: 18, x: 0.5, y: 0.12 }
+tags:
+  - rp2040
+  - motor
+  - encoder
+  - robotics
+  - pimoroni
+library:
+  module: motor
+  docs: https://github.com/pimoroni/pimoroni-pico/tree/main/micropython/examples/motor2040
+help: help.md

--- a/examples/parts/snakie-standard/servo2040/help.md
+++ b/examples/parts/snakie-standard/servo2040/help.md
@@ -1,0 +1,55 @@
+# Pimoroni Servo 2040 (RP2040)
+
+An **RP2040** board that drives up to **18 servos** with 3-pin headers, plus
+current/voltage sensing, **6 analog sensor inputs**, **6 RGB LEDs** (WS2812) and
+a Qw/ST (Qwiic / STEMMA QT) **I²C** connector. Servo signals are **GP0–GP17**.
+
+## Servo channels → GPIO
+
+| Servo | GPIO | Servo | GPIO |
+|------:|:-----|------:|:-----|
+| 1 | GP0 | 10 | GP9 |
+| 2 | GP1 | 11 | GP10 |
+| 3 | GP2 | 12 | GP11 |
+| 4 | GP3 | 13 | GP12 |
+| 5 | GP4 | 14 | GP13 |
+| 6 | GP5 | 15 | GP14 |
+| 7 | GP6 | 16 | GP15 |
+| 8 | GP7 | 17 | GP16 |
+| 9 | GP8 | 18 | GP17 |
+
+Other pins: WS2812 LEDs **GP18**, I²C **INT GP19 · SDA GP20 · SCL GP21**, user
+button **GP23**, analog **A0 GP26 · A1 GP27 · A2 GP28**, and a shared sense ADC on
+**GP29** (current/voltage + the 6 sensor inputs, read through an analog mux).
+
+## Powering servos
+
+Feed servo power into the board's **screw terminal** (2.8–8 V for typical hobby
+servos — check your servo's rating). Each servo header is **Signal · V+ · GND**;
+V+ comes from that terminal, not from the RP2040's 3V3.
+
+## MicroPython
+
+The `servo` / `servo2040` modules are built into **Pimoroni's MicroPython
+firmware** — flash the Pico-family Pimoroni build (see the release link below),
+then:
+
+```python
+import time
+from servo import Servo, servo2040
+
+s = Servo(servo2040.SERVO_1)   # servo 1 = GP0
+s.enable()
+while True:
+    s.to_min(); time.sleep(1)   # ~ -90°
+    s.to_mid(); time.sleep(1)   # ~ 0°
+    s.to_max(); time.sleep(1)   # ~ +90°
+```
+
+Control many at once with `ServoCluster` (uses the RP2040 PIO). See the examples
+directory linked below.
+
+## Links
+- [Pimoroni Servo 2040 product page](https://shop.pimoroni.com/products/servo-2040) (PIM613)
+- [MicroPython examples](https://github.com/pimoroni/pimoroni-pico/tree/main/micropython/examples/servo2040)
+- [Pimoroni MicroPython firmware releases](https://github.com/pimoroni/pimoroni-pico/releases)

--- a/examples/parts/snakie-standard/servo2040/parts.yml
+++ b/examples/parts/snakie-standard/servo2040/parts.yml
@@ -1,0 +1,82 @@
+id: servo2040
+name: Pimoroni Servo 2040
+description: RP2040 18-channel servo controller with current sensing, 6 sensor inputs and a Qw/ST connector
+manufacturer: Pimoroni
+family: Microcontroller
+mcu: RP2040
+partNumber: PIM613
+package: Board
+pinSpacing: 2.54
+voltage: 3.3V
+version: 0.1.0
+pcbColor: "#12181f"
+# Board is 62 x 42 mm (landscape). Authored portrait-friendly: the 18 servo
+# signal outputs run down the two side rails (1-9 left, 10-18 right); the Qw/ST
+# I2C connector + utility pins sit along the bottom.
+aspect: 1.476
+dimensions:
+  width: 62
+  height: 42
+shape:
+  kind: rect
+  cornerRadius: 0.05
+# GPIO map verified against Pimoroni's firmware header
+# (pimoroni-pico/libraries/servo2040/servo2040.hpp): SERVO_1..18 = GP0..GP17,
+# LED_DATA(WS2812 x6)=GP18, I2C_INT=GP19, I2C_SDA=GP20, I2C_SCL=GP21,
+# ADC_ADDR_0/1/2=GP22/24/25 (internal analog mux), USER_SW=GP23,
+# ADC0/1/2=GP26/27/28, SHARED_ADC=GP29 (current/voltage/sensor sensing via mux).
+# Servo outputs are dedicated PWM; the pwm channel is A for even GPIO, B for odd.
+headers:
+  - edge: left
+    pins:
+      - { number: 1, name: S1, type: io, gpio: 0, capabilities: [digital, pwm], signals: { pwm: A }, shape: header, rotation: 180 }
+      - { number: 2, name: S2, type: io, gpio: 1, capabilities: [digital, pwm], signals: { pwm: B }, shape: header, rotation: 180 }
+      - { number: 3, name: S3, type: io, gpio: 2, capabilities: [digital, pwm], signals: { pwm: A }, shape: header, rotation: 180 }
+      - { number: 4, name: S4, type: io, gpio: 3, capabilities: [digital, pwm], signals: { pwm: B }, shape: header, rotation: 180 }
+      - { number: 5, name: S5, type: io, gpio: 4, capabilities: [digital, pwm], signals: { pwm: A }, shape: header, rotation: 180 }
+      - { number: 6, name: S6, type: io, gpio: 5, capabilities: [digital, pwm], signals: { pwm: B }, shape: header, rotation: 180 }
+      - { number: 7, name: S7, type: io, gpio: 6, capabilities: [digital, pwm], signals: { pwm: A }, shape: header, rotation: 180 }
+      - { number: 8, name: S8, type: io, gpio: 7, capabilities: [digital, pwm], signals: { pwm: B }, shape: header, rotation: 180 }
+      - { number: 9, name: S9, type: io, gpio: 8, capabilities: [digital, pwm], signals: { pwm: A }, shape: header, rotation: 180 }
+  - edge: right
+    pins:
+      - { number: 10, name: S10, type: io, gpio: 9, capabilities: [digital, pwm], signals: { pwm: B }, shape: header, rotation: 0 }
+      - { number: 11, name: S11, type: io, gpio: 10, capabilities: [digital, pwm], signals: { pwm: A }, shape: header, rotation: 0 }
+      - { number: 12, name: S12, type: io, gpio: 11, capabilities: [digital, pwm], signals: { pwm: B }, shape: header, rotation: 0 }
+      - { number: 13, name: S13, type: io, gpio: 12, capabilities: [digital, pwm], signals: { pwm: A }, shape: header, rotation: 0 }
+      - { number: 14, name: S14, type: io, gpio: 13, capabilities: [digital, pwm], signals: { pwm: B }, shape: header, rotation: 0 }
+      - { number: 15, name: S15, type: io, gpio: 14, capabilities: [digital, pwm], signals: { pwm: A }, shape: header, rotation: 0 }
+      - { number: 16, name: S16, type: io, gpio: 15, capabilities: [digital, pwm], signals: { pwm: B }, shape: header, rotation: 0 }
+      - { number: 17, name: S17, type: io, gpio: 16, capabilities: [digital, pwm], signals: { pwm: A }, shape: header, rotation: 0 }
+      - { number: 18, name: S18, type: io, gpio: 17, capabilities: [digital, pwm], signals: { pwm: B }, shape: header, rotation: 0 }
+  - edge: bottom
+    pins:
+      - { number: 19, name: INT, type: io, gpio: 19, capabilities: [digital], shape: header, rotation: 90 }
+      - { number: 20, name: USER, type: io, gpio: 23, capabilities: [digital], shape: header, rotation: 90 }
+      - { number: 21, name: A0, type: io, gpio: 26, capabilities: [digital, pwm, adc], signals: { pwm: A }, buses: { adc: 0 }, shape: header, rotation: 90 }
+      - { number: 22, name: A1, type: io, gpio: 27, capabilities: [digital, pwm, adc], signals: { pwm: B }, buses: { adc: 1 }, shape: header, rotation: 90 }
+      - { number: 23, name: A2, type: io, gpio: 28, capabilities: [digital, pwm, adc], signals: { pwm: A }, buses: { adc: 2 }, shape: header, rotation: 90 }
+# Qw/ST (Qwiic / STEMMA QT) I2C0 socket: SDA=GP20, SCL=GP21.
+connectors:
+  - kind: qwiic
+    label: QW/ST
+    x: 0.5
+    y: 0.92
+    pins:
+      - { name: GND, type: gnd }
+      - { name: "3V3", type: pwr }
+      - { name: SDA, type: io, gpio: 20, capabilities: [i2c], signals: { i2c: SDA }, buses: { i2c: 0 } }
+      - { name: SCL, type: io, gpio: 21, capabilities: [i2c], signals: { i2c: SCL }, buses: { i2c: 0 } }
+# 6 addressable RGB LEDs (WS2812) on GP18; onboard user button on GP23.
+onboardLeds:
+  - { kind: neopixel, gpio: 18, x: 0.5, y: 0.12 }
+tags:
+  - rp2040
+  - servo
+  - motor
+  - robotics
+  - pimoroni
+library:
+  module: servo
+  docs: https://github.com/pimoroni/pimoroni-pico/tree/main/micropython/examples/servo2040
+help: help.md

--- a/test/partExamples.test.ts
+++ b/test/partExamples.test.ts
@@ -76,7 +76,9 @@ describe('standard parts library (snakie-standard)', () => {
     { id: 'pico', pads: 40, mcu: 'RP2040' },
     { id: 'pico2w', pads: 40, mcu: 'RP2350' }, // canonical id, matches the built-in
     { id: 'esp32-devkit', pads: 30, mcu: 'ESP32' },
-    { id: 'tiny2350', pads: 16, mcu: 'RP2350' } // authored via the build-part-from-image skill (#198)
+    { id: 'tiny2350', pads: 16, mcu: 'RP2350' }, // authored via the build-part-from-image skill (#198)
+    { id: 'motor2040', pads: 20, mcu: 'RP2040' }, // Pimoroni quad motor controller
+    { id: 'servo2040', pads: 23, mcu: 'RP2040' } // Pimoroni 18-ch servo controller
   ]
 
   it('the Tiny 2350 ships a life-like background photo', () => {


### PR DESCRIPTION
Adds two Pimoroni RP2040 robotics boards to the Standard library, built with the `build-part-from-image` skill.

## Ground-truth pin maps
Pin assignments are **safety-critical**, so they were taken **verbatim** from Pimoroni's own firmware headers rather than inferred:
- `pimoroni-pico/libraries/motor2040/motor2040.hpp`
- `pimoroni-pico/libraries/servo2040/servo2040.hpp`

### Servo 2040 (PIM613, RP2040, 62×42 mm)
- Servo 1–18 → **GP0–GP17** (dedicated PWM outputs)
- WS2812 ×6 = GP18 · I²C INT/SDA/SCL = GP19/20/21 · user button = GP23 · A0–A2 = GP26–28 · shared sense ADC = GP29
- Driver: `from servo import Servo, servo2040`

### Motor 2040 (PIM618, RP2040, 52×38 mm)
- Motors A–D (+/−) = GP4/5, GP6/7, GP8/9, GP10/11 (complementary PWM pairs)
- Encoders A–D (A/B) = GP0/1, GP2/3, GP12/13, GP14/15
- TX/RX GP16/17 · WS2812 = GP18 · I²C GP19/20/21 · user button = GP23
- Driver: `from motor import Motor, motor2040`

## What each part ships
- `parts.yml` — `family: Microcontroller` (shows in the board picker), GPIO with `signals`/`buses`, a **Qw/ST (Qwiic/STEMMA QT) I²C0** connector, an onboard **WS2812**, and `library.module`.
- `help.md` — wiring table, powering notes, and a minimal MicroPython snippet. Both `motor`/`servo` modules are **built into Pimoroni's MicroPython firmware** (not a `mip` package), so the help points at flashing the Pimoroni Pico build.

## Validation
Both parts pass Snakie's full part pipeline (`parts.yml` parse → `validatePart` → board conversion → GPIO check) — added to `test/partExamples.test.ts`. Full suite: **1288 tests green**. Standard library bumped to **1.2.0**.

## Known gap (headless build box)
No board **photo** yet — this box lacks the image tooling (`sips`/`rembg`) and Pimoroni's shop rate-limited image fetches. So the parts render as a labelled board rectangle with evenly-spaced edge pads rather than the life-like photo the skill prefers. Follow-up: drop a licensed top-down photo into each folder and set photo-matched pad positions in the Part Editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)