### PR TITLE
Breadboard background is graph paper that pans/scales with the parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   store (writable without elevation).
 
 ### Changed
+- **Breadboard grid is now graph paper (#…).** The Board View's wiring
+  background scales and pans WITH the parts instead of sitting fixed behind
+  them — like paper the parts are placed on. The smallest square is the real
+  **2.54 mm** (0.1") pin pitch, so pads land on grid lines; 1-inch major lines
+  anchor the view, and a finer half-pitch grid fades in as you zoom in (the
+  minor grid fades out as you zoom out). Lines stay crisp at any zoom.
 - **Three focused modes: Code · Board · Data Lab (modes review).** The
   four-workspace switcher slims to three — *Lab* and *Data* merged into **Data
   Lab** (instrument bench + a tall console/plotter); existing layouts migrate

--- a/src/renderer/src/components/WiringCanvas.css
+++ b/src/renderer/src/components/WiringCanvas.css
@@ -20,12 +20,30 @@
   flex: 1 1 auto;
   min-height: 0;
   overflow: hidden;
+  /* The graph-paper grid is now drawn IN the SVG (see .wc__grid) so it pans and
+     scales with the parts; the stage is just the flat "desk" behind it. */
   background-color: #161719;
-  background-image:
-    linear-gradient(rgba(255, 255, 255, 0.035) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255, 255, 255, 0.035) 1px, transparent 1px);
-  background-size: 28px 28px;
   transition: box-shadow 0.12s ease;
+}
+
+/* --- Graph-paper grid (drawn inside the pan/zoom content group) ------------- */
+.wc__grid {
+  fill: none;
+  /* Constant on-screen line weight regardless of zoom — crisp at any scale. */
+  vector-effect: non-scaling-stroke;
+  stroke-width: 1;
+  shape-rendering: crispEdges;
+}
+.wc__grid--fine {
+  stroke: #7f8794;
+}
+.wc__grid--minor {
+  stroke: #8b93a1;
+}
+.wc__grid--major {
+  /* The 1-inch anchor lines — a touch brighter, like ruled paper. */
+  stroke: #9aa2b0;
+  stroke-width: 1.2;
 }
 
 /* A part is being dragged in from the Parts panel (#159) — frame the drop zone. */

--- a/src/renderer/src/components/WiringCanvas.tsx
+++ b/src/renderer/src/components/WiringCanvas.tsx
@@ -55,6 +55,79 @@ export type WiringRenderMode = 'lifelike' | 'schematic'
 
 const VIEW_W = 1180
 const VIEW_H = 720
