### PR TITLE
fix: keep the blueprint grid wobble in image/PDF exports

### DIFF
--- a/src/renderer/src/components/svg-export.ts
+++ b/src/renderer/src/components/svg-export.ts
@@ -152,6 +152,8 @@ const INLINE_PROPS = [
   'opacity',
   // Preserve the blueprint paper's soft-light mottle in exports.
   'mix-blend-mode',
+  // Preserve CSS-applied filters (e.g. the blueprint grid's ink-on-paper wobble).
+  'filter',
   'color',
   'font-family',
   'font-size',


### PR DESCRIPTION
The grid roughen filter is applied via CSS (`filter: url(#wc-grid-rough)`), but the export inlined only a fixed set of presentation props — `filter` wasn't one — so exported grids came out machine-straight. Added `filter` to `INLINE_PROPS` so the CSS filter bakes onto the cloned grid layer (the filter def is already cloned with the SVG, so it resolves). Verified the computed filter + def are present. Gate: typecheck + lint clean, 1400 tests, build ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)