### PR TITLE
Warp the blueprint grid lines with the paper fibre (ink-on-paper wobble)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   store (writable without elevation).
 
 ### Changed
+- **Blueprint grid lines pick up the paper's imperfections.** The grid is warped
+  a hair by the same fractal-noise paper fibre (an SVG displacement filter), so
+  the lines wobble subtly like ink on textured paper instead of being machine-
+  perfect. Blueprint mode only; scales with the grid; no measurable pan cost.
 - **Instrument dock defaults per mode + exports always fit the whole board.**
   The instrument dock now starts **closed in Board mode** (the board gets the
   room) and **Code**, and **open in Data Lab** (the instrument bench). And

--- a/src/renderer/src/components/WiringCanvas.css
+++ b/src/renderer/src/components/WiringCanvas.css
@@ -63,6 +63,11 @@
 :root[data-breadboard-bg='blueprint'] .wc--lifelike .wc__grid {
   stroke: #d6e6ff;
 }
+/* Blueprint only: warp the grid with the paper fibre so the lines aren't
+   machine-perfect — a subtle ink-on-paper wobble that scales with the grid. */
+:root[data-breadboard-bg='blueprint'] .wc--lifelike .wc__grid-layer {
+  filter: url(#wc-grid-rough);
+}
 
 /* Procedural paper mottle — only on the blueprint sheet. `soft-light` turns the
    grey fractal noise into a faint light/dark undulation over the blue paper;

--- a/src/renderer/src/components/WiringCanvas.tsx
+++ b/src/renderer/src/components/WiringCanvas.tsx
@@ -171,6 +171,27 @@ function WiringPaper({
         <pattern id="wc-paper" patternUnits="userSpaceOnUse" width="90" height="90">
           <rect width="90" height="90" filter="url(#wc-paper-fx)" />
         </pattern>
+        {/* Roughen filter (applied to the grid via CSS in blueprint mode): the
+            same paper fibre displaces the lines a hair, so they wobble like ink
+            on textured paper instead of being machine-perfect. Low frequency +
+            small scale keeps it a subtle undulation. */}
+        <filter id="wc-grid-rough" x="-5%" y="-5%" width="110%" height="110%">
+          <feTurbulence
+            type="fractalNoise"
+            baseFrequency="0.028"
+            numOctaves={2}
+            seed={11}
+            stitchTiles="stitch"
+            result="warp"
+          />
+          <feDisplacementMap
+            in="SourceGraphic"
+            in2="warp"
+            scale={3}
+            xChannelSelector="R"
+            yChannelSelector="G"
+          />
+        </filter>
       </defs>
       <rect
         className="wc__paper"


### PR DESCRIPTION
The blueprint grid lines were always machine-perfect — you asked for the paper's imperfections to affect them too.

Adds an SVG **displacement filter** (`feTurbulence` → `feDisplacementMap`) so the same fractal-noise paper fibre nudges the grid lines a hair, giving a subtle ink-on-textured-paper wobble. Applied to `.wc__grid-layer` via CSS scoped to **blueprint mode only**; the displacement is in world units so it scales with the grid. Low frequency + small scale = subtle.

Verified in-app: the filter resolves on the grid layer, the wobble shows when zoomed, and panning stays smooth (~121 fps in the probe — no perf cost, which matters for Chromebooks). Gate: typecheck + lint clean, 1400 tests, build ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)