### PR TITLE
Robot View: pop-out + assembly panel + one-click STL import (#324)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Robot View — pop-out, assembly panel & one-click STL import (#324, epic
+  #309).** The docked mini 3-D viewer gains a **⤢ Pop out** button that opens the
+  robot full-screen (Code mode) with the pose tool. The full-screen view now
+  shows an **Assembly** panel — every link + the STL/mesh file it uses — and a
+  **+ STL** button: pick a mesh and it's copied into the robot's KRF
+  `urdf/meshes/` folder (collision-safe) and wired into the `.urdf` as a new link
+  + fixed joint, so it appears in the model and the assembly immediately.
 - **Robot View — Pose tool (#312, epic #309 Phase 2).** Opening a `.urdf`
   full-screen now gives a **pose tool**: a joint sidebar with a slider per joint
   (degrees for revolute, mm for prismatic) that moves the robot live, respecting

--- a/docs/krf.md
+++ b/docs/krf.md
@@ -82,6 +82,12 @@ note in the panel — the rest of the robot still renders. `.obj`/`.glb` and oth
 formats aren't loaded yet (they show a placeholder). See
 `examples/mesh-demo/mesh-demo.urdf` for a zero-setup example.
 
+**Importing a mesh (#324).** The pose tool's **Assembly** panel has a **+ STL**
+button: pick an `.stl`/`.dae` and Snakie copies it into `<urdf-folder>/meshes/`
+(never overwriting — it appends `-1`, `-2`, …) and appends a new `<link>` (with
+that `<mesh>`) plus a fixed `<joint>` onto the root link, so it shows in the model
+straight away. The assembly panel lists every link + the mesh file it uses.
+
 ## Versioning
 
 `robot.version` is bumped on breaking changes; `sanitiseRobotModel` migrates /

--- a/src/main/robot/ipc.ts
+++ b/src/main/robot/ipc.ts
@@ -8,11 +8,44 @@
  * handlers return serialisable values and never throw across the bridge.
  */
 
-import { app, ipcMain, BrowserWindow } from 'electron'
-import { join } from 'path'
+import { app, ipcMain, BrowserWindow, dialog } from 'electron'
+import { basename, dirname, extname, join } from 'path'
 import { promises as fsp } from 'fs'
 import { robotFromYaml, robotToYaml } from '../../shared/robot-yaml'
 import { blankRobot, type RobotDefinition } from '../../shared/robot'
+
+/** Result of importing a mesh: the path relative to the URDF's folder, or a
+ *  cancellation. */
+export interface ImportMeshResult {
+  cancelled?: boolean
+  error?: string
+  /** Mesh path relative to the URDF's folder, e.g. `meshes/wheel.stl`. */
+  rel?: string
+  /** The copied file's base name, e.g. `wheel.stl`. */
+  name?: string
+}
+
+/** Copy `src` into `<urdfDir>/meshes/`, never overwriting (appends -1, -2 …). */
+async function copyIntoMeshes(urdfPath: string, src: string): Promise<{ rel: string; name: string }> {
+  const meshesDir = join(dirname(urdfPath), 'meshes')
+  await fsp.mkdir(meshesDir, { recursive: true })
+  const ext = extname(src)
+  const stem = basename(src, ext)
+  let name = `${stem}${ext}`
+  let n = 1
+  // Collision-safe: keep an existing file, land the import next to it.
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      await fsp.access(join(meshesDir, name))
+      name = `${stem}-${n++}${ext}`
+    } catch {
+      break
+    }
+  }
+  await fsp.copyFile(src, join(meshesDir, name))
+  return { rel: `meshes/${name}`, name }
+}
 
 /** Resolve the robot.yml path: `<folder>/robot.yml` if the folder is a real
  *  directory, else `<userData>/robot.yml`. */
@@ -68,6 +101,34 @@ export function registerRobotIpc(): void {
         return { ok: true }
       } catch (err) {
         return { ok: false, error: (err as Error).message }
+      }
+    }
+  )
+
+  // Import an STL/DAE mesh into the robot's KRF folder (#309): a native picker,
+  // then copy the chosen file into `<urdf-folder>/meshes/`. The renderer wires
+  // the returned relative path into the URDF. The copy is binary-safe.
+  ipcMain.handle(
+    'robot:importMesh',
+    async (e, args: { urdfPath: string }): Promise<ImportMeshResult> => {
+      try {
+        if (!args?.urdfPath) return { error: 'No robot file to import into.' }
+        const win = BrowserWindow.fromWebContents(e.sender) ?? undefined
+        const opts = {
+          title: 'Import mesh',
+          properties: ['openFile' as const],
+          filters: [
+            { name: '3D mesh', extensions: ['stl', 'dae'] },
+            { name: 'All files', extensions: ['*'] }
+          ]
+        }
+        const result = win
+          ? await dialog.showOpenDialog(win, opts)
+          : await dialog.showOpenDialog(opts)
+        if (result.canceled || result.filePaths.length === 0) return { cancelled: true }
+        return await copyIntoMeshes(args.urdfPath, result.filePaths[0])
+      } catch (err) {
+        return { error: (err as Error).message }
       }
     }
   )

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -971,6 +971,12 @@ const robot = {
   /** Save the robot definition. Resolves to {ok,error} — never rejects. */
   save: (folder: string | undefined, def: RobotDefinition): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('robot:save', { folder, def }),
+  /** Import an STL/DAE mesh into the robot's `<urdf-folder>/meshes/` via a native
+   *  picker (#309). Resolves to the mesh path relative to the URDF, or cancelled. */
+  importMesh: (
+    urdfPath: string
+  ): Promise<{ cancelled?: boolean; error?: string; rel?: string; name?: string }> =>
+    ipcRenderer.invoke('robot:importMesh', { urdfPath }),
   /** Subscribe to robot.yml changes from ANOTHER window (e.g. the Board View
    *  adding/removing a part). Returns an unsubscribe. */
   onChanged: (cb: () => void): (() => void) => {

--- a/src/renderer/src/components/RobotDockPanel.tsx
+++ b/src/renderer/src/components/RobotDockPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { RobotView } from './RobotView'
 import { dirname } from './robot-mesh'
 import { useWorkspace } from '../store/workspace'
+import { useWorkspaceLayout } from '../store/layout'
 import { readRobotModel } from '../../../shared/krf'
 import demoArm from '../assets/demo-arm.urdf?raw'
 
@@ -14,7 +15,8 @@ import demoArm from '../assets/demo-arm.urdf?raw'
  * as the Pose tool (#312).
  */
 export function RobotDockPanel(): JSX.Element {
-  const { currentFolder, openFile } = useWorkspace()
+  const { currentFolder, openFile, openBuffer } = useWorkspace()
+  const { switchWorkspace } = useWorkspaceLayout()
   const [urdf, setUrdf] = useState<string>(demoArm)
   // The URDF's folder, so RobotView resolves the robot's meshes (#319). Empty
   // for the bundled demo arm (all primitives — no meshes to resolve).
@@ -52,19 +54,26 @@ export function RobotDockPanel(): JSX.Element {
     }
   }, [currentFolder])
 
+  // Pop the robot out full-screen (the Pose tool + assembly): a saved project
+  // URDF opens as its file; the bundled demo arm opens as a buffer. Switch to
+  // Code mode so the routed viewer fills the editor pane.
+  const popOut = (): void => {
+    if (urdfPath) void openFile('local', urdfPath)
+    else openBuffer('demo-arm.urdf', urdf)
+    switchWorkspace('code')
+  }
+
   return (
     <div className="robotdock">
       <RobotView urdfContent={urdf} basePath={base} compact />
-      {urdfPath && (
-        <button
-          type="button"
-          className="robotdock__expand"
-          title="Open the robot full-screen (Pose tool)"
-          onClick={() => void openFile('local', urdfPath)}
-        >
-          ⤢ Pose
-        </button>
-      )}
+      <button
+        type="button"
+        className="robotdock__expand"
+        title="Pop out full-screen (Pose tool + assembly)"
+        onClick={popOut}
+      >
+        ⤢ Pop out
+      </button>
     </div>
   )
 }

--- a/src/renderer/src/components/RobotJointPanel.css
+++ b/src/renderer/src/components/RobotJointPanel.css
@@ -187,6 +187,39 @@
   border-color: #b4544e;
 }
 
