### PR TITLE
feat: requirement panels for Barometer / IMU / Range (increment 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   They adopt the file's PWM/ADC pin — or live `SNK` telemetry — the moment one
   appears. Backed by a reusable `InstrumentRequirement` panel for conditional
   instruments.
+- **The Barometer, IMU and Range instruments now explain themselves too.**
+  Opened with no telemetry, they show the same "how to use me" panel (with a
+  runnable snippet + Learn-more) instead of a dead dial, a frozen neutral pose or
+  an empty gauge — and swap to the live view the moment `SNK ENV` / `IMU` /
+  `DIST` data arrives. The Range instrument keeps its HC-SR04 pin pickers and
+  "Run range demo" prompt visible below the panel.
 - **Seven new Getting Started help articles (#231).** The Help Library now
   covers every advertised feature: **Files & sync** (the two file trees, the
   transfer bridge, and keeping tagged files in sync on save), **Flash MicroPython

--- a/src/renderer/src/components/EnvInstrument.tsx
+++ b/src/renderer/src/components/EnvInstrument.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState, type CSSProperties } from 'react'
 import { InstrumentWindow, type FloatProps } from './InstrumentWindow'
+import { InstrumentRequirement } from './InstrumentRequirement'
 import { type InstrumentDef } from './instruments-registry'
 import { useTelemetryStream } from './instrument-telemetry-subscribe'
 import {
@@ -39,10 +40,16 @@ export interface EnvInstrumentProps {
   docked?: boolean
   onToggleDock?: () => void
   float?: FloatProps
+  /**
+   * Seed readings (per channel), mirroring the scope's `samples` seam (#256):
+   * lets render tests exercise the live dials without a telemetry stream
+   * (effects don't run under static render). Live `SNK ENV` merges on top.
+   */
+  initialReadings?: Record<string, EnvReading>
 }
 
 /** One environmental reading per reporting channel. */
-interface EnvReading {
+export interface EnvReading {
   temp: number
   pressure: number
   humidity: number
@@ -148,11 +155,12 @@ export function EnvInstrument({
   onClose,
   docked = true,
   onToggleDock,
-  float
+  float,
+  initialReadings
 }: EnvInstrumentProps): JSX.Element {
   // Latest reading per channel + the user's picked channel (same pattern as the
   // Potentiometer: the sole/first reporting channel "just works").
-  const [readings, setReadings] = useState<Record<string, EnvReading>>({})
+  const [readings, setReadings] = useState<Record<string, EnvReading>>(initialReadings ?? {})
   const [picked, setPicked] = useState<string>('env')
 
   useTelemetryStream(
@@ -166,6 +174,35 @@ export function EnvInstrument({
   const channel = readings[picked] !== undefined ? picked : (channels[0] ?? picked)
   const reading = readings[channel]
   const hasData = reading !== undefined
+
+  // No `SNK ENV` telemetry yet → the shared how-to panel instead of a dead dial
+  // (#257 increment 2, matching the scope/meter pattern from #256).
+  if (!hasData) {
+    return (
+      <InstrumentWindow
+        name={def.name.toUpperCase()}
+        helpId={`inst-${def.id}`}
+        source="waiting for ENV"
+        docked={docked}
+        onClose={onClose}
+        onToggleDock={onToggleDock}
+        {...float}
+      >
+        <InstrumentRequirement
+          title="No sensor readings yet"
+          lines={[
+            'The barometer shows temperature, pressure and humidity from an environment sensor (like a BME280). Watch one in your program and the dials come alive.'
+          ]}
+          code={
+            'import instruments as inst\nfrom machine import I2C, Pin\nfrom bme280 import BME280\n\nbme = BME280(I2C(0, sda=Pin(0), scl=Pin(1)))\ninst.watch(env=bme)   # then inst.update() in your loop'
+          }
+          helpId={`inst-${def.id}`}
+          accent={def.accent}
+        />
+      </InstrumentWindow>
+    )
+  }
+
   const pressure = reading?.pressure ?? PRESS_MIN
   const angle = pressureAngle(pressure)
   const tip = dialPoint(angle, CX, CY, R * 0.78)

--- a/src/renderer/src/components/ImuInstrument.tsx
+++ b/src/renderer/src/components/ImuInstrument.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState, type CSSProperties } from 'react'
 import { InstrumentWindow, PhosphorScreen, type FloatProps } from './InstrumentWindow'
+import { InstrumentRequirement } from './InstrumentRequirement'
 import { type InstrumentDef } from './instruments-registry'
 import {
   applyCalibration,
@@ -138,6 +139,34 @@ export function ImuInstrument({
   const calibrated = offset.roll !== 0 || offset.pitch !== 0 || offset.yaw !== 0
 
   const source = `IMU · 9-DOF${channel ? ` · ${channel}` : ''}`
+
+  // No `SNK IMU`/`IMUQ` telemetry yet → the shared how-to panel instead of a
+  // frozen neutral pose (#257 increment 2, matching the scope/meter pattern).
+  if (!hasData) {
+    return (
+      <InstrumentWindow
+        name={def.name.toUpperCase()}
+        helpId={`inst-${def.id}`}
+        source="waiting for IMU"
+        docked={docked}
+        onClose={onClose}
+        onToggleDock={onToggleDock}
+        {...float}
+      >
+        <InstrumentRequirement
+          title="No orientation data yet"
+          lines={[
+            'The IMU viewer tilts a 3-D board from roll/pitch/yaw telemetry. Watch an IMU in your program and it comes alive.'
+          ]}
+          code={
+            'import instruments as inst\nfrom icm20948 import ICM20948\n\nimu = ICM20948()\ninst.watch(imu=imu)   # then inst.update() in your loop'
+          }
+          helpId={`inst-${def.id}`}
+          accent={def.accent}
+        />
+      </InstrumentWindow>
+    )
+  }
 
   return (
     <InstrumentWindow

--- a/src/renderer/src/components/RangeInstrument.tsx
+++ b/src/renderer/src/components/RangeInstrument.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { reporter } from '../lib/report-error'
 import { InstrumentWindow, PhosphorScreen, type FloatProps } from './InstrumentWindow'
+import { InstrumentRequirement } from './InstrumentRequirement'
 import type { InstrumentDef } from './range-instrument-def'
 import { useTelemetryStream, type DistanceTelemetry } from './range-telemetry'
 import { useSnakiePresence } from './snakie-presence'
@@ -328,6 +329,22 @@ export function RangeInstrument({
           } as React.CSSProperties
         }
       >
+        {/* No `SNK DIST` telemetry yet → the shared how-to panel in place of an
+            empty gauge (#257 increment 2). The wiring footer + demo prompt below
+            stay mounted, so the pin pickers and "Run range demo" remain reachable. */}
+        {latest === null ? (
+          <InstrumentRequirement
+            title="No distance readings yet"
+            lines={[
+              'The radar draws anything your program measures with a rangefinder (HC-SR04, ToF). Feed it distance telemetry and the sweep begins — or use the HC-SR04 pin pickers below to retarget a running program.'
+            ]}
+            code={
+              'import instruments as inst\nimport time\n\nwhile True:\n    mm = read_my_sensor()   # HC-SR04 / VL53L0X…\n    inst.distance(mm)       # feeds this radar\n    time.sleep(0.1)'
+            }
+            helpId={`inst-${def.id}`}
+            accent={def.accent}
+          />
+        ) : (
         <PhosphorScreen className="range__screen">
           <svg
             className="range__svg"
@@ -465,6 +482,7 @@ export function RangeInstrument({
             {rangeUnit && <span className="range__big-unit">{rangeUnit}</span>}
           </div>
         </PhosphorScreen>
+        )}
 
         {/* Demo prompt — shown when a TRIG/ECHO retarget can't reach a live program. */}
         {prompt && (

--- a/test/envInstrument.test.ts
+++ b/test/envInstrument.test.ts
@@ -111,8 +111,12 @@ describe('EnvInstrument render (#216)', () => {
     expect(def.hints).toContain('bme280')
     expect(INSTRUMENTS.filter((d) => d.id === 'env')).toHaveLength(1)
   })
-  it('draws the aneroid face: bezel, dial, legend, needle + no-data readouts', () => {
-    const html = renderToStaticMarkup(createElement(EnvInstrument, { def, docked: true }))
+  // Seed a reading (mirrors the scope's `samples` seam, #256) so the live dials
+  // render under static markup; with NO data the instrument now shows the shared
+  // requirement panel instead (#257 increment 2 — instrumentRequirement.test.ts).
+  const seeded = { initialReadings: { env: { temp: 21.5, pressure: 1001.2, humidity: 55 } } }
+  it('draws the aneroid face: bezel, dial, legend, needle + readouts', () => {
+    const html = renderToStaticMarkup(createElement(EnvInstrument, { def, docked: true, ...seeded }))
     expect(html).toContain('envbaro__bezel')
     expect(html).toContain('envbaro__dial')
     expect(html).toContain('envbaro__needle')
@@ -122,19 +126,20 @@ describe('EnvInstrument render (#216)', () => {
     // Major scale numbers 950..1050.
     expect(html).toContain('>950<')
     expect(html).toContain('>1050<')
-    // No data yet → dashes in the cells.
+    // The seeded reading fills the cells.
     expect(html).toContain('TEMP')
     expect(html).toContain('HUMIDITY')
-    expect(html).toContain('——')
+    expect(html).toContain('21.5°C')
+    expect(html).toContain('55%')
   })
   it('draws the thermometer (glass tube, mercury, °C scale)', () => {
-    const html = renderToStaticMarkup(createElement(EnvInstrument, { def, docked: true }))
+    const html = renderToStaticMarkup(createElement(EnvInstrument, { def, docked: true, ...seeded }))
     expect(html).toContain('envtherm__glass')
     expect(html).toContain('envtherm__hg')
     expect(html).toContain('°C')
   })
   it('draws the hygrometer with blue-dry / red-damp extremes', () => {
-    const html = renderToStaticMarkup(createElement(EnvInstrument, { def, docked: true }))
+    const html = renderToStaticMarkup(createElement(EnvInstrument, { def, docked: true, ...seeded }))
     expect(html).toContain('envhygro__dial')
     expect(html).toContain('envhygro__arc--dry')
     expect(html).toContain('envhygro__arc--damp')

--- a/test/instrumentRequirement.test.ts
+++ b/test/instrumentRequirement.test.ts
@@ -3,6 +3,11 @@ import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { Oscilloscope } from '../src/renderer/src/components/Oscilloscope'
 import { Multimeter } from '../src/renderer/src/components/Multimeter'
+import { EnvInstrument } from '../src/renderer/src/components/EnvInstrument'
+import { ImuInstrument } from '../src/renderer/src/components/ImuInstrument'
+import { RangeInstrument } from '../src/renderer/src/components/RangeInstrument'
+import { INSTRUMENTS } from '../src/renderer/src/components/instruments-registry'
+import { WorkspaceProvider } from '../src/renderer/src/store/workspace'
 import type { UsedPins } from '../src/renderer/src/components/parse-pins'
 
 const pwmPlaceholder: UsedPins = { type: 'pwm', pins: [], variable: '', constructor: '' }
@@ -53,5 +58,42 @@ describe('Multimeter open-anytime requirement panel', () => {
     const html = renderToStaticMarkup(createElement(Multimeter, { conn: adcReal, sources: [adcReal] }))
     expect(html).toContain('dmm')
     expect(html).not.toContain('No ADC input yet')
+  })
+})
+
+// Increment 2 (#257): the telemetry singletons show the same requirement panel
+// (instead of a dead dial / frozen pose / empty gauge) until their SNK data
+// arrives. First render = no telemetry, so the panel must be what's drawn.
+const defOf = (id: string) => INSTRUMENTS.find((d) => d.id === id)!
+
+describe('Barometer requirement panel (no ENV telemetry yet)', () => {
+  it('shows the how-to panel instead of the dials', () => {
+    const html = renderToStaticMarkup(createElement(EnvInstrument, { def: defOf('env') }))
+    expect(html).toContain('instr-req')
+    expect(html).toContain('No sensor readings yet')
+    expect(html).toContain('inst.watch(env=bme)')
+    expect(html).not.toContain('envbaro__dial') // the aneroid face is NOT drawn
+  })
+})
+
+describe('IMU requirement panel (no IMU telemetry yet)', () => {
+  it('shows the how-to panel instead of the frozen neutral pose', () => {
+    const html = renderToStaticMarkup(createElement(ImuInstrument, { def: defOf('imu') }))
+    expect(html).toContain('instr-req')
+    expect(html).toContain('No orientation data yet')
+    expect(html).toContain('inst.watch(imu=imu)')
+    expect(html).not.toContain('imu__model') // the 3-D board is NOT drawn
+  })
+})
+
+describe('Range requirement panel (no DIST telemetry yet)', () => {
+  it('replaces only the screen — the wiring footer stays reachable', () => {
+    const html = renderToStaticMarkup(
+      createElement(WorkspaceProvider, undefined, createElement(RangeInstrument, { def: defOf('range') }))
+    )
+    expect(html).toContain('instr-req')
+    expect(html).toContain('No distance readings yet')
+    expect(html).not.toContain('range__svg') // the radar screen is NOT drawn…
+    expect(html).toContain('range__wiring') // …but the TRIG/ECHO pickers remain
   })
 })


### PR DESCRIPTION
Increment 2 of the "conditional instruments explain themselves" work (#256 was increment 1; the plan lives in catch-up issue #257).

The three telemetry singletons that previously opened to a dead view now show the shared `<InstrumentRequirement>` panel until their data arrives:

| Instrument | Before (no data) | Now |
|---|---|---|
| **Barometer** | dial pinned at 950 hPa, `——` cells | "No sensor readings yet" + `inst.watch(env=bme)` snippet |
| **IMU** | frozen neutral 3-D pose | "No orientation data yet" + `inst.watch(imu=imu)` snippet |
| **Range** | empty gauge, `NO ECHO` | "No distance readings yet" + `inst.distance()` snippet |

Each swaps to the live view the moment its `SNK ENV` / `IMU` / `DIST` telemetry arrives, and links to its help article.

**Design note on Range:** unlike Env/IMU (early-return, matching the scope/meter pattern), Range replaces **only the phosphor screen** — its HC-SR04 TRIG/ECHO pin pickers and the "Run range demo" prompt stay mounted below the panel, so the existing retarget/demo flow remains reachable. A test guards this.

**Test seam:** `EnvInstrument` gains an `initialReadings` prop (mirroring the scope's `samples` seam from #256) so the pre-existing dial render tests keep exercising the live view — with no data the component now legitimately renders the panel instead.

Scanners (I²C-detect / Wi-Fi / Bluetooth / Display) intentionally untouched — they already have good "not ready" prompts. Plotter left as-is (its canvas message; different shape, lower priority).

typecheck ✅ · lint ✅ · **1306 tests** ✅ (3 new) · build ✅ — not GUI-smoke-tested (headless box); the conditional is a pure data-presence swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)