### PR TITLE
fix: Board-mode Help button opens the Help panel + wider min width

### DIFF
--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -868,6 +868,11 @@ export function AppShell(): JSX.Element {
       const detail = (e as CustomEvent<HelpEventDetail>).detail
       if (!detail?.articleId) return
       setActivityView('help')
+      // Reveal the left sidebar if it's collapsed — otherwise switching to the
+      // help view has no visible effect (e.g. Board mode collapses the sidebar,
+      // so the Board's Help button appeared to do nothing). expand() is
+      // idempotent, so this is a no-op when the sidebar is already open.
+      filesRef.current?.expand()
       setHelpTarget((prev) => ({ id: detail.articleId, nonce: (prev?.nonce ?? 0) + 1 }))
     }
     window.addEventListener(HELP_EVENT, handler)
@@ -955,7 +960,7 @@ export function AppShell(): JSX.Element {
             collapsible
             collapsedSize={0}
             defaultSize={initialSizes.current.h[0]}
-            minSize={12}
+            minSize={24}
             onCollapse={() => layout.setCollapsed('files', true)}
             onExpand={() => layout.setCollapsed('files', false)}
           >


### PR DESCRIPTION
Two fixes for the Help panel behaviour reported after the modes work merged.

**1. Board Help button did nothing.** The button (and any `dispatchOpenHelp`) sets the activity view to `help`, but Board mode collapses the left sidebar — so switching the view had no visible effect. The `HELP_EVENT` handler now calls `filesRef.expand()` to reveal the sidebar (idempotent — a no-op when it's already open).

**2. Help panel too narrow.** Doubled the left sidebar's minimum width (`minSize` 12 → 24) so the article is readable when it pops open, especially over the Board's tri-split.

Verified in-app: Board mode → Breadboard → **Help** now expands the sidebar and shows the article (~240px wide vs ~120 before). Gate: typecheck/lint clean, 1342 tests, build ✅.

Note: the wider minimum also applies to the file tree (same shared left Panel) — the Code sidebar clamps up from 18% to 24%. Shout if you'd rather keep the file tree narrower and only widen Help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)