### PR TITLE
feat(help): seven Getting Started articles for undocumented features (#231)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Seven new Getting Started help articles (#231).** The Help Library now
+  covers every advertised feature: **Files & sync** (the two file trees, the
+  transfer bridge, and keeping tagged files in sync on save), **Flash MicroPython
+  firmware** (auto-detect, the MicroPython.org catalog, BOOTSEL, the micro:bit
+  maintenance-mode warning), **Install packages (mip)**, **Problems & validation**
+  (squiggles, the Problems tab, YAML/JSON autofix, board-aware bus checks),
+  **Version control (Git)**, **AI chat & autocomplete** (provider setup, keys,
+  inline suggestions), and **Keeping Snakie up to date**.
+
 ## [0.23.2] - 2026-07-04
 
 ### Fixed

--- a/src/renderer/src/components/help-content.ts
+++ b/src/renderer/src/components/help-content.ts
@@ -48,7 +48,14 @@ export const HELP_SECTIONS: HelpNode[] = [
       { id: 'gs-connect', kind: 'article', title: 'Connect your board', accent: '#3f74ad' },
       { id: 'gs-run', kind: 'article', title: 'Write & run code', accent: '#37a04f' },
       { id: 'gs-instruments', kind: 'article', title: 'Using instruments', accent: '#8b5fc0' },
-      { id: 'gs-board-view', kind: 'article', title: 'The Board View', accent: '#2f7c70' }
+      { id: 'gs-board-view', kind: 'article', title: 'The Board View', accent: '#2f7c70' },
+      { id: 'gs-files', kind: 'article', title: 'Files & sync', accent: '#c07a2a' },
+      { id: 'gs-firmware', kind: 'article', title: 'Flash MicroPython firmware', accent: '#c2483a' },
+      { id: 'gs-packages', kind: 'article', title: 'Install packages (mip)', accent: '#3f74ad' },
+      { id: 'gs-validation', kind: 'article', title: 'Problems & validation', accent: '#b58a2e' },
+      { id: 'gs-git', kind: 'article', title: 'Version control (Git)', accent: '#37884a' },
+      { id: 'gs-chat', kind: 'article', title: 'AI chat & autocomplete', accent: '#8b5fc0' },
+      { id: 'gs-updater', kind: 'article', title: 'Keeping Snakie up to date', accent: '#8a7f62' }
     ]
   },
   {

--- a/src/renderer/src/components/help/gs-chat.md
+++ b/src/renderer/src/components/help/gs-chat.md
@@ -1,0 +1,34 @@
+An AI helper that lives next to your code — ask questions, generate MicroPython,
+fix errors.
+
+## Set it up (once)
+
+The chat needs an API key for at least one provider:
+
+1. Open **Settings ▸ Chat** (the gear, or the ⚙ in the chat panel).
+2. Pick a provider — **Anthropic (Claude)**, **OpenAI**, **Grok**, or
+   **GitHub Copilot** — and paste its API key (each has a "Get a key" link).
+   Copilot signs in with a device code instead of a key.
+3. Keys are stored encrypted on your machine and never leave it except to call
+   the provider you chose.
+
+## Using the chat
+
+Open the chat panel (right side). Ask anything — "write MicroPython to sweep a
+servo on GP15", "why does this traceback happen?", "explain PWM like I'm 10".
+The chat can see your **active file**, so "find the bug in this" works. Code
+blocks have a copy button; paste into the editor and run.
+
+Switch provider/model from the dropdown in the chat footer at any time.
+
+## Inline autocomplete
+
+The same providers can power **inline code suggestions** in the editor
+(ghost text as you type — <kbd>Tab</kbd> accepts). Turn it on and choose its
+provider in **Settings ▸ Chat ▸ Autocomplete**. It's independent of the chat,
+so you can use either without the other.
+
+## No key?
+
+Everything else in Snakie works without one — the chat panel is the only thing
+that needs it. You can hide the panel with its knob in the toolbar.

--- a/src/renderer/src/components/help/gs-files.md
+++ b/src/renderer/src/components/help/gs-files.md
@@ -1,0 +1,36 @@
+Work with files on your computer and on the board, side by side.
+
+## Two trees
+
+The **Files** view (activity bar) stacks two panes:
+
+- **Local files** — a folder on your computer. Open one with the folder button;
+  the breadcrumb re-roots the tree to any ancestor. Right-click for New File /
+  New Folder / Rename / Delete / **Upload to board**.
+- **Device files** — the connected board's filesystem. Click a file to open it
+  (its editor tab shows in `[brackets]` so you can tell it apart from local
+  files). Right-click to rename, delete, or **Download to computer**.
+  Multi-select and drag-into-folder work here too, and the gauge at the top
+  shows the board's flash usage.
+
+Between the panes sits the **transfer bridge**: ↓ uploads the active editor
+file to the board, ↑ saves the active device file to a local folder.
+
+## Keep files in sync
+
+Editing locally but running on the board? Stop re-uploading by hand:
+
+1. **Hover a local file** and **tick its checkbox** — the file is now tagged
+   for sync (it shows a green **⇄** at rest; hover to untick).
+2. Turn on the **sync toggle** in the Device files toolbar. That pushes every
+   tagged file to the board immediately **and** re-pushes each one whenever you
+   save it. The icon spins while syncing and shows a green tick when done.
+
+Each tagged file lands at `/<filename>` on the board. Tags and the toggle
+survive restarts. Click the toggle again to stop auto-syncing.
+
+## No board handy?
+
+Connect to the **Simulated device (offline)** in the port dropdown — it has a
+real (in-memory) filesystem, so uploads, downloads and sync all work exactly
+the same. It resets when you disconnect.

--- a/src/renderer/src/components/help/gs-firmware.md
+++ b/src/renderer/src/components/help/gs-firmware.md
@@ -1,0 +1,36 @@
+Put MicroPython onto a board (or update it) without leaving Snakie.
+
+## Open the flasher
+
+Click the **⚡ Flash firmware** button at the right of the status bar. Snakie
+auto-detects connected boards — ESP32/ESP8266 on their serial port, an RP2040 /
+Pico holding **BOOTSEL** (the `RPI-RP2` drive), or a micro:bit (the `MICROBIT`
+drive). Press **⟳ Detect** to re-scan.
+
+## Pick the firmware
+
+- **Download from MicroPython.org** — choose a **Family → Model → Variant →
+  Version** from the official catalog and Snakie downloads it for you.
+- **Local file** — browse to a `.uf2` (RP2040), `.bin` (ESP32/ESP8266) or
+  `.hex` (micro:bit) you already have.
+
+## Flash it
+
+- **Pico / RP2040** — unplug, hold **BOOTSEL** while plugging back in, pick the
+  `RPI-RP2` drive, then **Flash**. The file is copied over and the board reboots
+  into MicroPython.
+- **ESP32 / ESP8266** — pick the serial port and flash offset (pre-filled).
+  Flashing uses `esptool`; install it once with `pip install esptool` if the
+  dialog says it's missing.
+- **micro:bit** — pick the `MICROBIT` drive. If you see a `MAINTENANCE` drive
+  instead, unplug and replug **without** holding reset — flashing MicroPython in
+  maintenance mode can brick the interface firmware, so Snakie blocks it.
+
+A progress bar and log show the whole flash; hit **Done** when it finishes,
+then **Connect** as usual.
+
+## Updates
+
+When a board is connected, Snakie can check whether a newer MicroPython exists
+for it and offer the update from the same ⚡ button (toggle this in
+**Settings ▸ Editor ▸ Firmware updates**).

--- a/src/renderer/src/components/help/gs-git.md
+++ b/src/renderer/src/components/help/gs-git.md
@@ -1,0 +1,34 @@
+Keep your project's history with the built-in Source Control panel.
+
+## Point it at your project
+
+Open **Source Control** in the activity bar. It follows your working folder
+(the one open in Local files). If the folder isn't a Git repository yet, use
+**Init** to create one.
+
+## The everyday loop
+
+1. Edit and save files — changes appear grouped as **Staged**, **Changes** and
+   **Untracked**.
+2. Click a file to see its **diff**; use **Stage** / **Unstage** to choose what
+   goes into the commit (or let commit stage everything).
+3. Type a **commit message** and hit **Commit** (it stages all changes and
+   commits when nothing is staged yet).
+4. **Push** and **Pull** sync with the remote; the **↑ / ↓ counts** show how
+   many commits you're ahead/behind.
+
+**Discard changes** on a file restores it to the last commit — handy when an
+experiment goes sideways (that's rather the point of version control).
+
+## Branches
+
+The **branch dropdown** switches branches; pick an existing one or create a new
+branch to try an idea without touching your working code.
+
+## Tips
+
+- The status bar shows a **⎇ changed-file count** for the working folder at a
+  glance.
+- Commit small and often — "got the servo sweeping" is a great commit message.
+- Files on the **board** aren't versioned; keep your source local (use file
+  sync to push it to the board) so Git sees every change.

--- a/src/renderer/src/components/help/gs-packages.md
+++ b/src/renderer/src/components/help/gs-packages.md
@@ -1,0 +1,35 @@
+Install MicroPython libraries onto your board with **mip**, straight from Snakie.
+
+## The Packages panel
+
+Open **Packages** in the activity bar (left edge). With a board connected you'll
+see:
+
+- a **search box** — find a package in the registry (`micropython-lib` and
+  GitHub packages),
+- the **REGISTRY** list — search results, each with an **INSTALL** action,
+- the **INSTALLED** list — what's already on the board,
+- a **Flash storage used** meter, so you can see how much room is left.
+
+## Installing
+
+1. Connect your board (installing runs code on it over the REPL).
+2. Search for the package (e.g. `ssd1306`, `umqtt.simple`).
+3. Click **INSTALL**. Snakie runs `mip.install(...)` on the board and streams
+   the log; packages land in `/lib`, which is on `sys.path` — so after a
+   reboot (or straight away) you can just `import` it.
+
+Boards without Wi-Fi (like a plain Pico) can't fetch packages themselves —
+Snakie handles that by downloading on the computer and copying the files over,
+so mip works on every board.
+
+## Advanced options
+
+Expand **Advanced options** to install from a **custom index URL** or a
+`github:user/repo` spec, and to control whether existing files are overwritten.
+
+## Parts install their own drivers
+
+When a part on the Board View needs a driver (e.g. the VL53L0X), Snakie offers
+to install it for you — see the banner that appears above the editor. Bundled
+drivers copy to `/lib`; registry ones install via mip, exactly as above.

--- a/src/renderer/src/components/help/gs-updater.md
+++ b/src/renderer/src/components/help/gs-updater.md
@@ -1,0 +1,25 @@
+Snakie tells you when a new version is out — updating is one click.
+
+## How you'll notice
+
+The **version number** in the status bar (bottom right) doubles as the update
+control. When a new release is published it becomes an **Update** button;
+click it to download in the background (you'll see the progress), then
+**Restart** to finish. You can also check on demand — **Snakie ▸ Check for
+Updates…** on macOS, **Help ▸ Check for Updates…** on Windows/Linux.
+
+## What's in an update?
+
+Every release's changes are listed in the
+[changelog](https://github.com/kevinmcaleer/Snakie/blob/master/CHANGELOG.md)
+and on the
+[releases page](https://github.com/kevinmcaleer/Snakie/releases) — new
+instruments, parts, fixes and features land there first.
+
+## Notes
+
+- Updates only apply to the **installed** app (dmg/exe/AppImage/deb builds).
+  If you run Snakie from source, `git pull` instead.
+- On Linux, the AppImage updates in place; the `.deb` is updated by installing
+  the new release's package.
+- Your settings, parts libraries and projects are never touched by an update.

--- a/src/renderer/src/components/help/gs-validation.md
+++ b/src/renderer/src/components/help/gs-validation.md
@@ -1,0 +1,28 @@
+Snakie checks your code as you type and collects everything it finds in one
+place.
+
+## Squiggles & the Problems tab
+
+Python files are linted live (via the bundled linter plugins); **YAML** and
+**JSON** files are validated too — a stray tab, duplicate key or unclosed
+bracket gets a squiggle right in the editor.
+
+The **Problems** tab (bottom panel, next to Console) lists every diagnostic for
+the active file with its line and message. Click a row to jump straight to the
+spot. Errors and warnings are labelled so screen readers and colour-blind users
+get the severity too. Linting can be toggled from the Problems header.
+
+## Autofix for YAML & JSON
+
+When a YAML/JSON file parses but is untidy (or uses a fixable style), the
+Problems panel shows a **Fix / Format** button — one click rewrites the file in
+canonical form and the squiggles disappear. This is handy for `parts.yml` and
+`robot.yml`, which Snakie itself reads.
+
+## Board-aware checks
+
+With a board selected, Snakie also checks your **bus wiring in code**: an
+`I2C(0, sda=Pin(...), scl=Pin(...))` with pins that don't belong to I2C0 on
+*your* board gets flagged, with a quick-fix to the nearest valid pins. The same
+applies to SPI and UART. It's the "wrong pin number" mistake — caught before
+you spend an hour on it.

--- a/test/helpContent.test.ts
+++ b/test/helpContent.test.ts
@@ -32,6 +32,26 @@ describe('help tree', () => {
       expect((HELP_ARTICLES[id] ?? '').length, id).toBeGreaterThan(20)
     }
   })
+
+  it('every Getting Started article in the tree has authored content (#231)', () => {
+    const gs = find(HELP_SECTIONS, 'getting-started')!
+    // The feature articles added in #231 are registered…
+    for (const id of [
+      'gs-files',
+      'gs-firmware',
+      'gs-packages',
+      'gs-validation',
+      'gs-git',
+      'gs-chat',
+      'gs-updater'
+    ]) {
+      expect(gs.children!.some((n) => n.id === id), `${id} in tree`).toBe(true)
+    }
+    // …and every tree entry has a real body (no "not written yet" stubs).
+    for (const n of gs.children!) {
+      expect((HELP_ARTICLES[n.id] ?? '').length, `content for ${n.id}`).toBeGreaterThan(200)
+    }
+  })
 })
 
 const libs = (parts: object[]): PartLibraryWithParts[] =>


### PR DESCRIPTION
Closes #231 — the first item of the "Now" tier in the roadmap epic (#247).

The Help Library covered instruments (18/18 ✓) and the MicroPython reference fully, but **none of these README-advertised features had any help article**. This adds all seven, registered under **Getting Started**:

| Article | Covers |
|---|---|
| **Files & sync** | the two file trees, transfer bridge, device multi-select, and keeping tagged files in sync on save (#178) — plus the simulated device's filesystem |
| **Flash MicroPython firmware** | auto-detect, the MicroPython.org catalog cascade, BOOTSEL, esptool, the micro:bit maintenance-mode warning, firmware update checks |
| **Install packages (mip)** | Packages panel, `/lib` + `sys.path`, flash meter, custom index, part-driver installs (#184) |
| **Problems & validation** | live squiggles, the Problems tab, YAML/JSON autofix, board-aware I2C/SPI/UART checks with quick-fix |
| **Version control (Git)** | init, the stage→commit→push loop, branches, discard, beginner tips |
| **AI chat & autocomplete** | provider setup (Anthropic / OpenAI / Grok / Copilot device-flow), encrypted key storage, inline suggestions |
| **Keeping Snakie up to date** | the status-bar update button, menu check, changelog/release links |

Articles were written against the actual UI (labels verified in the components) in the established gs-article voice — short, task-first, with a troubleshooting note where it matters.

**Test:** a new guard asserts every Getting Started tree entry has authored content (>200 chars), so a registered-but-stub article can never ship silently again.

typecheck ✅ · lint ✅ · **1287 tests** ✅ · build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)