+.robotpanel__assembly {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+.robotpanel__part {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.4rem;
+  font-size: 0.64rem;
+}
+.robotpanel__part-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.robotpanel__part-geo {
+  flex: 0 0 auto;
+  max-width: 55%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-muted, #7d838d);
+  font-size: 0.58rem;
+}
+.robotpanel__part-geo.is-mesh {
+  color: #c8a24a;
+}
+
 .robotpanel__measure.is-on {
   border-color: #c8a24a;
   color: #c8a24a;

--- a/src/renderer/src/components/RobotJointPanel.tsx
+++ b/src/renderer/src/components/RobotJointPanel.tsx
@@ -7,6 +7,8 @@ import {
   toNative,
   unitLabel
 } from './robot-pose'
+import type { AssemblyItem } from './robot-assembly'
+import { baseName } from './robot-mesh'
 import './RobotJointPanel.css'
 
 /** A saved pose (name + joint→display-value map). Mirrors KRF `NamedPose`. */
@@ -34,6 +36,12 @@ export interface RobotJointPanelProps {
   measureDistance: number | null
   /** Whether the current pose has been persisted (for a subtle saved hint). */
   savingLabel: string | null
+  /** The model's links + the meshes they use (assembly list). */
+  assembly: AssemblyItem[]
+  onImportStl: () => void
+  /** Import is only possible for a saved project robot (a file to edit). */
+  canImport: boolean
+  importing: boolean
 }
 
 /** Round a display value for compact display. */
@@ -55,7 +63,11 @@ export function RobotJointPanel({
   measureActive,
   onToggleMeasure,
   measureDistance,
-  savingLabel
+  savingLabel,
+  assembly,
+  onImportStl,
+  canImport,
+  importing
 }: RobotJointPanelProps): JSX.Element {
   const [poseName, setPoseName] = useState('')
   const movable = joints.filter((j) => !j.isMimic)
@@ -154,6 +166,44 @@ export function RobotJointPanel({
           )
         })}
       </div>
+
+      <section className="robotpanel__section">
+        <div className="robotpanel__section-head">
+          <span>Assembly</span>
+          <button
+            type="button"
+            className="robotpanel__btn"
+            disabled={!canImport || importing}
+            onClick={onImportStl}
+            title={
+              canImport
+                ? 'Import an STL / DAE mesh into this robot'
+                : 'Open a saved project robot to import meshes'
+            }
+          >
+            {importing ? 'Importing…' : '+ STL'}
+          </button>
+        </div>
+        {assembly.length === 0 ? (
+          <p className="robotpanel__empty">No links.</p>
+        ) : (
+          <ul className="robotpanel__assembly">
+            {assembly.map((it) => (
+              <li className="robotpanel__part" key={it.link}>
+                <span className="robotpanel__part-name" title={it.link}>
+                  {it.link}
+                </span>
+                <span
+                  className={`robotpanel__part-geo${it.kind === 'mesh' ? ' is-mesh' : ''}`}
+                  title={it.kind === 'mesh' ? it.mesh : it.kind}
+                >
+                  {it.kind === 'mesh' ? baseName(it.mesh ?? '') : it.kind}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
 
       <section className="robotpanel__section">
         <div className="robotpanel__section-head">

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import * as THREE from 'three'
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
 import { STLLoader } from 'three/examples/jsm/loaders/STLLoader.js'
@@ -16,6 +16,7 @@ import {
   toDisplay,
   toNative
 } from './robot-pose'
+import { addMeshLink, parseAssembly } from './robot-assembly'
 import type { RobotDefinition, RobotModel } from '../../../shared/robot'
 import './RobotView.css'
 
@@ -63,7 +64,7 @@ export function RobotView({
   basePath,
   compact = false
 }: RobotViewProps = {}): JSX.Element {
-  const { openFiles, activeId, currentFolder } = useWorkspace()
+  const { openFiles, activeId, currentFolder, updateContent, saveFile } = useWorkspace()
   const activeFile = openFiles.find((f) => f.id === activeId) ?? null
   const content = urdfContent ?? activeFile?.content ?? ''
   // Where to resolve mesh files from: an explicit base (docked panel) else the
@@ -190,6 +191,48 @@ export function RobotView({
     }
     applyToRobot(nv)
     setValues(nv)
+  }
+
+  // The model's links + meshes, for the assembly panel.
+  const assembly = useMemo(() => parseAssembly(content), [content])
+  // Import is only possible for a saved local `.urdf` (a file we can edit).
+  const canImport = poseUI && activeFile?.source === 'local' && !!activeFile.path
+  const [importing, setImporting] = useState(false)
+  const pendingSaveRef = useRef<string | null>(null)
+
+  // Persist a just-imported URDF once the buffer state has updated (so saveFile
+  // writes the new content + clears the dirty flag). Keyed on `content`.
+  useEffect(() => {
+    const id = pendingSaveRef.current
+    if (id) {
+      pendingSaveRef.current = null
+      void saveFile(id)
+    }
+  }, [content, saveFile])
+
+  const handleImportStl = async (): Promise<void> => {
+    if (!activeFile || activeFile.source !== 'local' || !activeFile.path) return
+    setImporting(true)
+    try {
+      const res = await window.api.robot.importMesh(activeFile.path)
+      if (res.cancelled || !res.rel) {
+        if (res.error) setSavingLabel(`import failed: ${res.error}`)
+        return
+      }
+      // Add the mesh to the URDF (a new link + fixed joint) so it renders now.
+      const linkBase = res.name?.replace(/\.(stl|dae)$/i, '') ?? 'part'
+      const next = addMeshLink(content, { meshRel: res.rel, linkBase })
+      // Update the buffer (RobotView re-renders + the tab reflects it), then let
+      // an effect persist it once the store state is fresh (saveFile() called
+      // here would write the stale pre-edit content).
+      updateContent(activeFile.id, next.urdf)
+      pendingSaveRef.current = activeFile.id
+      setSavingLabel(`added ${next.link}`)
+    } catch (e) {
+      setSavingLabel(`import failed: ${e instanceof Error ? e.message : 'error'}`)
+    } finally {
+      setImporting(false)
+    }
   }
 
   // Toggling measure off clears the markers + readout.
@@ -582,6 +625,10 @@ export function RobotView({
           onToggleMeasure={() => setMeasureActive((a) => !a)}
           measureDistance={measureDist}
           savingLabel={savingLabel}
+          assembly={assembly}
+          onImportStl={() => void handleImportStl()}
+          canImport={!!canImport}
+          importing={importing}
         />
       )}
     </div>

--- a/src/renderer/src/components/robot-assembly.ts
+++ b/src/renderer/src/components/robot-assembly.ts
@@ -1,0 +1,110 @@
+/**
+ * ROBOT ASSEMBLY HELPERS (epic #309) — pure text utilities for the pose tool's
+ * assembly panel + STL import: reading a URDF's links + the mesh files they use,
+ * and appending an imported mesh as a new link/joint. Regex-based (no DOM) so
+ * they're cheap to unit-test in a node env.
+ */
+
+/** One link of the model + the visual geometry it uses. */
+export interface AssemblyItem {
+  link: string
+  kind: 'mesh' | 'box' | 'cylinder' | 'sphere' | 'none'
+  /** For `kind: 'mesh'`, the mesh filename as written in the URDF. */
+  mesh?: string
+}
+
+/** The links of a URDF + their visual geometry, in document order. */
+export function parseAssembly(urdf: string): AssemblyItem[] {
+  const items: AssemblyItem[] = []
+  const seen = new Set<string>()
+  const openRe = /<link\b([^>]*?)(\/?)>/g
+  let m: RegExpExecArray | null
+  while ((m = openRe.exec(urdf))) {
+    const attrs = m[1]
+    const selfClose = m[2] === '/'
+    const name = /\bname\s*=\s*"([^"]+)"/.exec(attrs)?.[1]
+    if (!name || seen.has(name)) continue
+    seen.add(name)
+    let body = ''
+    if (!selfClose) {
+      const end = urdf.indexOf('</link>', openRe.lastIndex)
+      body = end >= 0 ? urdf.slice(openRe.lastIndex, end) : ''
+    }
+    const mesh = /<mesh\b[^>]*\bfilename\s*=\s*"([^"]+)"/i.exec(body)?.[1]
+    if (mesh) {
+      items.push({ link: name, kind: 'mesh', mesh })
+    } else {
+      const prim = /<(box|cylinder|sphere)\b/i.exec(body)?.[1]
+      items.push({ link: name, kind: (prim?.toLowerCase() as AssemblyItem['kind']) ?? 'none' })
+    }
+  }
+  return items
+}
+
+/** The distinct mesh files a URDF references, in first-seen order. */
+export function meshFiles(urdf: string): string[] {
+  const out: string[] = []
+  const seen = new Set<string>()
+  const re = /<mesh\b[^>]*\bfilename\s*=\s*"([^"]+)"/gi
+  let m: RegExpExecArray | null
+  while ((m = re.exec(urdf))) {
+    if (!seen.has(m[1])) {
+      seen.add(m[1])
+      out.push(m[1])
+    }
+  }
+  return out
+}
+
+/** The root link — one that is never a joint `child` (falls back to the first
+ *  link). Used as the parent when attaching an imported mesh. */
+export function rootLink(urdf: string): string | undefined {
+  const links = parseAssembly(urdf).map((i) => i.link)
+  if (links.length === 0) return undefined
+  const children = new Set<string>()
+  const re = /<child\b[^>]*\blink\s*=\s*"([^"]+)"/gi
+  let m: RegExpExecArray | null
+  while ((m = re.exec(urdf))) children.add(m[1])
+  return links.find((l) => !children.has(l)) ?? links[0]
+}
+
+/** A link name derived from `base`, made XML-safe + unique within the URDF. */
+export function uniqueLinkName(urdf: string, base: string): string {
+  const existing = new Set(parseAssembly(urdf).map((i) => i.link))
+  const safe = base.replace(/[^A-Za-z0-9_]+/g, '_').replace(/^_+|_+$/g, '') || 'part'
+  if (!existing.has(safe)) return safe
+  let n = 2
+  while (existing.has(`${safe}_${n}`)) n++
+  return `${safe}_${n}`
+}
+
+/**
+ * Append an imported mesh to a URDF as a new link (+ a fixed joint onto the root
+ * link) so it shows in the model immediately. `meshRel` is the mesh path
+ * relative to the URDF folder (e.g. `meshes/wheel.stl`). Returns the new URDF
+ * text and the created link name.
+ */
+export function addMeshLink(
+  urdf: string,
+  opts: { meshRel: string; linkBase: string }
+): { urdf: string; link: string } {
+  const parent = rootLink(urdf)
+  const name = uniqueLinkName(urdf, opts.linkBase)
+  const joint = parent
+    ? `  <joint name="${name}_joint" type="fixed">\n` +
+      `    <parent link="${parent}"/>\n` +
+      `    <child link="${name}"/>\n` +
+      `    <origin xyz="0 0 0" rpy="0 0 0"/>\n` +
+      `  </joint>\n`
+    : '' // first link of an empty URDF needs no joint
+  const block =
+    `  <link name="${name}">\n` +
+    `    <visual>\n` +
+    `      <geometry><mesh filename="${opts.meshRel}"/></geometry>\n` +
+    `    </visual>\n` +
+    `  </link>\n` +
+    joint
+  const idx = urdf.lastIndexOf('</robot>')
+  const next = idx < 0 ? `${urdf.trimEnd()}\n${block}` : urdf.slice(0, idx) + block + urdf.slice(idx)
+  return { urdf: next, link: name }
+}

