### PR TITLE
Web W0: extract raw-REPL protocol to a transport-agnostic shared module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- **Raw-REPL protocol extracted to a transport-agnostic module (#281, epic
+  #267 Phase W0).** The MicroPython raw-REPL handshake, `exec`/`eval`, and the
+  filesystem helpers built on them (`listDir`, `readFile`, `writeFile`,
+  `remove`, `mkdir`, `rename`, `stat`) moved out of `MicroPythonDevice` into
+  `src/shared/raw-repl.ts` as a standalone `RawReplEngine`, driven through a
+  minimal `write()`-only transport interface using `Uint8Array` instead of
+  Node's `Buffer`. `MicroPythonDevice` is now a thin `serialport` adapter over
+  the engine — pure refactor, no behaviour change, now covered by dedicated
+  unit tests that exercise the protocol against a fake board (no real serial
+  port needed). This is the first step of Snakie for Web (#267): the same
+  engine will later be driven by a Web Serial transport in the browser build.
+
 ### Added
 - **Data View — open a logged CSV as a table (#274, epic #272).** Opening a
   `.csv` / `.tsv` file now shows a spreadsheet-like viewer instead of raw text:

--- a/src/main/device/MicroPythonDevice.ts
+++ b/src/main/device/MicroPythonDevice.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events'
 import { SerialPort } from 'serialport'
 import { buildControlLine } from '../../shared/control'
+import { CTRL_C, CTRL_D, RawReplEngine } from '../../shared/raw-repl'
 import type {
   ConnectOptions,
   ConnectionState,
@@ -11,27 +12,6 @@ import type {
   SnakieDevice,
   StatResult
 } from './types'
-
-/**
- * Control bytes used by the MicroPython REPL.
- *
- * The MicroPython "raw REPL" is a machine-friendly mode that lets a host run a
- * snippet of code and reliably capture its output. The handshake is:
- *
- *  1. Send Ctrl-C (twice) to interrupt anything currently running.
- *  2. Send Ctrl-A to enter raw REPL. The device replies with a banner that
- *     ends in `raw REPL; CTRL-B to exit\r\n>`.
- *  3. Send the code followed by Ctrl-D to execute it. The device responds with
- *     `OK`, then stdout, then `\x04` (end of stdout), then stderr/traceback,
- *     then another `\x04` (end of stderr), then `>` to prompt for more.
- *  4. Send Ctrl-B to leave raw REPL and return to the friendly REPL.
- *
- * @see https://docs.micropython.org/en/latest/reference/repl.html
- */
-const CTRL_A = '\x01' // enter raw REPL
-const CTRL_B = '\x02' // exit raw REPL
-const CTRL_C = '\x03' // interrupt / KeyboardInterrupt
-const CTRL_D = '\x04' // soft reset (friendly) / execute (raw)
 
 /** Map of events emitted by {@link MicroPythonDevice} to their payload types. */
 export interface MicroPythonDeviceEvents {
@@ -46,7 +26,11 @@ export interface MicroPythonDeviceEvents {
  *
  * Responsibilities:
  *  - own the {@link SerialPort} lifecycle (connect / disconnect / state),
- *  - implement the raw-REPL protocol (`exec`, `eval`),
+ *  - implement the raw-REPL protocol (`exec`, `eval`) by delegating to the
+ *    transport-agnostic {@link RawReplEngine} (issue #281, epic #267 Phase
+ *    W0) — this class supplies the engine with a `write` transport and feeds
+ *    it received bytes; the browser build supplies the same engine with a Web
+ *    Serial transport instead,
  *  - provide filesystem helpers built on top of `exec` so that later features
  *    (file tree, upload, file ops) can reuse them,
  *  - stream raw serial output and status changes via events.
@@ -62,32 +46,13 @@ export class MicroPythonDevice extends EventEmitter implements SnakieDevice {
   private currentBaud?: number
 
   /**
-   * Buffer of bytes received from the device. When a command is awaiting a
-   * specific marker, {@link readUntil} consumes from this buffer; otherwise
-   * incoming bytes are simply forwarded to listeners.
+   * The transport-agnostic raw-REPL protocol engine (buffering, handshake,
+   * exec/eval, filesystem helpers). This adapter's only job is to feed it
+   * bytes and give it a way to write bytes back.
    */
-  private rxBuffer = Buffer.alloc(0)
-
-  /** Resolver waiting for a particular byte sequence to appear in `rxBuffer`. */
-  private pending: {
-    marker: Buffer
-    resolve: (data: Buffer) => void
-    reject: (err: Error) => void
-    timer: NodeJS.Timeout
-  } | null = null
-
-  /**
-   * Serializes raw-REPL operations. Each `exec` chains onto this promise so two
-   * callers never interleave on the wire.
-   */
-  private opQueue: Promise<unknown> = Promise.resolve()
-
-  /** True once we have entered raw REPL and not yet exited it. */
-  private inRawRepl = false
-
-  /** True while an internal `exec` runs — suppresses the console `data` broadcast
-   * so raw-REPL/probe traffic (live-value polls, etc.) never hits the terminal. */
-  private execActive = false
+  private readonly engine = new RawReplEngine({
+    write: (data) => this.write(data)
+  })
 
   // ---------------------------------------------------------------------------
   // Typed event helpers (thin wrappers over EventEmitter)
@@ -170,7 +135,7 @@ export class MicroPythonDevice extends EventEmitter implements SnakieDevice {
           // disconnect() handles its own state change.
           if (this.state === 'connected' || this.state === 'connecting') {
             this.port = null
-            this.inRawRepl = false
+            this.engine.reset()
             this.setState('disconnected')
           }
         })
@@ -184,8 +149,7 @@ export class MicroPythonDevice extends EventEmitter implements SnakieDevice {
   async disconnect(): Promise<void> {
     const port = this.port
     this.port = null
-    this.inRawRepl = false
-    this.failPending(new Error('Disconnected'))
+    this.engine.reset()
     if (port && port.isOpen) {
       await new Promise<void>((resolve) => port.close(() => resolve()))
     }
@@ -208,71 +172,31 @@ export class MicroPythonDevice extends EventEmitter implements SnakieDevice {
   // ---------------------------------------------------------------------------
 
   private handleData(chunk: Buffer): void {
-    // Always buffer for the raw-REPL reader (readUntil).
-    this.rxBuffer = Buffer.concat([this.rxBuffer, chunk])
-    this.tryResolvePending()
+    // Always feed the raw-REPL engine (its `readUntil` waiters need every byte).
+    this.engine.handleData(chunk)
     // Forward raw bytes to the renderer REPL — EXCEPT while an internal `exec`
     // is in flight. Exec drives the raw REPL (banners, Ctrl-C interrupts, our
     // live-value probes like `<<SNKV>>0:9922`); that machine traffic must not
     // pollute the user's console. User typing + Run go through `sendData` (the
     // friendly REPL), not `exec`, so they still stream through.
-    if (!this.execActive) this.emit('data', chunk)
-  }
-
-  private tryResolvePending(): void {
-    if (!this.pending) return
-    const idx = this.rxBuffer.indexOf(this.pending.marker)
-    if (idx === -1) return
-    const end = idx + this.pending.marker.length
-    const data = this.rxBuffer.subarray(0, end)
-    this.rxBuffer = this.rxBuffer.subarray(end)
-    const { resolve, timer } = this.pending
-    clearTimeout(timer)
-    this.pending = null
-    resolve(data)
-  }
-
-  private failPending(err: Error): void {
-    if (!this.pending) return
-    clearTimeout(this.pending.timer)
-    const { reject } = this.pending
-    this.pending = null
-    reject(err)
+    if (!this.engine.execActive) this.emit('data', chunk)
   }
 
   /** Write raw bytes to the port, rejecting if not connected. */
-  private write(data: string | Buffer): Promise<void> {
+  private write(data: string | Buffer | Uint8Array): Promise<void> {
     return new Promise((resolve, reject) => {
       if (!this.port || !this.port.isOpen) {
         reject(new Error('Not connected'))
         return
       }
-      this.port.write(data, (err) => {
+      const payload = typeof data === 'string' ? data : Buffer.from(data)
+      this.port.write(payload, (err) => {
         if (err) {
           reject(new Error(err.message))
           return
         }
         this.port?.drain(() => resolve())
       })
-    })
-  }
-
-  /**
-   * Wait until `marker` appears in the receive buffer, returning everything up
-   * to and including it. Rejects after `timeoutMs`.
-   */
-  private readUntil(marker: string, timeoutMs = 5000): Promise<Buffer> {
-    if (this.pending) {
-      return Promise.reject(new Error('A read is already in progress'))
-    }
-    return new Promise<Buffer>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        this.pending = null
-        reject(new Error(`Timed out waiting for ${JSON.stringify(marker)}`))
-      }, timeoutMs)
-      this.pending = { marker: Buffer.from(marker, 'binary'), resolve, reject, timer }
-      // The marker may already be in the buffer from a previous read.
-      this.tryResolvePending()
     })
   }
 
@@ -317,20 +241,12 @@ export class MicroPythonDevice extends EventEmitter implements SnakieDevice {
 
   /** Enter raw REPL mode (Ctrl-A), interrupting any running program first. */
   async enterRawRepl(): Promise<void> {
-    // Clear any stale buffered output.
-    this.rxBuffer = Buffer.alloc(0)
-    // Interrupt twice to break out of running code or input().
-    await this.write(CTRL_C)
-    await this.write(CTRL_C)
-    await this.write(CTRL_A)
-    await this.readUntil('raw REPL; CTRL-B to exit\r\n>')
-    this.inRawRepl = true
+    await this.engine.enterRawRepl()
   }
 
   /** Leave raw REPL mode (Ctrl-B), returning to the friendly REPL. */
   async exitRawRepl(): Promise<void> {
-    await this.write(CTRL_B)
-    this.inRawRepl = false
+    await this.engine.exitRawRepl()
   }
 
   /**
@@ -341,56 +257,11 @@ export class MicroPythonDevice extends EventEmitter implements SnakieDevice {
    * not corrupt the protocol state.
    */
   exec(code: string, timeoutMs = 10000): Promise<ExecResult> {
-    const op = this.opQueue.then(() => this.execLocked(code, timeoutMs))
-    // Keep the queue alive even if this op rejects.
-    this.opQueue = op.catch(() => undefined)
-    return op
-  }
-
-  private async execLocked(code: string, timeoutMs: number): Promise<ExecResult> {
-    if (!this.isConnected()) {
-      throw new Error('Not connected')
-    }
-    // Suppress the renderer-console broadcast for the WHOLE exec (raw-REPL enter
-    // through exit) so probe/banner/interrupt bytes never reach the terminal.
-    this.execActive = true
-    try {
-      const enteredHere = !this.inRawRepl
-      if (enteredHere) {
-        await this.enterRawRepl()
-      }
-      try {
-        // Send the code and execute with Ctrl-D.
-        await this.write(code)
-        await this.write(CTRL_D)
-
-        // The device acknowledges a well-formed paste with "OK".
-        const ack = await this.readUntil('OK', timeoutMs)
-        if (!ack.toString('binary').includes('OK')) {
-          throw new Error('Device did not acknowledge code (no "OK")')
-        }
-
-        // stdout is everything up to the first \x04.
-        const stdoutRaw = await this.readUntil(CTRL_D, timeoutMs)
-        const stdout = stdoutRaw.subarray(0, stdoutRaw.length - 1).toString('utf8')
-
-        // stderr/traceback is everything up to the second \x04.
-        const stderrRaw = await this.readUntil(CTRL_D, timeoutMs)
-        const stderr = stderrRaw.subarray(0, stderrRaw.length - 1).toString('utf8')
-
-        // Consume the trailing prompt so the buffer is clean for the next op.
-        await this.readUntil('>', timeoutMs)
-
-        return { stdout, stderr }
-      } finally {
-        if (enteredHere) {
-          // Best-effort return to friendly REPL.
-          await this.exitRawRepl().catch(() => undefined)
-        }
-      }
-    } finally {
-      this.execActive = false
-    }
+    // No explicit `isConnected()` guard here: the engine's first `write()`
+    // call (via this adapter's `write`) already rejects with 'Not connected'
+    // as soon as the port is closed/null, so disconnected calls fail with the
+    // same error either way.
+    return this.engine.exec(code, timeoutMs)
   }
 
   /**
@@ -410,55 +281,20 @@ export class MicroPythonDevice extends EventEmitter implements SnakieDevice {
   // Filesystem helpers (built on top of exec/eval)
   // ---------------------------------------------------------------------------
 
-  /**
-   * List a directory. Returns entries with name, type and size. Uses
-   * `os.ilistdir` when available (gives type + size in one call) and emits a
-   * compact, machine-parseable line per entry.
-   */
+  /** List a directory. Returns entries with name, type and size. */
   async listDir(path = '/'): Promise<DirEntry[]> {
-    const code = [
-      'import os, json',
-      `def _ls(p):`,
-      '    out=[]',
-      '    try:',
-      '        it=os.ilistdir(p)',
-      '    except AttributeError:',
-      '        it=[(n,0,0) for n in os.listdir(p)]',
-      '    for e in it:',
-      '        name=e[0]; typ=e[1] if len(e)>1 else 0',
-      '        full=(p.rstrip("/")+"/"+name) if p else name',
-      '        isdir=(typ & 0x4000)!=0',
-      '        try: size=0 if isdir else os.stat(full)[6]',
-      '        except OSError: size=0',
-      '        out.append([name,isdir,size])',
-      '    return out',
-      `print(json.dumps(_ls(${pyStr(path)})))`
-    ].join('\n')
-    const raw = (await this.eval(code)).trim()
-    const parsed = JSON.parse(raw) as [string, boolean, number][]
-    return parsed.map(([name, isDir, size]) => ({ name, isDir, size }))
+    return this.engine.listDir(path)
   }
 
   /** Read a file from the device and return its contents as a string (UTF-8). */
   async readFile(path: string): Promise<string> {
-    const buf = await this.readFileBytes(path)
-    return buf.toString('utf8')
+    return this.engine.readFile(path)
   }
 
   /** Read a file from the device and return its raw bytes. */
   async readFileBytes(path: string): Promise<Buffer> {
-    // `ubinascii` is exposed as `binascii` on some ports; import defensively.
-    const code = [
-      'import sys',
-      'try:\n import ubinascii\nexcept ImportError:\n import binascii as ubinascii',
-      `with open(${pyStr(path)},'rb') as f:`,
-      '    while True:',
-      '        b=f.read(256)',
-      '        if not b: break',
-      '        sys.stdout.write(ubinascii.hexlify(b))'
-    ].join('\n')
-    const hex = (await this.eval(code)).trim()
-    return Buffer.from(hex, 'hex')
+    const bytes = await this.engine.readFileBytes(path)
+    return Buffer.from(bytes)
   }
 
   /**
@@ -467,72 +303,27 @@ export class MicroPythonDevice extends EventEmitter implements SnakieDevice {
    * text-oriented REPL transport.
    */
   async writeFile(path: string, contents: string | Buffer, chunkSize = 256): Promise<void> {
-    const data = Buffer.isBuffer(contents) ? contents : Buffer.from(contents, 'utf8')
-    // Open the file once, then stream hex chunks via repeated exec calls so we
-    // never put a multi-megabyte literal on a single line.
-    const open = [
-      'import sys',
-      'try:\n import ubinascii\nexcept ImportError:\n import binascii as ubinascii',
-      `_f=open(${pyStr(path)},'wb')`
-    ].join('\n')
-    await this.eval(open)
-    try {
-      for (let i = 0; i < data.length; i += chunkSize) {
-        const slice = data.subarray(i, i + chunkSize)
-        const hex = slice.toString('hex')
-        await this.eval(`_f.write(ubinascii.unhexlify(${pyStr(hex)}))`)
-      }
-    } finally {
-      await this.eval('_f.close()').catch(() => undefined)
-    }
+    await this.engine.writeFile(path, contents, chunkSize)
   }
 
-  /** Remove a file OR a directory tree. `os.remove()` can't delete directories
-   *  (and `os.rmdir()` only empty ones), so walk depth-first with an explicit
-   *  stack: children first, then the emptied folder (#219). */
+  /** Remove a file OR a directory tree (#219). */
   async remove(path: string): Promise<void> {
-    await this.eval(
-      [
-        'import os',
-        `_s = [${pyStr(path)}]`,
-        'while _s:',
-        '    _p = _s[-1]',
-        '    if (os.stat(_p)[0] & 0x4000) != 0:',
-        '        _c = os.listdir(_p)',
-        '        if _c:',
-        "            _s.extend([_p + '/' + _x for _x in _c])",
-        '        else:',
-        '            os.rmdir(_p)',
-        '            _s.pop()',
-        '    else:',
-        '        os.remove(_p)',
-        '        _s.pop()'
-      ].join('\n')
-    )
+    await this.engine.remove(path)
   }
 
   /** Create a directory. */
   async mkdir(path: string): Promise<void> {
-    await this.eval(`import os\nos.mkdir(${pyStr(path)})`)
+    await this.engine.mkdir(path)
   }
 
   /** Rename / move a path. */
   async rename(from: string, to: string): Promise<void> {
-    await this.eval(`import os\nos.rename(${pyStr(from)}, ${pyStr(to)})`)
+    await this.engine.rename(from, to)
   }
 
   /** Stat a path, returning type, size and mtime when available. */
   async stat(path: string): Promise<StatResult> {
-    const code = [
-      'import os, json',
-      `st=os.stat(${pyStr(path)})`,
-      'isdir=(st[0] & 0x4000)!=0',
-      'mtime=st[8] if len(st)>8 else None',
-      'print(json.dumps([isdir, st[6], mtime]))'
-    ].join('\n')
-    const raw = (await this.eval(code)).trim()
-    const [isDir, size, mtime] = JSON.parse(raw) as [boolean, number, number | null]
-    return { isDir, size, mtime: mtime ?? undefined }
+    return this.engine.stat(path)
   }
 
   /** Tear down resources (called on app quit). */
@@ -540,17 +331,4 @@ export class MicroPythonDevice extends EventEmitter implements SnakieDevice {
     this.removeAllListeners()
     await this.disconnect().catch(() => undefined)
   }
-}
-
-/**
- * Render a JS string as a Python string literal, escaping characters that would
- * break out of the quotes. Used to inject paths/data into generated Python.
- */
-function pyStr(value: string): string {
-  const escaped = value
-    .replace(/\\/g, '\\\\')
-    .replace(/'/g, "\\'")
-    .replace(/\n/g, '\\n')
-    .replace(/\r/g, '\\r')
-  return `'${escaped}'`
 }

--- a/src/shared/raw-repl.ts
+++ b/src/shared/raw-repl.ts
@@ -1,0 +1,451 @@
+/**
+ * Transport-agnostic MicroPython raw-REPL protocol engine (issue #281, epic #267
+ * Phase W0 — "the seam").
+ *
+ * This module used to live inline in `src/main/device/MicroPythonDevice.ts`,
+ * tangled together with `serialport`. It has been extracted here so a second
+ * transport — Web Serial, for the browser build — can drive the exact same
+ * protocol/state-machine code without depending on Node or Electron.
+ *
+ * Everything on the wire is modelled as `Uint8Array` (not Node's `Buffer`) so
+ * this module has zero Node dependencies and can run in a browser tab or a Web
+ * Worker unmodified. `serialport` (Electron main) and Web Serial (browser) both
+ * happily accept/emit anything that quacks like `Uint8Array`.
+ *
+ * @see https://docs.micropython.org/en/latest/reference/repl.html
+ */
+
+/**
+ * The only thing this engine needs from its host: a way to write bytes to the
+ * wire, in order, one at a time, resolving once the write has been flushed.
+ * Received bytes are pushed IN via {@link RawReplEngine.handleData} — the
+ * engine does not subscribe to anything itself, so callers stay in full
+ * control of when/whether raw traffic reaches other listeners (e.g. suppress
+ * a console broadcast while an internal exec is in flight).
+ */
+export interface RawReplTransport {
+  write(data: string | Uint8Array): Promise<void>
+}
+
+/** Result of running code in the raw REPL. */
+export interface ExecResult {
+  /** Decoded stdout captured between the raw-REPL output markers. */
+  stdout: string
+  /** Decoded stderr / traceback captured after the first `\x04` marker. */
+  stderr: string
+}
+
+/** A single entry returned by {@link RawReplEngine.listDir}. */
+export interface DirEntry {
+  name: string
+  /** True when the entry is a directory. */
+  isDir: boolean
+  /** File size in bytes (0 for directories). */
+  size: number
+}
+
+/** Result of {@link RawReplEngine.stat}, mirroring `os.stat` essentials. */
+export interface StatResult {
+  isDir: boolean
+  size: number
+  /** st_mtime (seconds since epoch) as reported by the device, if available. */
+  mtime?: number
+}
+
+/** Control bytes used by the MicroPython REPL. */
+export const CTRL_A = '\x01' // enter raw REPL
+export const CTRL_B = '\x02' // exit raw REPL
+export const CTRL_C = '\x03' // interrupt / KeyboardInterrupt
+export const CTRL_D = '\x04' // soft reset (friendly) / execute (raw)
+
+// ---------------------------------------------------------------------------
+// Byte-buffer helpers (Uint8Array equivalents of the Buffer calls the old
+// implementation relied on — see MicroPythonDevice.ts pre-#281 history).
+// ---------------------------------------------------------------------------
+
+const textEncoder = new TextEncoder()
+const textDecoder = new TextDecoder('utf-8')
+
+/** Encode a plain ASCII/latin1 string (protocol markers, hex digits) to bytes. */
+function asciiToBytes(str: string): Uint8Array {
+  const out = new Uint8Array(str.length)
+  for (let i = 0; i < str.length; i++) out[i] = str.charCodeAt(i) & 0xff
+  return out
+}
+
+/** Decode a string, assuming UTF-8 (used for REPL stdout/stderr). */
+function bytesToUtf8(bytes: Uint8Array): string {
+  return textDecoder.decode(bytes)
+}
+
+function concatBytes(a: Uint8Array, b: Uint8Array): Uint8Array {
+  const out = new Uint8Array(a.length + b.length)
+  out.set(a, 0)
+  out.set(b, a.length)
+  return out
+}
+
+/** Find `needle` within `haystack`, or -1. Naive but fine for small buffers. */
+function indexOfSubarray(haystack: Uint8Array, needle: Uint8Array): number {
+  if (needle.length === 0) return 0
+  outer: for (let i = 0; i <= haystack.length - needle.length; i++) {
+    for (let j = 0; j < needle.length; j++) {
+      if (haystack[i + j] !== needle[j]) continue outer
+    }
+    return i
+  }
+  return -1
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  let out = ''
+  for (const b of bytes) out += b.toString(16).padStart(2, '0')
+  return out
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2)
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(hex.substr(i * 2, 2), 16)
+  return out
+}
+
+/**
+ * Render a JS string as a Python string literal, escaping characters that
+ * would break out of the quotes. Used to inject paths/data into generated
+ * Python.
+ */
+function pyStr(value: string): string {
+  const escaped = value
+    .replace(/\\/g, '\\\\')
+    .replace(/'/g, "\\'")
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+  return `'${escaped}'`
+}
+
+/**
+ * Transport-agnostic implementation of the MicroPython raw-REPL handshake
+ * (`exec`/`eval`) plus the filesystem helpers built on top of it. Owns receive
+ * buffering and the "wait for marker" logic; knows nothing about serial ports,
+ * Web Serial, or any other specific transport — just an object it can call
+ * `.write()` on.
+ *
+ * Usage: construct with a {@link RawReplTransport}, feed every received chunk
+ * to {@link handleData}, then call {@link exec}/{@link eval}/the filesystem
+ * helpers as needed. Call {@link reset} when the underlying connection drops
+ * so stale buffered state doesn't leak into the next connection.
+ */
+export class RawReplEngine {
+  private rxBuffer: Uint8Array = new Uint8Array(0)
+
+  private pending: {
+    marker: Uint8Array
+    resolve: (data: Uint8Array) => void
+    reject: (err: Error) => void
+    timer: ReturnType<typeof setTimeout>
+  } | null = null
+
+  /** Serializes raw-REPL operations so two callers never interleave on the wire. */
+  private opQueue: Promise<unknown> = Promise.resolve()
+
+  /** True once we have entered raw REPL and not yet exited it. */
+  private inRawRepl = false
+
+  constructor(private readonly transport: RawReplTransport) {}
+
+  /** True while an internal `exec` is in flight (enter raw-REPL through exit). */
+  get execActive(): boolean {
+    return this._execActive
+  }
+  private _execActive = false
+
+  /**
+   * Feed newly-received bytes into the engine. Callers own subscribing to the
+   * underlying transport's data event and should call this for every chunk,
+   * before deciding whether to also forward the chunk elsewhere (e.g. a
+   * console view) — see {@link execActive} to suppress that while a probe is
+   * in flight.
+   */
+  handleData(chunk: Uint8Array): void {
+    this.rxBuffer = concatBytes(this.rxBuffer, chunk)
+    this.tryResolvePending()
+  }
+
+  /** Clear all buffered/pending state. Call this when the connection drops. */
+  reset(): void {
+    this.rxBuffer = new Uint8Array(0)
+    this.inRawRepl = false
+    this.failPending(new Error('Disconnected'))
+  }
+
+  private tryResolvePending(): void {
+    if (!this.pending) return
+    const idx = indexOfSubarray(this.rxBuffer, this.pending.marker)
+    if (idx === -1) return
+    const end = idx + this.pending.marker.length
+    const data = this.rxBuffer.subarray(0, end)
+    this.rxBuffer = this.rxBuffer.subarray(end)
+    const { resolve, timer } = this.pending
+    clearTimeout(timer)
+    this.pending = null
+    resolve(data)
+  }
+
+  private failPending(err: Error): void {
+    if (!this.pending) return
+    clearTimeout(this.pending.timer)
+    const { reject } = this.pending
+    this.pending = null
+    reject(err)
+  }
+
+  private write(data: string | Uint8Array): Promise<void> {
+    return this.transport.write(data)
+  }
+
+  /**
+   * Wait until `marker` (an ASCII/latin1 string) appears in the receive
+   * buffer, returning everything up to and including it. Rejects after
+   * `timeoutMs`.
+   */
+  private readUntil(marker: string, timeoutMs = 5000): Promise<Uint8Array> {
+    if (this.pending) {
+      return Promise.reject(new Error('A read is already in progress'))
+    }
+    return new Promise<Uint8Array>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending = null
+        reject(new Error(`Timed out waiting for ${JSON.stringify(marker)}`))
+      }, timeoutMs)
+      this.pending = { marker: asciiToBytes(marker), resolve, reject, timer }
+      // The marker may already be in the buffer from a previous read.
+      this.tryResolvePending()
+    })
+  }
+
+  // ---------------------------------------------------------------------------
+  // Raw REPL control
+  // ---------------------------------------------------------------------------
+
+  /** Enter raw REPL mode (Ctrl-A), interrupting any running program first. */
+  async enterRawRepl(): Promise<void> {
+    // Clear any stale buffered output.
+    this.rxBuffer = new Uint8Array(0)
+    // Interrupt twice to break out of running code or input().
+    await this.write(CTRL_C)
+    await this.write(CTRL_C)
+    await this.write(CTRL_A)
+    await this.readUntil('raw REPL; CTRL-B to exit\r\n>')
+    this.inRawRepl = true
+  }
+
+  /** Leave raw REPL mode (Ctrl-B), returning to the friendly REPL. */
+  async exitRawRepl(): Promise<void> {
+    await this.write(CTRL_B)
+    this.inRawRepl = false
+  }
+
+  /**
+   * Execute `code` in the raw REPL and capture its output.
+   *
+   * Enters raw REPL if not already in it, runs the snippet, and returns the
+   * captured stdout/stderr. Operations are serialized so concurrent callers
+   * do not corrupt the protocol state.
+   */
+  exec(code: string, timeoutMs = 10000): Promise<ExecResult> {
+    const op = this.opQueue.then(() => this.execLocked(code, timeoutMs))
+    // Keep the queue alive even if this op rejects.
+    this.opQueue = op.catch(() => undefined)
+    return op
+  }
+
+  private async execLocked(code: string, timeoutMs: number): Promise<ExecResult> {
+    // Suppress the caller's console broadcast for the WHOLE exec (raw-REPL
+    // enter through exit) so probe/banner/interrupt bytes never reach a
+    // terminal — callers check {@link execActive} before forwarding chunks.
+    this._execActive = true
+    try {
+      const enteredHere = !this.inRawRepl
+      if (enteredHere) {
+        await this.enterRawRepl()
+      }
+      try {
+        // Send the code and execute with Ctrl-D.
+        await this.write(code)
+        await this.write(CTRL_D)
+
+        // The device acknowledges a well-formed paste with "OK".
+        const ack = await this.readUntil('OK', timeoutMs)
+        if (!bytesToUtf8(ack).includes('OK')) {
+          throw new Error('Device did not acknowledge code (no "OK")')
+        }
+
+        // stdout is everything up to the first \x04.
+        const stdoutRaw = await this.readUntil(CTRL_D, timeoutMs)
+        const stdout = bytesToUtf8(stdoutRaw.subarray(0, stdoutRaw.length - 1))
+
+        // stderr/traceback is everything up to the second \x04.
+        const stderrRaw = await this.readUntil(CTRL_D, timeoutMs)
+        const stderr = bytesToUtf8(stderrRaw.subarray(0, stderrRaw.length - 1))
+
+        // Consume the trailing prompt so the buffer is clean for the next op.
+        await this.readUntil('>', timeoutMs)
+
+        return { stdout, stderr }
+      } finally {
+        if (enteredHere) {
+          // Best-effort return to friendly REPL.
+          await this.exitRawRepl().catch(() => undefined)
+        }
+      }
+    } finally {
+      this._execActive = false
+    }
+  }
+
+  /**
+   * Run `code` and return its stdout, throwing if the device produced a
+   * traceback on stderr. Convenience wrapper around {@link exec} for small
+   * snippets whose output we care about.
+   */
+  async eval(code: string, timeoutMs = 10000): Promise<string> {
+    const { stdout, stderr } = await this.exec(code, timeoutMs)
+    if (stderr.trim().length > 0) {
+      throw new Error(stderr.trim())
+    }
+    return stdout
+  }
+
+  // ---------------------------------------------------------------------------
+  // Filesystem helpers (built on top of exec/eval)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * List a directory. Returns entries with name, type and size. Uses
+   * `os.ilistdir` when available (gives type + size in one call) and emits a
+   * compact, machine-parseable line per entry.
+   */
+  async listDir(path = '/'): Promise<DirEntry[]> {
+    const code = [
+      'import os, json',
+      `def _ls(p):`,
+      '    out=[]',
+      '    try:',
+      '        it=os.ilistdir(p)',
+      '    except AttributeError:',
+      '        it=[(n,0,0) for n in os.listdir(p)]',
+      '    for e in it:',
+      '        name=e[0]; typ=e[1] if len(e)>1 else 0',
+      '        full=(p.rstrip("/")+"/"+name) if p else name',
+      '        isdir=(typ & 0x4000)!=0',
+      '        try: size=0 if isdir else os.stat(full)[6]',
+      '        except OSError: size=0',
+      '        out.append([name,isdir,size])',
+      '    return out',
+      `print(json.dumps(_ls(${pyStr(path)})))`
+    ].join('\n')
+    const raw = (await this.eval(code)).trim()
+    const parsed = JSON.parse(raw) as [string, boolean, number][]
+    return parsed.map(([name, isDir, size]) => ({ name, isDir, size }))
+  }
+
+  /** Read a file from the device and return its contents as a string (UTF-8). */
+  async readFile(path: string): Promise<string> {
+    const bytes = await this.readFileBytes(path)
+    return bytesToUtf8(bytes)
+  }
+
+  /** Read a file from the device and return its raw bytes. */
+  async readFileBytes(path: string): Promise<Uint8Array> {
+    // `ubinascii` is exposed as `binascii` on some ports; import defensively.
+    const code = [
+      'import sys',
+      'try:\n import ubinascii\nexcept ImportError:\n import binascii as ubinascii',
+      `with open(${pyStr(path)},'rb') as f:`,
+      '    while True:',
+      '        b=f.read(256)',
+      '        if not b: break',
+      '        sys.stdout.write(ubinascii.hexlify(b))'
+    ].join('\n')
+    const hex = (await this.eval(code)).trim()
+    return hexToBytes(hex)
+  }
+
+  /**
+   * Write `contents` to `path`, creating/overwriting the file. The payload is
+   * sent in hex-encoded chunks so that arbitrary binary content survives the
+   * text-oriented REPL transport.
+   */
+  async writeFile(
+    path: string,
+    contents: string | Uint8Array,
+    chunkSize = 256
+  ): Promise<void> {
+    const data = typeof contents === 'string' ? textEncoder.encode(contents) : contents
+    // Open the file once, then stream hex chunks via repeated exec calls so we
+    // never put a multi-megabyte literal on a single line.
+    const open = [
+      'import sys',
+      'try:\n import ubinascii\nexcept ImportError:\n import binascii as ubinascii',
+      `_f=open(${pyStr(path)},'wb')`
+    ].join('\n')
+    await this.eval(open)
+    try {
+      for (let i = 0; i < data.length; i += chunkSize) {
+        const slice = data.subarray(i, i + chunkSize)
+        const hex = bytesToHex(slice)
+        await this.eval(`_f.write(ubinascii.unhexlify(${pyStr(hex)}))`)
+      }
+    } finally {
+      await this.eval('_f.close()').catch(() => undefined)
+    }
+  }
+
+  /** Remove a file OR a directory tree. `os.remove()` can't delete directories
+   *  (and `os.rmdir()` only empty ones), so walk depth-first with an explicit
+   *  stack: children first, then the emptied folder (#219). */
+  async remove(path: string): Promise<void> {
+    await this.eval(
+      [
+        'import os',
+        `_s = [${pyStr(path)}]`,
+        'while _s:',
+        '    _p = _s[-1]',
+        '    if (os.stat(_p)[0] & 0x4000) != 0:',
+        '        _c = os.listdir(_p)',
+        '        if _c:',
+        "            _s.extend([_p + '/' + _x for _x in _c])",
+        '        else:',
+        '            os.rmdir(_p)',
+        '            _s.pop()',
+        '    else:',
+        '        os.remove(_p)',
+        '        _s.pop()'
+      ].join('\n')
+    )
+  }
+
+  /** Create a directory. */
+  async mkdir(path: string): Promise<void> {
+    await this.eval(`import os\nos.mkdir(${pyStr(path)})`)
+  }
+
+  /** Rename / move a path. */
+  async rename(from: string, to: string): Promise<void> {
+    await this.eval(`import os\nos.rename(${pyStr(from)}, ${pyStr(to)})`)
+  }
+
+  /** Stat a path, returning type, size and mtime when available. */
+  async stat(path: string): Promise<StatResult> {
+    const code = [
+      'import os, json',
+      `st=os.stat(${pyStr(path)})`,
+      'isdir=(st[0] & 0x4000)!=0',
+      'mtime=st[8] if len(st)>8 else None',
+      'print(json.dumps([isdir, st[6], mtime]))'
+    ].join('\n')
+    const raw = (await this.eval(code)).trim()
+    const [isDir, size, mtime] = JSON.parse(raw) as [boolean, number, number | null]
+    return { isDir, size, mtime: mtime ?? undefined }
+  }
+}

--- a/test/rawReplEngine.test.ts
+++ b/test/rawReplEngine.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from 'vitest'
+import { CTRL_A, CTRL_B, CTRL_C, CTRL_D, RawReplEngine, type RawReplTransport } from '../src/shared/raw-repl'
+
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
+
+/**
+ * A minimal fake MicroPython board: replies to the raw-REPL handshake and to
+ * `exec`'d code via a caller-supplied `script`, without any real serial port
+ * or hardware. This is the whole point of issue #281 (epic #267 Phase W0):
+ * the raw-REPL protocol, once extracted from `MicroPythonDevice`, can be unit
+ * tested against a fake transport instead of a real board.
+ */
+class FakeBoard implements RawReplTransport {
+  private engine: RawReplEngine | null = null
+  private acc = ''
+  writes: string[] = []
+
+  /** Wire this fake up to the engine it's driving (for pushing responses back). */
+  attach(engine: RawReplEngine): void {
+    this.engine = engine
+  }
+
+  constructor(private readonly script: (code: string) => { stdout: string; stderr: string }) {}
+
+  async write(data: string | Uint8Array): Promise<void> {
+    const str = typeof data === 'string' ? data : decoder.decode(data)
+    this.writes.push(str)
+    this.acc += str
+
+    if (this.acc.endsWith(CTRL_C + CTRL_C + CTRL_A)) {
+      this.acc = ''
+      this.reply('raw REPL; CTRL-B to exit\r\n>')
+      return
+    }
+    if (str === CTRL_B) {
+      this.acc = ''
+      return
+    }
+    if (str === CTRL_D) {
+      const code = this.acc.slice(0, -1)
+      this.acc = ''
+      const { stdout, stderr } = this.script(code)
+      this.reply(`OK${stdout}${CTRL_D}${stderr}${CTRL_D}>`)
+      return
+    }
+  }
+
+  private reply(text: string): void {
+    // Simulate the async nature of a real serial link (data arrives later).
+    queueMicrotask(() => this.engine?.handleData(encoder.encode(text)))
+  }
+}
+
+/** Build an engine + fake board pair, wired together, for a given script. */
+function makeHarness(
+  script: (code: string) => { stdout: string; stderr: string } = () => ({ stdout: '', stderr: '' })
+): { engine: RawReplEngine; board: FakeBoard } {
+  const board = new FakeBoard(script)
+  const engine = new RawReplEngine(board)
+  board.attach(engine)
+  return { engine, board }
+}
+
+describe('RawReplEngine (#281 — transport-agnostic raw-REPL protocol)', () => {
+  it('performs the raw-REPL handshake and executes code, capturing stdout', async () => {
+    const { engine } = makeHarness((code) => ({ stdout: `ran:${code}\n`, stderr: '' }))
+    const result = await engine.exec('print(1+1)')
+    expect(result.stdout).toBe('ran:print(1+1)\n')
+    expect(result.stderr).toBe('')
+  })
+
+  it('captures stderr/tracebacks without throwing from exec()', async () => {
+    const { engine } = makeHarness(() => ({ stdout: '', stderr: 'Traceback...\nNameError: x\n' }))
+    const result = await engine.exec('x')
+    expect(result.stderr).toContain('NameError')
+  })
+
+  it('eval() throws when the device produced a non-empty stderr', async () => {
+    const { engine } = makeHarness(() => ({ stdout: '', stderr: 'ValueError: boom' }))
+    await expect(engine.eval('raise ValueError("boom")')).rejects.toThrow('ValueError: boom')
+  })
+
+  it('eval() returns stdout when there is no error', async () => {
+    const { engine } = makeHarness(() => ({ stdout: '42\n', stderr: '' }))
+    await expect(engine.eval('print(42)')).resolves.toBe('42\n')
+  })
+
+  it('serializes concurrent exec calls so they do not interleave on the wire', async () => {
+    const seen: string[] = []
+    const { engine } = makeHarness((code) => {
+      seen.push(code)
+      return { stdout: `${code}-out\n`, stderr: '' }
+    })
+    const [a, b] = await Promise.all([engine.exec('A'), engine.exec('B')])
+    expect(seen).toEqual(['A', 'B']) // never interleaved
+    expect(a.stdout).toBe('A-out\n')
+    expect(b.stdout).toBe('B-out\n')
+  })
+
+  it('reuses the same connection to enter+exit raw REPL around each independent exec()', async () => {
+    const { engine, board } = makeHarness((code) => ({ stdout: `${code}\n`, stderr: '' }))
+    await engine.exec('one')
+    await engine.exec('two')
+    // Each exec is self-contained: enter raw REPL, run, exit raw REPL — so two
+    // sequential execs perform the handshake twice (no protocol regression
+    // from the extraction: this matches pre-#281 MicroPythonDevice behaviour).
+    const enters = board.writes.filter((w) => w === CTRL_A).length
+    expect(enters).toBe(2)
+  })
+
+  it('rejects with a timeout when the device never acknowledges exec', async () => {
+    const board = new FakeBoard(() => ({ stdout: '', stderr: '' }))
+    // Suppress replies to the execution ack ("OK") so the exec-phase readUntil
+    // times out (the handshake's readUntil uses a fixed 5s, so we exercise the
+    // caller-supplied `timeoutMs` via the post-handshake reads instead).
+    const originalReply = (board as unknown as { reply: (t: string) => void }).reply.bind(board)
+    ;(board as unknown as { reply: (t: string) => void }).reply = (text: string) => {
+      if (text.startsWith('raw REPL')) originalReply(text)
+      // else: swallow the "OK..." execution response entirely.
+    }
+    const engine = new RawReplEngine(board)
+    board.attach(engine)
+    await expect(engine.exec('print(1)', 50)).rejects.toThrow(/Timed out/)
+  })
+
+  it('reset() clears pending state so a stale waiter does not leak into the next connection', async () => {
+    const board: RawReplTransport = { write: async () => undefined } // never replies
+    const engine = new RawReplEngine(board)
+    const pendingExec = engine.exec('print(1)', 5000)
+    // Let the handshake's writes/awaits run so `pending` is actually set
+    // before we reset — otherwise reset() would race an as-yet-nonexistent
+    // waiter.
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    engine.reset()
+    await expect(pendingExec).rejects.toThrow('Disconnected')
+  })
+
+  it('execActive is true only while an exec is in flight', async () => {
+    const states: boolean[] = []
+    const { engine } = makeHarness((code) => {
+      states.push(engine.execActive)
+      return { stdout: code, stderr: '' }
+    })
+    expect(engine.execActive).toBe(false)
+    await engine.exec('x')
+    expect(engine.execActive).toBe(false)
+    expect(states).toEqual([true])
+  })
+
+  it('round-trips binary content through writeFile/readFileBytes via hex encoding', async () => {
+    // Simulate a tiny virtual file so we can exercise the hex chunking path.
+    let stored = new Uint8Array(0)
+    const { engine } = makeHarness((code) => {
+      if (code.includes("open('/x.bin','wb')")) return { stdout: '', stderr: '' }
+      const writeMatch = code.match(/_f\.write\(ubinascii\.unhexlify\('([0-9a-f]*)'\)\)/)
+      if (writeMatch) {
+        const chunk = Uint8Array.from(Buffer.from(writeMatch[1], 'hex'))
+        const merged = new Uint8Array(stored.length + chunk.length)
+        merged.set(stored, 0)
+        merged.set(chunk, stored.length)
+        stored = merged
+        return { stdout: '', stderr: '' }
+      }
+      if (code.includes('_f.close()')) return { stdout: '', stderr: '' }
+      if (code.includes("open('/x.bin','rb')")) {
+        return { stdout: Buffer.from(stored).toString('hex'), stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+    const payload = new Uint8Array([0, 1, 2, 250, 251, 252, 253])
+    await engine.writeFile('/x.bin', payload)
+    const readBack = await engine.readFileBytes('/x.bin')
+    expect(Array.from(readBack)).toEqual(Array.from(payload))
+  })
+})


### PR DESCRIPTION
Closes #281. Part of epic #267 (Snakie for Web).

## What
Extracts the MicroPython raw-REPL protocol out of `src/main/device/MicroPythonDevice.ts` into a new transport-agnostic `RawReplEngine` in `src/shared/raw-repl.ts`:

- Raw-REPL handshake (`enterRawRepl`/`exitRawRepl`), `exec`/`eval`, and the `readUntil` receive-buffering logic.
- Filesystem helpers built on top of `exec` (`listDir`, `readFile`/`readFileBytes`, `writeFile`, `remove`, `mkdir`, `rename`, `stat`), including the hex-encoding for binary file transfer.
- Uses `Uint8Array` instead of Node's `Buffer` throughout, so the engine has **zero Node/Electron dependencies** and can run unmodified in a browser tab or Web Worker — a prerequisite for the Web Serial transport in #283.

`MicroPythonDevice` is now a thin adapter: it owns the `serialport` lifecycle (connect/disconnect/status) and feeds bytes to/from the engine via a minimal `write()`-only transport interface. All public behaviour is unchanged.

## Why
This is Phase W0 ("the seam") of the Snakie-for-Web epic (#267) — nothing else in the epic (WASM sim worker, Web Serial transport, OPFS) can start until the protocol is decoupled from `serialport`.

## Testing
- Added `test/rawReplEngine.test.ts`: 10 new unit tests driving the engine against a fake in-memory "board" (handshake, exec/eval, stderr handling, concurrent-op serialization, timeout, `reset()`, binary round-trip via hex encoding) — the protocol logic is now testable with **no real serial port**, which was the point of the refactor.
- `npm run typecheck` — clean.
- `npm run lint` — clean (one pre-existing unrelated warning).
- `npm test` — all 83 test files / 1379 tests pass (10 new).
- `npm run build` — electron-vite build succeeds.

CHANGELOG updated under `[Unreleased]`.