### PR TITLE
Robot View — 3D URDF viewer (#311, epic #309 Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Robot View — 3D URDF viewer (#311, epic #309 Phase 1).** Opening a `.urdf`
+  file now shows the robot model in a three.js scene with orbit / pan / zoom.
+  URDF primitives render with no external meshes (the bundled
+  `examples/demo-arm.urdf` is zero-setup), the camera auto-frames the model on a
+  ground grid, and a malformed URDF shows a graceful error instead of a blank
+  panel. The 3D engine is code-split, so it only loads when you open a robot.
+  Built on the KRF format (#310); the pose tool, servo↔joint binding and motion
+  timeline follow.
+
 ## [0.24.0] - 2026-07-08
 
 ### Added

--- a/examples/demo-arm.urdf
+++ b/examples/demo-arm.urdf
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<!-- Snakie demo arm (#311): a 3-DOF arm from URDF primitives — no external
+     meshes, so it renders zero-setup in the Robot View. -->
+<robot name="demo_arm">
+  <link name="base">
+    <visual>
+      <geometry><cylinder radius="0.09" length="0.05"/></geometry>
+      <material name="base_mat"><color rgba="0.30 0.34 0.40 1"/></material>
+    </visual>
+  </link>
+
+  <joint name="shoulder" type="revolute">
+    <parent link="base"/>
+    <child link="upper_arm"/>
+    <origin xyz="0 0 0.05" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-1.5708" upper="1.5708" effort="1" velocity="1"/>
+  </joint>
+
+  <link name="upper_arm">
+    <visual>
+      <origin xyz="0 0 0.16" rpy="0 0 0"/>
+      <geometry><box size="0.055 0.055 0.30"/></geometry>
+      <material name="arm_mat"><color rgba="0.90 0.62 0.22 1"/></material>
+    </visual>
+  </link>
+
+  <joint name="elbow" type="revolute">
+    <parent link="upper_arm"/>
+    <child link="forearm"/>
+    <origin xyz="0 0 0.31" rpy="0 0 0"/>
+    <axis xyz="1 0 0"/>
+    <limit lower="-2.2" upper="2.2" effort="1" velocity="1"/>
+  </joint>
+
+  <link name="forearm">
+    <visual>
+      <origin xyz="0 0 0.13" rpy="0 0 0"/>
+      <geometry><box size="0.045 0.045 0.26"/></geometry>
+      <material name="fore_mat"><color rgba="0.24 0.60 0.90 1"/></material>
+    </visual>
+  </link>
+
+  <joint name="wrist" type="revolute">
+    <parent link="forearm"/>
+    <child link="gripper"/>
+    <origin xyz="0 0 0.26" rpy="0 0 0"/>
+    <axis xyz="1 0 0"/>
+    <limit lower="-1.5708" upper="1.5708" effort="1" velocity="1"/>
+  </joint>
+
+  <link name="gripper">
+    <visual>
+      <origin xyz="0 0 0.03" rpy="0 0 0"/>
+      <geometry><box size="0.09 0.025 0.06"/></geometry>
+      <material name="grip_mat"><color rgba="0.85 0.86 0.90 1"/></material>
+    </visual>
+  </link>
+</robot>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snakie",
-  "version": "0.23.2",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "snakie",
-      "version": "0.23.2",
+      "version": "0.24.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -26,6 +26,8 @@
         "react-resizable-panels": "^2.1.9",
         "serialport": "^13.0.0",
         "simple-git": "^3.36.0",
+        "three": "^0.185.1",
+        "urdf-loader": "^0.13.1",
         "yaml": "^2.9.0"
       },
       "devDependencies": {
@@ -33,6 +35,7 @@
         "@types/node": "^20.17.9",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
+        "@types/three": "^0.185.0",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@typescript-eslint/parser": "^7.18.0",
         "@vitejs/plugin-react": "^4.3.4",
@@ -389,6 +392,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@electron-toolkit/preload": {
       "version": "3.0.2",
@@ -2068,6 +2078,13 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2215,6 +2232,28 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.185.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.0.tgz",
+      "integrity": "sha512-O2Uy8Cj4Nonr8dWUUbifMdPe8B0Mq7EdOHb89S4+kjUw/KhbjTZrUuYlrQ1bpUKG+EP9QJnN7qNxbHGlGoLHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -2228,6 +2267,13 @@
       "integrity": "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -5004,6 +5050,13 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -6601,6 +6654,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -8410,6 +8470,12 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "node_modules/three": {
+      "version": "0.185.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.185.1.tgz",
+      "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
+      "license": "MIT"
+    },
     "node_modules/tiny-typed-emitter": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
@@ -8680,6 +8746,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/urdf-loader": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/urdf-loader/-/urdf-loader-0.13.1.tgz",
+      "integrity": "sha512-bHHoh0Yxrgrw91dPAmVnzKleA8HiVMeHy6xYqOVRw3LuZ2hDOwUiQVCbrzPZckO5S30F1Yym8zLCINN0HfcM3w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "three": ">=0.152.0"
       }
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "react-resizable-panels": "^2.1.9",
     "serialport": "^13.0.0",
     "simple-git": "^3.36.0",
+    "three": "^0.185.1",
+    "urdf-loader": "^0.13.1",
     "yaml": "^2.9.0"
   },
   "devDependencies": {
@@ -50,6 +52,7 @@
     "@types/node": "^20.17.9",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
+    "@types/three": "^0.185.0",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
     "@vitejs/plugin-react": "^4.3.4",

--- a/src/renderer/src/components/EditorArea.tsx
+++ b/src/renderer/src/components/EditorArea.tsx
@@ -9,11 +9,19 @@ import { useWorkspace } from '../store/workspace'
 const MonacoEditor = lazy(() => import('./MonacoEditor'))
 // Data View (#274) is code-split too — only pulled in when a data file is open.
 const DataView = lazy(() => import('./DataView').then((m) => ({ default: m.DataView })))
+// Robot View (#311) — the three.js chunk only loads when a .urdf file is open.
+const RobotView = lazy(() => import('./RobotView'))
 
 /** Files opened as a table (Data View) rather than in the code editor (#274). */
 const DATA_FILE_RE = /\.(csv|tsv|tab)$/i
 function isDataFile(name: string | undefined): boolean {
   return !!name && DATA_FILE_RE.test(name)
+}
+
+/** Files opened in the 3D Robot View rather than the code editor (#311). */
+const ROBOT_FILE_RE = /\.urdf$/i
+function isRobotFile(name: string | undefined): boolean {
+  return !!name && ROBOT_FILE_RE.test(name)
 }
 
 /**
@@ -33,6 +41,7 @@ export function EditorArea(): JSX.Element {
   const hasFiles = openFiles.length > 0
   const activeFile = openFiles.find((f) => f.id === activeId) ?? null
   const showData = isDataFile(activeFile?.name)
+  const showRobot = isRobotFile(activeFile?.name)
 
   // Open the Find & Replace window. The window itself drives the editor over IPC
   // (issue #146); we only need to open/focus it.
@@ -74,7 +83,7 @@ export function EditorArea(): JSX.Element {
     >
       <div className="editor-header">
         <EditorTabs />
-        {hasFiles && !showData && (
+        {hasFiles && !showData && !showRobot && (
           <div className="editor-header__actions">
             <button
               type="button"
@@ -93,6 +102,10 @@ export function EditorArea(): JSX.Element {
         ) : showData ? (
           <Suspense fallback={<EditorPlaceholder text="Loading data view…" />}>
             <DataView />
+          </Suspense>
+        ) : showRobot ? (
+          <Suspense fallback={<EditorPlaceholder text="Loading robot view…" />}>
+            <RobotView />
           </Suspense>
         ) : (
           <Suspense fallback={<EditorPlaceholder text="Loading editor…" />}>

--- a/src/renderer/src/components/RobotView.css
+++ b/src/renderer/src/components/RobotView.css
@@ -1,0 +1,71 @@
+/* ROBOT VIEW (#311) — the 3D URDF panel. Prefix `robotview__`. */
+
+.robotview {
+  position: relative;
+  height: 100%;
+  min-height: 0;
+  background: #191a1d;
+  font-family: var(--font-mono), 'JetBrains Mono', monospace;
+}
+
+.robotview__canvas {
+  position: absolute;
+  inset: 0;
+}
+.robotview__canvas canvas {
+  display: block;
+}
+
+/* Centred overlay: empty-state prompt or an error. */
+.robotview__overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  text-align: center;
+  padding: 1.5rem;
+  color: var(--text-muted, #8b919b);
+  pointer-events: none;
+}
+
+.robotview__overlay-title {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--text, #d6dae0);
+}
+.robotview__overlay-msg {
+  margin: 0;
+  font-size: 0.72rem;
+  max-width: 24rem;
+}
+
+.robotview__overlay--error .robotview__overlay-title {
+  color: #e0774a;
+}
+
+/* Bottom-left readout. */
+.robotview__hud {
+  position: absolute;
+  left: 0.6rem;
+  bottom: 0.55rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
+  padding: 0.3rem 0.55rem;
+  border-radius: 6px;
+  background: rgba(20, 21, 24, 0.72);
+  border: 1px solid var(--border, #2c2e33);
+  font-size: 0.64rem;
+  color: var(--text, #cdd2d9);
+  pointer-events: none;
+}
+.robotview__hud strong {
+  color: #c8a24a;
+}
+.robotview__hud-hint {
+  color: var(--text-muted, #7d838d);
+}

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import * as THREE from 'three'
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
+import URDFLoader from 'urdf-loader'
+import type { URDFRobot } from 'urdf-loader'
+import { useWorkspace } from '../store/workspace'
+import './RobotView.css'
+
+/**
+ * ROBOT VIEW (#311, epic #309) — Phase 1: a 3D panel that renders a URDF robot.
+ * =============================================================================
+ *
+ * Opening a `.urdf` file shows the model in a three.js scene with orbit / pan /
+ * zoom. The URDF is parsed from the OPEN FILE's content (so it lives in the
+ * workspace, no server), primitives (box / cylinder / sphere) render with no
+ * external meshes — the bundled `examples/demo-arm.urdf` is zero-setup. Later
+ * phases add the pose tool, servo↔joint binding and the timeline; this is just
+ * "see the robot". Code-split so three.js stays out of the initial bundle.
+ */
+export function RobotView(): JSX.Element {
+  const { openFiles, activeId } = useWorkspace()
+  const activeFile = openFiles.find((f) => f.id === activeId) ?? null
+  const content = activeFile?.content ?? ''
+
+  const mountRef = useRef<HTMLDivElement>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [info, setInfo] = useState<{ name: string; joints: number; links: number } | null>(null)
+
+  // Parse once per content change (cheap; the scene rebuild below consumes it).
+  const parsed = useMemo<{ robot: URDFRobot | null; err: string | null }>(() => {
+    if (!content.trim()) return { robot: null, err: 'empty' }
+    try {
+      const loader = new URDFLoader()
+      loader.parseVisual = true
+      loader.parseCollision = false
+      const robot = loader.parse(content)
+      const linkCount = robot ? Object.keys(robot.links).length : 0
+      if (!robot || linkCount === 0) return { robot: null, err: 'This file has no URDF links to show.' }
+      return { robot, err: null }
+    } catch (e) {
+      return { robot: null, err: e instanceof Error ? e.message : 'Could not parse this URDF.' }
+    }
+  }, [content])
+
+  useEffect(() => {
+    const mount = mountRef.current
+    if (!mount) return
+
+    if (!parsed.robot) {
+      setError(parsed.err === 'empty' ? null : parsed.err)
+      setInfo(null)
+      return
+    }
+    setError(null)
+
+    const scene = new THREE.Scene()
+    scene.background = new THREE.Color(0x191a1d)
+
+    const camera = new THREE.PerspectiveCamera(50, 1, 0.01, 100)
+    const renderer = new THREE.WebGLRenderer({ antialias: true })
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2))
+    renderer.outputColorSpace = THREE.SRGBColorSpace
+    mount.appendChild(renderer.domElement)
+
+    const controls = new OrbitControls(camera, renderer.domElement)
+    controls.enableDamping = true
+    controls.dampingFactor = 0.08
+
+    // Lights: soft ambient + a key + a fill so the coloured links read.
+    scene.add(new THREE.HemisphereLight(0xffffff, 0x30333a, 0.9))
+    const key = new THREE.DirectionalLight(0xffffff, 1.1)
+    key.position.set(1.5, 2.5, 1.5)
+    scene.add(key)
+    const fill = new THREE.DirectionalLight(0x9fb4d0, 0.35)
+    fill.position.set(-1.5, 1, -1.2)
+    scene.add(fill)
+
+    // The robot. URDF is Z-up; rotate into three's Y-up so it stands up.
+    const robot = parsed.robot
+    robot.rotation.x = -Math.PI / 2
+    scene.add(robot)
+    // Flush the world matrices BEFORE measuring — setting rotation only marks
+    // them dirty, so an immediate Box3 would frame the un-rotated (stale) box.
+    robot.updateMatrixWorld(true)
+    setInfo({
+      name: robot.robotName || robot.name || 'robot',
+      joints: Object.keys(robot.joints).length,
+      links: Object.keys(robot.links).length
+    })
+
+    // Frame the model: fit the camera to its bounds + a ground grid at its base.
+    const box = new THREE.Box3().setFromObject(robot)
+    const size = box.getSize(new THREE.Vector3())
+    const centre = box.getCenter(new THREE.Vector3())
+    const radius = Math.max(size.x, size.y, size.z, 0.1) * 0.5
+    const dist = radius / Math.sin((camera.fov * Math.PI) / 180 / 2)
+    camera.position.set(centre.x + dist * 0.8, box.max.y + dist * 0.35, centre.z + dist * 1.0)
+    controls.target.copy(centre)
+    controls.update()
+
+    const gridSize = Math.max(size.x, size.z) * 3 + 0.4
+    const grid = new THREE.GridHelper(gridSize, 20, 0x3a3d44, 0x27292e)
+    grid.position.y = box.min.y
+    scene.add(grid)
+
+    const resize = (): void => {
+      const w = mount.clientWidth
+      const h = mount.clientHeight
+      if (w === 0 || h === 0) return
+      // updateStyle defaults true → the canvas CSS size fits the container while
+      // the drawing buffer scales by the pixel ratio (passing false made the
+      // canvas render at its oversized device-pixel size and overflow).
+      renderer.setSize(w, h)
+      camera.aspect = w / h
+      camera.updateProjectionMatrix()
+    }
+    resize()
+    const ro = new ResizeObserver(resize)
+    ro.observe(mount)
+
+    let raf = 0
+    const tick = (): void => {
+      controls.update()
+      renderer.render(scene, camera)
+      raf = requestAnimationFrame(tick)
+    }
+    tick()
+
+    return () => {
+      cancelAnimationFrame(raf)
+      ro.disconnect()
+      controls.dispose()
+      scene.traverse((o) => {
+        const mesh = o as THREE.Mesh
+        if (mesh.geometry) mesh.geometry.dispose()
+        const mat = mesh.material as THREE.Material | THREE.Material[] | undefined
+        if (Array.isArray(mat)) mat.forEach((m) => m.dispose())
+        else mat?.dispose()
+      })
+      renderer.dispose()
+      if (renderer.domElement.parentNode === mount) mount.removeChild(renderer.domElement)
+    }
+  }, [parsed])
+
+  return (
+    <div className="robotview">
+      <div className="robotview__canvas" ref={mountRef} />
+      {error ? (
+        <div className="robotview__overlay robotview__overlay--error" role="alert">
+          <p className="robotview__overlay-title">Couldn&apos;t show this robot</p>
+          <p className="robotview__overlay-msg">{error}</p>
+        </div>
+      ) : parsed.err === 'empty' ? (
+        <div className="robotview__overlay">
+          <p className="robotview__overlay-title">Robot View</p>
+          <p className="robotview__overlay-msg">Open a .urdf file to see the 3D model.</p>
+        </div>
+      ) : (
+        info && (
+          <div className="robotview__hud" aria-hidden="true">
+            <strong>{info.name}</strong> · {info.joints} joints · {info.links} links
+            <span className="robotview__hud-hint">drag to orbit · scroll to zoom</span>
+          </div>
+        )
+      )}
+    </div>
+  )
+}
+
+export default RobotView


### PR DESCRIPTION
Phase 1 of the Robot View epic (#309): a 3D URDF viewer. Opening a `.urdf` file shows the robot model — the "see the robot" discovery.

## What
- **three.js + urdf-loader** scene with **orbit / pan / zoom**, parsed from the open file's content (lives in the workspace, no server).
- **Bundled demo arm** (`examples/demo-arm.urdf`) — a 3-DOF arm from URDF **primitives** (box/cylinder), so it renders **zero-setup** with no external meshes.
- **Auto-frames** the model (fits the camera to its bounds) on a ground grid, with a HUD (name · joints · links · controls hint).
- **Graceful errors** — a malformed URDF shows an error overlay, never a blank panel or crash.
- **Code-split** — the ~1.3 MB 3D chunk only loads when a `.urdf` opens (routed in `EditorArea`, like Data View for `.csv`).
- Built on the KRF format (#310).

## Verified (in-app, Playwright)
- The demo arm renders correctly framed (grey base, orange upper arm, blue forearm, grey gripper), HUD reads "demo_arm · 3 joints · 4 links" (screenshot).
- A malformed URDF shows the error overlay, no crash.
- Fixed two rendering bugs found on the way: camera framing (needed `updateMatrixWorld` before the `Box3`) and canvas overflow (`setSize` was disabling the CSS style).

Gate: typecheck + lint clean, **1410 tests**, build ✅.

## Remaining #311 (follow-up)
STL/DAE **mesh loading from the workspace folder** — needs a custom `loadMeshCb` that reads meshes via the app's fs and parses them with three's STL/Collada loaders. The primitive demo covers the core; this is the next commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
