### PR TITLE
Robot View: Pose tool — joint sliders, mimic, named poses, measure (#312)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Robot View — Pose tool (#312, epic #309 Phase 2).** Opening a `.urdf`
+  full-screen now gives a **pose tool**: a joint sidebar with a slider per joint
+  (degrees for revolute, mm for prismatic) that moves the robot live, respecting
+  the URDF limits. `<mimic>` joints follow their master (multiplier + offset),
+  shown read-only. Edit a joint's min/max inline; save & recall **named poses**;
+  and a **measure tool** reports the point-to-point distance between two clicks.
+  Limit overrides + poses persist to `robot.yml` (KRF), and the docked Robot-mode
+  panel gains an **⤢ Pose** button to open the robot full-screen. Also fixes the
+  `robot.yml` (de)serialiser to round-trip the KRF `robot:` section.
 - **Robot View — STL & DAE meshes (#319, epic #309).** Robot View now renders
   real robots: a URDF's `.stl` / `.dae` (Collada) meshes load straight from the
   project folder — no web server. Relative (`meshes/link.stl`) and `package://`

--- a/docs/krf.md
+++ b/docs/krf.md
@@ -48,6 +48,16 @@ robot:                # ← the KRF robot MODEL (optional)
       values: { shoulder: 0 }
 ```
 
+### Pose tool (#312)
+
+Opening a robot's `.urdf` full-screen shows the **pose tool** — a slider per
+movable joint (degrees for revolute, mm for prismatic) that drives the model
+within its URDF limits. `<mimic>` joints follow their master (`multiplier *
+master + offset`). Editing a joint's min/max writes an override into
+`robot.joints`; saving a named pose appends to `robot.poses`; both persist here
+(display units — deg/mm). A measure tool reports the distance between two clicked
+points. The `robot.yml` (de)serialiser round-trips this whole `robot:` section.
+
 ### Servo → joint mapping
 
 A running program's servo write drives the mapped joint (Phase 3): the servo

--- a/src/renderer/src/components/RobotDockPanel.tsx
+++ b/src/renderer/src/components/RobotDockPanel.tsx
@@ -10,14 +10,17 @@ import demoArm from '../assets/demo-arm.urdf?raw'
  * instrument dock in the **Robot** workspace. It finds the project's URDF via
  * the KRF `robot.yml` (`robot.urdf`, resolved against the workspace folder) and
  * falls back to the bundled demo arm so the panel is never empty. Isometric,
- * compact chrome (the full viewer opens by opening the `.urdf` itself).
+ * compact chrome. An **expand** button opens the project's `.urdf` full-screen
+ * as the Pose tool (#312).
  */
 export function RobotDockPanel(): JSX.Element {
-  const { currentFolder } = useWorkspace()
+  const { currentFolder, openFile } = useWorkspace()
   const [urdf, setUrdf] = useState<string>(demoArm)
   // The URDF's folder, so RobotView resolves the robot's meshes (#319). Empty
   // for the bundled demo arm (all primitives — no meshes to resolve).
   const [base, setBase] = useState<string>('')
+  // The project URDF's path, so the expand button can open it full-screen.
+  const [urdfPath, setUrdfPath] = useState<string | null>(null)
 
   useEffect(() => {
     let live = true
@@ -31,6 +34,7 @@ export function RobotDockPanel(): JSX.Element {
           if (live && content.trim()) {
             setUrdf(content)
             setBase(dirname(path))
+            setUrdfPath(path)
             return
           }
         }
@@ -40,6 +44,7 @@ export function RobotDockPanel(): JSX.Element {
       if (live) {
         setUrdf(demoArm)
         setBase('')
+        setUrdfPath(null)
       }
     })()
     return () => {
@@ -47,7 +52,21 @@ export function RobotDockPanel(): JSX.Element {
     }
   }, [currentFolder])
 
-  return <RobotView urdfContent={urdf} basePath={base} compact />
+  return (
+    <div className="robotdock">
+      <RobotView urdfContent={urdf} basePath={base} compact />
+      {urdfPath && (
+        <button
+          type="button"
+          className="robotdock__expand"
+          title="Open the robot full-screen (Pose tool)"
+          onClick={() => void openFile('local', urdfPath)}
+        >
+          ⤢ Pose
+        </button>
+      )}
+    </div>
+  )
 }
 
 export default RobotDockPanel

--- a/src/renderer/src/components/RobotJointPanel.css
+++ b/src/renderer/src/components/RobotJointPanel.css
@@ -1,0 +1,202 @@
+/* Pose-tool sidebar (#312). Retro NES-ish, JetBrains Mono, matches Robot View. */
+.robotpanel {
+  flex: 0 0 260px;
+  min-width: 220px;
+  max-width: 320px;
+  height: 100%;
+  overflow-y: auto;
+  box-sizing: border-box;
+  padding: 0.55rem 0.6rem 1rem;
+  background: var(--panel, #202227);
+  border-left: var(--border-w, 2px) solid var(--border, #2c2e33);
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  color: var(--text, #cdd2d9);
+  font-size: 0.68rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.robotpanel__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.robotpanel__title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: #c8a24a;
+  letter-spacing: 0.04em;
+}
+.robotpanel__empty {
+  color: var(--text-muted, #7d838d);
+  font-size: 0.66rem;
+}
+
+.robotpanel__btn {
+  font-family: inherit;
+  font-size: 0.64rem;
+  color: var(--text, #cdd2d9);
+  background: var(--panel-2, #2a2d33);
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 5px;
+  padding: 0.22rem 0.5rem;
+  cursor: pointer;
+}
+.robotpanel__btn:hover {
+  border-color: #c8a24a;
+}
+.robotpanel__btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.robotpanel__joints {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+.robotpanel__joint {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+.robotpanel__joint-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.4rem;
+}
+.robotpanel__joint-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.robotpanel__joint-val {
+  color: #c8a24a;
+  font-variant-numeric: tabular-nums;
+  flex: 0 0 auto;
+}
+.robotpanel__slider-row {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+.robotpanel__slider {
+  flex: 1 1 auto;
+  min-width: 0;
+  accent-color: #c8a24a;
+  cursor: pointer;
+}
+.robotpanel__limit {
+  flex: 0 0 3rem;
+  width: 3rem;
+  font-family: inherit;
+  font-size: 0.6rem;
+  color: var(--text-muted, #9aa0a6);
+  background: var(--panel-2, #24262b);
+  border: 1px solid var(--border, #34373d);
+  border-radius: 4px;
+  padding: 0.12rem 0.2rem;
+  text-align: center;
+}
+.robotpanel__joint--mimic .robotpanel__joint-name {
+  color: var(--text-muted, #9aa0a6);
+}
+.robotpanel__mimic-hint {
+  font-size: 0.58rem;
+  color: var(--text-muted, #7d838d);
+  font-style: italic;
+}
+
+.robotpanel__section {
+  border-top: 1px solid var(--border, #2c2e33);
+  padding-top: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+.robotpanel__section-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: var(--text, #cdd2d9);
+}
+.robotpanel__saved {
+  font-size: 0.56rem;
+  font-weight: 400;
+  color: #6fae6f;
+}
+.robotpanel__pose-add {
+  display: flex;
+  gap: 0.3rem;
+}
+.robotpanel__pose-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-family: inherit;
+  font-size: 0.64rem;
+  color: var(--text, #cdd2d9);
+  background: var(--panel-2, #24262b);
+  border: 1px solid var(--border, #34373d);
+  border-radius: 5px;
+  padding: 0.2rem 0.4rem;
+}
+.robotpanel__poses {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+.robotpanel__pose {
+  display: flex;
+  align-items: stretch;
+  gap: 0.25rem;
+}
+.robotpanel__pose-recall {
+  flex: 1 1 auto;
+  text-align: left;
+  font-family: inherit;
+  font-size: 0.64rem;
+  color: var(--text, #cdd2d9);
+  background: var(--panel-2, #2a2d33);
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 5px;
+  padding: 0.2rem 0.45rem;
+  cursor: pointer;
+}
+.robotpanel__pose-recall:hover {
+  border-color: #c8a24a;
+}
+.robotpanel__pose-del {
+  flex: 0 0 auto;
+  font-family: inherit;
+  color: var(--text-muted, #9aa0a6);
+  background: transparent;
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 5px;
+  padding: 0 0.4rem;
+  cursor: pointer;
+}
+.robotpanel__pose-del:hover {
+  color: #b4544e;
+  border-color: #b4544e;
+}
+
+.robotpanel__measure.is-on {
+  border-color: #c8a24a;
+  color: #c8a24a;
+}
+.robotpanel__measure-out {
+  font-size: 0.72rem;
+  color: #c8a24a;
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+  padding: 0.2rem;
+  border: 1px dashed var(--border, #3a3d44);
+  border-radius: 5px;
+}

--- a/src/renderer/src/components/RobotJointPanel.tsx
+++ b/src/renderer/src/components/RobotJointPanel.tsx
@@ -1,0 +1,237 @@
+import { useState } from 'react'
+import {
+  type JointMeta,
+  effectiveLimit,
+  mimicValue,
+  toDisplay,
+  toNative,
+  unitLabel
+} from './robot-pose'
+import './RobotJointPanel.css'
+
+/** A saved pose (name + joint→display-value map). Mirrors KRF `NamedPose`. */
+export interface NamedPoseLike {
+  name: string
+  values: Record<string, number>
+}
+
+export interface RobotJointPanelProps {
+  joints: JointMeta[]
+  /** Live NATIVE values for the movable (non-mimic) joints. */
+  values: Record<string, number>
+  /** In-app limit overrides (display units — deg/mm), by joint name. */
+  overrides: Record<string, { min?: number; max?: number }>
+  onJointChange: (name: string, native: number) => void
+  onLimitChange: (name: string, next: { min: number; max: number }) => void
+  poses: NamedPoseLike[]
+  onSavePose: (name: string) => void
+  onRecallPose: (pose: NamedPoseLike) => void
+  onDeletePose: (name: string) => void
+  onResetPose: () => void
+  measureActive: boolean
+  onToggleMeasure: () => void
+  /** Point-to-point distance in mm, or null when fewer than 2 points are set. */
+  measureDistance: number | null
+  /** Whether the current pose has been persisted (for a subtle saved hint). */
+  savingLabel: string | null
+}
+
+/** Round a display value for compact display. */
+function fmt(v: number): string {
+  return Math.abs(v) >= 100 ? v.toFixed(0) : v.toFixed(1)
+}
+
+export function RobotJointPanel({
+  joints,
+  values,
+  overrides,
+  onJointChange,
+  onLimitChange,
+  poses,
+  onSavePose,
+  onRecallPose,
+  onDeletePose,
+  onResetPose,
+  measureActive,
+  onToggleMeasure,
+  measureDistance,
+  savingLabel
+}: RobotJointPanelProps): JSX.Element {
+  const [poseName, setPoseName] = useState('')
+  const movable = joints.filter((j) => !j.isMimic)
+  const mimics = joints.filter((j) => j.isMimic)
+
+  const saveDisabled = poseName.trim().length === 0
+
+  return (
+    <aside className="robotpanel" aria-label="Pose controls">
+      <header className="robotpanel__head">
+        <span className="robotpanel__title">Pose</span>
+        <button
+          type="button"
+          className="robotpanel__btn"
+          onClick={onResetPose}
+          title="Reset all joints to the default pose"
+        >
+          Reset
+        </button>
+      </header>
+
+      {joints.length === 0 && (
+        <p className="robotpanel__empty">This robot has no movable joints.</p>
+      )}
+
+      <div className="robotpanel__joints">
+        {movable.map((j) => {
+          const lim = effectiveLimit(j, overrides[j.name])
+          const dLower = toDisplay(j.type, lim.lower)
+          const dUpper = toDisplay(j.type, lim.upper)
+          const dVal = toDisplay(j.type, values[j.name] ?? 0)
+          const step = j.type === 'prismatic' ? 0.5 : 1
+          return (
+            <div className="robotpanel__joint" key={j.name}>
+              <div className="robotpanel__joint-head">
+                <span className="robotpanel__joint-name" title={j.name}>
+                  {j.name}
+                </span>
+                <span className="robotpanel__joint-val">
+                  {fmt(dVal)}
+                  {unitLabel(j.type)}
+                </span>
+              </div>
+              <div className="robotpanel__slider-row">
+                <input
+                  className="robotpanel__limit"
+                  type="number"
+                  aria-label={`${j.name} minimum`}
+                  value={Number(dLower.toFixed(1))}
+                  step={step}
+                  onChange={(e) =>
+                    onLimitChange(j.name, { min: Number(e.target.value), max: dUpper })
+                  }
+                />
+                <input
+                  className="robotpanel__slider"
+                  type="range"
+                  aria-label={j.name}
+                  min={dLower}
+                  max={dUpper}
+                  step={step}
+                  value={Math.min(Math.max(dVal, dLower), dUpper)}
+                  onChange={(e) => onJointChange(j.name, toNative(j.type, Number(e.target.value)))}
+                />
+                <input
+                  className="robotpanel__limit"
+                  type="number"
+                  aria-label={`${j.name} maximum`}
+                  value={Number(dUpper.toFixed(1))}
+                  step={step}
+                  onChange={(e) =>
+                    onLimitChange(j.name, { min: dLower, max: Number(e.target.value) })
+                  }
+                />
+              </div>
+            </div>
+          )
+        })}
+
+        {mimics.map((j) => {
+          const masterNative = values[j.master ?? ''] ?? 0
+          const dVal = toDisplay(j.type, mimicValue(j, masterNative))
+          return (
+            <div className="robotpanel__joint robotpanel__joint--mimic" key={j.name}>
+              <div className="robotpanel__joint-head">
+                <span className="robotpanel__joint-name" title={j.name}>
+                  {j.name}
+                </span>
+                <span className="robotpanel__joint-val">
+                  {fmt(dVal)}
+                  {unitLabel(j.type)}
+                </span>
+              </div>
+              <span className="robotpanel__mimic-hint">follows {j.master}</span>
+            </div>
+          )
+        })}
+      </div>
+
+      <section className="robotpanel__section">
+        <div className="robotpanel__section-head">
+          <span>Poses</span>
+          {savingLabel && <span className="robotpanel__saved">{savingLabel}</span>}
+        </div>
+        <div className="robotpanel__pose-add">
+          <input
+            className="robotpanel__pose-name"
+            placeholder="name this pose"
+            value={poseName}
+            onChange={(e) => setPoseName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !saveDisabled) {
+                onSavePose(poseName.trim())
+                setPoseName('')
+              }
+            }}
+          />
+          <button
+            type="button"
+            className="robotpanel__btn"
+            disabled={saveDisabled}
+            onClick={() => {
+              onSavePose(poseName.trim())
+              setPoseName('')
+            }}
+          >
+            Save
+          </button>
+        </div>
+        {poses.length > 0 && (
+          <ul className="robotpanel__poses">
+            {poses.map((p) => (
+              <li className="robotpanel__pose" key={p.name}>
+                <button
+                  type="button"
+                  className="robotpanel__pose-recall"
+                  onClick={() => onRecallPose(p)}
+                  title={`Recall ${p.name}`}
+                >
+                  {p.name}
+                </button>
+                <button
+                  type="button"
+                  className="robotpanel__pose-del"
+                  onClick={() => onDeletePose(p.name)}
+                  aria-label={`Delete ${p.name}`}
+                >
+                  ×
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="robotpanel__section">
+        <div className="robotpanel__section-head">
+          <span>Measure</span>
+        </div>
+        <button
+          type="button"
+          className={`robotpanel__btn robotpanel__measure${measureActive ? ' is-on' : ''}`}
+          onClick={onToggleMeasure}
+        >
+          {measureActive ? 'Measuring — click 2 points' : 'Measure distance'}
+        </button>
+        {measureDistance != null && (
+          <div className="robotpanel__measure-out">
+            {measureDistance < 1000
+              ? `${measureDistance.toFixed(1)} mm`
+              : `${(measureDistance / 1000).toFixed(3)} m`}
+          </div>
+        )}
+      </section>
+    </aside>
+  )
+}
+
+export default RobotJointPanel

--- a/src/renderer/src/components/RobotView.css
+++ b/src/renderer/src/components/RobotView.css
@@ -2,10 +2,21 @@
 
 .robotview {
   position: relative;
+  display: flex;
+  flex-direction: row;
   height: 100%;
   min-height: 0;
   background: #191a1d;
   font-family: var(--font-mono), 'JetBrains Mono', monospace;
+}
+
+/* The 3D area (canvas + overlays); the pose sidebar sits beside it. */
+.robotview__stage {
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  height: 100%;
 }
 
 .robotview__canvas {

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -7,6 +7,16 @@ import URDFLoader from 'urdf-loader'
 import type { URDFRobot } from 'urdf-loader'
 import { useWorkspace } from '../store/workspace'
 import { baseName, dirname, meshKind } from './robot-mesh'
+import { RobotJointPanel, type NamedPoseLike } from './RobotJointPanel'
+import {
+  type JointMeta,
+  clamp,
+  effectiveLimit,
+  extractJoints,
+  toDisplay,
+  toNative
+} from './robot-pose'
+import type { RobotDefinition, RobotModel } from '../../../shared/robot'
 import './RobotView.css'
 
 /**
@@ -53,7 +63,7 @@ export function RobotView({
   basePath,
   compact = false
 }: RobotViewProps = {}): JSX.Element {
-  const { openFiles, activeId } = useWorkspace()
+  const { openFiles, activeId, currentFolder } = useWorkspace()
   const activeFile = openFiles.find((f) => f.id === activeId) ?? null
   const content = urdfContent ?? activeFile?.content ?? ''
   // Where to resolve mesh files from: an explicit base (docked panel) else the
@@ -67,6 +77,129 @@ export function RobotView({
   const [meshNote, setMeshNote] = useState<string | null>(null)
 
   const isEmpty = !content.trim()
+  // The full-screen (non-compact) view is the Pose tool (#312): a joint sidebar,
+  // named poses and a measure tool. The docked mini-panel stays view-only.
+  const poseUI = !compact
+
+  const [jointMeta, setJointMeta] = useState<JointMeta[]>([])
+  const [values, setValues] = useState<Record<string, number>>({}) // native (rad/m)
+  const [overrides, setOverrides] = useState<Record<string, { min?: number; max?: number }>>({})
+  const [poses, setPoses] = useState<NamedPoseLike[]>([])
+  const [measureActive, setMeasureActive] = useState(false)
+  const [measureDist, setMeasureDist] = useState<number | null>(null)
+  const [savingLabel, setSavingLabel] = useState<string | null>(null)
+
+  // Refs kept fresh for imperative handlers + the three.js pointer callbacks.
+  const robotRef = useRef<URDFRobot | null>(null)
+  const defRef = useRef<RobotDefinition | null>(null)
+  const metaRef = useRef<JointMeta[]>([])
+  const valuesRef = useRef<Record<string, number>>({})
+  const overridesRef = useRef<Record<string, { min?: number; max?: number }>>({})
+  const defaultPoseRef = useRef<Record<string, number>>({}) // native, non-mimic
+  const measureActiveRef = useRef(false)
+  const measureApiRef = useRef<{ clear: () => void } | null>(null)
+  metaRef.current = jointMeta
+  valuesRef.current = values
+  overridesRef.current = overrides
+
+  // Set a joint on the live robot (mimic followers update automatically).
+  const applyToRobot = (native: Record<string, number>): void => {
+    const r = robotRef.current
+    if (!r) return
+    for (const m of metaRef.current) {
+      if (!m.isMimic && typeof native[m.name] === 'number') r.setJointValue(m.name, native[m.name])
+    }
+  }
+
+  // Merge a patch into robot.yml's `robot:` section and persist (preserving the
+  // wiring). Writes to the project folder's robot.yml, else userData.
+  const persist = async (mutate: (m: RobotModel) => void): Promise<void> => {
+    const def: RobotDefinition = defRef.current ?? { parts: [], connections: [] }
+    def.robot = { ...(def.robot ?? {}) }
+    mutate(def.robot)
+    defRef.current = def
+    setSavingLabel('saving…')
+    try {
+      const res = await window.api.robot.save(currentFolder || undefined, def)
+      setSavingLabel(res.ok ? 'saved ✓' : 'save failed')
+    } catch {
+      setSavingLabel('save failed')
+    }
+  }
+
+  const handleJointChange = (name: string, native: number): void => {
+    robotRef.current?.setJointValue(name, native)
+    setValues((v) => ({ ...v, [name]: native }))
+  }
+
+  const handleLimitChange = (name: string, raw: { min: number; max: number }): void => {
+    const round2 = (n: number): number => Math.round(n * 100) / 100
+    const next = { min: round2(raw.min), max: round2(raw.max) }
+    setOverrides((o) => ({ ...o, [name]: next }))
+    const meta = metaRef.current.find((m) => m.name === name)
+    if (meta) {
+      const lim = effectiveLimit(meta, next)
+      const cur = valuesRef.current[name] ?? 0
+      const cl = clamp(cur, lim.lower, lim.upper)
+      if (cl !== cur) handleJointChange(name, cl)
+    }
+    void persist((m) => {
+      m.joints = { ...(m.joints ?? {}), [name]: next }
+    })
+  }
+
+  const handleSavePose = (name: string): void => {
+    const vals: Record<string, number> = {}
+    for (const m of metaRef.current) {
+      if (!m.isMimic) vals[m.name] = Number(toDisplay(m.type, valuesRef.current[m.name] ?? 0).toFixed(2))
+    }
+    const next = [...poses.filter((p) => p.name !== name), { name, values: vals }]
+    setPoses(next)
+    void persist((m) => {
+      m.poses = next
+    })
+  }
+
+  const handleRecallPose = (pose: NamedPoseLike): void => {
+    const nv = { ...valuesRef.current }
+    for (const m of metaRef.current) {
+      if (!m.isMimic && typeof pose.values[m.name] === 'number') {
+        const lim = effectiveLimit(m, overridesRef.current[m.name])
+        nv[m.name] = clamp(toNative(m.type, pose.values[m.name]), lim.lower, lim.upper)
+      }
+    }
+    applyToRobot(nv)
+    setValues(nv)
+  }
+
+  const handleDeletePose = (name: string): void => {
+    const next = poses.filter((p) => p.name !== name)
+    setPoses(next)
+    void persist((m) => {
+      m.poses = next
+    })
+  }
+
+  const handleResetPose = (): void => {
+    const dp = defaultPoseRef.current
+    const nv = { ...valuesRef.current }
+    for (const m of metaRef.current) {
+      if (m.isMimic) continue
+      const lim = effectiveLimit(m, overridesRef.current[m.name])
+      nv[m.name] = clamp(dp[m.name] ?? 0, lim.lower, lim.upper)
+    }
+    applyToRobot(nv)
+    setValues(nv)
+  }
+
+  // Toggling measure off clears the markers + readout.
+  useEffect(() => {
+    measureActiveRef.current = measureActive
+    if (!measureActive) {
+      measureApiRef.current?.clear()
+      setMeasureDist(null)
+    }
+  }, [measureActive])
 
   useEffect(() => {
     const mount = mountRef.current
@@ -155,6 +288,8 @@ export function RobotView({
     let pending = 0 // async meshes still loading
     let ready = false // parse finished (guards mid-parse settles)
     const failed: string[] = []
+    let teardownPose = (): void => {} // set when the pose tool wires up (below)
+    robotRef.current = null
 
     // Once the URDF is parsed and all async meshes have settled: reframe (meshes
     // may have grown the model) and surface any that couldn't load.
@@ -245,10 +380,127 @@ export function RobotView({
           links: Object.keys(robot.links).length
         })
         frameModel(robot) // frame primitives immediately; reframe when meshes land
+
+        if (poseUI) {
+          // POSE TOOL (#312): expose the movable joints, seed a neutral pose, then
+          // overlay the saved KRF overrides / defaultPose / poses from robot.yml.
+          const meta = extractJoints(robot)
+          robotRef.current = robot
+          const initial: Record<string, number> = {}
+          for (const m of meta) {
+            if (m.isMimic) continue
+            const v = clamp(0, m.lower, m.upper)
+            initial[m.name] = v
+            robot.setJointValue(m.name, v)
+          }
+          defaultPoseRef.current = { ...initial }
+          setJointMeta(meta)
+          setValues(initial)
+          setOverrides({})
+          setPoses([])
+          setMeasureDist(null)
+
+          void (async () => {
+            try {
+              const def = await window.api.robot.load(currentFolder || undefined)
+              if (disposed || !robotRef.current) return
+              defRef.current = def
+              const model = def.robot ?? {}
+              const ov = (model.joints ?? {}) as Record<string, { min?: number; max?: number }>
+              const dp = model.defaultPose ?? {}
+              const nv = { ...initial }
+              for (const m of meta) {
+                if (m.isMimic) continue
+                const lim = effectiveLimit(m, ov[m.name])
+                nv[m.name] =
+                  typeof dp[m.name] === 'number'
+                    ? clamp(toNative(m.type, dp[m.name]), lim.lower, lim.upper)
+                    : clamp(nv[m.name], lim.lower, lim.upper)
+                robot.setJointValue(m.name, nv[m.name])
+              }
+              defaultPoseRef.current = { ...nv } // "Reset" returns to the saved default
+              setOverrides(ov)
+              setPoses(Array.isArray(model.poses) ? model.poses : [])
+              setValues(nv)
+            } catch {
+              // No robot.yml (or unreadable) — keep the neutral pose.
+            }
+          })()
+
+          // MEASURE TOOL (#312): click two points on the model → distance readout.
+          const raycaster = new THREE.Raycaster()
+          const ndc = new THREE.Vector2()
+          const pts: THREE.Vector3[] = []
+          const markerMat = new THREE.MeshBasicMaterial({ color: 0xc8a24a, depthTest: false })
+          const lineMat = new THREE.LineBasicMaterial({ color: 0xc8a24a, depthTest: false })
+          const markers: THREE.Mesh[] = []
+          let line: THREE.Line | null = null
+          const clearMeasure = (): void => {
+            pts.length = 0
+            markers.forEach((m) => {
+              scene.remove(m)
+              m.geometry.dispose()
+            })
+            markers.length = 0
+            if (line) {
+              scene.remove(line)
+              line.geometry.dispose()
+              line = null
+            }
+          }
+          measureApiRef.current = { clear: clearMeasure }
+          let downX = 0
+          let downY = 0
+          const onDown = (e: PointerEvent): void => {
+            downX = e.clientX
+            downY = e.clientY
+          }
+          const onUp = (e: PointerEvent): void => {
+            if (!measureActiveRef.current || !robotRef.current) return
+            // Ignore orbit drags — only a near-stationary click places a point.
+            if (Math.hypot(e.clientX - downX, e.clientY - downY) > 4) return
+            const rect = renderer.domElement.getBoundingClientRect()
+            ndc.x = ((e.clientX - rect.left) / rect.width) * 2 - 1
+            ndc.y = -((e.clientY - rect.top) / rect.height) * 2 + 1
+            raycaster.setFromCamera(ndc, camera)
+            const hit = raycaster.intersectObject(robotRef.current, true)[0]
+            if (!hit) return
+            if (pts.length >= 2) clearMeasure()
+            const p = hit.point.clone()
+            pts.push(p)
+            const dot = new THREE.Mesh(new THREE.SphereGeometry(halfView * 0.03 + 0.002, 12, 12), markerMat)
+            dot.position.copy(p)
+            dot.renderOrder = 999
+            scene.add(dot)
+            markers.push(dot)
+            if (pts.length === 2) {
+              line = new THREE.Line(new THREE.BufferGeometry().setFromPoints(pts), lineMat)
+              line.renderOrder = 998
+              scene.add(line)
+              setMeasureDist(pts[0].distanceTo(pts[1]) * 1000)
+            } else {
+              setMeasureDist(null)
+            }
+          }
+          renderer.domElement.addEventListener('pointerdown', onDown)
+          renderer.domElement.addEventListener('pointerup', onUp)
+          teardownPose = () => {
+            renderer.domElement.removeEventListener('pointerdown', onDown)
+            renderer.domElement.removeEventListener('pointerup', onUp)
+            clearMeasure()
+            markerMat.dispose()
+            lineMat.dispose()
+            measureApiRef.current = null
+          }
+        }
       }
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Could not parse this URDF.')
       setInfo(null)
+      if (poseUI) {
+        setJointMeta([])
+        setValues({})
+      }
     }
     ready = true
     finalize() // no meshes (or all failed synchronously) → settle the note now
@@ -267,6 +519,8 @@ export function RobotView({
 
     return () => {
       disposed = true
+      robotRef.current = null
+      teardownPose()
       cancelAnimationFrame(raf)
       ro.disconnect()
       controls.dispose()
@@ -280,33 +534,55 @@ export function RobotView({
       renderer.dispose()
       if (renderer.domElement.parentNode === mount) mount.removeChild(renderer.domElement)
     }
-  }, [content, effectiveBase, isEmpty])
+  }, [content, effectiveBase, isEmpty, poseUI, currentFolder])
+
+  const showPanel = poseUI && !error && !isEmpty
 
   return (
-    <div className={`robotview${compact ? ' robotview--compact' : ''}`}>
-      <div className="robotview__canvas" ref={mountRef} />
-      {error ? (
-        <div className="robotview__overlay robotview__overlay--error" role="alert">
-          <p className="robotview__overlay-title">Couldn&apos;t show this robot</p>
-          <p className="robotview__overlay-msg">{error}</p>
-        </div>
-      ) : isEmpty ? (
-        <div className="robotview__overlay">
-          <p className="robotview__overlay-title">Robot View</p>
-          <p className="robotview__overlay-msg">Open a .urdf file to see the 3D model.</p>
-        </div>
-      ) : (
-        info && (
-          <div className="robotview__hud" aria-hidden="true">
-            <strong>{info.name}</strong> · {info.joints} joints · {info.links} links
-            {!compact && <span className="robotview__hud-hint">drag to orbit · scroll to zoom</span>}
+    <div className={`robotview${compact ? ' robotview--compact' : ''}${poseUI ? ' robotview--pose' : ''}`}>
+      <div className="robotview__stage">
+        <div className="robotview__canvas" ref={mountRef} />
+        {error ? (
+          <div className="robotview__overlay robotview__overlay--error" role="alert">
+            <p className="robotview__overlay-title">Couldn&apos;t show this robot</p>
+            <p className="robotview__overlay-msg">{error}</p>
           </div>
-        )
-      )}
-      {!error && meshNote && (
-        <div className="robotview__note" role="status">
-          {meshNote}
-        </div>
+        ) : isEmpty ? (
+          <div className="robotview__overlay">
+            <p className="robotview__overlay-title">Robot View</p>
+            <p className="robotview__overlay-msg">Open a .urdf file to see the 3D model.</p>
+          </div>
+        ) : (
+          info && (
+            <div className="robotview__hud" aria-hidden="true">
+              <strong>{info.name}</strong> · {info.joints} joints · {info.links} links
+              {!compact && <span className="robotview__hud-hint">drag to orbit · scroll to zoom</span>}
+            </div>
+          )
+        )}
+        {!error && meshNote && (
+          <div className="robotview__note" role="status">
+            {meshNote}
+          </div>
+        )}
+      </div>
+      {showPanel && (
+        <RobotJointPanel
+          joints={jointMeta}
+          values={values}
+          overrides={overrides}
+          onJointChange={handleJointChange}
+          onLimitChange={handleLimitChange}
+          poses={poses}
+          onSavePose={handleSavePose}
+          onRecallPose={handleRecallPose}
+          onDeletePose={handleDeletePose}
+          onResetPose={handleResetPose}
+          measureActive={measureActive}
+          onToggleMeasure={() => setMeasureActive((a) => !a)}
+          measureDistance={measureDist}
+          savingLabel={savingLabel}
+        />
       )}
     </div>
   )

--- a/src/renderer/src/components/robot-pose.ts
+++ b/src/renderer/src/components/robot-pose.ts
@@ -1,0 +1,132 @@
+/**
+ * ROBOT POSE LOGIC (#312, epic #309 Phase 2) — pure helpers for the pose tool:
+ * extracting movable joints from a parsed URDF, converting between the URDF's
+ * native units (radians / metres) and the human-facing display + persistence
+ * units (degrees / millimetres, matching KRF `robot.yml`), and computing mimic
+ * (`<mimic>`) follower values. Kept free of three.js / React so it's unit-tested.
+ */
+
+/** Joint types the pose tool exposes as a slider. */
+export type MovableType = 'revolute' | 'continuous' | 'prismatic'
+
+/** What the sidebar needs to render + drive one joint. Angles are NATIVE. */
+export interface JointMeta {
+  name: string
+  type: MovableType
+  /** Native lower/upper limit (rad for revolute/continuous, m for prismatic). */
+  lower: number
+  upper: number
+  /** True when this joint mimics another (driven; shown read-only). */
+  isMimic: boolean
+  /** For a mimic: the master joint + `value = multiplier * master + offset`. */
+  master?: string
+  multiplier?: number
+  offset?: number
+}
+
+/** A joint as seen on a parsed `URDFRobot` (duck-typed so this stays testable). */
+export interface JointLike {
+  jointType: string
+  limit?: { lower?: number; upper?: number }
+  mimicJoints?: Array<{ name: string }>
+  mimicJoint?: string | { name?: string } | null
+  multiplier?: number
+  offset?: number
+}
+export interface RobotLike {
+  joints: Record<string, JointLike>
+}
+
+/** A continuous (limitless) joint gets a ±180° slider range so it's usable. */
+export const CONTINUOUS_RANGE = Math.PI
+
+const RAD2DEG = 180 / Math.PI
+const DEG2RAD = Math.PI / 180
+
+export function isAngular(type: MovableType): boolean {
+  return type === 'revolute' || type === 'continuous'
+}
+
+/** Native (rad/m) → display (deg/mm). */
+export function toDisplay(type: MovableType, native: number): number {
+  return isAngular(type) ? native * RAD2DEG : native * 1000
+}
+
+/** Display (deg/mm) → native (rad/m). */
+export function toNative(type: MovableType, display: number): number {
+  return isAngular(type) ? display * DEG2RAD : display / 1000
+}
+
+/** The unit suffix shown next to a value. */
+export function unitLabel(type: MovableType): string {
+  return isAngular(type) ? '°' : 'mm'
+}
+
+export function clamp(v: number, lo: number, hi: number): number {
+  return v < lo ? lo : v > hi ? hi : v
+}
+
+/** The name of the joint a mimic follows, or undefined. */
+function masterOf(j: JointLike): string | undefined {
+  if (typeof j.mimicJoint === 'string') return j.mimicJoint || undefined
+  if (j.mimicJoint && typeof j.mimicJoint === 'object') return j.mimicJoint.name || undefined
+  return undefined
+}
+
+/**
+ * The movable joints of a parsed URDF, in insertion order. `fixed`/`floating`/
+ * `planar` joints are skipped. Mimic joints are flagged (and carry their master
+ * + multiplier/offset) so the sidebar can show them read-only.
+ */
+export function extractJoints(robot: RobotLike): JointMeta[] {
+  // A joint is driven if it names a master, or a master lists it as a mimic.
+  const driven = new Set<string>()
+  for (const [name, j] of Object.entries(robot.joints)) {
+    if (masterOf(j)) driven.add(name)
+    ;(j.mimicJoints ?? []).forEach((m) => m?.name && driven.add(m.name))
+  }
+
+  const out: JointMeta[] = []
+  for (const [name, j] of Object.entries(robot.joints)) {
+    const type = j.jointType as MovableType
+    if (type !== 'revolute' && type !== 'continuous' && type !== 'prismatic') continue
+    let lower = j.limit?.lower ?? 0
+    let upper = j.limit?.upper ?? 0
+    // Continuous / limitless joints: give a symmetric usable range.
+    if (type === 'continuous' || !(upper > lower)) {
+      lower = -CONTINUOUS_RANGE
+      upper = CONTINUOUS_RANGE
+    }
+    const meta: JointMeta = { name, type, lower, upper, isMimic: driven.has(name) }
+    if (meta.isMimic) {
+      meta.master = masterOf(j)
+      meta.multiplier = j.multiplier ?? 1
+      meta.offset = j.offset ?? 0
+    }
+    out.push(meta)
+  }
+  return out
+}
+
+/** A mimic joint's native value from its master's native value. */
+export function mimicValue(meta: JointMeta, masterNative: number): number {
+  return (meta.multiplier ?? 1) * masterNative + (meta.offset ?? 0)
+}
+
+/**
+ * The EFFECTIVE native limits for a joint: the URDF limits, overridden by any
+ * in-app min/max (stored in KRF as display units — deg/mm).
+ */
+export function effectiveLimit(
+  meta: JointMeta,
+  override?: { min?: number; max?: number }
+): { lower: number; upper: number } {
+  let lower = meta.lower
+  let upper = meta.upper
+  if (override) {
+    if (typeof override.min === 'number') lower = toNative(meta.type, override.min)
+    if (typeof override.max === 'number') upper = toNative(meta.type, override.max)
+  }
+  if (!(upper > lower)) upper = lower + 1e-4 // never a zero/negative span
+  return { lower, upper }
+}

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -2142,6 +2142,29 @@ body {
 .shell__dock--robot .instr-dock {
   min-height: 0;
 }
+/* The docked mini-viewer fills its slot; an expand button opens it full-screen. */
+.robotdock {
+  position: absolute;
+  inset: 0;
+}
+.robotdock__expand {
+  position: absolute;
+  top: 0.35rem;
+  left: 0.35rem;
+  z-index: 2;
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  color: var(--text, #cdd2d9);
+  background: rgba(20, 21, 24, 0.78);
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 5px;
+  padding: 0.15rem 0.4rem;
+  cursor: pointer;
+}
+.robotdock__expand:hover {
+  border-color: #c8a24a;
+  color: #c8a24a;
+}
 
 .activitybar {
   display: flex;

--- a/src/shared/robot-yaml.ts
+++ b/src/shared/robot-yaml.ts
@@ -8,6 +8,7 @@
 
 import { parse, stringify } from 'yaml'
 import type { RobotConnection, RobotDefinition, RobotNet, RobotPart } from './robot'
+import { sanitiseRobotModel } from './krf'
 
 const NETS: RobotNet[] = ['vcc', 'gnd', 'signal']
 
@@ -78,6 +79,11 @@ export function robotToYaml(def: RobotDefinition): string {
     if (c.color) o.color = c.color
     return o
   })
+  // The KRF robot MODEL section (URDF + servo↔joint map + limits + poses, epic
+  // #309). Round-trip it through the sanitiser so only clean, non-empty fields
+  // are written and a legacy wiring-only robot.yml stays untouched.
+  const model = sanitiseRobotModel(def.robot)
+  if (model) obj.robot = model
   return stringify(obj, { lineWidth: 0 })
 }
 
@@ -100,5 +106,7 @@ export function robotFromYaml(text: string): RobotDefinition {
   const by = num(raw.boardY)
   if (bx !== undefined) def.boardX = bx
   if (by !== undefined) def.boardY = by
+  const model = sanitiseRobotModel(raw.robot)
+  if (model) def.robot = model
   return def
 }

--- a/test/robotPose.test.ts
+++ b/test/robotPose.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest'
+import {
+  extractJoints,
+  toDisplay,
+  toNative,
+  unitLabel,
+  clamp,
+  mimicValue,
+  effectiveLimit,
+  CONTINUOUS_RANGE,
+  type RobotLike
+} from '../src/renderer/src/components/robot-pose'
+
+describe('robot-pose unit conversions (#312)', () => {
+  it('converts revolute rad ↔ deg and prismatic m ↔ mm', () => {
+    expect(toDisplay('revolute', Math.PI)).toBeCloseTo(180)
+    expect(toNative('revolute', 90)).toBeCloseTo(Math.PI / 2)
+    expect(toDisplay('prismatic', 0.05)).toBeCloseTo(50)
+    expect(toNative('prismatic', 25)).toBeCloseTo(0.025)
+  })
+  it('labels units + clamps', () => {
+    expect(unitLabel('revolute')).toBe('°')
+    expect(unitLabel('prismatic')).toBe('mm')
+    expect(clamp(5, 0, 3)).toBe(3)
+    expect(clamp(-1, 0, 3)).toBe(0)
+    expect(clamp(2, 0, 3)).toBe(2)
+  })
+})
+
+describe('extractJoints (#312)', () => {
+  const robot: RobotLike = {
+    joints: {
+      base: { jointType: 'fixed', limit: { lower: 0, upper: 0 } },
+      shoulder: { jointType: 'revolute', limit: { lower: -1, upper: 1 } },
+      slide: { jointType: 'prismatic', limit: { lower: 0, upper: 0.1 } },
+      wheel: { jointType: 'continuous', limit: {} },
+      // a mimic following the shoulder at 0.5× + 0.1 offset
+      finger: {
+        jointType: 'revolute',
+        limit: { lower: -1, upper: 1 },
+        mimicJoint: 'shoulder',
+        multiplier: 0.5,
+        offset: 0.1
+      }
+    }
+  }
+  const meta = extractJoints(robot)
+
+  it('skips fixed joints, keeps revolute/prismatic/continuous', () => {
+    expect(meta.map((m) => m.name)).toEqual(['shoulder', 'slide', 'wheel', 'finger'])
+  })
+  it('gives a continuous joint a symmetric ±180° range', () => {
+    const wheel = meta.find((m) => m.name === 'wheel')!
+    expect(wheel.lower).toBeCloseTo(-CONTINUOUS_RANGE)
+    expect(wheel.upper).toBeCloseTo(CONTINUOUS_RANGE)
+  })
+  it('flags a mimic joint with its master + factors', () => {
+    const finger = meta.find((m) => m.name === 'finger')!
+    expect(finger.isMimic).toBe(true)
+    expect(finger.master).toBe('shoulder')
+    expect(finger.multiplier).toBe(0.5)
+    expect(finger.offset).toBe(0.1)
+    // masters are NOT flagged
+    expect(meta.find((m) => m.name === 'shoulder')!.isMimic).toBe(false)
+  })
+  it('also detects a mimic declared via the master mimicJoints list', () => {
+    const r: RobotLike = {
+      joints: {
+        a: { jointType: 'revolute', limit: { lower: -1, upper: 1 }, mimicJoints: [{ name: 'b' }] },
+        b: { jointType: 'revolute', limit: { lower: -1, upper: 1 } }
+      }
+    }
+    expect(extractJoints(r).find((m) => m.name === 'b')!.isMimic).toBe(true)
+  })
+})
+
+describe('mimicValue + effectiveLimit (#312)', () => {
+  const finger = {
+    name: 'finger',
+    type: 'revolute' as const,
+    lower: -1,
+    upper: 1,
+    isMimic: true,
+    master: 'shoulder',
+    multiplier: 0.5,
+    offset: 0.1
+  }
+  it('computes a mimic follower value', () => {
+    expect(mimicValue(finger, 1)).toBeCloseTo(0.6)
+    expect(mimicValue(finger, 0)).toBeCloseTo(0.1)
+  })
+  it('applies display-unit overrides onto native limits', () => {
+    const shoulder = {
+      name: 'shoulder',
+      type: 'revolute' as const,
+      lower: -1,
+      upper: 1,
+      isMimic: false
+    }
+    const lim = effectiveLimit(shoulder, { min: -90, max: 45 })
+    expect(lim.lower).toBeCloseTo(-Math.PI / 2)
+    expect(lim.upper).toBeCloseTo(Math.PI / 4)
+  })
+  it('never returns a zero/negative span', () => {
+    const j = { name: 'j', type: 'prismatic' as const, lower: 0, upper: 0, isMimic: false }
+    const lim = effectiveLimit(j)
+    expect(lim.upper).toBeGreaterThan(lim.lower)
+  })
+})

--- a/test/robotYaml.test.ts
+++ b/test/robotYaml.test.ts
@@ -67,6 +67,33 @@ describe('robot.yml round-trip', () => {
   })
 })
 
+describe('KRF robot model round-trips (#312)', () => {
+  it('serialises + parses the robot: section (limits, defaultPose, poses)', () => {
+    const def: RobotDefinition = {
+      parts: [],
+      connections: [],
+      robot: {
+        version: 1,
+        urdf: 'urdf/arm.urdf',
+        joints: { shoulder: { min: -45, max: 45 } },
+        defaultPose: { shoulder: 10 },
+        poses: [{ name: 'home', values: { shoulder: 0, elbow: 20 } }]
+      }
+    }
+    const round = robotFromYaml(robotToYaml(def))
+    expect(round.robot?.urdf).toBe('urdf/arm.urdf')
+    expect(round.robot?.joints?.shoulder).toEqual({ min: -45, max: 45 })
+    expect(round.robot?.defaultPose).toEqual({ shoulder: 10 })
+    expect(round.robot?.poses).toEqual([{ name: 'home', values: { shoulder: 0, elbow: 20 } }])
+  })
+
+  it('a wiring-only robot.yml stays free of a robot: section', () => {
+    const yaml = robotToYaml({ parts: [], connections: [] })
+    expect(yaml).not.toMatch(/\brobot:/)
+    expect(robotFromYaml(yaml).robot).toBeUndefined()
+  })
+})
+
 describe('connection colours', () => {
   it('vcc is red, gnd flips with the theme, signal uses its colour', () => {
     expect(connectionColor({ id: '1', from: 'a', to: 'b', net: 'vcc' }, false)).toBe('#c0392b')


### PR DESCRIPTION
Epic #309 **Phase 2**. Opening a robot's `.urdf` full-screen becomes a **pose tool** — pose the robot by hand.

## What
- **Joint sidebar** — a slider per movable joint (**degrees** for revolute, **mm** for prismatic) that drives the model live, clamped to the URDF limits.
- **`<mimic>` joints** — followers update automatically from their master (`multiplier * master + offset`); shown read-only as *"follows &lt;master&gt;"*.
- **Editable limits** — inline min/max per joint; editing updates the slider range and **persists**.
- **Named poses** — save / recall / delete keyframe snapshots.
- **Measure tool** — toggle on, click two points on the model → point-to-point distance (mm) with on-model markers + a line.
- **Persistence** — limit overrides + poses write to `robot.yml`'s KRF `robot:` section (project folder, else userData). This also **fixes a gap from #316**: the `robot.yml` (de)serialiser never round-tripped the `robot:` model, so *nothing* under it persisted — now it does (with a regression test).
- The docked Robot-mode mini-panel stays view-only and gains an **⤢ Pose** button to open the robot full-screen.
- New pure module `robot-pose.ts` (joint extraction, unit conversions, effective limits, mimic value) with unit tests.

## Acceptance — all verified in-app (Playwright, a mimic-joint URDF)
- ✅ Dragging the `left` slider to 56.7° drives the mimic `right` to −56.7°; motion respects limits.
- ✅ Editing `shoulder` max to 45° updates the slider range **and** persists (`robot.yml` → `joints.shoulder.max: 45`).
- ✅ Saving `home` then moving a joint and recalling restores every angle (56.7 / −56.7).
- ✅ Measure reports a correct distance (157.0 mm).

Gate: typecheck + lint clean, **1427 tests** (+11), build ✅. Docs: `docs/krf.md` gains a Pose-tool section.

Part of epic #309. Remaining: #313 (servo↔joint binding — a running program drives these joints), #314 (motion timeline), #315 (URDF builder), #310 remainder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
