### PR TITLE
Web W3: micro:bit WebUSB/DAPLink + Pico guided drive-copy flashing (part 2/3 of #284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,23 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the same live log + progress bar the desktop flasher shows. This lands
   first (of a 3-part split for #284) since it needs no other web-track work;
   the desktop Electron flashing path (esptool shell-out, UF2/DAPLink drive
-  copy) is unchanged. Known limitations for this round, to close in
-  follow-ups: RP2040/micro:bit browser flashing and a browser-native firmware
-  catalog download aren't available yet (the board picker and catalog tab
-  are hidden outside Electron accordingly).
+  copy) is unchanged. A browser-native firmware catalog download isn't
+  available yet, so the catalog tab is hidden outside Electron (Local file
+  only) — RP2040/micro:bit browser flashing follows below.
+- **micro:bit and Pico (RP2040) firmware flashing in the browser (Web W3,
+  #284, epic #267).** The second part of the browser flashing work: a
+  micro:bit now flashes over **WebUSB/DAPLink** via ARM's
+  [`dapjs`](https://github.com/ARMmbed/dapjs) — the same approach the
+  MakeCode editor uses — with a one-click **"Copy to drive instead"**
+  fallback (and automatic fallback when the browser has no WebUSB) for
+  boards/browsers where WebUSB DAPLink doesn't respond. A Pico's BOOTSEL
+  bootloader has no WebUSB interface at all, so it always uses that same
+  guided drive-copy flow: Snakie tells you to hold BOOTSEL (or just plug in a
+  micro:bit), then uses the **File System Access API**'s save-file picker to
+  write the firmware straight onto whichever mounted drive you pick — no
+  auto-detected mass-storage path required. Chrome/Edge only for both the
+  WebUSB and File System Access paths; the desktop Electron flashing path is
+  unchanged.
 - **Desktop-only chrome hidden outside Electron (Web W3, #284, epic #267).**
   The Source Control and Plugins views — both need a real filesystem and a
   spawned local process, neither available in a browser tab — are now hidden
@@ -28,7 +41,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   app only" notice instead of a broken panel if somehow selected. Backed by a
   new shared `isElectron()`/`hasWebSerial()`/`hasWebUSB()`/
   `hasFileSystemAccess()` capability-detection module, reused by the ESP
-  browser-flashing work above and by upcoming micro:bit/Pico web flashing.
+  browser-flashing work and by the micro:bit/Pico web flashing above.
 - **Data View — open a logged CSV as a table (#274, epic #272).** Opening a
   `.csv` / `.tsv` file now shows a spreadsheet-like viewer instead of raw text:
   it auto-detects the delimiter (comma / tab / semicolon / whitespace) and the

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@micropython/micropython-webassembly-pyscript": "^1.28.0-6",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
+        "dapjs": "^2.3.0",
         "dompurify": "^3.4.11",
         "electron-updater": "^6.8.3",
         "esptool-js": "^0.6.0",
@@ -2173,6 +2174,15 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/node-hid": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@types/node-hid/-/node-hid-1.3.4.tgz",
+      "integrity": "sha512-0ootpsYetN9vjqkDSwm/cA4fk/9yGM/PO0X8SLPE/BzXlUaBelImMWMymtF9QEoEzxY0pnhcROIJM0CNSUqO8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/plist": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/plist/-/plist-3.0.5.tgz",
@@ -2224,6 +2234,15 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@types/usb": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@types/usb/-/usb-1.5.4.tgz",
+      "integrity": "sha512-NOUza/8yuswu6RoECQyPHEjA34qpDaeONQ72fm+bCnnN2DJjDePAY+NsmV17H88oIlq4JlJ2mD5Kh5d6R2MwTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/verror": {
       "version": "1.10.11",
       "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.11.tgz",
@@ -2236,6 +2255,12 @@
       "resolved": "https://registry.npmjs.org/@types/w3c-web-serial/-/w3c-web-serial-1.0.8.tgz",
       "integrity": "sha512-QQOT+bxQJhRGXoZDZGLs3ksLud1dMNnMiSQtBA0w8KXvLpXX4oM4TZb6J0GgJ8UbCaHo5s9/4VQT8uXy9JER2A==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/w3c-web-usb": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@types/w3c-web-usb/-/w3c-web-usb-1.0.14.tgz",
+      "integrity": "sha512-Qu3Nn6JFuF4+sHKYl+IcX9vYiI40ogleXzFFSxoE1W94rG98o/kXs8uJ0QSfFzuwBCZWlGfUGpPkgwuuX4PchA==",
       "license": "MIT"
     },
     "node_modules/@types/yauzl": {
@@ -3730,6 +3755,20 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true
+    },
+    "node_modules/dapjs": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/dapjs/-/dapjs-2.3.0.tgz",
+      "integrity": "sha512-quanzq7+2xnqgGqqYgARz9o3iBcZ3Ir5r5mTA7WPsjrp9ilEqqCToSFGTL+8HuGP35dUIL7O+yMBloYHhHgZDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node-hid": "^1.2.0",
+        "@types/usb": "^1.5.1",
+        "@types/w3c-web-usb": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=8.14.0"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@micropython/micropython-webassembly-pyscript": "^1.28.0-6",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
+    "dapjs": "^2.3.0",
     "dompurify": "^3.4.11",
     "electron-updater": "^6.8.3",
     "esptool-js": "^0.6.0",

--- a/src/renderer/src/components/FirmwareFlasher.tsx
+++ b/src/renderer/src/components/FirmwareFlasher.tsx
@@ -7,8 +7,10 @@ import type {
   FlashProgress
 } from '../../../preload/index.d'
 import { useFocusTrap } from '../hooks/useFocusTrap'
-import { isElectron } from '../lib/platform'
+import { hasWebUSB, isElectron } from '../lib/platform'
 import { flashEspInBrowser, requestEspPort } from '../lib/webFirmware/espFlash'
+import { flashMicrobitInBrowser, requestMicrobitDevice } from '../lib/webFirmware/microbitFlash'
+import { copyFirmwareToDrive } from '../lib/webFirmware/driveCopyFlash'
 import './FirmwareFlasher.css'
 
 interface FirmwareFlasherProps {
@@ -76,13 +78,24 @@ function flashTargetForFamily(family: string): { board: BoardType; offset?: stri
  *
  * In Electron, all heavy lifting happens in the main process via
  * `window.api.firmware`. Outside Electron (a browser tab — Web W3, issue
- * #284) there's no process to shell out to `esptool`, so ESP32/ESP8266
- * flashing instead runs entirely in the renderer over the Web Serial API via
- * `esptool-js` (see `lib/webFirmware/espFlash.ts`); the board picker is
- * narrowed to ESP boards only and the firmware-catalog download is hidden
- * (RP2040/micro:bit browser flashing and a browser-native catalog fetch are
- * follow-up work). `isElectron()` from `lib/platform` decides which path a
- * given render takes.
+ * #284) there's no process to shell out to, so every board flashes entirely
+ * client-side instead, over whichever browser API fits it:
+ *  - ESP32/ESP8266: Web Serial via Espressif's `esptool-js`
+ *    (`lib/webFirmware/espFlash.ts`).
+ *  - micro:bit: WebUSB/DAPLink via ARM's `dapjs`
+ *    (`lib/webFirmware/microbitFlash.ts`), the same approach MakeCode uses —
+ *    with an explicit "copy to drive instead" fallback for browsers/boards
+ *    where WebUSB DAPLink doesn't respond.
+ *  - RP2040 (BOOTSEL): there's no WebUSB interface to talk to in bootloader
+ *    mode, so this ALWAYS uses the guided drive-copy flow below.
+ *  - The guided drive-copy flow (`lib/webFirmware/driveCopyFlash.ts`) talks
+ *    the user through the manual mount step (hold BOOTSEL / plug in), then
+ *    uses the File System Access API's save-file picker to write the
+ *    firmware onto whichever drive they pick.
+ * A browser-native firmware-catalog fetch isn't implemented yet, so the
+ * catalog-download source is hidden outside Electron; only "Local file" is
+ * offered there. `isElectron()`/`hasWebUSB()` from `lib/platform` decide
+ * which path a given render takes.
  */
 export function FirmwareFlasher({ onClose }: FirmwareFlasherProps): JSX.Element {
   const [candidates, setCandidates] = useState<BoardCandidate[]>([])
@@ -91,10 +104,15 @@ export function FirmwareFlasher({ onClose }: FirmwareFlasherProps): JSX.Element 
   const [mountPath, setMountPath] = useState<string>('')
   const [offset, setOffset] = useState<string>(DEFAULT_OFFSET.esp32)
   const [firmwarePath, setFirmwarePath] = useState<string>('')
-  // The picked firmware's raw bytes, for the browser (Web Serial) flash path,
-  // which has no filesystem path to hand to esptool — only a `File` (Web W3).
-  const [webFirmwareBytes, setWebFirmwareBytes] = useState<Uint8Array | null>(null)
+  // The picked firmware's raw bytes, for the browser flash paths, which have
+  // no filesystem path to hand to esptool/dapjs — only a `File` (Web W3).
+  const [webFirmwareBytes, setWebFirmwareBytes] = useState<Uint8Array<ArrayBuffer> | null>(null)
   const webFileInputRef = useRef<HTMLInputElement>(null)
+  // For a browser micro:bit flash: false tries WebUSB/DAPLink first (the
+  // default when the browser supports it); true skips straight to the
+  // guided drive-copy flow, either because the user hit the explicit
+  // fallback button or because this browser has no WebUSB at all.
+  const [microbitUseDriveCopy, setMicrobitUseDriveCopy] = useState(false)
   const [esptool, setEsptool] = useState<EsptoolInfo | null>(null)
   // Generation of a detected micro:bit (v1/v2), to pre-select the right firmware.
   const [detectedMicrobit, setDetectedMicrobit] = useState<'v1' | 'v2' | undefined>(undefined)
@@ -117,6 +135,13 @@ export function FirmwareFlasher({ onClose }: FirmwareFlasherProps): JSX.Element 
   const [selVersionUrl, setSelVersionUrl] = useState<string>('')
 
   const isEsp = board === 'esp32' || board === 'esp8266'
+  // In the browser, micro:bit flashes via WebUSB/DAPLink unless the browser
+  // lacks WebUSB or the user chose the drive-copy fallback; RP2040 always
+  // uses drive-copy (BOOTSEL has no WebUSB interface).
+  const browserMicrobitViaWebUsb =
+    !isElectron() && board === 'microbit' && hasWebUSB() && !microbitUseDriveCopy
+  const browserDriveCopy =
+    !isElectron() && (board === 'rp2040' || (board === 'microbit' && !browserMicrobitViaWebUsb))
 
   // A single handler for a streamed progress line, shared by BOTH the
   // Electron IPC subscription below AND the browser (Web Serial) flash path,
@@ -192,6 +217,9 @@ export function FirmwareFlasher({ onClose }: FirmwareFlasherProps): JSX.Element 
   const handleBoardChange = useCallback((next: BoardType): void => {
     setBoard(next)
     setOffset(DEFAULT_OFFSET[next])
+    // Reset the drive-copy opt-in so switching away from and back to
+    // micro:bit re-tries WebUSB/DAPLink first (Web W3, issue #284).
+    setMicrobitUseDriveCopy(false)
     // The catalog now serves ESP (`.bin`) and RP2040 (`.uf2`) alike (issue
     // #125), so the source is no longer gated by board.
   }, [])
@@ -328,11 +356,12 @@ export function FirmwareFlasher({ onClose }: FirmwareFlasherProps): JSX.Element 
 
   const canFlash = useMemo(() => {
     if (flashing) return false
-    if (!isElectron() && isEsp) {
-      // Browser (Web Serial) flashing reads bytes picked via `<input type=file>`
+    if (!isElectron() && (isEsp || browserMicrobitViaWebUsb || browserDriveCopy)) {
+      // Every browser flash path reads bytes picked via `<input type=file>`
       // directly — there's no IPC firmwarePath/esptool-availability check to
-      // make, and the serial port itself is only requested once Flash is
-      // clicked (Web W3, issue #284).
+      // make, and the port/device/save-location itself is only requested
+      // once Flash is clicked, since each of Web Serial/WebUSB/File System
+      // Access requires a user gesture (Web W3, issue #284).
       return webFirmwareBytes !== null && webFirmwareBytes.length > 0
     }
     if (!haveFirmware) return false
@@ -344,7 +373,18 @@ export function FirmwareFlasher({ onClose }: FirmwareFlasherProps): JSX.Element 
     // A drive board (RP2040 / micro:bit) needs the boot drive to copy onto, and a
     // micro:bit must NOT be in maintenance mode.
     return mountPath.length > 0 && !selectedMaintenance
-  }, [flashing, isEsp, webFirmwareBytes, haveFirmware, port, esptool, mountPath, selectedMaintenance])
+  }, [
+    flashing,
+    isEsp,
+    browserMicrobitViaWebUsb,
+    browserDriveCopy,
+    webFirmwareBytes,
+    haveFirmware,
+    port,
+    esptool,
+    mountPath,
+    selectedMaintenance
+  ])
 
   const resetRun = useCallback((): void => {
     setLog([])
@@ -367,6 +407,32 @@ export function FirmwareFlasher({ onClose }: FirmwareFlasherProps): JSX.Element 
         }
         const serialPort = await requestEspPort()
         await flashEspInBrowser(serialPort, { firmware: webFirmwareBytes, offset }, handleProgress)
+        return
+      }
+      if (browserMicrobitViaWebUsb) {
+        // Browser micro:bit flash via WebUSB/DAPLink: the device is
+        // requested here — inside this click handler — because
+        // `navigator.usb.requestDevice()` requires a user gesture (Web W3,
+        // issue #284).
+        if (!webFirmwareBytes) {
+          throw new Error('Choose a firmware .hex file first.')
+        }
+        const device = await requestMicrobitDevice()
+        await flashMicrobitInBrowser(device, webFirmwareBytes, handleProgress)
+        return
+      }
+      if (browserDriveCopy) {
+        // Browser guided drive-copy flash (RP2040 always; micro:bit when
+        // WebUSB isn't available or the user opted into this fallback). The
+        // save-file picker is requested here for the same user-gesture
+        // reason as above (Web W3, issue #284).
+        if (!webFirmwareBytes) {
+          throw new Error(
+            `Choose a firmware ${board === 'microbit' ? '.hex' : '.uf2'} file first.`
+          )
+        }
+        const suggestedName = firmwarePath || (board === 'microbit' ? 'firmware.hex' : 'firmware.uf2')
+        await copyFirmwareToDrive(webFirmwareBytes, suggestedName, handleProgress)
         return
       }
       if (usingCatalog) {
@@ -404,6 +470,8 @@ export function FirmwareFlasher({ onClose }: FirmwareFlasherProps): JSX.Element 
   }, [
     resetRun,
     isEsp,
+    browserMicrobitViaWebUsb,
+    browserDriveCopy,
     webFirmwareBytes,
     offset,
     handleProgress,
@@ -462,16 +530,11 @@ export function FirmwareFlasher({ onClose }: FirmwareFlasherProps): JSX.Element 
                 disabled={flashing || usingCatalog}
                 onChange={(e) => handleBoardChange(e.target.value as BoardType)}
               >
-                {(Object.keys(BOARD_LABELS) as BoardType[])
-                  // Outside Electron, only ESP32/ESP8266 flash today (Web
-                  // Serial via esptool-js) — RP2040/micro:bit browser flashing
-                  // is follow-up work (Web W3, issue #284).
-                  .filter((b) => isElectron() || isEspBoard(b))
-                  .map((b) => (
-                    <option key={b} value={b}>
-                      {BOARD_LABELS[b]}
-                    </option>
-                  ))}
+                {(Object.keys(BOARD_LABELS) as BoardType[]).map((b) => (
+                  <option key={b} value={b}>
+                    {BOARD_LABELS[b]}
+                  </option>
+                ))}
               </select>
               {isElectron() && (
                 <button
@@ -493,12 +556,6 @@ export function FirmwareFlasher({ onClose }: FirmwareFlasherProps): JSX.Element 
             {candidates.length > 0 && (
               <p className="firmware-hint">
                 Detected: {candidates.map((c) => c.label).join('; ')}
-              </p>
-            )}
-            {!isElectron() && (
-              <p className="firmware-hint">
-                micro:bit and Pico flashing in the browser are coming soon — use the desktop app for
-                those boards today.
               </p>
             )}
           </div>
@@ -563,8 +620,7 @@ export function FirmwareFlasher({ onClose }: FirmwareFlasherProps): JSX.Element 
                 </p>
               )}
             </>
-          ) : (
-
+          ) : isElectron() ? (
             <div className="firmware-field">
               <label className="firmware-field__label" htmlFor="firmware-mount">
                 {board === 'microbit' ? 'micro:bit drive (MICROBIT)' : 'RP2040 boot drive (RPI-RP2)'}
@@ -603,6 +659,54 @@ export function FirmwareFlasher({ onClose }: FirmwareFlasherProps): JSX.Element 
                   <strong>without holding the reset button</strong> so the MICROBIT drive appears,
                   then press Detect.
                 </p>
+              )}
+            </div>
+          ) : (
+            <div className="firmware-field">
+              <span className="firmware-field__label">
+                {board === 'microbit' ? 'micro:bit' : 'RP2040 (Pico) boot drive'}
+              </span>
+              {board === 'rp2040' && (
+                <p className="firmware-hint">
+                  Hold the <strong>BOOTSEL</strong> button while plugging your Pico in via USB, then
+                  click Flash — you&apos;ll be asked to pick the <strong>RPI-RP2</strong> drive that
+                  appears (File System Access — Chrome or Edge only).
+                </p>
+              )}
+              {board === 'microbit' && browserMicrobitViaWebUsb && (
+                <>
+                  <p className="firmware-hint">
+                    Clicking Flash will prompt you to select your micro:bit over WebUSB (Chrome or
+                    Edge only).
+                  </p>
+                  <button
+                    type="button"
+                    className="btn btn--ghost btn--sm"
+                    onClick={() => setMicrobitUseDriveCopy(true)}
+                    disabled={flashing}
+                  >
+                    Trouble connecting? Copy to drive instead
+                  </button>
+                </>
+              )}
+              {board === 'microbit' && !browserMicrobitViaWebUsb && (
+                <>
+                  <p className="firmware-hint">
+                    Plug your micro:bit in via USB, then click Flash — you&apos;ll be asked to pick
+                    the <strong>MICROBIT</strong> drive that appears (File System Access — Chrome or
+                    Edge only).
+                  </p>
+                  {hasWebUSB() && (
+                    <button
+                      type="button"
+                      className="btn btn--ghost btn--sm"
+                      onClick={() => setMicrobitUseDriveCopy(false)}
+                      disabled={flashing}
+                    >
+                      Use WebUSB instead
+                    </button>
+                  )}
+                </>
               )}
             </div>
           )}

--- a/src/renderer/src/lib/webFirmware/driveCopyFlash.ts
+++ b/src/renderer/src/lib/webFirmware/driveCopyFlash.ts
@@ -1,0 +1,114 @@
+/**
+ * Browser-native guided "drive-copy" firmware flashing (Web W3, issue #284).
+ *
+ * RP2040 (BOOTSEL bootloader) and BBC micro:bit both flash on desktop by
+ * copying a firmware file onto a mass-storage drive they mount as
+ * (`src/main/firmware/flasher.ts` does this with a plain `fs` stream copy —
+ * `.uf2` onto `RPI-RP2`, `.hex` onto `MICROBIT`). A browser tab can't see or
+ * auto-detect that mounted drive, so this flow instead GUIDES the user
+ * through the manual steps (hold BOOTSEL and plug in for RP2040; just plug
+ * in for a micro:bit) and then uses the File System Access API's save-file
+ * picker (`window.showSaveFilePicker`) to write the firmware bytes onto
+ * whichever drive the user navigates to and picks in that OS-native dialog.
+ *
+ * This is the ONLY flashing option for RP2040 in a browser — BOOTSEL is pure
+ * USB mass storage, with no WebUSB/DAPLink interface to talk to — and is
+ * offered as an explicit fallback button for micro:bit boards where WebUSB
+ * DAPLink (`microbitFlash.ts`) isn't available or doesn't respond (notably
+ * older micro:bit v1 DAPLink firmware).
+ *
+ * Feature-detected via `hasFileSystemAccess()` from `../platform`; callers
+ * should show a clear "use Chrome/Edge" message when it's unavailable — as
+ * of writing, Firefox and Safari don't implement `showSaveFilePicker`.
+ *
+ * `FlashProgress`/`FlashResult` are the SAME shapes the desktop flasher
+ * emits (re-exported, type-only, from the preload), so `FirmwareFlasher.tsx`
+ * can render this alongside the ESP/micro:bit flows with identical
+ * log/progress UI.
+ */
+import { hasFileSystemAccess } from '../platform'
+import type { FlashProgress, FlashResult } from '../../../../preload/index.d'
+
+/** Minimal shape of a File System Access API writable stream this module needs. */
+export interface FileSystemWritableFileStreamLike {
+  write(data: BufferSource): Promise<void>
+  close(): Promise<void>
+}
+
+/** Minimal shape of a File System Access API file handle this module needs. */
+export interface FileSystemFileHandleLike {
+  createWritable(): Promise<FileSystemWritableFileStreamLike>
+}
+
+/** Minimal shape of `window.showSaveFilePicker`, narrowed to what this module calls. */
+export type SaveFilePickerLike = (options?: {
+  suggestedName?: string
+  types?: { description?: string; accept: Record<string, string[]> }[]
+}) => Promise<FileSystemFileHandleLike>
+
+/**
+ * Everything the flow needs from the File System Access API, injectable so
+ * tests can substitute a fake picker/stream without a real OS file dialog.
+ */
+export interface DriveCopyDriver {
+  showSaveFilePicker: SaveFilePickerLike
+}
+
+/** The real browser-backed driver, used in production. */
+export const realDriveCopyDriver: DriveCopyDriver = {
+  showSaveFilePicker: (options) =>
+    (window as unknown as { showSaveFilePicker: SaveFilePickerLike }).showSaveFilePicker(options)
+}
+
+/** A sink for streamed progress lines — same shape the desktop flasher emits. */
+export type Emit = (p: FlashProgress) => void
+
+/**
+ * Write `firmware` bytes to a user-picked location via the save-file picker,
+ * streaming progress through `emit`. Intended to be called AFTER the user
+ * has been shown on-screen instructions for mounting the target drive (hold
+ * BOOTSEL and plug in for RP2040; just plug in for a micro:bit) — the
+ * `showSaveFilePicker` dialog itself is where they navigate to and select
+ * that mounted drive, `suggestedName` pre-fills the filename (e.g.
+ * `firmware.uf2`) so they just need to pick the right folder.
+ */
+export async function copyFirmwareToDrive(
+  // Constrained to a real `ArrayBuffer` (never `SharedArrayBuffer`) so it
+  // satisfies `FileSystemWritableFileStream.write()`'s `BufferSource` type —
+  // matches what `new Uint8Array(await file.arrayBuffer())` actually produces.
+  firmware: Uint8Array<ArrayBuffer>,
+  suggestedName: string,
+  emit: Emit,
+  driver: DriveCopyDriver = realDriveCopyDriver
+): Promise<FlashResult> {
+  if (!hasFileSystemAccess()) {
+    const message =
+      'Saving directly to a drive is not available in this browser. Use Google Chrome or Microsoft Edge.'
+    emit({ kind: 'error', message })
+    emit({ kind: 'done', ok: false, message })
+    return { ok: false, error: message }
+  }
+
+  let result: FlashResult
+  try {
+    emit({ kind: 'log', message: `Choose the mounted drive, keeping the name "${suggestedName}"…` })
+    const handle = await driver.showSaveFilePicker({ suggestedName })
+    const writable = await handle.createWritable()
+    emit({ kind: 'log', message: 'Copying firmware…', percent: 0 })
+    await writable.write(firmware)
+    await writable.close()
+    emit({ kind: 'log', message: 'Copy complete.', percent: 100 })
+    result = { ok: true }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    emit({ kind: 'error', message })
+    result = { ok: false, error: message }
+  }
+
+  emit({
+    kind: 'done',
+    ok: result.ok,
+    message: result.ok ? 'Done.' : (result.error ?? 'Copy failed.')
+  })
+  return result
+}

--- a/src/renderer/src/lib/webFirmware/microbitFlash.ts
+++ b/src/renderer/src/lib/webFirmware/microbitFlash.ts
@@ -1,0 +1,144 @@
+/**
+ * Browser-native BBC micro:bit firmware flashing (Web W3, issue #284).
+ *
+ * The desktop app copies a `.hex` file onto the mounted `MICROBIT` drive
+ * (`src/main/firmware/flasher.ts`) — the SAME drive-copy mechanism it uses
+ * for RP2040. A browser tab can't see or auto-mount that drive directly, but
+ * a micro:bit's on-board DAPLink interface chip also speaks CMSIS-DAP over
+ * WebUSB, so this flashes it directly via ARM's `dapjs`, following the same
+ * approach MakeCode uses for its "Connect device" flash flow. Requires a
+ * Chromium browser with WebUSB (`navigator.usb`); callers should
+ * feature-detect with `hasWebUSB()` from `../platform` before offering this
+ * flow, and it must be triggered from a user gesture (a click), since
+ * `requestDevice()` requires one. `driveCopyFlash.ts` provides a guided
+ * fallback for browsers/boards where WebUSB DAPLink isn't available or
+ * doesn't respond (older micro:bit v1 DAPLink firmware in particular).
+ *
+ * dapjs's `WebUSB`/`DAPLink` are wrapped behind the small {@link
+ * MicrobitDriver} interface so the orchestration logic here — progress
+ * mapping, connect/flash/disconnect sequencing, error handling — is
+ * unit-testable without a real USB device (mirrors how `espFlash.ts` wraps
+ * esptool-js).
+ *
+ * `FlashProgress`/`FlashResult` are the SAME shapes the desktop flasher
+ * emits (re-exported, type-only, from the preload), so `FirmwareFlasher.tsx`
+ * can render both with identical log/progress UI.
+ */
+import { DAPLink, WebUSB } from 'dapjs'
+import { hasWebUSB } from '../platform'
+import type { FlashProgress, FlashResult } from '../../../../preload/index.d'
+
+/** ARM Mbed/DAPLink USB vendor id — the micro:bit's on-board interface chip. */
+export const MICROBIT_USB_VENDOR_ID = 0x0d28
+
+/** Minimal shape of dapjs's `DAPLink` target, narrowed to what this module calls. */
+export interface MicrobitTargetLike {
+  connect(): Promise<void>
+  disconnect(): Promise<void>
+  flash(buffer: BufferSource, pageSize?: number): Promise<void>
+}
+
+/**
+ * Everything the flash flow needs from dapjs, injectable so tests can
+ * substitute fakes. Generic over the transport type so `createTarget` gets
+ * back exactly what `createTransport` produced (no unsafe casts needed).
+ */
+export interface MicrobitDriver<TTransport = unknown> {
+  createTransport(device: USBDevice): TTransport
+  /**
+   * Builds the DAPLink target, wiring `onProgress` to its progress event
+   * (`DAPLink.EVENT_PROGRESS`, a 0–1 fraction) — kept out of the shared
+   * orchestration function below so it doesn't need to know dapjs's actual
+   * event-name constant.
+   */
+  createTarget(transport: TTransport, onProgress: (fraction: number) => void): MicrobitTargetLike
+}
+
+/** The real dapjs-backed driver, used in production. */
+export const realMicrobitDriver: MicrobitDriver<WebUSB> = {
+  createTransport: (device) => new WebUSB(device),
+  createTarget: (transport, onProgress) => {
+    const target = new DAPLink(transport)
+    target.on(DAPLink.EVENT_PROGRESS, onProgress)
+    return target
+  }
+}
+
+/** A sink for streamed progress lines — same shape the desktop flasher emits. */
+export type Emit = (p: FlashProgress) => void
+
+/**
+ * Map a dapjs `EVENT_PROGRESS` payload (a 0–1 fraction) to a
+ * {@link FlashProgress} line.
+ */
+export function mapDapProgress(fraction: number): FlashProgress {
+  const percent = Math.max(0, Math.min(100, Math.round(fraction * 100)))
+  return { kind: 'log', message: `Flashing… ${percent}%`, percent }
+}
+
+/**
+ * Request a micro:bit's DAPLink USB device via WebUSB (must be called from a
+ * user gesture). Throws a friendly error when WebUSB isn't available at all
+ * (non-Chromium browser) rather than letting `navigator.usb` be `undefined`
+ * throw a cryptic `TypeError`.
+ */
+export async function requestMicrobitDevice(): Promise<USBDevice> {
+  if (!hasWebUSB()) {
+    throw new Error(
+      'WebUSB is not available in this browser. Use Google Chrome or Microsoft Edge, or use ' +
+        '"Copy to drive" instead.'
+    )
+  }
+  return navigator.usb.requestDevice({ filters: [{ vendorId: MICROBIT_USB_VENDOR_ID }] })
+}
+
+/**
+ * Flash a BBC micro:bit over an already-selected WebUSB device. Dispatches
+ * to dapjs (via the injectable {@link MicrobitDriver}), streaming
+ * connect/flash progress through `emit`, and always emits a terminal `done`
+ * event — mirroring `flashEspInBrowser` in `espFlash.ts` so the renderer's
+ * log/progress UI works identically for every board.
+ */
+export async function flashMicrobitInBrowser<TTransport>(
+  device: USBDevice,
+  // Constrained to a real `ArrayBuffer` (never `SharedArrayBuffer`) so it
+  // satisfies dapjs's `BufferSource`-typed `flash()` — matches what
+  // `new Uint8Array(await file.arrayBuffer())` actually produces.
+  firmware: Uint8Array<ArrayBuffer>,
+  emit: Emit,
+  driver: MicrobitDriver<TTransport> = realMicrobitDriver as unknown as MicrobitDriver<TTransport>
+): Promise<FlashResult> {
+  let result: FlashResult
+  let target: MicrobitTargetLike | undefined
+  try {
+    const transport = driver.createTransport(device)
+    target = driver.createTarget(transport, (fraction) => emit(mapDapProgress(fraction)))
+
+    emit({ kind: 'log', message: 'Connecting to micro:bit…' })
+    await target.connect()
+
+    emit({ kind: 'log', message: 'Flashing…' })
+    await target.flash(firmware)
+    emit({ kind: 'log', message: 'Flash complete.' })
+
+    result = { ok: true }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    emit({ kind: 'error', message })
+    result = { ok: false, error: message }
+  } finally {
+    if (target) {
+      await target.disconnect().catch(() => {
+        // Best-effort: the device may already be gone (e.g. it reset after
+        // flashing), which isn't worth surfacing as an error.
+      })
+    }
+  }
+
+  emit({
+    kind: 'done',
+    ok: result.ok,
+    message: result.ok ? 'Done.' : (result.error ?? 'Flashing failed.')
+  })
+  return result
+}

--- a/test/driveCopyFlash.test.ts
+++ b/test/driveCopyFlash.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  copyFirmwareToDrive,
+  realDriveCopyDriver,
+  type DriveCopyDriver,
+  type FileSystemWritableFileStreamLike
+} from '../src/renderer/src/lib/webFirmware/driveCopyFlash'
+import type { FlashProgress } from '../src/main/firmware/types'
+
+/**
+ * Unit tests for the guided drive-copy flash flow (Web W3, issue #284).
+ * `window.showSaveFilePicker` is stubbed behind a fake `DriveCopyDriver` so
+ * this exercises the orchestration (feature detection, write/close
+ * sequencing, error handling) without a real OS file dialog. Tests that
+ * exercise the "available" path stub a minimal `window` global too, since
+ * `hasFileSystemAccess()` — the feature-detection gate — checks for
+ * `showSaveFilePicker` there (the vitest environment is plain Node, with no
+ * `window` at all).
+ */
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function makeFakeDriver(overrides?: {
+  write?: FileSystemWritableFileStreamLike['write']
+  close?: FileSystemWritableFileStreamLike['close']
+  showSaveFilePicker?: DriveCopyDriver['showSaveFilePicker']
+}): { driver: DriveCopyDriver; writes: BufferSource[]; closed: boolean } {
+  const writes: BufferSource[] = []
+  let closed = false
+  const writable: FileSystemWritableFileStreamLike = {
+    write:
+      overrides?.write ??
+      (async (data) => {
+        writes.push(data)
+      }),
+    close:
+      overrides?.close ??
+      (async () => {
+        closed = true
+      })
+  }
+  const driver: DriveCopyDriver = {
+    showSaveFilePicker:
+      overrides?.showSaveFilePicker ??
+      (async () => ({
+        createWritable: async () => writable
+      }))
+  }
+  return { driver, writes, closed }
+}
+
+describe('copyFirmwareToDrive', () => {
+  it('reports a friendly error when File System Access is unavailable', async () => {
+    // The vitest environment is plain Node — no `window`/`showSaveFilePicker`.
+    const events: FlashProgress[] = []
+    const result = await copyFirmwareToDrive(
+      new Uint8Array([1]),
+      'firmware.uf2',
+      (p) => events.push(p),
+      realDriveCopyDriver
+    )
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toMatch(/not available in this browser/)
+    expect(events.at(-1)?.kind).toBe('done')
+  })
+
+  it('writes the firmware bytes, closes the stream, and reports success', async () => {
+    vi.stubGlobal('window', { showSaveFilePicker: () => {} })
+    const { driver, writes } = makeFakeDriver()
+    const firmware = new Uint8Array([1, 2, 3, 4])
+    const events: FlashProgress[] = []
+
+    const result = await copyFirmwareToDrive(firmware, 'firmware.uf2', (p) => events.push(p), driver)
+
+    expect(result).toEqual({ ok: true })
+    expect(writes).toEqual([firmware])
+    expect(events.at(-1)).toEqual({ kind: 'done', ok: true, message: 'Done.' })
+  })
+
+  it('passes the suggested name through to the save-file picker', async () => {
+    vi.stubGlobal('window', { showSaveFilePicker: () => {} })
+    const showSaveFilePicker = vi.fn(async () => ({
+      createWritable: async () => ({ write: async () => {}, close: async () => {} })
+    }))
+    const { driver } = makeFakeDriver({ showSaveFilePicker })
+
+    await copyFirmwareToDrive(new Uint8Array([1]), 'my-firmware.hex', () => {}, driver)
+
+    expect(showSaveFilePicker).toHaveBeenCalledWith({ suggestedName: 'my-firmware.hex' })
+  })
+
+  it('reports failure when the user cancels the picker', async () => {
+    vi.stubGlobal('window', { showSaveFilePicker: () => {} })
+    const { driver } = makeFakeDriver({
+      showSaveFilePicker: async () => {
+        throw new Error('The user aborted a request.')
+      }
+    })
+
+    const result = await copyFirmwareToDrive(new Uint8Array([1]), 'firmware.uf2', () => {}, driver)
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toMatch(/aborted/)
+  })
+
+  it('reports failure when writing fails', async () => {
+    vi.stubGlobal('window', { showSaveFilePicker: () => {} })
+    const { driver } = makeFakeDriver({
+      write: async () => {
+        throw new Error('disk full')
+      }
+    })
+
+    const result = await copyFirmwareToDrive(new Uint8Array([1]), 'firmware.uf2', () => {}, driver)
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toMatch(/disk full/)
+  })
+})

--- a/test/microbitFlash.test.ts
+++ b/test/microbitFlash.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import {
+  MICROBIT_USB_VENDOR_ID,
+  flashMicrobitInBrowser,
+  mapDapProgress,
+  requestMicrobitDevice,
+  type MicrobitDriver,
+  type MicrobitTargetLike
+} from '../src/renderer/src/lib/webFirmware/microbitFlash'
+import type { FlashProgress } from '../src/main/firmware/types'
+
+/**
+ * Unit tests for the browser BBC micro:bit flash flow (Web W3, issue #284).
+ * dapjs's `WebUSB`/`DAPLink` are stubbed behind a fake `MicrobitDriver` so
+ * this exercises the orchestration (progress mapping, connect/flash/
+ * disconnect sequencing, error handling) without a real WebUSB device.
+ */
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('mapDapProgress', () => {
+  it('converts a 0-1 fraction to a rounded percentage', () => {
+    expect(mapDapProgress(0.5)).toEqual<FlashProgress>({
+      kind: 'log',
+      message: 'Flashing… 50%',
+      percent: 50
+    })
+    expect(mapDapProgress(0)).toEqual<FlashProgress>({
+      kind: 'log',
+      message: 'Flashing… 0%',
+      percent: 0
+    })
+    expect(mapDapProgress(1)).toEqual<FlashProgress>({
+      kind: 'log',
+      message: 'Flashing… 100%',
+      percent: 100
+    })
+  })
+
+  it('clamps out-of-range fractions', () => {
+    expect(mapDapProgress(-0.2).percent).toBe(0)
+    expect(mapDapProgress(1.5).percent).toBe(100)
+  })
+})
+
+describe('requestMicrobitDevice', () => {
+  it('throws a friendly error when WebUSB is unavailable', async () => {
+    // The vitest environment is plain Node — no `navigator.usb`.
+    await expect(requestMicrobitDevice()).rejects.toThrow(/WebUSB is not available/)
+  })
+
+  it('requests a device filtered to the DAPLink vendor id when WebUSB exists', async () => {
+    const requestDevice = vi.fn(async () => ({}) as USBDevice)
+    vi.stubGlobal('navigator', { userAgent: 'x', usb: { requestDevice } })
+
+    await requestMicrobitDevice()
+
+    expect(requestDevice).toHaveBeenCalledWith({ filters: [{ vendorId: MICROBIT_USB_VENDOR_ID }] })
+  })
+})
+
+/** A fake transport handle — just needs identity for the fake driver to track. */
+interface FakeTransport {
+  closed: boolean
+}
+
+function makeFakeDriver(overrides?: {
+  connect?: MicrobitTargetLike['connect']
+  flash?: MicrobitTargetLike['flash']
+}): { driver: MicrobitDriver<FakeTransport>; target: MicrobitTargetLike & { disconnected: boolean } } {
+  const target = {
+    disconnected: false,
+    connect: overrides?.connect ?? (async () => {}),
+    flash: overrides?.flash ?? (async () => {}),
+    disconnect: async () => {
+      target.disconnected = true
+    }
+  }
+  const driver: MicrobitDriver<FakeTransport> = {
+    createTransport: () => ({ closed: false }),
+    createTarget: (_transport, onProgress) => {
+      // Simulate dapjs emitting a couple of progress ticks during flash().
+      const originalFlash = target.flash
+      target.flash = async (buffer) => {
+        onProgress(0.5)
+        await originalFlash(buffer)
+        onProgress(1)
+      }
+      return target
+    }
+  }
+  return { driver, target }
+}
+
+describe('flashMicrobitInBrowser', () => {
+  const fakeDevice = {} as USBDevice
+
+  it('connects, flashes, disconnects, and reports success', async () => {
+    const { driver, target } = makeFakeDriver()
+    const events: FlashProgress[] = []
+
+    const result = await flashMicrobitInBrowser(
+      fakeDevice,
+      new Uint8Array([1, 2, 3]),
+      (p) => events.push(p),
+      driver
+    )
+
+    expect(result).toEqual({ ok: true })
+    expect(target.disconnected).toBe(true)
+    expect(events.some((e) => e.percent === 50)).toBe(true)
+    expect(events.some((e) => e.percent === 100)).toBe(true)
+    expect(events.at(-1)).toEqual({ kind: 'done', ok: true, message: 'Done.' })
+  })
+
+  it('reports failure and still disconnects when connect() rejects', async () => {
+    const { driver, target } = makeFakeDriver({
+      connect: async () => {
+        throw new Error('No device selected.')
+      }
+    })
+    const events: FlashProgress[] = []
+
+    const result = await flashMicrobitInBrowser(
+      fakeDevice,
+      new Uint8Array([1]),
+      (p) => events.push(p),
+      driver
+    )
+
+    expect(result).toEqual({ ok: false, error: 'No device selected.' })
+    expect(target.disconnected).toBe(true)
+    expect(events.at(-1)).toEqual({ kind: 'done', ok: false, message: 'No device selected.' })
+  })
+
+  it('reports failure when flash() rejects', async () => {
+    const { driver } = makeFakeDriver({
+      flash: async () => {
+        throw new Error('Flash error')
+      }
+    })
+
+    const result = await flashMicrobitInBrowser(fakeDevice, new Uint8Array([1]), () => {}, driver)
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toMatch(/Flash error/)
+  })
+
+  it('does not throw when disconnecting a lost device fails', async () => {
+    const target = {
+      connect: async () => {},
+      flash: async () => {},
+      disconnect: async () => {
+        throw new Error('device already gone')
+      }
+    }
+    const driver: MicrobitDriver<FakeTransport> = {
+      createTransport: () => ({ closed: false }),
+      createTarget: () => target
+    }
+
+    const result = await flashMicrobitInBrowser(fakeDevice, new Uint8Array([1]), () => {}, driver)
+
+    expect(result).toEqual({ ok: true })
+  })
+})


### PR DESCRIPTION
Part of #284, epic #267. Second of a 3-PR split for Web W3 (firmware flashing
+ parts installs + feature-flagged chrome). Stacked on #293 (PR1: ESP32/ESP8266
browser flashing + feature-flagged desktop chrome) — base branch is that PR's
branch, so this diff only shows the incremental change; once #293 merges,
GitHub will retarget this PR to `master` automatically.

## What's here

- **`src/renderer/src/lib/webFirmware/microbitFlash.ts`** — browser BBC
  micro:bit flashing over **WebUSB/DAPLink** via ARM's
  [`dapjs`](https://github.com/ARMmbed/dapjs), the same approach the MakeCode
  editor uses. Injectable driver interface mirrors PR1's `espFlash.ts`
  pattern; maps dapjs's raw 0-1 `EVENT_PROGRESS` fraction onto the shared
  `FlashProgress`/`FlashResult` shapes from `src/main/firmware/types.ts` so
  the existing modal's log/progress UI works unmodified.
- **`src/renderer/src/lib/webFirmware/driveCopyFlash.ts`** — a generic
  guided drive-copy flow for boards that mount as mass storage (RP2040
  BOOTSEL `.uf2`, micro:bit DAPLink-fallback `.hex`), using the File
  System Access API's `showSaveFilePicker` to write firmware bytes
  straight onto whichever drive the user picks - no auto-detected
  mass-storage path required in the browser.
- **`FirmwareFlasher.tsx`** - all four board types are now selectable
  outside Electron:
  - micro:bit defaults to WebUSB/DAPLink, with a one-click "Copy to drive
    instead" escape hatch (and automatic fallback when the browser has no
    WebUSB) for boards/browsers where DAPLink doesn't respond (e.g. some
    micro:bit v1 DAPLink firmware).
  - RP2040 always uses the guided drive-copy flow in the browser, since its
    BOOTSEL bootloader is pure USB mass-storage with no WebUSB interface.
  - Desktop Electron flashing paths (esptool shell-out, fs-based drive
    copy) are completely unchanged.
- 13 new unit tests (test/microbitFlash.test.ts, test/driveCopyFlash.test.ts)
  against fake injected drivers (dapjs/File System Access mocked out).
- CHANGELOG.md [Unreleased] updated (MINOR - new feature; not bumping
  package.json here per repo convention).

## Verification

- `npm run lint` - clean (only the pre-existing unrelated
  `DriverInstallBanner.tsx` warning).
- `npm run typecheck` (node + web) - clean.
- `npm test` - 1399/1399 passing.
- `npm run build` - succeeds.

## Follow-up

PR3 (final part of #284): parts-registry zip/tarball install fallback for
when git isn't usable. Issue #284 stays open until all 3 land.
