### PR TITLE
Reopen previous files on launch + crash-guard safe mode (#266)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Reopen your files on launch, with crash-safe recovery (#266).** Snakie now
+  remembers the open local files (and which tab was active) and reopens them
+  next time — alongside the working folder it already restored (#177). A
+  **crash-guard** protects startup: if a file broke the app last launch, Snakie
+  opens clean, drops that session so it can't loop, and shows a "Opened without
+  restoring files" note — no keystroke or admin needed, which matters on a
+  locked-down school machine. Session state lives in the per-user `userData`
+  store (writable without elevation).
+
 ### Changed
 - **Three focused modes: Code · Board · Data Lab (modes review).** The
   four-workspace switcher slims to three — *Lab* and *Data* merged into **Data

--- a/src/renderer/src/store/session-restore.ts
+++ b/src/renderer/src/store/session-restore.ts
@@ -1,0 +1,126 @@
+/**
+ * SESSION RESTORE (#266) — reopen the previously-open files on launch, with a
+ * crash-guard so a file that breaks startup can't wedge the app.
+ * =============================================================================
+ *
+ * We persist the list of open LOCAL file paths + which was active, and reopen
+ * them next launch. Device files are deliberately NOT persisted — they need a
+ * connected board and a re-read would fail without one.
+ *
+ * CRASH-GUARD: before restoring we set a "restoring" marker and only clear it
+ * once the app has been up and stable for a moment. If a launch finds the marker
+ * still set, the previous restore never finished (a file crashed the renderer),
+ * so we SKIP restore this time and clear the marker — the app opens clean and
+ * the student does nothing. Self-healing, which matters in a locked-down
+ * classroom where nobody knows a recovery keystroke.
+ *
+ * STORAGE: everything lives in `localStorage`, which Electron keeps in the app's
+ * per-user `userData` partition — writable without admin rights and part of the
+ * roaming profile, so it works on a locked-down school image with no elevation.
+ *
+ * Pure + storage-injected (no direct `window`) so it unit-tests in node.
+ */
+
+/** Minimal storage shape (mirrors the layout store's StorageLike). */
+export interface SessionStorage {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+  removeItem(key: string): void
+}
+
+/** What we remember between launches. */
+export interface PersistedSession {
+  /** Absolute paths of the open LOCAL files, in tab order. */
+  paths: string[]
+  /** The active file's path, or null. */
+  activePath: string | null
+}
+
+export const SESSION_KEY = 'snakie.session.v1'
+/** The crash-guard marker: present while a restore is in-flight/unconfirmed. */
+export const RESTORE_GUARD_KEY = 'snakie.session.restoring'
+
+/** A file with the fields we serialise from (a subset of OpenFile). */
+interface SerialisableFile {
+  source: 'local' | 'device'
+  path: string
+  id: string
+}
+
+/** Build the persistable session from the open files + active id (pure). */
+export function serialiseSession(
+  files: readonly SerialisableFile[],
+  activeId: string | null
+): PersistedSession {
+  const local = files.filter((f) => f.source === 'local' && f.path)
+  const active = local.find((f) => f.id === activeId)
+  return {
+    paths: local.map((f) => f.path),
+    activePath: active?.path ?? null
+  }
+}
+
+/** Persist the session (best-effort — storage may be full/disabled). */
+export function saveSession(
+  storage: SessionStorage,
+  files: readonly SerialisableFile[],
+  activeId: string | null
+): void {
+  try {
+    const session = serialiseSession(files, activeId)
+    if (session.paths.length === 0) storage.removeItem(SESSION_KEY)
+    else storage.setItem(SESSION_KEY, JSON.stringify(session))
+  } catch {
+    // ignore
+  }
+}
+
+/** Read the persisted session, or null when absent/corrupt. */
+export function readSession(storage: SessionStorage): PersistedSession | null {
+  try {
+    const raw = storage.getItem(SESSION_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<PersistedSession>
+    if (!parsed || !Array.isArray(parsed.paths)) return null
+    const paths = parsed.paths.filter((p): p is string => typeof p === 'string' && p.length > 0)
+    const activePath = typeof parsed.activePath === 'string' ? parsed.activePath : null
+    return { paths, activePath }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * The crash-guard decision for this launch (pure read):
+ *  - `'recover'` — a marker from last time is still set ⇒ the previous restore
+ *    crashed; SKIP restore this launch.
+ *  - `'safe'` — no marker ⇒ it's safe to restore.
+ */
+export function restoreMode(storage: SessionStorage): 'safe' | 'recover' {
+  try {
+    return storage.getItem(RESTORE_GUARD_KEY) ? 'recover' : 'safe'
+  } catch {
+    return 'recover' // if we can't even read, don't risk a crash loop
+  }
+}
+
+/** Arm the crash-guard immediately before restoring. */
+export function markRestoreStart(storage: SessionStorage): void {
+  try {
+    storage.setItem(RESTORE_GUARD_KEY, '1')
+  } catch {
+    // ignore
+  }
+}
+
+/** Clear the crash-guard once the app has proven stable. */
+export function markRestoreDone(storage: SessionStorage): void {
+  try {
+    storage.removeItem(RESTORE_GUARD_KEY)
+  } catch {
+    // ignore
+  }
+}
+
+/** How long the app must stay up (ms) before we trust the restore + clear the guard. */
+export const RESTORE_STABLE_MS = 4000

--- a/src/renderer/src/store/workspace.ts
+++ b/src/renderer/src/store/workspace.ts
@@ -44,8 +44,18 @@ import {
   useEffect,
   useMemo,
   useReducer,
+  useRef,
+  useState,
   type ReactNode
 } from 'react'
+import {
+  saveSession,
+  readSession,
+  restoreMode,
+  markRestoreStart,
+  markRestoreDone,
+  RESTORE_STABLE_MS
+} from './session-restore'
 
 export type FileSource = 'local' | 'device'
 
@@ -352,6 +362,103 @@ export function WorkspaceProvider({ children }: { children: ReactNode }): JSX.El
     return () => {
       cancelled = true
     }
+  }, [])
+
+  // Read the persisted session + crash-guard decision at FIRST RENDER, before
+  // any effect runs (#266). This must happen before the persist effect below,
+  // which would otherwise wipe the saved session (open files start empty) on
+  // mount, before the restore effect could read it. No writes here — pure read.
+  const [boot] = useState(() => {
+    // Guard `window` — this initializer runs during render, and some unit tests
+    // render components in a DOM-less node env where `window` is undefined.
+    const storage = typeof window !== 'undefined' ? window.localStorage : null
+    if (!storage) return { mode: 'safe' as const, session: null }
+    const mode = restoreMode(storage)
+    return { mode, session: mode === 'safe' ? readSession(storage) : null }
+  })
+  // Gate the persist effect until the initial restore has settled, so it never
+  // overwrites the saved session before (or while) we reopen it.
+  const hydrated = useRef(false)
+
+  // Persist the open LOCAL files whenever they change (#266), so the next launch
+  // can reopen them. Device files aren't persisted (they need a live board).
+  useEffect(() => {
+    if (!hydrated.current) return
+    saveSession(window.localStorage, state.openFiles, state.activeId)
+  }, [state.openFiles, state.activeId])
+
+  // Reopen the previously-open files on launch — guarded against a crash loop
+  // (#266). If a file broke startup last time, the guard is still set: we skip
+  // restore AND drop the offending session so we don't retry it (self-healing;
+  // no keystroke needed, which matters in a locked-down classroom). Runs once.
+  const didRestore = useRef(false)
+  useEffect(() => {
+    if (didRestore.current) return
+    didRestore.current = true
+    const storage = window.localStorage
+
+    if (boot.mode === 'recover') {
+      // The previous restore never confirmed stable → a file likely crashed the
+      // app. Clear the guard AND the crashing session (so the next launch is
+      // clean, not a crash loop), and tell the user why.
+      markRestoreDone(storage)
+      saveSession(storage, [], null)
+      hydrated.current = true
+      try {
+        window.dispatchEvent(
+          new CustomEvent('snakie:status', {
+            detail: {
+              text: 'Opened without restoring files',
+              tooltip:
+                'A file may have caused a problem last time, so Snakie started clean. Reopen your files from the Files panel.',
+              priority: 6
+            }
+          })
+        )
+      } catch {
+        // status bar not listening yet — non-fatal
+      }
+      return
+    }
+
+    const session = boot.session
+    if (!session || session.paths.length === 0) {
+      hydrated.current = true
+      return
+    }
+
+    markRestoreStart(storage)
+    let cancelled = false
+    void (async () => {
+      for (const path of session.paths) {
+        if (cancelled) return
+        try {
+          await openFile('local', path)
+        } catch {
+          // Missing / unreadable — skip this file, keep going.
+        }
+      }
+      // Re-activate the tab that was focused last session.
+      if (!cancelled && session.activePath) {
+        try {
+          await openFile('local', session.activePath)
+        } catch {
+          // ignore
+        }
+      }
+      // Now that the restore has applied, allow future edits to persist.
+      if (!cancelled) hydrated.current = true
+    })()
+
+    // Trust the restore once the app has stayed up a moment, then disarm the
+    // guard. If a restored file crashes the renderer first, this timer never
+    // fires, the guard survives, and the NEXT launch recovers.
+    const stable = window.setTimeout(() => markRestoreDone(storage), RESTORE_STABLE_MS)
+    return () => {
+      cancelled = true
+      window.clearTimeout(stable)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- run once on mount
   }, [])
 
   const revealLine = useCallback((line: number): void => {

--- a/test/sessionRestore.test.ts
+++ b/test/sessionRestore.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest'
+import {
+  serialiseSession,
+  saveSession,
+  readSession,
+  restoreMode,
+  markRestoreStart,
+  markRestoreDone,
+  SESSION_KEY,
+  RESTORE_GUARD_KEY
+} from '../src/renderer/src/store/session-restore'
+
+/** In-memory SessionStorage. */
+const mem = (seed: Record<string, string> = {}) => {
+  const store: Record<string, string> = { ...seed }
+  return {
+    store,
+    getItem: (k: string) => (k in store ? store[k] : null),
+    setItem: (k: string, v: string) => {
+      store[k] = v
+    },
+    removeItem: (k: string) => {
+      delete store[k]
+    }
+  }
+}
+
+const f = (source: 'local' | 'device', path: string) => ({ source, path, id: `${source}:${path}` })
+
+describe('serialiseSession (#266)', () => {
+  it('keeps LOCAL files (in order) and the active path; drops device + unsaved', () => {
+    const files = [f('local', '/a.py'), f('device', '/dev/x.py'), f('local', '/b.py'), f('local', '')]
+    const s = serialiseSession(files, 'local:/b.py')
+    expect(s.paths).toEqual(['/a.py', '/b.py'])
+    expect(s.activePath).toBe('/b.py')
+  })
+
+  it('active on a non-local file → null active', () => {
+    const s = serialiseSession([f('local', '/a.py'), f('device', '/d.py')], 'device:/d.py')
+    expect(s.activePath).toBeNull()
+    expect(s.paths).toEqual(['/a.py'])
+  })
+})
+
+describe('save / read session (#266)', () => {
+  it('round-trips', () => {
+    const s = mem()
+    saveSession(s, [f('local', '/a.py'), f('local', '/b.py')], 'local:/a.py')
+    expect(readSession(s)).toEqual({ paths: ['/a.py', '/b.py'], activePath: '/a.py' })
+  })
+
+  it('an empty session removes the key (no stale restore)', () => {
+    const s = mem({ [SESSION_KEY]: '{"paths":["/old.py"],"activePath":"/old.py"}' })
+    saveSession(s, [f('device', '/d.py')], null) // no local files
+    expect(s.getItem(SESSION_KEY)).toBeNull()
+  })
+
+  it('corrupt / wrong-shape stored session → null', () => {
+    expect(readSession(mem({ [SESSION_KEY]: 'not json{{' }))).toBeNull()
+    expect(readSession(mem({ [SESSION_KEY]: '{"paths":"nope"}' }))).toBeNull()
+    expect(readSession(mem())).toBeNull()
+  })
+
+  it('sanitises non-string paths out of a stored list', () => {
+    const s = mem({ [SESSION_KEY]: '{"paths":["/a.py",5,"",null,"/b.py"],"activePath":7}' })
+    expect(readSession(s)).toEqual({ paths: ['/a.py', '/b.py'], activePath: null })
+  })
+})
+
+describe('crash-guard (#266)', () => {
+  it('no marker → safe to restore; sets + clears the marker', () => {
+    const s = mem()
+    expect(restoreMode(s)).toBe('safe')
+    markRestoreStart(s)
+    expect(s.getItem(RESTORE_GUARD_KEY)).toBe('1')
+    markRestoreDone(s)
+    expect(s.getItem(RESTORE_GUARD_KEY)).toBeNull()
+  })
+
+  it('a leftover marker from a crashed launch → recover (skip restore)', () => {
+    const s = mem({ [RESTORE_GUARD_KEY]: '1' })
+    expect(restoreMode(s)).toBe('recover')
+  })
+
+  it('models a crash loop then self-heal', () => {
+    const s = mem()
+    // Launch 1: safe → arm, then "crash" before markRestoreDone.
+    expect(restoreMode(s)).toBe('safe')
+    markRestoreStart(s)
+    // Launch 2: marker survived → recover, and we clear it.
+    expect(restoreMode(s)).toBe('recover')
+    markRestoreDone(s)
+    // Launch 3: clean again.
+    expect(restoreMode(s)).toBe('safe')
+  })
+})


### PR DESCRIPTION
Closes #266. Snakie now reopens the files you had open, and recovers cleanly if one breaks startup.

## What
- **Restore open files** — the open *local* files (+ the active tab) are remembered and reopened next launch, alongside the working folder that #177 already restores. (Device files aren't persisted — they need a live board.)
- **Crash-guard safe mode** (your pick over hold-Shift, which is unreliable in Electron): a marker is set before restore and cleared once the app is stable. If a launch finds the marker still set, the previous restore crashed → Snakie **skips restore, drops that session so it can't loop, and shows a notice**. Self-healing — no keystroke, no admin, which is what a locked-down classroom needs.
- **Storage** — everything lives in `localStorage`, which Electron keeps in the per-user `userData` partition: writable without elevation, part of the roaming profile. Right for a school image.

## Note on #266's original report
The *folder* retention it describes already works (shipped in #177, in 0.23.2) — verified in-app across Files→Packages→Files, Files→Report Bug→Files, and restart. The real remaining gap was reopening the **files**, plus the safe recovery — which this adds.

## Implementation notes
- Session is read at **first render** (a window-guarded `useState` initializer) so the persist effect can't wipe it before restore reads it (fixed an effect-order race found in testing); persist is gated on a `hydrated` ref until restore settles.
- Pure `session-restore` module (serialise / save / read / crash-guard) — **9 unit tests**.

## Verified
In-app (Playwright): two files reopen with the correct active tab and persist across restarts; a leftover marker skips restore and surfaces "Opened without restoring files". Gate: typecheck + lint clean, **1351 tests**, build ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)