### PR TITLE
fix: paper grid fills the whole stage + replaces the static blueprint/schematic grids

### DIFF
--- a/src/renderer/src/components/WiringCanvas.css
+++ b/src/renderer/src/components/WiringCanvas.css
@@ -52,18 +52,16 @@
   background-color: #191b1f;
 }
 
-/* Blueprint breadboard background (Settings → Appearance): classic blue paper
-   with a fine light grid + bolder major lines. Applied via `data-breadboard-bg`
-   on the Board View window's root. Scoped to the LIFELIKE breadboard — the
-   schematic view keeps a plain white/dark sheet (blueprint doesn't suit it). */
+/* Blueprint breadboard background (Settings → Appearance): classic blue paper.
+   Applied via `data-breadboard-bg` on the Board View window's root, scoped to
+   the LIFELIKE breadboard. The grid LINES come from the SVG graph-paper grid
+   now (which pans/scales with the parts); here we only set the blue paper +
+   recolour those lines to a light blue (see `.wc__grid` overrides below). */
 :root[data-breadboard-bg='blueprint'] .wc--lifelike .wc__stage {
   background-color: #0d3b66;
-  background-image:
-    linear-gradient(rgba(214, 230, 255, 0.28) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(214, 230, 255, 0.28) 1px, transparent 1px),
-    linear-gradient(rgba(214, 230, 255, 0.11) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(214, 230, 255, 0.11) 1px, transparent 1px);
-  background-size: 140px 140px, 140px 140px, 28px 28px, 28px 28px;
+}
+:root[data-breadboard-bg='blueprint'] .wc--lifelike .wc__grid {
+  stroke: #d6e6ff;
 }
 
 /* Keep the mat blue (not the dark drop tint) while dragging a part over blueprint. */
