### PR TITLE
feat: create a new blank robot (.urdf) from Robot mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **New blank robot (.urdf) from Robot mode.** The docked mini-viewer gains a
+  **＋ New robot** button (highlighted when there's no robot yet) that creates a
+  minimal starter `.urdf` (one `base_link`) and opens it in the pose tool — a
+  real file in the project folder (so STL import + persistence work immediately),
+  or an untitled buffer when no folder is open. Import meshes from the Assembly
+  panel to build it up.
 - **Robot View — servo↔joint binding & code-driven simulation (#313, epic #309
   Phase 3).** The keystone: a running MicroPython program's servo writes now
   animate the 3-D robot, **headless** (no board — it runs in the simulator).

--- a/src/renderer/src/components/RobotDockPanel.tsx
+++ b/src/renderer/src/components/RobotDockPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { RobotView } from './RobotView'
 import { dirname } from './robot-mesh'
+import { blankUrdf } from './robot-assembly'
 import { useWorkspace } from '../store/workspace'
 import { useWorkspaceLayout } from '../store/layout'
 import { readRobotModel } from '../../../shared/krf'
@@ -63,17 +64,60 @@ export function RobotDockPanel(): JSX.Element {
     switchWorkspace('code')
   }
 
+  // Create a new blank robot (.urdf) and open it full-screen in the pose tool.
+  // With a project folder we write a real file (so STL import + persistence work
+  // straight away, next-numbered if `robot.urdf` exists); otherwise an untitled
+  // buffer the user can Save.
+  const newRobot = async (): Promise<void> => {
+    const content = blankUrdf('my_robot')
+    if (currentFolder) {
+      const folder = currentFolder.replace(/[/\\]$/, '')
+      let name = 'robot.urdf'
+      for (let n = 2; n < 1000; n++) {
+        try {
+          await window.api.fs.readFile(`${folder}/${name}`)
+          name = `robot-${n}.urdf` // taken → try the next
+        } catch {
+          break // free
+        }
+      }
+      const path = `${folder}/${name}`
+      try {
+        await window.api.fs.writeFile(path, content)
+        await openFile('local', path)
+      } catch {
+        openBuffer('robot.urdf', content) // write failed → fall back to a buffer
+      }
+    } else {
+      openBuffer('robot.urdf', content)
+    }
+    switchWorkspace('code')
+  }
+
+  // No project robot yet (the demo arm is a stand-in) → nudge toward "New robot".
+  const hasProjectRobot = urdfPath !== null
+
   return (
     <div className="robotdock">
       <RobotView urdfContent={urdf} basePath={base} compact />
-      <button
-        type="button"
-        className="robotdock__expand"
-        title="Pop out full-screen (Pose tool + assembly)"
-        onClick={popOut}
-      >
-        ⤢ Pop out
-      </button>
+      <div className="robotdock__actions">
+        <button
+          type="button"
+          className={`robotdock__btn${hasProjectRobot ? '' : ' robotdock__btn--cta'}`}
+          title="Create a new blank robot (.urdf) and open it in the pose tool"
+          onClick={() => void newRobot()}
+        >
+          ＋ New robot
+        </button>
+        <button
+          type="button"
+          className="robotdock__btn"
+          title="Pop out full-screen (pose tool + assembly)"
+          onClick={popOut}
+        >
+          ⤢ Pop out
+        </button>
+      </div>
     </div>
   )
 }

--- a/src/renderer/src/components/robot-assembly.ts
+++ b/src/renderer/src/components/robot-assembly.ts
@@ -5,6 +5,28 @@
  * they're cheap to unit-test in a node env.
  */
 
