### PR TITLE
Backfill mini-help for the 14 remaining standard-library parts (#213)

### DIFF
--- a/examples/parts/snakie-standard/adafruit-feather-esp32s3/help.md
+++ b/examples/parts/snakie-standard/adafruit-feather-esp32s3/help.md
@@ -1,0 +1,56 @@
+# Adafruit Feather ESP32-S3
+
+Adafruit's ESP32-S3 Feather (product 5323): a 3.3 V Wi-Fi + Bluetooth board with
+USB-C, LiPo charging, a STEMMA QT connector, and an onboard NeoPixel.
+
+## Wiring
+
+Key pins (portrait, USB-C at the top):
+
+| Pin | What it is |
+|-----|------------|
+| **3V** | 3.3 V out — power for sensors |
+| **GND** | ground |
+| **BAT** | LiPo battery voltage |
+| **USB** | 5 V from the USB-C port |
+| **EN** | pull low to switch off the 3.3 V regulator |
+| **A0–A5** | analogue-capable GPIO (GP18, 17, 16, 15, 14, 8) |
+| **D5–D13** | digital/PWM GPIO (GP5, 6, 9, 10, 11, 12, 13) |
+| **SDA / SCL** | I2C bus 0 (GP3 / GP4) — same bus as the STEMMA QT socket |
+| **SCK / MO / MI** | SPI (GP36 / GP35 / GP37) |
+| **TX / RX** | UART (GP39 / GP38) |
+
+The little red LED is on **GP13** (shared with pin D13). The NeoPixel is on
+**GP33**, with its power switched by **GP21** — drive GP21 high first.
+
+## Quick start
+
+Blink the red LED and light the NeoPixel:
+
+```python
+from machine import Pin
+import neopixel, time
+
+led = Pin(13, Pin.OUT)                 # onboard red LED
+
+Pin(21, Pin.OUT).value(1)              # enable NeoPixel power
+np = neopixel.NeoPixel(Pin(33), 1)
+
+while True:
+    led.toggle()
+    np[0] = (0, 16, 0) if led.value() else (16, 0, 0)
+    np.write()
+    time.sleep(0.5)
+```
+
+⚠️ Everything is **3.3 V only** — don't feed 5 V signals into any GPIO.
+
+⚠️ The NeoPixel stays dark unless **GP21** (its power enable) is driven high.
+
+⚠️ The ESP32-S3 has a flexible GPIO matrix, so SDA/SCL, SPI and TX/RX are the
+board's *designated* pins — pass them explicitly, e.g.
+`I2C(0, sda=Pin(3), scl=Pin(4))`.
+
+To flash MicroPython, use Snakie's **Flash firmware** button with the
+ESP32_GENERIC_S3 build (hold **BOOT** while tapping **RESET** if the board
+isn't detected).

--- a/examples/parts/snakie-standard/adafruit-feather-esp32s3/parts.yml
+++ b/examples/parts/snakie-standard/adafruit-feather-esp32s3/parts.yml
@@ -1,4 +1,5 @@
 id: adafruit-feather-esp32s3
+help: help.md
 name: Adafruit Feather ESP32-S3
 description: ESP32-S3 Feather (8MB Flash) with USB-C, LiPo charging, STEMMA QT + NeoPixel.
 manufacturer: Adafruit

--- a/examples/parts/snakie-standard/adafruit-feather-nrf52840/help.md
+++ b/examples/parts/snakie-standard/adafruit-feather-nrf52840/help.md
@@ -1,0 +1,47 @@
+# Adafruit Feather nRF52840 Express
+
+A 3.3 V Feather board built on the Nordic **nRF52840** — Bluetooth Low Energy,
+native USB, LiPo charging, and an onboard NeoPixel. Great for wireless sensors
+and battery-powered projects.
+
+## Wiring
+
+Key pins (portrait, USB at the top):
+
+| Pin | What it is |
+|-----|------------|
+| **3V** | 3.3 V out from the regulator |
+| **GND** | ground |
+| **VBAT** | LiPo battery voltage (JST connector) |
+| **VBUS** | 5 V from USB — for powering **5 V loads**, not logic |
+| **EN** | pull to GND to switch the 3.3 V regulator off |
+| **A0–A5** | analogue inputs (ADC), also digital/PWM |
+| **SCL / SDA** | I2C (GPIO 11 / 12) |
+| **SCK / MO / MI** | SPI (GPIO 14 / 13 / 15) |
+| **TX / RX** | UART (GPIO 25 / 24) |
+| **D2, D5–D13** | general digital/PWM pins |
+
+Pin names map to nRF ports: `P0.n` → GPIO `n`, `P1.n` → GPIO `32 + n`
+(so **D13** = P1.09 = GPIO 41).
+
+## Quick start
+
+Blink the red user LED (P1.15 = GPIO 47):
+
+```python
+from machine import Pin
+import time
+
+led = Pin(47, Pin.OUT)     # red user LED
+while True:
+    led.toggle()
+    time.sleep(0.5)
+```
+
+The onboard **NeoPixel** is on GPIO 16 — drive GPIO 46 **high** first to power it.
+
+⚠️ This is a **3.3 V** board — its GPIO pins are *not* 5 V tolerant. Use VBUS
+only as a 5 V supply rail, never into a GPIO.
+
+⚠️ MicroPython isn't pre-installed: double-tap **RESET** for the UF2 bootloader
+and copy a MicroPython UF2 for the Feather nRF52840 onto the drive that appears.

--- a/examples/parts/snakie-standard/adafruit-feather-nrf52840/parts.yml
+++ b/examples/parts/snakie-standard/adafruit-feather-nrf52840/parts.yml
@@ -1,4 +1,5 @@
 id: adafruit-feather-nrf52840
+help: help.md
 name: Adafruit Feather nRF52840 Express
 description: nRF52840 Feather — BLE + USB, LiPo charging, NeoPixel. Portrait, USB at top.
 manufacturer: Adafruit

--- a/examples/parts/snakie-standard/adafruit-feather-rp2040/help.md
+++ b/examples/parts/snakie-standard/adafruit-feather-rp2040/help.md
@@ -1,0 +1,50 @@
+# Adafruit Feather RP2040
+
+Adafruit's Feather-format RP2040 board with USB-C, a LiPo charger, a STEMMA QT
+(I2C) connector and an onboard NeoPixel. Runs MicroPython at **3.3 V** logic.
+
+## Wiring
+
+Key power pins:
+
+| Pin | What it is |
+|-----|------------|
+| **USB** | 5 V from the USB-C port |
+| **BAT** | LiPo battery voltage (chargeable via USB) |
+| **3.3V** | 3.3 V out from the regulator |
+| **EN** | pull to GND to disable the 3.3 V regulator |
+| **GND / RST** | ground / reset |
+
+Notable GPIO groups (Feather label → RP2040 GPIO):
+
+- **Analog**: A0–A3 → GP26–GP29 (the four ADC channels)
+- **I2C (STEMMA QT)**: SDA → GP2, SCL → GP3 — bus **I2C1**
+- **SPI**: SCK → GP18, MO → GP19, MI → GP20 — bus **SPI0**
+- **UART**: TX → GP0, RX → GP1 — bus **UART0**
+- **Digital**: D4–D13, D24, D25 — general-purpose, all PWM-capable
+- **Onboard**: red LED on **GP13**, NeoPixel on **GP16**
+
+## Quick start
+
+```python
+from machine import Pin
+from neopixel import NeoPixel
+import time
+
+led = Pin(13, Pin.OUT)          # onboard red LED (D13)
+px = NeoPixel(Pin(16), 1)       # onboard NeoPixel
+
+while True:
+    led.toggle()
+    px[0] = (16, 0, 16) if led.value() else (0, 16, 0)
+    px.write()
+    time.sleep(0.5)
+```
+
+⚠️ It's a **3.3 V** board — don't feed 5 V signals into any GPIO.
+
+⚠️ The STEMMA QT connector is **I2C1** (SDA = GP2, SCL = GP3), so use
+`I2C(1, ...)`, not `I2C(0, ...)`.
+
+To install MicroPython, hold **BOOTSEL** while plugging in USB (it mounts as a
+drive), then use Snakie's **Flash firmware** button and pick the RP2040 build.

--- a/examples/parts/snakie-standard/adafruit-feather-rp2040/parts.yml
+++ b/examples/parts/snakie-standard/adafruit-feather-rp2040/parts.yml
@@ -1,4 +1,5 @@
 id: adafruit-feather-rp2040
+help: help.md
 name: Adafruit Feather RP2040
 description: RP2040 Feather with USB-C, LiPo charging, STEMMA QT (I2C) + NeoPixel.
 manufacturer: Adafruit

--- a/examples/parts/snakie-standard/adafruit-itsybitsy-rp2040/help.md
+++ b/examples/parts/snakie-standard/adafruit-itsybitsy-rp2040/help.md
@@ -1,0 +1,47 @@
+# Adafruit ItsyBitsy RP2040
+
+A tiny **RP2040** board in Adafruit's ItsyBitsy form factor — micro-USB, an
+onboard red LED on **D13** (GP11) and a **NeoPixel** on GP17 (its power switched
+by GP16). Runs at **3.3 V** logic.
+
+## Wiring
+
+Key power pins (micro-USB at the top):
+
+| Pin | What it is |
+|-----|------------|
+| **BAT** | Battery input (feeds the regulator) |
+| **USB** | 5 V from the USB port |
+| **VHi** | The higher of BAT/USB — good for powering 5 V-ish loads |
+| **3.3V** | Regulated 3.3 V out |
+| **G** | Ground |
+| **RST** | Reset |
+
+Notable GPIO groups:
+
+- **A0–A3** (GP26–GP29) — the four **ADC** channels (ADC0–3), also digital/PWM.
+- **SDA / SCL** (GP2 / GP3) — the labelled **I2C** pair (bus 1).
+- **SCK / MO / MI** (GP18 / GP19 / GP20) — the labelled **SPI** pins (bus 0).
+- **TX / RX** (GP0 / GP1) — **UART 0**.
+- **D2–D5, D7, D9–D13, D24, D25** — general digital/PWM pins.
+
+Note: the **D-numbers on the silkscreen are not the GP numbers** — e.g. D13 is
+GP11, D5 is GP14. MicroPython wants the GP number.
+
+## Quick start
+
+```python
+from machine import Pin
+import time
+
+led = Pin(11, Pin.OUT)      # onboard red LED (silkscreen D13)
+while True:
+    led.toggle()
+    time.sleep(0.5)
+```
+
+⚠️ It's a **3.3 V** board — don't feed 5 V into any GPIO. ⚠️ The NeoPixel needs
+GP16 driven **high** to power it before you write to GP17.
+
+To install MicroPython: hold **BOOTSEL** while plugging in USB (it mounts as a
+drive), then use Snakie's **Flash firmware** button.

--- a/examples/parts/snakie-standard/adafruit-itsybitsy-rp2040/parts.yml
+++ b/examples/parts/snakie-standard/adafruit-itsybitsy-rp2040/parts.yml
@@ -1,4 +1,5 @@
 id: adafruit-itsybitsy-rp2040
+help: help.md
 name: Adafruit ItsyBitsy RP2040
 description: Small RP2040 board (ItsyBitsy form factor) with micro-USB + NeoPixel.
 manufacturer: Adafruit

--- a/examples/parts/snakie-standard/adafruit-qt-py-rp2040/help.md
+++ b/examples/parts/snakie-standard/adafruit-qt-py-rp2040/help.md
@@ -1,0 +1,48 @@
+---
+---
+# Adafruit QT Py RP2040
+
+A thumb-sized RP2040 board with USB-C, castellated pads, a STEMMA QT connector
+and an onboard NeoPixel. Runs MicroPython — same chip as the Pico, just tiny.
+
+## Wiring
+
+Only 14 pads, and most do double duty:
+
+| Pad(s) | What they are |
+|--------|---------------|
+| **5V / GND / 3V** | Power — 5 V in from USB, 3.3 V out (logic is **3V3**) |
+| **A0–A3** (GP29/28/27/26) | Analogue inputs (ADC3–ADC0), also digital/PWM |
+| **SDA / SCL** (GP24/25) | I2C0 on the pads |
+| **MOSI / MISO / SCK** (GP3/4/6) | SPI0 |
+| **TX / RX** (GP20/5) | UART1 |
+| **STEMMA QT** | Plug-and-play **I2C1** (SDA1=GP22, SCL1=GP23) |
+
+## Quick start
+
+Blink the onboard NeoPixel (GP12 — you must power it via GP11 first):
+
+```python
+from machine import Pin
+from neopixel import NeoPixel
+import time
+
+Pin(11, Pin.OUT, value=1)        # NeoPixel power enable
+px = NeoPixel(Pin(12), 1)
+while True:
+    px[0] = (16, 0, 16); px.write()
+    time.sleep(0.5)
+    px[0] = (0, 0, 0); px.write()
+    time.sleep(0.5)
+```
+
+⚠️ There's **no plain user LED** — the NeoPixel on GP12 is it, and it stays dark
+until you drive **GP11 high**.
+
+⚠️ Everything is **3.3 V logic**; the 5V pad is USB power in/out only.
+
+⚠️ The STEMMA QT port is **I2C1**, not I2C0 — use
+`I2C(1, sda=Pin(22), scl=Pin(23))` for plug-in sensors.
+
+To flash MicroPython: hold **BOOT**, tap **RESET** (it appears as a USB drive),
+then use Snakie's **Flash firmware** button.

--- a/examples/parts/snakie-standard/adafruit-qt-py-rp2040/parts.yml
+++ b/examples/parts/snakie-standard/adafruit-qt-py-rp2040/parts.yml
@@ -1,4 +1,5 @@
 id: adafruit-qt-py-rp2040
+help: help.md
 name: Adafruit QT Py RP2040
 description: Thumb-sized castellated RP2040 board with USB-C, STEMMA QT + NeoPixel.
 manufacturer: Adafruit

--- a/examples/parts/snakie-standard/esp32-12f/help.md
+++ b/examples/parts/snakie-standard/esp32-12f/help.md
@@ -1,0 +1,46 @@
+# ESP32-12F
+
+An Espressif **ESP32** module with Wi-Fi and Bluetooth built in — a 3.3 V
+microcontroller you can run MicroPython on. Breadboard-friendly (2.54 mm pins),
+with castellated edges and four mounting holes.
+
+## Wiring
+
+Key power pins (it's a **3.3 V** board):
+
+| Pin | Purpose |
+|-----|---------|
+| **VCC / 3v3** | 3.3 V power in — top-right VCC, plus 3v3 pins on both edges |
+| **GND** | Ground — several, on both edges |
+| **EN** | Chip enable — must be **high** for the chip to run |
+| **RST** | Reset |
+
+Notable GPIO groups (from the part's pinout):
+
+- **D0–D8** — general digital I/O (GPIO 0, 1, 4, 5, 6, 11–14); **d0** also does PWM.
+- **RX / TX** (GPIO 15 / 16) — UART, also used for the REPL/serial link.
+- **CLK / CMD / SD0–SD3** (GPIO 21–26) — the SD/flash bus group; avoid these for
+  general I/O.
+- **A0** (GPIO 29) — analogue-capable pin.
+- **RSV** pins are reserved — leave them unconnected.
+
+## Quick start
+
+```python
+from machine import Pin
+import time
+
+led = Pin(0, Pin.OUT)      # d0
+while True:
+    led.value(not led.value())
+    time.sleep(0.5)
+```
+
+⚠️ **3.3 V only** — the GPIO pins are not 5 V tolerant; use a level shifter for
+5 V sensors.
+
+⚠️ **GPIO 0 is a boot-strap pin** — if it's held **low** at reset the chip enters
+flashing mode, so don't tie d0 to GND.
+
+⚠️ Bare modules have **no USB-serial chip** — you'll need a USB-UART adapter on
+RX/TX (with EN pulled high) to flash MicroPython and talk to the REPL.

--- a/examples/parts/snakie-standard/esp32-12f/parts.yml
+++ b/examples/parts/snakie-standard/esp32-12f/parts.yml
@@ -1,4 +1,5 @@
 id: esp32-12f
+help: help.md
 name: ESP32-12F
 description: esp32
 manufacturer: Espressif

--- a/examples/parts/snakie-standard/esp32-devkit/help.md
+++ b/examples/parts/snakie-standard/esp32-devkit/help.md
@@ -1,0 +1,47 @@
+# ESP32 DevKit
+
+An ESP32-WROOM-32 development board from Espressif with 2.4 GHz **Wi-Fi** and
+**Bluetooth** built in. A great step up from a Pico when your project needs to
+get online.
+
+## Wiring
+
+Key power pins:
+
+| Pin | What it is |
+|-----|------------|
+| **VIN** | 5 V in (e.g. from USB) — the on-board regulator drops it to 3.3 V |
+| **3V3** | 3.3 V out for sensors (the ESP32 runs at 2.3–3.6 V) |
+| **GND** | ground (one on each side) |
+| **EN** | enable / reset — pull low to reset the chip |
+
+Handy GPIO groups:
+
+- **ADC inputs**: IO32–IO36, IO39 (IO34/35/36/39 are **input-only** — no output, no pull-ups).
+- **I2C** (common default): **IO21 = SDA**, **IO22 = SCL**.
+- **SPI (VSPI)**: IO18 (SCK), IO19 (MISO), IO23 (MOSI), IO5 (CS).
+- **UART0**: TX0 (GPIO 1) / RX0 (GPIO 3) — used by the USB REPL, leave free.
+- **IO2** drives the on-board LED; PWM works on most IO pins.
+
+## Quick start
+
+```python
+from machine import Pin
+import time
+
+led = Pin(2, Pin.OUT)     # on-board LED on GPIO 2
+while True:
+    led.value(not led.value())   # toggle
+    time.sleep(0.5)
+```
+
+## Gotchas
+
+- ⚠️ **3.3 V logic only** — 5 V on a GPIO will damage the chip. Power 5 V
+  gear from VIN, but level-shift any signals coming back.
+- ⚠️ **IO0 is the boot pin** — hold it low at reset to enter flashing mode;
+  avoid parts that pull it low at power-up.
+- ⚠️ **IO12 is a strapping pin** — if it's high at boot the board may fail to
+  start; don't tie it high.
+- Flash MicroPython with Snakie's **Flash firmware** button (pick the ESP32
+  generic build); some boards need **IO0/BOOT** held while flashing starts.

--- a/examples/parts/snakie-standard/esp32-devkit/parts.yml
+++ b/examples/parts/snakie-standard/esp32-devkit/parts.yml
@@ -1,4 +1,5 @@
 id: esp32-devkit
+help: help.md
 name: ESP32 DevKit
 description: ESP32-WROOM-32 development board with 2.4GHz Wi-Fi + Bluetooth.
 manufacturer: Espressif

--- a/examples/parts/snakie-standard/hr-sr04/help.md
+++ b/examples/parts/snakie-standard/hr-sr04/help.md
@@ -1,0 +1,49 @@
+# HC-SR04 Ultrasonic Range Finder
+
+An ultrasonic distance sensor: it pings a short burst of sound from one
+transducer and times the echo back into the other. Good for roughly 2 cm–4 m —
+obstacle avoidance, parking sensors, level gauges.
+
+## Wiring
+
+| Pin | Connect to |
+|---------|------------|
+| VCC | 3V3 (see ⚠️ below) |
+| Trigger | any GPIO (e.g. **GP1**) |
+| Echo | any GPIO (e.g. **GP0**) |
+| GND | GND |
+
+⚠️ Classic HC-SR04 boards are **5 V** parts. If yours is a 3.3 V variant (like
+this one) wire VCC to **3V3** and you're done. If it needs 5 V, power it from
+**VBUS/5 V** and put a **voltage divider** (e.g. 1 kΩ / 2 kΩ) on **Echo** — a
+5 V echo pulse straight into a Pico GPIO can damage the pin.
+
+## Quick start
+
+```python
+import machine
+import time
+from machine import Pin
+
+trig = Pin(1, Pin.OUT)          # Trigger on GP1
+echo = Pin(0, Pin.IN)           # Echo on GP0
+
+def distance_cm():
+    trig.low(); time.sleep_us(2)
+    trig.high(); time.sleep_us(10)   # 10 µs ping
+    trig.low()
+    us = machine.time_pulse_us(echo, 1, 30000)  # wait for the echo
+    return us * 0.0343 / 2           # speed of sound, there and back
+
+while True:
+    print(round(distance_cm(), 1), "cm")
+    time.sleep(0.2)
+```
+
+## Tips
+
+- **-1 or -2 readings** → `time_pulse_us` timed out: nothing in range (>4 m),
+  or Trigger/Echo swapped.
+- Soft or angled surfaces scatter the ping — readings get flaky; average a few
+  samples for a steadier number.
+- Leave ~60 ms between pings so a late echo doesn't bleed into the next reading.

--- a/examples/parts/snakie-standard/hr-sr04/parts.yml
+++ b/examples/parts/snakie-standard/hr-sr04/parts.yml
@@ -1,4 +1,5 @@
 id: hr-sr04
+help: help.md
 name: HR SR04
 manufacturer: Generic
 family: Sensor

--- a/examples/parts/snakie-standard/mx1508/help.md
+++ b/examples/parts/snakie-standard/mx1508/help.md
@@ -1,0 +1,49 @@
+# MX1508 Dual H-Bridge Motor Driver
+
+A tiny, cheap dual H-bridge that drives **two DC motors** forwards and backwards.
+Great for little robots — each motor gets two input pins, and PWM on those pins
+sets the speed.
+
+## Wiring
+
+| Pin | Connect to |
+|-----|------------|
+| VCC | motor supply **+** (2–10 V, e.g. 4×AA or VBUS 5 V) |
+| GND | supply **−** and board GND (**shared**) |
+| IN1 / IN2 | two GPIOs (Motor A direction/speed) |
+| IN3 / IN4 | two GPIOs (Motor B direction/speed) |
+| OUT1 / OUT2 | Motor A terminals |
+| OUT3 / OUT4 | Motor B terminals |
+
+⚠️ **VCC is the motor supply, not logic power** — don't feed it from the Pico's
+3V3 pin; motors will brown the board out. Power it from batteries or 5 V and
+tie the grounds together. The 3.3 V GPIO inputs are fine as-is.
+
+## Quick start
+
+```python
+from machine import Pin, PWM
+import time
+
+FREQ = 1000
+in1 = PWM(Pin(0), freq=FREQ)   # Motor A
+in2 = PWM(Pin(1), freq=FREQ)
+in3 = PWM(Pin(4), freq=FREQ)   # Motor B
+in4 = PWM(Pin(5), freq=FREQ)
+
+def motor(a, b, speed):        # speed −100 … +100
+    duty = int(abs(speed) * 65535 / 100)
+    a.duty_u16(duty if speed >= 0 else 0)
+    b.duty_u16(0 if speed >= 0 else duty)
+
+motor(in1, in2, 75)            # Motor A forwards at 75 %
+motor(in3, in4, -75)           # Motor B backwards
+time.sleep(2)
+motor(in1, in2, 0)             # stop both
+motor(in3, in4, 0)
+```
+
+Drive **one input high, the other low** for direction; PWM the high one for
+speed. Both low = coast, both high = brake.
+
+⚠️ If a motor spins the wrong way, just swap its two OUT wires.

--- a/examples/parts/snakie-standard/mx1508/parts.yml
+++ b/examples/parts/snakie-standard/mx1508/parts.yml
@@ -1,4 +1,5 @@
 id: mx1508
+help: help.md
 name: MX1508
 family: Breakout
 package: THT

--- a/examples/parts/snakie-standard/n20-motor/help.md
+++ b/examples/parts/snakie-standard/n20-motor/help.md
@@ -1,0 +1,51 @@
+# N20 Motor
+
+A tiny **6 V brushed DC gear motor** in the classic N20 metal-gearbox package —
+small, quiet, and torquey for its size. A favourite for micro robots, line
+followers, and anything on wheels.
+
+## Wiring
+
+| Pin | Connect to |
+|-----|------------|
+| VCC | motor driver **output** (e.g. MX1508 / DRV8833 OUT1) |
+| GND | motor driver **output** (e.g. OUT2) |
+
+⚠️ **Never wire a motor straight to a GPIO pin.** A GPIO supplies a few
+milliamps; a motor wants hundreds. Drive it through an H-bridge (MX1508,
+DRV8833, L298N…) powered from its own **6 V** supply, with GND shared with the
+Pico.
+
+⚠️ The two terminals aren't really "+" and "−" — swapping them just reverses
+the spin direction. That's how the H-bridge reverses it too.
+
+## Quick start
+
+Via an H-bridge with its two inputs on **GP2** and **GP3** — PWM one input to
+set the speed, swap which input gets the PWM to reverse:
+
+```python
+from machine import Pin, PWM
+import time
+
+in1 = PWM(Pin(2), freq=1000)
+in2 = PWM(Pin(3), freq=1000)
+
+def drive(speed):                 # -100 … +100 %
+    duty = int(abs(speed) * 65535 / 100)
+    in1.duty_u16(duty if speed > 0 else 0)
+    in2.duty_u16(duty if speed < 0 else 0)
+
+drive(75)          # forward at 75 %
+time.sleep(2)
+drive(-75)         # reverse
+time.sleep(2)
+drive(0)           # stop
+```
+
+## Tips
+
+- Below ~30 % duty the gearbox may stall — start higher, then ease down.
+- Solder a small **ceramic capacitor** across the terminals to tame electrical
+  noise if your board resets when the motor kicks in.
+- Gear ratios vary (100:1, 150:1, 298:1…) — higher ratio = slower but stronger.

--- a/examples/parts/snakie-standard/n20-motor/parts.yml
+++ b/examples/parts/snakie-standard/n20-motor/parts.yml
@@ -1,4 +1,5 @@
 id: n20-motor
+help: help.md
 name: N20 Motor
 manufacturer: Generic
 family: Motor

--- a/examples/parts/snakie-standard/pico-w/help.md
+++ b/examples/parts/snakie-standard/pico-w/help.md
@@ -1,0 +1,44 @@
+# Raspberry Pi Pico W
+
+The **Pico W** is Raspberry Pi's RP2040 microcontroller board with 2.4 GHz
+wireless (Wi-Fi / Bluetooth via the CYW43439). It runs MicroPython brilliantly —
+this is the "brain" you wire everything else to.
+
+## Wiring (key pins)
+
+| Pin | What it's for |
+|-----|---------------|
+| **VBUS** (40) | 5 V straight from USB — good for servos/LED strips |
+| **VSYS** (39) | Power the board here (1.8–5.5 V) when not on USB |
+| **3V3** (36) | 3.3 V out for sensors (regulated) |
+| **GND** (3, 8, 13, 18, 23, 28, 33, 38) | Ground — every circuit needs one |
+| **GP26 / GP27 / GP28** | The only **ADC** (analogue) pins — ADC0/1/2 |
+| **GP0–GP15, GP16–GP22** | General GPIO — all do digital, PWM, I2C, SPI |
+| **RUN** (30) | Pull to GND to reset the board |
+| **3V3_EN** (37) | Pull low to switch off the 3.3 V regulator |
+
+Handy defaults: **I2C0 = GP0 (SDA) / GP1 (SCL)**, **I2C1 = GP2 (SDA) / GP3 (SCL)**.
+The onboard **LED** is on the wireless chip, so you address it as `"LED"`, not a
+pin number.
+
+## Quick start
+
+```python
+from machine import Pin
+import time
+
+led = Pin("LED", Pin.OUT)   # the onboard LED (via the Wi-Fi chip)
+while True:
+    led.toggle()
+    time.sleep(0.5)
+```
+
+No MicroPython on it yet? Hold **BOOTSEL** while plugging in the USB cable, then
+use Snakie's **Flash firmware** button — pick the **Pico W** build (the plain
+Pico firmware won't drive the LED or Wi-Fi).
+
+⚠️ GPIO pins are **3.3 V only** — connecting 5 V signals to a GPIO can kill the
+RP2040. Level-shift anything 5 V.
+
+⚠️ Powering heavy loads (servos, motors) from **3V3** will brown out the board —
+take 5 V from **VBUS** instead and share GND.

--- a/examples/parts/snakie-standard/pico-w/parts.yml
+++ b/examples/parts/snakie-standard/pico-w/parts.yml
@@ -1,4 +1,5 @@
 id: pico-w
+help: help.md
 name: Raspberry Pi Pico W
 description: RP2040 microcontroller board with CYW43439 2.4GHz wireless (Wi-Fi / BLE).
 manufacturer: Raspberry Pi

--- a/examples/parts/snakie-standard/pico/help.md
+++ b/examples/parts/snakie-standard/pico/help.md
@@ -1,0 +1,46 @@
+# Raspberry Pi Pico
+
+Raspberry Pi's **RP2040** microcontroller board — a dual-core Arm chip on a 40-pin
+board (same header layout as the Pico W / 2 W). Runs MicroPython beautifully.
+
+## Wiring
+
+Key power pins (right edge):
+
+| Pin | What it is |
+|-----|------------|
+| **VBUS** (40) | 5 V straight from USB |
+| **VSYS** (39) | power the Pico here (1.8–5.5 V) when not on USB |
+| **3V3** (36) | 3.3 V out for sensors (keep it under ~300 mA) |
+| **GND** | eight ground pins spread along both edges |
+
+Notable GPIO groups:
+
+- **GP0–GP15** down the left edge, **GP16–GP22** up the right — all do digital,
+  PWM, I2C and SPI.
+- **GP26 / GP27 / GP28** — the only three **ADC** channels (ADC0–2), for pots
+  and analogue sensors. **ADC_VREF** (35) sets their reference.
+- **I2C0** default pins: GP0 (SDA) / GP1 (SCL). **I2C1**: GP2 (SDA) / GP3 (SCL).
+- The onboard **LED** is on **pin 25**.
+- **RUN** (30) — short to GND to reset the board.
+
+## Quick start
+
+```python
+from machine import Pin
+import time
+
+led = Pin(25, Pin.OUT)   # onboard LED
+while True:
+    led.toggle()
+    time.sleep(0.5)
+```
+
+## Flashing MicroPython
+
+Hold **BOOTSEL** while plugging in the USB cable and the Pico mounts as a USB
+drive — or just use Snakie's **Flash firmware** button, which does it for you.
+
+⚠️ GPIO pins are **3.3 V only** — 5 V on a GPIO will damage the RP2040. 5 V
+sensors need a level shifter (or wire them to VBUS for power and check their
+signal levels).

--- a/examples/parts/snakie-standard/pico/parts.yml
+++ b/examples/parts/snakie-standard/pico/parts.yml
@@ -1,4 +1,5 @@
 id: pico
+help: help.md
 name: Raspberry Pi Pico
 description: RP2040 microcontroller board (40-pin, same header layout as the Pico W / 2 W).
 manufacturer: Raspberry Pi

--- a/examples/parts/snakie-standard/pico2w/help.md
+++ b/examples/parts/snakie-standard/pico2w/help.md
@@ -1,0 +1,53 @@
+# Raspberry Pi Pico 2 W
+
+Raspberry Pi's RP2350 microcontroller board with a CYW43439 radio for 2.4 GHz
+**Wi-Fi and Bluetooth LE**. The brain of your project — everything else in the
+parts library wires into it.
+
+## Wiring
+
+The key pins (40-pin board, both edges castellated):
+
+| Pin | What it's for |
+|-----|---------------|
+| **VBUS** (40) | 5 V straight from USB — power servos/motors here |
+| **VSYS** (39) | Power the board from a battery (1.8–5.5 V in) |
+| **3V3** (36) | 3.3 V out for sensors (keep the load light) |
+| **GND** (3, 8, 13, 18, 23, 28, 33, 38) | Ground — share it with everything |
+| **GP0–GP15** (left edge) | General GPIO — digital, PWM, I2C, SPI |
+| **GP16–GP22** (right edge) | More GPIO — digital, PWM, I2C, SPI |
+| **GP26 / GP27 / GP28** | The only **ADC** pins (ADC0/1/2) — analogue sensors go here |
+| **RUN** (30) | Pull to GND to reset the board |
+
+⚠️ All GPIO are **3.3 V only** — never feed 5 V into a GP pin. 5 V belongs on
+VBUS/VSYS only.
+
+## Quick start
+
+Blink the onboard LED (it's on the wireless chip, so use the name `"LED"`):
+
+```python
+from machine import Pin
+import time
+
+led = Pin("LED", Pin.OUT)
+while True:
+    led.toggle()
+    time.sleep(0.5)
+```
+
+## Flashing MicroPython
+
+New board, or no REPL? Use Snakie's **Flash firmware** button — or hold
+**BOOTSEL** while plugging in USB and drop the Pico 2 W `.uf2` onto the
+`RP2350` drive. Make sure you grab the **Pico 2 W** firmware, not plain Pico 2 —
+Wi-Fi and the LED won't work otherwise.
+
+## Wi-Fi in one line (well, four)
+
+```python
+import network
+wlan = network.WLAN(network.STA_IF)
+wlan.active(True)
+wlan.connect("your-ssid", "your-password")
+```

--- a/examples/parts/snakie-standard/pico2w/parts.yml
+++ b/examples/parts/snakie-standard/pico2w/parts.yml
@@ -1,4 +1,5 @@
 id: pico2w
+help: help.md
 name: Raspberry Pi Pico 2 W
 description: RP2350 microcontroller board with CYW43439 2.4GHz wireless (Wi-Fi / BLE).
 manufacturer: Raspberry Pi

--- a/examples/parts/snakie-standard/tiny2350/help.md
+++ b/examples/parts/snakie-standard/tiny2350/help.md
@@ -1,0 +1,45 @@
+# Pimoroni Tiny 2350
+
+A postage-stamp RP2350 board (PIM721) with USB-C, an onboard RGB LED and
+castellated edges — solder it flat onto your own PCB or use it on a breadboard.
+16 pads, 8 per edge, running MicroPython at **3.3 V** logic.
+
+## Wiring
+
+**Left edge** (USB at the top):
+
+| Pin | What it is |
+|-----|------------|
+| 5V | power in/out (from USB-C) |
+| GND | ground (×2 — top and bottom of the edge) |
+| 3V3 | 3.3 V out for sensors |
+| A3–A0 | **GP29–GP26** — the four ADC-capable GPIOs (also digital, PWM, I2C, SPI, UART) |
+
+**Right edge**: **GP0–GP7** — general-purpose GPIO (digital, PWM, I2C, SPI, UART).
+
+## Quick start
+
+```python
+from machine import ADC, Pin
+import time
+
+led = Pin(0, Pin.OUT)     # something on GP0
+pot = ADC(Pin(26))        # analogue input on A0 (GP26)
+
+while True:
+    led.toggle()
+    print(pot.read_u16())  # 0 … 65535
+    time.sleep(0.5)
+```
+
+## Flashing MicroPython
+
+Hold the **BOOT** button while plugging in the USB-C cable (or while tapping
+**RST**) to enter bootloader mode, then use Snakie's **Flash firmware** button
+and pick an RP2350 (Pico 2 family) MicroPython build.
+
+⚠️ Everything here is **3.3 V** — don't feed 5 V signals into any GPIO. The
+**5V** pad is fine as a power input, but logic pins are not 5 V tolerant.
+
+⚠️ Only **A0–A3** (GP26–GP29) can read analogue voltages — the GP0–GP7 edge
+is digital-only (with PWM, I2C, SPI and UART available on every pin).

--- a/examples/parts/snakie-standard/tiny2350/parts.yml
+++ b/examples/parts/snakie-standard/tiny2350/parts.yml
@@ -1,4 +1,5 @@
 id: tiny2350
+help: help.md
 name: Pimoroni Tiny 2350
 description: RP2350A in a tiny castellated board with an RGB LED + USB-C
 manufacturer: Pimoroni


### PR DESCRIPTION
Closes #213. Every standard-library part now ships a `help.md` — was **2 of 16**, now **16 of 16**.

## What
Authored a mini-help article for each remaining part, each grounded in the part's **own `parts.yml`** (pins, labels, capabilities, dimensions are ground truth — never guessed):

**Microcontrollers** — `pico`, `pico-w`, `pico2w`, `tiny2350`, `esp32-devkit`, `esp32-12f`, `adafruit-feather-rp2040`, `adafruit-feather-esp32s3`, `adafruit-feather-nrf52840`, `adafruit-itsybitsy-rp2040`, `adafruit-qt-py-rp2040`
**Sensors / motors / drivers** — `hr-sr04`, `n20-motor`, `mx1508`

## Format (matches the potentiometer / sg90 exemplars)
- H1 + what it is → **Wiring** table/pinout → **Quick start** with ONE runnable MicroPython block (the first code block feeds the **⧉ Open example** button) → the gotchas that actually bite (BOOTSEL/UF2 flashing, 3V3-only GPIO, motor-supply-vs-logic-power, NeoPixel power-enable pins)
- Each `parts.yml` gains a `help: help.md` key so the Board View help drawer + the main Help Library surface it
- Mirrored into the userData `snakie-standard` copies so `npm run dev` shows them
- `kevsrobots:` guide links intentionally omitted (added later once each URL is verified)

## Verified
All 14 `parts.yml` parse as YAML; the help-content test (article-per-instrument/part coverage) + parts-library test stay green. Authored via a 14-way parallel pass, each agent restricted to its part's `parts.yml` as the source of pin facts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)