### PR TITLE
Per-mode instrument dock defaults + export the fit-to-all view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   store (writable without elevation).
 
 ### Changed
+- **Instrument dock defaults per mode + exports always fit the whole board.**
+  The instrument dock now starts **closed in Board mode** (the board gets the
+  room) and **Code**, and **open in Data Lab** (the instrument bench). And
+  image/PDF exports of the breadboard now always save the **zoom-to-fit** view —
+  every placed item is included and fully backed by the grid/paper, whatever the
+  on-screen zoom.
 - **Blueprint is now the default breadboard background**, and the wiring grid is
   hidden on the **schematic** view (the schematic is a clean sheet). Image/PDF
   exports now bake in the on-screen sheet colour — the blueprint blue for the

--- a/src/renderer/src/components/WiringCanvas.tsx
+++ b/src/renderer/src/components/WiringCanvas.tsx
@@ -9,6 +9,7 @@ import {
   type PointerEvent as ReactPointerEvent,
   type WheelEvent
 } from 'react'
+import { flushSync } from 'react-dom'
 import { loadPin, savePin, shouldAutoHide, PIN_KEYS } from './pin-overlay'
 import {
   connectionColor,
@@ -97,6 +98,36 @@ function visibleWorldBounds(
  *  any export frame margin — comfortably beyond the 24-unit export margin. */
 const GRID_OVERSCAN = 90
 
+interface WorldRect {
+  minX: number
+  minY: number
+  maxX: number
+  maxY: number
+}
+
+/**
+ * The world rect the grid/paper should COVER: the visible area (overscanned)
+ * UNION the placed content's bounds. The union means an EXPORT — which frames to
+ * all parts regardless of the on-screen zoom — always has grid/paper to its
+ * edges, even for parts currently scrolled off-screen. Off-screen coverage is
+ * clipped by the viewport on screen, so it's free visually.
+ */
+function coverBounds(
+  view: { tx: number; ty: number; scale: number },
+  stageW: number,
+  stageH: number,
+  content: WorldRect | null
+): WorldRect {
+  const v = visibleWorldBounds(view, stageW, stageH, GRID_OVERSCAN)
+  if (!content) return v
+  return {
+    minX: Math.min(v.minX, content.minX - GRID_OVERSCAN),
+    minY: Math.min(v.minY, content.minY - GRID_OVERSCAN),
+    maxX: Math.max(v.maxX, content.maxX + GRID_OVERSCAN),
+    maxY: Math.max(v.maxY, content.maxY + GRID_OVERSCAN)
+  }
+}
+
 /**
  * PROCEDURAL PAPER (blueprint mode): a whisper-subtle fractal-noise mottle drawn
  * INSIDE the pan/zoom content group so it pans + scales with the grid + parts,
@@ -108,14 +139,16 @@ const GRID_OVERSCAN = 90
 function WiringPaper({
   view,
   stageW,
-  stageH
+  stageH,
+  content
 }: {
   view: { tx: number; ty: number; scale: number }
   stageW: number
   stageH: number
+  content: WorldRect | null
 }): JSX.Element | null {
   if (!(view.scale > 0)) return null
-  const { minX, maxX, minY, maxY } = visibleWorldBounds(view, stageW, stageH, GRID_OVERSCAN)
+  const { minX, maxX, minY, maxY } = coverBounds(view, stageW, stageH, content)
   if (!Number.isFinite(minX) || !Number.isFinite(maxX)) return null
   return (
     <>
@@ -163,22 +196,25 @@ function WiringGrid({
   view,
   pxPerMm,
   stageW,
-  stageH
+  stageH,
+  content
 }: {
   view: { tx: number; ty: number; scale: number }
   pxPerMm: number
   /** The SVG element's pixel size, to fill the letterbox margins too. */
   stageW: number
   stageH: number
+  /** Placed-content bounds — covered too, so exports fill to the edges. */
+  content: WorldRect | null
 }): JSX.Element | null {
   const { scale } = view
   if (!(scale > 0) || !(pxPerMm > 0)) return null
 
-  const { minX: wMinX, maxX: wMaxX, minY: wMinY, maxY: wMaxY } = visibleWorldBounds(
+  const { minX: wMinX, maxX: wMaxX, minY: wMinY, maxY: wMaxY } = coverBounds(
     view,
     stageW,
     stageH,
-    GRID_OVERSCAN
+    content
   )
 
   // Levels: [mm spacing, class, base opacity, fade-in start/full in viewBox px].
@@ -1178,6 +1214,12 @@ export function WiringCanvas({ robot, onChange, libraries, boardDef, boardPart, 
     setExportOpen(false)
     const svg = svgRef.current
     if (!svg) return
+    // Always export the ZOOM-TO-FIT view so every item is included AND fully
+    // backed by the grid/paper (which are view-derived). flushSync applies the
+    // fit + restores the previous view WITHIN this call, so the serialise reads
+    // the fit-state DOM while the user never sees the intermediate frame paint.
+    const prev = { ...view }
+    flushSync(() => fitView())
     // The sheet colour lives in CSS on the stage (blueprint blue / schematic
     // white / dark mat) — read the LIVE computed value so the export matches
     // exactly what's on screen, whatever the mode/theme.
@@ -1190,6 +1232,7 @@ export function WiringCanvas({ robot, onChange, libraries, boardDef, boardPart, 
       // Frame to the parts, not the full-canvas grid/paper — they just fill it.
       bboxExclude: ['.wc__grid-layer', '.wc__paper']
     })
+    flushSync(() => setView(prev))
     if (!res) return
     const base =
       (robot.name?.trim() || 'board').replace(/[^\w.-]+/g, '-').replace(/^[-.]+|[-.]+$/g, '').toLowerCase() || 'board'
@@ -1381,6 +1424,21 @@ export function WiringCanvas({ robot, onChange, libraries, boardDef, boardPart, 
     return { left: top.x - rect.left, top: y, below }
   })()
 
+  // The placed content's world bounds (all subjects) — the grid/paper cover this
+  // too, so an EXPORT (which frames to all parts) always fills to its edges even
+  // for parts scrolled off-screen. Null when nothing is placed.
+  const partsBounds: WorldRect | null = subjects.length
+    ? subjects.reduce<WorldRect>(
+        (b, s) => ({
+          minX: Math.min(b.minX, s.hit.x),
+          minY: Math.min(b.minY, s.hit.y),
+          maxX: Math.max(b.maxX, s.hit.x + s.hit.w),
+          maxY: Math.max(b.maxY, s.hit.y + s.hit.h)
+        }),
+        { minX: Infinity, minY: Infinity, maxX: -Infinity, maxY: -Infinity }
+      )
+    : null
+
   return (
     <div
       className={`wc wc--${renderMode}${dropActive ? ' wc--drop' : ''}`}
@@ -1411,9 +1469,15 @@ export function WiringCanvas({ robot, onChange, libraries, boardDef, boardPart, 
             {renderMode === 'lifelike' && (
               <>
                 {/* Procedural paper mottle (blueprint mode only, via CSS). */}
-                <WiringPaper view={view} stageW={stageSize.w} stageH={stageSize.h} />
+                <WiringPaper view={view} stageW={stageSize.w} stageH={stageSize.h} content={partsBounds} />
                 {/* Graph-paper grid at true 2.54 mm pitch, behind the parts. */}
-                <WiringGrid view={view} pxPerMm={pxPerMm} stageW={stageSize.w} stageH={stageSize.h} />
+                <WiringGrid
+                  view={view}
+                  pxPerMm={pxPerMm}
+                  stageW={stageSize.w}
+                  stageH={stageSize.h}
+                  content={partsBounds}
+                />
               </>
             )}
             {/* Subjects (the MCU + placed parts) FIRST — wires draw on top (#182). */}

--- a/src/renderer/src/store/layout.ts
+++ b/src/renderer/src/store/layout.ts
@@ -102,7 +102,9 @@ export const WORKSPACE_PRESETS: Record<WorkspaceId, WorkspaceLayout> = {
     filesCollapsed: true,
     shellCollapsed: false,
     rightCollapsed: true,
-    dockOpen: true,
+    // Instruments HIDDEN by default in Board mode — the board is the star, so it
+    // gets the room (Data Lab opens the dock, Code keeps it closed).
+    dockOpen: false,
     boardPaneOpen: true,
     horizontal: [0, 42, 58, 0],
     vertical: [65, 35]

--- a/test/layoutStore.test.ts
+++ b/test/layoutStore.test.ts
@@ -25,15 +25,16 @@ describe('workspace presets (epic #259 Phase 1; slimmed to 3 by the modes review
     }
   })
 
-  it("'code' preserves today's default layout; the others open the dock", () => {
+  it("'code' preserves today's default layout; instrument dock per workspace", () => {
     const code = WORKSPACE_PRESETS.code
     expect(code.filesCollapsed).toBe(false)
     expect(code.shellCollapsed).toBe(false)
     expect(code.rightCollapsed).toBe(true)
+    // Instrument dock: closed in Code + Board (the board is the star), open only
+    // in Data Lab (the instrument bench).
     expect(code.dockOpen).toBe(false)
-    for (const id of ['board', 'datalab'] as const) {
-      expect(WORKSPACE_PRESETS[id].dockOpen, id).toBe(true)
-    }
+    expect(WORKSPACE_PRESETS.board.dockOpen).toBe(false)
+    expect(WORKSPACE_PRESETS.datalab.dockOpen).toBe(true)
     // Board: the embedded Board View pane opens with a real share beside the
     // code; the other workspaces keep it closed at 0.
     expect(WORKSPACE_PRESETS.board.boardPaneOpen).toBe(true)


### PR DESCRIPTION
Two requests.

## 1. Instrument dock defaults per mode
The instrument dock now starts:
- **closed in Board mode** (the embedded Board View is the star, gets the room)
- **closed in Code**
- **open in Data Lab** (the instrument bench)

Preset default change (`dockOpen`) + updated the layout test. Existing users keep their saved per-workspace state; this is the fresh-profile default.

## 2. Exports always save the zoom-to-fit view
Image/PDF/SVG export of the breadboard now always saves the **fit-to-all** view, so every placed item is included and fully backed by the grid/paper, no matter the on-screen zoom. `doExport` wraps `fitView()` in `flushSync` — apply fit → serialise the fit-state DOM → restore the view, all within one call, so the intermediate frame never paints (no visible flash) and your working view is unchanged. The grid/paper also cover the placed-content bounds as belt-and-braces.

## Verified (in-app)
- Board dock = 0 / Data Lab = 1 / Code = 0 by default
- After zooming to 285%, the fit view (which the export uses) has the paper covering all parts + the export margin (`paperCoversAllPartsAtFit: true`)
- Gate: typecheck + lint clean, **1400 tests**, build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