+/**
+ * A minimal, VALID starter URDF: one `base_link` with a small box so the pose
+ * tool renders something and an imported STL (via `addMeshLink`) has a root to
+ * attach to. `name` is sanitised to a URDF-safe robot name.
+ */
+export function blankUrdf(name = 'my_robot'): string {
+  const safe = name.replace(/[^A-Za-z0-9_]+/g, '_').replace(/^_+|_+$/g, '') || 'my_robot'
+  return (
+    `<?xml version="1.0"?>\n` +
+    `<!-- New robot — add links/joints, or import meshes from the Assembly panel. -->\n` +
+    `<robot name="${safe}">\n` +
+    `  <material name="steel"><color rgba="0.62 0.65 0.69 1"/></material>\n` +
+    `  <link name="base_link">\n` +
+    `    <visual>\n` +
+    `      <geometry><box size="0.08 0.08 0.02"/></geometry>\n` +
+    `      <material name="steel"/>\n` +
+    `    </visual>\n` +
+    `  </link>\n` +
+    `</robot>\n`
+  )
+}
+
 /** One link of the model + the visual geometry it uses. */
 export interface AssemblyItem {
   link: string

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -2142,16 +2142,21 @@ body {
 .shell__dock--robot .instr-dock {
   min-height: 0;
 }
-/* The docked mini-viewer fills its slot; an expand button opens it full-screen. */
+/* The docked mini-viewer fills its slot; a top action row creates a new robot
+   or pops the viewer out full-screen (#320 / new-URDF). */
 .robotdock {
   position: absolute;
   inset: 0;
 }
-.robotdock__expand {
+.robotdock__actions {
   position: absolute;
   top: 0.35rem;
   left: 0.35rem;
   z-index: 2;
+  display: flex;
+  gap: 0.3rem;
+}
+.robotdock__btn {
   font-family: var(--font-mono);
   font-size: 0.6rem;
   color: var(--text, #cdd2d9);
@@ -2161,9 +2166,20 @@ body {
   padding: 0.15rem 0.4rem;
   cursor: pointer;
 }
-.robotdock__expand:hover {
+.robotdock__btn:hover {
   border-color: #c8a24a;
   color: #c8a24a;
+}
+/* Highlight "New robot" when there's no project robot yet (the demo is a stand-in). */
+.robotdock__btn--cta {
+  color: #191a1d;
+  background: #c8a24a;
+  border-color: #c8a24a;
+  font-weight: 700;
+}
+.robotdock__btn--cta:hover {
+  color: #191a1d;
+  background: #d8b45c;
 }
 
 .activitybar {

--- a/test/robotAssembly.test.ts
+++ b/test/robotAssembly.test.ts
@@ -4,7 +4,8 @@ import {
   meshFiles,
   rootLink,
   uniqueLinkName,
-  addMeshLink
+  addMeshLink,
+  blankUrdf
 } from '../src/renderer/src/components/robot-assembly'
 
 const URDF = `<?xml version="1.0"?>
@@ -72,5 +73,20 @@ describe('addMeshLink (#309)', () => {
     expect(link).toBe('x')
     expect(urdf).toContain('<link name="x">')
     expect(urdf).not.toContain('<joint')
+  })
+})
+
+describe('blankUrdf — new robot starter', () => {
+  it('is a valid single-link URDF the parser accepts', () => {
+    const u = blankUrdf('My Robot!')
+    expect(u).toContain('<robot name="My_Robot">') // sanitised name
+    const a = parseAssembly(u)
+    expect(a).toEqual([{ link: 'base_link', kind: 'box' }])
+    expect(rootLink(u)).toBe('base_link')
+  })
+  it('an imported mesh attaches to its base_link', () => {
+    const { urdf, link } = addMeshLink(blankUrdf(), { meshRel: 'meshes/w.stl', linkBase: 'w' })
+    expect(link).toBe('w')
+    expect(urdf).toContain('<parent link="base_link"/>')
   })
 })


### PR DESCRIPTION
Adds an obvious way to **start a new robot** — a beginner had no entry point to create a URDF.

## What + where
- The docked mini 3-D viewer (Robot mode) gains a **＋ New robot** button, next to **⤢ Pop out**. It's **highlighted** (amber CTA) when there's no project robot yet (the demo arm is a stand-in), and normal once you have one.
- Clicking it creates a minimal valid starter `.urdf` (one `base_link`) and opens it full-screen in the pose tool. With a project folder open it writes a real `robot.urdf` (next-numbered if one exists), so STL import + `robot.yml` persistence work straight away; with no folder it's an untitled buffer you can Save.
- Placed in **Robot mode** (per the request) so it's discoverable exactly where you're looking at the robot, without adding confusion to the main toolbar.

New pure helper `blankUrdf(name)` (sanitised single-link URDF the parser accepts + an imported STL attaches to) with unit tests.

## Verified (in-app, Playwright)
- The button appears in Robot mode (CTA-highlighted with no robot).
- Clicking it creates `robot.urdf` in the project folder and opens the pose tool with `base_link` in the Assembly panel (screenshot).

Gate: typecheck + lint clean, **1442 tests** (+2), build ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
