### PR TITLE
Robot View: load STL & DAE meshes from the workspace (#319)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Robot View — STL & DAE meshes (#319, epic #309).** Robot View now renders
+  real robots: a URDF's `.stl` / `.dae` (Collada) meshes load straight from the
+  project folder — no web server. Relative (`meshes/link.stl`) and `package://`
+  paths both resolve against the URDF's folder, the URDF `<material>` colour is
+  applied to meshes that carry none, and the camera reframes once they arrive. A
+  mesh that can't load degrades to a small placeholder + a panel note (the rest
+  of the robot still shows) instead of a blank model or a crash. Try
+  `examples/mesh-demo/mesh-demo.urdf`. The mesh loaders stay code-split in the
+  Robot View chunk.
 - **Robot workspace mode (#320, epic #309).** A new **Robot** tab joins Code ·
   Board · Data Lab: files collapsed, your code on the left (~⅓), the Board View
   in the middle, and on the right a **mini 3-D Robot panel over the instrument

--- a/docs/krf.md
+++ b/docs/krf.md
@@ -55,6 +55,23 @@ angle is clamped to `servoMin..servoMax`, optionally inverted, and lerped onto
 `jointMin..jointMax`. Pure implementation + tests: `src/shared/krf.ts`
 (`servoToJoint`), `test/krf.test.ts`.
 
+## Meshes (#319)
+
+A URDF's `<visual>`/`<geometry>` can reference **STL** or **DAE (Collada)** mesh
+files instead of primitives. Robot View loads them straight from the project
+folder — no web server:
+
+- **Relative** paths (`meshes/base.stl`) resolve against the URDF's own folder.
+- **`package://<pkg>/rest`** paths resolve `<pkg>` to that same folder, so
+  `package://my-robot/meshes/link.stl` → `<urdf-folder>/meshes/link.stl`.
+
+Meshes are read through the app's filesystem (binary-safe for STL), the URDF
+`<material>` colour is applied to meshes that carry none, and the camera reframes
+once they load. A mesh that can't be read degrades to a small placeholder plus a
+note in the panel — the rest of the robot still renders. `.obj`/`.glb` and other
+formats aren't loaded yet (they show a placeholder). See
+`examples/mesh-demo/mesh-demo.urdf` for a zero-setup example.
+
 ## Versioning
 
 `robot.version` is bumped on breaking changes; `sanitiseRobotModel` migrates /

--- a/examples/mesh-demo/mesh-demo.urdf
+++ b/examples/mesh-demo/mesh-demo.urdf
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<!--
+  MESH DEMO (#319) — a robot whose links are STL *meshes* loaded from this folder,
+  proving Robot View's mesh loading. `base_link` uses a plain relative mesh path
+  (meshes/base.stl); `upper_link` uses a package:// path (package://mesh-demo/…),
+  so both resolution styles are exercised. Open this file in Snakie's Robot View,
+  or point a robot.yml `model.urdf` at it.
+-->
+<robot name="mesh_demo">
+  <material name="steel"><color rgba="0.62 0.65 0.69 1"/></material>
+  <material name="amber"><color rgba="0.85 0.55 0.18 1"/></material>
+
+  <link name="base_link">
+    <visual>
+      <geometry>
+        <mesh filename="meshes/base.stl"/>
+      </geometry>
+      <material name="steel"/>
+    </visual>
+  </link>
+
+  <link name="upper_link">
+    <visual>
+      <geometry>
+        <mesh filename="package://mesh-demo/meshes/link.stl"/>
+      </geometry>
+      <material name="amber"/>
+    </visual>
+  </link>
+
+  <joint name="shoulder" type="revolute">
+    <parent link="base_link"/>
+    <child link="upper_link"/>
+    <origin xyz="0 0 0.04" rpy="0 0 0"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-1.57" upper="1.57" effort="1" velocity="1"/>
+  </joint>
+</robot>

--- a/examples/mesh-demo/meshes/base.stl
+++ b/examples/mesh-demo/meshes/base.stl
@@ -1,0 +1,86 @@
+solid base
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex -7.000000e-02 -7.000000e-02 0.000000e+00
+      vertex 7.000000e-02 -7.000000e-02 0.000000e+00
+      vertex 7.000000e-02 7.000000e-02 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex -7.000000e-02 -7.000000e-02 0.000000e+00
+      vertex 7.000000e-02 7.000000e-02 0.000000e+00
+      vertex -7.000000e-02 7.000000e-02 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 1.000000e+00
+    outer loop
+      vertex -7.000000e-02 -7.000000e-02 4.000000e-02
+      vertex -7.000000e-02 7.000000e-02 4.000000e-02
+      vertex 7.000000e-02 7.000000e-02 4.000000e-02
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 1.000000e+00
+    outer loop
+      vertex -7.000000e-02 -7.000000e-02 4.000000e-02
+      vertex 7.000000e-02 7.000000e-02 4.000000e-02
+      vertex 7.000000e-02 -7.000000e-02 4.000000e-02
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex -7.000000e-02 -7.000000e-02 0.000000e+00
+      vertex -7.000000e-02 -7.000000e-02 4.000000e-02
+      vertex 7.000000e-02 -7.000000e-02 4.000000e-02
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex -7.000000e-02 -7.000000e-02 0.000000e+00
+      vertex 7.000000e-02 -7.000000e-02 4.000000e-02
+      vertex 7.000000e-02 -7.000000e-02 0.000000e+00
+    endloop
+  endfacet
+  facet normal 1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex 7.000000e-02 -7.000000e-02 0.000000e+00
+      vertex 7.000000e-02 -7.000000e-02 4.000000e-02
+      vertex 7.000000e-02 7.000000e-02 4.000000e-02
+    endloop
+  endfacet
+  facet normal 1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex 7.000000e-02 -7.000000e-02 0.000000e+00
+      vertex 7.000000e-02 7.000000e-02 4.000000e-02
+      vertex 7.000000e-02 7.000000e-02 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex 7.000000e-02 7.000000e-02 0.000000e+00
+      vertex 7.000000e-02 7.000000e-02 4.000000e-02
+      vertex -7.000000e-02 7.000000e-02 4.000000e-02
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex 7.000000e-02 7.000000e-02 0.000000e+00
+      vertex -7.000000e-02 7.000000e-02 4.000000e-02
+      vertex -7.000000e-02 7.000000e-02 0.000000e+00
+    endloop
+  endfacet
+  facet normal -1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex -7.000000e-02 7.000000e-02 0.000000e+00
+      vertex -7.000000e-02 7.000000e-02 4.000000e-02
+      vertex -7.000000e-02 -7.000000e-02 4.000000e-02
+    endloop
+  endfacet
+  facet normal -1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex -7.000000e-02 7.000000e-02 0.000000e+00
+      vertex -7.000000e-02 -7.000000e-02 4.000000e-02
+      vertex -7.000000e-02 -7.000000e-02 0.000000e+00
+    endloop
+  endfacet
+endsolid base

--- a/examples/mesh-demo/meshes/link.stl
+++ b/examples/mesh-demo/meshes/link.stl
@@ -1,0 +1,86 @@
+solid link
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex -2.500000e-02 -2.500000e-02 0.000000e+00
+      vertex 2.500000e-02 -2.500000e-02 0.000000e+00
+      vertex 2.500000e-02 2.500000e-02 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex -2.500000e-02 -2.500000e-02 0.000000e+00
+      vertex 2.500000e-02 2.500000e-02 0.000000e+00
+      vertex -2.500000e-02 2.500000e-02 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 1.000000e+00
+    outer loop
+      vertex -2.500000e-02 -2.500000e-02 2.400000e-01
+      vertex -2.500000e-02 2.500000e-02 2.400000e-01
+      vertex 2.500000e-02 2.500000e-02 2.400000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 1.000000e+00
+    outer loop
+      vertex -2.500000e-02 -2.500000e-02 2.400000e-01
+      vertex 2.500000e-02 2.500000e-02 2.400000e-01
+      vertex 2.500000e-02 -2.500000e-02 2.400000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex -2.500000e-02 -2.500000e-02 0.000000e+00
+      vertex -2.500000e-02 -2.500000e-02 2.400000e-01
+      vertex 2.500000e-02 -2.500000e-02 2.400000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex -2.500000e-02 -2.500000e-02 0.000000e+00
+      vertex 2.500000e-02 -2.500000e-02 2.400000e-01
+      vertex 2.500000e-02 -2.500000e-02 0.000000e+00
+    endloop
+  endfacet
+  facet normal 1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex 2.500000e-02 -2.500000e-02 0.000000e+00
+      vertex 2.500000e-02 -2.500000e-02 2.400000e-01
+      vertex 2.500000e-02 2.500000e-02 2.400000e-01
+    endloop
+  endfacet
+  facet normal 1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex 2.500000e-02 -2.500000e-02 0.000000e+00
+      vertex 2.500000e-02 2.500000e-02 2.400000e-01
+      vertex 2.500000e-02 2.500000e-02 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex 2.500000e-02 2.500000e-02 0.000000e+00
+      vertex 2.500000e-02 2.500000e-02 2.400000e-01
+      vertex -2.500000e-02 2.500000e-02 2.400000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex 2.500000e-02 2.500000e-02 0.000000e+00
+      vertex -2.500000e-02 2.500000e-02 2.400000e-01
+      vertex -2.500000e-02 2.500000e-02 0.000000e+00
+    endloop
+  endfacet
+  facet normal -1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex -2.500000e-02 2.500000e-02 0.000000e+00
+      vertex -2.500000e-02 2.500000e-02 2.400000e-01
+      vertex -2.500000e-02 -2.500000e-02 2.400000e-01
+    endloop
+  endfacet
+  facet normal -1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex -2.500000e-02 2.500000e-02 0.000000e+00
+      vertex -2.500000e-02 -2.500000e-02 2.400000e-01
+      vertex -2.500000e-02 -2.500000e-02 0.000000e+00
+    endloop
+  endfacet
+endsolid link

--- a/src/main/fs/ipc.ts
+++ b/src/main/fs/ipc.ts
@@ -71,6 +71,12 @@ export function registerFsIpc(getWindow: () => BrowserWindow | undefined): void 
 
   ipcMain.handle('fs:readFile', (_e, path: string) => wrap(() => fs.readFile(path, 'utf-8')))
 
+  // Binary read (base64) — for meshes (binary STL etc.) that a utf-8 read would
+  // corrupt. Robot View decodes it back to an ArrayBuffer (#319).
+  ipcMain.handle('fs:readFileBase64', (_e, path: string) =>
+    wrap(async () => (await fs.readFile(path)).toString('base64'))
+  )
+
   ipcMain.handle('fs:writeFile', (_e, path: string, contents: string) =>
     wrap(async () => {
       await fs.writeFile(path, contents, 'utf-8')

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -257,6 +257,11 @@ const fs = {
   readDir: (path: string): Promise<FsEntry[]> => unwrap(ipcRenderer.invoke('fs:readDir', path)),
   /** Read a file's contents (UTF-8). */
   readFile: (path: string): Promise<string> => unwrap(ipcRenderer.invoke('fs:readFile', path)),
+  /** Read a file's raw bytes (for binary meshes — #319). */
+  readFileBytes: (path: string): Promise<Uint8Array> =>
+    unwrap<string>(ipcRenderer.invoke('fs:readFileBase64', path)).then((b64) =>
+      Uint8Array.from(Buffer.from(b64, 'base64'))
+    ),
   /** Write contents to a file (created/overwritten). */
   writeFile: (path: string, contents: string): Promise<void> =>
     unwrap(ipcRenderer.invoke('fs:writeFile', path, contents)),

--- a/src/renderer/src/components/RobotDockPanel.tsx
+++ b/src/renderer/src/components/RobotDockPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { RobotView } from './RobotView'
+import { dirname } from './robot-mesh'
 import { useWorkspace } from '../store/workspace'
 import { readRobotModel } from '../../../shared/krf'
 import demoArm from '../assets/demo-arm.urdf?raw'
@@ -14,6 +15,9 @@ import demoArm from '../assets/demo-arm.urdf?raw'
 export function RobotDockPanel(): JSX.Element {
   const { currentFolder } = useWorkspace()
   const [urdf, setUrdf] = useState<string>(demoArm)
+  // The URDF's folder, so RobotView resolves the robot's meshes (#319). Empty
+  // for the bundled demo arm (all primitives — no meshes to resolve).
+  const [base, setBase] = useState<string>('')
 
   useEffect(() => {
     let live = true
@@ -26,20 +30,24 @@ export function RobotDockPanel(): JSX.Element {
           const content = await window.api.fs.readFile(path)
           if (live && content.trim()) {
             setUrdf(content)
+            setBase(dirname(path))
             return
           }
         }
       } catch {
         // No project URDF (or unreadable) — fall through to the demo arm.
       }
-      if (live) setUrdf(demoArm)
+      if (live) {
+        setUrdf(demoArm)
+        setBase('')
+      }
     })()
     return () => {
       live = false
     }
   }, [currentFolder])
 
-  return <RobotView urdfContent={urdf} compact />
+  return <RobotView urdfContent={urdf} basePath={base} compact />
 }
 
 export default RobotDockPanel

--- a/src/renderer/src/components/RobotView.css
+++ b/src/renderer/src/components/RobotView.css
@@ -69,3 +69,19 @@
 .robotview__hud-hint {
   color: var(--text-muted, #7d838d);
 }
+
+/* A non-blocking banner when one or more meshes couldn't load (#319). */
+.robotview__note {
+  position: absolute;
+  right: 0.6rem;
+  top: 0.55rem;
+  max-width: 70%;
+  padding: 0.3rem 0.55rem;
+  border-radius: 6px;
+  background: rgba(80, 44, 40, 0.82);
+  border: 1px solid #b4544e;
+  font-size: 0.62rem;
+  line-height: 1.35;
+  color: #f2d7d3;
+  pointer-events: none;
+}

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -1,65 +1,82 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import * as THREE from 'three'
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
+import { STLLoader } from 'three/examples/jsm/loaders/STLLoader.js'
+import { ColladaLoader } from 'three/examples/jsm/loaders/ColladaLoader.js'
 import URDFLoader from 'urdf-loader'
 import type { URDFRobot } from 'urdf-loader'
 import { useWorkspace } from '../store/workspace'
+import { baseName, dirname, meshKind } from './robot-mesh'
 import './RobotView.css'
 
 /**
- * ROBOT VIEW (#311, epic #309) — Phase 1: a 3D panel that renders a URDF robot.
+ * ROBOT VIEW (#311, epic #309) — a 3D panel that renders a URDF robot.
  * =============================================================================
  *
  * Opening a `.urdf` file shows the model in a three.js scene with orbit / pan /
  * zoom. The URDF is parsed from the OPEN FILE's content (so it lives in the
- * workspace, no server), primitives (box / cylinder / sphere) render with no
- * external meshes — the bundled `examples/demo-arm.urdf` is zero-setup. Later
- * phases add the pose tool, servo↔joint binding and the timeline; this is just
- * "see the robot". Code-split so three.js stays out of the initial bundle.
+ * workspace, no server); primitives (box / cylinder / sphere) render with no
+ * external files — the bundled `examples/demo-arm.urdf` is zero-setup.
+ *
+ * Phase 1b (#319) adds STL + DAE mesh loading: a real robot references meshes by
+ * relative or `package://` path, which we resolve against the URDF's folder and
+ * read through the app's fs (binary-safe for STL), so meshes render straight from
+ * the workspace with no web server. A mesh that can't load degrades to a small
+ * placeholder + a panel note rather than a blank model. Code-split so three.js
+ * and the mesh loaders stay out of the initial bundle.
  */
 export interface RobotViewProps {
   /** URDF text to render. When omitted, the active editor file is used (opening
    *  a `.urdf`). Provided directly by the docked Robot-mode panel (#320). */
   urdfContent?: string
+  /** The URDF's folder — the base for resolving relative / `package://` mesh
+   *  refs. When omitted it's derived from the active local file's path. */
+  basePath?: string
   /** Compact chrome for the small docked panel (a slimmer HUD). */
   compact?: boolean
 }
 
-export function RobotView({ urdfContent, compact = false }: RobotViewProps = {}): JSX.Element {
+/** A neutral material for a mesh (e.g. STL) that carries no URDF `<material>`. */
+function neutralMaterial(): THREE.MeshStandardMaterial {
+  return new THREE.MeshStandardMaterial({ color: 0x9aa0a6, metalness: 0.1, roughness: 0.85 })
+}
+
+/** A small wireframe cube standing in for a mesh that failed to load (#319). */
+function placeholderMesh(material: THREE.Material | null): THREE.Mesh {
+  const mat =
+    material ?? new THREE.MeshStandardMaterial({ color: 0xb4544e, wireframe: true })
+  return new THREE.Mesh(new THREE.BoxGeometry(0.04, 0.04, 0.04), mat)
+}
+
+export function RobotView({
+  urdfContent,
+  basePath,
+  compact = false
+}: RobotViewProps = {}): JSX.Element {
   const { openFiles, activeId } = useWorkspace()
   const activeFile = openFiles.find((f) => f.id === activeId) ?? null
   const content = urdfContent ?? activeFile?.content ?? ''
+  // Where to resolve mesh files from: an explicit base (docked panel) else the
+  // open local file's folder (opening a `.urdf` from a project).
+  const effectiveBase =
+    basePath ?? (activeFile && activeFile.source === 'local' ? dirname(activeFile.path) : '')
 
   const mountRef = useRef<HTMLDivElement>(null)
   const [error, setError] = useState<string | null>(null)
   const [info, setInfo] = useState<{ name: string; joints: number; links: number } | null>(null)
+  const [meshNote, setMeshNote] = useState<string | null>(null)
 
-  // Parse once per content change (cheap; the scene rebuild below consumes it).
-  const parsed = useMemo<{ robot: URDFRobot | null; err: string | null }>(() => {
-    if (!content.trim()) return { robot: null, err: 'empty' }
-    try {
-      const loader = new URDFLoader()
-      loader.parseVisual = true
-      loader.parseCollision = false
-      const robot = loader.parse(content)
-      const linkCount = robot ? Object.keys(robot.links).length : 0
-      if (!robot || linkCount === 0) return { robot: null, err: 'This file has no URDF links to show.' }
-      return { robot, err: null }
-    } catch (e) {
-      return { robot: null, err: e instanceof Error ? e.message : 'Could not parse this URDF.' }
-    }
-  }, [content])
+  const isEmpty = !content.trim()
 
   useEffect(() => {
     const mount = mountRef.current
     if (!mount) return
-
-    if (!parsed.robot) {
-      setError(parsed.err === 'empty' ? null : parsed.err)
+    if (isEmpty) {
+      setError(null)
       setInfo(null)
+      setMeshNote(null)
       return
     }
-    setError(null)
 
     const scene = new THREE.Scene()
     scene.background = new THREE.Color(0x191a1d)
@@ -86,36 +103,8 @@ export function RobotView({ urdfContent, compact = false }: RobotViewProps = {})
     fill.position.set(-1.5, 1, -1.2)
     scene.add(fill)
 
-    // The robot. URDF is Z-up; rotate into three's Y-up so it stands up.
-    const robot = parsed.robot
-    robot.rotation.x = -Math.PI / 2
-    scene.add(robot)
-    // Flush the world matrices BEFORE measuring — setting rotation only marks
-    // them dirty, so an immediate Box3 would frame the un-rotated (stale) box.
-    robot.updateMatrixWorld(true)
-    setInfo({
-      name: robot.robotName || robot.name || 'robot',
-      joints: Object.keys(robot.joints).length,
-      links: Object.keys(robot.links).length
-    })
-
-    // Frame the model: an ISO viewpoint (equal x/y/z direction) + a ground grid.
-    const box = new THREE.Box3().setFromObject(robot)
-    const size = box.getSize(new THREE.Vector3())
-    const centre = box.getCenter(new THREE.Vector3())
-    const radius = Math.max(size.x, size.y, size.z, 0.1) * 0.5
-    // Half-height the ortho frustum should show (a little padding around the model).
-    const halfView = radius * 1.35
-    const isoDir = new THREE.Vector3(1, 0.9, 1).normalize()
-    camera.position.copy(centre).addScaledVector(isoDir, radius * 6)
-    controls.target.copy(centre)
-    controls.update()
-
-    const gridSize = Math.max(size.x, size.z) * 3 + 0.4
-    const grid = new THREE.GridHelper(gridSize, 20, 0x3a3d44, 0x27292e)
-    grid.position.y = box.min.y
-    scene.add(grid)
-
+    // Half-height of the ortho frustum (updated by frameModel as bounds change).
+    let halfView = 1
     const resize = (): void => {
       const w = mount.clientWidth
       const h = mount.clientHeight
@@ -132,6 +121,138 @@ export function RobotView({ urdfContent, compact = false }: RobotViewProps = {})
       camera.bottom = -halfView
       camera.updateProjectionMatrix()
     }
+
+    // Frame the model isometrically + (re)lay a ground grid under it. Called once
+    // up-front (primitives) and again when async meshes arrive and grow the box.
+    let grid: THREE.GridHelper | null = null
+    const frameModel = (robot: URDFRobot): void => {
+      // Flush world matrices BEFORE measuring — a dirty transform frames stale.
+      robot.updateMatrixWorld(true)
+      const box = new THREE.Box3().setFromObject(robot)
+      if (!Number.isFinite(box.min.x) || box.isEmpty()) return
+      const size = box.getSize(new THREE.Vector3())
+      const centre = box.getCenter(new THREE.Vector3())
+      const radius = Math.max(size.x, size.y, size.z, 0.1) * 0.5
+      halfView = radius * 1.35 // a little padding around the model
+      const isoDir = new THREE.Vector3(1, 0.9, 1).normalize()
+      camera.position.copy(centre).addScaledVector(isoDir, radius * 6)
+      controls.target.copy(centre)
+      controls.update()
+      if (grid) {
+        scene.remove(grid)
+        grid.geometry.dispose()
+        ;(grid.material as THREE.Material).dispose()
+      }
+      const gridSize = Math.max(size.x, size.z) * 3 + 0.4
+      grid = new THREE.GridHelper(gridSize, 20, 0x3a3d44, 0x27292e)
+      grid.position.y = box.min.y
+      scene.add(grid)
+      resize()
+    }
+
+    let disposed = false
+    let robot: URDFRobot | null = null
+    let pending = 0 // async meshes still loading
+    let ready = false // parse finished (guards mid-parse settles)
+    const failed: string[] = []
+
+    // Once the URDF is parsed and all async meshes have settled: reframe (meshes
+    // may have grown the model) and surface any that couldn't load.
+    const finalize = (): void => {
+      if (disposed || !ready || pending > 0 || !robot) return
+      frameModel(robot)
+      if (failed.length) {
+        const shown = failed.slice(0, 3).join(', ')
+        const more = failed.length > 3 ? ` +${failed.length - 3} more` : ''
+        setMeshNote(
+          `${failed.length} mesh${failed.length > 1 ? 'es' : ''} couldn't load (${shown}${more}) — showing placeholders.`
+        )
+      } else {
+        setMeshNote(null)
+      }
+    }
+    const settle = (): void => {
+      pending -= 1
+      finalize()
+    }
+
+    // Resolve meshes against the URDF's folder: a `packages` resolver maps every
+    // `package://<pkg>/rel` to `<base>/rel`, and `workingPath` handles plain
+    // relative refs. We read the file through the app's fs (binary-safe for STL)
+    // — no web server, works straight from the workspace.
+    const base = effectiveBase ? effectiveBase.replace(/[/\\]+$/, '') : ''
+    const loader = new URDFLoader()
+    loader.parseVisual = true
+    loader.parseCollision = false
+    if (base) {
+      loader.packages = () => base
+      loader.workingPath = base + '/' // resolves plain relative mesh refs
+    }
+    loader.loadMeshCb = (path, manager, material, done): void => {
+      const mat = (material as THREE.Material | null) ?? null
+      pending += 1
+      const kind = meshKind(path)
+      const ok = (obj: THREE.Object3D): void => {
+        if (disposed) return
+        done(obj)
+        settle()
+      }
+      const fail = (): void => {
+        if (disposed) return
+        failed.push(baseName(path))
+        done(placeholderMesh(mat))
+        settle()
+      }
+      if (kind === 'stl') {
+        window.api.fs
+          .readFileBytes(path)
+          .then((bytes) => {
+            if (disposed) return
+            const geo = new STLLoader(manager).parse(bytes.buffer as ArrayBuffer)
+            ok(new THREE.Mesh(geo, mat ?? neutralMaterial()))
+          })
+          .catch(fail)
+      } else if (kind === 'dae') {
+        window.api.fs
+          .readFile(path)
+          .then((text) => {
+            if (disposed) return
+            const dae = new ColladaLoader(manager).parse(text, dirname(path) + '/')
+            if (dae?.scene) ok(dae.scene)
+            else fail()
+          })
+          .catch(fail)
+      } else {
+        fail() // unsupported (.obj/.glb/…) — placeholder + note
+      }
+    }
+
+    try {
+      // URDF is Z-up; rotate into three's Y-up so it stands. `workingPath` (set
+      // above) resolves relative mesh refs; loadMeshCb fires (async) during
+      // parse, so meshes populate after this returns.
+      robot = loader.parse(content)
+      if (!robot || Object.keys(robot.links).length === 0) {
+        setError('This file has no URDF links to show.')
+        setInfo(null)
+      } else {
+        robot.rotation.x = -Math.PI / 2
+        scene.add(robot)
+        setError(null)
+        setInfo({
+          name: robot.robotName || robot.name || 'robot',
+          joints: Object.keys(robot.joints).length,
+          links: Object.keys(robot.links).length
+        })
+        frameModel(robot) // frame primitives immediately; reframe when meshes land
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not parse this URDF.')
+      setInfo(null)
+    }
+    ready = true
+    finalize() // no meshes (or all failed synchronously) → settle the note now
+
     resize()
     const ro = new ResizeObserver(resize)
     ro.observe(mount)
@@ -145,6 +266,7 @@ export function RobotView({ urdfContent, compact = false }: RobotViewProps = {})
     tick()
 
     return () => {
+      disposed = true
       cancelAnimationFrame(raf)
       ro.disconnect()
       controls.dispose()
@@ -158,7 +280,7 @@ export function RobotView({ urdfContent, compact = false }: RobotViewProps = {})
       renderer.dispose()
       if (renderer.domElement.parentNode === mount) mount.removeChild(renderer.domElement)
     }
-  }, [parsed])
+  }, [content, effectiveBase, isEmpty])
 
   return (
     <div className={`robotview${compact ? ' robotview--compact' : ''}`}>
@@ -168,7 +290,7 @@ export function RobotView({ urdfContent, compact = false }: RobotViewProps = {})
           <p className="robotview__overlay-title">Couldn&apos;t show this robot</p>
           <p className="robotview__overlay-msg">{error}</p>
         </div>
-      ) : parsed.err === 'empty' ? (
+      ) : isEmpty ? (
         <div className="robotview__overlay">
           <p className="robotview__overlay-title">Robot View</p>
           <p className="robotview__overlay-msg">Open a .urdf file to see the 3D model.</p>
@@ -180,6 +302,11 @@ export function RobotView({ urdfContent, compact = false }: RobotViewProps = {})
             {!compact && <span className="robotview__hud-hint">drag to orbit · scroll to zoom</span>}
           </div>
         )
+      )}
+      {!error && meshNote && (
+        <div className="robotview__note" role="status">
+          {meshNote}
+        </div>
       )}
     </div>
   )

--- a/src/renderer/src/components/robot-mesh.ts
+++ b/src/renderer/src/components/robot-mesh.ts
@@ -1,0 +1,28 @@
+/**
+ * ROBOT MESH PATH HELPERS (#319, epic #309) — pure string utilities used by the
+ * Robot View's `loadMeshCb` to resolve + classify URDF mesh references. Kept free
+ * of three.js so they're cheap to unit-test. The heavy STL/DAE parsers live in
+ * RobotView (code-split behind the lazy Robot View chunk).
+ */
+
+/** The directory portion of a path (POSIX or Windows separators), '' at root. */
+export function dirname(p: string): string {
+  const i = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\'))
+  return i < 0 ? '' : p.slice(0, i)
+}
+
+/** The final path segment (file name incl. extension). */
+export function baseName(p: string): string {
+  const i = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\'))
+  return i < 0 ? p : p.slice(i + 1)
+}
+
+/**
+ * The supported mesh kind for a path, or `null` for anything we can't render
+ * (`.obj`, `.glb`, …) — the caller shows a placeholder + a note for those.
+ * Tolerant of a trailing `?query`/`#frag` on the reference.
+ */
+export function meshKind(path: string): 'stl' | 'dae' | null {
+  const m = /\.(stl|dae)(?:$|[?#])/i.exec(path)
+  return m ? (m[1].toLowerCase() as 'stl' | 'dae') : null
+}

--- a/test/robotMesh.test.ts
+++ b/test/robotMesh.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { dirname, baseName, meshKind } from '../src/renderer/src/components/robot-mesh'
+
+describe('robot-mesh path helpers (#319)', () => {
+  it('dirname returns the folder (POSIX + Windows), empty at root', () => {
+    expect(dirname('/home/kev/robot/arm.urdf')).toBe('/home/kev/robot')
+    expect(dirname('C:\\robots\\arm.urdf')).toBe('C:\\robots')
+    expect(dirname('arm.urdf')).toBe('')
+  })
+
+  it('baseName returns the final segment', () => {
+    expect(baseName('/home/kev/robot/meshes/link.stl')).toBe('link.stl')
+    expect(baseName('C:\\robots\\base.STL')).toBe('base.STL')
+    expect(baseName('link.dae')).toBe('link.dae')
+  })
+
+  it('meshKind classifies stl/dae case-insensitively, null otherwise', () => {
+    expect(meshKind('meshes/link.stl')).toBe('stl')
+    expect(meshKind('meshes/LINK.STL')).toBe('stl')
+    expect(meshKind('package://r/meshes/body.dae')).toBe('dae')
+    expect(meshKind('meshes/body.DAE')).toBe('dae')
+    // unsupported / no extension → null (caller shows a placeholder)
+    expect(meshKind('meshes/body.obj')).toBe(null)
+    expect(meshKind('meshes/body.glb')).toBe(null)
+    expect(meshKind('meshes/body')).toBe(null)
+  })
+
+  it('meshKind tolerates a trailing query/fragment', () => {
+    expect(meshKind('link.stl?v=2')).toBe('stl')
+    expect(meshKind('body.dae#scene')).toBe('dae')
+  })
+})


### PR DESCRIPTION
Part of epic #309. Phase 1 (#311) drew URDF *primitives*; real robots reference **meshes**. Robot View now loads a URDF's **STL** and **DAE (Collada)** meshes straight from the project folder — no web server — so real-world URDFs render.

## What
- **Binary-safe fs read** (`fs:readFileBase64` → preload `readFileBytes`): binary STL would be corrupted by the existing utf-8 `readFile`.
- **Mesh resolution + loading** in RobotView via a `loadMeshCb`:
  - **Relative** refs (`meshes/link.stl`) resolve against the URDF's folder (`workingPath`).
  - **`package://<pkg>/rest`** maps `<pkg>` → that same folder (a `packages` resolver), so classroom URDFs "just work".
  - STL via `STLLoader` (binary + ASCII), DAE via `ColladaLoader`. The URDF `<material>` colour is applied to meshes that carry none; the camera reframes once async meshes land.
- **Graceful degradation**: a missing / unreadable / unsupported (`.obj`, `.glb`) mesh becomes a small placeholder cube **+ a panel note naming it** — the rest of the robot still renders, never a blank model or a crash. Meshes are disposed on unmount.
- **Zero-setup example**: `examples/mesh-demo/` — an ASCII-STL robot (steel base + amber arm) exercising both relative and `package://` resolution.
- **Pure helpers** `robot-mesh.ts` (dirname/baseName/meshKind) + unit tests.
- The STL/Collada loaders stay **code-split** in the Robot View chunk (out of the initial bundle).

## Verified (in-app, Playwright)
- `mesh-demo.urdf` renders both STL meshes, `note: null`, canvas centre fully drawn (screenshot).
- A URDF with a missing mesh shows `"1 mesh couldn't load (nope.stl) — showing placeholders."` with the good mesh + placeholder both visible — no crash.
- A generated Collada cube renders (DAE path).
- Gate: typecheck + lint clean, **1416 tests** (+4), build ✅; mesh loaders confirmed in the lazy `RobotView-*.js` chunk, not the initial bundle.

Docs: `docs/krf.md` gains a **Meshes** section. Next in the epic: #312 (Pose tool) drives these joints; #310 remainder (scaffold + snakie.org page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
