### PR TITLE
fix: image/PDF export was cropping parts (child-transform bbox bug)

### DIFF
--- a/src/renderer/src/components/svg-export.ts
+++ b/src/renderer/src/components/svg-export.ts
@@ -185,8 +185,41 @@ const SVG_NS = 'http://www.w3.org/2000/svg'
  * styles are inlined so it renders without the app's CSS. Returns null when the
  * content has no measurable box.
  */
-/** Union bbox of a group's direct children, skipping `<defs>` + `exclude`
- *  selectors. Falls back to the full getBBox if nothing qualifies. */
+/** A child's bbox mapped into its PARENT's coordinate space. `getBBox()` alone
+ *  is in the child's own (pre-transform) space, so a translated group would be
+ *  mislocated — apply the child's transform matrix to the box corners. */
+function childBoxInParent(k: SVGGraphicsElement): { x0: number; y0: number; x1: number; y1: number } | null {
+  let bb: DOMRect
+  try {
+    bb = k.getBBox()
+  } catch {
+    return null
+  }
+  if (!bb.width && !bb.height) return null
+  const m = k.transform?.baseVal?.consolidate?.()?.matrix
+  if (!m) return { x0: bb.x, y0: bb.y, x1: bb.x + bb.width, y1: bb.y + bb.height }
+  let x0 = Infinity
+  let y0 = Infinity
+  let x1 = -Infinity
+  let y1 = -Infinity
+  for (const [px, py] of [
+    [bb.x, bb.y],
+    [bb.x + bb.width, bb.y],
+    [bb.x, bb.y + bb.height],
+    [bb.x + bb.width, bb.y + bb.height]
+  ]) {
+    const X = m.a * px + m.c * py + m.e
+    const Y = m.b * px + m.d * py + m.f
+    x0 = Math.min(x0, X)
+    y0 = Math.min(y0, Y)
+    x1 = Math.max(x1, X)
+    y1 = Math.max(y1, Y)
+  }
+  return { x0, y0, x1, y1 }
+}
+
+/** Union bbox (in the group's own space) of a group's direct children, skipping
+ *  `<defs>` + `exclude` selectors. Falls back to the full getBBox if none. */
 function bboxExcluding(
   content: SVGGraphicsElement,
   exclude: string[]
@@ -198,17 +231,12 @@ function bboxExcluding(
   content.querySelectorAll(':scope > *').forEach((k) => {
     if (k.tagName.toLowerCase() === 'defs') return
     if (exclude.some((sel) => (k as Element).matches?.(sel))) return
-    let bb: DOMRect
-    try {
-      bb = (k as SVGGraphicsElement).getBBox()
-    } catch {
-      return
-    }
-    if (!bb.width && !bb.height) return
-    x0 = Math.min(x0, bb.x)
-    y0 = Math.min(y0, bb.y)
-    x1 = Math.max(x1, bb.x + bb.width)
-    y1 = Math.max(y1, bb.y + bb.height)
+    const b = childBoxInParent(k as SVGGraphicsElement)
+    if (!b) return
+    x0 = Math.min(x0, b.x0)
+    y0 = Math.min(y0, b.y0)
+    x1 = Math.max(x1, b.x1)
+    y1 = Math.max(y1, b.y1)
   })
   if (!Number.isFinite(x0)) return content.getBBox()
   return { x: x0, y: y0, width: x1 - x0, height: y1 - y0 }


### PR DESCRIPTION
The export frame was computed by unioning each child's `getBBox()` — but `getBBox()` is in the child's OWN pre-transform space. Subjects are **translated** `<g>` groups, so their boxes were mislocated and the union came out too small → parts outside it were **cropped**.

Fix: map each child's box through its transform matrix (`childBoxInParent`) before unioning.

Verified in-app: the transform-aware parts bbox now **exactly matches ground truth** (`content.getBBox()` with the grid/paper hidden) — `[81,72,712,488]`, vs the buggy `[-46,-46,662,479]`. Combined with the existing fit-before-export, saved images now include every item, uncropped, on full grid/paper. Gate: typecheck + lint clean, 1400 tests, build ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)