### PR TITLE
fix: Files panel won't reopen after a workspace switch (toggle desync)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   timeline follow.
 
 ### Fixed
+- **Files panel now always reopens from the toolbar button / activity icon.** A
+  workspace switch (or the Robot pop-out) could leave the panel visually
+  collapsed while the store thought it was open, so the next toggle click called
+  collapse() and it stayed shut. The toggle now reads the panel's actual state
+  and the switch syncs both ways, so it's self-healing.
 - **Robot pose/servo panel is now legible in the light skin.** The panel used an
   undefined colour token, so it rendered dark-on-dark in the parchment theme; it
   now uses the theme surface tokens (parchment ⇄ charcoal) like the file panel.

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -289,16 +289,22 @@ export function AppShell(): JSX.Element {
   }
 
   // Collapse/expand a panel; the Panel's own onCollapse/onExpand callbacks sync
-  // the store flag, so this stays the single imperative entry point.
-  const toggle = useCallback(
-    (ref: React.RefObject<ImperativePanelHandle>, collapsed: boolean): void => {
-      const panel = ref.current
-      if (!panel) return
-      if (collapsed) panel.expand()
-      else panel.collapse()
-    },
-    []
-  )
+  // the store flag, so this stays the single imperative entry point. Read the
+  // ACTUAL panel state (not the store flag), so a transient desync — e.g. after
+  // a workspace switch or a drag-collapse — can never leave the toggle stuck
+  // calling collapse() on an already-collapsed panel (the "won't reopen" bug).
+  const toggle = useCallback((ref: React.RefObject<ImperativePanelHandle>): void => {
+    const panel = ref.current
+    if (!panel) return
+    if (panel.isCollapsed()) panel.expand()
+    else panel.collapse()
+  }, [])
+
+  // Ensure a panel is open (no-op when already expanded).
+  const openPanel = useCallback((ref: React.RefObject<ImperativePanelHandle>): void => {
+    const panel = ref.current
+    if (panel && panel.isCollapsed()) panel.expand()
+  }, [])
 
   // Apply the active workspace's geometry whenever it changes (switch / reset).
   // setLayout drives the sizes; the explicit collapse() calls are belt-and-braces
@@ -319,9 +325,18 @@ export function AppShell(): JSX.Element {
           : [ws.horizontal[0], ws.horizontal[1] + ws.horizontal[2], ws.horizontal[3]]
       )
       vGroupRef.current?.setLayout([...ws.vertical])
-      if (ws.filesCollapsed) filesRef.current?.collapse()
-      if (ws.shellCollapsed) shellRef.current?.collapse()
-      if (ws.rightCollapsed) rightRef.current?.collapse()
+      // Sync each collapsible panel BOTH ways to the target workspace, so the RRP
+      // panel state can't drift from the store flag (which would strand the
+      // toggle button / activity icon on the next click).
+      const sync = (ref: React.RefObject<ImperativePanelHandle>, collapsed: boolean): void => {
+        const panel = ref.current
+        if (!panel) return
+        if (collapsed) panel.collapse()
+        else panel.expand()
+      }
+      sync(filesRef, ws.filesCollapsed)
+      sync(shellRef, ws.shellCollapsed)
+      sync(rightRef, ws.rightCollapsed)
     })
     return () => cancelAnimationFrame(raf)
     // eslint-disable-next-line react-hooks/exhaustive-deps -- applyNonce IS the signal
@@ -920,11 +935,11 @@ export function AppShell(): JSX.Element {
       </div>
       <Toolbar
         filesCollapsed={filesCollapsed}
-        onToggleFiles={() => toggle(filesRef, filesCollapsed)}
+        onToggleFiles={() => toggle(filesRef)}
         shellCollapsed={shellCollapsed}
-        onToggleShell={() => toggle(shellRef, shellCollapsed)}
+        onToggleShell={() => toggle(shellRef)}
         rightCollapsed={rightCollapsed}
-        onToggleRight={() => toggle(rightRef, rightCollapsed)}
+        onToggleRight={() => toggle(rightRef)}
         onOpenBoard={toggleBoard}
         onToggleInstruments={toggleInstruments}
         instrumentsVisible={instrumentsVisible}
@@ -939,13 +954,13 @@ export function AppShell(): JSX.Element {
             // Clicking the already-active view toggles the left panel collapse
             // (issue #86): collapse it when open, re-expand it when collapsed.
             if (view === activityView) {
-              toggle(filesRef, filesCollapsed)
+              toggle(filesRef)
               return
             }
             // Switching to a different view selects it and reveals the sidebar
             // if it was collapsed.
             setActivityView(view)
-            if (filesCollapsed) toggle(filesRef, true)
+            openPanel(filesRef)
           }}
         />
         {/* Sizes are recorded into the ACTIVE workspace via onLayout and applied


### PR DESCRIPTION
Fixes a reported bug: **in Code mode the left (Files) panel wouldn't reopen** via the toolbar toggle button or the Files activity icon.

## Cause
A workspace switch (e.g. Robot → Code, or the Robot **pop-out**) could leave the react-resizable-panels files panel visually collapsed while the layout store still read `filesCollapsed: false`. Both the toolbar button and the activity-icon handler branched on that **stale store flag**, so a click ran `collapse()` on an already-collapsed panel — and it could never be reopened.

## Fix
- `toggle()` now reads the panel's **actual** state (`ImperativePanelHandle.isCollapsed()`) rather than the store flag, so it always does the right thing — self-healing even if a desync slips through.
- New `openPanel()` (expand-only) for the "switch activity view → reveal the sidebar" path.
- The workspace-apply effect now **syncs each collapsible panel both ways** (expand the open ones, collapse the closed ones), so the RRP state can't drift from the store flag in the first place.

## Verified (in-app, Playwright)
- `Code → Robot → Code` and `Robot → ⤢ pop-out → Code` both leave Files **open**.
- Collapsing then clicking the toolbar button **or** the Files activity icon reopens it every time.

Gate: typecheck + lint clean, 1440 tests, build ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
