### PR TITLE
Open scope/meter any time, with an in-instrument requirement panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Open the Oscilloscope / Multimeter any time — with in-instrument help.**
+  The scope and meter no longer stay locked out until your program declares a
+  PWM/ADC pin: toggle them on from the dock and, when there's no source yet, they
+  show a built-in "how to use me" panel (what's needed + a runnable
+  `inst.watch(scope=pwm)` snippet + a Learn-more link) instead of a blank screen.
+  They adopt the file's PWM/ADC pin — or live `SNK` telemetry — the moment one
+  appears. Backed by a reusable `InstrumentRequirement` panel for conditional
+  instruments.
 - **Seven new Getting Started help articles (#231).** The Help Library now
   covers every advertised feature: **Files & sync** (the two file trees, the
   transfer bridge, and keeping tagged files in sync on save), **Flash MicroPython

--- a/docs/common-parts.md
+++ b/docs/common-parts.md
@@ -18,6 +18,7 @@ Computer, Sensor, Input, Output, Motor, Display, Communication, Power, IC**.
 | Arduino Nano / Nano RP2040 Connect | — | classic 5 V / 3.3 V footprints |
 | Seeed XIAO (RP2040 / ESP32-C3 / SAMD21) | — | thumb-sized castellated |
 | BBC micro:bit v2 | edge connector | nRF52833 |
+| Pimoroni Servo2040 | — | RP2040 servo controller: 18 servo channels + per-channel current sensing, RGB LED, user button |
 
 ## Computers
 
@@ -38,6 +39,7 @@ Computer, Sensor, Input, Output, Motor, Display, Communication, Power, IC**.
 | TCS34725 colour sensor | I²C | RGB + clear |
 | Line-follower (IR reflectance, TCRT5000) | analog / digital | array or single |
 | Hall-effect / reed switch | digital | wheel-encoder / endstop |
+| INMP441 I²S MEMS microphone | I²S | omnidirectional digital mic; common ESP32 audio input |
 
 ## Inputs
 
@@ -86,6 +88,7 @@ Computer, Sensor, Input, Output, Motor, Display, Communication, Power, IC**.
 | HC-05 / HC-06 Bluetooth | UART | classic BT serial |
 | RFID-RC522 | SPI | 13.56 MHz RFID |
 | NEO-6M GPS | UART | GNSS |
+| IR receiver + remote (VS1838B / TSOP38238) | digital (demodulated) | NEC / RC5 remote-control decoding |
 
 ## Power
 

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -22,7 +22,7 @@ import {
   type OpenInstrument
 } from './InstrumentHost'
 import { defaultVisibility, deriveInUse, moduleCoveredByInstrument } from './instruments-registry'
-import { parsePins, type UsedPins } from './parse-pins'
+import { type UsedPins } from './parse-pins'
 import { runFindCommand } from './findController'
 import { ShellPanel } from './ShellPanel'
 import { RightPanel } from './RightPanel'
@@ -340,12 +340,6 @@ export function AppShell(): JSX.Element {
 
   // The PWM/ADC pins declared in the active file — so the dock's SCOPE/METER
   // buttons can summon an instrument directly (without going through the
-  // board-view window's node launchers).
-  const fileConns = useMemo(
-    () => (boardIsPython ? parsePins(boardSource) : []),
-    [boardSource, boardIsPython]
-  )
-
   // Toggle one instrument's dock-header visibility (keyed by registry id, #119).
   //  - SCOPE/METER (per-pin): if NOTHING of this kind is open yet, the click
   //    SUMMONS one (the first matching PWM/ADC pin in the active file) and shows
@@ -362,21 +356,10 @@ export function AppShell(): JSX.Element {
     (id: string): void => {
       if (id === 'scope' || id === 'meter') {
         const kind = id
-        const hasOpen = openInstruments.some((it) => it.kind === kind)
-        if (!hasOpen) {
-          const wantType = kind === 'scope' ? 'pwm' : 'adc'
-          const conn = fileConns.find((c) => c.type === wantType)
-          if (conn) {
-            setOpenInstruments((cur) =>
-              cur.some((it) => it.kind === kind && it.conn.variable === conn.variable)
-                ? cur
-                : [...cur, { kind, conn }]
-            )
-            setKindVisible(kind, true)
-            redockKind(kind)
-          }
-          return
-        }
+        // Toggle the scope/meter like a singleton. It can be opened with NO
+        // PWM/ADC pin at all — the dock renders it from the file's PWM/ADC conns
+        // when present, else a placeholder that shows the requirement help (see
+        // InstrumentDockRegion). No `openInstruments` injection needed.
         const next = !visibility[id]
         setVisibility({ ...visibility, [id]: next })
         if (next) redockKind(kind)
@@ -387,7 +370,7 @@ export function AppShell(): JSX.Element {
       setVisibility({ ...visibility, [id]: next })
       if (next) redockByKey(`singleton:${id}`)
     },
-    [visibility, setVisibility, setKindVisible, redockKind, redockByKey, openInstruments, fileConns]
+    [visibility, setVisibility, redockKind, redockByKey]
   )
 
   // Persisted collapsed state. Shell is open by default (core REPL tool); the

--- a/src/renderer/src/components/InstrumentHost.tsx
+++ b/src/renderer/src/components/InstrumentHost.tsx
@@ -834,6 +834,29 @@ export function InstrumentDockRegion({
   }, [inUse, feed.binds])
   const scopeDocked = host.dockedItems.filter((r) => r.it.kind === 'scope')
   const meterDocked = host.dockedItems.filter((r) => r.it.kind === 'meter')
+
+  // A scope/meter can be toggled on with NO board-view open. Render it from the
+  // file's first PWM/ADC conn when present, else a PLACEHOLDER (empty pins) so the
+  // instrument shows its requirement-help panel instead of a blank screen. Live
+  // telemetry is resolved from `feed` for the chosen channel, so it starts drawing
+  // the moment the program prints for it (or `inst.watch(scope=…)`).
+  const mkFallback = (kind: 'scope' | 'meter'): ResolvedInstrument => {
+    const conn: UsedPins =
+      (kind === 'scope' ? host.pwmConns[0] : host.adcConns[0]) ??
+      { type: kind === 'scope' ? 'pwm' : 'adc', pins: [], variable: '', constructor: '' }
+    const samples = kind === 'scope' ? scopeSamplesFor(feed, conn.variable) : undefined
+    return {
+      it: { kind, conn },
+      conn,
+      live: undefined,
+      stats: undefined,
+      telemetrySamples: samples && samples.length > 0 ? samples : undefined,
+      telemetryReading: kind === 'meter' ? meterReadingFor(feed, conn.variable) : undefined,
+      pwmReading: kind === 'scope' ? pwmReadingFor(feed, conn.variable) : undefined,
+      isDocked: true,
+      cascade: 0
+    }
+  }
   // Singleton placeholders to render: every VISIBLE singleton id that isn't the
   // real Plotter (and exists in the registry). Order follows registry order so
   // the dock stack is stable.
@@ -868,13 +891,21 @@ export function InstrumentDockRegion({
         />
       )}
       {isVisible(vis, 'scope') &&
-        scopeDocked.map((r) => (
-          <DockItem key={`scope:${r.it.conn.variable}`}>{renderResolved(r, host)}</DockItem>
-        ))}
+        (scopeDocked.length > 0
+          ? scopeDocked.map((r) => (
+              <DockItem key={`scope:${r.it.conn.variable}`}>{renderResolved(r, host)}</DockItem>
+            ))
+          : (
+              <DockItem key="scope:__fallback__">{renderResolved(mkFallback('scope'), host)}</DockItem>
+            ))}
       {isVisible(vis, 'meter') &&
-        meterDocked.map((r) => (
-          <DockItem key={`meter:${r.it.conn.variable}`}>{renderResolved(r, host)}</DockItem>
-        ))}
+        (meterDocked.length > 0
+          ? meterDocked.map((r) => (
+              <DockItem key={`meter:${r.it.conn.variable}`}>{renderResolved(r, host)}</DockItem>
+            ))
+          : (
+              <DockItem key="meter:__fallback__">{renderResolved(mkFallback('meter'), host)}</DockItem>
+            ))}
       {isVisible(vis, 'plotter') && host.singletonDocked['plotter'] !== false && (
         <DockItem>
           <InstrumentWindow

--- a/src/renderer/src/components/InstrumentRequirement.css
+++ b/src/renderer/src/components/InstrumentRequirement.css
@@ -1,0 +1,74 @@
+/*
+ * Shared in-instrument "requirement / how to use me" panel (open-anytime
+ * instruments). Fills the instrument body with centred, readable guidance.
+ */
+.instr-req {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 180px;
+  padding: 22px 20px;
+  text-align: center;
+  color: #b7bec6;
+}
+
+.instr-req__icon {
+  width: 30px;
+  height: 30px;
+  color: var(--req-accent, #7f8790);
+  opacity: 0.9;
+}
+
+.instr-req__title {
+  font-family: 'Space Grotesk', system-ui, sans-serif;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  color: #e7ebf0;
+}
+
+.instr-req__line {
+  margin: 0;
+  max-width: 32ch;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: #9aa1aa;
+}
+
+.instr-req__code {
+  margin: 6px 0 0;
+  padding: 10px 12px;
+  max-width: 100%;
+  overflow-x: auto;
+  text-align: left;
+  border-radius: 7px;
+  background: rgba(6, 9, 11, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.instr-req__code code {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11.5px;
+  line-height: 1.55;
+  color: #cdd6df;
+  white-space: pre;
+}
+
+.instr-req__more {
+  margin-top: 4px;
+  padding: 5px 12px;
+  border: 1px solid var(--req-accent, #4a4e56);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--req-accent, #cdd2d8);
+  font-family: 'Space Grotesk', system-ui, sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.instr-req__more:hover {
+  background: color-mix(in srgb, var(--req-accent, #6b7280) 18%, transparent);
+}

--- a/src/renderer/src/components/InstrumentRequirement.tsx
+++ b/src/renderer/src/components/InstrumentRequirement.tsx
@@ -1,0 +1,69 @@
+import type { CSSProperties } from 'react'
+import { dispatchOpenHelp } from './editorBridge'
+import './InstrumentRequirement.css'
+
+/**
+ * INSTRUMENT REQUIREMENT — a shared in-instrument "here's how to use me" panel.
+ * =============================================================================
+ *
+ * Every instrument can now be OPENED from the dock even when its precondition
+ * isn't met yet (no PWM pin for the scope, no `SNK ENV` telemetry for the
+ * barometer, …). Instead of showing a blank dial / dashes with no explanation,
+ * the instrument renders THIS panel in its body: a short headline, a couple of
+ * plain-language lines, an optional runnable code snippet, and a "Learn more"
+ * link that opens the instrument's help article. The moment the precondition is
+ * satisfied, the instrument swaps back to its live view.
+ *
+ * Consistent across instruments so the guidance reads the same everywhere.
+ */
+
+export interface InstrumentRequirementProps {
+  /** Short headline, e.g. "No PWM signal yet". */
+  title: string
+  /** One or more plain explanation lines. */
+  lines: string[]
+  /** Optional example code shown in a mono block (the thing to add to run). */
+  code?: string
+  /** Optional help-article id → a "Learn more" link opens the Help Library. */
+  helpId?: string
+  /** Instrument accent colour, tints the icon + link. */
+  accent?: string
+}
+
+export function InstrumentRequirement({
+  title,
+  lines,
+  code,
+  helpId,
+  accent
+}: InstrumentRequirementProps): JSX.Element {
+  return (
+    <div
+      className="instr-req"
+      role="note"
+      style={accent ? ({ '--req-accent': accent } as CSSProperties) : undefined}
+    >
+      <svg className="instr-req__icon" viewBox="0 0 24 24" aria-hidden="true">
+        <circle cx="12" cy="12" r="9.2" fill="none" stroke="currentColor" strokeWidth="1.6" />
+        <circle cx="12" cy="7.6" r="1.15" fill="currentColor" />
+        <rect x="11.1" y="10.4" width="1.8" height="7" rx="0.9" fill="currentColor" />
+      </svg>
+      <div className="instr-req__title">{title}</div>
+      {lines.map((line, i) => (
+        <p key={i} className="instr-req__line">
+          {line}
+        </p>
+      ))}
+      {code && (
+        <pre className="instr-req__code">
+          <code>{code}</code>
+        </pre>
+      )}
+      {helpId && (
+        <button type="button" className="instr-req__more" onClick={() => dispatchOpenHelp(helpId)}>
+          Learn more →
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/Multimeter.tsx
+++ b/src/renderer/src/components/Multimeter.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { InstrumentWindow, SourceSlot, type FloatProps } from './InstrumentWindow'
+import { InstrumentRequirement } from './InstrumentRequirement'
 import { adcChannel, ADC_MAX_RAW, type AdcSample, type Stats } from './instrument-data'
 import type { MeterReading } from './instrument-telemetry-feed'
 import type { UsedPins } from './parse-pins'
@@ -96,6 +97,40 @@ export function Multimeter({
   const raw = liveValue ? undefined : sample?.raw
   // Bargraph fill is the fraction of the 3.3 V range (0 when idle).
   const pct = volts === undefined ? 0 : Math.max(0, Math.min(1, volts / 3.3)) * 100
+
+  // Opened from the dock with no ADC pin in the file → a placeholder connection.
+  // Auto-adopt the first real ADC source when one appears; until then show the
+  // requirement panel instead of an idle meter with dashes and no explanation.
+  const isPlaceholder = conn.pins.length === 0 && conn.variable === ''
+  useEffect(() => {
+    if (isPlaceholder && sources.length > 0) onSelectSource?.(sources[0])
+  }, [isPlaceholder, sources, onSelectSource])
+
+  if (isPlaceholder && sources.length === 0 && volts === undefined) {
+    return (
+      <InstrumentWindow
+        name="MULTIMETER"
+        helpId="inst-meter"
+        source="no source"
+        live={live}
+        onToggleLive={onToggleLive}
+        onToggleDock={onToggleDock}
+        docked={docked}
+        onClose={onClose}
+        {...float}
+      >
+        <InstrumentRequirement
+          title="No ADC input yet"
+          lines={[
+            'The multimeter reads an analog pin (ADC). Add one in your program (or watch it) and the live voltage shows here.'
+          ]}
+          code={'import instruments as inst\nfrom machine import Pin, ADC\n\nadc = ADC(Pin(26))\ninst.watch(meter=adc)   # then inst.update() in your loop'}
+          helpId="inst-meter"
+          accent="#5ce08a"
+        />
+      </InstrumentWindow>
+    )
+  }
 
   return (
     <InstrumentWindow

--- a/src/renderer/src/components/Oscilloscope.tsx
+++ b/src/renderer/src/components/Oscilloscope.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { InstrumentWindow, PhosphorScreen, SourceSlot, type FloatProps } from './InstrumentWindow'
+import { InstrumentRequirement } from './InstrumentRequirement'
 import {
   formatDuty,
   formatFreq,
@@ -132,6 +133,41 @@ export function Oscilloscope({
   // Time/div derived from the real PWM period so the period reads point-to-point
   // against the graticule (a period spans DIV_X / CYCLES divisions).
   const timePerDiv = cfg.freq && cfg.freq > 0 ? 1 / (cfg.freq * (DIV_X / CYCLES)) : undefined
+
+  // A "placeholder" connection = the scope was opened from the dock with no PWM
+  // pin in the file. Auto-adopt the first real PWM source the moment one appears
+  // (in the code, or via `inst.watch`); until then show the requirement panel so
+  // the instrument is never a blank screen with no explanation.
+  const isPlaceholder = conn.pins.length === 0 && conn.variable === ''
+  useEffect(() => {
+    if (isPlaceholder && sources.length > 0) onSelectSource?.(sources[0])
+  }, [isPlaceholder, sources, onSelectSource])
+
+  if (isPlaceholder && sources.length === 0 && !onTelemetry && liveDuty === undefined) {
+    return (
+      <InstrumentWindow
+        name="OSCILLOSCOPE"
+        helpId="inst-scope"
+        source="no source"
+        live={live}
+        onToggleLive={onToggleLive}
+        onToggleDock={onToggleDock}
+        docked={docked}
+        onClose={onClose}
+        {...float}
+      >
+        <InstrumentRequirement
+          title="No PWM signal yet"
+          lines={[
+            'The oscilloscope traces a PWM pin. Define one in your program (or watch it) and the live waveform appears here.'
+          ]}
+          code={'import instruments as inst\nfrom machine import Pin, PWM\n\npwm = PWM(Pin(0)); pwm.freq(1000)\ninst.watch(scope=pwm)   # then inst.update() in your loop'}
+          helpId="inst-scope"
+          accent="#5ce08a"
+        />
+      </InstrumentWindow>
+    )
+  }
 
   return (
     <InstrumentWindow

--- a/test/instrumentRequirement.test.ts
+++ b/test/instrumentRequirement.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { Oscilloscope } from '../src/renderer/src/components/Oscilloscope'
+import { Multimeter } from '../src/renderer/src/components/Multimeter'
+import type { UsedPins } from '../src/renderer/src/components/parse-pins'
+
+const pwmPlaceholder: UsedPins = { type: 'pwm', pins: [], variable: '', constructor: '' }
+const pwmReal: UsedPins = { type: 'pwm', pins: ['0'], variable: 'led', constructor: 'PWM(Pin(0))' }
+const adcPlaceholder: UsedPins = { type: 'adc', pins: [], variable: '', constructor: '' }
+const adcReal: UsedPins = { type: 'adc', pins: ['26'], variable: 'pot', constructor: 'ADC(Pin(26))' }
+
+describe('Oscilloscope open-anytime requirement panel', () => {
+  it('shows the requirement help when opened with no PWM source', () => {
+    const html = renderToStaticMarkup(
+      createElement(Oscilloscope, { conn: pwmPlaceholder, sources: [], fileSource: '' })
+    )
+    expect(html).toContain('instr-req')
+    expect(html).toContain('No PWM signal yet')
+    expect(html).toContain('inst.watch(scope=pwm)') // the runnable hint
+    expect(html).not.toContain('osc__svg') // the live screen is NOT drawn
+  })
+
+  it('draws the normal scope once a real PWM connection is present', () => {
+    const html = renderToStaticMarkup(
+      createElement(Oscilloscope, { conn: pwmReal, sources: [pwmReal], fileSource: '' })
+    )
+    expect(html).toContain('osc__svg')
+    expect(html).not.toContain('No PWM signal yet')
+  })
+
+  it('draws the normal scope for a placeholder once live SNK SCOPE samples arrive', () => {
+    const html = renderToStaticMarkup(
+      createElement(Oscilloscope, { conn: pwmPlaceholder, sources: [], fileSource: '', samples: [0, 0.5, 1] })
+    )
+    expect(html).toContain('osc__svg')
+    expect(html).not.toContain('No PWM signal yet')
+  })
+})
+
+describe('Multimeter open-anytime requirement panel', () => {
+  it('shows the requirement help when opened with no ADC source', () => {
+    const html = renderToStaticMarkup(
+      createElement(Multimeter, { conn: adcPlaceholder, sources: [] })
+    )
+    expect(html).toContain('instr-req')
+    expect(html).toContain('No ADC input yet')
+    expect(html).toContain('inst.watch(meter=adc)')
+    expect(html).not.toContain('dmm__body')
+  })
+
+  it('draws the normal meter once a real ADC connection is present', () => {
+    const html = renderToStaticMarkup(createElement(Multimeter, { conn: adcReal, sources: [adcReal] }))
+    expect(html).toContain('dmm')
+    expect(html).not.toContain('No ADC input yet')
+  })
+})


### PR DESCRIPTION
The Oscilloscope and Multimeter could only open once the active file declared a PWM/ADC pin — toggling them from the dock with no such pin did nothing. Now they open like singletons and, when there's no source, show a built-in help panel instead of a blank screen.

**What changed**
- `InstrumentRequirement` (+css): a reusable in-instrument "how to use me" panel — headline, explanation, a runnable code snippet, and a *Learn more →* link to the help article.
- Scope/Meter: render a requirement panel when there's no PWM/ADC source; adopt the file's pin or live `SNK` telemetry the moment one appears.
- Dock: toggle scope/meter like singletons; the dock renders them from the file's first PWM/ADC conn, else a placeholder (no `openInstruments` injection — the open path stays clean).
- Render tests for the placeholder + normal states.

Verified in-app: toggling the Oscilloscope from the palette with no PWM pin shows the "No PWM signal yet" help panel.

**Scoped as increment 1** of the broader "reusable pattern for all conditional instruments": the singleton instruments (Barometer, IMU, Range, Plotter) that currently show dashes with no data are a small follow-up using the same `InstrumentRequirement` panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)