### PR TITLE
fix: PNG/PDF export draws the grid + paper to the edges

### DIFF
--- a/src/renderer/src/components/WiringCanvas.tsx
+++ b/src/renderer/src/components/WiringCanvas.tsx
@@ -72,7 +72,10 @@ const SNAP_GRID_KEY = 'snakie.board.snapGrid'
 function visibleWorldBounds(
   view: { tx: number; ty: number; scale: number },
   stageW: number,
-  stageH: number
+  stageH: number,
+  /** Extra world-unit overscan on every side — so the grid/paper fill past the
+   *  viewport edges (and past an export's frame margin) with no bare band. */
+  padWorld = 0
 ): { minX: number; maxX: number; minY: number; maxY: number } {
   const { tx, ty, scale } = view
   const fit = stageW > 0 && stageH > 0 ? Math.min(stageW / VIEW_W, stageH / VIEW_H) : 1
@@ -83,12 +86,16 @@ function visibleWorldBounds(
   const uMinY = (VIEW_H - uH) / 2
   const uMaxY = (VIEW_H + uH) / 2
   return {
-    minX: (uMinX - tx) / scale,
-    maxX: (uMaxX - tx) / scale,
-    minY: (uMinY - ty) / scale,
-    maxY: (uMaxY - ty) / scale
+    minX: (uMinX - tx) / scale - padWorld,
+    maxX: (uMaxX - tx) / scale + padWorld,
+    minY: (uMinY - ty) / scale - padWorld,
+    maxY: (uMaxY - ty) / scale + padWorld
   }
 }
+
+/** Overscan (world units) for the grid/paper so they fill past the viewport +
+ *  any export frame margin — comfortably beyond the 24-unit export margin. */
+const GRID_OVERSCAN = 90
 
 /**
  * PROCEDURAL PAPER (blueprint mode): a whisper-subtle fractal-noise mottle drawn
@@ -108,7 +115,7 @@ function WiringPaper({
   stageH: number
 }): JSX.Element | null {
   if (!(view.scale > 0)) return null
-  const { minX, maxX, minY, maxY } = visibleWorldBounds(view, stageW, stageH)
+  const { minX, maxX, minY, maxY } = visibleWorldBounds(view, stageW, stageH, GRID_OVERSCAN)
   if (!Number.isFinite(minX) || !Number.isFinite(maxX)) return null
   return (
     <>
@@ -170,7 +177,8 @@ function WiringGrid({
   const { minX: wMinX, maxX: wMaxX, minY: wMinY, maxY: wMaxY } = visibleWorldBounds(
     view,
     stageW,
-    stageH
+    stageH,
+    GRID_OVERSCAN
   )
 
   // Levels: [mm spacing, class, base opacity, fade-in start/full in viewBox px].
@@ -1175,7 +1183,13 @@ export function WiringCanvas({ robot, onChange, libraries, boardDef, boardPart, 
     // exactly what's on screen, whatever the mode/theme.
     const stageBg = svg.parentElement ? getComputedStyle(svg.parentElement).backgroundColor : ''
     const background = stageBg && !/rgba?\([^)]*,\s*0\s*\)/.test(stageBg) ? stageBg : '#161719'
-    const res = serializeLiveSvg(svg, '.wc__content', { background, margin: 24, exclude: ['.wc__sel-ring'] })
+    const res = serializeLiveSvg(svg, '.wc__content', {
+      background,
+      margin: 24,
+      exclude: ['.wc__sel-ring'],
+      // Frame to the parts, not the full-canvas grid/paper — they just fill it.
+      bboxExclude: ['.wc__grid-layer', '.wc__paper']
+    })
     if (!res) return
     const base =
       (robot.name?.trim() || 'board').replace(/[^\w.-]+/g, '-').replace(/^[-.]+|[-.]+$/g, '').toLowerCase() || 'board'

--- a/src/renderer/src/components/svg-export.ts
+++ b/src/renderer/src/components/svg-export.ts
@@ -185,16 +185,53 @@ const SVG_NS = 'http://www.w3.org/2000/svg'
  * styles are inlined so it renders without the app's CSS. Returns null when the
  * content has no measurable box.
  */
+/** Union bbox of a group's direct children, skipping `<defs>` + `exclude`
+ *  selectors. Falls back to the full getBBox if nothing qualifies. */
+function bboxExcluding(
+  content: SVGGraphicsElement,
+  exclude: string[]
+): { x: number; y: number; width: number; height: number } {
+  let x0 = Infinity
+  let y0 = Infinity
+  let x1 = -Infinity
+  let y1 = -Infinity
+  content.querySelectorAll(':scope > *').forEach((k) => {
+    if (k.tagName.toLowerCase() === 'defs') return
+    if (exclude.some((sel) => (k as Element).matches?.(sel))) return
+    let bb: DOMRect
+    try {
+      bb = (k as SVGGraphicsElement).getBBox()
+    } catch {
+      return
+    }
+    if (!bb.width && !bb.height) return
+    x0 = Math.min(x0, bb.x)
+    y0 = Math.min(y0, bb.y)
+    x1 = Math.max(x1, bb.x + bb.width)
+    y1 = Math.max(y1, bb.y + bb.height)
+  })
+  if (!Number.isFinite(x0)) return content.getBBox()
+  return { x: x0, y: y0, width: x1 - x0, height: y1 - y0 }
+}
+
 export function serializeLiveSvg(
   svg: SVGSVGElement,
   contentSelector: string,
-  opts: { background?: string; margin?: number; exclude?: string[] } = {}
+  opts: {
+    background?: string
+    margin?: number
+    exclude?: string[]
+    /** Frame to everything EXCEPT children matching these selectors (e.g. the
+     *  full-canvas grid/paper) so the export is tight to the drawing, and those
+     *  large backdrop layers just fill the framed area to the edges. */
+    bboxExclude?: string[]
+  } = {}
 ): { svg: string; width: number; height: number } | null {
   const content = svg.querySelector(contentSelector) as SVGGraphicsElement | null
   if (!content) return null
-  let bbox: DOMRect
+  let bbox: { x: number; y: number; width: number; height: number }
   try {
-    bbox = content.getBBox()
+    bbox = opts.bboxExclude?.length ? bboxExcluding(content, opts.bboxExclude) : content.getBBox()
   } catch {
     return null
   }


### PR DESCRIPTION
The export framed to the content bbox + a 24-unit margin, but the grid/paper end at their own extent — so that margin band had background colour but no grid/paper (the bare edges you saw).

- `serializeLiveSvg` gains `bboxExclude`: frame to the **parts** (exclude the full-canvas `.wc__grid-layer` + `.wc__paper`) so the drawing is tight and the backdrop layers just fill it.
- Grid + paper get an **overscan** (90 world units) so they extend past the viewport and past the export's frame margin — no bare band.

Verified in-app: the export frame is tight to the parts and fully inside the paper/grid extent (`paperCoversFrame: true`). Gate: typecheck + lint clean, 1400 tests, build ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)