### PR TITLE
Data Logger instrument — dot-matrix printer with CSV tear-off (#242 core)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Data Logger instrument — a vintage dot-matrix printer (#242).** Hit
+  **RECORD** and every numeric `SNK` reading (meter, plot, distance, IMU,
+  environment…) is captured with a timestamp and "printed" onto tractor-feed
+  paper: a strip-chart per series plus periodic printed value rows in a dotty
+  printhead style. **TEAR OFF** downloads the session as a spreadsheet-ready
+  wide CSV (`time_s` + one column per series) and starts a fresh sheet. Works
+  fully offline against the Simulated device, so a hardware-free classroom gets
+  real data logging — a £4 Pico doing a £100 classroom logger's job. The
+  session/CSV/paper geometry is pure and unit-tested; RECORD is always
+  reachable (arm before any telemetry arrives).
+
 ### Changed
 - **Three focused modes: Code · Board · Data Lab (modes review).** The
   four-workspace switcher slims to three — *Lab* and *Data* merged into **Data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- **Three focused modes: Code · Board · Data Lab (modes review).** The
+  four-workspace switcher slims to three — *Lab* and *Data* merged into **Data
+  Lab** (instrument bench + a tall console/plotter); existing layouts migrate
+  automatically, including a stale active workspace. **Board mode now gives the
+  board every pixel**: the parts **library** became an Obsidian-style pinnable
+  overlay (open it from its edge tab; it slides away when it loses focus unless
+  you pin it — the pin sits top-left of its header), the **connections table**
+  starts collapsed to a bottom bar with the same pin behaviour, the floating
+  **components browser** starts collapsed, the driver banner is height-capped,
+  and the redundant chrome (the drag grip, the BOARD VIEW title, the dock's
+  mini board) is hidden while the board lives in the main window. Also fixes
+  the Board pane opening at the wrong size (a panel-mount race) and the board
+  column not filling its pane (a collapsed connections table used to strand
+  dead space below itself).
+- **The Board toolbar knob now pops the board out — like undocking an
+  instrument.** Opening the Board window while Board mode is active hands the
+  board to its own OS window and returns the main split to Code; closing that
+  window brings Board back as a mode; picking Board mode while the window is
+  open re-docks it. One board, two homes, never both.
+
 ### Added
 - **Workspace layouts (epic #259, phases 0+1).** A new **Code · Board · Lab ·
   Data** switcher in the toolbar restyles the whole shell in one click: each

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the Board pane opening at the wrong size (a panel-mount race) and the board
   column not filling its pane (a collapsed connections table used to strand
   dead space below itself).
+- **Board View chrome slimmed further.** The "New board" and "open boards
+  folder" header buttons are gone from both the Board mode and the floating
+  window — the Library panel owns part/board authoring and library management
+  now. And in Board MODE, part mini-help opens in the main **Help Library**
+  (which now also lists board-placed parts under "In This Project") instead of
+  the pane's own drawer — one help surface, not two. The floating window keeps
+  its built-in help drawer.
 - **The Board toolbar knob now pops the board out — like undocking an
   instrument.** Opening the Board window while Board mode is active hands the
   board to its own OS window and returns the main split to Code; closing that

--- a/src/renderer/src/board-main.tsx
+++ b/src/renderer/src/board-main.tsx
@@ -29,7 +29,6 @@ import ReactDOM from 'react-dom/client'
 import { BoardGraph } from './components/BoardGraph'
 import { OPEN_PART_EDITOR_EVENT, PARTS_CHANGED_EVENT, type OpenPartEditorDetail } from './components/PartsPanel'
 import { PartEditor } from './components/PartEditor'
-import { blankPart } from './components/part-editor.util'
 import { blankRobot, type RobotDefinition } from '../../shared/robot'
 import type {
   BoardDefinition,
@@ -269,17 +268,6 @@ function BoardWindowApp(): JSX.Element {
 
   // Author a NEW board: open the Part Editor on a starter Microcontroller part in
   // the user's library (boards are just Microcontroller-family parts now).
-  const newBoard = (): void => {
-    const starter: PartDefinition = { ...blankPart(), id: 'my-board', name: 'My Board', family: 'Microcontroller' }
-    window.api.parts
-      .listLibraries()
-      .then((libs) => {
-        const lib = libs.find((l) => l.id === 'my-parts')
-        setEditing({ libraryId: 'my-parts', part: starter, libraries: libs, existingParts: lib?.parts ?? [], isNew: true })
-      })
-      .catch(() => setEditing({ libraryId: 'my-parts', part: starter, libraries: [], existingParts: [], isNew: true }))
-  }
-
   return (
     <>
       <BoardGraph
@@ -288,8 +276,6 @@ function BoardWindowApp(): JSX.Element {
         isPython={payload.isPython}
         userBoards={userBoards}
         asWindow
-        onOpenBoardsFolder={() => void window.api.board.openBoardsFolder().catch(() => undefined)}
-        onEnterCreator={newBoard}
         robot={robot}
         onChangeRobot={saveRobot}
         libraries={libraries}

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -182,13 +182,28 @@ export function AppShell(): JSX.Element {
   // read/write robot.yml next to the user's code.
   const boardFolder = currentFolder ?? undefined
 
+  // Board pop-out plumbing (modes review) — declared BEFORE the open handlers so
+  // they can consult/flip these synchronously. The `.current` values are kept
+  // fresh in the workspace-layout block further down (after `layout` exists).
+  const poppedFromBoardRef = useRef(false)
+  const switchWorkspaceRef = useRef<(id: 'code' | 'board' | 'datalab') => void>(() => undefined)
+  const activeWsRef = useRef<'code' | 'board' | 'datalab'>('code')
+
   // Toggle the floating Board View window from the toolbar button: open (and
   // push the current file immediately so it isn't blank) if closed, or close it
   // if it's already open. `onClosed` resets `boardOpened` either way.
+  // Pop-out: opening while Board MODE is active hands the board to the window —
+  // the workspace switch happens HERE, in the same handler as the open, so both
+  // state updates land in one commit (no half-switched state for the re-dock
+  // effect to misread).
   const toggleBoard = useCallback((): void => {
     if (boardOpened) {
       window.api.board.close()
       return
+    }
+    if (activeWsRef.current === 'board') {
+      poppedFromBoardRef.current = true
+      switchWorkspaceRef.current('code')
     }
     setBoardOpened(true)
     window.api.board
@@ -230,8 +245,19 @@ export function AppShell(): JSX.Element {
   // mini board panel's open button, which calls board.open() directly. Flipping
   // `boardOpened` true triggers the streaming effect above to relay the active
   // file, so the full viewer isn't left blank ("Open a Python file…").
+  // Pop-out (modes review): if the window opens while Board MODE is active, the
+  // board moved homes — hand it to the window and return the main split to Code
+  // IN THE SAME HANDLER (the two state updates batch into one commit, so the
+  // "close the window when Board mode is picked while it's open" effect below
+  // never sees a half-switched state and can't mistake a pop-out for a re-dock).
   useEffect(() => {
-    const off = window.api.board.onOpened(() => setBoardOpened(true))
+    const off = window.api.board.onOpened(() => {
+      setBoardOpened(true)
+      if (activeWsRef.current === 'board') {
+        poppedFromBoardRef.current = true
+        switchWorkspaceRef.current('code')
+      }
+    })
     return off
   }, [])
 
@@ -277,17 +303,24 @@ export function AppShell(): JSX.Element {
   useEffect(() => {
     if (layout.applyNonce === 0) return // initial mount already used defaultSize
     const ws = layout.workspace
-    // The horizontal group's setLayout array must match the RENDERED panels:
-    // 4 with the board pane open, 3 (board slot elided) when it's closed.
-    hGroupRef.current?.setLayout(
-      ws.boardPaneOpen
-        ? [...ws.horizontal]
-        : [ws.horizontal[0], ws.horizontal[1] + ws.horizontal[2], ws.horizontal[3]]
-    )
-    vGroupRef.current?.setLayout([...ws.vertical])
-    if (ws.filesCollapsed) filesRef.current?.collapse()
-    if (ws.shellCollapsed) shellRef.current?.collapse()
-    if (ws.rightCollapsed) rightRef.current?.collapse()
+    // Deferred one frame: switching INTO the Board workspace mounts the board
+    // Panel in this same commit, and a setLayout issued before the group has
+    // registered the new panel is ignored (the pane then lands on defaultSize —
+    // the "board pane opens tiny" bug). After rAF the group knows all panels.
+    const raf = requestAnimationFrame(() => {
+      // The horizontal group's setLayout array must match the RENDERED panels:
+      // 4 with the board pane open, 3 (board slot elided) when it's closed.
+      hGroupRef.current?.setLayout(
+        ws.boardPaneOpen
+          ? [...ws.horizontal]
+          : [ws.horizontal[0], ws.horizontal[1] + ws.horizontal[2], ws.horizontal[3]]
+      )
+      vGroupRef.current?.setLayout([...ws.vertical])
+      if (ws.filesCollapsed) filesRef.current?.collapse()
+      if (ws.shellCollapsed) shellRef.current?.collapse()
+      if (ws.rightCollapsed) rightRef.current?.collapse()
+    })
+    return () => cancelAnimationFrame(raf)
     // eslint-disable-next-line react-hooks/exhaustive-deps -- applyNonce IS the signal
   }, [layout.applyNonce])
 
@@ -423,12 +456,38 @@ export function AppShell(): JSX.Element {
   // group — NOT a `Panel` in the group — so its show/hide is fully independent of
   // the chat panel (two collapsible panels in one PanelGroup redistribute each
   // other's freed space, which made toggling one reveal the other). Its flag is
-  // part of the workspace layout (the Board/Lab/Data workspaces open it).
+  // part of the workspace layout (the Board/Data Lab workspaces open it).
   const setDockOpen = layout.setDockOpen
   const instrumentsVisible = dockOpen
   const toggleInstruments = useCallback((): void => {
     setDockOpen(!dockOpen)
   }, [dockOpen, setDockOpen])
+
+  // --- Board pop-out (modes review): the floating window and the Board MODE are
+  // the same board in two homes, never both. Mirrors instrument undocking:
+  //  - opening the window while Board mode is active (the toolbar knob, or the
+  //    mini board's open button) POPS the board out → main window returns to Code
+  //    (the switch happens inside the open handlers themselves — see toggleBoard
+  //    and the board.onOpened subscription — so it batches with the open);
+  //  - closing the window returns the board to being a mode (switch back);
+  //  - picking the Board mode while the window is open re-docks (closes) it.
+  switchWorkspaceRef.current = layout.switchWorkspace
+  activeWsRef.current = layout.active
+  useEffect(() => {
+    const off = window.api.board.onClosed(() => {
+      if (poppedFromBoardRef.current) {
+        poppedFromBoardRef.current = false
+        switchWorkspaceRef.current('board')
+      }
+    })
+    return off
+  }, [])
+  useEffect(() => {
+    if (layout.active === 'board' && boardOpened) {
+      poppedFromBoardRef.current = false
+      window.api.board.close()
+    }
+  }, [layout.active, boardOpened])
 
   // --- Offer to install the instrument library (#108) ------------------------
   // When the dock opens AND a board is connected, we check (once per connection)
@@ -940,7 +999,10 @@ export function AppShell(): JSX.Element {
           {boardPaneOpen && (
             <>
               <PanelResizeHandle className="resize-handle resize-handle--vertical" />
-              <Panel order={3} minSize={25} defaultSize={initialSizes.current.h[2]}>
+              {/* defaultSize = the ACTIVE workspace's board share (not the mount-time
+                  snapshot): the pane mounts when switching into Board, and the deferred
+                  setLayout can lose a race — this keeps the fallback correct too. */}
+              <Panel order={3} minSize={25} defaultSize={layout.workspace.horizontal[2] || 40}>
                 <Suspense
                   fallback={
                     <div className="board-pane__loading" role="status">
@@ -982,6 +1044,7 @@ export function AppShell(): JSX.Element {
               vis={visibility}
               inUse={inUse}
               onToggleVisible={toggleVisible}
+              hideMiniBoard={layout.workspace.boardPaneOpen}
             />
           </aside>
         )}

--- a/src/renderer/src/components/BoardGraph.css
+++ b/src/renderer/src/components/BoardGraph.css
@@ -14,6 +14,11 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  /* Fill the host (the embedded Board-mode pane). Without this the column
+     sizes to CONTENT — a collapsed connections table "collapsed in place"
+     with dead space below, instead of the canvas taking the freed height. */
+  height: 100%;
+  min-height: 0;
   background: #1a1b1e;
   color: #e6e8ec;
   font-family: var(--font-mono), 'JetBrains Mono', monospace;
@@ -883,4 +888,43 @@
   border-radius: 3px;
   padding: 1px 4px;
   text-transform: uppercase;
+}
+
+/* --- Pinnable library overlay (modes review) ------------------------------
+   In the embedded Board mode the library is Obsidian-style: UNPINNED it floats
+   OVER the canvas (right edge) and auto-hides on focus loss; PINNED it sits
+   in-flow exactly as before. The pin lives at the top-left of the header. */
+.boardgraph__dock--overlay {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 30;
+  outline: none;
+  border-left: 1px solid var(--border, #2c2e33);
+  box-shadow: -14px 0 28px -16px rgba(0, 0, 0, 0.55);
+}
+
+.boardgraph__pin {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  margin-right: 0.35rem;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-muted, #8b919b);
+  cursor: pointer;
+}
+
+.boardgraph__pin:hover {
+  background: rgba(128, 128, 128, 0.18);
+  color: var(--text, #d6dae0);
+}
+
+.boardgraph__pin.is-pinned {
+  color: var(--accent, #34ad4f);
 }

--- a/src/renderer/src/components/BoardGraph.tsx
+++ b/src/renderer/src/components/BoardGraph.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { loadPin, savePin, shouldAutoHide, PIN_KEYS } from './pin-overlay'
+import { dispatchOpenHelp } from './editorBridge'
 import {
   parsePins,
   PIN_TYPE_COLOR,
@@ -104,10 +105,6 @@ export interface BoardGraphProps {
   userBoards?: BoardDefinition[]
   /** When true, render the window title-bar chrome (drag region + selector). */
   asWindow?: boolean
-  /** Enter the Board Creator. When set, the gold edit knob is shown. */
-  onEnterCreator?: () => void
-  /** Open the user's boards folder (wired in the floating window). */
-  onOpenBoardsFolder?: () => void
   // --- Wiring + Parts (merged into this view, #139/#140). When `robot` +
   // `onChangeRobot` are provided, the Life-like / Schematic view tabs and the
   // right-side library dock appear; otherwise this is a graph-only board view.
@@ -317,8 +314,6 @@ export function BoardGraph({
   isPython,
   userBoards,
   asWindow = false,
-  onEnterCreator,
-  onOpenBoardsFolder,
   robot,
   onChangeRobot,
   libraries,
@@ -430,16 +425,34 @@ export function BoardGraph({
   // When help is opened for ONE part (its mini-toolbar help button, #207), focus
   // that part's card in the drawer; null = the header button opened the whole list.
   const [helpFocusKey, setHelpFocusKey] = useState<string | null>(null)
-  const [helpToast, setHelpToast] = useState<{ name: string } | null>(null)
+  const [helpToast, setHelpToast] = useState<{ name: string; partId?: string } | null>(null)
   useEffect(() => {
     if (!helpToast) return
     const t = window.setTimeout(() => setHelpToast(null), 7000)
     return () => window.clearTimeout(t)
   }, [helpToast])
+
+  // ONE help surface (modes review): the OS window keeps its own PartHelpDrawer;
+  // the EMBEDDED Board mode routes part help to the main Help Library instead
+  // (`part-<id>` articles — placed parts resolve there), so help never shows in
+  // two places at once. `focusKey` is `${lib}:${part}` / `board:<id>` / null.
+  const openPartHelp = useCallback(
+    (focusKey: string | null): void => {
+      if (asWindow) {
+        setHelpFocusKey(focusKey)
+        setHelpOpen(true)
+        return
+      }
+      const partId = focusKey ? focusKey.split(':').pop() : null
+      dispatchOpenHelp(partId ? `part-${partId}` : 'gs-board-view')
+    },
+    [asWindow]
+  )
+
   const handleAddToProject = useCallback(
     (libraryId: string, part: PartDefinition, pos?: { x: number; y: number }): void => {
       onAddToProject?.(libraryId, part, pos)
-      if ((part.helpText ?? '').trim()) setHelpToast({ name: part.name })
+      if ((part.helpText ?? '').trim()) setHelpToast({ name: part.name, partId: part.id })
     },
     [onAddToProject]
   )
@@ -827,6 +840,10 @@ export function BoardGraph({
               type="button"
               className={`boardgraph__help-btn${helpOpen ? ' is-active' : ''}`}
               onClick={() => {
+                if (!asWindow) {
+                  openPartHelp(null) // embedded: the main Help Library is THE surface
+                  return
+                }
                 setHelpFocusKey(null) // header opens the whole list, not one card
                 setHelpOpen((o) => !o)
               }}
@@ -837,36 +854,8 @@ export function BoardGraph({
               {helpItems.length > 0 && <span className="boardgraph__help-count">{helpItems.length}</span>}
             </button>
           )}
-          {onEnterCreator && (
-            <button
-              type="button"
-              className="boardgraph__knob"
-              onClick={onEnterCreator}
-              title="New board (opens the Part Editor)"
-              aria-label="Create a new board in the Part Editor"
-            >
-              <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <path
-                  d="M4 20l4-1 11-11-3-3L5 16l-1 4z"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.8"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            </button>
-          )}
-          {onOpenBoardsFolder && (
-            <button
-              type="button"
-              className="boardgraph__key"
-              onClick={onOpenBoardsFolder}
-              title="Open the boards folder (add your own board JSON here)"
-              aria-label="Open boards folder"
-            >
-              📁
-            </button>
-          )}
+          {/* The "New board" + "boards folder" knobs are gone (modes review):
+              the LIBRARY panel owns part/board authoring + library management. */}
           {/* Close is handled by the native window chrome now (#185); Esc also
               closes via board-main's key handler. */}
         </div>
@@ -890,8 +879,7 @@ export function BoardGraph({
               onDropPart={onAddToProject ? handleAddToProject : undefined}
               onShowHelp={(id) => {
                 const rp = (robot?.parts ?? []).find((p) => p.id === id)
-                setHelpFocusKey(rp ? `${rp.lib}:${rp.part}` : null)
-                setHelpOpen(true)
+                openPartHelp(rp ? `${rp.lib}:${rp.part}` : null)
               }}
             />
           </div>
@@ -1202,7 +1190,7 @@ export function BoardGraph({
       )}
       {/* Board View HELP: a right-side drawer stacking the placed parts' bundled
           mini-help, + a "help available" toast when a part with help is added. */}
-      {effectiveView !== 'graph' && helpOpen && (
+      {effectiveView !== 'graph' && helpOpen && asWindow && (
         <PartHelpDrawer items={helpItems} focusKey={helpFocusKey} onClose={() => setHelpOpen(false)} />
       )}
       {effectiveView !== 'graph' && helpToast && (
@@ -1214,7 +1202,7 @@ export function BoardGraph({
             type="button"
             className="boardgraph__help-toast-btn"
             onClick={() => {
-              setHelpOpen(true)
+              openPartHelp(helpToast.partId ? `toast:${helpToast.partId}` : null)
               setHelpToast(null)
             }}
           >

--- a/src/renderer/src/components/BoardGraph.tsx
+++ b/src/renderer/src/components/BoardGraph.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { loadPin, savePin, shouldAutoHide, PIN_KEYS } from './pin-overlay'
 import {
   parsePins,
   PIN_TYPE_COLOR,
@@ -351,7 +352,19 @@ export function BoardGraph({
       // Ignore storage write failures (disabled / quota).
     }
   }, [])
-  const [dockOpen, setDockOpen] = useState(true)
+  // Library dock (modes review): in the EMBEDDED Board mode (`!asWindow`) the
+  // library is a pinnable Obsidian-style overlay — closed by default, opened
+  // from its edge tab, auto-hiding on focus loss unless PINNED. The floating
+  // Board window defaults to open+pinned (the pre-review behaviour).
+  const [dockPinned, setDockPinnedState] = useState<boolean>(() =>
+    asWindow ? true : loadPin(window.localStorage, PIN_KEYS.library, false)
+  )
+  const [dockOpen, setDockOpen] = useState<boolean>(() => asWindow || dockPinned)
+  const dockRef = useRef<HTMLElement | null>(null)
+  const setDockPinned = useCallback((v: boolean): void => {
+    setDockPinnedState(v)
+    savePin(window.localStorage, PIN_KEYS.library, v)
+  }, [])
   // If wiring gets disabled (e.g. props change), never strand a wiring view.
   const effectiveView = wiringEnabled ? viewType : 'graph'
 
@@ -706,13 +719,18 @@ export function BoardGraph({
   return (
     <div className={`boardgraph ${asWindow ? 'boardgraph--window' : ''}`} aria-label="Board View">
       <header className={`boardgraph__bar ${asWindow ? 'boardgraph__bar--drag' : ''}`}>
-        <span className="boardgraph__grip" aria-hidden="true">
-          {/* 6-dot drag grip (2×3). */}
-          {Array.from({ length: 6 }).map((_, i) => (
-            <span key={i} className="boardgraph__grip-dot" />
-          ))}
-        </span>
-        <span className="boardgraph__title">BOARD&nbsp;VIEW</span>
+        {/* The 6-dot drag grip only means something in the frameless OS window
+            (the bar is its drag region) — hide it in the embedded Board mode. */}
+        {asWindow && (
+          <span className="boardgraph__grip" aria-hidden="true">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <span key={i} className="boardgraph__grip-dot" />
+            ))}
+          </span>
+        )}
+        {/* The title only earns its width in the OS window; in Board MODE the
+            pane is self-evident (and every pixel goes to the board). */}
+        {asWindow && <span className="boardgraph__title">BOARD&nbsp;VIEW</span>}
 
         {wiringEnabled && (
           <div className="boardgraph__viewtabs" role="tablist" aria-label="Board view type">
@@ -863,6 +881,7 @@ export function BoardGraph({
             <WiringCanvas
               boardDef={def}
               boardPart={boardPart}
+              focusedChrome={!asWindow}
               renderMode={effectiveView}
               robot={robot as RobotDefinition}
               onChange={onChangeRobot as (next: RobotDefinition) => void}
@@ -878,8 +897,37 @@ export function BoardGraph({
           </div>
           {onAddToProject &&
             (dockOpen ? (
-              <aside className="boardgraph__dock" aria-label="Parts library">
+              <aside
+                className={`boardgraph__dock${dockPinned ? '' : ' boardgraph__dock--overlay'}`}
+                aria-label="Parts library"
+                ref={dockRef}
+                tabIndex={-1}
+                onBlur={(e) => {
+                  // Obsidian-style: an UNPINNED library hides when focus leaves it.
+                  if (shouldAutoHide(dockPinned, dockRef.current, e.relatedTarget)) {
+                    setDockOpen(false)
+                  }
+                }}
+              >
                 <div className="boardgraph__dock-head">
+                  <button
+                    type="button"
+                    className={`boardgraph__pin${dockPinned ? ' is-pinned' : ''}`}
+                    onClick={() => setDockPinned(!dockPinned)}
+                    aria-pressed={dockPinned}
+                    title={dockPinned ? 'Unpin — hide the library when it loses focus' : 'Pin the library open'}
+                    aria-label={dockPinned ? 'Unpin the library panel' : 'Pin the library panel open'}
+                  >
+                    <svg viewBox="0 0 16 16" width="12" height="12" aria-hidden="true">
+                      <path
+                        d="M9.5 1.5l5 5-2.2.6-2.5 2.5.4 3.1-1.8-.3-2.6-2.6L2 13.6 1.4 13l3.8-3.8L2.6 6.6l-.3-1.8 3.1.4L7.9 2.7z"
+                        fill={dockPinned ? 'currentColor' : 'none'}
+                        stroke="currentColor"
+                        strokeWidth="1.3"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  </button>
                   <span>Library</span>
                   <button
                     type="button"
@@ -899,7 +947,11 @@ export function BoardGraph({
               <button
                 type="button"
                 className="boardgraph__dock-tab"
-                onClick={() => setDockOpen(true)}
+                onClick={() => {
+                  setDockOpen(true)
+                  // Focus the overlay so an unpinned library can auto-hide on blur.
+                  requestAnimationFrame(() => dockRef.current?.focus())
+                }}
                 title="Show the library panel"
                 aria-label="Show the library panel"
               >

--- a/src/renderer/src/components/BoardPane.tsx
+++ b/src/renderer/src/components/BoardPane.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { BoardGraph } from './BoardGraph'
 import { PartEditor } from './PartEditor'
 import { OPEN_PART_EDITOR_EVENT, PARTS_CHANGED_EVENT, type OpenPartEditorDetail } from './PartsPanel'
-import { blankPart } from './part-editor.util'
 import { blankRobot, type RobotDefinition } from '../../../shared/robot'
 import { useWorkspace } from '../store/workspace'
 import { useEditorSettings } from '../store/settings'
@@ -187,30 +186,6 @@ export function BoardPane(): JSX.Element {
   }, [])
 
   // Author a NEW board (a starter Microcontroller-family part in `my-parts`).
-  const newBoard = useCallback((): void => {
-    const starter: PartDefinition = {
-      ...blankPart(),
-      id: 'my-board',
-      name: 'My Board',
-      family: 'Microcontroller'
-    }
-    window.api.parts
-      .listLibraries()
-      .then((libs) => {
-        const lib = libs.find((l) => l.id === 'my-parts')
-        setEditing({
-          libraryId: 'my-parts',
-          part: starter,
-          libraries: libs,
-          existingParts: lib?.parts ?? [],
-          isNew: true
-        })
-      })
-      .catch(() =>
-        setEditing({ libraryId: 'my-parts', part: starter, libraries: [], existingParts: [], isNew: true })
-      )
-  }, [])
-
   return (
     <section className="board-pane" aria-label="Board View" style={{ height: '100%', minWidth: 0 }}>
       <BoardGraph
@@ -218,8 +193,6 @@ export function BoardPane(): JSX.Element {
         fileName={fileName}
         isPython={isPython}
         userBoards={userBoards}
-        onOpenBoardsFolder={() => void window.api.board.openBoardsFolder().catch(() => undefined)}
-        onEnterCreator={newBoard}
         robot={robot}
         onChangeRobot={saveRobot}
         libraries={libraries}

--- a/src/renderer/src/components/DataLoggerInstrument.css
+++ b/src/renderer/src/components/DataLoggerInstrument.css
@@ -1,0 +1,213 @@
+/* DATA LOGGER (#242) — a beige dot-matrix printer writing to tractor-feed paper.
+   Unique BEM prefix `dlog__` (instrument CSS is global — see the parts-archive
+   note about prefix collisions). */
+
+.dlog {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  min-height: 0;
+  height: 100%;
+  background: linear-gradient(#d8d2c4, #c8c1b0);
+  border-radius: 6px;
+  overflow: hidden;
+  font-family: var(--font-mono), 'JetBrains Mono', monospace;
+}
+
+/* --- Printer head ---------------------------------------------------------- */
+.dlog__head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.6rem;
+  background: linear-gradient(#e7e2d6, #cfc8b7);
+  border-bottom: 2px solid #9a9282;
+}
+
+.dlog__lamp {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: #7a8a6a;
+  box-shadow: inset 0 0 2px rgba(0, 0, 0, 0.5);
+  flex: 0 0 auto;
+}
+
+.dlog__lamp.is-rec {
+  background: #d84a3a;
+  box-shadow: 0 0 6px #ff5a44, inset 0 0 2px rgba(0, 0, 0, 0.3);
+  animation: dlog-blink 1s steps(2, start) infinite;
+}
+
+@keyframes dlog-blink {
+  50% {
+    opacity: 0.35;
+  }
+}
+
+.dlog__model {
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: #6b6454;
+}
+
+.dlog__controls {
+  margin-left: auto;
+  display: flex;
+  gap: 0.35rem;
+}
+
+.dlog__btn {
+  font-family: inherit;
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 0.28rem 0.55rem;
+  border-radius: 4px;
+  border: 1px solid #8f8879;
+  background: linear-gradient(#f2eee3, #d7d0be);
+  color: #4a4536;
+  cursor: pointer;
+  box-shadow: 0 1px 0 #fffaf0 inset, 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+
+.dlog__btn:hover:not(:disabled) {
+  background: linear-gradient(#fff9ec, #e0d9c6);
+}
+
+.dlog__btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.dlog__btn--rec.is-active {
+  background: linear-gradient(#e86a5a, #c8402f);
+  border-color: #a5281b;
+  color: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3) inset;
+}
+
+/* --- Tractor-feed paper ----------------------------------------------------- */
+.dlog__paper-frame {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  background: #7f7869;
+  padding: 0;
+}
+
+.dlog__sprockets {
+  flex: 0 0 14px;
+  background-color: #efeadd;
+  /* Punched sprocket holes down the margin. */
+  background-image: radial-gradient(circle, #6f6858 0 2.2px, transparent 2.6px);
+  background-size: 14px 16px;
+  background-position: center 6px;
+  border-left: 1px solid #cfc7b4;
+  border-right: 1px solid #cfc7b4;
+}
+
+.dlog__paper {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  background:
+    repeating-linear-gradient(
+      transparent 0 22px,
+      rgba(120, 130, 110, 0.06) 22px 23px
+    ),
+    #f7f4ea;
+  padding: 0.4rem 0.55rem 0.8rem;
+}
+
+.dlog__chart {
+  width: 100%;
+  height: 60px;
+  flex: 0 0 auto;
+  margin-bottom: 0.3rem;
+}
+
+.dlog__gridline {
+  stroke: rgba(90, 100, 80, 0.18);
+  stroke-width: 0.5;
+  stroke-dasharray: 2 2;
+}
+
+.dlog__trace {
+  fill: none;
+  stroke-width: 1.2;
+  /* Dotty printhead look: a dashed line reads as struck dots. */
+  stroke-dasharray: 1.4 1.1;
+  stroke-linecap: round;
+  vector-effect: non-scaling-stroke;
+}
+
+.dlog__print {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.dlog__row {
+  margin: 0;
+  font-size: 0.66rem;
+  line-height: 1.35;
+  color: #33301f;
+  white-space: pre;
+  /* Faint ink-ribbon inconsistency + the dotty impression. */
+  text-shadow: 0.4px 0 rgba(0, 0, 0, 0.18);
+  letter-spacing: 0.02em;
+}
+
+.dlog__row--muted {
+  color: #9a9482;
+  font-style: italic;
+}
+
+.dlog__caret {
+  color: #6a6450;
+  animation: dlog-blink 0.7s steps(2, start) infinite;
+}
+
+/* Empty-state hint on the paper (RECORD stays available in the head). */
+.dlog__paper--empty {
+  align-items: center;
+  justify-content: center;
+}
+
+.dlog__hint {
+  max-width: 280px;
+  padding: 0.5rem 0.2rem;
+  color: #4a4636;
+}
+
+.dlog__hint-title {
+  margin: 0 0 0.4rem;
+  font-size: 0.74rem;
+  font-weight: 700;
+  color: #33301f;
+}
+
+.dlog__hint-line {
+  margin: 0 0 0.4rem;
+  font-size: 0.66rem;
+  line-height: 1.4;
+}
+
+.dlog__hint-code {
+  margin: 0.3rem 0 0;
+  padding: 0.4rem 0.5rem;
+  background: rgba(60, 60, 40, 0.08);
+  border: 1px dashed #b3ab97;
+  border-radius: 3px;
+  font-size: 0.62rem;
+  line-height: 1.4;
+  color: #33301f;
+  white-space: pre;
+  overflow-x: auto;
+}

--- a/src/renderer/src/components/DataLoggerInstrument.tsx
+++ b/src/renderer/src/components/DataLoggerInstrument.tsx
@@ -1,0 +1,248 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { InstrumentWindow, type FloatProps } from './InstrumentWindow'
+import { type InstrumentDef } from './instruments-registry'
+import { useTelemetryStream } from './instrument-telemetry-subscribe'
+import {
+  emptySession,
+  foldReading,
+  seriesKeys,
+  seriesSamples,
+  paperRows,
+  pointsFor,
+  csvFor,
+  csvFilename,
+  type LogSession
+} from './logger-logic'
+import './DataLoggerInstrument.css'
+
+/**
+ * DATA LOGGER (#242) — a vintage **dot-matrix printer** that writes the robot's
+ * measurements onto tractor-feed paper.
+ * =============================================================================
+ *
+ * Hit **RECORD** and every numeric `SNK` telemetry reading (meter, plot, dist,
+ * imu, env…) is captured with a timestamp and "printed" onto continuous paper
+ * scrolling out of the printer: a strip-chart per series plus periodic printed
+ * value rows in a dotty printhead font. **TEAR OFF** exports the session as a
+ * spreadsheet-ready CSV (the `time_s` + one-column-per-series wide format) and
+ * starts a fresh sheet. All the session/CSV/paper geometry is the pure,
+ * unit-tested {@link ./logger-logic}; this component is the printer chrome +
+ * capture wiring.
+ *
+ * On-brand for the retro theme and instantly legible to kids: the robot is
+ * literally *writing down* what it measures. Works fully offline against the
+ * Simulated device, so a hardware-free classroom still gets real data logging.
+ */
+
+export interface DataLoggerProps {
+  def: InstrumentDef
+  onClose?: () => void
+  docked?: boolean
+  onToggleDock?: () => void
+  float?: FloatProps
+  /**
+   * Seed a session (mirrors the scope's `samples` seam, #256): lets render
+   * tests exercise the printed paper without a live stream (effects don't run
+   * under static markup).
+   */
+  initialSession?: LogSession
+}
+
+/** How often the paper re-renders while recording (ms) — paint, not capture. */
+const PAINT_MS = 250
+/** Printed-row cadence on the paper (ms of recording per printed line). */
+const PRINT_INTERVAL_MS = 1000
+/** Strip-chart box (viewBox units). */
+const CHART_W = 260
+const CHART_H = 54
+
+const TRACE_COLORS = ['#3a3a3a', '#5a4a2a', '#2a3a4a', '#3a2a3a', '#2a4a3a', '#4a3a2a']
+
+export function DataLoggerInstrument({
+  def,
+  onClose,
+  docked = true,
+  onToggleDock,
+  float,
+  initialSession
+}: DataLoggerProps): JSX.Element {
+  // The recording session lives in a ref (high-rate capture must not re-render
+  // per sample); a paint tick bumps a few times a second to redraw the paper.
+  const sessionRef = useRef<LogSession>(initialSession ?? emptySession())
+  const startRef = useRef<number | null>(null)
+  const [recording, setRecording] = useState(false)
+  const [, setPaintTick] = useState(0)
+  // Bump each time we tear off, so a fresh empty session re-mounts cleanly.
+  const [sheet, setSheet] = useState(0)
+
+  useTelemetryStream(
+    useCallback(
+      (r) => {
+        if (!recording || startRef.current === null) return
+        foldReading(sessionRef.current, r, performance.now() - startRef.current)
+      },
+      [recording]
+    )
+  )
+
+  // Repaint the paper while recording.
+  useEffect(() => {
+    if (!recording) return
+    const id = window.setInterval(() => setPaintTick((t) => t + 1), PAINT_MS)
+    return () => window.clearInterval(id)
+  }, [recording])
+
+  const toggleRecord = useCallback((): void => {
+    setRecording((on) => {
+      if (!on && startRef.current === null) startRef.current = performance.now()
+      return !on
+    })
+  }, [])
+
+  const tearOff = useCallback((): void => {
+    const csv = csvFor(sessionRef.current)
+    try {
+      const stamp = new Date().toISOString().replace(/[:.]/g, '-')
+      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = csvFilename(stamp)
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch {
+      // Download blocked (rare) — the session still resets below.
+    }
+    sessionRef.current = emptySession()
+    startRef.current = null
+    setRecording(false)
+    setSheet((s) => s + 1)
+  }, [])
+
+  const session = sessionRef.current
+  const keys = seriesKeys(session)
+  const hasData = session.samples.length > 0
+  const duration = hasData ? session.samples[session.samples.length - 1].t : 0
+  const rows = paperRows(session, PRINT_INTERVAL_MS)
+  const sourcePill = recording
+    ? `REC · ${keys.length} series · ${(duration / 1000).toFixed(0)}s`
+    : hasData
+      ? `${session.samples.length} samples`
+      : 'ready'
+
+  // The empty state is NOT an early return: RECORD must always be reachable so
+  // you can arm the logger BEFORE any telemetry arrives. The printer head is
+  // always shown; only the PAPER swaps between the how-to hint and the chart.
+  const empty = !hasData && !recording
+
+  return (
+    <InstrumentWindow
+      name={def.name.toUpperCase()}
+      helpId={`inst-${def.id}`}
+      source={sourcePill}
+      docked={docked}
+      onClose={onClose}
+      onToggleDock={onToggleDock}
+      {...float}
+    >
+      <div className="dlog">
+        {/* The printer head: status lamp + the transport controls. */}
+        <div className="dlog__head">
+          <span className={`dlog__lamp${recording ? ' is-rec' : ''}`} aria-hidden="true" />
+          <span className="dlog__model">SNAKIE&nbsp;DMP-242</span>
+          <div className="dlog__controls">
+            <button
+              type="button"
+              className={`dlog__btn dlog__btn--rec${recording ? ' is-active' : ''}`}
+              onClick={toggleRecord}
+              aria-pressed={recording}
+              title={recording ? 'Pause recording' : 'Record telemetry'}
+            >
+              {recording ? '❚❚ PAUSE' : '● REC'}
+            </button>
+            <button
+              type="button"
+              className="dlog__btn dlog__btn--tear"
+              onClick={tearOff}
+              disabled={!hasData}
+              title="Tear off the page — export this session as CSV"
+            >
+              ✂ TEAR OFF
+            </button>
+          </div>
+        </div>
+
+        {/* Tractor-feed paper: sprocket holes down each edge, the strip-chart at
+            the top, printed value rows below, freshest at the bottom. */}
+        <div className="dlog__paper-frame">
+          <div className="dlog__sprockets dlog__sprockets--l" aria-hidden="true" />
+          {empty ? (
+            <div className="dlog__paper dlog__paper--empty">
+              <div className="dlog__hint">
+                <p className="dlog__hint-title">Nothing logged yet</p>
+                <p className="dlog__hint-line">
+                  The logger prints every reading your program streams — meter volts,
+                  plotted values, distances, temperature — as a chart you can tear off
+                  as a CSV.
+                </p>
+                <p className="dlog__hint-line">
+                  Press <strong>● REC</strong>, then stream some telemetry:
+                </p>
+                <pre className="dlog__hint-code">
+                  <code>{'import instruments as inst\n\ninst.plot(temp=t, light=l)\ninst.update()'}</code>
+                </pre>
+              </div>
+            </div>
+          ) : (
+            <div className="dlog__paper" key={sheet}>
+            <svg
+              className="dlog__chart"
+              viewBox={`0 0 ${CHART_W} ${CHART_H}`}
+              preserveAspectRatio="none"
+              role="img"
+              aria-label="Recorded strip chart"
+            >
+              {/* Faint feed lines. */}
+              {[0.25, 0.5, 0.75].map((f) => (
+                <line
+                  key={f}
+                  className="dlog__gridline"
+                  x1={0}
+                  x2={CHART_W}
+                  y1={CHART_H * f}
+                  y2={CHART_H * f}
+                />
+              ))}
+              {keys.map((k, i) => {
+                const pts = pointsFor(seriesSamples(session, k), duration || 1, CHART_W, CHART_H)
+                return pts ? (
+                  <polyline
+                    key={k}
+                    className="dlog__trace"
+                    points={pts}
+                    stroke={TRACE_COLORS[i % TRACE_COLORS.length]}
+                  />
+                ) : null
+              })}
+            </svg>
+
+            <div className="dlog__print">
+              {rows.length === 0 ? (
+                <p className="dlog__row dlog__row--muted">— waiting for readings —</p>
+              ) : (
+                rows.slice(-40).map((r) => (
+                  <p className="dlog__row" key={r.t}>
+                    {r.text}
+                  </p>
+                ))
+              )}
+              {recording && <p className="dlog__row dlog__caret">▮</p>}
+            </div>
+            </div>
+          )}
+          <div className="dlog__sprockets dlog__sprockets--r" aria-hidden="true" />
+        </div>
+      </div>
+    </InstrumentWindow>
+  )
+}

--- a/src/renderer/src/components/DriverInstallBanner.css
+++ b/src/renderer/src/components/DriverInstallBanner.css
@@ -164,3 +164,12 @@
   width: 100%;
   padding-left: 16px;
 }
+
+/* Modes review: the banner must never eat the board pane — cap it and scroll
+   its own content instead (the narrow embedded pane made it swallow the
+   canvas's full height). */
+.drvbanner {
+  max-height: 200px;
+  overflow-y: auto;
+  flex: 0 0 auto;
+}

--- a/src/renderer/src/components/HelpPanel.tsx
+++ b/src/renderer/src/components/HelpPanel.tsx
@@ -31,8 +31,30 @@ import './HelpPanel.css'
  * an instrument's `?`, via AppShell) opens a specific article.
  */
 export function HelpPanel({ target }: { target?: { id: string; nonce: number } }): JSX.Element {
-  const { openFiles, activeId, openBuffer } = useWorkspace()
+  const { openFiles, activeId, openBuffer, currentFolder } = useWorkspace()
   const source = openFiles.find((f) => f.id === activeId)?.content ?? ''
+
+  // Parts PLACED on the board (robot.yml) — so the "In This Project" section
+  // (and the embedded Board mode's routed part help, modes review) covers parts
+  // that are wired but not imported yet. Refreshes on cross-window edits.
+  const [placedParts, setPlacedParts] = useState<{ lib: string; part: string }[]>([])
+  useEffect(() => {
+    let live = true
+    const load = (): void => {
+      window.api.robot
+        .load(currentFolder ?? undefined)
+        .then((r) => {
+          if (live) setPlacedParts((r.parts ?? []).map((p) => ({ lib: p.lib, part: p.part })))
+        })
+        .catch(() => undefined)
+    }
+    load()
+    const off = window.api.robot.onChanged(load)
+    return () => {
+      live = false
+      off()
+    }
+  }, [currentFolder])
 
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set(DEFAULT_EXPANDED))
   const [selected, setSelected] = useState<string | null>(null)
@@ -80,8 +102,8 @@ export function HelpPanel({ target }: { target?: { id: string; nonce: number } }
 
   // The project-aware "In This Project" parts + a lookup for their bundled help.
   const projectParts = useMemo<ProjectPart[]>(
-    () => detectProjectParts(source, libraries, cursorLine),
-    [source, libraries, cursorLine]
+    () => detectProjectParts(source, libraries, cursorLine, placedParts),
+    [source, libraries, cursorLine, placedParts]
   )
   const partHelp = useMemo(() => {
     const m = new Map<string, string>()

--- a/src/renderer/src/components/InstrumentHost.tsx
+++ b/src/renderer/src/components/InstrumentHost.tsx
@@ -814,13 +814,17 @@ export function InstrumentDockRegion({
   host,
   vis,
   inUse,
-  onToggleVisible
+  onToggleVisible,
+  hideMiniBoard = false
 }: {
   host: UseInstrumentsResult
   vis: InstrumentVisibility
   /** Instrument ids the active file declares in-use (prominent in the header). */
   inUse: Set<string>
   onToggleVisible: (id: string) => void
+  /** Hide the mini board pinned above the toggles — Board MODE shows the real
+   *  embedded Board View beside the dock, so the mini twin is redundant. */
+  hideMiniBoard?: boolean
 }): JSX.Element {
   const [paletteOpen, setPaletteOpen] = useState(false)
   // Merge the LIVE object bindings (from `inst.watch(pwm=…)` → `SNK BIND`) into the
@@ -869,8 +873,9 @@ export function InstrumentDockRegion({
     <InstrumentDock
       top={
         // #168: a compact node-graph board (MCU + code-used pins) pinned above the
-        // instrument toggle icons.
-        <MiniBoardView source={host.source} isPython={host.isPython} />
+        // instrument toggle icons — hidden in Board mode (the embedded Board View
+        // is right there; two boards would be redundant).
+        hideMiniBoard ? undefined : <MiniBoardView source={host.source} isPython={host.isPython} />
       }
       header={
         <DockHeader

--- a/src/renderer/src/components/InstrumentHost.tsx
+++ b/src/renderer/src/components/InstrumentHost.tsx
@@ -24,6 +24,7 @@ import { GamepadInstrument } from './GamepadInstrument'
 import { RangeInstrument } from './RangeInstrument'
 import { ImuInstrument } from './ImuInstrument'
 import { EnvInstrument } from './EnvInstrument'
+import { DataLoggerInstrument } from './DataLoggerInstrument'
 import { LedInstrument } from './LedInstrument'
 import { ServoInstrument } from './ServoInstrument'
 import { PotentiometerInstrument } from './PotentiometerInstrument'
@@ -972,6 +973,8 @@ export function renderSingleton(
       return <ImuInstrument {...p} />
     case 'env':
       return <EnvInstrument {...p} />
+    case 'logger':
+      return <DataLoggerInstrument {...p} />
     case 'led':
       return <LedInstrument {...p} />
     case 'servo':

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -299,7 +299,7 @@ export function Toolbar({
           type="button"
           className="btn btn--ghost btn--icon btn--knob"
           onClick={onOpenBoard}
-          title="Board View — visualise pin wiring (toggle)"
+          title="Board View — pop out into its own window (toggle)"
           aria-label="Toggle Board View"
         >
           {/* dev board: outlined PCB with two rows of header pads + a chip */}

--- a/src/renderer/src/components/WiringCanvas.css
+++ b/src/renderer/src/components/WiringCanvas.css
@@ -767,3 +767,40 @@
 .wc__bus--spi .wc__bus-text {
   fill: #2fb3b3;
 }
+
+/* --- Pinnable connections table (modes review) ----------------------------
+   Focused Board mode: the table starts collapsed; the pin (left of the header)
+   keeps it expanded, unpinned it re-collapses when focus leaves it. */
+.wc__table-headrow {
+  display: flex;
+  align-items: center;
+  gap: 0.15rem;
+}
+
+.wc__table-headrow .wc__table-head--toggle {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.wc__pin {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-muted, #8b919b);
+  cursor: pointer;
+}
+
+.wc__pin:hover {
+  background: rgba(128, 128, 128, 0.18);
+  color: var(--text, #d6dae0);
+}
+
+.wc__pin.is-pinned {
+  color: var(--accent, #34ad4f);
+}

--- a/src/renderer/src/components/WiringCanvas.tsx
+++ b/src/renderer/src/components/WiringCanvas.tsx
@@ -9,6 +9,7 @@ import {
   type PointerEvent as ReactPointerEvent,
   type WheelEvent
 } from 'react'
+import { loadPin, savePin, shouldAutoHide, PIN_KEYS } from './pin-overlay'
 import {
   connectionColor,
   connectionId,
@@ -315,6 +316,14 @@ export interface WiringCanvasProps {
   /** Open the Board View help drawer for a placed part (its instance id). When set,
    *  the selected part's mini-toolbar shows a help button if that part ships help. */
   onShowHelp?: (partInstanceId: string) => void
+  /**
+   * Focused chrome (modes review): true in the EMBEDDED Board mode, where the
+   * canvas is the star — the project browser starts collapsed and the
+   * connections table starts collapsed + unpinned (Obsidian-style: it auto-
+   * collapses on focus loss unless pinned). The floating Board window leaves
+   * this unset and keeps the roomier always-open defaults.
+   */
+  focusedChrome?: boolean
 }
 
 interface Drag {
@@ -339,13 +348,14 @@ interface Drag {
   cy?: number
 }
 
-export function WiringCanvas({ robot, onChange, libraries, boardDef, boardPart, renderMode, usedByCode, onDropPart, onShowHelp }: WiringCanvasProps): JSX.Element {
+export function WiringCanvas({ robot, onChange, libraries, boardDef, boardPart, renderMode, usedByCode, onDropPart, onShowHelp, focusedChrome = false }: WiringCanvasProps): JSX.Element {
   const svgRef = useRef<SVGSVGElement>(null)
   const dragRef = useRef<Drag | null>(null)
   const [view, setView] = useState({ tx: 0, ty: 0, scale: 1 })
   // The floating project BROWSER's open state — lifted here so the fit math can
   // inset content to the right of it (so the leftmost item isn't hidden under it).
-  const [browserOpen, setBrowserOpen] = useState(true)
+  // Focused chrome (Board mode) starts it collapsed so the canvas gets the room.
+  const [browserOpen, setBrowserOpen] = useState(!focusedChrome)
   const [, force] = useState(0) // re-render during a wire/pan/box drag (ref-driven)
   // What the pointer is over (breadboard view): a part (`pin: null`) reveals all
   // its pins' capability chips; a specific pin emphasises its own.
@@ -357,8 +367,18 @@ export function WiringCanvas({ robot, onChange, libraries, boardDef, boardPart, 
   // Whether a rename-input blur should commit (Esc sets it false to cancel cleanly,
   // since closing the input fires a blur we must not treat as a save).
   const renameCommitRef = useRef(true)
-  // Whether the bottom connections table is expanded (collapse it to a header bar).
-  const [connOpen, setConnOpen] = useState(true)
+  // Whether the bottom connections table is expanded (collapse it to a header
+  // bar). Focused chrome (Board mode): starts collapsed and — unless PINNED —
+  // auto-collapses again when focus leaves it (Obsidian-style).
+  const [connOpen, setConnOpen] = useState(!focusedChrome)
+  const [connPinned, setConnPinnedState] = useState<boolean>(() =>
+    focusedChrome ? loadPin(window.localStorage, PIN_KEYS.connections, false) : true
+  )
+  const connRef = useRef<HTMLDivElement | null>(null)
+  const setConnPinned = (v: boolean): void => {
+    setConnPinnedState(v)
+    savePin(window.localStorage, PIN_KEYS.connections, v)
+  }
   // The image-export format menu (PNG / SVG / PDF) on the zoom toolbar.
   const [exportOpen, setExportOpen] = useState(false)
 
@@ -1413,14 +1433,31 @@ export function WiringCanvas({ robot, onChange, libraries, boardDef, boardPart, 
         )}
       </div>
 
-      <div className="wc__bottom">
+      <div
+        className="wc__bottom"
+        ref={connRef}
+        tabIndex={focusedChrome ? -1 : undefined}
+        onBlur={(e) => {
+          // Focused chrome: an UNPINNED expanded table collapses on focus loss.
+          if (focusedChrome && connOpen && shouldAutoHide(connPinned, connRef.current, e.relatedTarget)) {
+            setConnOpen(false)
+          }
+        }}
+      >
         <ConnectionsTable
           connections={robot.connections}
           isDark={isDark}
           onRemove={removeConnection}
           onColor={setConnectionColor}
           open={connOpen}
-          onToggle={() => setConnOpen((o) => !o)}
+          onToggle={() => {
+            const next = !connOpen
+            setConnOpen(next)
+            // Focus the region so an unpinned table can auto-collapse on blur.
+            if (next && focusedChrome) requestAnimationFrame(() => connRef.current?.focus())
+          }}
+          pinned={focusedChrome ? connPinned : undefined}
+          onPin={focusedChrome ? setConnPinned : undefined}
         />
       </div>
     </div>
@@ -1851,7 +1888,9 @@ function ConnectionsTable({
   onRemove,
   onColor,
   open,
-  onToggle
+  onToggle,
+  pinned,
+  onPin
 }: {
   connections: RobotConnection[]
   isDark: boolean
@@ -1860,16 +1899,42 @@ function ConnectionsTable({
   /** Whether the table body is shown (collapsible — hides to just this header). */
   open: boolean
   onToggle: () => void
+  /** Obsidian-style pin (focused Board mode): pinned = stays expanded; unpinned
+   *  = auto-collapses when focus leaves the table. Omit to hide the pin. */
+  pinned?: boolean
+  onPin?: (v: boolean) => void
 }): JSX.Element {
   return (
     <div className="wc__table">
-      <button type="button" className="wc__table-head wc__table-head--toggle" onClick={onToggle} aria-expanded={open}>
-        <span className="wc__tree-caret" aria-hidden="true">
-          {open ? '▾' : '▸'}
-        </span>
-        <span>Connections</span>
-        <span className="wc__table-count">{connections.length}</span>
-      </button>
+      <div className="wc__table-headrow">
+        {onPin && open && (
+          <button
+            type="button"
+            className={`wc__pin${pinned ? ' is-pinned' : ''}`}
+            onClick={() => onPin(!pinned)}
+            aria-pressed={pinned}
+            title={pinned ? 'Unpin — collapse the table when it loses focus' : 'Pin the connections table open'}
+            aria-label={pinned ? 'Unpin the connections table' : 'Pin the connections table open'}
+          >
+            <svg viewBox="0 0 16 16" width="11" height="11" aria-hidden="true">
+              <path
+                d="M9.5 1.5l5 5-2.2.6-2.5 2.5.4 3.1-1.8-.3-2.6-2.6L2 13.6 1.4 13l3.8-3.8L2.6 6.6l-.3-1.8 3.1.4L7.9 2.7z"
+                fill={pinned ? 'currentColor' : 'none'}
+                stroke="currentColor"
+                strokeWidth="1.3"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+        )}
+        <button type="button" className="wc__table-head wc__table-head--toggle" onClick={onToggle} aria-expanded={open}>
+          <span className="wc__tree-caret" aria-hidden="true">
+            {open ? '▾' : '▸'}
+          </span>
+          <span>Connections</span>
+          <span className="wc__table-count">{connections.length}</span>
+        </button>
+      </div>
       {!open ? null : connections.length === 0 ? (
         <p className="wc__muted wc__table-empty">No wires yet — drag between two pins to connect them.</p>
       ) : (

--- a/src/renderer/src/components/help-content.ts
+++ b/src/renderer/src/components/help-content.ts
@@ -156,31 +156,52 @@ function partTokens(p: PartDefinition): string[] {
 export function detectProjectParts(
   source: string,
   libraries: PartLibraryWithParts[],
-  cursorLine?: string
+  cursorLine?: string,
+  /** Parts PLACED on the board (robot.yml `{lib, part}` pairs) — included even
+   *  with no matching import, so the embedded Board mode's part help resolves
+   *  here (modes review: one help surface). Rendered as non-live entries. */
+  placed?: { lib: string; part: string }[]
 ): ProjectPart[] {
-  if (!source) return []
-  const lower = source.toLowerCase()
+  const lower = (source ?? '').toLowerCase()
   const curLower = (cursorLine ?? '').toLowerCase()
   const out: ProjectPart[] = []
   const seen = new Set<string>()
-  for (const lib of libraries) {
-    for (const part of lib.parts) {
-      const toks = partTokens(part)
-      if (toks.length === 0) continue
-      // Match an `import <tok>` / `from <tok> import` usage anywhere in the file.
-      const used = toks.some((t) => new RegExp(`\\b(?:import|from)\\s+${t}\\b`).test(lower))
-      if (!used || seen.has(part.id)) continue
-      seen.add(part.id)
-      out.push({
-        part,
-        articleId: `part-${part.id}`,
-        name: part.name,
-        meta: part.library?.module ?? part.id,
-        accent: part.pcbColor || A.project,
-        live: true,
-        atCursor: toks.some((t) => curLower.includes(t))
-      })
+  if (source) {
+    for (const lib of libraries) {
+      for (const part of lib.parts) {
+        const toks = partTokens(part)
+        if (toks.length === 0) continue
+        // Match an `import <tok>` / `from <tok> import` usage anywhere in the file.
+        const used = toks.some((t) => new RegExp(`\\b(?:import|from)\\s+${t}\\b`).test(lower))
+        if (!used || seen.has(part.id)) continue
+        seen.add(part.id)
+        out.push({
+          part,
+          articleId: `part-${part.id}`,
+          name: part.name,
+          meta: part.library?.module ?? part.id,
+          accent: part.pcbColor || A.project,
+          live: true,
+          atCursor: toks.some((t) => curLower.includes(t))
+        })
+      }
     }
+  }
+  // Board-placed parts join the section too (deduped against import matches).
+  for (const rp of placed ?? []) {
+    if (seen.has(rp.part)) continue
+    const part = libraries.find((l) => l.id === rp.lib)?.parts.find((p) => p.id === rp.part)
+    if (!part) continue
+    seen.add(part.id)
+    out.push({
+      part,
+      articleId: `part-${part.id}`,
+      name: part.name,
+      meta: 'on the board',
+      accent: part.pcbColor || A.project,
+      live: false,
+      atCursor: false
+    })
   }
   return out
 }

--- a/src/renderer/src/components/help/inst-logger.md
+++ b/src/renderer/src/components/help/inst-logger.md
@@ -1,0 +1,61 @@
+# Data Logger
+
+A vintage **dot-matrix printer** that writes your robot's measurements onto
+tractor-feed paper. Every numeric reading your program streams — meter volts,
+plotted values, distances, temperature, IMU angles — is captured with a
+timestamp, drawn as a strip-chart and "printed" as value rows. **Tear the page
+off** to save the whole session as a CSV you can open in a spreadsheet.
+
+It works fully offline against the **Simulated device**, so you can log data
+with no hardware at all.
+
+## Recording
+
+1. Open the Data Logger from the instrument dock.
+2. Press **● REC**. The red lamp blinks while it captures.
+3. Stream some telemetry from your program (see below), or run a sketch that
+   already does.
+4. Press **❚❚ PAUSE** to stop; **● REC** again to resume onto the same page.
+5. Press **✂ TEAR OFF** to download the session as `snakie-log-….csv` and start
+   a fresh sheet.
+
+## Streaming values to log
+
+Anything you send through the `instruments` helper is captured:
+
+```python
+import instruments as inst
+import time
+
+while True:
+    inst.plot(temp=read_temp(), light=read_light())  # named series
+    inst.update()
+    time.sleep(1)
+```
+
+Meter, distance, IMU and environment readings are logged too:
+
+```python
+inst.meter(adc=sensor.read_u16() * 3.3 / 65535)   # one column "meter:adc"
+inst.env(t, p, h)                                   # temp / pressure / humidity
+```
+
+## The CSV
+
+The tear-off is a **wide** CSV — a `time_s` column plus one column per series —
+so it drops straight into Excel, Google Sheets or Python/pandas for a chart or a
+lab write-up:
+
+```
+time_s,plot:temp,plot:light
+0.000,21.4,880
+1.001,21.6,875
+2.003,21.9,860
+```
+
+## Tips
+
+- Each distinct series (channel/label) becomes its own trace and its own CSV
+  column, so log several sensors at once.
+- Recording keeps going while the instrument is docked or popped out — pop it
+  out to watch a long run in its own window.

--- a/src/renderer/src/components/instruments-registry.ts
+++ b/src/renderer/src/components/instruments-registry.ts
@@ -119,6 +119,17 @@ export const INSTRUMENTS: InstrumentDef[] = [
     kind: 'singleton',
     description: 'Plot printed serial values over time as a scrolling chart.'
   },
+  {
+    id: 'logger',
+    name: 'Data Logger',
+    accent: '#c8a24a',
+    border: 'rgba(200,162,74,.45)',
+    // a printer with a sheet of paper feeding out
+    icon: 'M6 4 h12 v5 H6 Z M4 9 h16 v6 H4 Z M7 15 h10 v5 H7 Z M9 18 h6',
+    group: 'input',
+    kind: 'singleton',
+    description: 'Record telemetry onto dot-matrix paper; tear off the page as CSV.'
+  },
 
   // --- New placeholder bodies (#110–#121) ----------------------------------
   {

--- a/src/renderer/src/components/logger-logic.ts
+++ b/src/renderer/src/components/logger-logic.ts
@@ -1,0 +1,216 @@
+/**
+ * DATA LOGGER logic (#242) — pure, unit-tested session/CSV/paper helpers for
+ * the dot-matrix-printer Data Logger instrument.
+ * =============================================================================
+ *
+ * A recording SESSION captures every numeric field the `SNK` telemetry stream
+ * produces (meter volts, plot series, distances, IMU angles, env t/p/h, …) as
+ * flat `(t, key, value)` samples — `key` is `<kind>:<channel>[.<field>]`, e.g.
+ * `meter:adc0`, `env:env.temp`, `plot:light`. Tearing the page off exports the
+ * session as a WIDE CSV (one column per key) ready for a spreadsheet, and the
+ * paper renders periodic printed value rows + a strip-chart per series.
+ *
+ * DOM-free and Date-free: callers supply timestamps (ms since the session
+ * started), so everything here is deterministic and testable.
+ */
+import type { Telemetry } from './instrument-telemetry'
+
+/** One captured numeric sample. */
+export interface LogSample {
+  /** ms since the session started. */
+  t: number
+  /** `<kind>:<channel>[.<field>]` series key. */
+  key: string
+  value: number
+}
+
+/** A recording session: flat samples in arrival order. */
+export interface LogSession {
+  samples: LogSample[]
+}
+
+export const emptySession = (): LogSession => ({ samples: [] })
+
+/**
+ * Flatten one parsed telemetry reading into `(key, value)` pairs. Non-numeric
+ * kinds (binds, screen frames, scan results…) produce nothing. Booleans log as
+ * 0/1 so a button press draws as a step trace.
+ */
+export function pairsForReading(r: Telemetry): Array<[string, number]> {
+  switch (r.kind) {
+    case 'scope':
+      return [[`scope:${r.ch}`, r.value]]
+    case 'pwm':
+      return [[`pwm:${r.ch}.duty`, r.duty]]
+    case 'meter':
+      return [[`meter:${r.ch}`, r.value]]
+    case 'plot':
+      return r.series.map((s) => [`plot:${s.label}`, s.value])
+    case 'imu':
+      return [
+        [`imu:${r.ch}.roll`, r.roll],
+        [`imu:${r.ch}.pitch`, r.pitch],
+        [`imu:${r.ch}.yaw`, r.yaw]
+      ]
+    case 'env':
+      return [
+        [`env:${r.ch}.temp`, r.temp],
+        [`env:${r.ch}.pressure`, r.pressure],
+        [`env:${r.ch}.humidity`, r.humidity]
+      ]
+    case 'dist': {
+      const out: Array<[string, number]> = [[`dist:${r.ch}`, r.mm]]
+      if (r.angle !== undefined) out.push([`dist:${r.ch}.angle`, r.angle])
+      return out
+    }
+    case 'enc':
+      return [[`enc:${r.ch}`, r.count]]
+    case 'btn':
+      return [[`btn:${r.name}`, r.pressed ? 1 : 0]]
+    default:
+      return []
+  }
+}
+
+/** Fold a reading into the session (mutates + returns it — hot path). */
+export function foldReading(session: LogSession, r: Telemetry, t: number): LogSession {
+  for (const [key, value] of pairsForReading(r)) {
+    if (Number.isFinite(value)) session.samples.push({ t, key, value })
+  }
+  return session
+}
+
+/** The distinct series keys, in first-seen order. */
+export function seriesKeys(session: LogSession): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const s of session.samples) {
+    if (seen.has(s.key)) continue
+    seen.add(s.key)
+    out.push(s.key)
+  }
+  return out
+}
+
+/** All samples of one series, in order. */
+export function seriesSamples(session: LogSession, key: string): LogSample[] {
+  return session.samples.filter((s) => s.key === key)
+}
+
+/** Escape one CSV cell (quotes cells containing separators/quotes/newlines). */
+function csvCell(v: string): string {
+  return /[",\n\r]/.test(v) ? `"${v.replace(/"/g, '""')}"` : v
+}
+
+/**
+ * The tear-off: a WIDE CSV — `time_s` + one column per series key; one row per
+ * distinct sample time (samples sharing a timestamp share a row; gaps stay
+ * empty). Times print in seconds to 3 dp.
+ */
+export function csvFor(session: LogSession): string {
+  const keys = seriesKeys(session)
+  const header = ['time_s', ...keys].map(csvCell).join(',')
+  if (session.samples.length === 0) return header + '\n'
+  // Group by timestamp, preserving first-seen time order.
+  const byT = new Map<number, Map<string, number>>()
+  for (const s of session.samples) {
+    let row = byT.get(s.t)
+    if (!row) {
+      row = new Map()
+      byT.set(s.t, row)
+    }
+    row.set(s.key, s.value) // later sample at the same t wins (latest reading)
+  }
+  const lines = [header]
+  for (const [t, row] of byT) {
+    lines.push(
+      [
+        (t / 1000).toFixed(3),
+        ...keys.map((k) => (row.has(k) ? String(row.get(k)) : ''))
+      ].join(',')
+    )
+  }
+  return lines.join('\n') + '\n'
+}
+
+/** A printed paper row: `12.5s  adc0=1.63  temp=22.1` (short key names). */
+export interface PaperRow {
+  t: number
+  text: string
+}
+
+/** Trim `<kind>:` and keep `channel[.field]` for the printed rows. */
+export function shortKey(key: string): string {
+  const i = key.indexOf(':')
+  return i >= 0 ? key.slice(i + 1) : key
+}
+
+/**
+ * The periodic printed value rows for the paper: the LATEST value of every
+ * series at each `intervalMs` boundary crossed by the recording. The final
+ * partial interval prints too (so a short session still shows a row).
+ */
+export function paperRows(session: LogSession, intervalMs: number): PaperRow[] {
+  if (session.samples.length === 0 || intervalMs <= 0) return []
+  const keys = seriesKeys(session)
+  const latest = new Map<string, number>()
+  const rows: PaperRow[] = []
+  let nextTick = intervalMs
+  const push = (t: number): void => {
+    const cells = keys
+      .filter((k) => latest.has(k))
+      .map((k) => `${shortKey(k)}=${formatValue(latest.get(k)!)}`)
+    if (cells.length > 0) rows.push({ t, text: `${(t / 1000).toFixed(1)}s  ${cells.join('  ')}` })
+  }
+  for (const s of session.samples) {
+    while (s.t >= nextTick) {
+      push(nextTick)
+      nextTick += intervalMs
+    }
+    latest.set(s.key, s.value)
+  }
+  const lastT = session.samples[session.samples.length - 1].t
+  push(lastT)
+  return rows
+}
+
+/** Compact number for the printed rows (≤ 4 significant-ish chars). */
+export function formatValue(v: number): string {
+  if (!Number.isFinite(v)) return '—'
+  if (Number.isInteger(v)) return String(v)
+  return Math.abs(v) >= 100 ? v.toFixed(0) : Math.abs(v) >= 10 ? v.toFixed(1) : v.toFixed(2)
+}
+
+/** Min/max extent of a sample list (empty → null). */
+export function extentOf(samples: LogSample[]): { min: number; max: number } | null {
+  if (samples.length === 0) return null
+  let min = Infinity
+  let max = -Infinity
+  for (const s of samples) {
+    if (s.value < min) min = s.value
+    if (s.value > max) max = s.value
+  }
+  return { min, max }
+}
+
+/**
+ * SVG polyline points for one series across `[0, durationMs]` mapped into a
+ * `w×h` box (y flipped; flat series draw a centre line). Empty series → ''.
+ */
+export function pointsFor(samples: LogSample[], durationMs: number, w: number, h: number): string {
+  if (samples.length === 0 || durationMs <= 0) return ''
+  const ext = extentOf(samples)!
+  const span = ext.max - ext.min
+  return samples
+    .map((s) => {
+      const x = (s.t / durationMs) * w
+      const y = span === 0 ? h / 2 : h - ((s.value - ext.min) / span) * h
+      return `${x.toFixed(1)},${y.toFixed(1)}`
+    })
+    .join(' ')
+}
+
+/** Suggested tear-off filename (caller supplies the wall-clock stamp). */
+export function csvFilename(stamp: string): string {
+  return `snakie-log-${stamp.replace(/[^0-9T-]/g, '').slice(0, 15)}.csv`
+}

--- a/src/renderer/src/components/pin-overlay.ts
+++ b/src/renderer/src/components/pin-overlay.ts
@@ -1,0 +1,65 @@
+/**
+ * PIN-OVERLAY helpers — Obsidian-style pinnable panels (modes review).
+ * =============================================================================
+ *
+ * In the focused Board mode the side panels (parts library, connections table)
+ * behave like Obsidian's sidebars: they open as OVERLAYS over the canvas and
+ * auto-hide when they lose focus — unless PINNED, in which case they stay put
+ * (the pin sits at the top-left of the panel header). The floating Board View
+ * window defaults to pinned, which is exactly the pre-review behaviour.
+ *
+ * DOM-free decision + persistence helpers so the behaviour is unit-testable;
+ * the components own the actual focus wiring.
+ */
+
+/** Minimal storage shape (mirrors `store/layout.ts`'s StorageLike). */
+export interface PinStorage {
+  getItem(key: string): string | null
+  setItem?(key: string, value: string): void
+}
+
+/**
+ * Should an unpinned panel hide after a focusout? True when focus moved OUTSIDE
+ * the panel (`next` not contained in it). A pinned panel never auto-hides; a
+ * null `next` (focus left the document / clicked bare canvas) does hide.
+ */
+export function shouldAutoHide(
+  pinned: boolean,
+  panel: { contains(other: Node | null): boolean } | null,
+  next: EventTarget | null
+): boolean {
+  if (pinned) return false
+  if (!panel) return false
+  // Duck-typed rather than `instanceof Node` — robust across realms (and the
+  // node test env, which has no DOM globals).
+  const node = next && typeof next === 'object' ? (next as Node) : null
+  if (node && panel.contains(node)) return false
+  return true
+}
+
+/** Read a persisted pin flag; anything unreadable → `fallback`. */
+export function loadPin(storage: PinStorage, key: string, fallback: boolean): boolean {
+  try {
+    const raw = storage.getItem(key)
+    if (raw === null) return fallback
+    const v = JSON.parse(raw)
+    return typeof v === 'boolean' ? v : fallback
+  } catch {
+    return fallback
+  }
+}
+
+/** Persist a pin flag (best-effort — storage may be unavailable). */
+export function savePin(storage: PinStorage, key: string, value: boolean): void {
+  try {
+    storage.setItem?.(key, JSON.stringify(value))
+  } catch {
+    // Quota/full/denied — the pin just won't stick across restarts.
+  }
+}
+
+/** The persisted pin keys (one per pinnable board panel). */
+export const PIN_KEYS = {
+  library: 'snakie.board.pin.library',
+  connections: 'snakie.board.pin.connections'
+} as const

--- a/src/renderer/src/store/layout.ts
+++ b/src/renderer/src/store/layout.ts
@@ -38,16 +38,17 @@ import {
 } from 'react'
 import type { ActivityView } from '../components/ActivityBar'
 
-/** The named workspaces (Phase 1). Order = the switcher's display order. */
-export const WORKSPACE_IDS = ['code', 'board', 'lab', 'data'] as const
+/** The named workspaces (Phase 1; slimmed 4 → 3 by the modes review). Order =
+ *  the switcher's display order. Old `lab`/`data` envelopes migrate to
+ *  `datalab` in {@link loadLayoutState}. */
+export const WORKSPACE_IDS = ['code', 'board', 'datalab'] as const
 export type WorkspaceId = (typeof WORKSPACE_IDS)[number]
 
 /** Display labels + a one-line description for the switcher tooltips. */
 export const WORKSPACE_INFO: Record<WorkspaceId, { label: string; hint: string }> = {
   code: { label: 'Code', hint: 'Editor-first: files, editor and console' },
-  board: { label: 'Board', hint: 'Tri-split: code · Board View · instruments, side by side' },
-  lab: { label: 'Lab', hint: 'Instrument bench: big dock, editor and console' },
-  data: { label: 'Data', hint: 'Data-first: large console/plotter under the editor' }
+  board: { label: 'Board', hint: 'Focused Board View beside your code' },
+  datalab: { label: 'Data Lab', hint: 'Instrument bench + a tall console/plotter' }
 }
 
 /** One workspace's remembered geometry. */
@@ -106,8 +107,9 @@ export const WORKSPACE_PRESETS: Record<WorkspaceId, WorkspaceLayout> = {
     horizontal: [0, 42, 58, 0],
     vertical: [65, 35]
   },
-  // Instrument bench: maximum dock, slim console for the REPL.
-  lab: {
+  // Data Lab (the old Lab + Data merged): the instrument bench — dock open —
+  // with a tall shell region (Console | Plotter | Problems) for data work.
+  datalab: {
     activityView: 'files',
     filesCollapsed: true,
     shellCollapsed: false,
@@ -115,19 +117,7 @@ export const WORKSPACE_PRESETS: Record<WorkspaceId, WorkspaceLayout> = {
     dockOpen: true,
     boardPaneOpen: false,
     horizontal: [0, 100, 0, 0],
-    vertical: [75, 25]
-  },
-  // Data-first: a tall shell region (Console | Plotter | Problems) + the dock
-  // for the Plotter/logger instruments.
-  data: {
-    activityView: 'files',
-    filesCollapsed: true,
-    shellCollapsed: false,
-    rightCollapsed: true,
-    dockOpen: true,
-    boardPaneOpen: false,
-    horizontal: [0, 100, 0, 0],
-    vertical: [45, 55]
+    vertical: [50, 50]
   }
 }
 
@@ -239,11 +229,18 @@ export function loadLayoutState(storage: StorageLike): LayoutState {
       const parsed = JSON.parse(raw) as Partial<LayoutState>
       if (parsed && parsed.version === 1 && parsed.workspaces) {
         const state = defaultLayoutState()
-        state.active = WORKSPACE_IDS.includes(parsed.active as WorkspaceId)
-          ? (parsed.active as WorkspaceId)
-          : 'code'
+        // Modes review: the old `lab` and `data` workspaces merged into
+        // `datalab`. Map a stale active id, and seed datalab's geometry from
+        // the old data (preferred — it's the closer layout) else lab entry, so
+        // an existing user's sizes carry over.
+        const saved = parsed.workspaces as Record<string, unknown>
+        const activeRaw = ['lab', 'data'].includes(parsed.active as string)
+          ? 'datalab'
+          : (parsed.active as WorkspaceId)
+        state.active = WORKSPACE_IDS.includes(activeRaw) ? activeRaw : 'code'
         for (const id of WORKSPACE_IDS) {
-          state.workspaces[id] = sanitiseWorkspace(parsed.workspaces[id], WORKSPACE_PRESETS[id])
+          const legacy = id === 'datalab' ? (saved.datalab ?? saved.data ?? saved.lab) : saved[id]
+          state.workspaces[id] = sanitiseWorkspace(legacy, WORKSPACE_PRESETS[id])
         }
         return state
       }

--- a/test/dataLoggerRender.test.ts
+++ b/test/dataLoggerRender.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { DataLoggerInstrument } from '../src/renderer/src/components/DataLoggerInstrument'
+import { instrumentById, INSTRUMENTS } from '../src/renderer/src/components/instruments-registry'
+import { emptySession, foldReading } from '../src/renderer/src/components/logger-logic'
+import { parseTelemetry } from '../src/renderer/src/components/instrument-telemetry'
+
+const def = instrumentById('logger')!
+
+describe('Data Logger instrument (#242)', () => {
+  it('registers the logger singleton', () => {
+    expect(def).toBeDefined()
+    expect(def.kind).toBe('singleton')
+    expect(def.name).toBe('Data Logger')
+    expect(INSTRUMENTS.filter((d) => d.id === 'logger')).toHaveLength(1)
+  })
+
+  it('with NO data still shows the printer head (RECORD reachable) + a how-to hint', () => {
+    const html = renderToStaticMarkup(createElement(DataLoggerInstrument, { def, docked: true }))
+    // The empty paper carries the how-to hint…
+    expect(html).toContain('Nothing logged yet')
+    expect(html).toContain('inst.plot')
+    // …but the RECORD button is present so you can arm before any telemetry.
+    expect(html).toContain('● REC')
+    expect(html).toContain('dlog__paper--empty')
+  })
+
+  it('with a seeded session draws the printer: chart trace + printed rows', () => {
+    const session = emptySession()
+    foldReading(session, parseTelemetry('SNK PLOT temp=21 light=880')!, 200)
+    foldReading(session, parseTelemetry('SNK PLOT temp=22 light=875')!, 1200)
+    foldReading(session, parseTelemetry('SNK PLOT temp=23 light=860')!, 2200)
+    const html = renderToStaticMarkup(
+      createElement(DataLoggerInstrument, { def, docked: true, initialSession: session })
+    )
+    // Printer chrome + tractor-feed paper.
+    expect(html).toContain('dlog__paper')
+    expect(html).toContain('DMP-242')
+    expect(html).toContain('TEAR OFF')
+    // A strip-chart trace rendered for a series.
+    expect(html).toContain('dlog__trace')
+    // Printed value rows carry the short series names.
+    expect(html).toContain('temp=')
+    expect(html).toContain('light=')
+  })
+})

--- a/test/layoutStore.test.ts
+++ b/test/layoutStore.test.ts
@@ -13,9 +13,9 @@ const storage = (entries: Record<string, string> = {}): StorageLike => ({
   getItem: (k: string) => (k in entries ? entries[k] : null)
 })
 
-describe('workspace presets (epic #259 Phase 1)', () => {
-  it('defines the four workspaces with valid geometry', () => {
-    expect(WORKSPACE_IDS).toEqual(['code', 'board', 'lab', 'data'])
+describe('workspace presets (epic #259 Phase 1; slimmed to 3 by the modes review)', () => {
+  it('defines the three workspaces with valid geometry', () => {
+    expect(WORKSPACE_IDS).toEqual(['code', 'board', 'datalab'])
     for (const id of WORKSPACE_IDS) {
       const p = WORKSPACE_PRESETS[id]
       expect(p.horizontal).toHaveLength(4)
@@ -31,19 +31,19 @@ describe('workspace presets (epic #259 Phase 1)', () => {
     expect(code.shellCollapsed).toBe(false)
     expect(code.rightCollapsed).toBe(true)
     expect(code.dockOpen).toBe(false)
-    for (const id of ['board', 'lab', 'data'] as const) {
+    for (const id of ['board', 'datalab'] as const) {
       expect(WORKSPACE_PRESETS[id].dockOpen, id).toBe(true)
     }
-    // Board is the education tri-split: the embedded Board View pane opens with
-    // a real share beside the code; the other workspaces keep it closed at 0.
+    // Board: the embedded Board View pane opens with a real share beside the
+    // code; the other workspaces keep it closed at 0.
     expect(WORKSPACE_PRESETS.board.boardPaneOpen).toBe(true)
     expect(WORKSPACE_PRESETS.board.horizontal[2]).toBeGreaterThan(0)
-    for (const id of ['code', 'lab', 'data'] as const) {
+    for (const id of ['code', 'datalab'] as const) {
       expect(WORKSPACE_PRESETS[id].boardPaneOpen, id).toBe(false)
       expect(WORKSPACE_PRESETS[id].horizontal[2], id).toBe(0)
     }
-    // Data is console-first: the shell gets the larger vertical share.
-    expect(WORKSPACE_PRESETS.data.vertical[1]).toBeGreaterThan(
+    // Data Lab gives the shell a bigger share than Code (data work under the editor).
+    expect(WORKSPACE_PRESETS.datalab.vertical[1]).toBeGreaterThan(
       WORKSPACE_PRESETS.code.vertical[1]
     )
   })
@@ -61,7 +61,7 @@ describe('loadLayoutState (corruption-safe, versioned)', () => {
     const s = loadLayoutState(storage())
     expect(s.version).toBe(1)
     expect(s.active).toBe('code')
-    expect(s.workspaces.lab).toEqual(WORKSPACE_PRESETS.lab)
+    expect(s.workspaces.datalab).toEqual(WORKSPACE_PRESETS.datalab)
   })
 
   it('survives corrupt JSON and wrong shapes', () => {
@@ -74,11 +74,44 @@ describe('loadLayoutState (corruption-safe, versioned)', () => {
 
   it('round-trips a valid envelope and keeps the active workspace', () => {
     const saved = defaultLayoutState()
-    saved.active = 'lab'
-    saved.workspaces.lab.vertical = [60, 40]
+    saved.active = 'datalab'
+    saved.workspaces.datalab.vertical = [60, 40]
     const s = loadLayoutState(storage({ [LAYOUT_STORAGE_KEY]: JSON.stringify(saved) }))
-    expect(s.active).toBe('lab')
-    expect(s.workspaces.lab.vertical).toEqual([60, 40])
+    expect(s.active).toBe('datalab')
+    expect(s.workspaces.datalab.vertical).toEqual([60, 40])
+  })
+
+  it('migrates an old 4-workspace envelope: lab/data merge into datalab', () => {
+    // A pre-modes-review envelope with the old ids, `data` sized distinctively.
+    const old = {
+      version: 1,
+      active: 'lab',
+      workspaces: {
+        code: { ...WORKSPACE_PRESETS.code },
+        board: { ...WORKSPACE_PRESETS.board },
+        lab: { ...WORKSPACE_PRESETS.datalab, vertical: [75, 25] },
+        data: { ...WORKSPACE_PRESETS.datalab, vertical: [41, 59] }
+      }
+    }
+    const s = loadLayoutState(storage({ [LAYOUT_STORAGE_KEY]: JSON.stringify(old) }))
+    // Stale active id maps to the merged workspace…
+    expect(s.active).toBe('datalab')
+    // …which seeds its geometry from the old `data` entry (preferred over lab).
+    expect(s.workspaces.datalab.vertical).toEqual([41, 59])
+  })
+
+  it('migrates active "data" too, and falls back to the lab entry when data is absent', () => {
+    const old = {
+      version: 1,
+      active: 'data',
+      workspaces: {
+        code: { ...WORKSPACE_PRESETS.code },
+        lab: { ...WORKSPACE_PRESETS.datalab, vertical: [76, 24] }
+      }
+    }
+    const s = loadLayoutState(storage({ [LAYOUT_STORAGE_KEY]: JSON.stringify(old) }))
+    expect(s.active).toBe('datalab')
+    expect(s.workspaces.datalab.vertical).toEqual([76, 24])
   })
 
   it('sanitises bad fields per-workspace back to the preset (not all-or-nothing)', () => {

--- a/test/loggerLogic.test.ts
+++ b/test/loggerLogic.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest'
+import {
+  emptySession,
+  foldReading,
+  pairsForReading,
+  seriesKeys,
+  seriesSamples,
+  csvFor,
+  paperRows,
+  shortKey,
+  formatValue,
+  extentOf,
+  pointsFor,
+  csvFilename
+} from '../src/renderer/src/components/logger-logic'
+import { parseTelemetry } from '../src/renderer/src/components/instrument-telemetry'
+
+describe('pairsForReading (#242)', () => {
+  it('flattens every numeric telemetry kind to keyed pairs', () => {
+    expect(pairsForReading(parseTelemetry('SNK METER adc0 1.65 V')!)).toEqual([['meter:adc0', 1.65]])
+    expect(pairsForReading(parseTelemetry('SNK SCOPE ch1 0.5')!)).toEqual([['scope:ch1', 0.5]])
+    expect(pairsForReading(parseTelemetry('SNK ENV env 21.5 1013.2 45')!)).toEqual([
+      ['env:env.temp', 21.5],
+      ['env:env.pressure', 1013.2],
+      ['env:env.humidity', 45]
+    ])
+    expect(pairsForReading(parseTelemetry('SNK IMU imu 1 2 3')!)).toEqual([
+      ['imu:imu.roll', 1],
+      ['imu:imu.pitch', 2],
+      ['imu:imu.yaw', 3]
+    ])
+    expect(pairsForReading(parseTelemetry('SNK DIST dist 150')!)).toEqual([['dist:dist', 150]])
+    expect(pairsForReading(parseTelemetry('SNK ENC enc 42')!)).toEqual([['enc:enc', 42]])
+    // Buttons log as a 0/1 step trace.
+    expect(pairsForReading(parseTelemetry('SNK BTN a 1')!)).toEqual([['btn:a', 1]])
+    // Plot rows expand per series.
+    expect(pairsForReading(parseTelemetry('SNK PLOT temp=22.1 light=88')!)).toEqual([
+      ['plot:temp', 22.1],
+      ['plot:light', 88]
+    ])
+  })
+
+  it('non-numeric kinds (binds/ready) produce nothing', () => {
+    const bind = parseTelemetry('SNK BIND pwm pwm')
+    if (bind) expect(pairsForReading(bind)).toEqual([])
+  })
+})
+
+describe('session fold + series (#242)', () => {
+  const session = emptySession()
+  foldReading(session, parseTelemetry('SNK METER adc0 1.0 V')!, 0)
+  foldReading(session, parseTelemetry('SNK PLOT temp=20')!, 500)
+  foldReading(session, parseTelemetry('SNK METER adc0 2.0 V')!, 1000)
+
+  it('captures samples with timestamps + first-seen key order', () => {
+    expect(session.samples).toHaveLength(3)
+    expect(seriesKeys(session)).toEqual(['meter:adc0', 'plot:temp'])
+    expect(seriesSamples(session, 'meter:adc0').map((s) => s.value)).toEqual([1, 2])
+  })
+
+  it('exports a WIDE csv: time_s + one column per series', () => {
+    const csv = csvFor(session)
+    const lines = csv.trim().split('\n')
+    expect(lines[0]).toBe('time_s,meter:adc0,plot:temp')
+    expect(lines[1]).toBe('0.000,1,')
+    expect(lines[2]).toBe('0.500,,20')
+    expect(lines[3]).toBe('1.000,2,')
+  })
+
+  it('an empty session still exports a header row', () => {
+    expect(csvFor(emptySession())).toBe('time_s\n')
+  })
+
+  it('samples sharing a timestamp share a CSV row (latest wins per key)', () => {
+    const s = emptySession()
+    foldReading(s, parseTelemetry('SNK METER adc0 1.0 V')!, 100)
+    foldReading(s, parseTelemetry('SNK PLOT temp=20')!, 100)
+    foldReading(s, parseTelemetry('SNK METER adc0 1.5 V')!, 100)
+    const lines = csvFor(s).trim().split('\n')
+    expect(lines).toHaveLength(2)
+    expect(lines[1]).toBe('0.100,1.5,20')
+  })
+})
+
+describe('paper rows (#242)', () => {
+  it('prints the latest values at each interval boundary + the tail', () => {
+    const s = emptySession()
+    foldReading(s, parseTelemetry('SNK METER adc0 1.0 V')!, 200)
+    foldReading(s, parseTelemetry('SNK METER adc0 1.5 V')!, 1200)
+    foldReading(s, parseTelemetry('SNK METER adc0 2.0 V')!, 2400)
+    const rows = paperRows(s, 1000)
+    // Boundaries at 1s (latest=1.0) and 2s (latest=1.5), tail at 2.4s (2.0).
+    expect(rows.map((r) => r.text)).toEqual([
+      '1.0s  adc0=1',
+      '2.0s  adc0=1.50',
+      '2.4s  adc0=2'
+    ])
+  })
+
+  it('empty session → no rows', () => {
+    expect(paperRows(emptySession(), 1000)).toEqual([])
+  })
+})
+
+describe('chart geometry + formatting (#242)', () => {
+  it('extent + points map into the box with y flipped', () => {
+    const samples = [
+      { t: 0, key: 'k', value: 0 },
+      { t: 500, key: 'k', value: 5 },
+      { t: 1000, key: 'k', value: 10 }
+    ]
+    expect(extentOf(samples)).toEqual({ min: 0, max: 10 })
+    const pts = pointsFor(samples, 1000, 100, 50)
+    expect(pts).toBe('0.0,50.0 50.0,25.0 100.0,0.0')
+  })
+
+  it('a flat series draws the centre line; empty series → empty string', () => {
+    const flat = [
+      { t: 0, key: 'k', value: 3 },
+      { t: 1000, key: 'k', value: 3 }
+    ]
+    expect(pointsFor(flat, 1000, 100, 50)).toBe('0.0,25.0 100.0,25.0')
+    expect(pointsFor([], 1000, 100, 50)).toBe('')
+  })
+
+  it('shortKey trims the kind prefix; formatValue is compact', () => {
+    expect(shortKey('env:env.temp')).toBe('env.temp')
+    expect(shortKey('bare')).toBe('bare')
+    expect(formatValue(1013.25)).toBe('1013')
+    expect(formatValue(21.54)).toBe('21.5')
+    expect(formatValue(1.234)).toBe('1.23')
+    expect(formatValue(42)).toBe('42')
+  })
+
+  it('csvFilename builds a safe name from a wall-clock stamp', () => {
+    expect(csvFilename('2026-07-07T193000')).toMatch(/^snakie-log-[0-9T-]+\.csv$/)
+  })
+})

--- a/test/pinOverlay.test.ts
+++ b/test/pinOverlay.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+import { shouldAutoHide, loadPin, savePin, PIN_KEYS } from '../src/renderer/src/components/pin-overlay'
+
+/** A fake panel: "contains" exactly the nodes in the set. */
+const panelWith = (...nodes: Node[]): { contains(n: Node | null): boolean } => ({
+  contains: (n) => n !== null && nodes.includes(n)
+})
+// Minimal Node stand-ins — shouldAutoHide duck-types (no `instanceof Node`),
+// so plain objects work in the DOM-less node test environment.
+const mkNode = (): Node => ({} as Node)
+
+describe('shouldAutoHide (pinnable board panels)', () => {
+  it('a pinned panel never auto-hides', () => {
+    expect(shouldAutoHide(true, panelWith(), null)).toBe(false)
+    expect(shouldAutoHide(true, null, null)).toBe(false)
+  })
+
+  it('no panel element → never hides (not mounted yet)', () => {
+    expect(shouldAutoHide(false, null, null)).toBe(false)
+  })
+
+  it('focus moving OUTSIDE the panel hides it; inside keeps it', () => {
+    const inside = mkNode()
+    const outside = mkNode()
+    const panel = panelWith(inside)
+    expect(shouldAutoHide(false, panel, inside)).toBe(false)
+    expect(shouldAutoHide(false, panel, outside)).toBe(true)
+  })
+
+  it('focus leaving the document (null) hides an unpinned panel', () => {
+    expect(shouldAutoHide(false, panelWith(), null)).toBe(true)
+  })
+})
+
+describe('pin persistence', () => {
+  const mem = (): { store: Record<string, string>; getItem: (k: string) => string | null; setItem: (k: string, v: string) => void } => {
+    const store: Record<string, string> = {}
+    return {
+      store,
+      getItem: (k) => (k in store ? store[k] : null),
+      setItem: (k, v) => {
+        store[k] = v
+      }
+    }
+  }
+
+  it('round-trips a pin flag', () => {
+    const s = mem()
+    savePin(s, PIN_KEYS.library, true)
+    expect(loadPin(s, PIN_KEYS.library, false)).toBe(true)
+    savePin(s, PIN_KEYS.library, false)
+    expect(loadPin(s, PIN_KEYS.library, true)).toBe(false)
+  })
+
+  it('missing / corrupt values fall back', () => {
+    const s = mem()
+    expect(loadPin(s, PIN_KEYS.connections, true)).toBe(true)
+    s.store[PIN_KEYS.connections] = 'not json{{'
+    expect(loadPin(s, PIN_KEYS.connections, false)).toBe(false)
+    s.store[PIN_KEYS.connections] = '"yes"'
+    expect(loadPin(s, PIN_KEYS.connections, true)).toBe(true)
+  })
+
+  it('savePin tolerates a read-only storage', () => {
+    expect(() => savePin({ getItem: () => null }, PIN_KEYS.library, true)).not.toThrow()
+    expect(() =>
+      savePin(
+        {
+          getItem: () => null,
+          setItem: () => {
+            throw new Error('quota')
+          }
+        },
+        PIN_KEYS.library,
+        true
+      )
+    ).not.toThrow()
+  })
+})


### PR DESCRIPTION
The core of #242: a **Data Logger instrument styled as a vintage dot-matrix printer**. Sensor readings 'print' onto tractor-feed paper; tearing the page off saves the session as CSV.

> Stacks on #268 (three-modes) — merge that first, or this can rebase onto master after it lands.

## What it does
- **RECORD** captures every numeric `SNK` telemetry reading (meter · plot · distance · IMU · environment · encoder · button) with a timestamp
- The **tractor-feed paper** draws a strip-chart per series + periodic printed value rows in a dotty printhead style (sprocket holes down both margins, blinking print caret)
- **TEAR OFF** downloads a spreadsheet-ready **wide CSV** (`time_s` + one column per series; samples sharing a timestamp share a row) and starts a fresh sheet
- **Works fully offline** against the Simulated device — a hardware-free classroom still gets real data logging (a £4 Pico doing a £100 classroom logger's job)

## Design notes
- `logger-logic.ts` is pure + DOM/Date-free (callers pass timestamps) → **12 unit tests** cover fold/CSV/paper/chart geometry
- Capture accumulates in a **ref** with a ~4 Hz paint tick, so high-rate streams don't re-render per sample
- **RECORD is always reachable** — the empty state shows a how-to hint on the paper rather than early-returning a panel that hides the button (caught + fixed via an in-app smoke test)

## Verified
In-app (Playwright): opens from the palette, RECORD lights the lamp + paper, TEAR OFF disabled until there's data. Screenshot: beige printer head, red REC/PAUSE, 'SNAKIE DMP-242' plate, sprocketed paper.
Gate: typecheck + lint clean · **1342 tests** (15 new) · build ✅.

## Deliberately out of scope (follow-up issues to file)
#242's richer classroom features — experiment presets, event markers, compare-runs overlay, long-run/on-board logging, units & calibration, lab-report PDF export, and a PNG chart export — are a whole epic; this PR ships the headline printer + CSV core they build on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)