### PR TITLE
KRF (Kev's Robot File) schema + helpers foundation (#310)

### DIFF
--- a/docs/krf.md
+++ b/docs/krf.md
@@ -1,0 +1,68 @@
+# KRF — Kev's Robot File
+
+KRF is Snakie's standard folder layout for a **robot project**: the wiring, the
+MicroPython code, and the 3D model, together in one folder that the Board View
+and Robot View (epic #309) both understand.
+
+```
+my-robot/
+├── robot.yml      # manifest: wiring + the robot MODEL (below)
+├── code/          # MicroPython source
+├── urdf/          # .urdf + meshes/ (STL, DAE)
+└── stl/           # 3D-printable files
+```
+
+`New Robot Project` in Snakie scaffolds this structure; Robot View
+auto-discovers `robot.yml` in the workspace root.
+
+## `robot.yml`
+
+`robot.yml` already describes the board + placed parts + wiring (see
+`src/shared/robot.ts`). KRF adds an **optional** `robot:` section for the 3D
+model — a legacy wiring-only `robot.yml` is unaffected (every new field is
+optional and validated corruption-safe).
+
+```yaml
+name: My Robot
+board: pico2w
+parts: [...]          # existing wiring
+connections: [...]    # existing wiring
+
+robot:                # ← the KRF robot MODEL (optional)
+  version: 1
+  urdf: urdf/robot.urdf
+  servoJointMap:      # servo pin ↔ URDF joint, with angle calibration
+    - pin: GP0
+      joint: shoulder
+      servoMin: 0     # servo input sweep (deg) — default 0..180
+      servoMax: 180
+      jointMin: -90   # joint output range (deg for revolute, mm for prismatic)
+      jointMax: 90
+      invert: false
+  joints:             # per-joint limit overrides (edited in the pose tool)
+    shoulder: { min: -80, max: 80 }
+  defaultPose:        # applied on load
+    shoulder: 0
+  poses:              # saved named poses
+    - name: home
+      values: { shoulder: 0 }
+```
+
+### Servo → joint mapping
+
+A running program's servo write drives the mapped joint (Phase 3): the servo
+angle is clamped to `servoMin..servoMax`, optionally inverted, and lerped onto
+`jointMin..jointMax`. Pure implementation + tests: `src/shared/krf.ts`
+(`servoToJoint`), `test/krf.test.ts`.
+
+## Versioning
+
+`robot.version` is bumped on breaking changes; `sanitiseRobotModel` migrates /
+drops unknown shapes without throwing. Current version: **1**.
+
+## Scope
+
+KRF is the folder + manifest contract for the Robot View epic (#309): the URDF
+viewer, pose tool, servo↔joint binding, motion timeline and URDF builder all
+read/write this one `robot.yml`. Physics, IK and serial-bus servos are
+explicitly out of scope for now.

--- a/src/shared/krf.ts
+++ b/src/shared/krf.ts
@@ -1,0 +1,171 @@
+/**
+ * KRF — Kev's Robot File (epic #309 / #310).
+ * =============================================================================
+ *
+ * A standard folder layout + a versioned robot-model section of `robot.yml`
+ * for robot projects:
+ *
+ *   my-robot/
+ *   ├── robot.yml      # manifest (wiring + the robot MODEL below)
+ *   ├── code/          # MicroPython source
+ *   ├── urdf/          # .urdf + meshes/
+ *   └── stl/           # 3D-printable files
+ *
+ * The robot MODEL ({@link RobotModel}) extends the existing wiring `robot.yml`
+ * with a URDF path, the servo↔joint map + calibration, per-joint limits and
+ * saved poses. This module holds the PURE, unit-tested helpers: validation
+ * (corruption-safe + version-migrating), the servo→joint mapping maths, and the
+ * "New Robot Project" scaffold plan. No DOM / fs — the main process does the I/O.
+ */
+import {
+  blankRobot,
+  type JointConfig,
+  type NamedPose,
+  type RobotDefinition,
+  type RobotModel,
+  type ServoJointBinding
+} from './robot'
+
+/** Current KRF schema version. */
+export const KRF_VERSION = 1
+
+/** Default servo input sweep (degrees) when a binding doesn't override it. */
+export const DEFAULT_SERVO_MIN = 0
+export const DEFAULT_SERVO_MAX = 180
+
+const isFiniteNum = (v: unknown): v is number => typeof v === 'number' && Number.isFinite(v)
+const isStr = (v: unknown): v is string => typeof v === 'string'
+
+/**
+ * Map a servo angle (degrees) onto its bound joint value via the calibration.
+ * Clamps to the servo range, honours `invert`, and lerps onto the joint range.
+ */
+export function servoToJoint(b: ServoJointBinding, servoAngle: number): number {
+  const sMin = b.servoMin ?? DEFAULT_SERVO_MIN
+  const sMax = b.servoMax ?? DEFAULT_SERVO_MAX
+  const span = sMax - sMin
+  let t = span === 0 ? 0 : (servoAngle - sMin) / span
+  t = Math.max(0, Math.min(1, t))
+  if (b.invert) t = 1 - t
+  return b.jointMin + t * (b.jointMax - b.jointMin)
+}
+
+/** Validate one servo↔joint binding; null if it can't be salvaged. */
+function sanitiseBinding(raw: unknown): ServoJointBinding | null {
+  const r = (raw ?? {}) as Record<string, unknown>
+  if (!isStr(r.pin) || !isStr(r.joint)) return null
+  if (!isFiniteNum(r.jointMin) || !isFiniteNum(r.jointMax)) return null
+  const b: ServoJointBinding = { pin: r.pin, joint: r.joint, jointMin: r.jointMin, jointMax: r.jointMax }
+  if (isFiniteNum(r.servoMin)) b.servoMin = r.servoMin
+  if (isFiniteNum(r.servoMax)) b.servoMax = r.servoMax
+  if (r.invert === true) b.invert = true
+  return b
+}
+
+/** A numeric-valued record (joint name → number), dropping bad entries. */
+function sanitiseNumberMap(raw: unknown): Record<string, number> {
+  const out: Record<string, number> = {}
+  if (raw && typeof raw === 'object') {
+    for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+      if (isFiniteNum(v)) out[k] = v
+    }
+  }
+  return out
+}
+
+/**
+ * Validate the robot-model section, corruption-safe: unknown/legacy shapes and
+ * bad fields are dropped, never thrown. Returns `undefined` when there's no
+ * meaningful model (so a wiring-only robot.yml stays wiring-only).
+ */
+export function sanitiseRobotModel(raw: unknown): RobotModel | undefined {
+  if (!raw || typeof raw !== 'object') return undefined
+  const r = raw as Record<string, unknown>
+  const model: RobotModel = { version: KRF_VERSION }
+
+  if (isStr(r.urdf) && r.urdf.trim()) model.urdf = r.urdf.trim()
+
+  if (Array.isArray(r.servoJointMap)) {
+    const map = r.servoJointMap.map(sanitiseBinding).filter((b): b is ServoJointBinding => b !== null)
+    if (map.length) model.servoJointMap = map
+  }
+
+  if (r.joints && typeof r.joints === 'object') {
+    const joints: Record<string, JointConfig> = {}
+    for (const [name, jc] of Object.entries(r.joints as Record<string, unknown>)) {
+      const j = (jc ?? {}) as Record<string, unknown>
+      const cfg: JointConfig = {}
+      if (isFiniteNum(j.min)) cfg.min = j.min
+      if (isFiniteNum(j.max)) cfg.max = j.max
+      if (cfg.min !== undefined || cfg.max !== undefined) joints[name] = cfg
+    }
+    if (Object.keys(joints).length) model.joints = joints
+  }
+
+  const def = sanitiseNumberMap(r.defaultPose)
+  if (Object.keys(def).length) model.defaultPose = def
+
+  if (Array.isArray(r.poses)) {
+    const poses = r.poses
+      .map((p): NamedPose | null => {
+        const pr = (p ?? {}) as Record<string, unknown>
+        if (!isStr(pr.name)) return null
+        return { name: pr.name, values: sanitiseNumberMap(pr.values) }
+      })
+      .filter((p): p is NamedPose => p !== null)
+    if (poses.length) model.poses = poses
+  }
+
+  // Nothing but the version stamp → treat as "no model".
+  const keys = Object.keys(model)
+  return keys.length === 1 && keys[0] === 'version' ? undefined : model
+}
+
+/** Read + validate the robot model off a parsed robot.yml object. */
+export function readRobotModel(robot: RobotDefinition | null | undefined): RobotModel | undefined {
+  return sanitiseRobotModel(robot?.robot)
+}
+
+/** One file the scaffold should create (path relative to the project root). */
+export interface ScaffoldFile {
+  path: string
+  content: string
+}
+
+/** The plan for a "New Robot Project" (KRF) — the manifest object + the other
+ *  files. The caller serialises `robotYml` (YAML) and writes everything. Pure. */
+export interface ScaffoldPlan {
+  /** The `robot.yml` manifest to serialise + write at the project root. */
+  robotYml: RobotDefinition
+  /** The remaining files/dirs to create. */
+  files: ScaffoldFile[]
+}
+
+/** Build the KRF scaffold plan for a new project named `name`. */
+export function scaffoldKrf(name: string): ScaffoldPlan {
+  const clean = name.trim() || 'My Robot'
+  const robotYml: RobotDefinition = {
+    ...blankRobot(),
+    name: clean,
+    robot: { version: KRF_VERSION, urdf: 'urdf/robot.urdf', servoJointMap: [], defaultPose: {} }
+  }
+  const main = [
+    '# ' + clean,
+    'import time',
+    '',
+    '# Your robot code. Bind servos to URDF joints in Robot View, then the',
+    '# 3D model follows your servo writes — no board required.',
+    '',
+    'while True:',
+    '    time.sleep(1)',
+    ''
+  ].join('\n')
+  return {
+    robotYml,
+    files: [
+      { path: 'code/main.py', content: main },
+      { path: 'urdf/.gitkeep', content: '' },
+      { path: 'stl/.gitkeep', content: '' }
+    ]
+  }
+}

--- a/src/shared/robot.ts
+++ b/src/shared/robot.ts
@@ -43,6 +43,54 @@ export interface RobotConnection {
   color?: string
 }
 
+/**
+ * The robot-MODEL section of a KRF `robot.yml` (epic #309 / #310). All fields
+ * are optional so a legacy wiring-only robot.yml still loads. Pure helpers to
+ * read/validate this live in {@link ./krf}.
+ */
+export interface RobotModel {
+  /** KRF schema version (bumped on breaking changes). */
+  version?: number
+  /** Path to the `.urdf` file, relative to the project root (e.g. `urdf/arm.urdf`). */
+  urdf?: string
+  /** Servo pin ↔ URDF joint bindings with angle calibration (Phase 3). */
+  servoJointMap?: ServoJointBinding[]
+  /** Per-joint limit / calibration overrides edited in-app (Phase 2). */
+  joints?: Record<string, JointConfig>
+  /** The default pose applied on load: joint name → value (deg / mm). */
+  defaultPose?: Record<string, number>
+  /** Saved named poses (Phase 2). */
+  poses?: NamedPose[]
+}
+
+/** A servo(pin) ↔ URDF joint binding with angle-range calibration (Phase 3). */
+export interface ServoJointBinding {
+  /** The board pin the servo signal is on (e.g. `GP0`, or a bare pin number). */
+  pin: string
+  /** The URDF joint this servo drives. */
+  joint: string
+  /** Servo input range in degrees (default 0…180). */
+  servoMin?: number
+  servoMax?: number
+  /** Joint output range the servo maps onto (revolute = degrees, prismatic = mm). */
+  jointMin: number
+  jointMax: number
+  /** Reverse the mapping (servo min → joint max). */
+  invert?: boolean
+}
+
+/** Per-joint limit overrides (edited in the pose tool, written back here). */
+export interface JointConfig {
+  min?: number
+  max?: number
+}
+
+/** A saved pose: joint name → value (degrees for revolute, mm for prismatic). */
+export interface NamedPose {
+  name: string
+  values: Record<string, number>
+}
+
 /** A full robot/project definition. */
 export interface RobotDefinition {
   /** Project name. */
@@ -58,6 +106,9 @@ export interface RobotDefinition {
   parts: RobotPart[]
   /** The pin-to-pin wires. */
   connections: RobotConnection[]
+  /** The KRF robot-model section (URDF, servo↔joint map, poses) — optional so a
+   *  legacy wiring-only robot.yml is unaffected (epic #309). */
+  robot?: RobotModel
 }
 
 /** A fresh, empty robot definition. */

--- a/test/krf.test.ts
+++ b/test/krf.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import {
+  KRF_VERSION,
+  servoToJoint,
+  sanitiseRobotModel,
+  readRobotModel,
+  scaffoldKrf
+} from '../src/shared/krf'
+import type { ServoJointBinding } from '../src/shared/robot'
+
+describe('servoToJoint calibration (#310)', () => {
+  const b: ServoJointBinding = { pin: 'GP0', joint: 'j1', jointMin: -90, jointMax: 90 }
+  it('maps the default 0..180 servo sweep onto the joint range', () => {
+    expect(servoToJoint(b, 0)).toBeCloseTo(-90)
+    expect(servoToJoint(b, 90)).toBeCloseTo(0)
+    expect(servoToJoint(b, 180)).toBeCloseTo(90)
+  })
+  it('clamps out-of-range servo angles', () => {
+    expect(servoToJoint(b, -50)).toBeCloseTo(-90)
+    expect(servoToJoint(b, 999)).toBeCloseTo(90)
+  })
+  it('honours invert', () => {
+    expect(servoToJoint({ ...b, invert: true }, 0)).toBeCloseTo(90)
+    expect(servoToJoint({ ...b, invert: true }, 180)).toBeCloseTo(-90)
+  })
+  it('respects a custom servo input range', () => {
+    const c: ServoJointBinding = { pin: 'GP1', joint: 'j', servoMin: 500, servoMax: 2500, jointMin: 0, jointMax: 100 }
+    expect(servoToJoint(c, 500)).toBeCloseTo(0)
+    expect(servoToJoint(c, 1500)).toBeCloseTo(50)
+    expect(servoToJoint(c, 2500)).toBeCloseTo(100)
+  })
+})
+
+describe('sanitiseRobotModel — corruption-safe (#310)', () => {
+  it('reads a full model, stamping the version', () => {
+    const m = sanitiseRobotModel({
+      urdf: 'urdf/arm.urdf',
+      servoJointMap: [{ pin: 'GP0', joint: 'j1', jointMin: -90, jointMax: 90, invert: true }],
+      joints: { j1: { min: -80, max: 80 } },
+      defaultPose: { j1: 0 },
+      poses: [{ name: 'home', values: { j1: 0 } }]
+    })
+    expect(m).toBeDefined()
+    expect(m!.version).toBe(KRF_VERSION)
+    expect(m!.urdf).toBe('urdf/arm.urdf')
+    expect(m!.servoJointMap).toHaveLength(1)
+    expect(m!.servoJointMap![0].invert).toBe(true)
+    expect(m!.joints!.j1).toEqual({ min: -80, max: 80 })
+    expect(m!.poses![0]).toEqual({ name: 'home', values: { j1: 0 } })
+  })
+
+  it('drops malformed bindings/poses instead of throwing', () => {
+    const m = sanitiseRobotModel({
+      urdf: 'urdf/x.urdf',
+      servoJointMap: [
+        { pin: 'GP0', joint: 'j1', jointMin: -90, jointMax: 90 }, // ok
+        { pin: 'GP1' }, // missing joint + range → dropped
+        { joint: 'j2', jointMin: 0, jointMax: 1 } // missing pin → dropped
+      ],
+      poses: [{ name: 'p', values: { a: 1, b: 'x' } }, { values: {} }] // 2nd has no name → dropped
+    })
+    expect(m!.servoJointMap).toHaveLength(1)
+    expect(m!.poses).toHaveLength(1)
+    expect(m!.poses![0].values).toEqual({ a: 1 }) // non-numeric 'b' dropped
+  })
+
+  it('a wiring-only robot.yml (no model) → undefined', () => {
+    expect(sanitiseRobotModel(undefined)).toBeUndefined()
+    expect(sanitiseRobotModel({})).toBeUndefined()
+    expect(sanitiseRobotModel('nonsense')).toBeUndefined()
+    // Only-version, no real content → still "no model".
+    expect(sanitiseRobotModel({ servoJointMap: [], defaultPose: {} })).toBeUndefined()
+  })
+
+  it('readRobotModel pulls the model off a RobotDefinition', () => {
+    expect(readRobotModel({ parts: [], connections: [] })).toBeUndefined()
+    const m = readRobotModel({ parts: [], connections: [], robot: { urdf: 'urdf/a.urdf' } })
+    expect(m!.urdf).toBe('urdf/a.urdf')
+  })
+})
+
+describe('scaffoldKrf (#310)', () => {
+  it('builds a valid KRF project plan', () => {
+    const plan = scaffoldKrf('  Walker  ')
+    expect(plan.robotYml.name).toBe('Walker')
+    expect(plan.robotYml.parts).toEqual([])
+    expect(plan.robotYml.robot!.version).toBe(KRF_VERSION)
+    expect(plan.robotYml.robot!.urdf).toBe('urdf/robot.urdf')
+    const paths = plan.files.map((f) => f.path)
+    expect(paths).toContain('code/main.py')
+    expect(paths).toContain('urdf/.gitkeep')
+    expect(paths).toContain('stl/.gitkeep')
+    expect(plan.files.find((f) => f.path === 'code/main.py')!.content).toContain('Walker')
+  })
+  it('falls back to a default name', () => {
+    expect(scaffoldKrf('   ').robotYml.name).toBe('My Robot')
+  })
+})


### PR DESCRIPTION
The robot-project format the Robot View epic (#309) builds on. Extends today's `robot.yml` with an **optional** `robot:` model section (URDF path, servo↔joint map + calibration, per-joint limits, default pose, named poses) — a legacy wiring-only `robot.yml` is unaffected.

- `shared/robot.ts`: the model types + `robot?: RobotModel` field
- `shared/krf.ts` (pure, **10 tests**): `servoToJoint` calibration maths (clamp / invert / custom sweep), corruption-safe `sanitiseRobotModel`, `readRobotModel`, and `scaffoldKrf` (the New Robot Project plan)
- `docs/krf.md`: folder layout + `robot.yml` spec

Remaining #310 work (follow-up): the New-Robot-Project scaffold IPC/UI + Robot View auto-discovery. Gate: typecheck + lint clean, build ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)