### PR TITLE
tweak: stronger blueprint paper texture

### DIFF
--- a/src/renderer/src/components/WiringCanvas.css
+++ b/src/renderer/src/components/WiringCanvas.css
@@ -72,7 +72,7 @@
 }
 :root[data-breadboard-bg='blueprint'] .wc--lifelike .wc__paper {
   display: block;
-  opacity: 0.55;
+  opacity: 0.85;
   mix-blend-mode: soft-light;
 }
 


### PR DESCRIPTION
Bumps the procedural blueprint paper mottle from 0.55 → 0.85 opacity (soft-light) so the paper undulation reads more clearly, as requested. CSS-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)