### PR TITLE
Data View: column summary side panel (#276, epic #272 step 2b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Data View — column summary side panel (#276, epic #272).** A "Columns"
+  panel (DuckDB Column Explorer style) profiles every column of the current
+  filtered view: numbers/timestamps get a histogram with min/max/mean/median;
+  text gets its top values as frequency bars; each card shows the null/gap %
+  (the dropped-reading count that teaches data quality). Compact sparklines by
+  default — click a card to expand to the full chart + stats. Recomputes as you
+  sort/filter, and only computes while the panel is open.
 - **Data View — sort, filter and a live column summary (#275, epic #272).**
   Click a column header to sort it (type-aware — numbers order 2 < 10 < 100, not
   lexically; timestamps chronologically; asc → desc → off), with nulls always

--- a/src/renderer/src/components/DataColumnPanel.css
+++ b/src/renderer/src/components/DataColumnPanel.css
@@ -1,0 +1,209 @@
+/* DATA COLUMN PANEL (#276) — column summary side panel. Prefix `dcp__`. */
+
+.dcp {
+  flex: 0 0 232px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  border-left: 1px solid var(--border, #2c2e33);
+  background: var(--bg-elevated, #212226);
+  font-family: var(--font-mono), 'JetBrains Mono', monospace;
+}
+
+.dcp__head {
+  flex: 0 0 auto;
+  padding: 0.4rem 0.7rem;
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-muted, #8b919b);
+  border-bottom: 1px solid var(--border, #2c2e33);
+}
+
+.dcp__list {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0.3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+/* --- One column card ------------------------------------------------------- */
+.dcp__card {
+  border: 1px solid var(--border, #2c2e33);
+  border-radius: 5px;
+  background: var(--bg, #1b1c1f);
+  overflow: hidden;
+}
+.dcp__card.is-expanded {
+  border-color: #3f6f8f;
+}
+
+.dcp__card-head {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.45rem;
+  font: inherit;
+  background: transparent;
+  border: none;
+  color: var(--text, #d6dae0);
+  cursor: pointer;
+}
+.dcp__card-head:hover {
+  background: rgba(128, 148, 200, 0.08);
+}
+
+.dcp__card-caret {
+  flex: 0 0 auto;
+  font-size: 0.6rem;
+  color: var(--text-muted, #8b919b);
+}
+
+.dcp__card-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.dcp__card-type {
+  flex: 0 0 auto;
+  font-size: 0.52rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--text-muted, #8b919b);
+}
+.dcp__card-type--number {
+  color: #7fc4f0;
+}
+.dcp__card-type--timestamp {
+  color: #b58aef;
+}
+.dcp__card-type--string {
+  color: #8b919b;
+}
+
+.dcp__card-gap {
+  flex: 0 0 auto;
+  font-size: 0.54rem;
+  color: #e0a44a;
+}
+
+/* --- Body ------------------------------------------------------------------ */
+.dcp__body {
+  padding: 0.1rem 0.5rem 0.5rem;
+}
+
+.dcp__empty {
+  margin: 0;
+  padding: 0.2rem 0.5rem 0.5rem;
+  font-size: 0.62rem;
+  font-style: italic;
+  color: var(--text-muted, #6b7078);
+}
+
+/* Histogram (bars). */
+.dcp__hist {
+  display: flex;
+  align-items: flex-end;
+  gap: 1px;
+  height: 30px;
+  margin-bottom: 0.25rem;
+}
+.dcp__hist--tall {
+  height: 64px;
+}
+.dcp__bar {
+  flex: 1 1 auto;
+  min-height: 1px;
+  background: #4f8fbf;
+  border-radius: 1px 1px 0 0;
+}
+.is-expanded .dcp__bar {
+  background: #5fa8dc;
+}
+
+.dcp__range {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.58rem;
+  color: var(--text-muted, #8b919b);
+}
+.dcp__range-mid {
+  color: #7fc4f0;
+}
+
+.dcp__stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1px 0.6rem;
+  margin: 0.35rem 0 0;
+  font-size: 0.6rem;
+}
+.dcp__stats div {
+  display: flex;
+  justify-content: space-between;
+}
+.dcp__stats dt {
+  color: var(--text-muted, #7d838d);
+}
+.dcp__stats dd {
+  margin: 0;
+  color: var(--text, #d6dae0);
+}
+
+/* Text: frequency bars. */
+.dcp__uniq {
+  font-size: 0.58rem;
+  color: var(--text-muted, #8b919b);
+  margin-bottom: 0.25rem;
+}
+.dcp__freq {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.dcp__freq-row {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.6rem;
+}
+.dcp__freq-label {
+  flex: 0 0 auto;
+  max-width: 90px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text, #cdd2d9);
+  z-index: 1;
+}
+.dcp__freq-bar {
+  flex: 0 0 auto;
+  height: 8px;
+  min-width: 2px;
+  background: rgba(95, 168, 220, 0.4);
+  border-radius: 2px;
+}
+.dcp__freq-count {
+  margin-left: auto;
+  color: var(--text-muted, #7d838d);
+}
+.dcp__more {
+  margin-top: 0.25rem;
+  font-size: 0.56rem;
+  color: var(--text-muted, #6b7078);
+}

--- a/src/renderer/src/components/DataColumnPanel.tsx
+++ b/src/renderer/src/components/DataColumnPanel.tsx
@@ -1,0 +1,178 @@
+import { useMemo, useState } from 'react'
+import type { Column } from './data-table'
+import {
+  profileColumn,
+  gapPercent,
+  type ColumnProfile,
+  type NumericProfile,
+  type TextProfile
+} from './data-view-profile'
+import './DataColumnPanel.css'
+
+/**
+ * DATA COLUMN PANEL (#276, epic #272) — the DuckDB Column Explorer: a side panel
+ * that profiles every column of the CURRENT (filtered/sorted) view.
+ * =============================================================================
+ *
+ * One card per column, type-aware: numbers/timestamps get a histogram +
+ * min/max/mean/median; text gets its top values by frequency. Every card shows
+ * the null/gap % (dropped-reading quality signal). Compact by default — a
+ * sparkline you can click to expand to the full chart. Recomputes whenever the
+ * view changes; only mounted (hence only computed) when the panel is open.
+ */
+export function DataColumnPanel({
+  columns,
+  rows,
+  view
+}: {
+  columns: readonly Column[]
+  rows: readonly string[][]
+  /** Filtered/sorted row indices (the visible set). */
+  view: readonly number[]
+}): JSX.Element {
+  const profiles = useMemo(
+    () => columns.map((c) => profileColumn(rows, c.index, c.type, view)),
+    [columns, rows, view]
+  )
+  const [expanded, setExpanded] = useState<Set<number>>(new Set())
+  const toggle = (idx: number): void =>
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(idx)) next.delete(idx)
+      else next.add(idx)
+      return next
+    })
+
+  return (
+    <aside className="dcp" aria-label="Column summary">
+      <div className="dcp__head">Columns</div>
+      <div className="dcp__list">
+        {columns.map((c, i) => (
+          <ColumnCard
+            key={c.index}
+            column={c}
+            profile={profiles[i]}
+            expanded={expanded.has(c.index)}
+            onToggle={() => toggle(c.index)}
+          />
+        ))}
+      </div>
+    </aside>
+  )
+}
+
+function ColumnCard({
+  column,
+  profile,
+  expanded,
+  onToggle
+}: {
+  column: Column
+  profile: ColumnProfile
+  expanded: boolean
+  onToggle: () => void
+}): JSX.Element {
+  const gap = gapPercent(profile)
+  return (
+    <div className={`dcp__card${expanded ? ' is-expanded' : ''}`}>
+      <button type="button" className="dcp__card-head" onClick={onToggle} aria-expanded={expanded}>
+        <span className="dcp__card-caret" aria-hidden="true">
+          {expanded ? '▾' : '▸'}
+        </span>
+        <span className="dcp__card-name" title={column.name}>
+          {column.name}
+        </span>
+        <span className={`dcp__card-type dcp__card-type--${column.type}`}>{column.type}</span>
+        {gap > 0 && (
+          <span className="dcp__card-gap" title={`${profile.nulls} empty / dropped`}>
+            {gap < 1 ? '<1' : Math.round(gap)}% ∅
+          </span>
+        )}
+      </button>
+      {profile.kind === 'string'
+        ? renderText(profile, expanded)
+        : renderNumeric(profile, expanded)}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Numeric / timestamp: a histogram + stats.
+// ---------------------------------------------------------------------------
+function renderNumeric(p: NumericProfile, expanded: boolean): JSX.Element {
+  if (p.count === 0) return <p className="dcp__empty">all empty</p>
+  const fmt = (n: number): string =>
+    p.kind === 'timestamp' ? tsShort(n) : Math.abs(n) >= 1000 ? n.toFixed(0) : n.toFixed(2)
+  const peak = Math.max(1, ...p.bins)
+  return (
+    <div className="dcp__body">
+      <div className={`dcp__hist${expanded ? ' dcp__hist--tall' : ''}`} role="img" aria-label="distribution">
+        {p.bins.map((b, i) => (
+          <div
+            key={i}
+            className="dcp__bar"
+            style={{ height: `${(b / peak) * 100}%` }}
+            title={`${fmt(p.binEdges[i])}–${fmt(p.binEdges[i + 1])}: ${b}`}
+          />
+        ))}
+      </div>
+      {expanded ? (
+        <dl className="dcp__stats">
+          <div><dt>min</dt><dd>{fmt(p.min)}</dd></div>
+          <div><dt>max</dt><dd>{fmt(p.max)}</dd></div>
+          {p.kind === 'number' && (
+            <>
+              <div><dt>mean</dt><dd>{fmt(p.mean)}</dd></div>
+              <div><dt>median</dt><dd>{fmt(p.median)}</dd></div>
+            </>
+          )}
+          <div><dt>count</dt><dd>{p.count.toLocaleString()}</dd></div>
+          {p.nulls > 0 && (
+            <div><dt>empty</dt><dd>{p.nulls.toLocaleString()}</dd></div>
+          )}
+        </dl>
+      ) : (
+        <div className="dcp__range">
+          <span>{fmt(p.min)}</span>
+          {p.kind === 'number' && <span className="dcp__range-mid">μ {fmt(p.mean)}</span>}
+          <span>{fmt(p.max)}</span>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Text: top values by frequency.
+// ---------------------------------------------------------------------------
+function renderText(p: TextProfile, expanded: boolean): JSX.Element {
+  if (p.count === 0) return <p className="dcp__empty">all empty</p>
+  const peak = Math.max(1, ...p.top.map((t) => t.count))
+  const shown = expanded ? p.top : p.top.slice(0, 3)
+  return (
+    <div className="dcp__body">
+      <div className="dcp__uniq">{p.distinct.toLocaleString()} distinct</div>
+      <ul className="dcp__freq">
+        {shown.map((t) => (
+          <li key={t.value} className="dcp__freq-row" title={`${t.value}: ${t.count}`}>
+            <span className="dcp__freq-label">{t.value}</span>
+            <span className="dcp__freq-bar" style={{ width: `${(t.count / peak) * 100}%` }} />
+            <span className="dcp__freq-count">{t.count.toLocaleString()}</span>
+          </li>
+        ))}
+      </ul>
+      {!expanded && p.top.length > 3 && (
+        <div className="dcp__more">+{p.distinct - 3} more</div>
+      )}
+    </div>
+  )
+}
+
+/** Short timestamp label (epoch-ms date or ms-of-day clock). */
+function tsShort(ms: number): string {
+  if (ms < 86400000) {
+    const s = Math.floor(ms / 1000)
+    return `${String(Math.floor(s / 3600)).padStart(2, '0')}:${String(Math.floor((s % 3600) / 60)).padStart(2, '0')}`
+  }
+  return new Date(ms).toISOString().slice(0, 10)
+}

--- a/src/renderer/src/components/DataView.css
+++ b/src/renderer/src/components/DataView.css
@@ -78,9 +78,17 @@
   user-select: none;
 }
 
+/* --- Main row: the scrolling table + the (optional) column panel ----------- */
+.dv__main {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+}
+
 /* --- Scroll viewport (both axes) ------------------------------------------- */
 .dv__grid {
   flex: 1 1 auto;
+  min-width: 0;
   min-height: 0;
   overflow: auto;
 }

--- a/src/renderer/src/components/DataView.tsx
+++ b/src/renderer/src/components/DataView.tsx
@@ -10,6 +10,7 @@ import {
   type SortState,
   type ColumnSummary
 } from './data-view-ops'
+import { DataColumnPanel } from './DataColumnPanel'
 import './DataView.css'
 
 /**
@@ -49,6 +50,7 @@ export function DataView(): JSX.Element {
   const [sort, setSort] = useState<SortState | null>(null)
   const [filters, setFilters] = useState<Map<number, Filter>>(new Map())
   const [showFilters, setShowFilters] = useState(false)
+  const [showPanel, setShowPanel] = useState(false)
   useEffect(() => {
     setHeaderOverride(null)
     setSort(null)
@@ -171,6 +173,14 @@ export function DataView(): JSX.Element {
               Clear
             </button>
           )}
+          <button
+            type="button"
+            className={`dv__btn${showPanel ? ' is-on' : ''}`}
+            onClick={() => setShowPanel((s) => !s)}
+            title="Column summary — profiles, histograms and gap %"
+          >
+            Columns
+          </button>
           <label className="dv__toggle">
             <input
               type="checkbox"
@@ -182,6 +192,7 @@ export function DataView(): JSX.Element {
         </div>
       </div>
 
+      <div className="dv__main">
       <div className="dv__grid" ref={scrollRef} onScroll={(e) => setScrollTop(e.currentTarget.scrollTop)}>
         <div className="dv__inner" style={{ width: innerW + 48 }}>
           <div className="dv__top">
@@ -235,6 +246,8 @@ export function DataView(): JSX.Element {
             {visible}
           </div>
         </div>
+      </div>
+      {showPanel && <DataColumnPanel columns={columns} rows={rows} view={view} />}
       </div>
     </div>
   )

--- a/src/renderer/src/components/data-view-profile.ts
+++ b/src/renderer/src/components/data-view-profile.ts
@@ -1,0 +1,148 @@
+/**
+ * DATA VIEW column profiling (#276, epic #272) — per-column distributions for
+ * the summary side panel (the DuckDB Column Explorer pattern).
+ * =============================================================================
+ *
+ * Builds a type-aware profile over a set of row INDICES (the filtered/visible
+ * set from {@link ./data-view-ops}): numeric/timestamp → min/max/mean/median +
+ * a histogram; text → the top values by frequency. Plus the null/gap count,
+ * which teaches data-quality (dropped readings are common in device logs).
+ *
+ * Pure + DOM-free → unit-tested. One O(n) pass for the stats + one O(n log n)
+ * sort for the median; only run when the panel is open (see DataColumnPanel).
+ */
+import { numericValue } from './data-view-ops'
+import type { ColumnType } from './data-table'
+
+export interface NumericProfile {
+  kind: 'number' | 'timestamp'
+  /** Non-null values counted. */
+  count: number
+  /** Null / blank / non-parseable values in the visible set. */
+  nulls: number
+  min: number
+  max: number
+  mean: number
+  median: number
+  /** Histogram bucket counts. */
+  bins: number[]
+  /** Bucket edges (length = bins.length + 1). */
+  binEdges: number[]
+}
+
+export interface TextProfile {
+  kind: 'string'
+  count: number
+  nulls: number
+  distinct: number
+  /** The most frequent values, descending, capped. */
+  top: Array<{ value: string; count: number }>
+}
+
+export type ColumnProfile = NumericProfile | TextProfile
+
+export const DEFAULT_BINS = 16
+export const DEFAULT_TOP_K = 10
+
+/** Bucket `values` into `binCount` equal-width bins across [min, max]. */
+export function histogram(
+  values: readonly number[],
+  min: number,
+  max: number,
+  binCount: number = DEFAULT_BINS
+): { bins: number[]; binEdges: number[] } {
+  const n = Math.max(1, Math.floor(binCount))
+  const bins = new Array(n).fill(0)
+  const binEdges = new Array(n + 1)
+  const span = max - min
+  for (let i = 0; i <= n; i++) binEdges[i] = span === 0 ? min : min + (span * i) / n
+  if (span === 0) {
+    bins[0] = values.length
+    return { bins, binEdges }
+  }
+  for (const v of values) {
+    let b = Math.floor(((v - min) / span) * n)
+    if (b < 0) b = 0
+    if (b >= n) b = n - 1 // the max value lands in the last bin
+    bins[b]++
+  }
+  return { bins, binEdges }
+}
+
+/** Median of an already-collected value list (sorts a copy). */
+export function median(values: readonly number[]): number {
+  if (values.length === 0) return 0
+  const s = [...values].sort((a, b) => a - b)
+  const mid = s.length >> 1
+  return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2
+}
+
+/** Null / gap percentage (0–100) of a profile — dropped-reading quality signal. */
+export function gapPercent(p: ColumnProfile): number {
+  const total = p.count + p.nulls
+  return total === 0 ? 0 : (p.nulls / total) * 100
+}
+
+/**
+ * Profile one column over `indices`. Numeric/timestamp → stats + histogram;
+ * text → top values. Recomputed whenever the filtered view changes.
+ */
+export function profileColumn(
+  rows: readonly string[][],
+  col: number,
+  type: ColumnType,
+  indices: readonly number[],
+  binCount: number = DEFAULT_BINS,
+  topK: number = DEFAULT_TOP_K
+): ColumnProfile {
+  if (type === 'number' || type === 'timestamp') {
+    const vals: number[] = []
+    let nulls = 0
+    for (const i of indices) {
+      const v = numericValue(rows[i][col] ?? '', type)
+      if (Number.isNaN(v)) nulls++
+      else vals.push(v)
+    }
+    if (vals.length === 0) {
+      return { kind: type, count: 0, nulls, min: 0, max: 0, mean: 0, median: 0, bins: [], binEdges: [] }
+    }
+    let min = Infinity
+    let max = -Infinity
+    let sum = 0
+    for (const v of vals) {
+      if (v < min) min = v
+      if (v > max) max = v
+      sum += v
+    }
+    const { bins, binEdges } = histogram(vals, min, max, binCount)
+    return {
+      kind: type,
+      count: vals.length,
+      nulls,
+      min,
+      max,
+      mean: sum / vals.length,
+      median: median(vals),
+      bins,
+      binEdges
+    }
+  }
+
+  const freq = new Map<string, number>()
+  let nulls = 0
+  let count = 0
+  for (const i of indices) {
+    const v = (rows[i][col] ?? '').trim()
+    if (v === '') {
+      nulls++
+      continue
+    }
+    count++
+    freq.set(v, (freq.get(v) ?? 0) + 1)
+  }
+  const top = [...freq.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, topK)
+    .map(([value, c]) => ({ value, count: c }))
+  return { kind: 'string', count, nulls, distinct: freq.size, top }
+}

--- a/test/dataColumnPanel.test.ts
+++ b/test/dataColumnPanel.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { DataColumnPanel } from '../src/renderer/src/components/DataColumnPanel'
+import type { Column } from '../src/renderer/src/components/data-table'
+
+const cols = (...types: Column['type'][]): Column[] =>
+  types.map((type, index) => ({ name: `c${index}`, type, index }))
+
+describe('DataColumnPanel render (#276)', () => {
+  const columns = cols('number', 'string')
+  const rows = [
+    ['10', 'ok'],
+    ['20', 'ok'],
+    ['', 'warm'], // null number → drives a gap %
+    ['30', 'cool'],
+    ['40', 'ok']
+  ]
+  const view = [0, 1, 2, 3, 4]
+
+  it('renders a card per column with the type chip', () => {
+    const html = renderToStaticMarkup(createElement(DataColumnPanel, { columns, rows, view }))
+    expect(html).toContain('Columns')
+    expect(html).toContain('dcp__card-type--number')
+    expect(html).toContain('dcp__card-type--string')
+  })
+
+  it('numeric column draws a histogram + a min/mean/max range', () => {
+    const html = renderToStaticMarkup(createElement(DataColumnPanel, { columns, rows, view }))
+    expect(html).toContain('dcp__hist')
+    expect(html).toContain('dcp__bar')
+    expect(html).toContain('μ') // mean marker in the compact range
+  })
+
+  it('text column draws frequency bars with the top value', () => {
+    const html = renderToStaticMarkup(createElement(DataColumnPanel, { columns, rows, view }))
+    expect(html).toContain('dcp__freq')
+    expect(html).toContain('distinct')
+    expect(html).toContain('ok') // most frequent value
+  })
+
+  it('surfaces the gap % for a column with dropped readings', () => {
+    const html = renderToStaticMarkup(createElement(DataColumnPanel, { columns, rows, view }))
+    // 1 null of 5 → 20% ∅ on the numeric card.
+    expect(html).toContain('∅')
+    expect(html).toContain('20%')
+  })
+
+  it('reflects a FILTERED view (only the given indices are profiled)', () => {
+    // Just the two rows with temp 10 and 20 → range 10–20, no gap.
+    const html = renderToStaticMarkup(
+      createElement(DataColumnPanel, { columns, rows, view: [0, 1] })
+    )
+    expect(html).toContain('10.00')
+    expect(html).toContain('20.00')
+    expect(html).not.toContain('40.00')
+  })
+})

--- a/test/dataViewProfile.test.ts
+++ b/test/dataViewProfile.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import {
+  histogram,
+  median,
+  gapPercent,
+  profileColumn,
+  type NumericProfile,
+  type TextProfile
+} from '../src/renderer/src/components/data-view-profile'
+
+describe('histogram (#276)', () => {
+  it('buckets values into equal-width bins; max lands in the last bin', () => {
+    const { bins, binEdges } = histogram([0, 1, 2, 3, 4], 0, 4, 4)
+    expect(bins).toHaveLength(4)
+    expect(binEdges).toEqual([0, 1, 2, 3, 4])
+    // 0→b0, 1→b1, 2→b2, 3→b3, 4→last bin (b3)
+    expect(bins).toEqual([1, 1, 1, 2])
+    expect(bins.reduce((a, b) => a + b, 0)).toBe(5)
+  })
+  it('a zero-span column puts everything in one bin', () => {
+    const { bins } = histogram([7, 7, 7], 7, 7, 8)
+    expect(bins[0]).toBe(3)
+    expect(bins.slice(1).every((b) => b === 0)).toBe(true)
+  })
+})
+
+describe('median (#276)', () => {
+  it('odd + even lengths, unsorted input', () => {
+    expect(median([3, 1, 2])).toBe(2)
+    expect(median([4, 1, 3, 2])).toBe(2.5)
+    expect(median([])).toBe(0)
+  })
+})
+
+describe('profileColumn (#276)', () => {
+  const rows = [
+    ['10', 'ok'],
+    ['20', 'ok'],
+    ['', 'warm'], // null number
+    ['30', 'cool'],
+    ['40', 'ok']
+  ]
+
+  it('numeric: stats + histogram + null count over the visible set', () => {
+    const p = profileColumn(rows, 0, 'number', [0, 1, 2, 3, 4], 4) as NumericProfile
+    expect(p.kind).toBe('number')
+    expect(p.count).toBe(4)
+    expect(p.nulls).toBe(1)
+    expect(p.min).toBe(10)
+    expect(p.max).toBe(40)
+    expect(p.mean).toBeCloseTo(25)
+    expect(p.median).toBeCloseTo(25)
+    expect(p.bins.reduce((a, b) => a + b, 0)).toBe(4) // every non-null value binned
+  })
+
+  it('recomputes for a filtered subset only', () => {
+    const p = profileColumn(rows, 0, 'number', [0, 1], 4) as NumericProfile
+    expect(p.count).toBe(2)
+    expect(p.max).toBe(20)
+    expect(p.nulls).toBe(0)
+  })
+
+  it('text: top values by frequency (desc) + distinct + nulls', () => {
+    const p = profileColumn(rows, 1, 'string', [0, 1, 2, 3, 4]) as TextProfile
+    expect(p.kind).toBe('string')
+    expect(p.distinct).toBe(3) // ok, warm, cool
+    expect(p.top[0]).toEqual({ value: 'ok', count: 3 })
+    expect(p.count).toBe(5)
+    expect(p.nulls).toBe(0)
+  })
+
+  it('gapPercent reflects the dropped readings', () => {
+    const p = profileColumn(rows, 0, 'number', [0, 1, 2, 3, 4]) // 1 null of 5
+    expect(gapPercent(p)).toBeCloseTo(20)
+  })
+
+  it('an all-null numeric column → count 0, empty histogram', () => {
+    const p = profileColumn([['']], 0, 'number', [0]) as NumericProfile
+    expect(p.count).toBe(0)
+    expect(p.nulls).toBe(1)
+    expect(p.bins).toEqual([])
+    expect(gapPercent(p)).toBe(100)
+  })
+
+  it('timestamps profile like numbers (row-count-over-time buckets)', () => {
+    const ts = [['2026-01-01'], ['2026-02-01'], ['2026-03-01'], ['2026-04-01']]
+    const p = profileColumn(ts, 0, 'timestamp', [0, 1, 2, 3], 4) as NumericProfile
+    expect(p.kind).toBe('timestamp')
+    expect(p.count).toBe(4)
+    expect(p.bins.reduce((a, b) => a + b, 0)).toBe(4)
+  })
+})


### PR DESCRIPTION
Builds on #274/#275. A "Columns" side panel — the DuckDB Column Explorer pattern — that profiles every column of the current filtered/sorted view.

## What
- **Per-column, type-aware profile**: numbers/timestamps → histogram + min/max/mean/median; text → top values as frequency bars.
- **Null / gap %** on every card — the dropped-reading count that teaches data quality.
- **Glance-then-expand**: compact sparkline by default; click a card to expand to the full histogram + stats (or the full top-K list).
- **Recomputes on sort/filter** (shares the same filtered `view` as #275), and only computes while the panel is open.

## Correctness
- `data-view-profile.ts` is pure — **9 unit tests** (histogram bucketing incl. max-in-last-bin + zero-span, median odd/even, profile over a filtered subset, gap %, all-null column, timestamp buckets).
- Plus a **static-render test** of `DataColumnPanel` (histogram bars, frequency bars, gap %, and that a filtered `view` profiles only those rows).

## Note
Browser smoke skipped this round — `playwright` is no longer in `node_modules` (earlier runs had it). The component's output is covered by the static-render test instead; I visually verified the surrounding Data View surface in #274/#275.

Gate: typecheck + lint clean, **1400 tests** (14 new), build ✅.

Part of epic #272. Next: #277 pull-from-board + live tail, #278 graph, #279 export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
