### PR TITLE
Robot View: servo↔joint binding + code-driven simulation (#313)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Robot View — servo↔joint binding & code-driven simulation (#313, epic #309
+  Phase 3).** The keystone: a running MicroPython program's servo writes now
+  animate the 3-D robot, **headless** (no board — it runs in the simulator).
+  Bind a servo pin to a URDF joint in the pose tool's new **Servos** panel, with
+  angle-range calibration (servo 0–180° ↔ joint min–max, plus invert); the map
+  persists in `robot.yml` (`servoJointMap`). `inst.servo_on(pin).angle(...)`
+  emits pin-keyed telemetry that drives the bound joint in real time — try
+  `examples/servo-arm/` (open `arm.urdf`, Run `sweep.py`). Works tethered too
+  (same telemetry path on a real board).
 - **Robot View — pop-out, assembly panel & one-click STL import (#324, epic
   #309).** The docked mini 3-D viewer gains a **⤢ Pop out** button that opens the
   robot full-screen (Code mode) with the pose tool. The full-screen view now
@@ -48,6 +57,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   panel. The 3D engine is code-split, so it only loads when you open a robot.
   Built on the KRF format (#310); the pose tool, servo↔joint binding and motion
   timeline follow.
+
+### Fixed
+- **Robot pose/servo panel is now legible in the light skin.** The panel used an
+  undefined colour token, so it rendered dark-on-dark in the parchment theme; it
+  now uses the theme surface tokens (parchment ⇄ charcoal) like the file panel.
 
 ## [0.24.0] - 2026-07-08
 

--- a/docs/krf.md
+++ b/docs/krf.md
@@ -58,12 +58,25 @@ master + offset`). Editing a joint's min/max writes an override into
 (display units — deg/mm). A measure tool reports the distance between two clicked
 points. The `robot.yml` (de)serialiser round-trips this whole `robot:` section.
 
-### Servo → joint mapping
+### Servo → joint mapping (#313)
 
-A running program's servo write drives the mapped joint (Phase 3): the servo
-angle is clamped to `servoMin..servoMax`, optionally inverted, and lerped onto
-`jointMin..jointMax`. Pure implementation + tests: `src/shared/krf.ts`
-(`servoToJoint`), `test/krf.test.ts`.
+A running program's servo write drives the mapped joint — **headless**, in the
+simulator, no board required. The servo angle is clamped to `servoMin..servoMax`,
+optionally inverted, and lerped onto `jointMin..jointMax` (`servoToJoint` in
+`src/shared/krf.ts`; tests in `test/krf.test.ts`).
+
+Bind a pin to a joint in the pose tool's **Servos** panel (calibration + invert);
+it persists here as `servoJointMap`. In code, use one servo per joint::
+
+    import instruments as inst
+    shoulder = inst.servo_on(0)   # GP0
+    elbow = inst.servo_on(1)      # GP1
+    shoulder.angle(90)            # -> SNK SERVO 0 90 -> the joint bound to pin 0 moves
+
+`inst.servo_on(pin).angle(deg)` emits pin-keyed `SNK SERVO <pin> <deg>`
+telemetry, which Robot View parses and maps onto the bound joint in real time —
+so the same code animates the 3-D model (simulator) and drives real servos on a
+board. Worked example: `examples/servo-arm/` (open `arm.urdf`, Run `sweep.py`).
 
 ## Meshes (#319)
 

--- a/examples/servo-arm/arm.urdf
+++ b/examples/servo-arm/arm.urdf
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<!--
+  SERVO ARM (#313) — a 2-joint arm driven from MicroPython code. Bind GP0 →
+  shoulder and GP1 → elbow in the Robot View's Servos panel (or use the bundled
+  robot.yml), then Run sweep.py: each servo write animates the mapped joint live,
+  headless in the simulator — no board needed.
+-->
+<robot name="servo_arm">
+  <material name="steel"><color rgba="0.62 0.65 0.69 1"/></material>
+  <material name="amber"><color rgba="0.85 0.55 0.18 1"/></material>
+  <material name="blue"><color rgba="0.34 0.55 0.82 1"/></material>
+
+  <link name="base">
+    <visual><geometry><box size="0.14 0.14 0.04"/></geometry><material name="steel"/></visual>
+  </link>
+  <link name="upper_arm">
+    <visual><origin xyz="0 0 0.12"/><geometry><box size="0.05 0.05 0.24"/></geometry><material name="amber"/></visual>
+  </link>
+  <link name="forearm">
+    <visual><origin xyz="0 0 0.1"/><geometry><box size="0.04 0.04 0.2"/></geometry><material name="blue"/></visual>
+  </link>
+
+  <joint name="shoulder" type="revolute">
+    <parent link="base"/><child link="upper_arm"/>
+    <origin xyz="0 0 0.04"/><axis xyz="0 0 1"/>
+    <limit lower="-1.5708" upper="1.5708" effort="1" velocity="1"/>
+  </joint>
+  <joint name="elbow" type="revolute">
+    <parent link="upper_arm"/><child link="forearm"/>
+    <origin xyz="0 0 0.24"/><axis xyz="0 1 0"/>
+    <limit lower="-1.5708" upper="1.5708" effort="1" velocity="1"/>
+  </joint>
+</robot>

--- a/examples/servo-arm/robot.yml
+++ b/examples/servo-arm/robot.yml
@@ -1,0 +1,19 @@
+name: Servo Arm
+parts: []
+connections: []
+robot:
+  version: 1
+  urdf: arm.urdf
+  servoJointMap:
+    - pin: "0"
+      joint: shoulder
+      jointMin: -90
+      jointMax: 90
+      servoMin: 0
+      servoMax: 180
+    - pin: "1"
+      joint: elbow
+      jointMin: -90
+      jointMax: 90
+      servoMin: 0
+      servoMax: 180

--- a/examples/servo-arm/sweep.py
+++ b/examples/servo-arm/sweep.py
@@ -1,0 +1,23 @@
+"""Servo Arm — drive the 3-D robot from code (headless, #313).
+
+Open `arm.urdf` in the Robot View. The bundled `robot.yml` already binds
+GP0 -> shoulder and GP1 -> elbow (see the Servos panel). Press Run: each
+`inst.servo_on(pin).angle(...)` emits `SNK SERVO <pin> <deg>`, which the Robot
+View maps onto the bound joint and animates live — no board required, it runs in
+the simulator.
+"""
+import instruments as inst
+import time
+
+shoulder = inst.servo_on(0)  # GP0 -> the shoulder joint
+elbow = inst.servo_on(1)  # GP1 -> the elbow joint
+
+while True:
+    for a in range(0, 181, 10):
+        shoulder.angle(a)
+        elbow.angle(180 - a)
+        time.sleep(0.05)
+    for a in range(180, -1, -10):
+        shoulder.angle(a)
+        elbow.angle(180 - a)
+        time.sleep(0.05)

--- a/micropython/instruments.py
+++ b/micropython/instruments.py
@@ -1490,16 +1490,23 @@ class Servo:
     ``SNK PWM servo <freq> <duty>`` so the IDE Servo panel shows the position.
     """
 
-    def __init__(self, pwm=None, freq=50, min_us=500, max_us=2500):
+    def __init__(self, pwm=None, freq=50, min_us=500, max_us=2500, pin=None):
         self._pwm = pwm
         self._freq = freq
         self._period_us = 1000000 // freq
         self.min_us = min_us
         self.max_us = max_us
         self.angle_deg = 90
+        # The GPIO number, when known — emitted as pin-keyed SERVO telemetry so
+        # Robot View can drive the mapped URDF joint (#313). Set here works even
+        # with no ``machine`` (the simulator), so headless robots still animate.
+        self.pin = None
+        if pin is not None:
+            self.set_pin(pin)
 
     def set_pin(self, n):
         """(Re)target the PWM pin: build ``PWM(Pin(n))`` at 50 Hz (no-op w/o hw)."""
+        self.pin = int(n)  # remembered regardless of hardware, for SERVO telemetry
         try:
             from machine import Pin, PWM
         except ImportError:
@@ -1519,6 +1526,9 @@ class Servo:
         if self._pwm is not None:
             self._pwm.duty_u16(int(duty * 65535))
         print("%s PWM servo %s %s" % (SENTINEL, self._freq, duty))
+        # Pin-keyed position for Robot View's servo->joint binding (#313).
+        if self.pin is not None:
+            print("%s SERVO %s %s" % (SENTINEL, self.pin, deg))
         return deg
 
     def detach(self):
@@ -1770,3 +1780,19 @@ led = Led()
 ranger = Rangefinder()
 display = Display()
 servo = Servo()
+
+
+def servo_on(pin, freq=50):
+    """A :class:`Servo` attached to GPIO ``pin`` for the Robot View (#313).
+
+    Each ``angle(deg)`` emits ``SNK SERVO <pin> <deg>`` (pin-keyed), so the IDE
+    maps this servo onto its bound URDF joint and animates the 3-D robot — even
+    headless in the simulator (no ``machine`` needed). On a real board it also
+    drives ``PWM(Pin(pin))``. Use one per joint::
+
+        import instruments as inst
+        shoulder = inst.servo_on(0)
+        elbow = inst.servo_on(1)
+        shoulder.angle(90)   # -> SNK SERVO 0 90 -> the joint bound to pin 0 moves
+    """
+    return Servo(pin=pin, freq=freq)

--- a/python/tests/test_instruments.py
+++ b/python/tests/test_instruments.py
@@ -472,6 +472,26 @@ class BuzzerDevice(unittest.TestCase):
         self.assertIsNone(inst.servo_command("wat", srv))
         self.assertIsNone(inst.servo_command("", srv))
 
+    def test_servo_on_emits_pin_keyed_telemetry(self):
+        # servo_on(pin).angle() prints both the legacy channel line AND a
+        # pin-keyed SERVO line for Robot View (#313) — no `machine` needed.
+        srv = inst.servo_on(5)
+        self.assertEqual(srv.pin, 5)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            srv.angle(90)
+        lines = buf.getvalue().strip().splitlines()
+        self.assertIn("SNK SERVO 5 90", lines)
+        # the legacy channel line is still emitted for the Servo panel/scope
+        self.assertTrue(any(ln.startswith("SNK PWM servo ") for ln in lines))
+
+    def test_plain_servo_without_pin_omits_servo_line(self):
+        # A pin-less Servo (legacy singleton) emits no SERVO line.
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            inst.Servo().angle(45)
+        self.assertNotIn("SNK SERVO", buf.getvalue())
+
     def test_buzzer_receiver_via_control_feed(self):
         # Feed real SNKCMD buzzer lines through a Control wired to a fake-PWM
         # Buzzer — the registered handler must actuate it (end-to-end protocol).

--- a/src/renderer/src/components/RobotJointPanel.css
+++ b/src/renderer/src/components/RobotJointPanel.css
@@ -7,7 +7,9 @@
   overflow-y: auto;
   box-sizing: border-box;
   padding: 0.55rem 0.6rem 1rem;
-  background: var(--panel, #202227);
+  /* Parchment in the light skin, charcoal in dark — matches the file panel and
+     keeps text legible (uses the same theme tokens, #312/#313). */
+  background: var(--bg, #202227);
   border-left: var(--border-w, 2px) solid var(--border, #2c2e33);
   font-family: var(--font-mono, 'JetBrains Mono', monospace);
   color: var(--text, #cdd2d9);
@@ -37,7 +39,7 @@
   font-family: inherit;
   font-size: 0.64rem;
   color: var(--text, #cdd2d9);
-  background: var(--panel-2, #2a2d33);
+  background: var(--bg-elevated, #2a2d33);
   border: 1px solid var(--border, #3a3d44);
   border-radius: 5px;
   padding: 0.22rem 0.5rem;
@@ -94,7 +96,7 @@
   font-family: inherit;
   font-size: 0.6rem;
   color: var(--text-muted, #9aa0a6);
-  background: var(--panel-2, #24262b);
+  background: var(--bg-sunken, #24262b);
   border: 1px solid var(--border, #34373d);
   border-radius: 4px;
   padding: 0.12rem 0.2rem;
@@ -139,7 +141,7 @@
   font-family: inherit;
   font-size: 0.64rem;
   color: var(--text, #cdd2d9);
-  background: var(--panel-2, #24262b);
+  background: var(--bg-sunken, #24262b);
   border: 1px solid var(--border, #34373d);
   border-radius: 5px;
   padding: 0.2rem 0.4rem;
@@ -163,7 +165,7 @@
   font-family: inherit;
   font-size: 0.64rem;
   color: var(--text, #cdd2d9);
-  background: var(--panel-2, #2a2d33);
+  background: var(--bg-elevated, #2a2d33);
   border: 1px solid var(--border, #3a3d44);
   border-radius: 5px;
   padding: 0.2rem 0.45rem;
@@ -218,6 +220,101 @@
 }
 .robotpanel__part-geo.is-mesh {
   color: #c8a24a;
+}
+
+/* Servo → joint bindings (#313). */
+.robotpanel__servos {
+  list-style: none;
+  margin: 0 0 0.35rem;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+.robotpanel__servo {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding-bottom: 0.3rem;
+  border-bottom: 1px dashed var(--border, #2c2e33);
+}
+.robotpanel__servo-head {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+.robotpanel__servo-pin {
+  color: #c8a24a;
+  font-weight: 700;
+  flex: 0 0 auto;
+}
+.robotpanel__servo-arrow {
+  color: var(--text-muted, #7d838d);
+}
+.robotpanel__servo-joint {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-family: inherit;
+  font-size: 0.62rem;
+  color: var(--text, #cdd2d9);
+  background: var(--bg-sunken, #24262b);
+  border: 1px solid var(--border, #34373d);
+  border-radius: 4px;
+  padding: 0.1rem 0.2rem;
+}
+.robotpanel__servo-cal {
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+  flex-wrap: wrap;
+}
+.robotpanel__servo-cal input[type='number'] {
+  width: 2.4rem;
+  font-family: inherit;
+  font-size: 0.56rem;
+  color: var(--text-muted, #9aa0a6);
+  background: var(--bg-sunken, #24262b);
+  border: 1px solid var(--border, #34373d);
+  border-radius: 4px;
+  padding: 0.08rem 0.15rem;
+  text-align: center;
+}
+.robotpanel__servo-lbl {
+  font-size: 0.55rem;
+  color: var(--text-muted, #7d838d);
+}
+.robotpanel__servo-inv {
+  display: flex;
+  align-items: center;
+  gap: 0.15rem;
+  font-size: 0.55rem;
+  color: var(--text-muted, #9aa0a6);
+}
+.robotpanel__servo-add {
+  display: flex;
+  gap: 0.3rem;
+}
+.robotpanel__servo-newpin {
+  flex: 0 0 3rem;
+  width: 3rem;
+  font-family: inherit;
+  font-size: 0.62rem;
+  color: var(--text, #cdd2d9);
+  background: var(--bg-sunken, #24262b);
+  border: 1px solid var(--border, #34373d);
+  border-radius: 5px;
+  padding: 0.15rem 0.3rem;
+}
+.robotpanel__servo-newjoint {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-family: inherit;
+  font-size: 0.62rem;
+  color: var(--text, #cdd2d9);
+  background: var(--bg-sunken, #24262b);
+  border: 1px solid var(--border, #34373d);
+  border-radius: 5px;
+  padding: 0.15rem 0.3rem;
 }
 
 .robotpanel__measure.is-on {

--- a/src/renderer/src/components/RobotJointPanel.tsx
+++ b/src/renderer/src/components/RobotJointPanel.tsx
@@ -3,11 +3,13 @@ import {
   type JointMeta,
   effectiveLimit,
   mimicValue,
+  normPin,
   toDisplay,
   toNative,
   unitLabel
 } from './robot-pose'
 import type { AssemblyItem } from './robot-assembly'
+import type { ServoJointBinding } from '../../../shared/robot'
 import { baseName } from './robot-mesh'
 import './RobotJointPanel.css'
 
@@ -42,6 +44,11 @@ export interface RobotJointPanelProps {
   /** Import is only possible for a saved project robot (a file to edit). */
   canImport: boolean
   importing: boolean
+  /** Servo → joint bindings (KRF servoJointMap) + editors (#313). */
+  bindings: ServoJointBinding[]
+  onAddBinding: (pin: string, joint: string) => void
+  onUpdateBinding: (pin: string, patch: Partial<ServoJointBinding>) => void
+  onDeleteBinding: (pin: string) => void
 }
 
 /** Round a display value for compact display. */
@@ -67,9 +74,15 @@ export function RobotJointPanel({
   assembly,
   onImportStl,
   canImport,
-  importing
+  importing,
+  bindings,
+  onAddBinding,
+  onUpdateBinding,
+  onDeleteBinding
 }: RobotJointPanelProps): JSX.Element {
   const [poseName, setPoseName] = useState('')
+  const [newPin, setNewPin] = useState('')
+  const [newJoint, setNewJoint] = useState('')
   const movable = joints.filter((j) => !j.isMimic)
   const mimics = joints.filter((j) => j.isMimic)
 
@@ -202,6 +215,120 @@ export function RobotJointPanel({
               </li>
             ))}
           </ul>
+        )}
+      </section>
+
+      <section className="robotpanel__section">
+        <div className="robotpanel__section-head">
+          <span>Servos</span>
+        </div>
+        {movable.length === 0 ? (
+          <p className="robotpanel__empty">No joints to bind.</p>
+        ) : (
+          <>
+            {bindings.length > 0 && (
+              <ul className="robotpanel__servos">
+                {bindings.map((b) => (
+                  <li className="robotpanel__servo" key={b.pin}>
+                    <div className="robotpanel__servo-head">
+                      <span className="robotpanel__servo-pin">GP{normPin(b.pin)}</span>
+                      <span className="robotpanel__servo-arrow">→</span>
+                      <select
+                        className="robotpanel__servo-joint"
+                        value={b.joint}
+                        aria-label={`Joint for GP${normPin(b.pin)}`}
+                        onChange={(e) => onUpdateBinding(b.pin, { joint: e.target.value })}
+                      >
+                        {movable.map((j) => (
+                          <option key={j.name} value={j.name}>
+                            {j.name}
+                          </option>
+                        ))}
+                      </select>
+                      <button
+                        type="button"
+                        className="robotpanel__pose-del"
+                        onClick={() => onDeleteBinding(b.pin)}
+                        aria-label={`Unbind GP${normPin(b.pin)}`}
+                      >
+                        ×
+                      </button>
+                    </div>
+                    <div className="robotpanel__servo-cal">
+                      <span className="robotpanel__servo-lbl">servo</span>
+                      <input
+                        type="number"
+                        aria-label={`GP${normPin(b.pin)} servo min`}
+                        value={b.servoMin ?? 0}
+                        onChange={(e) => onUpdateBinding(b.pin, { servoMin: Number(e.target.value) })}
+                      />
+                      <input
+                        type="number"
+                        aria-label={`GP${normPin(b.pin)} servo max`}
+                        value={b.servoMax ?? 180}
+                        onChange={(e) => onUpdateBinding(b.pin, { servoMax: Number(e.target.value) })}
+                      />
+                      <span className="robotpanel__servo-lbl">joint</span>
+                      <input
+                        type="number"
+                        aria-label={`GP${normPin(b.pin)} joint min`}
+                        value={b.jointMin}
+                        onChange={(e) => onUpdateBinding(b.pin, { jointMin: Number(e.target.value) })}
+                      />
+                      <input
+                        type="number"
+                        aria-label={`GP${normPin(b.pin)} joint max`}
+                        value={b.jointMax}
+                        onChange={(e) => onUpdateBinding(b.pin, { jointMax: Number(e.target.value) })}
+                      />
+                      <label className="robotpanel__servo-inv" title="Reverse the mapping">
+                        <input
+                          type="checkbox"
+                          checked={!!b.invert}
+                          onChange={(e) => onUpdateBinding(b.pin, { invert: e.target.checked })}
+                        />
+                        inv
+                      </label>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+            <div className="robotpanel__servo-add">
+              <input
+                className="robotpanel__servo-newpin"
+                placeholder="pin"
+                aria-label="Servo pin"
+                value={newPin}
+                onChange={(e) => setNewPin(e.target.value)}
+              />
+              <select
+                className="robotpanel__servo-newjoint"
+                aria-label="Joint to bind"
+                value={newJoint}
+                onChange={(e) => setNewJoint(e.target.value)}
+              >
+                <option value="">joint…</option>
+                {movable.map((j) => (
+                  <option key={j.name} value={j.name}>
+                    {j.name}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                className="robotpanel__btn"
+                disabled={!normPin(newPin) || !newJoint}
+                onClick={() => {
+                  onAddBinding(normPin(newPin), newJoint)
+                  setNewPin('')
+                  setNewJoint('')
+                }}
+              >
+                Bind
+              </button>
+            </div>
+          </>
         )}
       </section>
 

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -13,11 +13,13 @@ import {
   clamp,
   effectiveLimit,
   extractJoints,
+  servoToJointNative,
   toDisplay,
   toNative
 } from './robot-pose'
 import { addMeshLink, parseAssembly } from './robot-assembly'
-import type { RobotDefinition, RobotModel } from '../../../shared/robot'
+import { useTelemetryStream } from './instrument-telemetry-subscribe'
+import type { RobotDefinition, RobotModel, ServoJointBinding } from '../../../shared/robot'
 import './RobotView.css'
 
 /**
@@ -115,7 +117,16 @@ export function RobotView({
   // Merge a patch into robot.yml's `robot:` section and persist (preserving the
   // wiring). Writes to the project folder's robot.yml, else userData.
   const persist = async (mutate: (m: RobotModel) => void): Promise<void> => {
-    const def: RobotDefinition = defRef.current ?? { parts: [], connections: [] }
+    // Never overwrite an existing robot.yml with a blank: load it first if we
+    // haven't captured the full definition yet (preserves wiring + urdf ref).
+    let def = defRef.current
+    if (!def) {
+      try {
+        def = await window.api.robot.load(currentFolder || undefined)
+      } catch {
+        def = { parts: [], connections: [] }
+      }
+    }
     def.robot = { ...(def.robot ?? {}) }
     mutate(def.robot)
     defRef.current = def
@@ -209,6 +220,79 @@ export function RobotView({
       void saveFile(id)
     }
   }, [content, saveFile])
+
+  // ── Servo → joint binding + code-driven simulation (#313) ──────────────────
+  // The KRF servo↔joint map, loaded from robot.yml. Kept in a ref for the
+  // telemetry callback (which must not re-subscribe on every binding edit).
+  const [bindings, setBindings] = useState<ServoJointBinding[]>([])
+  const bindingsRef = useRef<ServoJointBinding[]>([])
+  bindingsRef.current = bindings
+
+  // Load the servo map whenever the project folder changes — for the docked mini
+  // viewer too, so it animates on Run. (The full pose tool also refreshes it in
+  // its model load below.)
+  useEffect(() => {
+    let live = true
+    void (async () => {
+      try {
+        const def = await window.api.robot.load(currentFolder || undefined)
+        if (!live) return
+        defRef.current = def // seed so persist() never clobbers an unloaded robot.yml
+        setBindings(def.robot?.servoJointMap ?? [])
+      } catch {
+        if (live) setBindings([])
+      }
+    })()
+    return () => {
+      live = false
+    }
+  }, [currentFolder])
+
+  // A running program's servo writes drive the mapped joints in real time. This
+  // works headless: the simulator runs the Python and `inst.servo_on(pin).angle`
+  // emits `SNK SERVO <pin> <deg>` — no board required.
+  useTelemetryStream((r) => {
+    if (r.kind !== 'servo') return
+    const res = servoToJointNative(bindingsRef.current, metaRef.current, r.pin, r.angle)
+    if (!res || !robotRef.current) return
+    robotRef.current.setJointValue(res.joint, res.native)
+    setValues((v) => (v[res.joint] === res.native ? v : { ...v, [res.joint]: res.native }))
+  })
+
+  const handleAddBinding = (pin: string, joint: string): void => {
+    const m = metaRef.current.find((j) => j.name === joint)
+    const lim = m ? effectiveLimit(m, overridesRef.current[joint]) : null
+    // Default the joint range to its limits (display units) + servo 0..180.
+    const binding: ServoJointBinding = {
+      pin,
+      joint,
+      servoMin: 0,
+      servoMax: 180,
+      jointMin: m && lim ? Math.round(toDisplay(m.type, lim.lower)) : 0,
+      jointMax: m && lim ? Math.round(toDisplay(m.type, lim.upper)) : 180
+    }
+    const next = [...bindings.filter((b) => b.pin !== pin), binding]
+    setBindings(next)
+    void persist((mm) => {
+      mm.servoJointMap = next
+    })
+  }
+
+  const handleUpdateBinding = (pin: string, patch: Partial<ServoJointBinding>): void => {
+    const next = bindings.map((b) => (b.pin === pin ? { ...b, ...patch } : b))
+    setBindings(next)
+    void persist((mm) => {
+      mm.servoJointMap = next
+    })
+  }
+
+  const handleDeleteBinding = (pin: string): void => {
+    const next = bindings.filter((b) => b.pin !== pin)
+    setBindings(next)
+    void persist((mm) => {
+      mm.servoJointMap = next
+    })
+  }
 
   const handleImportStl = async (): Promise<void> => {
     if (!activeFile || activeFile.source !== 'local' || !activeFile.path) return
@@ -629,6 +713,10 @@ export function RobotView({
           onImportStl={() => void handleImportStl()}
           canImport={!!canImport}
           importing={importing}
+          bindings={bindings}
+          onAddBinding={handleAddBinding}
+          onUpdateBinding={handleUpdateBinding}
+          onDeleteBinding={handleDeleteBinding}
         />
       )}
     </div>

--- a/src/renderer/src/components/instrument-telemetry.ts
+++ b/src/renderer/src/components/instrument-telemetry.ts
@@ -65,6 +65,20 @@ export interface PwmTelemetry {
   duty: number
 }
 /**
+ * A servo position keyed by GPIO PIN (`SNK SERVO <pin> <deg>`), emitted by
+ * `inst.servo_on(pin).angle(...)`. Robot View maps the pin to a URDF joint via
+ * the KRF `servoJointMap` and animates it live — the code-driven-robot pipe
+ * (#313). Pin-keyed (unlike `SNK PWM`'s channel name) so several servos map to
+ * several joints. `angle` is in degrees (0..180).
+ */
+export interface ServoTelemetry {
+  kind: 'servo'
+  /** The GPIO pin the servo signal is on (e.g. `0`, `16`), as a string token. */
+  pin: string
+  /** Commanded servo angle in degrees (0..180). */
+  angle: number
+}
+/**
  * An object-BINDING descriptor from `inst.watch(name=obj)` — the board announces
  * a real Python object it's tracking, classified by duck-typing, so the IDE can
  * offer the right instrument BY TYPE. `objKind` is the object's kind (`pwm`,
@@ -191,6 +205,7 @@ export interface ReadyTelemetry {
 export type Telemetry =
   | ScopeTelemetry
   | PwmTelemetry
+  | ServoTelemetry
   | BindTelemetry
   | MeterTelemetry
   | PlotTelemetry
@@ -260,6 +275,15 @@ export function parseTelemetry(line: string): Telemetry | null {
     const duty = Number(parts[4])
     if (!ch || !Number.isFinite(freq) || !Number.isFinite(duty)) return null
     return { kind: 'pwm', ch, freq, duty }
+  }
+
+  if (kind === 'SERVO') {
+    // SNK SERVO <pin> <deg> — a servo position keyed by GPIO pin (Robot View
+    // maps it to a URDF joint). `inst.servo_on(pin).angle()` emits this.
+    const pin = parts[2]
+    const angle = Number(parts[3])
+    if (!pin || !Number.isFinite(angle)) return null
+    return { kind: 'servo', pin, angle }
   }
 
   if (kind === 'BIND') {

--- a/src/renderer/src/components/robot-pose.ts
+++ b/src/renderer/src/components/robot-pose.ts
@@ -37,6 +37,9 @@ export interface RobotLike {
   joints: Record<string, JointLike>
 }
 
+import type { ServoJointBinding } from '../../../shared/robot'
+import { servoToJoint } from '../../../shared/krf'
+
 /** A continuous (limitless) joint gets a ±180° slider range so it's usable. */
 export const CONTINUOUS_RANGE = Math.PI
 
@@ -111,6 +114,33 @@ export function extractJoints(robot: RobotLike): JointMeta[] {
 /** A mimic joint's native value from its master's native value. */
 export function mimicValue(meta: JointMeta, masterNative: number): number {
   return (meta.multiplier ?? 1) * masterNative + (meta.offset ?? 0)
+}
+
+/** Normalise a pin token for comparison: drop a `GP`/`gp` prefix + whitespace,
+ *  so `GP16`, `gp16` and `16` all match. */
+export function normPin(pin: string): string {
+  return String(pin).trim().replace(/^gp/i, '')
+}
+
+/**
+ * Resolve a servo telemetry reading (pin + angle in degrees) to a NATIVE joint
+ * value via the matching KRF binding (calibration + inversion in `servoToJoint`)
+ * and the joint's type. Returns null when no binding or joint matches — the
+ * live code-driven-robot pipe (#313).
+ */
+export function servoToJointNative(
+  bindings: ServoJointBinding[],
+  meta: JointMeta[],
+  pin: string,
+  servoAngle: number
+): { joint: string; native: number } | null {
+  const p = normPin(pin)
+  const b = bindings.find((x) => normPin(x.pin) === p)
+  if (!b) return null
+  const m = meta.find((j) => j.name === b.joint)
+  if (!m) return null
+  // servoToJoint returns the joint value in the binding's units (deg / mm).
+  return { joint: b.joint, native: toNative(m.type, servoToJoint(b, servoAngle)) }
 }
 
 /**

--- a/test/instrumentTelemetry.test.ts
+++ b/test/instrumentTelemetry.test.ts
@@ -66,6 +66,16 @@ describe('instrument-telemetry parseTelemetry — SCOPE', () => {
     expect(parseTelemetry('SNK PWM pwm x 0.5')).toBeNull() // non-numeric freq
   })
 
+  it('parses a pin-keyed SERVO position (#313)', () => {
+    expect(parseTelemetry('SNK SERVO 0 90')).toEqual({ kind: 'servo', pin: '0', angle: 90 })
+    expect(parseTelemetry('SNK SERVO 16 135')).toEqual({ kind: 'servo', pin: '16', angle: 135 })
+  })
+
+  it('rejects a malformed SERVO line', () => {
+    expect(parseTelemetry('SNK SERVO 0')).toBeNull() // missing angle
+    expect(parseTelemetry('SNK SERVO 0 x')).toBeNull() // non-numeric angle
+  })
+
   it('parses a BIND object descriptor (inst.watch)', () => {
     expect(parseTelemetry('SNK BIND pwm pwm')).toEqual({ kind: 'bind', name: 'pwm', objKind: 'pwm' })
     expect(parseTelemetry('SNK BIND pot adc')).toEqual({ kind: 'bind', name: 'pot', objKind: 'adc' })

--- a/test/robotPose.test.ts
+++ b/test/robotPose.test.ts
@@ -7,9 +7,13 @@ import {
   clamp,
   mimicValue,
   effectiveLimit,
+  normPin,
+  servoToJointNative,
   CONTINUOUS_RANGE,
+  type JointMeta,
   type RobotLike
 } from '../src/renderer/src/components/robot-pose'
+import type { ServoJointBinding } from '../src/shared/robot'
 
 describe('robot-pose unit conversions (#312)', () => {
   it('converts revolute rad ↔ deg and prismatic m ↔ mm', () => {
@@ -105,5 +109,40 @@ describe('mimicValue + effectiveLimit (#312)', () => {
     const j = { name: 'j', type: 'prismatic' as const, lower: 0, upper: 0, isMimic: false }
     const lim = effectiveLimit(j)
     expect(lim.upper).toBeGreaterThan(lim.lower)
+  })
+})
+
+describe('servoToJointNative — the code-driven pipe (#313)', () => {
+  const meta: JointMeta[] = [
+    { name: 'shoulder', type: 'revolute', lower: -Math.PI / 2, upper: Math.PI / 2, isMimic: false }
+  ]
+  it('normalises pin tokens (GP16 == 16)', () => {
+    expect(normPin('GP16')).toBe('16')
+    expect(normPin('gp0')).toBe('0')
+    expect(normPin(' 5 ')).toBe('5')
+  })
+  it('maps a servo angle onto the joint in native radians', () => {
+    const bindings: ServoJointBinding[] = [
+      { pin: 'GP16', joint: 'shoulder', servoMin: 0, servoMax: 180, jointMin: -90, jointMax: 90 }
+    ]
+    // servo 0 → joint -90° → -PI/2 rad ; via pin "16" (telemetry emits bare pin)
+    expect(servoToJointNative(bindings, meta, '16', 0)?.native).toBeCloseTo(-Math.PI / 2)
+    // servo 90 → joint 0° ; servo 180 → 90° → +PI/2
+    expect(servoToJointNative(bindings, meta, '16', 90)?.native).toBeCloseTo(0)
+    expect(servoToJointNative(bindings, meta, '16', 180)?.native).toBeCloseTo(Math.PI / 2)
+  })
+  it('honours inversion', () => {
+    const bindings: ServoJointBinding[] = [
+      { pin: '16', joint: 'shoulder', servoMin: 0, servoMax: 180, jointMin: -90, jointMax: 90, invert: true }
+    ]
+    // inverted: servo 0 → joint +90° → +PI/2
+    expect(servoToJointNative(bindings, meta, '16', 0)?.native).toBeCloseTo(Math.PI / 2)
+  })
+  it('returns null for an unbound pin or missing joint', () => {
+    const bindings: ServoJointBinding[] = [
+      { pin: '16', joint: 'shoulder', jointMin: -90, jointMax: 90 }
+    ]
+    expect(servoToJointNative(bindings, meta, '99', 90)).toBeNull()
+    expect(servoToJointNative([{ pin: '16', joint: 'ghost', jointMin: 0, jointMax: 1 }], meta, '16', 90)).toBeNull()
   })
 })


### PR DESCRIPTION
Epic #309 **Phase 3 — the keystone.** Because Snakie is *both* the editor and the board simulator, a running program's servo writes animate the 3-D robot — **headless**, no board required. `servo.angle()` in user code moves the mapped URDF joint live. Closes #313.

## The pipe
- **Python** — `Servo` now remembers its pin and emits pin-keyed `SNK SERVO <pin> <deg>` on `angle()`; a new `inst.servo_on(pin)` factory gives one servo per joint. Pure `print` (no `machine`), so it runs in the WASM simulator. On a real board it also drives `PWM(Pin(pin))`.
- **Telemetry** — parse `SNK SERVO <pin> <deg>` → `{kind:'servo', pin, angle}`.
- **RobotView** — `useTelemetryStream` → `servoToJointNative(servoJointMap, meta, pin, angle)` → `setJointValue` in real time. Bindings load from `robot.yml` (for the docked mini viewer too, so it animates on Run).
- **Mapping UI** — a **Servos** panel: add/edit/delete a pin↔joint binding with servo/joint range **calibration** + **invert**, persisted to `robot.yml`'s `servoJointMap`.
- **Example** — `examples/servo-arm/` (open `arm.urdf`, Run `sweep.py`).

Also **fixes** the pose/servo panel colours: it used an undefined `--panel` token (dark-on-dark in the light skin) and now uses the theme surface tokens (parchment ⇄ charcoal), matching the file panel and legible in both skins.

## Acceptance — verified in-app (Playwright)
- ✅ Bindings load from `robot.yml` into the Servos panel (GP0→shoulder, GP1→elbow).
- ✅ Driving servos moves the mapped joints: `SNK SERVO 0 180` → shoulder **+90°**, `SNK SERVO 1 0` → elbow **−90°**, `SNK SERVO 0 90` → **0°** (calibration correct; inversion covered by unit tests).
- ✅ Adding a binding persists to `robot.yml`; reloads on open.
- ✅ No board required — the whole path runs on the simulator's telemetry.

Gate: typecheck + lint clean, **1440 vitest + 165 Python** tests, build ✅. Docs: `docs/krf.md` gains a servo-mapping section.

Part of epic #309. Remaining: #314 (motion timeline), #315 (URDF builder), #310 remainder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