--- a/test/robotAssembly.test.ts
+++ b/test/robotAssembly.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import {
+  parseAssembly,
+  meshFiles,
+  rootLink,
+  uniqueLinkName,
+  addMeshLink
+} from '../src/renderer/src/components/robot-assembly'
+
+const URDF = `<?xml version="1.0"?>
+<robot name="arm">
+  <link name="base_link">
+    <visual><geometry><box size="0.1 0.1 0.04"/></geometry></visual>
+  </link>
+  <link name="upper">
+    <visual><geometry><mesh filename="meshes/upper.stl"/></geometry></visual>
+  </link>
+  <link name="tip"/>
+  <joint name="j1" type="revolute">
+    <parent link="base_link"/><child link="upper"/>
+  </joint>
+  <joint name="j2" type="fixed">
+    <parent link="upper"/><child link="tip"/>
+  </joint>
+</robot>`
+
+describe('parseAssembly + meshFiles (#309)', () => {
+  it('lists links with their geometry kind', () => {
+    const a = parseAssembly(URDF)
+    expect(a).toEqual([
+      { link: 'base_link', kind: 'box' },
+      { link: 'upper', kind: 'mesh', mesh: 'meshes/upper.stl' },
+      { link: 'tip', kind: 'none' }
+    ])
+  })
+  it('collects distinct mesh files', () => {
+    expect(meshFiles(URDF)).toEqual(['meshes/upper.stl'])
+  })
+})
+
+describe('rootLink + uniqueLinkName (#309)', () => {
+  it('finds the link that is never a child', () => {
+    expect(rootLink(URDF)).toBe('base_link')
+  })
+  it('makes a safe, unique link name', () => {
+    expect(uniqueLinkName(URDF, 'wheel')).toBe('wheel')
+    expect(uniqueLinkName(URDF, 'upper')).toBe('upper_2')
+    expect(uniqueLinkName(URDF, 'left wheel!')).toBe('left_wheel')
+  })
+})
+
+describe('addMeshLink (#309)', () => {
+  it('appends a link + fixed joint before </robot>, parented to the root', () => {
+    const { urdf, link } = addMeshLink(URDF, { meshRel: 'meshes/wheel.stl', linkBase: 'wheel' })
+    expect(link).toBe('wheel')
+    expect(urdf).toContain('<mesh filename="meshes/wheel.stl"/>')
+    expect(urdf).toContain('<joint name="wheel_joint" type="fixed">')
+    expect(urdf).toContain('<parent link="base_link"/>')
+    expect(urdf.indexOf('wheel_joint')).toBeLessThan(urdf.indexOf('</robot>'))
+    // the new link now parses back out
+    expect(parseAssembly(urdf).some((i) => i.link === 'wheel' && i.mesh === 'meshes/wheel.stl')).toBe(
+      true
+    )
+  })
+  it('avoids a name collision', () => {
+    const { link } = addMeshLink(URDF, { meshRel: 'meshes/upper.stl', linkBase: 'upper' })
+    expect(link).toBe('upper_2')
+  })
+  it('adds just a link (no joint) to an empty robot', () => {
+    const empty = `<robot name="e"></robot>`
+    const { urdf, link } = addMeshLink(empty, { meshRel: 'meshes/x.stl', linkBase: 'x' })
+    expect(link).toBe('x')
+    expect(urdf).toContain('<link name="x">')
+    expect(urdf).not.toContain('<joint')
+  })
+})


