### PR TITLE
Data View: virtualised CSV/log table viewer (#274, epic #272 step 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Data View — open a logged CSV as a table (#274, epic #272).** Opening a
+  `.csv` / `.tsv` file now shows a spreadsheet-like viewer instead of raw text:
+  it auto-detects the delimiter (comma / tab / semicolon / whitespace) and the
+  header row, infers each column's type (number / timestamp / text), and
+  tolerates the mess real device logs carry — ragged rows, blank lines and a
+  torn final row (board unplugged mid-write) are handled, never fatal, with a
+  data-quality "ragged" count and null markers for dropped readings. Rendering
+  is **virtualised**, so a 24-hour log (~86k rows) scrolls smoothly with only
+  the visible rows in the DOM. This is the foundation of the Data View epic
+  (#272); sort/filter, the column-summary panel, pull-from-board, graphing and
+  export build on the same parsed model.
 - **Reopen your files on launch, with crash-safe recovery (#266).** Snakie now
   remembers the open local files (and which tab was active) and reopens them
   next time — alongside the working folder it already restored (#177). A

--- a/examples/sensor_log.csv
+++ b/examples/sensor_log.csv
@@ -1,0 +1,6 @@
+time,temp,humidity,label
+0,21.5,40,ok
+1,21.6,41,ok
+2,21.9,43,ok
+3,22.1,44,warm
+4,22.4,45,warm

--- a/src/renderer/src/components/DataView.css
+++ b/src/renderer/src/components/DataView.css
@@ -1,0 +1,173 @@
+/* DATA VIEW (#274) — spreadsheet-like log viewer. Unique BEM prefix `dv__`
+   (instrument/panel CSS is global). */
+
+.dv {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  background: var(--bg, #1b1c1f);
+  color: var(--text, #d6dae0);
+  font-family: var(--font-mono), 'JetBrains Mono', monospace;
+}
+
+.dv--empty {
+  align-items: center;
+  justify-content: center;
+}
+
+.dv__empty-text {
+  color: var(--text-muted, #8b919b);
+  font-size: 0.8rem;
+}
+
+/* --- Toolbar --------------------------------------------------------------- */
+.dv__toolbar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 0.4rem 0.7rem;
+  border-bottom: 1px solid var(--border, #2c2e33);
+  background: var(--bg-elevated, #212226);
+  font-size: 0.68rem;
+}
+
+.dv__stat {
+  color: var(--text, #d6dae0);
+}
+.dv__stat--muted {
+  color: var(--text-muted, #8b919b);
+}
+.dv__stat--warn {
+  color: #e0a44a;
+}
+
+.dv__toggle {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--text-muted, #8b919b);
+  cursor: pointer;
+  user-select: none;
+}
+
+/* --- Scroll viewport (both axes) ------------------------------------------- */
+.dv__grid {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+}
+
+.dv__inner {
+  position: relative;
+  min-width: 100%;
+}
+
+/* Sticky header — stays on top while scrolling vertically, moves with content
+   horizontally. */
+.dv__head {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: grid;
+  height: 30px;
+  background: var(--bg-elevated, #26282d);
+  border-bottom: 1px solid var(--border, #34363c);
+}
+
+.dv__th {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 1px;
+  padding: 0 0.5rem;
+  overflow: hidden;
+  border-right: 1px solid var(--border, #2c2e33);
+}
+
+.dv__th-name {
+  font-size: 0.7rem;
+  font-weight: 700;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text, #d6dae0);
+}
+
+.dv__th-type {
+  font-size: 0.56rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted, #8b919b);
+}
+.dv__th-type--number {
+  color: #7fc4f0;
+}
+.dv__th-type--timestamp {
+  color: #b58aef;
+}
+.dv__th-type--string {
+  color: #8b919b;
+}
+
+/* --- Virtualised body ------------------------------------------------------ */
+.dv__body {
+  position: relative;
+}
+
+.dv__row {
+  position: absolute;
+  left: 0;
+  right: 0;
+  display: grid;
+  height: 26px;
+  align-items: center;
+  border-bottom: 1px solid rgba(128, 128, 128, 0.08);
+}
+
+.dv__row:hover {
+  background: rgba(128, 148, 200, 0.08);
+}
+
+.dv__cell {
+  padding: 0 0.5rem;
+  font-size: 0.7rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  border-right: 1px solid rgba(128, 128, 128, 0.06);
+}
+
+.dv__null {
+  color: rgba(128, 128, 128, 0.5);
+}
+
+/* Row-number gutter (left of every row + the header). */
+.dv__gutter {
+  position: absolute;
+  left: 0;
+  width: 48px;
+  padding-right: 0.4rem;
+  text-align: right;
+  font-size: 0.62rem;
+  color: var(--text-muted, #6b7078);
+  background: var(--bg, #1b1c1f);
+  border-right: 1px solid var(--border, #2c2e33);
+  align-self: stretch;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.dv__gutter--head {
+  background: var(--bg-elevated, #26282d);
+  z-index: 1;
+}
+
+/* Shift the header + rows right of the gutter so cells aren't hidden under it. */
+.dv__head,
+.dv__row {
+  padding-left: 48px;
+}

--- a/src/renderer/src/components/DataView.tsx
+++ b/src/renderer/src/components/DataView.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useWorkspace } from '../store/workspace'
+import { parseTable, delimiterLabel, type ColumnType } from './data-table'
+import './DataView.css'
+
+/**
+ * DATA VIEW (#274, epic #272) — a spreadsheet-like viewer for a logged CSV/TXT
+ * file, the retrospective counterpart to the live instruments.
+ * =============================================================================
+ *
+ * Reads the active local file, parses it with the robust {@link ./data-table}
+ * ingest (delimiter/header/type detection, ragged-row tolerant), and renders it
+ * VIRTUALISED — only the rows in view are in the DOM — so an 86k-row 24-hour log
+ * (1 reading/sec) scrolls without choking. This is the foundation; sort/filter
+ * (#275), the column summary panel (#276), pull-from-board (#277), graph (#278)
+ * and export (#279) build on the same parsed model.
+ */
+
+const ROW_H = 26 // px per data row (fixed → cheap virtualisation math)
+const COL_W = 150 // px per column (fixed → horizontal scroll when wide)
+const OVERSCAN = 8 // extra rows above/below the viewport
+
+const alignFor = (t: ColumnType): 'right' | 'left' => (t === 'number' ? 'right' : 'left')
+
+export function DataView(): JSX.Element {
+  const { openFiles, activeId } = useWorkspace()
+  const activeFile = openFiles.find((f) => f.id === activeId) ?? null
+  const content = activeFile?.content ?? ''
+
+  // A user override for the header toggle (null = use auto-detection).
+  const [headerOverride, setHeaderOverride] = useState<boolean | null>(null)
+
+  // Parsing is the expensive step — memoise on the content + the toggle.
+  const table = useMemo(
+    () => parseTable(content, headerOverride === null ? {} : { hasHeader: headerOverride }),
+    [content, headerOverride]
+  )
+
+  // Reset the header override when switching to a different file.
+  useEffect(() => {
+    setHeaderOverride(null)
+  }, [activeId])
+
+  // --- Virtualisation: track the scroll viewport + its height ----------------
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const [scrollTop, setScrollTop] = useState(0)
+  const [viewH, setViewH] = useState(600)
+
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+    const measure = (): void => setViewH(el.clientHeight)
+    measure()
+    const ro = new ResizeObserver(measure)
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
+
+  const { columns, rows, raggedRows } = table
+  const total = rows.length
+  const first = Math.max(0, Math.floor(scrollTop / ROW_H) - OVERSCAN)
+  const visibleCount = Math.ceil(viewH / ROW_H) + OVERSCAN * 2
+  const last = Math.min(total, first + visibleCount)
+  const template = `repeat(${columns.length}, ${COL_W}px)`
+  const innerW = columns.length * COL_W
+
+  if (columns.length === 0) {
+    return (
+      <div className="dv dv--empty">
+        <p className="dv__empty-text">
+          {content.trim() ? 'No table data found in this file.' : 'This file is empty.'}
+        </p>
+      </div>
+    )
+  }
+
+  const visible: JSX.Element[] = []
+  for (let i = first; i < last; i++) {
+    const row = rows[i]
+    visible.push(
+      <div
+        key={i}
+        className="dv__row"
+        style={{ transform: `translateY(${i * ROW_H}px)`, gridTemplateColumns: template }}
+      >
+        <div className="dv__gutter">{i + 1}</div>
+        {columns.map((c) => (
+          <div key={c.index} className="dv__cell" style={{ textAlign: alignFor(c.type) }}>
+            {row[c.index] === '' ? <span className="dv__null">·</span> : row[c.index]}
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div className="dv">
+      <div className="dv__toolbar">
+        <span className="dv__stat">
+          <strong>{total.toLocaleString()}</strong> rows · <strong>{columns.length}</strong> cols
+        </span>
+        <span className="dv__stat dv__stat--muted">{delimiterLabel(table.delimiter)}-delimited</span>
+        {raggedRows > 0 && (
+          <span className="dv__stat dv__stat--warn" title="Rows padded or truncated to fit the columns">
+            ⚠ {raggedRows.toLocaleString()} ragged
+          </span>
+        )}
+        <label className="dv__toggle">
+          <input
+            type="checkbox"
+            checked={table.hasHeader}
+            onChange={(e) => setHeaderOverride(e.target.checked)}
+          />
+          First row is a header
+        </label>
+      </div>
+
+      <div className="dv__grid" ref={scrollRef} onScroll={(e) => setScrollTop(e.currentTarget.scrollTop)}>
+        <div className="dv__inner" style={{ width: innerW + 48 }}>
+          <div className="dv__head" style={{ gridTemplateColumns: template }}>
+            <div className="dv__gutter dv__gutter--head" />
+            {columns.map((c) => (
+              <div key={c.index} className="dv__th" title={`${c.name} · ${c.type}`}>
+                <span className="dv__th-name">{c.name}</span>
+                <span className={`dv__th-type dv__th-type--${c.type}`}>{c.type}</span>
+              </div>
+            ))}
+          </div>
+          <div className="dv__body" style={{ height: total * ROW_H }}>
+            {visible}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/EditorArea.tsx
+++ b/src/renderer/src/components/EditorArea.tsx
@@ -7,6 +7,14 @@ import { useWorkspace } from '../store/workspace'
 // open, keeping it out of the initial renderer bundle. Until then EditorArea
 // renders the lightweight empty state below.
 const MonacoEditor = lazy(() => import('./MonacoEditor'))
+// Data View (#274) is code-split too — only pulled in when a data file is open.
+const DataView = lazy(() => import('./DataView').then((m) => ({ default: m.DataView })))
+
+/** Files opened as a table (Data View) rather than in the code editor (#274). */
+const DATA_FILE_RE = /\.(csv|tsv|tab)$/i
+function isDataFile(name: string | undefined): boolean {
+  return !!name && DATA_FILE_RE.test(name)
+}
 
 /**
  * CENTER — editor region.
@@ -21,8 +29,10 @@ const MonacoEditor = lazy(() => import('./MonacoEditor'))
  * dynamic import, with a matching fallback shown while it streams in.
  */
 export function EditorArea(): JSX.Element {
-  const { openFiles } = useWorkspace()
+  const { openFiles, activeId } = useWorkspace()
   const hasFiles = openFiles.length > 0
+  const activeFile = openFiles.find((f) => f.id === activeId) ?? null
+  const showData = isDataFile(activeFile?.name)
 
   // Open the Find & Replace window. The window itself drives the editor over IPC
   // (issue #146); we only need to open/focus it.
@@ -64,7 +74,7 @@ export function EditorArea(): JSX.Element {
     >
       <div className="editor-header">
         <EditorTabs />
-        {hasFiles && (
+        {hasFiles && !showData && (
           <div className="editor-header__actions">
             <button
               type="button"
@@ -78,12 +88,16 @@ export function EditorArea(): JSX.Element {
         )}
       </div>
       <div className="region__body region__body--editor">
-        {hasFiles ? (
+        {!hasFiles ? (
+          <EditorPlaceholder text="Open a file to start editing" />
+        ) : showData ? (
+          <Suspense fallback={<EditorPlaceholder text="Loading data view…" />}>
+            <DataView />
+          </Suspense>
+        ) : (
           <Suspense fallback={<EditorPlaceholder text="Loading editor…" />}>
             <MonacoEditor />
           </Suspense>
-        ) : (
-          <EditorPlaceholder text="Open a file to start editing" />
         )}
       </div>
     </section>

--- a/src/renderer/src/components/data-table.ts
+++ b/src/renderer/src/components/data-table.ts
@@ -1,0 +1,226 @@
+/**
+ * DATA TABLE ingest (#274, epic #272 Data View) — parse a logged CSV/TXT file
+ * into a typed, in-memory table, robust against the mess real device logs carry.
+ * =============================================================================
+ *
+ * Device logs are written by a microcontroller that can be unplugged mid-write,
+ * drop readings, or emit ragged rows — so parsing NEVER throws: bad rows are
+ * normalised and counted, never fatal. The result is a flat, column-typed model
+ * that the virtualised table renders and (later #272 steps) sorts/filters/graphs.
+ *
+ * Deliberately NOT single-file-hardcoded: {@link DataTable} is a plain value, so
+ * a future multi-file compare (epic #272 "Deferred") can hold several.
+ *
+ * Pure + DOM-free (parsing only) so it unit-tests in node. `Date.parse` is used
+ * for timestamp sniffing — it takes a string, so it's deterministic here.
+ */
+
+/** A column's inferred (or user-overridden) value type. */
+export type ColumnType = 'number' | 'timestamp' | 'string'
+
+/** The delimiter kinds we auto-detect. `ws` = run-of-whitespace. */
+export type Delimiter = ',' | '\t' | ';' | 'ws'
+
+export interface Column {
+  name: string
+  type: ColumnType
+  /** 0-based position. */
+  index: number
+}
+
+export interface DataTable {
+  columns: Column[]
+  /** Row-major cell strings, each row normalised to `columns.length` cells. */
+  rows: string[][]
+  delimiter: Delimiter
+  hasHeader: boolean
+  rowCount: number
+  /** How many rows were ragged (padded/truncated) — a data-quality signal. */
+  raggedRows: number
+}
+
+export interface ParseOptions {
+  /** Force a delimiter instead of auto-detecting. */
+  delimiter?: Delimiter
+  /** Force whether the first row is a header. */
+  hasHeader?: boolean
+  /** Per-column type overrides (by column index). */
+  columnTypes?: Record<number, ColumnType>
+}
+
+const DELIMS: Exclude<Delimiter, 'ws'>[] = [',', '\t', ';']
+/** A number cell: optional sign, digits, optional fraction, optional exponent. */
+const NUMBER_RE = /^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/
+/** Common timestamp shapes: ISO date(-time), `YYYY/MM/DD`, or `HH:MM(:SS)`. */
+const TIMESTAMP_RE =
+  /^(\d{4}[-/]\d{2}[-/]\d{2}([ T]\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:?\d{2})?)?|\d{1,2}:\d{2}(:\d{2})?)$/
+
+/** Split a file into non-empty physical lines (any newline style). */
+export function splitLines(text: string): string[] {
+  return text.split(/\r\n|\r|\n/).filter((l) => l.trim().length > 0)
+}
+
+/**
+ * Quote-aware split of one line on a single-char delimiter (RFC-4180-ish: a
+ * `"…"` cell may contain the delimiter, and `""` is an escaped quote). For the
+ * `ws` delimiter we split on runs of whitespace instead.
+ */
+export function splitLine(line: string, delim: Delimiter): string[] {
+  if (delim === 'ws') return line.trim().split(/\s+/)
+  const out: string[] = []
+  let cur = ''
+  let inQuotes = false
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i]
+    if (inQuotes) {
+      if (c === '"') {
+        if (line[i + 1] === '"') {
+          cur += '"'
+          i++
+        } else inQuotes = false
+      } else cur += c
+    } else if (c === '"') {
+      inQuotes = true
+    } else if (c === delim) {
+      out.push(cur)
+      cur = ''
+    } else cur += c
+  }
+  out.push(cur)
+  return out.map((s) => s.trim())
+}
+
+/**
+ * Auto-detect the delimiter: for each candidate, measure how CONSISTENTLY it
+ * splits the sampled lines (same count per line = a real delimiter). The most
+ * consistent candidate with ≥2 columns wins; fall back to whitespace.
+ */
+export function detectDelimiter(lines: string[]): Delimiter {
+  const sample = lines.slice(0, 50)
+  if (sample.length === 0) return ','
+  let best: Delimiter = 'ws'
+  let bestScore = -1
+  for (const d of [...DELIMS, 'ws' as const]) {
+    const counts = sample.map((l) => splitLine(l, d).length)
+    const cols = counts[0]
+    if (cols < 2) continue
+    const consistent = counts.filter((c) => c === cols).length / counts.length
+    // Prefer more columns as a tie-breaker (a real table beats accidental splits).
+    const score = consistent + Math.min(cols, 20) / 1000
+    if (score > bestScore) {
+      bestScore = score
+      best = d
+    }
+  }
+  return best
+}
+
+/**
+ * Header heuristic: the first row is a header when its cells are all non-empty,
+ * all distinct, and — crucially — at least one column is NUMERIC in the data
+ * rows but the header cell there is NOT (labels like `time,temp` over numbers).
+ * With no numeric columns we fall back to "first row is all non-numeric text".
+ */
+export function detectHeader(rows: string[][]): boolean {
+  if (rows.length === 0) return false
+  const first = rows[0]
+  if (first.some((c) => c.trim() === '')) return false
+  if (new Set(first).size !== first.length) return false
+  const body = rows.slice(1, 51)
+  if (body.length === 0) return first.every((c) => !isNumeric(c))
+  let numericColSawHeaderText = false
+  for (let col = 0; col < first.length; col++) {
+    const colVals = body.map((r) => r[col] ?? '').filter((v) => v !== '')
+    if (colVals.length === 0) continue
+    const numericShare = colVals.filter(isNumeric).length / colVals.length
+    if (numericShare >= 0.8 && !isNumeric(first[col])) numericColSawHeaderText = true
+  }
+  if (numericColSawHeaderText) return true
+  // No numeric column to contrast — treat an all-text first row as a header.
+  return first.every((c) => !isNumeric(c))
+}
+
+export function isNumeric(v: string): boolean {
+  return v !== '' && NUMBER_RE.test(v.trim())
+}
+
+export function isTimestamp(v: string): boolean {
+  const t = v.trim()
+  if (!TIMESTAMP_RE.test(t)) return false
+  // A bare `HH:MM` has no date for Date.parse; accept it on the regex alone.
+  if (/^\d{1,2}:\d{2}(:\d{2})?$/.test(t)) return true
+  return !Number.isNaN(Date.parse(t))
+}
+
+/**
+ * Infer a column's type from its (non-blank) values: `number` when ≥80% are
+ * numeric, else `timestamp` when ≥80% are timestamps, else `string`. Blank
+ * cells are ignored (they're nulls, common in device logs).
+ */
+export function inferColumnType(values: string[]): ColumnType {
+  const nonBlank = values.filter((v) => v.trim() !== '')
+  if (nonBlank.length === 0) return 'string'
+  const nums = nonBlank.filter(isNumeric).length
+  if (nums / nonBlank.length >= 0.8) return 'number'
+  const stamps = nonBlank.filter(isTimestamp).length
+  if (stamps / nonBlank.length >= 0.8) return 'timestamp'
+  return 'string'
+}
+
+/**
+ * Parse a whole file into a {@link DataTable}. Never throws: ragged rows are
+ * padded (short) or truncated (long) to the column count and tallied; blank
+ * lines are dropped; a torn final row is kept, padded.
+ */
+export function parseTable(text: string, opts: ParseOptions = {}): DataTable {
+  const lines = splitLines(text)
+  if (lines.length === 0) {
+    return { columns: [], rows: [], delimiter: ',', hasHeader: false, rowCount: 0, raggedRows: 0 }
+  }
+  const delimiter = opts.delimiter ?? detectDelimiter(lines)
+  const cells = lines.map((l) => splitLine(l, delimiter))
+  const hasHeader = opts.hasHeader ?? detectHeader(cells)
+
+  // Column count = the modal row width (robust to a ragged header/final row).
+  const width = modalWidth(cells)
+  const headerCells = hasHeader ? cells[0] : null
+  const bodyCells = hasHeader ? cells.slice(1) : cells
+
+  // Normalise every body row to `width` cells; count the ones we had to fix.
+  let raggedRows = 0
+  const rows = bodyCells.map((r) => {
+    if (r.length !== width) raggedRows++
+    if (r.length < width) return [...r, ...Array(width - r.length).fill('')]
+    if (r.length > width) return r.slice(0, width)
+    return r
+  })
+
+  const columns: Column[] = []
+  for (let i = 0; i < width; i++) {
+    const name = headerCells?.[i]?.trim() || `col ${i + 1}`
+    const type = opts.columnTypes?.[i] ?? inferColumnType(rows.map((r) => r[i] ?? ''))
+    columns.push({ name, type, index: i })
+  }
+
+  return { columns, rows, delimiter, hasHeader, rowCount: rows.length, raggedRows }
+}
+
+/** The most common row width across a sample — the table's true column count. */
+function modalWidth(cells: string[][]): number {
+  const freq = new Map<number, number>()
+  for (const r of cells.slice(0, 200)) freq.set(r.length, (freq.get(r.length) ?? 0) + 1)
+  let width = 0
+  let best = -1
+  for (const [w, n] of freq) {
+    if (n > best || (n === best && w > width)) {
+      best = n
+      width = w
+    }
+  }
+  return Math.max(width, 1)
+}
+
+/** A human label for a delimiter (for the UI / status). */
+export function delimiterLabel(d: Delimiter): string {
+  return d === ',' ? 'comma' : d === '\t' ? 'tab' : d === ';' ? 'semicolon' : 'whitespace'
+}

--- a/test/dataTable.test.ts
+++ b/test/dataTable.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest'
+import {
+  splitLines,
+  splitLine,
+  detectDelimiter,
+  detectHeader,
+  isNumeric,
+  isTimestamp,
+  inferColumnType,
+  parseTable,
+  delimiterLabel
+} from '../src/renderer/src/components/data-table'
+
+describe('splitLines / splitLine (#274)', () => {
+  it('splits on any newline style and drops blank lines', () => {
+    expect(splitLines('a\r\nb\n\n c \r\r')).toEqual(['a', 'b', ' c '])
+    expect(splitLines('')).toEqual([])
+  })
+  it('quote-aware comma split (RFC-4180-ish) with escaped quotes', () => {
+    expect(splitLine('a,b,c', ',')).toEqual(['a', 'b', 'c'])
+    expect(splitLine('"a,1","b ""x""",c', ',')).toEqual(['a,1', 'b "x"', 'c'])
+    expect(splitLine('1;2;3', ';')).toEqual(['1', '2', '3'])
+  })
+  it('whitespace split collapses runs', () => {
+    expect(splitLine('1   2\t3   4', 'ws')).toEqual(['1', '2', '3', '4'])
+  })
+})
+
+describe('detectDelimiter (#274)', () => {
+  it('detects comma / tab / semicolon / whitespace by consistency', () => {
+    expect(detectDelimiter(['t,temp,hum', '0,21.5,40', '1,21.6,41'])).toBe(',')
+    expect(detectDelimiter(['t\ttemp', '0\t21.5', '1\t21.6'])).toBe('\t')
+    expect(detectDelimiter(['t;temp', '0;21.5'])).toBe(';')
+    expect(detectDelimiter(['t temp hum', '0 21.5 40', '1 21.6 41'])).toBe('ws')
+  })
+  it('prefers the delimiter that splits consistently, not an incidental one', () => {
+    // Commas are the real delimiter; a stray semicolon in one text cell mustn't win.
+    expect(detectDelimiter(['name,note', 'a,hi; there', 'b,ok'])).toBe(',')
+  })
+})
+
+describe('type predicates + inference (#274)', () => {
+  it('isNumeric handles ints, floats, signs, exponents; rejects text/blank', () => {
+    for (const v of ['0', '-3', '21.5', '.5', '2.', '1e3', '-1.2E-4']) expect(isNumeric(v), v).toBe(true)
+    for (const v of ['', 'abc', '1,2', '0x10', '12:00']) expect(isNumeric(v), v).toBe(false)
+  })
+  it('isTimestamp matches ISO date/time, slashes and clock times', () => {
+    for (const v of ['2026-07-07', '2026-07-07T13:04:05', '2026/07/07 13:04', '13:04:05', '9:30'])
+      expect(isTimestamp(v), v).toBe(true)
+    for (const v of ['21.5', 'hello', '2026-13-40']) expect(isTimestamp(v), v).toBe(false)
+  })
+  it('inferColumnType: 80% rule, ignoring blanks', () => {
+    expect(inferColumnType(['1', '2', '3', ''])).toBe('number')
+    expect(inferColumnType(['2026-07-07', '2026-07-08', ''])).toBe('timestamp')
+    expect(inferColumnType(['on', 'off', 'on'])).toBe('string')
+    // Mostly numbers with one stray label → still number (≥80%).
+    expect(inferColumnType(['1', '2', '3', '4', 'n/a'])).toBe('number')
+    // Half and half → string.
+    expect(inferColumnType(['1', '2', 'a', 'b'])).toBe('string')
+  })
+})
+
+describe('detectHeader (#274)', () => {
+  it('spots a text header over numeric columns', () => {
+    expect(detectHeader([['time', 'temp'], ['0', '21.5'], ['1', '21.6']])).toBe(true)
+  })
+  it('no header when the first row is numeric like the rest', () => {
+    expect(detectHeader([['0', '21.5'], ['1', '21.6']])).toBe(false)
+  })
+  it('rejects a first row with blanks or duplicate names', () => {
+    expect(detectHeader([['time', ''], ['0', '1']])).toBe(false)
+    expect(detectHeader([['t', 't'], ['0', '1']])).toBe(false)
+  })
+})
+
+describe('parseTable — robustness (#274)', () => {
+  it('parses a clean CSV with header + inferred types', () => {
+    const t = parseTable('time,temp,label\n0,21.5,ok\n1,21.6,ok')
+    expect(t.delimiter).toBe(',')
+    expect(t.hasHeader).toBe(true)
+    expect(t.columns.map((c) => `${c.name}:${c.type}`)).toEqual(['time:number', 'temp:number', 'label:string'])
+    expect(t.rows).toEqual([
+      ['0', '21.5', 'ok'],
+      ['1', '21.6', 'ok']
+    ])
+    expect(t.rowCount).toBe(2)
+    expect(t.raggedRows).toBe(0)
+  })
+
+  it('tolerates ragged rows: pads a torn final row, truncates an over-long one', () => {
+    // Header defines 3 cols; row 2 is short (unplugged mid-write), row 3 too long.
+    const t = parseTable('a,b,c\n1,2,3\n4,5\n6,7,8,9')
+    expect(t.columns).toHaveLength(3)
+    expect(t.rows).toEqual([
+      ['1', '2', '3'],
+      ['4', '5', ''], // padded
+      ['6', '7', '8'] // truncated
+    ])
+    expect(t.raggedRows).toBe(2)
+    expect(t.rowCount).toBe(3)
+  })
+
+  it('drops blank lines and never throws on junk', () => {
+    expect(() => parseTable('')).not.toThrow()
+    expect(parseTable('').columns).toHaveLength(0)
+    const t = parseTable('x,y\n\n1,2\n\n3,4\n')
+    expect(t.rowCount).toBe(2)
+  })
+
+  it('a headerless numeric table gets positional column names', () => {
+    const t = parseTable('0 21.5\n1 21.6\n2 21.7')
+    expect(t.delimiter).toBe('ws')
+    expect(t.hasHeader).toBe(false)
+    expect(t.columns.map((c) => c.name)).toEqual(['col 1', 'col 2'])
+    expect(t.columns.every((c) => c.type === 'number')).toBe(true)
+  })
+
+  it('honours delimiter / header / type overrides', () => {
+    const t = parseTable('1;2;3\n4;5;6', {
+      delimiter: ';',
+      hasHeader: false,
+      columnTypes: { 0: 'string' }
+    })
+    expect(t.columns[0].type).toBe('string')
+    expect(t.columns[1].type).toBe('number')
+    expect(t.rows).toHaveLength(2)
+  })
+
+  it('scales to many rows without choking (smoke)', () => {
+    const lines = ['t,v']
+    for (let i = 0; i < 20000; i++) lines.push(`${i},${(i % 100) / 10}`)
+    const t = parseTable(lines.join('\n'))
+    expect(t.rowCount).toBe(20000)
+    expect(t.columns[1].type).toBe('number')
+  })
+})
+
+describe('delimiterLabel', () => {
+  it('names each delimiter', () => {
+    expect(delimiterLabel(',')).toBe('comma')
+    expect(delimiterLabel('\t')).toBe('tab')
+    expect(delimiterLabel(';')).toBe('semicolon')
+    expect(delimiterLabel('ws')).toBe('whitespace')
+  })
+})


### PR DESCRIPTION
The foundation of the Data View epic (#272) — the retrospective counterpart to the live instruments. Opening a `.csv` / `.tsv` file now shows a spreadsheet-like table instead of raw text.

## Ingest (`data-table.ts` — pure, 18 unit tests)
The make-or-break robustness against messy real device logs:
- **Delimiter auto-detect** — comma / tab / semicolon / whitespace, by split-consistency (a stray delimiter in a text cell can't win)
- **Header detection** — text-over-numeric heuristic, plus a manual "first row is a header" toggle
- **Type inference** — number / timestamp / string (80% rule, blank-tolerant), with per-column override support
- **Ragged-row tolerance** — short rows padded, long rows truncated, a **torn final row** (board unplugged mid-write) kept; all counted as a data-quality signal; **never throws**
- Quote-aware CSV splitting (RFC-4180-ish). Model is a plain value, **not single-file-hardcoded**, so the epic's deferred multi-file compare stays possible.

## Table render (`DataView.tsx`)
- **Virtualised** — fixed row height, only the visible rows in the DOM. Verified ~35 DOM rows for a 50k-row file; scroll stays smooth.
- Sticky headers showing each column's inferred type (colour-coded), a row-number gutter, per-type cell alignment (numbers right), null markers for dropped readings, and a ragged-row warning.
- Code-split; routed in `EditorArea` (data file → DataView, else Monaco).

## Verified
In-app (Playwright): a 50,001-row log opens with comma+header detected and the torn final row flagged "⚠ 1 ragged"; scrolling to row ~762 keeps the DOM row set constant at ~35. Gate: typecheck + lint clean, **1369 tests** (18 new), build ✅. A small `examples/sensor_log.csv` is included to try it.

Part of epic #272. Next steps build on this model: #275 sort/filter, #276 column summary panel, #277 pull-from-board, #278 graph, #279 export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)