### PR TITLE
Blueprint default, no grid on schematic, export the sheet background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   store (writable without elevation).
 
 ### Changed
+- **Blueprint is now the default breadboard background**, and the wiring grid is
+  hidden on the **schematic** view (the schematic is a clean sheet). Image/PDF
+  exports now bake in the on-screen sheet colour — the blueprint blue for the
+  breadboard, the sheet colour for the schematic — so a saved diagram looks
+  exactly as drawn (the paper mottle's soft-light blend is preserved too).
 - **Blueprint background gets subtle procedural paper texture.** A whisper-faint
   fractal-noise mottle (generated with SVG `feTurbulence`, no image) now gives
   the blueprint sheet the light/dark undulation of real drawing paper. It's

--- a/src/renderer/src/board-main.tsx
+++ b/src/renderer/src/board-main.tsx
@@ -101,12 +101,12 @@ function BoardWindowApp(): JSX.Element {
     }
     applyTheme(initial)
     setPayload((p) => ({ ...p, theme: initial }))
-    let bg = 'dark'
+    let bg = 'blueprint'
     try {
       const raw = window.localStorage.getItem(BREADBOARD_BG_KEY)
       if (raw) bg = JSON.parse(raw) as string
     } catch {
-      // Ignore — default dark.
+      // Ignore — default blueprint.
     }
     applyBreadboardBg(bg)
   }, [])

--- a/src/renderer/src/components/WiringCanvas.tsx
+++ b/src/renderer/src/components/WiringCanvas.tsx
@@ -1170,7 +1170,12 @@ export function WiringCanvas({ robot, onChange, libraries, boardDef, boardPart, 
     setExportOpen(false)
     const svg = svgRef.current
     if (!svg) return
-    const res = serializeLiveSvg(svg, '.wc__content', { background: '#161719', margin: 24, exclude: ['.wc__sel-ring'] })
+    // The sheet colour lives in CSS on the stage (blueprint blue / schematic
+    // white / dark mat) — read the LIVE computed value so the export matches
+    // exactly what's on screen, whatever the mode/theme.
+    const stageBg = svg.parentElement ? getComputedStyle(svg.parentElement).backgroundColor : ''
+    const background = stageBg && !/rgba?\([^)]*,\s*0\s*\)/.test(stageBg) ? stageBg : '#161719'
+    const res = serializeLiveSvg(svg, '.wc__content', { background, margin: 24, exclude: ['.wc__sel-ring'] })
     if (!res) return
     const base =
       (robot.name?.trim() || 'board').replace(/[^\w.-]+/g, '-').replace(/^[-.]+|[-.]+$/g, '').toLowerCase() || 'board'
@@ -1387,12 +1392,16 @@ export function WiringCanvas({ robot, onChange, libraries, boardDef, boardPart, 
               must be in scope for the life-like board body to paint. */}
           {boardDef && renderMode === 'lifelike' && <BoardDefs def={boardDef} />}
           <g className="wc__content" transform={`translate(${view.tx} ${view.ty}) scale(${view.scale})`}>
-            {/* Procedural paper mottle (blueprint mode only, via CSS) — the very
-                bottom layer, pans + scales with the content. */}
-            <WiringPaper view={view} stageW={stageSize.w} stageH={stageSize.h} />
-            {/* Graph-paper grid at true 2.54 mm pitch — behind everything, moves
-                + scales with the parts (drawn in world coords). */}
-            <WiringGrid view={view} pxPerMm={pxPerMm} stageW={stageSize.w} stageH={stageSize.h} />
+            {/* Paper + grid are the BREADBOARD's graph paper only — the schematic
+                is a clean sheet with no grid. Both are world-space (pan/scale). */}
+            {renderMode === 'lifelike' && (
+              <>
+                {/* Procedural paper mottle (blueprint mode only, via CSS). */}
+                <WiringPaper view={view} stageW={stageSize.w} stageH={stageSize.h} />
+                {/* Graph-paper grid at true 2.54 mm pitch, behind the parts. */}
+                <WiringGrid view={view} pxPerMm={pxPerMm} stageW={stageSize.w} stageH={stageSize.h} />
+              </>
+            )}
             {/* Subjects (the MCU + placed parts) FIRST — wires draw on top (#182). */}
             {subjects.map((s) => {
               const capsOn = renderMode === 'lifelike' && !dragRef.current && hover?.key === s.key

--- a/src/renderer/src/components/svg-export.ts
+++ b/src/renderer/src/components/svg-export.ts
@@ -150,6 +150,8 @@ const INLINE_PROPS = [
   'stroke-linejoin',
   'stroke-opacity',
   'opacity',
+  // Preserve the blueprint paper's soft-light mottle in exports.
+  'mix-blend-mode',
   'color',
   'font-family',
   'font-size',

--- a/src/renderer/src/store/settings.ts
+++ b/src/renderer/src/store/settings.ts
@@ -89,7 +89,7 @@ export function SettingsProvider({ children }: { children: ReactNode }): JSX.Ele
   const [minimap, setMinimap] = useLocalStorage<boolean>('snakie.editor.minimap', true)
   const [breadboardBg, setBreadboardBg] = useLocalStorage<BreadboardBg>(
     'snakie.board.breadboardBg',
-    'dark'
+    'blueprint'
   )
 
   // Apply the paper mode + spacing to the document root so the CSS ruled paper


### PR DESCRIPTION
Four related Board View fixes from your report.

## Changes
- **Blueprint is now the default** breadboard background (was dark) — settings default + the board-window fallback.
- **No grid on the schematic view** — the graph-paper grid (and paper) are gated to the breadboard (lifelike) view; the schematic is a clean sheet.
- **Exports bake in the sheet colour** — image/PDF/SVG export now reads the **live computed stage background** instead of a hardcoded dark, so the **blueprint blue** (breadboard) and the **sheet colour** (schematic) save exactly as on screen.
- **Paper blend survives export** — inlined `mix-blend-mode` so the paper mottle's `soft-light` is preserved in the exported file.

## Verified (via the actual serialize path, in-app)
- **Breadboard** → background rect `rgb(13,59,102)` (blueprint blue), grid ✓, paper ✓ with `soft-light`
- **Schematic** → background rect `rgb(251,251,250)` (sheet colour), **no grid**, no paper
- Default `data-breadboard-bg` = `blueprint` on a fresh profile

Gate: typecheck + lint clean, **1400 tests**, build ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
