### PR TITLE
Web W2: Web Serial transport, port picker + classroom Chrome policy docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,24 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   engine will later be driven by a Web Serial transport in the browser build.
 
 ### Added
+- **Web Serial transport, port picker + classroom Chrome policy docs (#283,
+  epic #267 Phase W2).** The groundwork for real Pico/ESP32 hardware in the
+  browser build: `WebSerialTransport` (`src/web/webSerialTransport.ts`) drives
+  the shared `RawReplEngine` (#281) over `navigator.serial` — open/baud, a
+  read pump into the engine, DTR/RTS reset via `setSignals`, and unplug/read-
+  error handling — and `WebSerialDevice` (`src/web/webSerialDevice.ts`) wraps
+  it with the same connect/exec/eval/file-tree/events surface as
+  `MicroPythonDevice`, so the file tree, module installs and instrument
+  telemetry streaming all come for free (they're built on `exec`). A port
+  picker (`src/web/portPicker.ts`) filters `requestPort()` to known
+  MicroPython board VID/PIDs and tries the zero-prompt `getPorts()` fast path
+  first, for pre-provisioned Chromebooks. The VID/PID table itself moved to
+  `src/shared/usb-bridges.ts` (shared with firmware-flashing detection,
+  extended with the Pico's native-USB id). New
+  `docs/web-serial-classroom-policy.md` gives school IT admins the exact
+  `SerialAllowUsbDevicesForUrls` JSON recipe to pre-grant students silent USB
+  access. Not yet wired into the renderer UI — that lands once the
+  `window.api` seam split (#281) and the WASM sim worker (#282) are in place.
 - **Data View — open a logged CSV as a table (#274, epic #272).** Opening a
   `.csv` / `.tsv` file now shows a spreadsheet-like viewer instead of raw text:
   it auto-detects the delimiter (comma / tab / semicolon / whitespace) and the

--- a/docs/web-serial-classroom-policy.md
+++ b/docs/web-serial-classroom-policy.md
@@ -1,0 +1,142 @@
+# Classroom Chrome policy: zero-prompt Pico/ESP32 access (#283)
+
+Part of Snakie for Web (epic #267), Phase W2 ("real hardware over Web
+Serial"). This is the recipe referenced by the epic's "killer classroom
+feature": pre-granting a whole school fleet of managed Chromebooks silent
+access to Pico/ESP32 boards over USB, so students **never see a permission
+prompt** the first time they plug in a board.
+
+## Why this is needed
+
+Web Serial (`navigator.serial`) is gated by Chromium's permission model: the
+first time a page calls `requestPort()`, the browser shows a picker dialog
+and the user must explicitly choose a device. That's the right default for
+the open web, but it's friction a classroom doesn't want repeated for every
+student, every session, on every machine.
+
+Chrome Enterprise has a policy for exactly this:
+[`SerialAllowUsbDevicesForUrls`](https://chromeenterprise.google/policies/?policy=SerialAllowUsbDevicesForUrls)
+— an admin-managed allowlist of `{ USB device(s), origin(s) }` pairs. Any
+device matching an entry is **silently granted** to the matching origin(s):
+`navigator.serial.getPorts()` returns it immediately, with no
+`requestPort()` prompt ever needed. This policy is only available on
+**managed** ChromeOS devices / Chrome browsers enrolled in an organization
+(school-fleet Chromebooks are the target — see epic #267's "why web, not
+Android" rationale).
+
+Snakie's port picker (`src/web/portPicker.ts`) already does the right thing
+without any classroom-specific code: `getGrantedPorts()` (backed by
+`navigator.serial.getPorts()`) is tried first on connect, and only falls back
+to the interactive `requestSnakiePort()` picker if it comes back empty. A
+device pre-granted by this policy is picked up by that fast path for free.
+
+## The VID/PID allowlist
+
+The same identifiers Snakie's port picker filters on
+(`src/shared/usb-bridges.ts`) — reused here so the admin's policy and the
+app's own filters never drift apart. `SerialAllowUsbDevicesForUrls` uses
+**decimal** vendor/product ids (not the `0x`-hex strings used elsewhere in
+Snakie), so this table gives both:
+
+| Board / chip                              | vendor_id (hex) | vendor_id (dec) | product_id (hex) | product_id (dec) |
+| ------------------------------------------ | ---------------- | ---------------- | ------------------ | ------------------ |
+| Raspberry Pi Pico / Pico 2 / Pico W (native USB, MicroPython running) | `0x2e8a` | 11914 | `0x0005` | 5 |
+| Any other RP2040/RP2350 board (native USB) | `0x2e8a` | 11914 | *(any — omit product_id)* | — |
+| Silicon Labs CP210x bridge (common ESP32 dev boards) | `0x10c4` | 4292 | `0xea60` | 60000 |
+| WCH CH340 bridge (cheaper ESP8266/ESP32 boards) | `0x1a86` | 6790 | `0x7523` | 29987 |
+| WCH CH341 bridge | `0x1a86` | 6790 | `0x5523` | 21795 |
+| FTDI FT232R bridge (older ESP dev boards) | `0x0403` | 1027 | `0x6001` | 24577 |
+| Espressif native USB (ESP32-S2/S3/C3 built-in USB) | `0x303a` | 12346 | *(any — omit product_id)* | — |
+
+Omitting `product_id` matches **any** device from that vendor — useful for
+`0x2e8a` (Raspberry Pi Foundation) and `0x303a` (Espressif), where the exact
+product id varies by board revision. Adding a broad vendor-only entry is
+usually the right classroom default (it also silently covers boards released
+after this doc was written); narrow it to specific `vendor_id`/`product_id`
+pairs if a school wants to be more restrictive.
+
+## The policy JSON
+
+`SerialAllowUsbDevicesForUrls` is a list of `{ devices, urls }` entries. Put
+this in the policy's value (see "Applying it" below for *where*):
+
+```json
+[
+  {
+    "devices": [
+      { "vendor_id": 11914, "product_id": 5 },
+      { "vendor_id": 11914 },
+      { "vendor_id": 4292, "product_id": 60000 },
+      { "vendor_id": 6790, "product_id": 29987 },
+      { "vendor_id": 6790, "product_id": 21795 },
+      { "vendor_id": 1027, "product_id": 24577 },
+      { "vendor_id": 12346 }
+    ],
+    "urls": ["https://app.snakie.org"]
+  }
+]
+```
+
+Notes on the schema (validated by Chromium — see
+`chrome/browser/policy/serial_allow_usb_devices_for_urls_policy_handler_unittest.cc`
+in the Chromium source for the exact rules):
+- Every entry needs both `devices` (a non-empty list) and `urls` (a non-empty
+  list) — a `devices`-only or `urls`-only entry is rejected.
+- Each device needs at least `vendor_id`; `product_id` is optional and, if
+  present, requires `vendor_id` to also be present.
+- `urls` are matched as **origins** — use the scheme + host Snakie for Web is
+  actually served from (see issue #286 for the `app.snakie.org` hosting
+  decision). Add `http://localhost:PORT` too if IT wants to pre-grant a local
+  dev/staging build.
+- IDs are **decimal**, not the hex strings used in Snakie's own source and
+  UI — double-check the table above if extending this list.
+
+## Applying it (Google Admin console)
+
+For a G Suite/Google Workspace-managed Chromebook fleet:
+
+1. Go to **admin.google.com** → **Devices** → **Chrome** → **Settings**.
+2. Pick the **organizational unit** (OU) to scope this to — e.g. a specific
+   school, grade, or "STEM Lab Chromebooks" OU. Policies set at a narrower OU
+   override a broader one, so you can pilot on one classroom's OU first.
+3. Search settings for **"Serial devices"** / **Allow USB devices to connect
+   to specified sites** (the console's human-readable name for
+   `SerialAllowUsbDevicesForUrls`, under **User & browser settings** — it's
+   also settable as a **Device** setting for kiosk/managed-guest sessions).
+4. Paste the JSON from above into the policy's value field.
+5. **Save**. Propagation to enrolled devices typically happens within
+   minutes to a few hours (ChromeOS policy refresh interval), or immediately
+   after the next sign-in / `chrome://policy` → **Reload policies**.
+
+For Windows/macOS/Linux Chrome managed via a different MDM (e.g. Microsoft
+Intune, Jamf), the same policy key
+(`SerialAllowUsbDevicesForUrls`) is set via that MDM's Chrome ADMX/plist
+template — the JSON payload is identical, only the delivery mechanism
+differs.
+
+## Verifying it worked
+
+- On the managed device, visit **`chrome://policy`** and confirm
+  `SerialAllowUsbDevicesForUrls` shows **Status: OK** with the expected JSON
+  under "Policy value". If it's missing, the device may not have refreshed
+  policy yet (use the **Reload policies** button on that page) or isn't in
+  the OU the policy was applied to.
+- Open Snakie for Web (`https://app.snakie.org`) with a Pico or ESP32 already
+  plugged in — the app should connect **without ever showing the browser's
+  "Select a device to connect" picker dialog**. If the picker still appears,
+  the policy either hasn't propagated yet or the board's actual VID/PID
+  isn't covered by the allowlist (unplug it, check `chrome://device-log` or
+  the OS's USB device list for its real vendor/product id, and add it).
+- This policy only affects **managed** browser profiles/devices. Testing on
+  an unmanaged personal Chrome install will always show the picker — that's
+  expected, not a bug.
+
+## Related
+
+- Epic #267 (Snakie for Web) — the "why web, not Android" rationale and the
+  full phase breakdown this classroom feature sits in.
+- Issue #283 (this issue) — the Web Serial transport + port picker
+  (`src/web/webSerialTransport.ts`, `src/web/portPicker.ts`) that this policy
+  makes prompt-free.
+- Issue #286 — the `app.snakie.org` hosting decision (the exact origin to put
+  in `urls` may change before launch; update this doc if it does).

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@types/node": "^20.17.9",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
+        "@types/w3c-web-serial": "^1.0.8",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@typescript-eslint/parser": "^7.18.0",
         "@vitejs/plugin-react": "^4.3.4",
@@ -2228,6 +2229,13 @@
       "integrity": "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/@types/w3c-web-serial": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/w3c-web-serial/-/w3c-web-serial-1.0.8.tgz",
+      "integrity": "sha512-QQOT+bxQJhRGXoZDZGLs3ksLud1dMNnMiSQtBA0w8KXvLpXX4oM4TZb6J0GgJ8UbCaHo5s9/4VQT8uXy9JER2A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@types/node": "^20.17.9",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
+    "@types/w3c-web-serial": "^1.0.8",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
     "@vitejs/plugin-react": "^4.3.4",

--- a/src/main/firmware/detect.ts
+++ b/src/main/firmware/detect.ts
@@ -21,38 +21,23 @@ import { promises as fs } from 'fs'
 import { homedir, platform } from 'os'
 import { join } from 'path'
 import { MicroPythonDevice } from '../device/MicroPythonDevice'
+import { matchUsbBridge } from '../../shared/usb-bridges'
 import type { BoardCandidate, BoardType } from './types'
 
 /**
- * Known USB-serial bridge VID/PIDs found on common ESP dev boards. Values are
- * lowercase hex without the `0x` prefix, matching {@link PortInfo}. The mapped
- * board is the *most likely* family; the user can change it before flashing.
+ * Match a serial port's VID/PID against the shared USB bridge table (#283),
+ * restricted to the ESP families this flashing-detection path cares about —
+ * `rp2040` (BOOTSEL-mode Picos) is detected separately via the UF2 boot
+ * drive below, never via its native-USB serial VID/PID here, so a Pico
+ * running MicroPython isn't mis-surfaced as a flashing candidate.
  */
-const ESP_USB_BRIDGES: Array<{ vid: string; pid?: string; board: BoardType; chip: string }> = [
-  // Silicon Labs CP210x — extremely common on ESP32 dev boards.
-  { vid: '10c4', pid: 'ea60', board: 'esp32', chip: 'CP210x' },
-  // WCH CH340 / CH341 — common on cheaper ESP8266 (NodeMCU) and some ESP32.
-  { vid: '1a86', pid: '7523', board: 'esp8266', chip: 'CH340' },
-  { vid: '1a86', pid: '5523', board: 'esp8266', chip: 'CH341' },
-  // FTDI FT232 — older ESP dev boards.
-  { vid: '0403', pid: '6001', board: 'esp32', chip: 'FT232R' },
-  // Espressif native USB CDC (ESP32-S2/S3/C3 built-in USB JTAG/serial).
-  { vid: '303a', board: 'esp32', chip: 'Espressif native USB' }
-]
-
-/** Match a serial port's VID/PID against the known ESP bridge table. */
 function matchEspBridge(
   vendorId?: string,
   productId?: string
 ): { board: BoardType; chip: string } | undefined {
-  if (!vendorId) return undefined
-  const vid = vendorId.toLowerCase()
-  const pid = productId?.toLowerCase()
-  // Prefer an exact vid+pid match, then fall back to a vid-only entry.
-  return (
-    ESP_USB_BRIDGES.find((e) => e.vid === vid && e.pid && e.pid === pid) ??
-    ESP_USB_BRIDGES.find((e) => e.vid === vid && !e.pid)
-  )
+  const match = matchUsbBridge(vendorId, productId)
+  if (!match || (match.board !== 'esp32' && match.board !== 'esp8266')) return undefined
+  return match
 }
 
 /** Detect ESP candidates from the enumerated serial ports. */

--- a/src/shared/usb-bridges.ts
+++ b/src/shared/usb-bridges.ts
@@ -1,0 +1,84 @@
+/**
+ * Known USB vendor/product ids for MicroPython-capable boards (issue #283,
+ * epic #267 Phase W2).
+ *
+ * This table started life inline in `src/main/firmware/detect.ts` (issue #14)
+ * as a heuristic for firmware-flashing board guesses from a `serialport`
+ * enumeration. It's extracted here — plain data, zero Node/DOM dependencies —
+ * so it can be shared by two very different consumers:
+ *
+ *  - `firmware/detect.ts` (Electron main, via `serialport`): guesses a board
+ *    family from an enumerated port's VID/PID for the flashing UI.
+ *  - `src/web/portPicker.ts` (browser, via Web Serial): builds
+ *    `SerialPortFilter[]` for `navigator.serial.requestPort()` and produces a
+ *    friendly label for a picked port — reusing the exact same identifiers so
+ *    the classroom enterprise-policy VID/PID allowlist (docs/
+ *    web-serial-classroom-policy.md) matches what the port picker itself
+ *    filters on.
+ *
+ * Two families of ids are covered:
+ *  - **USB-serial bridge chips** (CP210x, CH340/341, FT232R) — common on ESP32
+ *    / ESP8266 dev boards, which have no native USB and rely on a bridge chip.
+ *    The same bridge chip ships on boards from many different chip families,
+ *    so these are heuristic best-guesses, not a certain identification.
+ *  - **Native USB CDC** — boards with an MCU that talks USB directly, no
+ *    bridge chip: Espressif's native USB (ESP32-S2/S3/C3) and the Raspberry Pi
+ *    Foundation's vendor id (RP2040/RP2350 boards like the Pico, which enumerate
+ *    directly once MicroPython is running).
+ */
+
+/** Board families this table can identify. A subset of firmware's `BoardType`
+ *  (no `microbit`: BBC micro:bit is detected via its DAPLink mass-storage
+ *  drive, not a serial VID/PID, in both the flashing and web-picker paths). */
+export type KnownBoardFamily = 'esp32' | 'esp8266' | 'rp2040'
+
+/** One USB vendor/product id identifying a board family (exactly or by vendor only). */
+export interface UsbBridgeEntry {
+  /** USB vendor id, lowercase hex without the `0x` prefix (e.g. `2e8a`). */
+  vid: string
+  /** USB product id, lowercase hex without the `0x` prefix. Omitted = match any pid for this vid. */
+  pid?: string
+  /** Best-guess board family. */
+  board: KnownBoardFamily
+  /** Human-readable chip/board description, for UI labels. */
+  chip: string
+}
+
+/**
+ * Known USB-serial bridge chips + native-USB ids found on common MicroPython
+ * dev boards. Values are lowercase hex without the `0x` prefix, matching
+ * `PortInfo` (Electron) and `SerialPortInfo` (Web Serial).
+ */
+export const USB_SERIAL_BRIDGES: UsbBridgeEntry[] = [
+  // Silicon Labs CP210x — extremely common on ESP32 dev boards.
+  { vid: '10c4', pid: 'ea60', board: 'esp32', chip: 'CP210x' },
+  // WCH CH340 / CH341 — common on cheaper ESP8266 (NodeMCU) and some ESP32.
+  { vid: '1a86', pid: '7523', board: 'esp8266', chip: 'CH340' },
+  { vid: '1a86', pid: '5523', board: 'esp8266', chip: 'CH341' },
+  // FTDI FT232R — older ESP dev boards.
+  { vid: '0403', pid: '6001', board: 'esp32', chip: 'FT232R' },
+  // Espressif native USB CDC (ESP32-S2/S3/C3 built-in USB JTAG/serial).
+  { vid: '303a', board: 'esp32', chip: 'Espressif native USB' },
+  // Raspberry Pi Foundation native USB CDC — RP2040/RP2350 boards (Pico,
+  // Pico 2, Pico W, and third-party RP2040 boards using the same vendor id)
+  // enumerate directly with MicroPython running, no bridge chip needed.
+  { vid: '2e8a', pid: '0005', board: 'rp2040', chip: 'Raspberry Pi Pico (MicroPython native USB)' },
+  { vid: '2e8a', board: 'rp2040', chip: 'RP2040/RP2350 native USB' }
+]
+
+/**
+ * Match a vendor/product id pair against the known bridge table. Prefers an
+ * exact vid+pid match, then falls back to a vid-only entry. Case-insensitive.
+ */
+export function matchUsbBridge(
+  vendorId?: string,
+  productId?: string
+): UsbBridgeEntry | undefined {
+  if (!vendorId) return undefined
+  const vid = vendorId.toLowerCase()
+  const pid = productId?.toLowerCase()
+  return (
+    USB_SERIAL_BRIDGES.find((e) => e.vid === vid && e.pid && e.pid === pid) ??
+    USB_SERIAL_BRIDGES.find((e) => e.vid === vid && !e.pid)
+  )
+}

--- a/src/web/portPicker.ts
+++ b/src/web/portPicker.ts
@@ -1,0 +1,97 @@
+/**
+ * Web Serial port picker (issue #283, epic #267 Phase W2).
+ *
+ * Two entry points, matching the epic's classroom UX goal:
+ *
+ *  - {@link requestSnakiePort} — the user-gesture-driven path
+ *    (`navigator.serial.requestPort()`), filtered to the known MicroPython
+ *    board VID/PIDs (`shared/usb-bridges.ts`) so the browser's picker dialog
+ *    only lists relevant devices. Must be called from a click handler (or
+ *    other user-activation event) — Web Serial's security model requires it.
+ *
+ *  - {@link getGrantedPorts} — the zero-prompt fast path
+ *    (`navigator.serial.getPorts()`). Returns ports the user (or, on a
+ *    managed Chromebook, the `SerialAllowUsbDevicesForUrls` enterprise
+ *    policy — see docs/web-serial-classroom-policy.md) has already granted
+ *    to this origin. A classroom app should try this FIRST on load/connect
+ *    and only fall back to {@link requestSnakiePort} if it comes back empty,
+ *    so pre-provisioned students never see a permission prompt.
+ *
+ * {@link describePort} turns a granted `SerialPort` into a friendly label the
+ * same way `PortInfo.friendlyName` does on the Electron side, reusing the
+ * exact same VID/PID table so the label a student sees matches the id an IT
+ * admin allowlisted.
+ */
+import { matchUsbBridge, USB_SERIAL_BRIDGES } from '../shared/usb-bridges'
+
+/** Zero-pad a number to a 4-digit lowercase hex string (matches `PortInfo`'s VID/PID format). */
+function toHex4(n: number): string {
+  return n.toString(16).padStart(4, '0')
+}
+
+/**
+ * Build the `SerialPortFilter[]` for `navigator.serial.requestPort()` from
+ * the shared USB bridge table, so the browser's device picker only shows
+ * boards Snakie actually knows how to talk to.
+ */
+export function getSerialFilters(): SerialPortFilter[] {
+  return USB_SERIAL_BRIDGES.map((entry) => {
+    const filter: SerialPortFilter = { usbVendorId: parseInt(entry.vid, 16) }
+    if (entry.pid) filter.usbProductId = parseInt(entry.pid, 16)
+    return filter
+  })
+}
+
+/**
+ * Prompt the user to pick a serial port, filtered to known MicroPython
+ * boards. Must be called synchronously from a user gesture (e.g. a button
+ * click) — throws `DOMException` ("NotAllowedError" or the user cancelling
+ * the picker with "NotFoundError") otherwise, which callers should catch and
+ * surface as "no device selected" rather than a hard error.
+ */
+export async function requestSnakiePort(): Promise<SerialPort> {
+  if (!('serial' in navigator)) {
+    throw new Error('Web Serial is not supported in this browser')
+  }
+  return navigator.serial.requestPort({ filters: getSerialFilters() })
+}
+
+/**
+ * List ports already granted to this origin — no user gesture, no prompt.
+ * The classroom fast-path: pre-provisioned Chromebooks (via
+ * `SerialAllowUsbDevicesForUrls`) and returning users land here directly.
+ */
+export async function getGrantedPorts(): Promise<SerialPort[]> {
+  if (!('serial' in navigator)) return []
+  return navigator.serial.getPorts()
+}
+
+/** A human-friendly description of a granted port, when we can identify it. */
+export interface PortDescription {
+  /** e.g. "Raspberry Pi Pico (MicroPython native USB)" or "CP210x" — the best guess. */
+  label: string
+  /** Lowercase hex VID, e.g. `2e8a`, when the port info exposes one. */
+  vendorId?: string
+  /** Lowercase hex PID, e.g. `0005`, when the port info exposes one. */
+  productId?: string
+  /** True when the VID/PID matched a known entry in the bridge table. */
+  recognized: boolean
+}
+
+/**
+ * Describe a `SerialPort` for display in a port list, reusing the shared
+ * VID/PID table so the label matches what firmware detection (Electron) and
+ * the classroom policy docs call the same device.
+ */
+export function describePort(port: SerialPort): PortDescription {
+  const info = port.getInfo()
+  const vendorId = info.usbVendorId !== undefined ? toHex4(info.usbVendorId) : undefined
+  const productId = info.usbProductId !== undefined ? toHex4(info.usbProductId) : undefined
+  const match = matchUsbBridge(vendorId, productId)
+  return {
+    label: match ? match.chip : 'Unknown serial device',
+    vendorId,
+    productId,
+    recognized: match !== undefined
+  }
+}

--- a/src/web/webSerialDevice.ts
+++ b/src/web/webSerialDevice.ts
@@ -1,0 +1,300 @@
+/**
+ * MicroPython device driver over Web Serial (issue #283, epic #267 Phase W2).
+ *
+ * `WebSerialDevice` mirrors the public surface of
+ * `src/main/device/MicroPythonDevice.ts` (the Electron/`serialport` adapter)
+ * as closely as possible: connect/disconnect, status + data events, exec/eval,
+ * and the filesystem helpers. Both classes are thin adapters around the same
+ * transport-agnostic `RawReplEngine` (src/shared/raw-repl.ts, issue #281 Phase
+ * W0) — this one drives it with a `WebSerialTransport` instead of
+ * `serialport`. Because `listDir`/`readFile`/`writeFile`/etc. are all built on
+ * top of `exec`/`eval` inside the shared engine, they work here with zero
+ * extra protocol code — the "file tree / module installs / instrument
+ * streaming come for free" claim from the epic (#267), proven at the class
+ * level.
+ *
+ * **Deviation from `SnakieDevice` (`src/main/device/types.ts`):** that
+ * interface is `Buffer`-typed (`readFileBytes(): Promise<Buffer>`,
+ * `writeFile(path, contents: string | Buffer)`) because it crosses the
+ * Electron IPC boundary as Node data. `Buffer` doesn't exist in a plain
+ * browser target, so this class uses `Uint8Array` throughout instead and is
+ * not literally declared `implements SnakieDevice`. Once the `window.api`
+ * seam split (issue #281's other half) lands a `web-api.ts`, that thin layer
+ * is the natural place to convert `Uint8Array` <-> `Buffer` at the boundary —
+ * exactly the same pattern `MicroPythonDevice` already uses for the IPC
+ * boundary today.
+ *
+ * Lives under `src/web/` (not `src/shared/`) because `WebSerialTransport`
+ * needs DOM + Web Serial types unavailable under `tsconfig.node.json`.
+ */
+import { buildControlLine } from '../shared/control'
+import { CTRL_C, CTRL_D, RawReplEngine } from '../shared/raw-repl'
+import type { DirEntry, ExecResult, StatResult } from '../shared/raw-repl'
+import { WebSerialTransport } from './webSerialTransport'
+import type { WebSerialOpenOptions } from './webSerialTransport'
+
+/** Connection lifecycle states — matches `ConnectionState` in `device/types.ts`. */
+export type WebSerialConnectionState = 'disconnected' | 'connecting' | 'connected' | 'error'
+
+/** Current status of the device connection. Matches `DeviceStatus`'s shape. */
+export interface WebSerialDeviceStatus {
+  state: WebSerialConnectionState
+  baudRate?: number
+  /** Populated when `state === 'error'`. */
+  error?: string
+}
+
+/** Listener signatures for {@link WebSerialDevice}'s two event kinds. */
+export interface WebSerialDeviceEvents {
+  /** Raw bytes received from the device (forward to the REPL/console UI). */
+  data: (chunk: Uint8Array) => void
+  /** Connection status changed. */
+  status: (status: WebSerialDeviceStatus) => void
+}
+
+/**
+ * High-level driver for a MicroPython board over a Web Serial connection.
+ * Construct with a `SerialPort` obtained from `portPicker.ts`
+ * (`requestSnakiePort()` or the `getGrantedPorts()` fast-path), then
+ * {@link connect}.
+ */
+export class WebSerialDevice {
+  private transport: WebSerialTransport | null = null
+  private state: WebSerialConnectionState = 'disconnected'
+  private currentBaud?: number
+  private readonly listeners: {
+    data: Set<(chunk: Uint8Array) => void>
+    status: Set<(status: WebSerialDeviceStatus) => void>
+  } = { data: new Set(), status: new Set() }
+
+  /**
+   * The transport-agnostic raw-REPL protocol engine (buffering, handshake,
+   * exec/eval, filesystem helpers) — the exact same class `MicroPythonDevice`
+   * uses, just driven by a different transport.
+   */
+  private readonly engine = new RawReplEngine({
+    write: (data) => this.write(data)
+  })
+
+  constructor(private readonly port: SerialPort) {}
+
+  // ---------------------------------------------------------------------------
+  // Typed event helpers
+  // ---------------------------------------------------------------------------
+
+  on<E extends keyof WebSerialDeviceEvents>(event: E, listener: WebSerialDeviceEvents[E]): this {
+    this.listeners[event].add(listener as never)
+    return this
+  }
+
+  off<E extends keyof WebSerialDeviceEvents>(event: E, listener: WebSerialDeviceEvents[E]): this {
+    this.listeners[event].delete(listener as never)
+    return this
+  }
+
+  private emitData(chunk: Uint8Array): void {
+    for (const listener of this.listeners.data) listener(chunk)
+  }
+
+  private emitStatus(status: WebSerialDeviceStatus): void {
+    for (const listener of this.listeners.status) listener(status)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Connection lifecycle
+  // ---------------------------------------------------------------------------
+
+  /** Current connection status snapshot. */
+  getStatus(): WebSerialDeviceStatus {
+    return { state: this.state, baudRate: this.currentBaud }
+  }
+
+  isConnected(): boolean {
+    return this.state === 'connected'
+  }
+
+  /** Open the Web Serial connection at the given baud rate (default 115200). */
+  async connect(options: WebSerialOpenOptions = {}): Promise<void> {
+    if (this.transport) {
+      await this.disconnect()
+    }
+    const baudRate = options.baudRate ?? 115200
+    this.currentBaud = baudRate
+    this.setState('connecting')
+
+    const transport = new WebSerialTransport(
+      this.port,
+      (chunk) => this.handleData(chunk),
+      (reason) => this.handleTransportDisconnect(reason)
+    )
+    try {
+      await transport.open({ baudRate })
+    } catch (err) {
+      this.transport = null
+      const message = err instanceof Error ? err.message : String(err)
+      this.setState('error', message)
+      throw err instanceof Error ? err : new Error(message)
+    }
+    this.transport = transport
+    this.setState('connected')
+  }
+
+  /** Close the Web Serial connection if open. */
+  async disconnect(): Promise<void> {
+    const transport = this.transport
+    this.transport = null
+    this.engine.reset()
+    if (transport) {
+      await transport.close()
+    }
+    this.setState('disconnected')
+  }
+
+  /**
+   * Called when the transport reports the port stopped being usable (unplug,
+   * or a read error) rather than an explicit {@link disconnect}. Unlike a
+   * user-driven `disconnect()`, this does NOT clear `this.port` — the port
+   * object itself is what a caller can later re-open via `connect()` once
+   * it's replugged, without another `requestPort()` prompt (Web Serial only
+   * needs a user gesture the first time a specific device is granted).
+   */
+  private handleTransportDisconnect(reason: 'closed' | 'unplugged'): void {
+    if (!this.transport) return
+    this.transport = null
+    this.engine.reset()
+    this.setState('disconnected', reason === 'unplugged' ? 'Device unplugged' : undefined)
+  }
+
+  private setState(state: WebSerialConnectionState, error?: string): void {
+    this.state = state
+    const status: WebSerialDeviceStatus = { state, baudRate: this.currentBaud }
+    if (error) status.error = error
+    this.emitStatus(status)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Low-level serial IO
+  // ---------------------------------------------------------------------------
+
+  private handleData(chunk: Uint8Array): void {
+    // Always feed the raw-REPL engine (its `readUntil` waiters need every byte).
+    this.engine.handleData(chunk)
+    // Forward raw bytes to the console UI — EXCEPT while an internal `exec` is
+    // in flight, exactly like `MicroPythonDevice.handleData` (see its comment):
+    // exec drives the raw REPL (banners, Ctrl-C interrupts, live-value probes)
+    // and that machine traffic must not pollute the user's console.
+    if (!this.engine.execActive) this.emitData(chunk)
+  }
+
+  /** Write raw bytes to the port, rejecting if not connected. */
+  private write(data: string | Uint8Array): Promise<void> {
+    if (!this.transport) return Promise.reject(new Error('Not connected'))
+    return this.transport.write(data)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Raw REPL control
+  // ---------------------------------------------------------------------------
+
+  /** Write raw user keystrokes to the friendly (`>>>`) REPL, verbatim — no
+   *  raw-REPL handshake, matching `MicroPythonDevice.sendData`. */
+  async sendData(data: string): Promise<void> {
+    await this.write(data)
+  }
+
+  /** Write an IDE→board control line (issue #115): `SNKCMD <target> <payload>\n`.
+   *  See `MicroPythonDevice.sendControl` for the full protocol description. */
+  async sendControl(target: string, payload = ''): Promise<void> {
+    await this.write(buildControlLine(target, payload))
+  }
+
+  /** Send Ctrl-C to interrupt any running program. */
+  async interrupt(): Promise<void> {
+    await this.write(CTRL_C)
+  }
+
+  /** Send Ctrl-D to perform a soft reset (only meaningful in friendly REPL). */
+  async softReset(): Promise<void> {
+    await this.write(CTRL_D)
+  }
+
+  /** Toggle DTR/RTS — see `WebSerialTransport.resetViaSignals`. No-op if not connected. */
+  async resetViaSignals(): Promise<void> {
+    await this.transport?.resetViaSignals()
+  }
+
+  /** Enter raw REPL mode (Ctrl-A), interrupting any running program first. */
+  async enterRawRepl(): Promise<void> {
+    await this.engine.enterRawRepl()
+  }
+
+  /** Leave raw REPL mode (Ctrl-B), returning to the friendly REPL. */
+  async exitRawRepl(): Promise<void> {
+    await this.engine.exitRawRepl()
+  }
+
+  /**
+   * Execute `code` in the raw REPL and capture its output. Enters raw REPL if
+   * not already in it; operations are serialized so concurrent callers don't
+   * corrupt the protocol state.
+   */
+  exec(code: string, timeoutMs = 10000): Promise<ExecResult> {
+    return this.engine.exec(code, timeoutMs)
+  }
+
+  /**
+   * Run `code` and return its stdout, throwing if the device produced a
+   * traceback on stderr.
+   */
+  async eval(code: string, timeoutMs = 10000): Promise<string> {
+    const { stdout, stderr } = await this.exec(code, timeoutMs)
+    if (stderr.trim().length > 0) {
+      throw new Error(stderr.trim())
+    }
+    return stdout
+  }
+
+  // ---------------------------------------------------------------------------
+  // Filesystem helpers (built on top of exec/eval — free once exec works)
+  // ---------------------------------------------------------------------------
+
+  async listDir(path = '/'): Promise<DirEntry[]> {
+    return this.engine.listDir(path)
+  }
+
+  async readFile(path: string): Promise<string> {
+    return this.engine.readFile(path)
+  }
+
+  async readFileBytes(path: string): Promise<Uint8Array> {
+    return this.engine.readFileBytes(path)
+  }
+
+  async writeFile(path: string, contents: string | Uint8Array, chunkSize = 256): Promise<void> {
+    await this.engine.writeFile(path, contents, chunkSize)
+  }
+
+  /** Remove a file OR a directory tree (#219). */
+  async remove(path: string): Promise<void> {
+    await this.engine.remove(path)
+  }
+
+  async mkdir(path: string): Promise<void> {
+    await this.engine.mkdir(path)
+  }
+
+  async rename(from: string, to: string): Promise<void> {
+    await this.engine.rename(from, to)
+  }
+
+  async stat(path: string): Promise<StatResult> {
+    return this.engine.stat(path)
+  }
+
+  /** Tear down resources. */
+  async dispose(): Promise<void> {
+    this.listeners.data.clear()
+    this.listeners.status.clear()
+    await this.disconnect().catch(() => undefined)
+  }
+}

--- a/src/web/webSerialTransport.ts
+++ b/src/web/webSerialTransport.ts
@@ -1,0 +1,151 @@
+/**
+ * Web Serial transport for the shared MicroPython raw-REPL protocol (issue
+ * #283, epic #267 Phase W2).
+ *
+ * `RawReplEngine` (src/shared/raw-repl.ts, issue #281 Phase W0) needs only a
+ * `write(data)` sink and a stream of received `Uint8Array` chunks pushed in
+ * via `handleData`. This module supplies that over `navigator.serial`
+ * (Chromium's Web Serial API), mirroring exactly how `MicroPythonDevice`
+ * (src/main/device/MicroPythonDevice.ts) drives the same engine over
+ * `serialport`'s `write()` + `'data'` event — same shape, different transport.
+ *
+ * Lives under `src/web/` rather than `src/shared/` because it needs DOM +
+ * Web Serial ambient types (`@types/w3c-web-serial`) that are not available
+ * under `tsconfig.node.json` (no `lib: dom`) — see tsconfig.web.json's
+ * `include`.
+ *
+ * This file has no dependency on any specific UI framework or app shell: it
+ * only touches `navigator.serial` and the `SerialPort` it hands back, so it
+ * can be unit tested with a plain mocked `SerialPort` object (no real
+ * browser/hardware needed) and dropped into a future `web-api.ts` seam
+ * unmodified.
+ */
+
+/** Options for {@link WebSerialTransport.open}. */
+export interface WebSerialOpenOptions {
+  /** Baud rate. Defaults to 115200 (the MicroPython convention, matching
+   *  `ConnectOptions.baudRate` in `src/main/device/types.ts`). */
+  baudRate?: number
+}
+
+/** Why a {@link WebSerialTransport} reports a disconnect. */
+export type WebSerialDisconnectReason = 'closed' | 'unplugged'
+
+/**
+ * Drives a single `SerialPort` for the raw-REPL engine: opens it, pumps its
+ * `ReadableStream` into `onData` chunks, and exposes a `write()` the engine
+ * can call. Also surfaces the port's native `disconnect` event (unplug) so a
+ * higher layer (e.g. `WebSerialDevice`) can update connection state and reset
+ * the engine's buffered protocol state.
+ *
+ * Implements the `RawReplTransport` shape from `shared/raw-repl.ts`
+ * structurally (a `write(data): Promise<void>` method) without importing it,
+ * to keep this module's only external dependency the Web Serial API itself.
+ */
+export class WebSerialTransport {
+  private writer: WritableStreamDefaultWriter<Uint8Array> | null = null
+  private reader: ReadableStreamDefaultReader<Uint8Array> | null = null
+  private readLoopPromise: Promise<void> | null = null
+  private closing = false
+  private readonly encoder = new TextEncoder()
+  private readonly onDisconnectListener: (ev: Event) => void
+
+  /**
+   * @param port The already-picked/granted `SerialPort` (from `requestPort()`
+   *   or `getPorts()` — see `portPicker.ts`).
+   * @param onData Called with every chunk read from the board. Feed this
+   *   straight into `RawReplEngine.handleData`.
+   * @param onDisconnect Called once when the port stops being usable, either
+   *   because the browser fired its `disconnect` event (unplugged) or a read
+   *   errored out (some platforms only surface the error, not the event).
+   *   Never called for an explicit {@link close}.
+   */
+  constructor(
+    private readonly port: SerialPort,
+    private readonly onData: (chunk: Uint8Array) => void,
+    private readonly onDisconnect: (reason: WebSerialDisconnectReason) => void
+  ) {
+    this.onDisconnectListener = () => this.handleUnplug()
+  }
+
+  /** Open the port at the given baud rate and start the read pump. */
+  async open(options: WebSerialOpenOptions = {}): Promise<void> {
+    const baudRate = options.baudRate ?? 115200
+    await this.port.open({ baudRate })
+    this.port.addEventListener('disconnect', this.onDisconnectListener)
+
+    const writable = this.port.writable
+    if (!writable) throw new Error('Serial port has no writable stream')
+    this.writer = writable.getWriter()
+
+    this.closing = false
+    this.readLoopPromise = this.runReadLoop()
+  }
+
+  /** Feed bytes to the board. Accepts a string (UTF-8 encoded) or raw bytes. */
+  async write(data: string | Uint8Array): Promise<void> {
+    if (!this.writer) throw new Error('Not connected')
+    const bytes = typeof data === 'string' ? this.encoder.encode(data) : data
+    await this.writer.write(bytes)
+  }
+
+  /**
+   * Toggle DTR/RTS off then on — the equivalent of the reset pulse some
+   * boards' USB-serial bridge chips wire to the MCU's reset/bootloader pins.
+   * Exposed as an opt-in helper (not called automatically from {@link open}):
+   * the Electron `serialport` path doesn't toggle these either today, since
+   * MicroPython boards already reset appropriately on a fresh connection —
+   * callers that need an explicit hardware reset (e.g. before flashing) can
+   * call this directly.
+   */
+  async resetViaSignals(): Promise<void> {
+    await this.port.setSignals({ dataTerminalReady: false, requestToSend: false })
+    await this.port.setSignals({ dataTerminalReady: true, requestToSend: true })
+  }
+
+  /** Close the port and release all locks/readers/writers. Idempotent. */
+  async close(): Promise<void> {
+    if (this.closing) return
+    this.closing = true
+    this.port.removeEventListener('disconnect', this.onDisconnectListener)
+
+    if (this.reader) {
+      await this.reader.cancel().catch(() => undefined)
+    }
+    // Give the read loop a chance to observe cancellation and release its lock.
+    await this.readLoopPromise?.catch(() => undefined)
+
+    if (this.writer) {
+      await this.writer.close().catch(() => undefined)
+      this.writer.releaseLock()
+      this.writer = null
+    }
+    await this.port.close().catch(() => undefined)
+  }
+
+  private async runReadLoop(): Promise<void> {
+    const readable = this.port.readable
+    if (!readable) throw new Error('Serial port has no readable stream')
+    this.reader = readable.getReader()
+    try {
+      for (;;) {
+        const { value, done } = await this.reader.read()
+        if (done) break
+        if (value) this.onData(value)
+      }
+    } catch {
+      // A read error (most commonly the device being unplugged mid-read)
+      // surfaces here rather than via the `disconnect` event on some
+      // platforms — treat it the same way, unless we caused it via close().
+      if (!this.closing) this.onDisconnect('unplugged')
+    } finally {
+      this.reader?.releaseLock()
+      this.reader = null
+    }
+  }
+
+  private handleUnplug(): void {
+    if (this.closing) return
+    this.onDisconnect('unplugged')
+  }
+}

--- a/test/portPicker.test.ts
+++ b/test/portPicker.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import {
+  describePort,
+  getGrantedPorts,
+  getSerialFilters,
+  requestSnakiePort
+} from '../src/web/portPicker'
+import { USB_SERIAL_BRIDGES } from '../src/shared/usb-bridges'
+
+/** Minimal fake of the `Serial` (`navigator.serial`) surface used by `portPicker.ts`. */
+function installFakeNavigatorSerial(overrides: {
+  getPorts?: () => Promise<unknown[]>
+  requestPort?: (opts?: { filters?: unknown[] }) => Promise<unknown>
+}): void {
+  ;(globalThis as { navigator?: unknown }).navigator = {
+    serial: {
+      getPorts: overrides.getPorts ?? (async () => []),
+      requestPort: overrides.requestPort ?? (async () => ({}))
+    }
+  }
+}
+
+afterEach(() => {
+  delete (globalThis as { navigator?: unknown }).navigator
+})
+
+describe('getSerialFilters (#283 port picker)', () => {
+  it('builds one SerialPortFilter per shared bridge-table entry, hex-decoded to numbers', () => {
+    const filters = getSerialFilters()
+    expect(filters).toHaveLength(USB_SERIAL_BRIDGES.length)
+    // Spot-check the Pico native-USB entry (vid 2e8a, pid 0005).
+    const pico = filters.find((f) => f.usbVendorId === 0x2e8a && f.usbProductId === 0x0005)
+    expect(pico).toBeDefined()
+    // A vid-only entry (Espressif native USB, 303a) has no usbProductId.
+    const espNative = filters.find((f) => f.usbVendorId === 0x303a)
+    expect(espNative).toBeDefined()
+    expect(espNative?.usbProductId).toBeUndefined()
+  })
+})
+
+describe('requestSnakiePort (#283 port picker)', () => {
+  it('calls navigator.serial.requestPort with the shared VID/PID filters', async () => {
+    let capturedFilters: unknown[] | undefined
+    installFakeNavigatorSerial({
+      requestPort: async (opts) => {
+        capturedFilters = opts?.filters
+        return { fake: 'port' }
+      }
+    })
+    const port = await requestSnakiePort()
+    expect(port).toEqual({ fake: 'port' })
+    expect(capturedFilters).toHaveLength(USB_SERIAL_BRIDGES.length)
+  })
+
+  it('throws a clear error when Web Serial is unsupported', async () => {
+    delete (globalThis as { navigator?: unknown }).navigator
+    ;(globalThis as { navigator?: unknown }).navigator = {}
+    await expect(requestSnakiePort()).rejects.toThrow('Web Serial is not supported')
+  })
+})
+
+describe('getGrantedPorts (#283 port picker, classroom fast-path)', () => {
+  it('returns already-granted ports with zero prompt', async () => {
+    installFakeNavigatorSerial({ getPorts: async () => [{ id: 1 }, { id: 2 }] })
+    const ports = await getGrantedPorts()
+    expect(ports).toEqual([{ id: 1 }, { id: 2 }])
+  })
+
+  it('returns an empty list when Web Serial is unsupported, rather than throwing', async () => {
+    ;(globalThis as { navigator?: unknown }).navigator = {}
+    await expect(getGrantedPorts()).resolves.toEqual([])
+  })
+})
+
+describe('describePort (#283 port picker)', () => {
+  it('labels a known device using the shared bridge table', () => {
+    const fakePort = { getInfo: () => ({ usbVendorId: 0x2e8a, usbProductId: 0x0005 }) }
+    const description = describePort(fakePort as unknown as SerialPort)
+    expect(description.recognized).toBe(true)
+    expect(description.label).toMatch(/Raspberry Pi Pico/)
+    expect(description.vendorId).toBe('2e8a')
+    expect(description.productId).toBe('0005')
+  })
+
+  it('falls back to "Unknown serial device" for an unrecognized VID/PID', () => {
+    const fakePort = { getInfo: () => ({ usbVendorId: 0xffff, usbProductId: 0xffff }) }
+    const description = describePort(fakePort as unknown as SerialPort)
+    expect(description.recognized).toBe(false)
+    expect(description.label).toBe('Unknown serial device')
+  })
+
+  it('handles a port with no VID/PID info at all (e.g. Bluetooth)', () => {
+    const fakePort = { getInfo: () => ({}) }
+    const description = describePort(fakePort as unknown as SerialPort)
+    expect(description.recognized).toBe(false)
+    expect(description.vendorId).toBeUndefined()
+    expect(description.productId).toBeUndefined()
+  })
+})

--- a/test/webSerialDevice.test.ts
+++ b/test/webSerialDevice.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect } from 'vitest'
+import { WebSerialDevice } from '../src/web/webSerialDevice'
+import { CTRL_A, CTRL_B, CTRL_C, CTRL_D } from '../src/shared/raw-repl'
+
+const encoder = new TextEncoder()
+
+/**
+ * A fake `SerialPort` that plays a MicroPython board: replies to the raw-REPL
+ * handshake and to `exec`'d code via a caller-supplied `script`. Adapted from
+ * `test/webSerialTransport.test.ts`'s `FakeSerialPort`, with board reply logic
+ * layered on top matching `test/rawReplEngine.test.ts`'s `FakeBoard` — proving
+ * `WebSerialDevice` drives the exact same `RawReplEngine` protocol end-to-end
+ * over a (fake) Web Serial connection.
+ */
+class FakeMicroPythonPort {
+  opened = false
+  closed = false
+  signalCalls: Array<{ dataTerminalReady?: boolean; requestToSend?: boolean }> = []
+  /** Every raw string written to the port, in order (for asserting on the wire format). */
+  writeLog: string[] = []
+  private disconnectListeners: Array<() => void> = []
+  private pendingChunks: Uint8Array[] = []
+  private pendingReadResolvers: Array<(v: { value?: Uint8Array; done: boolean }) => void> = []
+  private acc = ''
+  private streamDone = false
+
+  constructor(private readonly script: (code: string) => { stdout: string; stderr: string }) {}
+
+  readable = {
+    getReader: () => ({
+      read: (): Promise<{ value?: Uint8Array; done: boolean }> => {
+        if (this.streamDone) return Promise.resolve({ done: true })
+        if (this.pendingChunks.length > 0) {
+          return Promise.resolve({ value: this.pendingChunks.shift(), done: false })
+        }
+        return new Promise((resolve) => this.pendingReadResolvers.push(resolve))
+      },
+      cancel: (): Promise<void> => {
+        while (this.pendingReadResolvers.length > 0) {
+          this.pendingReadResolvers.shift()?.({ done: true })
+        }
+        return Promise.resolve()
+      },
+      releaseLock: (): void => undefined
+    })
+  } as unknown as ReadableStream<Uint8Array>
+
+  writable = {
+    getWriter: () => ({
+      write: (chunk: Uint8Array): Promise<void> => {
+        const str = new TextDecoder().decode(chunk)
+        this.writeLog.push(str)
+        this.handleWrite(str)
+        return Promise.resolve()
+      },
+      close: (): Promise<void> => Promise.resolve(),
+      releaseLock: (): void => undefined
+    })
+  } as unknown as WritableStream<Uint8Array>
+
+  async open(): Promise<void> {
+    this.opened = true
+  }
+
+  async close(): Promise<void> {
+    this.closed = true
+  }
+
+  async setSignals(signals: { dataTerminalReady?: boolean; requestToSend?: boolean }): Promise<void> {
+    this.signalCalls.push(signals)
+  }
+
+  getSignals(): Promise<never> {
+    throw new Error('not implemented in fake')
+  }
+
+  getInfo(): { usbVendorId?: number; usbProductId?: number } {
+    return { usbVendorId: 0x2e8a, usbProductId: 0x0005 }
+  }
+
+  addEventListener(type: string, listener: () => void): void {
+    if (type === 'disconnect') this.disconnectListeners.push(listener)
+  }
+
+  removeEventListener(type: string, listener: () => void): void {
+    if (type === 'disconnect') {
+      this.disconnectListeners = this.disconnectListeners.filter((l) => l !== listener)
+    }
+  }
+
+  unplug(): void {
+    this.streamDone = true
+    for (const l of [...this.disconnectListeners]) l()
+  }
+
+  private handleWrite(str: string): void {
+    this.acc += str
+    if (this.acc.endsWith(CTRL_C + CTRL_C + CTRL_A)) {
+      this.acc = ''
+      this.reply('raw REPL; CTRL-B to exit\r\n>')
+      return
+    }
+    if (str === CTRL_B) {
+      this.acc = ''
+      return
+    }
+    if (str === CTRL_D) {
+      const code = this.acc.slice(0, -1)
+      this.acc = ''
+      const { stdout, stderr } = this.script(code)
+      this.reply(`OK${stdout}${CTRL_D}${stderr}${CTRL_D}>`)
+      return
+    }
+  }
+
+  private reply(text: string): void {
+    const chunk = encoder.encode(text)
+    if (this.pendingReadResolvers.length > 0) {
+      this.pendingReadResolvers.shift()?.({ value: chunk, done: false })
+    } else {
+      this.pendingChunks.push(chunk)
+    }
+  }
+}
+
+async function connectedDevice(
+  script: (code: string) => { stdout: string; stderr: string } = () => ({ stdout: '', stderr: '' })
+): Promise<{ device: WebSerialDevice; port: FakeMicroPythonPort }> {
+  const port = new FakeMicroPythonPort(script)
+  const device = new WebSerialDevice(port as unknown as SerialPort)
+  await device.connect()
+  return { device, port }
+}
+
+describe('WebSerialDevice (#283 Web Serial device parity)', () => {
+  it('connects, reaching the "connected" status', async () => {
+    const { device, port } = await connectedDevice()
+    expect(port.opened).toBe(true)
+    expect(device.isConnected()).toBe(true)
+    expect(device.getStatus()).toEqual({ state: 'connected', baudRate: 115200 })
+  })
+
+  it('exec() drives the raw-REPL handshake over the fake port and returns stdout', async () => {
+    const { device } = await connectedDevice((code) => ({ stdout: `ran:${code}`, stderr: '' }))
+    const result = await device.exec('1+1')
+    expect(result.stdout).toBe('ran:1+1')
+    expect(result.stderr).toBe('')
+  })
+
+  it('eval() throws when the board reports a traceback on stderr', async () => {
+    const { device } = await connectedDevice(() => ({ stdout: '', stderr: 'Traceback: boom' }))
+    await expect(device.eval('1/0')).rejects.toThrow('Traceback: boom')
+  })
+
+  it('listDir/readFile/writeFile work over the fake transport with zero extra protocol code', async () => {
+    const { device } = await connectedDevice((code) => {
+      if (code.includes('_ls(')) return { stdout: '[["main.py", false, 42]]', stderr: '' }
+      return { stdout: '', stderr: '' }
+    })
+    const entries = await device.listDir('/')
+    expect(entries).toEqual([{ name: 'main.py', isDir: false, size: 42 }])
+  })
+
+  it('forwards non-exec data to "data" listeners but suppresses exec traffic', async () => {
+    const { device } = await connectedDevice((code) => ({ stdout: `out:${code}`, stderr: '' }))
+    const seen: string[] = []
+    device.on('data', (chunk) => seen.push(new TextDecoder().decode(chunk)))
+
+    // Exec traffic (handshake/banner/OK/markers) must NOT reach the listener —
+    // the fake board only ever "replies", never echoes user keystrokes, so an
+    // empty capture here proves nothing reached the console during exec.
+    await device.exec('print(1)')
+    expect(seen.join('')).toBe('')
+  })
+
+  it('disconnect() closes the transport and resets state to "disconnected"', async () => {
+    const { device, port } = await connectedDevice()
+    const statuses: string[] = []
+    device.on('status', (s) => statuses.push(s.state))
+    await device.disconnect()
+    expect(port.closed).toBe(true)
+    expect(device.isConnected()).toBe(false)
+    expect(statuses).toContain('disconnected')
+  })
+
+  it('an unplug event transitions status to "disconnected" with an error message', async () => {
+    const { device, port } = await connectedDevice()
+    const statuses: Array<{ state: string; error?: string }> = []
+    device.on('status', (s) => statuses.push({ state: s.state, error: s.error }))
+    port.unplug()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(device.isConnected()).toBe(false)
+    expect(statuses.some((s) => s.state === 'disconnected' && s.error === 'Device unplugged')).toBe(true)
+  })
+
+  it('resetViaSignals() toggles DTR/RTS via the port', async () => {
+    const { device, port } = await connectedDevice()
+    await device.resetViaSignals()
+    expect(port.signalCalls).toEqual([
+      { dataTerminalReady: false, requestToSend: false },
+      { dataTerminalReady: true, requestToSend: true }
+    ])
+  })
+
+  it('sendControl() writes a sanitised SNKCMD line verbatim (no raw-REPL handshake)', async () => {
+    const { device, port } = await connectedDevice()
+    await device.sendControl('led', 'on')
+    expect(port.writeLog).toEqual(['SNKCMD led on\n'])
+  })
+
+  it('interrupt()/softReset() write the expected control bytes', async () => {
+    const { device, port } = await connectedDevice()
+    await device.interrupt()
+    await device.softReset()
+    expect(port.writeLog).toEqual([CTRL_C, CTRL_D])
+  })
+})

--- a/test/webSerialTransport.test.ts
+++ b/test/webSerialTransport.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi } from 'vitest'
+import { WebSerialTransport } from '../src/web/webSerialTransport'
+
+/**
+ * A minimal fake `SerialPort` (issue #283): implements exactly the surface
+ * `WebSerialTransport` touches (open/close/setSignals/getInfo/readable/
+ * writable/addEventListener/removeEventListener), without any real DOM or
+ * hardware — enough to drive the transport end-to-end in a plain Node test
+ * environment. Modeled after `test/rawReplEngine.test.ts`'s `FakeBoard`.
+ */
+class FakeSerialPort {
+  opened = false
+  closed = false
+  writes: Uint8Array[] = []
+  signalCalls: Array<{ dataTerminalReady?: boolean; requestToSend?: boolean }> = []
+  private disconnectListeners: Array<() => void> = []
+  /** Queue of chunks waiting to be delivered to the next `reader.read()`. */
+  private pendingChunks: Uint8Array[] = []
+  private pendingReadResolvers: Array<(v: { value?: Uint8Array; done: boolean }) => void> = []
+  private streamDone = false
+  private readCancelled = false
+
+  readable = {
+    getReader: () => ({
+      read: (): Promise<{ value?: Uint8Array; done: boolean }> => {
+        if (this.readCancelled || this.streamDone) return Promise.resolve({ done: true })
+        if (this.pendingChunks.length > 0) {
+          return Promise.resolve({ value: this.pendingChunks.shift(), done: false })
+        }
+        return new Promise((resolve) => this.pendingReadResolvers.push(resolve))
+      },
+      cancel: (): Promise<void> => {
+        this.readCancelled = true
+        // Wake up any pending read so the loop can exit.
+        while (this.pendingReadResolvers.length > 0) {
+          this.pendingReadResolvers.shift()?.({ done: true })
+        }
+        return Promise.resolve()
+      },
+      releaseLock: (): void => undefined
+    })
+  } as unknown as ReadableStream<Uint8Array>
+
+  writable = {
+    getWriter: () => ({
+      write: (chunk: Uint8Array): Promise<void> => {
+        this.writes.push(chunk)
+        return Promise.resolve()
+      },
+      close: (): Promise<void> => Promise.resolve(),
+      releaseLock: (): void => undefined
+    })
+  } as unknown as WritableStream<Uint8Array>
+
+  async open(): Promise<void> {
+    this.opened = true
+  }
+
+  async close(): Promise<void> {
+    this.closed = true
+  }
+
+  async setSignals(signals: { dataTerminalReady?: boolean; requestToSend?: boolean }): Promise<void> {
+    this.signalCalls.push(signals)
+  }
+
+  getSignals(): Promise<never> {
+    throw new Error('not implemented in fake')
+  }
+
+  getInfo(): { usbVendorId?: number; usbProductId?: number } {
+    return { usbVendorId: 0x2e8a, usbProductId: 0x0005 }
+  }
+
+  addEventListener(type: string, listener: () => void): void {
+    if (type === 'disconnect') this.disconnectListeners.push(listener)
+  }
+
+  removeEventListener(type: string, listener: () => void): void {
+    if (type === 'disconnect') {
+      this.disconnectListeners = this.disconnectListeners.filter((l) => l !== listener)
+    }
+  }
+
+  /** Test helper: push a chunk in as if the board sent it. */
+  emit(chunk: Uint8Array): void {
+    if (this.pendingReadResolvers.length > 0) {
+      this.pendingReadResolvers.shift()?.({ value: chunk, done: false })
+    } else {
+      this.pendingChunks.push(chunk)
+    }
+  }
+
+  /** Test helper: simulate the browser's native unplug event. */
+  unplug(): void {
+    this.streamDone = true
+    for (const l of [...this.disconnectListeners]) l()
+  }
+}
+
+const encoder = new TextEncoder()
+
+describe('WebSerialTransport (#283 Web Serial transport)', () => {
+  it('opens at the given baud rate and starts pumping reads into onData', async () => {
+    const port = new FakeSerialPort()
+    const received: Uint8Array[] = []
+    const transport = new WebSerialTransport(
+      port as unknown as SerialPort,
+      (chunk) => received.push(chunk),
+      () => undefined
+    )
+    await transport.open({ baudRate: 115200 })
+    expect(port.opened).toBe(true)
+
+    port.emit(encoder.encode('hello'))
+    // Let the read-loop microtask resolve.
+    await new Promise((r) => setTimeout(r, 0))
+    expect(received).toHaveLength(1)
+    expect(new TextDecoder().decode(received[0])).toBe('hello')
+  })
+
+  it('defaults to 115200 baud when no options are given', async () => {
+    const port = new FakeSerialPort()
+    const openSpy = vi.spyOn(port, 'open')
+    const transport = new WebSerialTransport(port as unknown as SerialPort, () => undefined, () => undefined)
+    await transport.open()
+    expect(openSpy).toHaveBeenCalledWith({ baudRate: 115200 })
+  })
+
+  it('write() sends bytes through the writer', async () => {
+    const port = new FakeSerialPort()
+    const transport = new WebSerialTransport(port as unknown as SerialPort, () => undefined, () => undefined)
+    await transport.open()
+    await transport.write('abc')
+    await transport.write(new Uint8Array([1, 2, 3]))
+    expect(port.writes).toHaveLength(2)
+    expect(new TextDecoder().decode(port.writes[0])).toBe('abc')
+    expect(Array.from(port.writes[1])).toEqual([1, 2, 3])
+  })
+
+  it('write() rejects before open()', async () => {
+    const port = new FakeSerialPort()
+    const transport = new WebSerialTransport(port as unknown as SerialPort, () => undefined, () => undefined)
+    await expect(transport.write('x')).rejects.toThrow('Not connected')
+  })
+
+  it('resetViaSignals() toggles DTR/RTS off then on', async () => {
+    const port = new FakeSerialPort()
+    const transport = new WebSerialTransport(port as unknown as SerialPort, () => undefined, () => undefined)
+    await transport.open()
+    await transport.resetViaSignals()
+    expect(port.signalCalls).toEqual([
+      { dataTerminalReady: false, requestToSend: false },
+      { dataTerminalReady: true, requestToSend: true }
+    ])
+  })
+
+  it('reports "unplugged" when the browser fires its native disconnect event', async () => {
+    const port = new FakeSerialPort()
+    const reasons: string[] = []
+    const transport = new WebSerialTransport(
+      port as unknown as SerialPort,
+      () => undefined,
+      (reason) => reasons.push(reason)
+    )
+    await transport.open()
+    port.unplug()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(reasons).toEqual(['unplugged'])
+  })
+
+  it('reports "unplugged" when the read loop errors (some platforms skip the event)', async () => {
+    const port = new FakeSerialPort()
+    const reasons: string[] = []
+    const transport = new WebSerialTransport(
+      port as unknown as SerialPort,
+      () => undefined,
+      (reason) => reasons.push(reason)
+    )
+    await transport.open()
+    // Simulate a mid-read error without the native event firing.
+    port.readable.getReader = () => ({
+      read: () => Promise.reject(new Error('device disappeared')),
+      cancel: () => Promise.resolve(),
+      releaseLock: () => undefined
+    })
+    // Re-open to restart the read loop against the erroring reader.
+    await transport.close()
+    const transport2 = new WebSerialTransport(
+      port as unknown as SerialPort,
+      () => undefined,
+      (reason) => reasons.push(reason)
+    )
+    await transport2.open()
+    await new Promise((r) => setTimeout(r, 0))
+    expect(reasons).toContain('unplugged')
+  })
+
+  it('close() is idempotent, releases the writer, and does not report a disconnect', async () => {
+    const port = new FakeSerialPort()
+    const reasons: string[] = []
+    const transport = new WebSerialTransport(
+      port as unknown as SerialPort,
+      () => undefined,
+      (reason) => reasons.push(reason)
+    )
+    await transport.open()
+    await transport.close()
+    await transport.close() // idempotent — must not throw
+    expect(port.closed).toBe(true)
+    expect(reasons).toEqual([])
+  })
+})

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -4,7 +4,8 @@
     "src/renderer/src/**/*",
     "src/renderer/src/**/*.tsx",
     "src/preload/index.d.ts",
-    "src/shared/**/*"
+    "src/shared/**/*",
+    "src/web/**/*"
   ],
   "compilerOptions": {
     "composite": true,


### PR DESCRIPTION
Closes #283. Part of epic #267 (Snakie for Web), Phase W2 — real hardware over Web Serial.

## Dependency reality check

Only Phase W0's raw-REPL extraction (#287, `RawReplEngine` in `src/shared/raw-repl.ts`) is actually landed on the epic branch this stacks on. The `window.api` seam split (#281's other half) and #282 (WASM sim worker / web SPA target) haven't started — there's no non-Electron app shell or `web-api.ts` seam yet. So this PR builds the Web Serial half of the stack completely and testably, shaped to drop in once that seam exists, rather than scope-creeping into #281/#282's work. Flagged this back to the epic session.

## What

- **`src/shared/usb-bridges.ts`** — the USB VID/PID bridge table extracted out of `firmware/detect.ts` (pure data, zero Node/DOM deps), extended with the Raspberry Pi Pico's native-USB CDC id (needed for the port picker, not previously in the ESP-only table). `detect.ts` now imports from it — no behaviour change (still esp32/esp8266 only; rp2040 stays UF2-boot-drive detected).
- **`src/web/webSerialTransport.ts`** — `WebSerialTransport` drives the shared `RawReplEngine` over `navigator.serial`: open at the right baud, a read pump decoding the port's `ReadableStream` into `Uint8Array` chunks, `write()` via the `WritableStream`, DTR/RTS reset via `setSignals()`, and unplug/read-error handling. Lives under `src/web/` (not `src/shared/`) since it needs DOM + Web Serial ambient types unavailable under `tsconfig.node.json`.
- **`src/web/webSerialDevice.ts`** — `WebSerialDevice` mirrors `MicroPythonDevice`'s public surface (connect/disconnect/status+data events, exec/eval, sendData/sendControl/interrupt/softReset, listDir/readFile/writeFile/remove/mkdir/rename/stat, dispose) built on `RawReplEngine` + the new transport. File tree, module installs and instrument telemetry streaming all come for free since they're built on `exec`/`eval`. Uses `Uint8Array` instead of `Buffer` (documented deviation from the IPC-boundary-typed `SnakieDevice` interface — a thin `web-api.ts` adapter converts at that boundary once it exists).
- **`src/web/portPicker.ts`** — `getSerialFilters()`/`requestSnakiePort()` (the user-gesture `requestPort()` path, filtered to known MicroPython boards) and `getGrantedPorts()` (the `getPorts()` zero-prompt fast path for pre-granted/enterprise-policy devices), plus `describePort()` for friendly labeling.
- **`docs/web-serial-classroom-policy.md`** — the `SerialAllowUsbDevicesForUrls` Chrome Enterprise policy recipe: decimal VID/PID JSON (verified against Chromium's own policy-handler schema/tests), Google Admin console steps, and `chrome://policy` verification, so school IT can pre-grant a Chromebook fleet silent USB access to Pico/ESP32 boards.
- `@types/w3c-web-serial` added (devDependency) + `src/web/**/*` wired into `tsconfig.web.json`'s `include`.
- CHANGELOG `[Unreleased]` entry added (new feature → MINOR bump on next release; package.json version not touched here).

## Testing

- `test/webSerialTransport.test.ts` (8 tests) — open/baud default, read pump → `onData`, write, DTR/RTS toggle sequence, native `disconnect` event handling, read-loop error → `'unplugged'`, idempotent `close()`.
- `test/webSerialDevice.test.ts` (10 tests) — connect/status, `exec`/`eval` round-trip through the raw-REPL handshake over a fake board (same pattern as `test/rawReplEngine.test.ts`'s `FakeBoard`), `listDir` built on `exec` with zero extra protocol code, exec-traffic suppression from the `data` event, disconnect/unplug → status transitions, `resetViaSignals`, `sendControl`/`interrupt`/`softReset` wire format.
- `test/portPicker.test.ts` (8 tests) — filter construction from the shared bridge table (hex → decimal), `requestPort`/`getPorts` against a mocked `navigator.serial`, `describePort` labeling (known + unknown + missing VID/PID).
- All mocked — no real browser/hardware needed.
- `npm run lint` — clean (1 pre-existing unrelated warning).
- `npm run typecheck` — clean (both node and web projects).
- `npm test` — **1405/1405 passing** (26 new).
- `npm run build` — electron-vite build succeeds.

## Not in this PR

Wiring `WebSerialDevice` into the actual renderer UI via `window.api`/a `web-api.ts` backend — there's no seam or web app shell to wire it into yet (that's #281's remaining half + #282). `WebSerialDevice`'s surface intentionally matches `MicroPythonDevice` so it's a drop-in once that lands.