### PR DESCRIPTION
Part of epic #309 (Robot View) — closes #324. Makes the 3-D robot easier to reach and grow.

## What
- **Pop-out** — the docked mini 3-D viewer gains a **⤢ Pop out** button that opens the robot **full-screen** (switches to Code mode so the pose tool fills the editor pane). A saved project URDF opens as its file; the bundled demo arm opens as a buffer.
- **Assembly panel** — the pose sidebar now lists every link + the STL/mesh file it uses (or its primitive kind). Parsed from the URDF text by a new pure `robot-assembly.ts`.
- **One-click STL/DAE import** — a **+ STL** button → native picker → `robot:importMesh` copies the file into the robot's KRF `<urdf-folder>/meshes/` (collision-safe, binary copy), and `addMeshLink` appends a new `<link>` + fixed `<joint>` to the `.urdf` referencing it — so it renders and lists immediately. The edited `.urdf` is written to disk with a deferred `saveFile` (fresh buffer state → no stale write; the tab stays clean).

## Verified (in-app, Playwright — native dialog stubbed in the main process)
- Assembly lists the links (base/arm/… with box/cylinder/mesh).
- Importing `base.stl` copies it into `meshes/`, adds a `base_2` link (4→5 links, 3→4 joints), renders it, and the on-disk `.urdf` gains the `<mesh>` ref + fixed joint — with the tab **clean** (not "Unsaved").
- Pop-out from Robot mode opens the full pose tool in Code mode (screenshotted).

Pure helpers (`parseAssembly` / `meshFiles` / `rootLink` / `uniqueLinkName` / `addMeshLink`) are unit-tested. Gate: typecheck + lint clean, **1434 tests** (+7), build ✅. Docs: `docs/krf.md` gains an import section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
