### PR TITLE
Data View: sort, filter + live column summary (#275, epic #272 step 2a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Data View — sort, filter and a live column summary (#275, epic #272).**
+  Click a column header to sort it (type-aware — numbers order 2 < 10 < 100, not
+  lexically; timestamps chronologically; asc → desc → off), with nulls always
+  last. A toggleable filter row gives numeric/timestamp columns a min–max range
+  and text columns contains/equals; filters compose across columns and show a
+  "27,501 of 50,001 rows" count with one-click **Clear**. A summary strip under
+  the header profiles each column (min–max, mean, distinct/top value, empty
+  count) and **recomputes against the filtered set** — all over the same
+  virtualised table, smooth at 86k rows.
 - **Data View — open a logged CSV as a table (#274, epic #272).** Opening a
   `.csv` / `.tsv` file now shows a spreadsheet-like viewer instead of raw text:
   it auto-detects the delimiter (comma / tab / semicolon / whitespace) and the

--- a/src/renderer/src/components/DataView.css
+++ b/src/renderer/src/components/DataView.css
@@ -43,8 +43,33 @@
   color: #e0a44a;
 }
 
-.dv__toggle {
+.dv__toolbar-actions {
   margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.dv__btn {
+  font: inherit;
+  font-size: 0.66rem;
+  padding: 0.2rem 0.5rem;
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 4px;
+  background: var(--bg, #1b1c1f);
+  color: var(--text-muted, #a2a8b2);
+  cursor: pointer;
+}
+.dv__btn:hover {
+  color: var(--text, #d6dae0);
+  border-color: var(--text-muted, #6b7078);
+}
+.dv__btn.is-on {
+  color: #7fc4f0;
+  border-color: #3f6f8f;
+}
+
+.dv__toggle {
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
@@ -65,18 +90,22 @@
   min-width: 100%;
 }
 
-/* Sticky header — stays on top while scrolling vertically, moves with content
-   horizontally. */
-.dv__head {
+/* Sticky top matter (header + summary + filters) — stays pinned while the body
+   scrolls vertically, moves with content horizontally. */
+.dv__top {
   position: sticky;
   top: 0;
   z-index: 2;
+}
+
+.dv__head {
   display: grid;
   height: 30px;
   background: var(--bg-elevated, #26282d);
   border-bottom: 1px solid var(--border, #34363c);
 }
 
+/* Header cells are sort buttons. */
 .dv__th {
   display: flex;
   flex-direction: column;
@@ -85,6 +114,98 @@
   padding: 0 0.5rem;
   overflow: hidden;
   border-right: 1px solid var(--border, #2c2e33);
+  font: inherit;
+  text-align: left;
+  background: transparent;
+  color: inherit;
+  border-top: none;
+  border-left: none;
+  border-bottom: none;
+  cursor: pointer;
+}
+.dv__th:hover {
+  background: rgba(128, 148, 200, 0.1);
+}
+.dv__th.is-sorted {
+  background: rgba(127, 196, 240, 0.12);
+}
+
+.dv__sort {
+  margin-left: 0.35rem;
+  font-size: 0.6rem;
+  color: #7fc4f0;
+}
+
+/* Summary strip — per-column quick stats over the visible set. */
+.dv__summary {
+  display: grid;
+  min-height: 24px;
+  background: var(--bg, #1b1c1f);
+  border-bottom: 1px solid var(--border, #2c2e33);
+}
+.dv__sum {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0 0.5rem;
+  overflow: hidden;
+  border-right: 1px solid rgba(128, 128, 128, 0.08);
+  font-size: 0.6rem;
+  white-space: nowrap;
+}
+.dv__sum-main {
+  color: var(--text, #cdd2d9);
+}
+.dv__sum-sub {
+  color: var(--text-muted, #7d838d);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.dv__sum-gap {
+  margin-left: auto;
+  color: #e0a44a;
+}
+
+/* Filter row. */
+.dv__filters {
+  display: grid;
+  min-height: 28px;
+  background: var(--bg-elevated, #212226);
+  border-bottom: 1px solid var(--border, #34363c);
+}
+.dv__filter {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px 0.35rem;
+  border-right: 1px solid rgba(128, 128, 128, 0.08);
+  min-width: 0;
+}
+.dv__filter-input {
+  min-width: 0;
+  flex: 1 1 auto;
+  font: inherit;
+  font-size: 0.64rem;
+  padding: 2px 4px;
+  background: var(--bg, #17181b);
+  color: var(--text, #d6dae0);
+  border: 1px solid var(--border, #34363c);
+  border-radius: 3px;
+}
+.dv__filter-input--range {
+  width: 50%;
+}
+.dv__filter-mode {
+  flex: 0 0 auto;
+  width: 18px;
+  height: 18px;
+  font-size: 0.62rem;
+  padding: 0;
+  border: 1px solid var(--border, #34363c);
+  border-radius: 3px;
+  background: var(--bg, #17181b);
+  color: #7fc4f0;
+  cursor: pointer;
 }
 
 .dv__th-name {
@@ -166,8 +287,10 @@
   z-index: 1;
 }
 
-/* Shift the header + rows right of the gutter so cells aren't hidden under it. */
+/* Shift every gridded row right of the gutter so cells aren't hidden under it. */
 .dv__head,
+.dv__summary,
+.dv__filters,
 .dv__row {
   padding-left: 48px;
 }

--- a/src/renderer/src/components/DataView.tsx
+++ b/src/renderer/src/components/DataView.tsx
@@ -1,6 +1,15 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useWorkspace } from '../store/workspace'
-import { parseTable, delimiterLabel, type ColumnType } from './data-table'
+import { parseTable, delimiterLabel, type Column, type ColumnType } from './data-table'
+import {
+  computeView,
+  nextSort,
+  summariseColumn,
+  isActiveFilter,
+  type Filter,
+  type SortState,
+  type ColumnSummary
+} from './data-view-ops'
 import './DataView.css'
 
 /**
@@ -36,10 +45,42 @@ export function DataView(): JSX.Element {
     [content, headerOverride]
   )
 
-  // Reset the header override when switching to a different file.
+  // Sort + per-column filters (#275). Reset both when switching file.
+  const [sort, setSort] = useState<SortState | null>(null)
+  const [filters, setFilters] = useState<Map<number, Filter>>(new Map())
+  const [showFilters, setShowFilters] = useState(false)
   useEffect(() => {
     setHeaderOverride(null)
+    setSort(null)
+    setFilters(new Map())
+    setShowFilters(false)
   }, [activeId])
+
+  const { columns, rows, raggedRows } = table
+
+  // The visible view = filtered + sorted row indices (recomputed on any change).
+  const view = useMemo(
+    () => computeView(rows, columns, filters, sort),
+    [rows, columns, filters, sort]
+  )
+  // Per-column summaries over the VISIBLE set (recompute on sort/filter).
+  const summaries = useMemo(
+    () => columns.map((c) => summariseColumn(rows, c.index, c.type, view)),
+    [rows, columns, view]
+  )
+  const activeFilters = useMemo(
+    () => [...filters.values()].filter(isActiveFilter).length,
+    [filters]
+  )
+
+  const setFilter = (col: number, f: Filter | null): void => {
+    setFilters((prev) => {
+      const next = new Map(prev)
+      if (f === null || !isActiveFilter(f)) next.delete(col)
+      else next.set(col, f)
+      return next
+    })
+  }
 
   // --- Virtualisation: track the scroll viewport + its height ----------------
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -56,8 +97,7 @@ export function DataView(): JSX.Element {
     return () => ro.disconnect()
   }, [])
 
-  const { columns, rows, raggedRows } = table
-  const total = rows.length
+  const total = view.length
   const first = Math.max(0, Math.floor(scrollTop / ROW_H) - OVERSCAN)
   const visibleCount = Math.ceil(viewH / ROW_H) + OVERSCAN * 2
   const last = Math.min(total, first + visibleCount)
@@ -75,15 +115,16 @@ export function DataView(): JSX.Element {
   }
 
   const visible: JSX.Element[] = []
-  for (let i = first; i < last; i++) {
-    const row = rows[i]
+  for (let k = first; k < last; k++) {
+    const rowIdx = view[k]
+    const row = rows[rowIdx]
     visible.push(
       <div
-        key={i}
+        key={rowIdx}
         className="dv__row"
-        style={{ transform: `translateY(${i * ROW_H}px)`, gridTemplateColumns: template }}
+        style={{ transform: `translateY(${k * ROW_H}px)`, gridTemplateColumns: template }}
       >
-        <div className="dv__gutter">{i + 1}</div>
+        <div className="dv__gutter">{rowIdx + 1}</div>
         {columns.map((c) => (
           <div key={c.index} className="dv__cell" style={{ textAlign: alignFor(c.type) }}>
             {row[c.index] === '' ? <span className="dv__null">·</span> : row[c.index]}
@@ -93,11 +134,22 @@ export function DataView(): JSX.Element {
     )
   }
 
+  const filtered = activeFilters > 0
+
   return (
     <div className="dv">
       <div className="dv__toolbar">
         <span className="dv__stat">
-          <strong>{total.toLocaleString()}</strong> rows · <strong>{columns.length}</strong> cols
+          {filtered ? (
+            <>
+              <strong>{total.toLocaleString()}</strong> of {rows.length.toLocaleString()} rows
+            </>
+          ) : (
+            <>
+              <strong>{rows.length.toLocaleString()}</strong> rows
+            </>
+          )}{' '}
+          · <strong>{columns.length}</strong> cols
         </span>
         <span className="dv__stat dv__stat--muted">{delimiterLabel(table.delimiter)}-delimited</span>
         {raggedRows > 0 && (
@@ -105,32 +157,205 @@ export function DataView(): JSX.Element {
             ⚠ {raggedRows.toLocaleString()} ragged
           </span>
         )}
-        <label className="dv__toggle">
-          <input
-            type="checkbox"
-            checked={table.hasHeader}
-            onChange={(e) => setHeaderOverride(e.target.checked)}
-          />
-          First row is a header
-        </label>
+        <div className="dv__toolbar-actions">
+          <button
+            type="button"
+            className={`dv__btn${showFilters ? ' is-on' : ''}`}
+            onClick={() => setShowFilters((s) => !s)}
+            title="Show per-column filters"
+          >
+            Filter{activeFilters > 0 ? ` (${activeFilters})` : ''}
+          </button>
+          {filtered && (
+            <button type="button" className="dv__btn" onClick={() => setFilters(new Map())}>
+              Clear
+            </button>
+          )}
+          <label className="dv__toggle">
+            <input
+              type="checkbox"
+              checked={table.hasHeader}
+              onChange={(e) => setHeaderOverride(e.target.checked)}
+            />
+            Header row
+          </label>
+        </div>
       </div>
 
       <div className="dv__grid" ref={scrollRef} onScroll={(e) => setScrollTop(e.currentTarget.scrollTop)}>
         <div className="dv__inner" style={{ width: innerW + 48 }}>
-          <div className="dv__head" style={{ gridTemplateColumns: template }}>
-            <div className="dv__gutter dv__gutter--head" />
-            {columns.map((c) => (
-              <div key={c.index} className="dv__th" title={`${c.name} · ${c.type}`}>
-                <span className="dv__th-name">{c.name}</span>
-                <span className={`dv__th-type dv__th-type--${c.type}`}>{c.type}</span>
+          <div className="dv__top">
+            <div className="dv__head" style={{ gridTemplateColumns: template }}>
+              <div className="dv__gutter dv__gutter--head" />
+              {columns.map((c) => {
+                const sorted = sort?.col === c.index ? sort.dir : null
+                return (
+                  <button
+                    key={c.index}
+                    type="button"
+                    className={`dv__th${sorted ? ' is-sorted' : ''}`}
+                    title={`${c.name} · ${c.type} — click to sort`}
+                    onClick={() => setSort((s) => nextSort(s, c.index))}
+                  >
+                    <span className="dv__th-name">
+                      {c.name}
+                      {sorted && <span className="dv__sort">{sorted === 'asc' ? '▲' : '▼'}</span>}
+                    </span>
+                    <span className={`dv__th-type dv__th-type--${c.type}`}>{c.type}</span>
+                  </button>
+                )
+              })}
+            </div>
+
+            <div className="dv__summary" style={{ gridTemplateColumns: template }}>
+              <div className="dv__gutter dv__gutter--head" />
+              {columns.map((c, i) => (
+                <div key={c.index} className="dv__sum">
+                  {renderSummary(summaries[i])}
+                </div>
+              ))}
+            </div>
+
+            {showFilters && (
+              <div className="dv__filters" style={{ gridTemplateColumns: template }}>
+                <div className="dv__gutter dv__gutter--head" />
+                {columns.map((c) => (
+                  <FilterCell
+                    key={c.index}
+                    column={c}
+                    value={filters.get(c.index) ?? null}
+                    onChange={(f) => setFilter(c.index, f)}
+                  />
+                ))}
               </div>
-            ))}
+            )}
           </div>
+
           <div className="dv__body" style={{ height: total * ROW_H }}>
             {visible}
           </div>
         </div>
       </div>
+    </div>
+  )
+}
+
+/** Compact per-column stats for the summary strip. */
+function renderSummary(s: ColumnSummary): JSX.Element {
+  const gap = s.nulls > 0 && (
+    <span className="dv__sum-gap" title={`${s.nulls} empty / dropped`}>
+      {s.nulls}∅
+    </span>
+  )
+  if ((s.type === 'number' || s.type === 'timestamp') && s.count > 0) {
+    const fmt = (n: number): string =>
+      s.type === 'timestamp' ? tsShort(n) : Math.abs(n) >= 100 ? n.toFixed(0) : n.toFixed(2)
+    return (
+      <>
+        <span className="dv__sum-main" title="min – max">
+          {fmt(s.min!)} – {fmt(s.max!)}
+        </span>
+        {s.type === 'number' && s.mean !== undefined && (
+          <span className="dv__sum-sub" title="mean">
+            μ {Math.abs(s.mean) >= 100 ? s.mean.toFixed(0) : s.mean.toFixed(2)}
+          </span>
+        )}
+        {gap}
+      </>
+    )
+  }
+  if (s.type === 'string') {
+    return (
+      <>
+        <span className="dv__sum-main" title="distinct values">
+          {s.distinct} uniq
+        </span>
+        {s.top !== undefined && (
+          <span className="dv__sum-sub" title={`most common (${s.topCount})`}>
+            {s.top}
+          </span>
+        )}
+        {gap}
+      </>
+    )
+  }
+  return <span className="dv__sum-sub">—</span>
+}
+
+/** A best-effort short timestamp label for the summary (epoch-ms or ms-of-day). */
+function tsShort(ms: number): string {
+  if (ms < 86400000) {
+    // ms-of-day (bare clock) → HH:MM
+    const s = Math.floor(ms / 1000)
+    return `${String(Math.floor(s / 3600)).padStart(2, '0')}:${String(Math.floor((s % 3600) / 60)).padStart(2, '0')}`
+  }
+  return new Date(ms).toISOString().slice(0, 10)
+}
+
+/** One column's filter input: min/max for number-ish, text for strings. */
+function FilterCell({
+  column,
+  value,
+  onChange
+}: {
+  column: Column
+  value: Filter | null
+  onChange: (f: Filter | null) => void
+}): JSX.Element {
+  if (column.type === 'string') {
+    const v = value?.kind === 'text' ? value : null
+    return (
+      <div className="dv__filter">
+        <button
+          type="button"
+          className="dv__filter-mode"
+          title={v?.mode === 'equals' ? 'Equals — click for contains' : 'Contains — click for equals'}
+          onClick={() =>
+            onChange({
+              kind: 'text',
+              mode: v?.mode === 'equals' ? 'contains' : 'equals',
+              value: v?.value ?? ''
+            })
+          }
+        >
+          {v?.mode === 'equals' ? '=' : '⊃'}
+        </button>
+        <input
+          className="dv__filter-input"
+          type="text"
+          placeholder="filter"
+          value={v?.value ?? ''}
+          onChange={(e) =>
+            onChange({ kind: 'text', mode: v?.mode ?? 'contains', value: e.target.value })
+          }
+        />
+      </div>
+    )
+  }
+  const r = value?.kind === 'range' ? value : null
+  // Blank OR non-finite → null (a NaN bound would mark the filter "active" yet
+  // never actually constrain — review #275). type=number already blocks most.
+  const num = (s: string): number | null => {
+    if (s.trim() === '') return null
+    const n = Number(s)
+    return Number.isFinite(n) ? n : null
+  }
+  return (
+    <div className="dv__filter">
+      <input
+        className="dv__filter-input dv__filter-input--range"
+        type="number"
+        placeholder="min"
+        value={r?.min ?? ''}
+        onChange={(e) => onChange({ kind: 'range', min: num(e.target.value), max: r?.max ?? null })}
+      />
+      <input
+        className="dv__filter-input dv__filter-input--range"
+        type="number"
+        placeholder="max"
+        value={r?.max ?? ''}
+        onChange={(e) => onChange({ kind: 'range', min: r?.min ?? null, max: num(e.target.value) })}
+      />
     </div>
   )
 }

--- a/src/renderer/src/components/data-view-ops.ts
+++ b/src/renderer/src/components/data-view-ops.ts
@@ -1,0 +1,189 @@
+/**
+ * DATA VIEW ops (#275, epic #272) — type-aware sort, filter and column summary
+ * over the parsed {@link ./data-table} model.
+ * =============================================================================
+ *
+ * Everything works on ROW INDICES (not row copies) so the virtualised table can
+ * render a filtered/sorted view of an 86k-row log without cloning it. Pure and
+ * DOM-free → unit-tested in node. `Date.parse` sniffs timestamps (string arg,
+ * deterministic).
+ */
+import type { Column, ColumnType } from './data-table'
+
+export type SortDir = 'asc' | 'desc'
+export interface SortState {
+  col: number
+  dir: SortDir
+}
+
+/** A per-column filter. Range for number/timestamp; text for string columns. */
+export type Filter =
+  | { kind: 'range'; min: number | null; max: number | null }
+  | { kind: 'text'; mode: 'contains' | 'equals'; value: string }
+
+/** Is a cell "null" for its type (blank, or non-parseable for number/timestamp)? */
+export function isBlank(cell: string): boolean {
+  return cell.trim() === ''
+}
+
+/** The numeric ordering value of a cell: float for numbers, epoch-ms for
+ *  timestamps (incl. bare `HH:MM(:SS)` as seconds-of-day), else NaN. */
+export function numericValue(cell: string, type: ColumnType): number {
+  const s = cell.trim()
+  if (s === '') return NaN
+  if (type === 'number') return Number(s)
+  if (type === 'timestamp') {
+    const clock = /^(\d{1,2}):(\d{2})(?::(\d{2}))?$/.exec(s)
+    if (clock) return (+clock[1] * 3600 + +clock[2] * 60 + (clock[3] ? +clock[3] : 0)) * 1000
+    const t = Date.parse(s)
+    return Number.isNaN(t) ? NaN : t
+  }
+  return NaN
+}
+
+/** Type-aware compare of two NON-null cells (-1/0/1). */
+export function compareCells(a: string, b: string, type: ColumnType): number {
+  if (type === 'number' || type === 'timestamp') {
+    const av = numericValue(a, type)
+    const bv = numericValue(b, type)
+    return av < bv ? -1 : av > bv ? 1 : 0
+  }
+  return a.localeCompare(b, undefined, { numeric: false, sensitivity: 'base' })
+}
+
+/** Whether a filter actually constrains anything (empty filters are ignored). */
+export function isActiveFilter(f: Filter): boolean {
+  return f.kind === 'range' ? f.min !== null || f.max !== null : f.value.trim() !== ''
+}
+
+/** Does one cell pass a filter? A null cell fails any active filter. */
+export function cellPasses(cell: string, type: ColumnType, f: Filter): boolean {
+  if (!isActiveFilter(f)) return true
+  if (f.kind === 'range') {
+    const v = numericValue(cell, type)
+    if (Number.isNaN(v)) return false
+    if (f.min !== null && v < f.min) return false
+    if (f.max !== null && v > f.max) return false
+    return true
+  }
+  const hay = cell.trim().toLowerCase()
+  const needle = f.value.trim().toLowerCase()
+  return f.mode === 'equals' ? hay === needle : hay.includes(needle)
+}
+
+/**
+ * Build the visible view: row indices that pass all active filters, then sorted
+ * by `sort` (nulls always last, independent of direction). Stable — equal keys
+ * keep their filtered order, so re-sorting is deterministic.
+ */
+export function computeView(
+  rows: readonly string[][],
+  columns: readonly Column[],
+  filters: ReadonlyMap<number, Filter>,
+  sort: SortState | null
+): number[] {
+  const active: Array<[number, Filter]> = []
+  for (const [col, f] of filters) if (isActiveFilter(f)) active.push([col, f])
+
+  const idx: number[] = []
+  for (let i = 0; i < rows.length; i++) {
+    let ok = true
+    for (const [col, f] of active) {
+      const type = columns[col]?.type ?? 'string'
+      if (!cellPasses(rows[i][col] ?? '', type, f)) {
+        ok = false
+        break
+      }
+    }
+    if (ok) idx.push(i)
+  }
+
+  if (sort && columns[sort.col]) {
+    const { col, dir } = sort
+    const type = columns[col].type
+    const mul = dir === 'asc' ? 1 : -1
+    const nullOf = (cell: string): boolean =>
+      type === 'string' ? isBlank(cell) : Number.isNaN(numericValue(cell, type))
+    idx.sort((ia, ib) => {
+      const a = rows[ia][col] ?? ''
+      const b = rows[ib][col] ?? ''
+      const an = nullOf(a)
+      const bn = nullOf(b)
+      if (an && bn) return 0
+      if (an) return 1 // nulls last, regardless of dir
+      if (bn) return -1
+      return mul * compareCells(a, b, type)
+    })
+  }
+  return idx
+}
+
+/** Cycle a column's sort: none → asc → desc → none. */
+export function nextSort(current: SortState | null, col: number): SortState | null {
+  if (!current || current.col !== col) return { col, dir: 'asc' }
+  if (current.dir === 'asc') return { col, dir: 'desc' }
+  return null
+}
+
+/** A per-column summary over a set of row indices (the filtered/visible set). */
+export interface ColumnSummary {
+  type: ColumnType
+  /** Non-null values counted. */
+  count: number
+  /** Null / blank values in the visible set. */
+  nulls: number
+  /** number/timestamp. */
+  min?: number
+  max?: number
+  mean?: number
+  /** text. */
+  distinct?: number
+  top?: string
+  topCount?: number
+}
+
+/** Summarise one column over `indices` (recomputed on every sort/filter). */
+export function summariseColumn(
+  rows: readonly string[][],
+  col: number,
+  type: ColumnType,
+  indices: readonly number[]
+): ColumnSummary {
+  let nulls = 0
+  if (type === 'number' || type === 'timestamp') {
+    let count = 0
+    let min = Infinity
+    let max = -Infinity
+    let sum = 0
+    for (const i of indices) {
+      const v = numericValue(rows[i][col] ?? '', type)
+      if (Number.isNaN(v)) {
+        nulls++
+        continue
+      }
+      count++
+      if (v < min) min = v
+      if (v > max) max = v
+      sum += v
+    }
+    return count === 0
+      ? { type, count: 0, nulls }
+      : { type, count, nulls, min, max, mean: sum / count }
+  }
+  // text: distinct + the most frequent value
+  const freq = new Map<string, number>()
+  let count = 0
+  for (const i of indices) {
+    const v = (rows[i][col] ?? '').trim()
+    if (v === '') {
+      nulls++
+      continue
+    }
+    count++
+    freq.set(v, (freq.get(v) ?? 0) + 1)
+  }
+  let top: string | undefined
+  let topCount = 0
+  for (const [v, n] of freq) if (n > topCount) ((top = v), (topCount = n))
+  return { type, count, nulls, distinct: freq.size, top, topCount }
+}

--- a/test/dataViewOps.test.ts
+++ b/test/dataViewOps.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest'
+import {
+  numericValue,
+  compareCells,
+  cellPasses,
+  isActiveFilter,
+  computeView,
+  nextSort,
+  summariseColumn,
+  type Filter
+} from '../src/renderer/src/components/data-view-ops'
+import type { Column } from '../src/renderer/src/components/data-table'
+
+const cols = (...types: Column['type'][]): Column[] =>
+  types.map((type, index) => ({ name: `c${index}`, type, index }))
+
+describe('numericValue (#275)', () => {
+  it('parses numbers, ISO timestamps and clock times', () => {
+    expect(numericValue('21.5', 'number')).toBe(21.5)
+    expect(numericValue('', 'number')).toBeNaN()
+    expect(numericValue('abc', 'number')).toBeNaN()
+    expect(numericValue('2026-01-01T00:00:00Z', 'timestamp')).toBe(Date.parse('2026-01-01T00:00:00Z'))
+    // Bare clock → ms-of-day.
+    expect(numericValue('01:00', 'timestamp')).toBe(3600 * 1000)
+    expect(numericValue('00:00:30', 'timestamp')).toBe(30 * 1000)
+  })
+})
+
+describe('compareCells — type-aware sort (#275)', () => {
+  it('numbers sort numerically, not lexically (2 < 10 < 100)', () => {
+    const nums = ['100', '2', '10'].sort((a, b) => compareCells(a, b, 'number'))
+    expect(nums).toEqual(['2', '10', '100'])
+  })
+  it('text sorts lexically', () => {
+    expect(['b', 'a', 'c'].sort((a, b) => compareCells(a, b, 'string'))).toEqual(['a', 'b', 'c'])
+  })
+  it('timestamps sort chronologically', () => {
+    const ts = ['2026-03-01', '2026-01-01', '2026-02-01'].sort((a, b) => compareCells(a, b, 'timestamp'))
+    expect(ts).toEqual(['2026-01-01', '2026-02-01', '2026-03-01'])
+  })
+})
+
+describe('filters (#275)', () => {
+  it('numeric range: min/max inclusive, null cell fails', () => {
+    const f: Filter = { kind: 'range', min: 10, max: 20 }
+    expect(cellPasses('15', 'number', f)).toBe(true)
+    expect(cellPasses('10', 'number', f)).toBe(true)
+    expect(cellPasses('20', 'number', f)).toBe(true)
+    expect(cellPasses('9', 'number', f)).toBe(false)
+    expect(cellPasses('', 'number', f)).toBe(false)
+  })
+  it('one-sided range', () => {
+    expect(cellPasses('5', 'number', { kind: 'range', min: null, max: 10 })).toBe(true)
+    expect(cellPasses('50', 'number', { kind: 'range', min: 10, max: null })).toBe(true)
+    expect(cellPasses('5', 'number', { kind: 'range', min: 10, max: null })).toBe(false)
+  })
+  it('text contains / equals (case-insensitive)', () => {
+    expect(cellPasses('Warm', 'string', { kind: 'text', mode: 'contains', value: 'arm' })).toBe(true)
+    expect(cellPasses('Warm', 'string', { kind: 'text', mode: 'equals', value: 'warm' })).toBe(true)
+    expect(cellPasses('Warm', 'string', { kind: 'text', mode: 'equals', value: 'war' })).toBe(false)
+  })
+  it('empty filters are inactive (pass everything)', () => {
+    expect(isActiveFilter({ kind: 'range', min: null, max: null })).toBe(false)
+    expect(isActiveFilter({ kind: 'text', mode: 'contains', value: '  ' })).toBe(false)
+    expect(cellPasses('anything', 'number', { kind: 'range', min: null, max: null })).toBe(true)
+  })
+})
+
+describe('computeView — filter + sort composition (#275)', () => {
+  const columns = cols('number', 'number', 'string')
+  const rows = [
+    ['1', '100', 'ok'],
+    ['2', '2', 'warm'],
+    ['3', '10', 'ok'],
+    ['4', '', 'cool'], // null in col 1
+    ['5', '50', 'warm']
+  ]
+
+  it('sorts a numeric column numerically, nulls last', () => {
+    const view = computeView(rows, columns, new Map(), { col: 1, dir: 'asc' })
+    // col1 values: 100,2,10,(null),50 → asc: 2,10,50,100, then null row.
+    expect(view.map((i) => rows[i][1])).toEqual(['2', '10', '50', '100', ''])
+  })
+
+  it('desc keeps nulls last (not first)', () => {
+    const view = computeView(rows, columns, new Map(), { col: 1, dir: 'desc' })
+    expect(view.map((i) => rows[i][1])).toEqual(['100', '50', '10', '2', ''])
+  })
+
+  it('a numeric range filter + a text contains filter combine', () => {
+    const filters = new Map<number, Filter>([
+      [1, { kind: 'range', min: 5, max: 100 }],
+      [2, { kind: 'text', mode: 'contains', value: 'warm' }]
+    ])
+    const view = computeView(rows, columns, filters, null)
+    // col1 in [5,100] → rows 0(100),2(10),4(50); of those col2=warm → row 4 only.
+    expect(view).toEqual([4])
+  })
+
+  it('stable across re-sorts (equal keys keep order)', () => {
+    const r2 = [
+      ['a', '1'],
+      ['b', '1'],
+      ['c', '1']
+    ]
+    const c2 = cols('string', 'number')
+    const view = computeView(r2, c2, new Map(), { col: 1, dir: 'asc' })
+    expect(view.map((i) => r2[i][0])).toEqual(['a', 'b', 'c'])
+  })
+})
+
+describe('nextSort cycle (#275)', () => {
+  it('none → asc → desc → none, resets on a new column', () => {
+    expect(nextSort(null, 2)).toEqual({ col: 2, dir: 'asc' })
+    expect(nextSort({ col: 2, dir: 'asc' }, 2)).toEqual({ col: 2, dir: 'desc' })
+    expect(nextSort({ col: 2, dir: 'desc' }, 2)).toBeNull()
+    expect(nextSort({ col: 2, dir: 'desc' }, 3)).toEqual({ col: 3, dir: 'asc' })
+  })
+})
+
+describe('summariseColumn — over the visible set (#275)', () => {
+  const rows = [
+    ['10', 'ok'],
+    ['20', 'ok'],
+    ['', 'warm'], // null number
+    ['30', 'ok']
+  ]
+
+  it('numeric: min/max/mean + null count over given indices', () => {
+    const s = summariseColumn(rows, 0, 'number', [0, 1, 2, 3])
+    expect(s).toMatchObject({ type: 'number', count: 3, nulls: 1, min: 10, max: 30 })
+    expect(s.mean).toBeCloseTo(20)
+  })
+
+  it('recomputes for a filtered subset only', () => {
+    const s = summariseColumn(rows, 0, 'number', [0, 1]) // just 10, 20
+    expect(s).toMatchObject({ count: 2, min: 10, max: 20 })
+    expect(s.mean).toBeCloseTo(15)
+  })
+
+  it('text: distinct + top value + null count', () => {
+    const s = summariseColumn(rows, 1, 'string', [0, 1, 2, 3])
+    expect(s).toMatchObject({ type: 'string', distinct: 2, top: 'ok', topCount: 3, nulls: 0 })
+  })
+
+  it('all-null column → count 0, no min/max', () => {
+    const s = summariseColumn([['']], 0, 'number', [0])
+    expect(s).toMatchObject({ count: 0, nulls: 1 })
+    expect(s.min).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Builds on #274. Makes the Data View table interrogable — sort, filter, and a summary strip that tracks the visible set.

## What
- **Type-aware sort** — click a header to cycle none → asc → desc. Numbers order 2 < 10 < 100 (not lexical), timestamps chronologically, text lexically; **nulls always last**, regardless of direction; stable across re-sorts.
- **Per-column filters** (toggleable row) — min–max **range** for number/timestamp columns, **contains/equals** for text. Filters **compose** (AND) across columns; a "27,501 of 50,001 rows" count + one-click **Clear**.
- **Summary strip** under the header — per-column min–max, mean, distinct/top value and empty-count, **recomputed against the filtered/visible set**.
- All over the same **virtualised** table (works on indices, not row copies) — smooth at 86k rows.

## Correctness
- `data-view-ops.ts` is pure — **17 unit tests** cover numeric-vs-lexical sort, timestamp chronology, nulls-last both directions, stability, range inclusivity + one-sided + null cells, contains/equals case-insensitivity, filter composition, and summary-over-a-subset.
- Ran an **adversarial review** (3 dimensions → per-finding skeptic verify): the verified findings came back not-real; of the rest I hardened one — the range filter now rejects a non-finite bound (a NaN would read as "active" yet never constrain).

## Verified
In-app (Playwright) on a 50k-row log: numeric sort (20.0 first asc / 29.9 first desc), composed filters (temp≥24.5 → 27,501; +state=cool → 9,167), summary recomputed on the filtered set, Clear resets. Gate: typecheck + lint clean, **1386 tests** (17 new), build ✅.

Part of epic #272. Next: #276 column summary side panel builds on this filtered-set model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)