@@ -73,14 +71,14 @@
 
 /* SCHEMATIC view sheet — follows the skin, never the blueprint/dark breadboard
    mat. Dark theme keeps the existing dark mat (light-on-dark symbols); the light
-   (skeuomorph) theme uses a white sheet with a faint grid, and the symbol
-   overrides below flip the symbols to dark-on-white so they stay legible. */
+   (skeuomorph) theme uses a white sheet, and the symbol overrides below flip the
+   symbols to dark-on-white so they stay legible. The grid LINES come from the
+   SVG graph-paper grid — on the white sheet we darken them (see below). */
 :root[data-theme='skeuomorph'] .wc--schematic .wc__stage {
   background-color: #fbfbfa;
-  background-image:
-    linear-gradient(rgba(20, 30, 50, 0.06) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(20, 30, 50, 0.06) 1px, transparent 1px);
-  background-size: 28px 28px;
+}
+:root[data-theme='skeuomorph'] .wc--schematic .wc__grid {
+  stroke: #2c3648;
 }
 
 /* Dark-on-white schematic symbols for the light theme: a light symbol body with

--- a/src/renderer/src/components/WiringCanvas.tsx
+++ b/src/renderer/src/components/WiringCanvas.tsx
@@ -69,19 +69,36 @@ const GRID_PITCH_MM = 2.54
  */
 function WiringGrid({
   view,
-  pxPerMm
+  pxPerMm,
+  stageW,
+  stageH
 }: {
   view: { tx: number; ty: number; scale: number }
   pxPerMm: number
+  /** The SVG element's pixel size, to fill the letterbox margins too. */
+  stageW: number
+  stageH: number
 }): JSX.Element | null {
   const { tx, ty, scale } = view
   if (!(scale > 0) || !(pxPerMm > 0)) return null
 
-  // World-coordinate rectangle currently visible in the viewBox.
-  const wMinX = -tx / scale
-  const wMaxX = (VIEW_W - tx) / scale
-  const wMinY = -ty / scale
-  const wMaxY = (VIEW_H - ty) / scale
+  // The SVG uses viewBox 1180×720 with `preserveAspectRatio=meet`, so the
+  // viewBox is fitted + centred, leaving letterbox margins where user-space
+  // coords fall OUTSIDE [0,VIEW_W]×[0,VIEW_H]. Compute the REAL visible user-
+  // space rectangle so the grid fills the WHOLE stage, not just the viewBox.
+  const fit = stageW > 0 && stageH > 0 ? Math.min(stageW / VIEW_W, stageH / VIEW_H) : 1
+  const uW = fit > 0 ? stageW / fit : VIEW_W // user-space width visible
+  const uH = fit > 0 ? stageH / fit : VIEW_H
+  const uMinX = (VIEW_W - uW) / 2
+  const uMaxX = (VIEW_W + uW) / 2
+  const uMinY = (VIEW_H - uH) / 2
+  const uMaxY = (VIEW_H + uH) / 2
+
+  // World-coordinate rectangle currently visible across the whole stage.
+  const wMinX = (uMinX - tx) / scale
+  const wMaxX = (uMaxX - tx) / scale
+  const wMinY = (uMinY - ty) / scale
+  const wMaxY = (uMaxY - ty) / scale
 
   // Levels: [mm spacing, class, base opacity, fade-in start/full in viewBox px].
   // A fadeFull of 0 means "always on" (the major anchor lines).
@@ -109,7 +126,7 @@ function WiringGrid({
     if (opacity < 0.012) continue
     // Safety cap: never emit an absurd number of lines (a level this dense has
     // already faded to ~0 above, but guard the fully-opaque major just in case).
-    if ((wMaxX - wMinX) / worldStep > 700 || (wMaxY - wMinY) / worldStep > 700) continue
+    if ((wMaxX - wMinX) / worldStep > 1200 || (wMaxY - wMinY) / worldStep > 1200) continue
 
     let d = ''
     const kx0 = Math.ceil(wMinX / worldStep)
@@ -425,6 +442,18 @@ export function WiringCanvas({ robot, onChange, libraries, boardDef, boardPart, 
   const svgRef = useRef<SVGSVGElement>(null)
   const dragRef = useRef<Drag | null>(null)
   const [view, setView] = useState({ tx: 0, ty: 0, scale: 1 })
+  // The SVG's pixel size, so the graph-paper grid fills the letterbox margins
+  // (the viewBox is fitted + centred; the visible region is wider/taller).
+  const [stageSize, setStageSize] = useState({ w: 0, h: 0 })
+  useEffect(() => {
+    const el = svgRef.current
+    if (!el) return
+    const measure = (): void => setStageSize({ w: el.clientWidth, h: el.clientHeight })
+    measure()
+    const ro = new ResizeObserver(measure)
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
   // The floating project BROWSER's open state — lifted here so the fit math can
   // inset content to the right of it (so the leftmost item isn't hidden under it).
   // Focused chrome (Board mode) starts it collapsed so the canvas gets the room.
@@ -1211,7 +1240,7 @@ export function WiringCanvas({ robot, onChange, libraries, boardDef, boardPart, 
           <g className="wc__content" transform={`translate(${view.tx} ${view.ty}) scale(${view.scale})`}>
             {/* Graph-paper grid at true 2.54 mm pitch — behind everything, moves
                 + scales with the parts (drawn in world coords). */}
-            <WiringGrid view={view} pxPerMm={pxPerMm} />
+            <WiringGrid view={view} pxPerMm={pxPerMm} stageW={stageSize.w} stageH={stageSize.h} />
             {/* Subjects (the MCU + placed parts) FIRST — wires draw on top (#182). */}
             {subjects.map((s) => {
               const capsOn = renderMode === 'lifelike' && !dragRef.current && hover?.key === s.key


### PR DESCRIPTION
Two follow-ups to the graph-paper grid (#297), from your report.

## 1. The grid didn't fill the whole screen
The SVG viewBox (1180×720, `preserveAspectRatio=meet`) is fitted + centred, so there are **letterbox margins** where user-space coords fall outside the viewBox. The grid was computed only across `[0,VIEW_W]×[0,VIEW_H]`, leaving those margins bare. Now the SVG element is measured (ResizeObserver) and the grid is drawn over the **real visible user-space rectangle** — verified the grid's bounding box equals the stage's exactly (438×561, edge to edge).

## 2. Blueprint mode still showed the old static grid
**Blueprint** mode and the skeuomorph **schematic** sheet each still painted their own static CSS grid (`background: linear-gradient`) on the stage — doubling up with the new SVG grid. Dropped those CSS grid lines (kept the blue-paper / white-sheet **colours**) and recoloured the SVG grid per context: **light blue** on blueprint, **dark** on the white schematic sheet.

Verified in-app: default fills the stage; blueprint is now a single light-blue graph-paper grid on blue paper (`backgroundImage: none`), filling edge to edge with parts on top.

Gate: typecheck + lint clean, 1400 tests, build ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
