### PR TITLE
Robot workspace mode + docked mini-3D + isometric camera (#320)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Robot workspace mode (#320, epic #309).** A new **Robot** tab joins Code ·
+  Board · Data Lab: files collapsed, your code on the left (~⅓), the Board View
+  in the middle, and on the right a **mini 3-D Robot panel over the instrument
+  dock** — code, wiring, the robot and live instruments in one glance. The 3-D
+  view now defaults to an **isometric** (orthographic) camera, and the docked
+  panel finds the project's URDF via the KRF `robot.yml` (falling back to the
+  bundled demo arm). The 3-D engine stays code-split (only loads in Robot mode).
+
 - **Robot View — 3D URDF viewer (#311, epic #309 Phase 1).** Opening a `.urdf`
   file now shows the robot model in a three.js scene with orbit / pan / zoom.
   URDF primitives render with no external meshes (the bundled

--- a/src/renderer/src/assets/demo-arm.urdf
+++ b/src/renderer/src/assets/demo-arm.urdf
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<!-- Snakie demo arm (#311): a 3-DOF arm from URDF primitives — no external
+     meshes, so it renders zero-setup in the Robot View. -->
+<robot name="demo_arm">
+  <link name="base">
+    <visual>
+      <geometry><cylinder radius="0.09" length="0.05"/></geometry>
+      <material name="base_mat"><color rgba="0.30 0.34 0.40 1"/></material>
+    </visual>
+  </link>
+
+  <joint name="shoulder" type="revolute">
+    <parent link="base"/>
+    <child link="upper_arm"/>
+    <origin xyz="0 0 0.05" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-1.5708" upper="1.5708" effort="1" velocity="1"/>
+  </joint>
+
+  <link name="upper_arm">
+    <visual>
+      <origin xyz="0 0 0.16" rpy="0 0 0"/>
+      <geometry><box size="0.055 0.055 0.30"/></geometry>
+      <material name="arm_mat"><color rgba="0.90 0.62 0.22 1"/></material>
+    </visual>
+  </link>
+
+  <joint name="elbow" type="revolute">
+    <parent link="upper_arm"/>
+    <child link="forearm"/>
+    <origin xyz="0 0 0.31" rpy="0 0 0"/>
+    <axis xyz="1 0 0"/>
+    <limit lower="-2.2" upper="2.2" effort="1" velocity="1"/>
+  </joint>
+
+  <link name="forearm">
+    <visual>
+      <origin xyz="0 0 0.13" rpy="0 0 0"/>
+      <geometry><box size="0.045 0.045 0.26"/></geometry>
+      <material name="fore_mat"><color rgba="0.24 0.60 0.90 1"/></material>
+    </visual>
+  </link>
+
+  <joint name="wrist" type="revolute">
+    <parent link="forearm"/>
+    <child link="gripper"/>
+    <origin xyz="0 0 0.26" rpy="0 0 0"/>
+    <axis xyz="1 0 0"/>
+    <limit lower="-1.5708" upper="1.5708" effort="1" velocity="1"/>
+  </joint>
+
+  <link name="gripper">
+    <visual>
+      <origin xyz="0 0 0.03" rpy="0 0 0"/>
+      <geometry><box size="0.09 0.025 0.06"/></geometry>
+      <material name="grip_mat"><color rgba="0.85 0.86 0.90 1"/></material>
+    </visual>
+  </link>
+</robot>

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -7,12 +7,15 @@ import {
   PanelResizeHandle
 } from 'react-resizable-panels'
 import { useLocalStorage } from '../hooks/useLocalStorage'
-import { useWorkspaceLayout } from '../store/layout'
+import { useWorkspaceLayout, type WorkspaceId } from '../store/layout'
 
 // The embedded Board View pane (the Board workspace's tri-split, #259) is
 // code-split: the whole board subsystem (BoardGraph + wiring + Part Editor)
 // loads only when a workspace with the pane open is activated.
 const BoardPane = lazy(() => import('./BoardPane'))
+// The mini 3-D Robot panel (Robot mode, #320) — lazy so three.js only loads
+// when you enter Robot mode.
+const RobotDockPanel = lazy(() => import('./RobotDockPanel'))
 import { useTheme } from '../hooks/useTheme'
 import { Toolbar } from './Toolbar'
 import { ActivityBar, ActivityView } from './ActivityBar'
@@ -186,8 +189,8 @@ export function AppShell(): JSX.Element {
   // they can consult/flip these synchronously. The `.current` values are kept
   // fresh in the workspace-layout block further down (after `layout` exists).
   const poppedFromBoardRef = useRef(false)
-  const switchWorkspaceRef = useRef<(id: 'code' | 'board' | 'datalab') => void>(() => undefined)
-  const activeWsRef = useRef<'code' | 'board' | 'datalab'>('code')
+  const switchWorkspaceRef = useRef<(id: WorkspaceId) => void>(() => undefined)
+  const activeWsRef = useRef<WorkspaceId>('code')
 
   // Toggle the floating Board View window from the toolbar button: open (and
   // push the current file immediately so it isn't blank) if closed, or close it
@@ -1043,7 +1046,17 @@ export function AppShell(): JSX.Element {
             redistribute each other's freed space). Shown by the toolbar
             Instruments button or an incoming `instruments:open`. */}
         {instrumentsVisible && (
-          <aside className="shell__dock" aria-label="Instrument dock">
+          <aside
+            className={`shell__dock${layout.active === 'robot' ? ' shell__dock--robot' : ''}`}
+            aria-label="Instrument dock"
+          >
+            {layout.active === 'robot' && (
+              <div className="shell__robot3d">
+                <Suspense fallback={<div className="shell__robot3d-loading">Loading 3D…</div>}>
+                  <RobotDockPanel />
+                </Suspense>
+              </div>
+            )}
             <InstrumentDockRegion
               host={instruments}
               vis={visibility}

--- a/src/renderer/src/components/RobotDockPanel.tsx
+++ b/src/renderer/src/components/RobotDockPanel.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react'
+import { RobotView } from './RobotView'
+import { useWorkspace } from '../store/workspace'
+import { readRobotModel } from '../../../shared/krf'
+import demoArm from '../assets/demo-arm.urdf?raw'
+
+/**
+ * ROBOT DOCK PANEL (#320) — the mini 3-D Robot view that sits above the
+ * instrument dock in the **Robot** workspace. It finds the project's URDF via
+ * the KRF `robot.yml` (`robot.urdf`, resolved against the workspace folder) and
+ * falls back to the bundled demo arm so the panel is never empty. Isometric,
+ * compact chrome (the full viewer opens by opening the `.urdf` itself).
+ */
+export function RobotDockPanel(): JSX.Element {
+  const { currentFolder } = useWorkspace()
+  const [urdf, setUrdf] = useState<string>(demoArm)
+
+  useEffect(() => {
+    let live = true
+    void (async () => {
+      try {
+        const robot = await window.api.robot.load(currentFolder ?? undefined)
+        const rel = readRobotModel(robot)?.urdf
+        if (rel && currentFolder) {
+          const path = `${currentFolder.replace(/[/\\]$/, '')}/${rel.replace(/^[/\\]/, '')}`
+          const content = await window.api.fs.readFile(path)
+          if (live && content.trim()) {
+            setUrdf(content)
+            return
+          }
+        }
+      } catch {
+        // No project URDF (or unreadable) — fall through to the demo arm.
+      }
+      if (live) setUrdf(demoArm)
+    })()
+    return () => {
+      live = false
+    }
+  }, [currentFolder])
+
+  return <RobotView urdfContent={urdf} compact />
+}
+
+export default RobotDockPanel

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -17,10 +17,18 @@ import './RobotView.css'
  * phases add the pose tool, servo↔joint binding and the timeline; this is just
  * "see the robot". Code-split so three.js stays out of the initial bundle.
  */
-export function RobotView(): JSX.Element {
+export interface RobotViewProps {
+  /** URDF text to render. When omitted, the active editor file is used (opening
+   *  a `.urdf`). Provided directly by the docked Robot-mode panel (#320). */
+  urdfContent?: string
+  /** Compact chrome for the small docked panel (a slimmer HUD). */
+  compact?: boolean
+}
+
+export function RobotView({ urdfContent, compact = false }: RobotViewProps = {}): JSX.Element {
   const { openFiles, activeId } = useWorkspace()
   const activeFile = openFiles.find((f) => f.id === activeId) ?? null
-  const content = activeFile?.content ?? ''
+  const content = urdfContent ?? activeFile?.content ?? ''
 
   const mountRef = useRef<HTMLDivElement>(null)
   const [error, setError] = useState<string | null>(null)
@@ -56,7 +64,10 @@ export function RobotView(): JSX.Element {
     const scene = new THREE.Scene()
     scene.background = new THREE.Color(0x191a1d)
 
-    const camera = new THREE.PerspectiveCamera(50, 1, 0.01, 100)
+    // Isometric ORTHOGRAPHIC camera (#320) — the three axes foreshorten equally
+    // and there's no perspective distortion, which reads cleaner for poses. Its
+    // frustum is sized from the model bounds below.
+    const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.01, 100)
     const renderer = new THREE.WebGLRenderer({ antialias: true })
     renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2))
     renderer.outputColorSpace = THREE.SRGBColorSpace
@@ -88,13 +99,15 @@ export function RobotView(): JSX.Element {
       links: Object.keys(robot.links).length
     })
 
-    // Frame the model: fit the camera to its bounds + a ground grid at its base.
+    // Frame the model: an ISO viewpoint (equal x/y/z direction) + a ground grid.
     const box = new THREE.Box3().setFromObject(robot)
     const size = box.getSize(new THREE.Vector3())
     const centre = box.getCenter(new THREE.Vector3())
     const radius = Math.max(size.x, size.y, size.z, 0.1) * 0.5
-    const dist = radius / Math.sin((camera.fov * Math.PI) / 180 / 2)
-    camera.position.set(centre.x + dist * 0.8, box.max.y + dist * 0.35, centre.z + dist * 1.0)
+    // Half-height the ortho frustum should show (a little padding around the model).
+    const halfView = radius * 1.35
+    const isoDir = new THREE.Vector3(1, 0.9, 1).normalize()
+    camera.position.copy(centre).addScaledVector(isoDir, radius * 6)
     controls.target.copy(centre)
     controls.update()
 
@@ -108,10 +121,15 @@ export function RobotView(): JSX.Element {
       const h = mount.clientHeight
       if (w === 0 || h === 0) return
       // updateStyle defaults true → the canvas CSS size fits the container while
-      // the drawing buffer scales by the pixel ratio (passing false made the
-      // canvas render at its oversized device-pixel size and overflow).
+      // the drawing buffer scales by the pixel ratio.
       renderer.setSize(w, h)
-      camera.aspect = w / h
+      // Orthographic: keep `halfView` world units visible vertically, widen the
+      // frustum by the aspect ratio so nothing is squashed.
+      const aspect = w / h
+      camera.left = -halfView * aspect
+      camera.right = halfView * aspect
+      camera.top = halfView
+      camera.bottom = -halfView
       camera.updateProjectionMatrix()
     }
     resize()
@@ -143,7 +161,7 @@ export function RobotView(): JSX.Element {
   }, [parsed])
 
   return (
-    <div className="robotview">
+    <div className={`robotview${compact ? ' robotview--compact' : ''}`}>
       <div className="robotview__canvas" ref={mountRef} />
       {error ? (
         <div className="robotview__overlay robotview__overlay--error" role="alert">
@@ -159,7 +177,7 @@ export function RobotView(): JSX.Element {
         info && (
           <div className="robotview__hud" aria-hidden="true">
             <strong>{info.name}</strong> · {info.joints} joints · {info.links} links
-            <span className="robotview__hud-hint">drag to orbit · scroll to zoom</span>
+            {!compact && <span className="robotview__hud-hint">drag to orbit · scroll to zoom</span>}
           </div>
         )
       )}

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -2118,6 +2118,31 @@ body {
   display: flex;
 }
 
+/* Robot mode (#320): the mini 3-D Robot panel sits ABOVE the instrument dock. */
+.shell__main .shell__dock--robot {
+  flex-direction: column;
+}
+.shell__robot3d {
+  flex: 0 0 42%;
+  min-height: 160px;
+  position: relative;
+  border-bottom: var(--border-w) solid var(--border);
+}
+.shell__robot3d-loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+/* The instrument dock takes the remaining height + scrolls. */
+.shell__dock--robot .instr-dock {
+  min-height: 0;
+}
+
 .activitybar {
   display: flex;
   flex-direction: column;

--- a/src/renderer/src/store/layout.ts
+++ b/src/renderer/src/store/layout.ts
@@ -41,14 +41,15 @@ import type { ActivityView } from '../components/ActivityBar'
 /** The named workspaces (Phase 1; slimmed 4 → 3 by the modes review). Order =
  *  the switcher's display order. Old `lab`/`data` envelopes migrate to
  *  `datalab` in {@link loadLayoutState}. */
-export const WORKSPACE_IDS = ['code', 'board', 'datalab'] as const
+export const WORKSPACE_IDS = ['code', 'board', 'datalab', 'robot'] as const
 export type WorkspaceId = (typeof WORKSPACE_IDS)[number]
 
 /** Display labels + a one-line description for the switcher tooltips. */
 export const WORKSPACE_INFO: Record<WorkspaceId, { label: string; hint: string }> = {
   code: { label: 'Code', hint: 'Editor-first: files, editor and console' },
   board: { label: 'Board', hint: 'Focused Board View beside your code' },
-  datalab: { label: 'Data Lab', hint: 'Instrument bench + a tall console/plotter' }
+  datalab: { label: 'Data Lab', hint: 'Instrument bench + a tall console/plotter' },
+  robot: { label: 'Robot', hint: 'Code · board · a 3D robot over the instruments' }
 }
 
 /** One workspace's remembered geometry. */
@@ -120,6 +121,19 @@ export const WORKSPACE_PRESETS: Record<WorkspaceId, WorkspaceLayout> = {
     boardPaneOpen: false,
     horizontal: [0, 100, 0, 0],
     vertical: [50, 50]
+  },
+  // Robot (#320): the robotics cockpit — files collapsed, CODE ~⅓ on the left,
+  // the Board View (breadboard) in the middle, and the dock on the right (which
+  // in this mode carries a mini 3-D Robot panel above the instruments).
+  robot: {
+    activityView: 'files',
+    filesCollapsed: true,
+    shellCollapsed: false,
+    rightCollapsed: true,
+    dockOpen: true,
+    boardPaneOpen: true,
+    horizontal: [0, 34, 66, 0],
+    vertical: [65, 35]
   }
 }
 

--- a/test/layoutStore.test.ts
+++ b/test/layoutStore.test.ts
@@ -13,9 +13,9 @@ const storage = (entries: Record<string, string> = {}): StorageLike => ({
   getItem: (k: string) => (k in entries ? entries[k] : null)
 })
 
-describe('workspace presets (epic #259 Phase 1; slimmed to 3 by the modes review)', () => {
-  it('defines the three workspaces with valid geometry', () => {
-    expect(WORKSPACE_IDS).toEqual(['code', 'board', 'datalab'])
+describe('workspace presets (epic #259; +Robot mode #320)', () => {
+  it('defines the workspaces with valid geometry', () => {
+    expect(WORKSPACE_IDS).toEqual(['code', 'board', 'datalab', 'robot'])
     for (const id of WORKSPACE_IDS) {
       const p = WORKSPACE_PRESETS[id]
       expect(p.horizontal).toHaveLength(4)
@@ -23,6 +23,27 @@ describe('workspace presets (epic #259 Phase 1; slimmed to 3 by the modes review
       expect(p.horizontal.reduce((a, b) => a + b, 0)).toBeCloseTo(100, 0)
       expect(p.vertical.reduce((a, b) => a + b, 0)).toBeCloseTo(100, 0)
     }
+  })
+
+  it("Robot mode: files collapsed, code ~1/3, board middle, dock open (#320)", () => {
+    const r = WORKSPACE_PRESETS.robot
+    expect(r.filesCollapsed).toBe(true)
+    expect(r.boardPaneOpen).toBe(true)
+    expect(r.dockOpen).toBe(true)
+    // code (centre) is roughly a third and the board (slot 2) gets the rest.
+    expect(r.horizontal[1]).toBeGreaterThan(25)
+    expect(r.horizontal[1]).toBeLessThan(45)
+    expect(r.horizontal[2]).toBeGreaterThan(r.horizontal[1])
+  })
+
+  it('a pre-Robot saved envelope gains the robot preset (migration)', () => {
+    const saved = {
+      version: 1,
+      active: 'code',
+      workspaces: { code: { ...WORKSPACE_PRESETS.code } } // no robot key
+    }
+    const s = loadLayoutState(storage({ [LAYOUT_STORAGE_KEY]: JSON.stringify(saved) }))
+    expect(s.workspaces.robot).toEqual(WORKSPACE_PRESETS.robot)
   })
 
   it("'code' preserves today's default layout; instrument dock per workspace", () => {


### PR DESCRIPTION
Realizes the layout requirements added to #311 (split out as #320): a dedicated **Robot** workspace mode so the 3-D view has a home alongside the code, board and instruments — the docked-discovery step before Phase 2's full-screen pose tool.

## What
- **A 4th workspace: Robot** (Code · Board · Data Lab · **Robot**). Layout: **files collapsed · code ~⅓ left · Board View (breadboard) middle · a mini 3-D Robot panel over the instrument dock** on the right. Persisted per-workspace; auto-migrates into existing layout envelopes.
- **Mini 3-D dock panel** (`RobotDockPanel`, lazy so three.js only loads in Robot mode): finds the project's URDF via the KRF `robot.yml` (`readRobotModel` → resolve `robot.urdf` against the folder → `fs.readFile`), falling back to the **bundled demo arm** so it's never empty.
- **Isometric camera**: the Robot View now uses an **orthographic isometric** camera (equal-axis, no perspective distortion) — cleaner for reading poses — with an ortho-aware resize. Added `compact` chrome + a `urdfContent` prop for docked use.

## Verified (in-app, Playwright)
- Switcher shows **Code · Board · Data Lab · Robot**; picking Robot lays out code(⅓) · board · mini-3D-over-instruments, files collapsed (screenshot).
- The mini-3D shows the demo arm ("demo_arm · 3 joints · 4 links") isometric.
- Layout persists per-workspace. Gate: typecheck + lint clean, **1412 tests** (+3), build ✅.

Part of epic #309. Next: #319 (STL/DAE meshes) so real robots render, then Phase 2 (#312 pose tool) which reuses this scene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
