### PR TITLE
feat: Robot pop-out stays in Robot mode (transient editor focus)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Built on the KRF format (#310); the pose tool, servo↔joint binding and motion
   timeline follow.
 
+### Changed
+- **Robot pop-out now keeps you in Robot mode.** Instead of switching to Code
+  mode, popping the robot out (or creating a new one) enters a transient *focus*:
+  it hides the board, instruments and console so the URDF fills the editor, and
+  restores your Robot layout the moment you switch modes, re-click the Robot tab,
+  or reopen any panel. Nothing about Robot mode is permanently changed.
+
 ### Fixed
 - **Files panel now always reopens from the toolbar button / activity icon.** A
   workspace switch (or the Robot pop-out) could leave the panel visually

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -274,6 +274,10 @@ export function AppShell(): JSX.Element {
   const { filesCollapsed, shellCollapsed, rightCollapsed, activityView, boardPaneOpen } =
     layout.workspace
   const dockOpen = layout.workspace.dockOpen
+  // Transient editor focus (Robot pop-out): hide the board, instruments + console
+  // around the URDF without touching the workspace (#320 follow-up).
+  const focus = layout.focus
+  const boardPaneVisible = boardPaneOpen && !focus
 
   const filesRef = useRef<ImperativePanelHandle>(null)
   const shellRef = useRef<ImperativePanelHandle>(null)
@@ -306,6 +310,16 @@ export function AppShell(): JSX.Element {
     if (panel && panel.isCollapsed()) panel.expand()
   }, [])
 
+  // A panel toggle (or activity click) while in focus mode simply LEAVES focus,
+  // restoring the full Robot layout, rather than fighting the focus overrides.
+  const exitFocus = useCallback((): boolean => {
+    if (layout.focus) {
+      layout.setFocus(false)
+      return true
+    }
+    return false
+  }, [layout])
+
   // Apply the active workspace's geometry whenever it changes (switch / reset).
   // setLayout drives the sizes; the explicit collapse() calls are belt-and-braces
   // so a collapsible panel lands collapsed even if the group clamps a 0 size.
@@ -319,15 +333,18 @@ export function AppShell(): JSX.Element {
     const raf = requestAnimationFrame(() => {
       // The horizontal group's setLayout array must match the RENDERED panels:
       // 4 with the board pane open, 3 (board slot elided) when it's closed.
+      // In focus mode the board pane elides, so the editor takes its share.
+      const boardOn = ws.boardPaneOpen && !focus
       hGroupRef.current?.setLayout(
-        ws.boardPaneOpen
+        boardOn
           ? [...ws.horizontal]
           : [ws.horizontal[0], ws.horizontal[1] + ws.horizontal[2], ws.horizontal[3]]
       )
       vGroupRef.current?.setLayout([...ws.vertical])
       // Sync each collapsible panel BOTH ways to the target workspace, so the RRP
       // panel state can't drift from the store flag (which would strand the
-      // toggle button / activity icon on the next click).
+      // toggle button / activity icon on the next click). Focus also collapses
+      // the console so only the URDF shows.
       const sync = (ref: React.RefObject<ImperativePanelHandle>, collapsed: boolean): void => {
         const panel = ref.current
         if (!panel) return
@@ -335,7 +352,7 @@ export function AppShell(): JSX.Element {
         else panel.expand()
       }
       sync(filesRef, ws.filesCollapsed)
-      sync(shellRef, ws.shellCollapsed)
+      sync(shellRef, focus || ws.shellCollapsed)
       sync(rightRef, ws.rightCollapsed)
     })
     return () => cancelAnimationFrame(raf)
@@ -476,7 +493,7 @@ export function AppShell(): JSX.Element {
   // other's freed space, which made toggling one reveal the other). Its flag is
   // part of the workspace layout (the Board/Data Lab workspaces open it).
   const setDockOpen = layout.setDockOpen
-  const instrumentsVisible = dockOpen
+  const instrumentsVisible = dockOpen && !focus
   const toggleInstruments = useCallback((): void => {
     setDockOpen(!dockOpen)
   }, [dockOpen, setDockOpen])
@@ -935,13 +952,23 @@ export function AppShell(): JSX.Element {
       </div>
       <Toolbar
         filesCollapsed={filesCollapsed}
-        onToggleFiles={() => toggle(filesRef)}
+        onToggleFiles={() => {
+          if (!exitFocus()) toggle(filesRef)
+        }}
         shellCollapsed={shellCollapsed}
-        onToggleShell={() => toggle(shellRef)}
+        onToggleShell={() => {
+          if (!exitFocus()) toggle(shellRef)
+        }}
         rightCollapsed={rightCollapsed}
-        onToggleRight={() => toggle(rightRef)}
-        onOpenBoard={toggleBoard}
-        onToggleInstruments={toggleInstruments}
+        onToggleRight={() => {
+          if (!exitFocus()) toggle(rightRef)
+        }}
+        onOpenBoard={() => {
+          if (!exitFocus()) toggleBoard()
+        }}
+        onToggleInstruments={() => {
+          if (!exitFocus()) toggleInstruments()
+        }}
         instrumentsVisible={instrumentsVisible}
         instrumentCount={openInstruments.length}
       />
@@ -951,6 +978,11 @@ export function AppShell(): JSX.Element {
           active={activityView}
           onOpenSettings={() => openSettings('appearance')}
           onSelect={(view) => {
+            // In focus mode, any activity click just restores the Robot layout.
+            if (exitFocus()) {
+              setActivityView(view)
+              return
+            }
             // Clicking the already-active view toggles the left panel collapse
             // (issue #86): collapse it when open, re-expand it when collapsed.
             if (view === activityView) {
@@ -1019,7 +1051,7 @@ export function AppShell(): JSX.Element {
           {/* The embedded Board View (the Board workspace's tri-split, #259):
               code on the left, the board here, the instrument dock at the far
               right — code, wiring and instruments visible together. */}
-          {boardPaneOpen && (
+          {boardPaneVisible && (
             <>
               <PanelResizeHandle className="resize-handle resize-handle--vertical" />
               {/* defaultSize = the ACTIVE workspace's board share (not the mount-time

--- a/src/renderer/src/components/RobotDockPanel.tsx
+++ b/src/renderer/src/components/RobotDockPanel.tsx
@@ -17,7 +17,7 @@ import demoArm from '../assets/demo-arm.urdf?raw'
  */
 export function RobotDockPanel(): JSX.Element {
   const { currentFolder, openFile, openBuffer } = useWorkspace()
-  const { switchWorkspace } = useWorkspaceLayout()
+  const { setFocus } = useWorkspaceLayout()
   const [urdf, setUrdf] = useState<string>(demoArm)
   // The URDF's folder, so RobotView resolves the robot's meshes (#319). Empty
   // for the bundled demo arm (all primitives — no meshes to resolve).
@@ -56,12 +56,13 @@ export function RobotDockPanel(): JSX.Element {
   }, [currentFolder])
 
   // Pop the robot out full-screen (the Pose tool + assembly): a saved project
-  // URDF opens as its file; the bundled demo arm opens as a buffer. Switch to
-  // Code mode so the routed viewer fills the editor pane.
+  // URDF opens as its file; the bundled demo arm opens as a buffer. Stay in Robot
+  // mode and enter transient FOCUS — hides the board, instruments + console so
+  // the URDF fills the editor, restored when you switch modes or reopen a panel.
   const popOut = (): void => {
     if (urdfPath) void openFile('local', urdfPath)
     else openBuffer('demo-arm.urdf', urdf)
-    switchWorkspace('code')
+    setFocus(true)
   }
 
   // Create a new blank robot (.urdf) and open it full-screen in the pose tool.
@@ -91,7 +92,7 @@ export function RobotDockPanel(): JSX.Element {
     } else {
       openBuffer('robot.urdf', content)
     }
-    switchWorkspace('code')
+    setFocus(true) // show the new robot full-screen (stay in Robot mode)
   }
 
   // No project robot yet (the demo arm is a stand-in) → nudge toward "New robot".

--- a/src/renderer/src/store/layout.ts
+++ b/src/renderer/src/store/layout.ts
@@ -305,6 +305,9 @@ export interface LayoutStore {
   workspace: WorkspaceLayout
   /** Bumps when geometry must be re-applied to the panel groups (switch/reset). */
   applyNonce: number
+  /** Transient editor focus (Robot pop-out): hide board/instruments/console so the
+   *  URDF fills the editor. NOT persisted; cleared on workspace switch. */
+  focus: boolean
   /** Latest sizes for a group (live ref-backed; safe to call every render). */
   getSizes: (group: 'horizontal' | 'vertical') => number[]
   switchWorkspace: (id: WorkspaceId) => void
@@ -313,6 +316,8 @@ export interface LayoutStore {
   setActivityView: (view: ActivityView) => void
   setCollapsed: (panel: 'files' | 'shell' | 'right', collapsed: boolean) => void
   setDockOpen: (open: boolean) => void
+  /** Enter/leave transient editor-focus mode. */
+  setFocus: (focus: boolean) => void
   /** Record a live panel-group layout (called from onLayout every drag frame). */
   recordSizes: (group: 'horizontal' | 'vertical', sizes: number[]) => void
 }
@@ -333,6 +338,8 @@ export function LayoutProvider({ children }: { children: ReactNode }): JSX.Eleme
     stateRef.current.workspaces[stateRef.current.active]
   )
   const [applyNonce, setApplyNonce] = useState(0)
+  // Transient editor-focus (Robot pop-out) — never persisted.
+  const [focus, setFocusState] = useState(false)
 
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const persist = useCallback((): void => {
@@ -387,10 +394,19 @@ export function LayoutProvider({ children }: { children: ReactNode }): JSX.Eleme
   const switchWorkspace = useCallback(
     (id: WorkspaceId): void => {
       const s = stateRef.current as LayoutState
-      if (s.active === id) return
+      if (s.active === id) {
+        // Re-clicking the active workspace tab exits focus mode (a way back to
+        // the normal layout without switching away).
+        setFocusState((f) => {
+          if (f) setApplyNonce((n) => n + 1)
+          return false
+        })
+        return
+      }
       s.active = id
       setActive(id)
       setWorkspace(s.workspaces[id])
+      setFocusState(false) // leaving focus mode when the workspace changes
       setApplyNonce((n) => n + 1)
       persist()
     },
@@ -430,29 +446,45 @@ export function LayoutProvider({ children }: { children: ReactNode }): JSX.Eleme
     [patchActive]
   )
 
+  // TRANSIENT focus mode (not persisted): the Robot pop-out hides the board,
+  // instruments + console so the URDF fills the editor, without changing the
+  // workspace. Bumps applyNonce so the shell re-collapses/expands + the board
+  // pane elides; switching workspace clears it (below).
+  const setFocus = useCallback((next: boolean): void => {
+    setFocusState((cur) => {
+      if (cur === next) return cur
+      setApplyNonce((n) => n + 1)
+      return next
+    })
+  }, [])
+
   const store = useMemo<LayoutStore>(
     () => ({
       active,
       workspace,
       applyNonce,
+      focus,
       getSizes,
       switchWorkspace,
       resetActive,
       setActivityView,
       setCollapsed,
       setDockOpen,
+      setFocus,
       recordSizes
     }),
     [
       active,
       workspace,
       applyNonce,
+      focus,
       getSizes,
       switchWorkspace,
       resetActive,
       setActivityView,
       setCollapsed,
       setDockOpen,
+      setFocus,
       recordSizes
     ]
   )


### PR DESCRIPTION
Reworks the Robot **pop-out** per your request: instead of switching to Code mode, it now **stays in Robot mode** and enters a transient *focus* — hiding the board, instruments and console so the URDF fills the editor — with your Robot layout restored intact the moment you leave.

## What
- **Transient focus** (`layout.focus`, not persisted): the Robot pop-out (and New robot) call `setFocus(true)` instead of `switchWorkspace('code')`. In focus the **board pane elides**, the **instruments dock hides**, and the **console collapses**, so only the URDF (pose tool) shows — full editor width + height.
- **Nothing is permanently changed.** Focus is cleared — and the full Robot layout restored — when you **switch modes**, **re-click the Robot tab**, or **reopen any panel** (a panel toggle / activity click while focused simply leaves focus rather than fighting it).

## Verified (in-app, Playwright)
- Pop-out keeps the **Robot** tab active; board + dock + console hidden; the URDF fills the editor (**1442×789** of a 1500px window) — screenshot.
- Re-clicking Robot, switching to another mode, and toggling a panel each restore board + dock + console intact.

Gate: typecheck + lint clean, **1442 tests**, build ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
