### PR TITLE
Host Snakie Web at app.snakie.org (Cloudflare Pages deploy pipeline)

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,48 @@
+name: Deploy Web (app.snakie.org)
+
+on:
+  push:
+    branches:
+      - master
+  # Lets a human re-trigger a deploy without needing a new commit (e.g. after
+  # rotating the Cloudflare API token, or re-running a flaky deploy step).
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # PLACEHOLDER BUILD (issue #286): the dedicated Vite web target (#281 /
+      # "Web W0") hasn't landed yet, so there is no `build:web` script or
+      # web-only bundle. This runs the existing Electron renderer build and
+      # deploys its `out/renderer` output as a stand-in, so the pipeline is
+      # wired end-to-end and app.snakie.org is live. Once #281 lands with a
+      # real web build script/output directory, swap the two lines below
+      # (script name + `directory:` in the deploy step) to point at it —
+      # nothing else in this workflow should need to change.
+      - name: Build web app
+        run: npm run build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: snakie-web
+          directory: out/renderer
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/src/renderer/public/_headers
+++ b/src/renderer/public/_headers
@@ -1,0 +1,11 @@
+# Cloudflare Pages custom response headers (also understood by Netlify).
+# See issue #286 (host app.snakie.org) and epic #267 (Snakie for Web).
+#
+# COOP/COEP are required for the WASM sim worker (issue #282) to use
+# SharedArrayBuffer/threads if/when it needs them — both headers must be
+# present together, on every response, for the browser to grant the isolated
+# "cross-origin isolated" context. This is why GitHub Pages (no custom
+# headers support) was disqualified as a host for app.snakie.org.
+/*
+  Cross-Origin-Opener-Policy: same-origin
+  Cross-Origin-Embedder-Policy: require-corp

--- a/src/renderer/public/_redirects
+++ b/src/renderer/public/_redirects
@@ -1,0 +1,4 @@
+# SPA fallback for Cloudflare Pages (also understood by Netlify): every path
+# serves index.html so client-side routing works on a hard refresh/deep link.
+# See issue #286 (host app.snakie.org).
+/*  /index.html  200


### PR DESCRIPTION
Closes #286. Part of epic #267.

## What this adds
- **`.github/workflows/deploy-web.yml`** — builds on every push to `master`
  (+ manual `workflow_dispatch`) and deploys to **Cloudflare Pages** via the
  official `cloudflare/pages-action@v1`.
- **`src/renderer/public/_headers`** — sets `Cross-Origin-Opener-Policy: same-origin`
  and `Cross-Origin-Embedder-Policy: require-corp` on every response.
- **`src/renderer/public/_redirects`** — `/* /index.html 200` SPA fallback so
  client-side routes survive a hard refresh / deep link.

Both files live in `src/renderer/public/`, which Vite copies verbatim into the
build output — verified locally that `npm run build` produces
`out/renderer/_headers` and `out/renderer/_redirects`.

## Host choice: Cloudflare Pages
Per discussion, your DNS for snakie.org already lives on Cloudflare, which
settles it, but it's also the right technical pick:

| Host | Custom headers (COOP/COEP) | Notes |
|---|---|---|
| **GitHub Pages** | ❌ **No** — disqualified | Can't set response headers at all |
| **Cloudflare Pages** | ✅ via in-repo `_headers` file | DNS already here; auto TLS; free tier |
| Netlify | ✅ via in-repo `_headers` file | Would also work, but a second DNS provider to manage |
| Vercel | ✅ via `vercel.json` | Same trade-off as Netlify |

COOP/COEP matter because the WASM sim worker (#282) may need
`SharedArrayBuffer`/threads, which browsers only grant in a cross-origin
isolated context — both headers must be present together on every response.

## Placeholder build (important)
The dedicated Vite web target (#281 / "Web W0", not yet merged) doesn't exist
yet — no `build:web` script or web-only bundle. This workflow currently runs
the existing `npm run build` and deploys its `out/renderer` output so the
*pipeline* is fully wired end-to-end and `app.snakie.org` goes live now. A
comment in the workflow flags exactly where to swap in the real script name
and output directory once #281 lands — nothing else should need to change.

## DNS
No manual DNS edit is needed from us: since the `snakie.org` zone is already
on Cloudflare, adding `app.snakie.org` as a custom domain in the Cloudflare
Pages project's dashboard **auto-provisions the CNAME** (and TLS cert) for
you. Nothing to do outside that one dashboard step.

## Manual one-time setup required (human, Cloudflare dashboard access needed — I can't do this from this session)
1. Create a Cloudflare Pages project (e.g. named `snakie-web`, matching
   `projectName` in the workflow — rename in the workflow if you pick a
   different name). Direct-upload/Actions-based deploy is used, so you do
   **not** need to connect Cloudflare Pages' own Git integration.
2. In that project's **Custom domains**, add `app.snakie.org` — Cloudflare
   auto-creates the DNS record and issues the TLS cert since the zone is
   already yours.
3. Create a Cloudflare API token (Pages:Edit permission) and note your
   Account ID, then add two repo secrets:
   - `CLOUDFLARE_API_TOKEN`
   - `CLOUDFLARE_ACCOUNT_ID`
4. Push to `master` (or run the workflow manually) to trigger the first
   deploy.

## Follow-ups (not code changes, noted for tracking)
- snakie.org's marketing site (separate Jekyll repo) should eventually link
  to `app.snakie.org`.
- #283's classroom docs (the `SerialAllowUsbDevicesForUrls` policy recipe)
  should reference `app.snakie.org` as the final origin once written.

## Testing
- `npm run build` — verified `_headers`/`_redirects` land in `out/renderer`.
- `npm run lint` — clean (one pre-existing unrelated warning).
- Validated `deploy-web.yml` YAML syntax.

No CHANGELOG entry — this repo's changelog has no "Infra/Internal" precedent
and this is deploy infra with no user-visible product change.