+
+/** The breadboard "paper" grid pitch: the 2.54 mm (0.1") standard pin pitch. */
+const GRID_PITCH_MM = 2.54
+
+/**
+ * The graph-paper background grid (#…): drawn INSIDE the pan/zoom content group
+ * (in world coordinates) so it moves + scales with the parts like paper they're
+ * placed on, with `non-scaling-stroke` keeping the lines crisp at any zoom. The
+ * smallest square is the real 2.54 mm pin pitch; a finer half-pitch grid fades
+ * IN as you zoom in, and the minor grid fades OUT as you zoom out, leaving the
+ * 1-inch major lines as the anchor. Rendered as one `<path>` per level (cheap).
+ */
+function WiringGrid({
+  view,
+  pxPerMm
+}: {
+  view: { tx: number; ty: number; scale: number }
+  pxPerMm: number
+}): JSX.Element | null {
+  const { tx, ty, scale } = view
+  if (!(scale > 0) || !(pxPerMm > 0)) return null
+
+  // World-coordinate rectangle currently visible in the viewBox.
+  const wMinX = -tx / scale
+  const wMaxX = (VIEW_W - tx) / scale
+  const wMinY = -ty / scale
+  const wMaxY = (VIEW_H - ty) / scale
+
+  // Levels: [mm spacing, class, base opacity, fade-in start/full in viewBox px].
+  // A fadeFull of 0 means "always on" (the major anchor lines).
+  const levels: Array<{
+    mm: number
+    cls: string
+    base: number
+    fadeStart: number
+    fadeFull: number
+  }> = [
+    { mm: GRID_PITCH_MM / 2, cls: 'wc__grid--fine', base: 0.14, fadeStart: 12, fadeFull: 26 },
+    { mm: GRID_PITCH_MM, cls: 'wc__grid--minor', base: 0.3, fadeStart: 5, fadeFull: 14 },
+    { mm: GRID_PITCH_MM * 10, cls: 'wc__grid--major', base: 0.42, fadeStart: 0, fadeFull: 0 }
+  ]
+
+  const paths: JSX.Element[] = []
+  for (const lvl of levels) {
+    const worldStep = lvl.mm * pxPerMm
+    const viewStep = worldStep * scale // spacing in viewBox units
+    const opacity =
+      lvl.fadeFull > 0
+        ? Math.max(0, Math.min(1, (viewStep - lvl.fadeStart) / (lvl.fadeFull - lvl.fadeStart))) *
+          lvl.base
+        : lvl.base
+    if (opacity < 0.012) continue
+    // Safety cap: never emit an absurd number of lines (a level this dense has
+    // already faded to ~0 above, but guard the fully-opaque major just in case).
+    if ((wMaxX - wMinX) / worldStep > 700 || (wMaxY - wMinY) / worldStep > 700) continue
+
+    let d = ''
+    const kx0 = Math.ceil(wMinX / worldStep)
+    const kx1 = Math.floor(wMaxX / worldStep)
+    for (let k = kx0; k <= kx1; k++) {
+      const x = k * worldStep
+      d += `M${x.toFixed(1)} ${wMinY.toFixed(1)}L${x.toFixed(1)} ${wMaxY.toFixed(1)}`
+    }
+    const ky0 = Math.ceil(wMinY / worldStep)
+    const ky1 = Math.floor(wMaxY / worldStep)
+    for (let k = ky0; k <= ky1; k++) {
+      const y = k * worldStep
+      d += `M${wMinX.toFixed(1)} ${y.toFixed(1)}L${wMaxX.toFixed(1)} ${y.toFixed(1)}`
+    }
+    if (d) paths.push(<path key={lvl.cls} className={`wc__grid ${lvl.cls}`} d={d} strokeOpacity={opacity} />)
+  }
+  return <g className="wc__grid-layer" aria-hidden="true">{paths}</g>
+}
 // Left inset (viewBox units) reserved for the floating BROWSER (14rem, pinned
 // top-left) so a fit places the leftmost item to the RIGHT of it, not under it.
 const BROWSER_INSET = 300
@@ -1136,6 +1209,9 @@ export function WiringCanvas({ robot, onChange, libraries, boardDef, boardPart, 
               must be in scope for the life-like board body to paint. */}
           {boardDef && renderMode === 'lifelike' && <BoardDefs def={boardDef} />}
           <g className="wc__content" transform={`translate(${view.tx} ${view.ty}) scale(${view.scale})`}>
+            {/* Graph-paper grid at true 2.54 mm pitch — behind everything, moves
+                + scales with the parts (drawn in world coords). */}
+            <WiringGrid view={view} pxPerMm={pxPerMm} />
             {/* Subjects (the MCU + placed parts) FIRST — wires draw on top (#182). */}
             {subjects.map((s) => {
               const capsOn = renderMode === 'lifelike' && !dragRef.current && hover?.key === s.key


### PR DESCRIPTION
The Board View's wiring background was a **fixed screen-space CSS grid** (28px squares glued to the viewport). Now it's **graph paper the parts sit on** — it scales and pans WITH the parts.

## What changed
- The grid is drawn **inside** the pan/zoom content group (world coordinates), so panning moves it with the parts and zooming scales the squares.
- The **smallest square is the real 2.54 mm (0.1") pin pitch**, anchored to the board's px/mm — so pads land on grid lines.
- **Level-of-detail fade**: a **1-inch major** grid always anchors the view; the **2.54 mm minor** grid fades out as you zoom out; a **finer half-pitch** grid fades in as you zoom in. Opacity is derived from each level's on-screen spacing.
- `vector-effect: non-scaling-stroke` keeps lines a crisp 1px at any zoom; one `<path>` per level with bounded segment counts keeps it cheap.

## Verified
In-app (Playwright) at three zoom levels — the numbers confirm the LOD:
- **rest (146%)**: minor (op 0.3) + major (0.42); fine hidden
- **zoomed in (259%)**: fine fades in (op 0.07), minor full, major on — squares align to the Pico's pin rows
- **zoomed out**: minor fades (0.24), major anchors, fine gone

Segment counts stayed bounded (49–154). Gate: typecheck + lint clean, **1400 tests**, build ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
