### PR TITLE
Robot View: kid-friendly URDF block builder — primitives + push/pull + floating panel (#315a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Robot View — kid-friendly block builder (#315a, epic #309 Phase 5).** Build a
+  robot from blocks: a floating, transparent, pinnable **Build** panel on the left
+  (like the breadboard's library dock) lists your components with a per-item edit
+  pencil (view by default). **＋ Box / Tube / Ball** adds a primitive that sticks
+  to the selected part (a fixed joint — no jargon). Grab a **face and pull** to
+  resize it — Fusion-style, with the **live measurement** shown and the opposite
+  face held put — or type exact mm. Edits save straight into the linked project
+  URDF, and the camera never jumps. (Revolute/prismatic joints + a mimic editor
+  are the follow-up #315b.)
 - **Robot View — motion timeline → MicroPython (#314, epic #309 Phase 4).** A
   keyframe timeline docks under the pose tool: a track per joint, **play / loop /
   scrub** with **linear or ease-in-out** easing, snapshot the pose as a keyframe

--- a/src/renderer/src/components/RobotBuildPanel.css
+++ b/src/renderer/src/components/RobotBuildPanel.css
@@ -1,0 +1,288 @@
+/* Build dock (#315a) — a floating, transparent, pinnable LEFT panel over the 3-D
+   stage (mirrors the breadboard library dock). Prefix robotbuild__. */
+
+/* Closed: a slim vertical edge tab on the left. */
+.robotbuild__tab {
+  position: absolute;
+  top: 0.6rem;
+  left: 0;
+  z-index: 4;
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  font-size: 0.62rem;
+  letter-spacing: 0.06em;
+  color: var(--text, #cdd2d9);
+  background: rgba(20, 21, 24, 0.72);
+  border: 1px solid var(--border, #3a3d44);
+  border-left: none;
+  border-radius: 0 6px 6px 0;
+  padding: 0.5rem 0.2rem;
+  cursor: pointer;
+}
+.robotbuild__tab:hover {
+  color: #c8a24a;
+  border-color: #c8a24a;
+}
+
+/* Open: the glass dock, anchored left. */
+.robotbuild__dock {
+  position: absolute;
+  top: 0.5rem;
+  left: 0.5rem;
+  bottom: 0.5rem;
+  z-index: 4;
+  width: 12.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.4rem 0.45rem;
+  box-sizing: border-box;
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 8px;
+  /* Transparent glassy fill (the "floating browser" look). */
+  background: rgba(20, 21, 24, 0.55);
+  backdrop-filter: blur(8px);
+  color: var(--text, #cdd2d9);
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  font-size: 0.66rem;
+  outline: none;
+}
+.robotbuild__dock--overlay {
+  box-shadow: 14px 0 28px -16px rgba(0, 0, 0, 0.55);
+}
+/* Light skin: a warm translucent parchment instead of dark glass. */
+:root[data-theme='skeuomorph'] .robotbuild__dock {
+  background: rgba(231, 226, 211, 0.72);
+}
+:root[data-theme='skeuomorph'] .robotbuild__tab {
+  background: rgba(231, 226, 211, 0.85);
+}
+
+.robotbuild__head {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+.robotbuild__title {
+  flex: 1 1 auto;
+  font-weight: 700;
+  color: #c8a24a;
+  letter-spacing: 0.04em;
+}
+.robotbuild__pin,
+.robotbuild__collapse {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted, #9aa0a6);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  padding: 0.1rem 0.25rem;
+  cursor: pointer;
+}
+.robotbuild__pin.is-pinned {
+  color: #c8a24a;
+}
+.robotbuild__pin:hover,
+.robotbuild__collapse:hover {
+  color: #c8a24a;
+  border-color: var(--border, #3a3d44);
+}
+.robotbuild__collapse {
+  font-size: 0.9rem;
+  line-height: 1;
+}
+
+.robotbuild__add {
+  display: flex;
+  gap: 0.25rem;
+}
+.robotbuild__add button {
+  flex: 1 1 0;
+  font-family: inherit;
+  font-size: 0.62rem;
+  color: var(--text, #cdd2d9);
+  background: var(--bg-sunken, rgba(0, 0, 0, 0.25));
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 5px;
+  padding: 0.25rem 0.1rem;
+  cursor: pointer;
+}
+.robotbuild__add button:hover:not(:disabled) {
+  border-color: #c8a24a;
+  color: #c8a24a;
+}
+.robotbuild__add button:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+.robotbuild__hint {
+  margin: 0;
+  font-size: 0.56rem;
+  color: var(--text-muted, #8b919b);
+}
+
+.robotbuild__parts {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.12rem;
+}
+.robotbuild__part {
+  border-radius: 5px;
+}
+.robotbuild__part.is-sel {
+  background: rgba(200, 162, 74, 0.18);
+  outline: 1px solid rgba(200, 162, 74, 0.5);
+}
+.robotbuild__part-row {
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+}
+.robotbuild__part-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.3rem;
+  font-family: inherit;
+  font-size: 0.64rem;
+  color: var(--text, #cdd2d9);
+  background: transparent;
+  border: none;
+  padding: 0.15rem 0.3rem;
+  cursor: pointer;
+  text-align: left;
+}
+.robotbuild__part-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.robotbuild__part-geo {
+  flex: 0 0 auto;
+  font-size: 0.54rem;
+  color: var(--text-muted, #8b919b);
+}
+.robotbuild__part-geo.is-mesh {
+  color: #c8a24a;
+}
+.robotbuild__edit {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  color: var(--text-muted, #8b919b);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  padding: 0.15rem 0.25rem;
+  cursor: pointer;
+}
+.robotbuild__edit:hover,
+.robotbuild__edit.is-on {
+  color: #c8a24a;
+  border-color: var(--border, #3a3d44);
+}
+.robotbuild__editrow {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.15rem 0.3rem 0.3rem;
+}
+.robotbuild__size {
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+  flex-wrap: wrap;
+}
+.robotbuild__mm {
+  display: flex;
+  align-items: center;
+  gap: 0.12rem;
+  font-size: 0.55rem;
+  color: var(--text-muted, #9aa0a6);
+}
+.robotbuild__mm input {
+  width: 2.6rem;
+  font-family: inherit;
+  font-size: 0.58rem;
+  color: var(--text, #cdd2d9);
+  background: var(--bg-sunken, rgba(0, 0, 0, 0.3));
+  border: 1px solid var(--border, #34373d);
+  border-radius: 4px;
+  padding: 0.08rem 0.15rem;
+  text-align: center;
+}
+.robotbuild__mm-unit {
+  font-size: 0.54rem;
+  color: var(--text-muted, #7d838d);
+}
+.robotbuild__editnote {
+  font-size: 0.56rem;
+  color: var(--text-muted, #8b919b);
+  font-style: italic;
+}
+.robotbuild__del {
+  margin-left: auto;
+  color: var(--text-muted, #9aa0a6);
+  background: transparent;
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 4px;
+  padding: 0 0.35rem;
+  cursor: pointer;
+}
+.robotbuild__del:hover {
+  color: #b4544e;
+  border-color: #b4544e;
+}
+.robotbuild__empty {
+  color: var(--text-muted, #8b919b);
+  font-size: 0.6rem;
+  padding: 0.3rem;
+}
+
+.robotbuild__foot {
+  border-top: 1px solid var(--border, #2c2e33);
+  padding-top: 0.35rem;
+}
+.robotbuild__stl {
+  width: 100%;
+  font-family: inherit;
+  font-size: 0.62rem;
+  color: var(--text, #cdd2d9);
+  background: var(--bg-sunken, rgba(0, 0, 0, 0.25));
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 5px;
+  padding: 0.25rem;
+  cursor: pointer;
+}
+.robotbuild__stl:hover:not(:disabled) {
+  border-color: #c8a24a;
+}
+.robotbuild__stl:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+/* Live push/pull measurement HUD (follows the pointer). */
+.robotbuild__dim {
+  position: absolute;
+  z-index: 5;
+  pointer-events: none;
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  font-size: 0.66rem;
+  color: #191a1d;
+  background: #c8a24a;
+  border-radius: 4px;
+  padding: 0.1rem 0.35rem;
+  white-space: nowrap;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+}

--- a/src/renderer/src/components/RobotBuildPanel.tsx
+++ b/src/renderer/src/components/RobotBuildPanel.tsx
@@ -1,0 +1,268 @@
+import { useEffect, useRef, useState } from 'react'
+import type { AssemblyItem, PrimitiveGeom } from './robot-assembly'
+import type { PrimitiveKind } from './robot-build'
+import { baseName } from './robot-mesh'
+import { shouldAutoHide } from './pin-overlay'
+import './RobotBuildPanel.css'
+
+/**
+ * ROBOT BUILD PANEL (#315a) — a floating, transparent, PINNABLE dock on the LEFT
+ * of the pose tool (mirrors the breadboard's library dock). It holds the model
+ * hierarchy (view-by-default; a pencil per row enters edit), buttons to add
+ * box / cylinder / sphere blocks (each sticks to the selected part), the STL
+ * import, and — while a primitive is being edited — a numeric size form. All the
+ * 3-D interaction (select, push/pull faces) lives in RobotView.
+ */
+const STAR = (
+  <svg viewBox="0 0 16 16" width="12" height="12" aria-hidden="true">
+    <path
+      d="M8 1.6l1.9 3.9 4.3.6-3.1 3 .8 4.3L8 11.9 4.1 13.4l.8-4.3-3.1-3 4.3-.6z"
+      fill="currentColor"
+    />
+  </svg>
+)
+const PENCIL = (
+  <svg viewBox="0 0 16 16" width="12" height="12" aria-hidden="true">
+    <path d="M11.5 1.5l3 3L5 14l-3.5.5L2 11z" fill="none" stroke="currentColor" strokeWidth="1.4" />
+  </svg>
+)
+
+export interface RobotBuildPanelProps {
+  open: boolean
+  pinned: boolean
+  onSetOpen: (open: boolean) => void
+  onSetPinned: (pinned: boolean) => void
+  assembly: AssemblyItem[]
+  selected: string | null
+  onSelect: (link: string | null) => void
+  editLink: string | null
+  onEdit: (link: string | null) => void
+  /** Geometry of the link being edited (for the size form), or null. */
+  editGeom: PrimitiveGeom | null
+  onAdd: (kind: PrimitiveKind) => void
+  onSetSize: (link: string, dims: number[]) => void
+  onDelete: (link: string) => void
+  onImportStl: () => void
+  canImport: boolean
+  importing: boolean
+  /** Editing needs a saved project file — disables add/edit with a hint. */
+  canEdit: boolean
+}
+
+/** metres → integer mm (display) and back. */
+const mm = (m: number): number => Math.round(m * 1000)
+const toM = (millis: number): number => millis / 1000
+
+function SizeForm({
+  geom,
+  onChange
+}: {
+  geom: PrimitiveGeom
+  onChange: (dims: number[]) => void
+}): JSX.Element {
+  // Local mm state so typing doesn't rebuild the scene per keystroke; commit on
+  // blur/Enter, clamped to a 1 mm minimum (a 0/blank field must never write a
+  // degenerate size). Re-seeds when the geometry changes externally (a drag).
+  const seed = geom.dims.map(mm)
+  const [vals, setVals] = useState<number[]>(seed)
+  const key = seed.join(',')
+  useEffect(() => setVals(seed), [key]) // eslint-disable-line react-hooks/exhaustive-deps
+  const commit = (): void => onChange(vals.map((v) => Math.max(0.001, toM(v > 0 ? v : 1))))
+  const field = (label: string, i: number): JSX.Element => (
+    <label className="robotbuild__mm" key={label}>
+      <span>{label}</span>
+      <input
+        type="number"
+        min={1}
+        step={5}
+        value={Number.isFinite(vals[i]) ? vals[i] : ''}
+        onChange={(e) => {
+          const n = [...vals]
+          n[i] = Number(e.target.value)
+          setVals(n)
+        }}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') commit()
+        }}
+      />
+    </label>
+  )
+  return (
+    <div className="robotbuild__size">
+      {geom.kind === 'box' && (
+        <>
+          {field('L', 0)}
+          {field('W', 1)}
+          {field('H', 2)}
+        </>
+      )}
+      {geom.kind === 'cylinder' && (
+        <>
+          {field('⌀r', 0)}
+          {field('len', 1)}
+        </>
+      )}
+      {geom.kind === 'sphere' && field('r', 0)}
+      <span className="robotbuild__mm-unit">mm</span>
+    </div>
+  )
+}
+
+export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
+  const {
+    open,
+    pinned,
+    onSetOpen,
+    onSetPinned,
+    assembly,
+    selected,
+    onSelect,
+    editLink,
+    onEdit,
+    editGeom,
+    onAdd,
+    onSetSize,
+    onDelete,
+    onImportStl,
+    canImport,
+    importing,
+    canEdit
+  } = props
+  const dockRef = useRef<HTMLElement | null>(null)
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        className="robotbuild__tab"
+        title="Build — add + edit blocks"
+        onClick={() => {
+          onSetOpen(true)
+          requestAnimationFrame(() => dockRef.current?.focus())
+        }}
+      >
+        Build
+      </button>
+    )
+  }
+
+  return (
+    <aside
+      className={`robotbuild__dock${pinned ? '' : ' robotbuild__dock--overlay'}`}
+      ref={dockRef}
+      tabIndex={-1}
+      aria-label="Build panel"
+      onBlur={(e) => {
+        if (shouldAutoHide(pinned, dockRef.current, e.relatedTarget)) onSetOpen(false)
+      }}
+    >
+      <div className="robotbuild__head">
+        <button
+          type="button"
+          className={`robotbuild__pin${pinned ? ' is-pinned' : ''}`}
+          onClick={() => onSetPinned(!pinned)}
+          title={pinned ? 'Unpin — hide when it loses focus' : 'Pin the panel open'}
+          aria-label={pinned ? 'Unpin the build panel' : 'Pin the build panel open'}
+        >
+          {STAR}
+        </button>
+        <span className="robotbuild__title">Build</span>
+        <button
+          type="button"
+          className="robotbuild__collapse"
+          onClick={() => onSetOpen(false)}
+          title="Hide"
+          aria-label="Hide the build panel"
+        >
+          ‹
+        </button>
+      </div>
+
+      <div className="robotbuild__add" role="group" aria-label="Add a block">
+        {(['box', 'cylinder', 'sphere'] as const).map((k) => (
+          <button
+            key={k}
+            type="button"
+            disabled={!canEdit}
+            onClick={() => onAdd(k)}
+            title={canEdit ? `Add a ${k}` : 'Save the robot to a project folder first'}
+          >
+            {k === 'box' ? '▦ Box' : k === 'cylinder' ? '⬭ Tube' : '● Ball'}
+          </button>
+        ))}
+      </div>
+      <p className="robotbuild__hint">
+        {canEdit ? 'A new block sticks to the part you picked.' : 'Save this robot to a folder to build.'}
+      </p>
+
+      <ul className="robotbuild__parts">
+        {assembly.map((it) => {
+          const isSel = it.link === selected
+          const isEdit = it.link === editLink
+          return (
+            <li
+              className={`robotbuild__part${isSel ? ' is-sel' : ''}`}
+              key={it.link}
+            >
+              <div className="robotbuild__part-row">
+                <button
+                  type="button"
+                  className="robotbuild__part-name"
+                  title={it.link}
+                  onClick={() => onSelect(it.link)}
+                >
+                  <span className="robotbuild__part-label">{it.link}</span>
+                  <span className={`robotbuild__part-geo${it.kind === 'mesh' ? ' is-mesh' : ''}`}>
+                    {it.kind === 'mesh' ? baseName(it.mesh ?? '') : it.kind}
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  className={`robotbuild__edit${isEdit ? ' is-on' : ''}`}
+                  onClick={() => onEdit(isEdit ? null : it.link)}
+                  title={isEdit ? 'Done editing' : 'Edit this block'}
+                  aria-label={`Edit ${it.link}`}
+                >
+                  {PENCIL}
+                </button>
+              </div>
+              {isEdit && (
+                <div className="robotbuild__editrow">
+                  {editGeom ? (
+                    <SizeForm geom={editGeom} onChange={(d) => onSetSize(it.link, d)} />
+                  ) : (
+                    <span className="robotbuild__editnote">Grab a face in 3D to resize, or…</span>
+                  )}
+                  <button
+                    type="button"
+                    className="robotbuild__del"
+                    onClick={() => onDelete(it.link)}
+                    title={`Delete ${it.link}`}
+                  >
+                    ✕
+                  </button>
+                </div>
+              )}
+            </li>
+          )
+        })}
+        {assembly.length === 0 && <li className="robotbuild__empty">No blocks yet — add one above.</li>}
+      </ul>
+
+      <div className="robotbuild__foot">
+        <button
+          type="button"
+          className="robotbuild__stl"
+          disabled={!canImport || importing}
+          onClick={onImportStl}
+          title={canImport ? 'Import an STL / DAE mesh' : 'Save the robot to a project folder to import meshes'}
+        >
+          {importing ? 'Importing…' : '+ STL / DAE'}
+        </button>
+      </div>
+    </aside>
+  )
+}
+
+export default RobotBuildPanel

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -17,7 +17,19 @@ import {
   toDisplay,
   toNative
 } from './robot-pose'
-import { addMeshLink, parseAssembly } from './robot-assembly'
+import {
+  addMeshLink,
+  addPrimitive,
+  parseAssembly,
+  readPrimitive,
+  removeLink,
+  setPrimitiveSize,
+  setVisualOrigin,
+  type PrimitiveGeom
+} from './robot-assembly'
+import { classifyFace, resizeFromDrag, type FaceEdit, type PrimitiveKind } from './robot-build'
+import { RobotBuildPanel } from './RobotBuildPanel'
+import { loadPin, savePin, PIN_KEYS } from './pin-overlay'
 import { RobotTimeline } from './RobotTimeline'
 import {
   autoMirrorPairs,
@@ -122,6 +134,7 @@ export function RobotView({
   const defaultPoseRef = useRef<Record<string, number>>({}) // native, non-mimic
   const measureActiveRef = useRef(false)
   const measureApiRef = useRef<{ clear: () => void } | null>(null)
+  const highlightApiRef = useRef<{ apply: (link: string | null) => void } | null>(null)
   metaRef.current = jointMeta
   valuesRef.current = values
   overridesRef.current = overrides
@@ -241,6 +254,78 @@ export function RobotView({
       void saveFile(id)
     }
   }, [content, saveFile])
+
+  // ── Block builder (#315a) ──────────────────────────────────────────────────
+  const [buildOpen, setBuildOpen] = useState(false)
+  const [buildPinned, setBuildPinned] = useState(() =>
+    loadPin(window.localStorage, PIN_KEYS.builder, false)
+  )
+  const [selectedLink, setSelectedLink] = useState<string | null>(null)
+  const [editLink, setEditLink] = useState<string | null>(null)
+  const [buildDim, setBuildDim] = useState<{ x: number; y: number; text: string } | null>(null)
+  // Refs the three.js pointer callbacks read (avoids re-subscribing on each edit).
+  const buildOpenRef = useRef(false)
+  const selectedLinkRef = useRef<string | null>(null)
+  const editLinkRef = useRef<string | null>(null)
+  buildOpenRef.current = buildOpen && poseUI
+  selectedLinkRef.current = selectedLink
+  editLinkRef.current = editLink
+  // Editing needs a real saved file (so the URDF text can be written next to it).
+  const canEdit = poseUI && activeFile?.source === 'local' && !!activeFile.path
+  const canEditRef = useRef(false)
+  canEditRef.current = canEdit
+  // Camera state preserved across the content re-parse (so an edit never jumps
+  // the view); keyed by the open file so a NEW robot still auto-frames.
+  const cameraStateRef = useRef<{
+    pos: THREE.Vector3
+    target: THREE.Vector3
+    zoom: number
+    halfView: number
+  } | null>(null)
+  const framedKeyRef = useRef<string | null>(null)
+
+  const editGeom: PrimitiveGeom | null = useMemo(
+    () => (editLink ? readPrimitive(content, editLink) : null),
+    [content, editLink]
+  )
+
+  const setBuildPinnedPersist = (p: boolean): void => {
+    setBuildPinned(p)
+    savePin(window.localStorage, PIN_KEYS.builder, p)
+  }
+
+  // Patch the URDF text + re-render + deferred-save (the STL-import path).
+  const commitUrdf = (next: string): void => {
+    if (!activeFile || activeFile.source !== 'local' || !activeFile.path) return
+    updateContent(activeFile.id, next)
+    pendingSaveRef.current = activeFile.id
+  }
+  const commitUrdfRef = useRef<((next: string) => void) | null>(null)
+  commitUrdfRef.current = commitUrdf
+  const contentRef = useRef(content)
+  contentRef.current = content
+
+  const handleAddPrimitive = (kind: PrimitiveKind): void => {
+    if (!canEdit) return // needs a saved project file — don't set a phantom selection
+    const { urdf, link } = addPrimitive(content, { kind, parent: selectedLink ?? undefined })
+    commitUrdf(urdf)
+    setSelectedLink(link)
+    setEditLink(link)
+    if (!buildOpen) setBuildOpen(true)
+  }
+  const handleSetSize = (link: string, dims: number[]): void => {
+    commitUrdf(setPrimitiveSize(content, link, dims))
+  }
+  const handleDeleteLink = (link: string): void => {
+    commitUrdf(removeLink(content, link))
+    setSelectedLink(null)
+    setEditLink(null)
+  }
+
+  // Re-apply the selection outline when the picked block changes (no re-parse).
+  useEffect(() => {
+    highlightApiRef.current?.apply(selectedLink)
+  }, [selectedLink])
 
   // ── Servo → joint binding + code-driven simulation (#313) ──────────────────
   // The KRF servo↔joint map, loaded from robot.yml. Kept in a ref for the
@@ -618,6 +703,44 @@ export function RobotView({
       resize()
     }
 
+    // Frame a NEW robot isometrically, but PRESERVE the camera when the same file
+    // is just re-parsed after a build edit (#315a must-fix — no view jump). The
+    // grid is refreshed to the new bounds either way.
+    const frameKey = activeFile?.id ?? ''
+    const relayGrid = (robot: URDFRobot): void => {
+      robot.updateMatrixWorld(true)
+      const box = new THREE.Box3().setFromObject(robot)
+      if (box.isEmpty()) return
+      const size = box.getSize(new THREE.Vector3())
+      if (grid) {
+        scene.remove(grid)
+        grid.geometry.dispose()
+        ;(grid.material as THREE.Material).dispose()
+      }
+      grid = new THREE.GridHelper(Math.max(size.x, size.z) * 3 + 0.4, 20, 0x3a3d44, 0x27292e)
+      grid.position.y = box.min.y
+      scene.add(grid)
+    }
+    const framePreservingCamera = (robot: URDFRobot): void => {
+      const saved = cameraStateRef.current
+      if (saved && framedKeyRef.current === frameKey) {
+        halfView = saved.halfView
+        camera.position.copy(saved.pos)
+        controls.target.copy(saved.target)
+        camera.zoom = saved.zoom
+        camera.updateProjectionMatrix()
+        controls.update()
+        relayGrid(robot)
+        resize()
+      } else {
+        frameModel(robot)
+        framedKeyRef.current = frameKey
+        // A genuinely new robot: drop any prior camera so the SECOND call this
+        // run (finalize/mesh-settle) re-frames THIS model, not the old one.
+        cameraStateRef.current = null
+      }
+    }
+
     let disposed = false
     let robot: URDFRobot | null = null
     let pending = 0 // async meshes still loading
@@ -630,7 +753,7 @@ export function RobotView({
     // may have grown the model) and surface any that couldn't load.
     const finalize = (): void => {
       if (disposed || !ready || pending > 0 || !robot) return
-      frameModel(robot)
+      framePreservingCamera(robot)
       if (failed.length) {
         const shown = failed.slice(0, 3).join(', ')
         const more = failed.length > 3 ? ` +${failed.length - 3} more` : ''
@@ -714,7 +837,7 @@ export function RobotView({
           joints: Object.keys(robot.joints).length,
           links: Object.keys(robot.links).length
         })
-        frameModel(robot) // frame primitives immediately; reframe when meshes land
+        framePreservingCamera(robot) // frame a new robot; keep the camera on an edit
 
         if (poseUI) {
           // POSE TOOL (#312): expose the movable joints, seed a neutral pose, then
@@ -834,15 +957,194 @@ export function RobotView({
               setMeasureDist(null)
             }
           }
+          // BLOCK BUILDER (#315a): push/pull a primitive face to resize (opposite
+          // face stays put) + a selection outline. Active when the build dock is
+          // open and NOT measuring — one guarded pointer path on this canvas.
+          const buildRay = new THREE.Raycaster()
+          const buildNdc = new THREE.Vector2()
+          const camDir = new THREE.Vector3()
+          const accentLineMat = new THREE.LineBasicMaterial({ color: 0xc8a24a, depthTest: false })
+          let outline: THREE.LineSegments | null = null
+          const applyHighlight = (link: string | null): void => {
+            if (outline) {
+              outline.parent?.remove(outline)
+              outline.geometry.dispose()
+              outline = null
+            }
+            const r = robotRef.current
+            if (!link || !r || !r.links[link]) return
+            let mesh: THREE.Mesh | null = null
+            r.links[link].traverse((o) => {
+              if (!mesh && (o as THREE.Mesh).isMesh) mesh = o as THREE.Mesh
+            })
+            if (!mesh) return
+            const seg = new THREE.LineSegments(new THREE.EdgesGeometry((mesh as THREE.Mesh).geometry), accentLineMat)
+            seg.renderOrder = 999
+            seg.raycast = () => {} // the outline must never intercept a face pick
+            ;(mesh as THREE.Mesh).add(seg)
+            outline = seg
+          }
+          highlightApiRef.current = { apply: applyHighlight }
+          applyHighlight(selectedLinkRef.current) // survive re-parse
+
+          const buildActive = (): boolean => buildOpenRef.current && !measureActiveRef.current
+          const buildNdcFrom = (e: PointerEvent): void => {
+            const rect = renderer.domElement.getBoundingClientRect()
+            buildNdc.x = ((e.clientX - rect.left) / rect.width) * 2 - 1
+            buildNdc.y = -((e.clientY - rect.top) / rect.height) * 2 + 1
+          }
+          const applyPreview = (
+            kind: PrimitiveKind,
+            m: THREE.Mesh,
+            g: THREE.Object3D,
+            dims: number[],
+            origin: [number, number, number]
+          ): void => {
+            if (kind === 'box') m.scale.set(dims[0], dims[1], dims[2])
+            else if (kind === 'cylinder') m.scale.set(dims[0], dims[1], dims[0])
+            else m.scale.set(dims[0], dims[0], dims[0])
+            g.position.set(origin[0], origin[1], origin[2])
+          }
+          const dimText = (kind: PrimitiveKind, face: FaceEdit, dims: number[]): string => {
+            const v = (x: number): number => Math.round(x * 1000)
+            if (kind === 'sphere') return `⌀ ${v(dims[0] * 2)} mm`
+            if (kind === 'cylinder') return face.dim === 1 ? `length ${v(dims[1])} mm` : `⌀ ${v(dims[0] * 2)} mm`
+            return `${v(dims[face.dim])} mm`
+          }
+          type Drag = {
+            link: string
+            kind: PrimitiveKind
+            face: FaceEdit
+            dims0: number[]
+            origin0: [number, number, number]
+            mesh: THREE.Mesh
+            group: THREE.Object3D
+            nWorld: THREE.Vector3
+            plane: THREE.Plane
+            anchor: THREE.Vector3
+            preview: { dims: number[]; origin: [number, number, number] } | null
+          }
+          let drag: Drag | null = null
+          let bDownX = 0
+          let bDownY = 0
+          const onBuildDown = (e: PointerEvent): void => {
+            bDownX = e.clientX
+            bDownY = e.clientY
+            const editName = editLinkRef.current
+            if (!buildActive() || !canEditRef.current || !robotRef.current || !editName) return
+            const linkObj = robotRef.current.links[editName]
+            const geom = readPrimitive(contentRef.current, editName)
+            if (!linkObj || !geom) return
+            buildNdcFrom(e)
+            buildRay.setFromCamera(buildNdc, camera)
+            // Skip non-face hits (e.g. the selection outline) — we need a mesh face.
+            const hit = buildRay.intersectObject(linkObj, true).find((h) => h.face)
+            if (!hit || !hit.face) return
+            // The face must belong to editName's OWN visual, not a nested child
+            // link's mesh (the link object contains its descendant subtree).
+            let owner: THREE.Object3D | null = hit.object
+            while (owner && !(owner as unknown as { isURDFLink?: boolean }).isURDFLink) owner = owner.parent
+            if ((owner as unknown as { urdfName?: string } | null)?.urdfName !== editName) return
+            const mesh = hit.object as THREE.Mesh
+            const group = mesh.parent
+            if (!group) return
+            const nWorld = hit.face.normal.clone().transformDirection(mesh.matrixWorld).normalize()
+            const q = new THREE.Quaternion()
+            linkObj.getWorldQuaternion(q)
+            const nLink = nWorld.clone().applyQuaternion(q.invert())
+            const face = classifyFace([nLink.x, nLink.y, nLink.z], geom.kind)
+            camera.getWorldDirection(camDir)
+            const plane = new THREE.Plane().setFromNormalAndCoplanarPoint(camDir, hit.point)
+            drag = {
+              link: editName,
+              kind: geom.kind,
+              face,
+              dims0: geom.dims,
+              origin0: geom.origin,
+              mesh,
+              group,
+              nWorld,
+              plane,
+              anchor: hit.point.clone(),
+              preview: null
+            }
+            controls.enabled = false // orbit yields to the drag (move early-returns)
+            ;(e.target as HTMLElement).setPointerCapture?.(e.pointerId)
+          }
+          const onBuildMove = (e: PointerEvent): void => {
+            if (!drag) return
+            buildNdcFrom(e)
+            buildRay.setFromCamera(buildNdc, camera)
+            const p = new THREE.Vector3()
+            if (!buildRay.ray.intersectPlane(drag.plane, p)) return
+            const delta = p.sub(drag.anchor).dot(drag.nWorld)
+            const step = e.shiftKey ? 0.001 : 0.005
+            const res = resizeFromDrag(drag.dims0, drag.origin0, drag.face, delta, { step })
+            applyPreview(drag.kind, drag.mesh, drag.group, res.dims, res.origin)
+            drag.preview = res
+            const rect = mount.getBoundingClientRect()
+            setBuildDim({
+              x: e.clientX - rect.left + 14,
+              y: e.clientY - rect.top + 14,
+              text: dimText(drag.kind, drag.face, res.dims)
+            })
+          }
+          const onBuildUp = (e: PointerEvent): void => {
+            const d = drag
+            drag = null
+            controls.enabled = true
+            if (d) {
+              setBuildDim(null)
+              if (d.preview) {
+                let next = setPrimitiveSize(contentRef.current, d.link, d.preview.dims)
+                next = setVisualOrigin(next, d.link, d.preview.origin)
+                commitUrdfRef.current?.(next)
+              }
+              return
+            }
+            if (!buildActive() || !robotRef.current) return
+            if (Math.hypot(e.clientX - bDownX, e.clientY - bDownY) > 4) return
+            buildNdcFrom(e)
+            buildRay.setFromCamera(buildNdc, camera)
+            const hit = buildRay.intersectObject(robotRef.current, true)[0]
+            if (!hit) return
+            let o: THREE.Object3D | null = hit.object
+            while (o && !(o as unknown as { isURDFLink?: boolean }).isURDFLink) o = o.parent
+            const name = (o as unknown as { urdfName?: string } | null)?.urdfName
+            if (name) setSelectedLink(name)
+          }
+
+          // A cancelled/interrupted drag must never strand OrbitControls disabled
+          // or leave a half-resized preview: revert to the pre-drag size.
+          const onBuildCancel = (): void => {
+            const d = drag
+            drag = null
+            controls.enabled = true
+            setBuildDim(null)
+            if (d) applyPreview(d.kind, d.mesh, d.group, d.dims0, d.origin0)
+          }
           renderer.domElement.addEventListener('pointerdown', onDown)
           renderer.domElement.addEventListener('pointerup', onUp)
+          renderer.domElement.addEventListener('pointerdown', onBuildDown)
+          renderer.domElement.addEventListener('pointermove', onBuildMove)
+          renderer.domElement.addEventListener('pointerup', onBuildUp)
+          renderer.domElement.addEventListener('pointercancel', onBuildCancel)
+          renderer.domElement.addEventListener('lostpointercapture', onBuildCancel)
           teardownPose = () => {
             renderer.domElement.removeEventListener('pointerdown', onDown)
             renderer.domElement.removeEventListener('pointerup', onUp)
+            renderer.domElement.removeEventListener('pointerdown', onBuildDown)
+            renderer.domElement.removeEventListener('pointermove', onBuildMove)
+            renderer.domElement.removeEventListener('pointerup', onBuildUp)
+            renderer.domElement.removeEventListener('pointercancel', onBuildCancel)
+            renderer.domElement.removeEventListener('lostpointercapture', onBuildCancel)
             clearMeasure()
             markerMat.dispose()
             lineMat.dispose()
+            if (outline) outline.geometry.dispose()
+            accentLineMat.dispose()
             measureApiRef.current = null
+            highlightApiRef.current = null
           }
         }
       }
@@ -871,6 +1173,14 @@ export function RobotView({
 
     return () => {
       disposed = true
+      // Snapshot the camera so the next rebuild (after a build edit) restores it
+      // instead of re-framing (#315a). Cleared by a NEW file via framedKeyRef.
+      cameraStateRef.current = {
+        pos: camera.position.clone(),
+        target: controls.target.clone(),
+        zoom: camera.zoom,
+        halfView
+      }
       robotRef.current = null
       teardownPose()
       cancelAnimationFrame(raf)
@@ -886,7 +1196,7 @@ export function RobotView({
       renderer.dispose()
       if (renderer.domElement.parentNode === mount) mount.removeChild(renderer.domElement)
     }
-  }, [content, effectiveBase, isEmpty, poseUI, currentFolder])
+  }, [content, effectiveBase, isEmpty, poseUI, currentFolder, activeFile?.id])
 
   const showPanel = poseUI && !error && !isEmpty
   const showTimeline = poseUI && !error && !isEmpty && movableNames.length > 0
@@ -917,6 +1227,32 @@ export function RobotView({
         {!error && meshNote && (
           <div className="robotview__note" role="status">
             {meshNote}
+          </div>
+        )}
+        {showPanel && (
+          <RobotBuildPanel
+            open={buildOpen}
+            pinned={buildPinned}
+            onSetOpen={setBuildOpen}
+            onSetPinned={setBuildPinnedPersist}
+            assembly={assembly}
+            selected={selectedLink}
+            onSelect={setSelectedLink}
+            editLink={editLink}
+            onEdit={setEditLink}
+            editGeom={editGeom}
+            onAdd={handleAddPrimitive}
+            onSetSize={handleSetSize}
+            onDelete={handleDeleteLink}
+            onImportStl={() => void handleImportStl()}
+            canImport={!!canImport}
+            importing={importing}
+            canEdit={canEdit}
+          />
+        )}
+        {buildDim && (
+          <div className="robotbuild__dim" style={{ left: buildDim.x, top: buildDim.y }}>
+            {buildDim.text}
           </div>
         )}
       </div>

--- a/src/renderer/src/components/pin-overlay.ts
+++ b/src/renderer/src/components/pin-overlay.ts
@@ -61,5 +61,6 @@ export function savePin(storage: PinStorage, key: string, value: boolean): void 
 /** The persisted pin keys (one per pinnable board panel). */
 export const PIN_KEYS = {
   library: 'snakie.board.pin.library',
-  connections: 'snakie.board.pin.connections'
+  connections: 'snakie.board.pin.connections',
+  builder: 'snakie.robot.pin.builder'
 } as const

--- a/src/renderer/src/components/robot-assembly.ts
+++ b/src/renderer/src/components/robot-assembly.ts
@@ -4,6 +4,7 @@
  * and appending an imported mesh as a new link/joint. Regex-based (no DOM) so
  * they're cheap to unit-test in a node env.
  */
+import type { PrimitiveKind } from './robot-build'
 
 /**
  * A minimal, VALID starter URDF: one `base_link` with a small box so the pose
@@ -129,4 +130,244 @@ export function addMeshLink(
   const idx = urdf.lastIndexOf('</robot>')
   const next = idx < 0 ? `${urdf.trimEnd()}\n${block}` : urdf.slice(0, idx) + block + urdf.slice(idx)
   return { urdf: next, link: name }
+}
+
+// ── Primitive builder (#315a) ────────────────────────────────────────────────
+
+/** A primitive link's geometry, read from / written to the URDF. Sizes in metres:
+ *  box `dims=[x,y,z]`, cylinder `[radius,length]`, sphere `[radius]`. */
+export interface PrimitiveGeom {
+  kind: PrimitiveKind
+  dims: number[]
+  /** The visual `<origin xyz>` (default [0,0,0]). */
+  origin: [number, number, number]
+}
+
+/** Compact metre formatter — up to 4 dp, trailing zeros stripped (`0.05`, `0.1`). */
+function fmtNum(n: number): string {
+  return (Math.round(n * 1e4) / 1e4).toString()
+}
+function fmtVec(v: readonly number[]): string {
+  return v.map(fmtNum).join(' ')
+}
+function parseVec3(s: string): [number, number, number] {
+  const p = s.trim().split(/\s+/).map(Number)
+  return [p[0] || 0, p[1] || 0, p[2] || 0]
+}
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/** The `<link name="X"> … </link>` span in the text (byte offsets), or null. */
+function linkSpan(
+  urdf: string,
+  name: string
+): { start: number; end: number; bodyStart: number; bodyEnd: number } | null {
+  const re = /<link\b([^>]*?)(\/?)>/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(urdf))) {
+    const nm = /\bname\s*=\s*"([^"]+)"/.exec(m[1])?.[1]
+    if (nm !== name) continue
+    const openEnd = re.lastIndex
+    if (m[2] === '/') return { start: m.index, end: openEnd, bodyStart: openEnd, bodyEnd: openEnd }
+    const close = urdf.indexOf('</link>', openEnd)
+    if (close < 0) return null
+    return { start: m.index, end: close + 7, bodyStart: openEnd, bodyEnd: close }
+  }
+  return null
+}
+
+/** The `<box|cylinder|sphere .../>` tag for a primitive. */
+function primitiveTag(kind: PrimitiveKind, dims: readonly number[]): string {
+  if (kind === 'cylinder') return `<cylinder radius="${fmtNum(dims[0])}" length="${fmtNum(dims[1])}"/>`
+  if (kind === 'sphere') return `<sphere radius="${fmtNum(dims[0])}"/>`
+  return `<box size="${fmtVec(dims)}"/>`
+}
+
+/** Sensible kid-friendly starter size (metres) per kind. */
+export function defaultPrimitiveDims(kind: PrimitiveKind): number[] {
+  if (kind === 'cylinder') return [0.02, 0.06]
+  if (kind === 'sphere') return [0.03]
+  return [0.04, 0.04, 0.04]
+}
+
+/** Ensure a `<material name="X">` DEFINITION exists (a bare ref renders default). */
+function ensureMaterial(urdf: string, name: string): string {
+  if (new RegExp(`<material\\b[^>]*\\bname\\s*=\\s*"${name}"[^>]*>[\\s\\S]*?</material>`).test(urdf)) {
+    return urdf
+  }
+  const def = `  <material name="${name}"><color rgba="0.62 0.65 0.69 1"/></material>\n`
+  const m = /<robot\b[^>]*>/i.exec(urdf)
+  return m ? urdf.slice(0, m.index + m[0].length) + '\n' + def + urdf.slice(m.index + m[0].length) : def + urdf
+}
+
+/** The first `<visual> … </visual>` sub-span within a link body, or null. Scopes
+ *  edits to the VISUAL (never a sibling `<collision>`, which also has geometry). */
+function visualSlice(body: string): { start: number; end: number } | null {
+  const open = /<visual\b[^>]*>/i.exec(body)
+  if (!open) return null
+  const close = body.indexOf('</visual>', open.index + open[0].length)
+  if (close < 0) return null
+  return { start: open.index, end: close + 9 }
+}
+
+/** Read a primitive link's geometry + visual origin, or null (mesh/none link). */
+export function readPrimitive(urdf: string, link: string): PrimitiveGeom | null {
+  const span = linkSpan(urdf, link)
+  if (!span) return null
+  const body = urdf.slice(span.bodyStart, span.bodyEnd)
+  const vs = visualSlice(body)
+  if (!vs) return null
+  const visual = body.slice(vs.start, vs.end)
+  const originM = /<origin\b[^>]*\bxyz\s*=\s*"([^"]+)"/i.exec(visual)
+  const origin = originM ? parseVec3(originM[1]) : ([0, 0, 0] as [number, number, number])
+  const box = /<box\b[^>]*\bsize\s*=\s*"([^"]+)"/i.exec(visual)
+  if (box) return { kind: 'box', dims: parseVec3(box[1]), origin }
+  const cyl = /<cylinder\b[^>]*>/i.exec(visual)?.[0]
+  if (cyl) {
+    const r = Number(/\bradius\s*=\s*"([^"]+)"/i.exec(cyl)?.[1])
+    const l = Number(/\blength\s*=\s*"([^"]+)"/i.exec(cyl)?.[1])
+    return { kind: 'cylinder', dims: [r || 0, l || 0], origin }
+  }
+  const sph = /<sphere\b[^>]*\bradius\s*=\s*"([^"]+)"/i.exec(visual)
+  if (sph) return { kind: 'sphere', dims: [Number(sph[1]) || 0], origin }
+  return null
+}
+
+/** Rewrite ONLY the primitive geometry tag inside a link's VISUAL (any kind, any
+ *  self-closing or open/close form). */
+export function setPrimitiveSize(urdf: string, link: string, dims: readonly number[]): string {
+  const span = linkSpan(urdf, link)
+  if (!span) return urdf
+  const body = urdf.slice(span.bodyStart, span.bodyEnd)
+  const vs = visualSlice(body)
+  if (!vs) return urdf
+  const visual = body
+    .slice(vs.start, vs.end)
+    .replace(/<(box|cylinder|sphere)\b[\s\S]*?(?:\/>|<\/\1>)/i, (_full, kind) =>
+      primitiveTag(kind.toLowerCase() as PrimitiveKind, dims)
+    )
+  const nextBody = body.slice(0, vs.start) + visual + body.slice(vs.end)
+  return urdf.slice(0, span.bodyStart) + nextBody + urdf.slice(span.bodyEnd)
+}
+
+/** Insert-or-replace a link's `<visual><origin xyz>` (keeps the opposite face put). */
+export function setVisualOrigin(
+  urdf: string,
+  link: string,
+  xyz: readonly [number, number, number]
+): string {
+  const span = linkSpan(urdf, link)
+  if (!span) return urdf
+  const body = urdf.slice(span.bodyStart, span.bodyEnd)
+  const vs = visualSlice(body)
+  if (!vs) return urdf
+  const tag = `<origin xyz="${fmtVec(xyz)}" rpy="0 0 0"/>`
+  let visual = body.slice(vs.start, vs.end)
+  if (/<origin\b[^>]*\/>/i.test(visual)) visual = visual.replace(/<origin\b[^>]*\/>/i, tag)
+  else visual = visual.replace(/<visual\b[^>]*>/i, (v) => `${v}\n      ${tag}`)
+  const nextBody = body.slice(0, vs.start) + visual + body.slice(vs.end)
+  return urdf.slice(0, span.bodyStart) + nextBody + urdf.slice(span.bodyEnd)
+}
+
+/** Set the fixed-joint origin whose child is `childLink` (moves the whole part). */
+export function setJointOrigin(
+  urdf: string,
+  childLink: string,
+  xyz: readonly [number, number, number]
+): string {
+  const re = /<joint\b[^>]*>[\s\S]*?<\/joint>/gi
+  const childRe = new RegExp(`<child\\b[^>]*\\blink\\s*=\\s*"${escapeRe(childLink)}"`, 'i')
+  let m: RegExpExecArray | null
+  while ((m = re.exec(urdf))) {
+    if (!childRe.test(m[0])) continue
+    const tag = `<origin xyz="${fmtVec(xyz)}" rpy="0 0 0"/>`
+    const block = /<origin\b[^>]*\/>/i.test(m[0])
+      ? m[0].replace(/<origin\b[^>]*\/>/i, tag)
+      : m[0].replace(/<\/joint>/i, `  ${tag}\n  </joint>`)
+    return urdf.slice(0, m.index) + block + urdf.slice(m.index + m[0].length)
+  }
+  return urdf
+}
+
+/**
+ * Add a primitive as a new link + FIXED joint onto `parent` (root fallback), so it
+ * attaches to the selected part. Returns the new URDF + the created link name.
+ */
+export function addPrimitive(
+  urdf: string,
+  opts: {
+    kind: PrimitiveKind
+    parent?: string
+    linkBase?: string
+    dims?: number[]
+    origin?: [number, number, number]
+    jointXyz?: [number, number, number]
+  }
+): { urdf: string; link: string } {
+  const parent = opts.parent ?? rootLink(urdf)
+  const name = uniqueLinkName(urdf, opts.linkBase ?? opts.kind)
+  const dims = opts.dims ?? defaultPrimitiveDims(opts.kind)
+  const origin = opts.origin ?? [0, 0, 0]
+  const jointXyz = opts.jointXyz ?? [0.06, 0, 0] // beside the parent so it doesn't overlap
+  const linkBlock =
+    `  <link name="${name}">\n` +
+    `    <visual>\n` +
+    `      <origin xyz="${fmtVec(origin)}" rpy="0 0 0"/>\n` +
+    `      <geometry>${primitiveTag(opts.kind, dims)}</geometry>\n` +
+    `      <material name="steel"/>\n` +
+    `    </visual>\n` +
+    `  </link>\n`
+  const jointBlock = parent
+    ? `  <joint name="${name}_joint" type="fixed">\n` +
+      `    <parent link="${parent}"/>\n` +
+      `    <child link="${name}"/>\n` +
+      `    <origin xyz="${fmtVec(jointXyz)}" rpy="0 0 0"/>\n` +
+      `  </joint>\n`
+    : ''
+  const block = linkBlock + jointBlock
+  const idx = urdf.lastIndexOf('</robot>')
+  const next = idx < 0 ? `${urdf.trimEnd()}\n${block}` : urdf.slice(0, idx) + block + urdf.slice(idx)
+  return { urdf: ensureMaterial(next, 'steel'), link: name }
+}
+
+/**
+ * Remove a link AND its whole subtree (every descendant reachable through child
+ * joints), plus every joint that references any removed link. A URDF is a tree —
+ * deleting a non-leaf block otherwise leaves a joint with a dangling parent, which
+ * crashes the loader. Best-effort, corruption-safe.
+ */
+export function removeLink(urdf: string, link: string): string {
+  // Collect the subtree: `link` + everything joined below it (transitively).
+  const doomed = new Set<string>([link])
+  const jointOf = (block: string, attr: 'parent' | 'child'): string | undefined =>
+    new RegExp(`<${attr}\\b[^>]*\\blink\\s*=\\s*"([^"]+)"`, 'i').exec(block)?.[1]
+  for (let changed = true; changed; ) {
+    changed = false
+    const re = /<joint\b[^>]*>[\s\S]*?<\/joint>/gi
+    let m: RegExpExecArray | null
+    while ((m = re.exec(urdf))) {
+      const parent = jointOf(m[0], 'parent')
+      const child = jointOf(m[0], 'child')
+      if (parent && child && doomed.has(parent) && !doomed.has(child)) {
+        doomed.add(child)
+        changed = true
+      }
+    }
+  }
+  let out = urdf
+  for (const name of doomed) {
+    const span = linkSpan(out, name)
+    if (!span) continue
+    let start = span.start
+    while (start > 0 && /\s/.test(out[start - 1])) start--
+    out = out.slice(0, start) + '\n' + out.slice(span.end)
+  }
+  // Drop every joint touching a removed link (as parent OR child).
+  out = out.replace(/\s*<joint\b[^>]*>[\s\S]*?<\/joint>/gi, (block) => {
+    const parent = jointOf(block, 'parent')
+    const child = jointOf(block, 'child')
+    return (parent && doomed.has(parent)) || (child && doomed.has(child)) ? '\n' : block
+  })
+  return out
 }

--- a/src/renderer/src/components/robot-build.ts
+++ b/src/renderer/src/components/robot-build.ts
@@ -1,0 +1,73 @@
+/**
+ * ROBOT BUILD MATH (#315a, epic #309 Phase 5) — PURE, unit-tested. The push/pull
+ * face-drag maths, free of three.js: which dimension a picked face edits, snapping
+ * a dimension to a friendly grid, and resizing a primitive while keeping the
+ * OPPOSITE face fixed (Fusion-style). Sizes are in METRES. `dims` is kind-shaped:
+ * box `[x, y, z]`, cylinder `[radius, length]`, sphere `[radius]`.
+ */
+export type PrimitiveKind = 'box' | 'cylinder' | 'sphere'
+
+/** Which dimension a picked face resizes, and how. */
+export interface FaceEdit {
+  /** The LINK-frame axis the face normal points along (0=x, 1=y, 2=z). */
+  axis: 0 | 1 | 2
+  /** +1 for the +axis face, −1 for the −axis face. */
+  sign: 1 | -1
+  /** Index into `dims` that this face grows. */
+  dim: number
+  /** True when the shape is symmetric about the axis (radius/sphere) — no origin
+   *  shift needed; false (box face, cylinder cap) shifts the origin to pin the
+   *  opposite face. */
+  symmetric: boolean
+}
+
+/**
+ * Classify a picked face from its LINK-frame normal + the primitive kind. Returns
+ * null only for a non-primitive. The cylinder's length axis is the link Z (the
+ * mesh is rotated 90° so geometry-Y → link-Z), so a |z|-dominant normal is the
+ * CAP (edits length) and any other is the SIDE (edits radius).
+ */
+export function classifyFace(nLink: readonly [number, number, number], kind: PrimitiveKind): FaceEdit {
+  const abs = [Math.abs(nLink[0]), Math.abs(nLink[1]), Math.abs(nLink[2])]
+  const axis: 0 | 1 | 2 = abs[0] >= abs[1] && abs[0] >= abs[2] ? 0 : abs[1] >= abs[2] ? 1 : 2
+  const sign: 1 | -1 = nLink[axis] >= 0 ? 1 : -1
+  if (kind === 'box') return { axis, sign, dim: axis, symmetric: false }
+  if (kind === 'sphere') return { axis, sign, dim: 0, symmetric: true }
+  // cylinder
+  if (axis === 2) return { axis: 2, sign, dim: 1, symmetric: false } // cap → length (dims[1])
+  return { axis, sign, dim: 0, symmetric: true } // side → radius (dims[0]), symmetric
+}
+
+/** Snap a metre dimension to a `step` grid (e.g. 5 mm), keeping it finite. */
+export function snapDimension(metres: number, step: number): number {
+  if (!(step > 0) || !Number.isFinite(metres)) return metres
+  // Round via mm to avoid float cruft, then back to metres.
+  return Math.round(metres / step) * step
+}
+
+/**
+ * Resize a primitive from a face drag. `deltaM` is the signed distance (metres)
+ * the grabbed face travels along its OUTWARD normal (+ grows). Snaps the resulting
+ * dimension to `step`, clamps to `min`, and — for an asymmetric face (box, cylinder
+ * cap) — shifts the visual origin by half the growth so the opposite face stays put.
+ */
+export function resizeFromDrag(
+  dims: readonly number[],
+  origin: readonly [number, number, number],
+  face: FaceEdit,
+  deltaM: number,
+  opts: { min?: number; step?: number } = {}
+): { dims: number[]; origin: [number, number, number] } {
+  const min = opts.min ?? 0.002
+  const step = opts.step ?? 0.005
+  const d = [...dims]
+  const o: [number, number, number] = [origin[0], origin[1], origin[2]]
+  const oldDim = d[face.dim]
+  let newDim = snapDimension(oldDim + deltaM, step)
+  if (!(newDim >= min)) newDim = min
+  // Clean tiny float error so the emitted XML is tidy (5 mm grid → 4 dp is exact).
+  newDim = Math.round(newDim * 1e6) / 1e6
+  d[face.dim] = newDim
+  if (!face.symmetric) o[face.axis] += (face.sign * (newDim - oldDim)) / 2
+  return { dims: d, origin: o }
+}

--- a/test/robotBuild.test.ts
+++ b/test/robotBuild.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest'
+import { classifyFace, snapDimension, resizeFromDrag } from '../src/renderer/src/components/robot-build'
+import {
+  addPrimitive,
+  setPrimitiveSize,
+  setVisualOrigin,
+  setJointOrigin,
+  readPrimitive,
+  removeLink,
+  parseAssembly,
+  blankUrdf
+} from '../src/renderer/src/components/robot-assembly'
+
+describe('robot-build face maths (#315a)', () => {
+  it('classifies a box face by dominant axis + sign', () => {
+    expect(classifyFace([0.98, 0.1, 0.1], 'box')).toEqual({ axis: 0, sign: 1, dim: 0, symmetric: false })
+    expect(classifyFace([0, -1, 0], 'box')).toEqual({ axis: 1, sign: -1, dim: 1, symmetric: false })
+  })
+  it('classifies a cylinder cap (z) as length, side as symmetric radius', () => {
+    expect(classifyFace([0, 0, 1], 'cylinder')).toEqual({ axis: 2, sign: 1, dim: 1, symmetric: false })
+    expect(classifyFace([1, 0, 0], 'cylinder')).toEqual({ axis: 0, sign: 1, dim: 0, symmetric: true })
+  })
+  it('a sphere face always edits the (symmetric) radius', () => {
+    expect(classifyFace([0, 0.3, -0.95], 'sphere')).toEqual({ axis: 2, sign: -1, dim: 0, symmetric: true })
+  })
+  it('snaps to a grid', () => {
+    expect(snapDimension(0.043, 0.005)).toBeCloseTo(0.045)
+    expect(snapDimension(0.041, 0.005)).toBeCloseTo(0.04)
+  })
+  it('resizes a box face and keeps the OPPOSITE face fixed', () => {
+    // +X face pulled out ~20mm: x 40→60mm; origin shifts +10mm so the −X face stays put.
+    const face = classifyFace([1, 0, 0], 'box')
+    const r = resizeFromDrag([0.04, 0.04, 0.04], [0, 0, 0], face, 0.02)
+    expect(r.dims[0]).toBeCloseTo(0.06)
+    expect(r.origin[0]).toBeCloseTo(0.01) // +sign * (0.06-0.04)/2
+    // the fixed (−X) face: centre − size/2 unchanged
+    expect(r.origin[0] - r.dims[0] / 2).toBeCloseTo(0 - 0.04 / 2)
+  })
+  it('a −face shift is negative; a symmetric (radius) drag never shifts the origin', () => {
+    const neg = resizeFromDrag([0.04, 0.04, 0.04], [0, 0, 0], classifyFace([-1, 0, 0], 'box'), 0.02)
+    expect(neg.origin[0]).toBeCloseTo(-0.01)
+    const rad = resizeFromDrag([0.02, 0.06], [0, 0, 0], classifyFace([1, 0, 0], 'cylinder'), 0.01)
+    expect(rad.dims[0]).toBeCloseTo(0.025)
+    expect(rad.origin).toEqual([0, 0, 0]) // symmetric → no shift
+  })
+  it('clamps to a minimum', () => {
+    const r = resizeFromDrag([0.04, 0.04, 0.04], [0, 0, 0], classifyFace([1, 0, 0], 'box'), -1)
+    expect(r.dims[0]).toBe(0.002)
+  })
+})
+
+describe('URDF primitive text helpers (#315a)', () => {
+  const base = blankUrdf('bot') // one base_link box
+
+  it('adds a primitive as a link + fixed joint onto the selected parent', () => {
+    const { urdf, link } = addPrimitive(base, { kind: 'box', parent: 'base_link' })
+    expect(link).toBe('box')
+    expect(urdf).toContain('<joint name="box_joint" type="fixed">')
+    expect(urdf).toContain('<parent link="base_link"/>')
+    const a = parseAssembly(urdf)
+    expect(a.find((i) => i.link === 'box')?.kind).toBe('box')
+  })
+
+  it('cylinder + sphere primitives round-trip via readPrimitive', () => {
+    let u = base
+    u = addPrimitive(u, { kind: 'cylinder' }).urdf
+    u = addPrimitive(u, { kind: 'sphere' }).urdf
+    expect(readPrimitive(u, 'cylinder')).toEqual({ kind: 'cylinder', dims: [0.02, 0.06], origin: [0, 0, 0] })
+    expect(readPrimitive(u, 'sphere')).toEqual({ kind: 'sphere', dims: [0.03], origin: [0, 0, 0] })
+  })
+
+  it('setPrimitiveSize rewrites ONLY the target link, leaving siblings byte-identical', () => {
+    const two = addPrimitive(base, { kind: 'box', linkBase: 'arm' }).urdf
+    const before = two
+    const after = setPrimitiveSize(two, 'arm', [0.1, 0.02, 0.02])
+    expect(readPrimitive(after, 'arm')?.dims).toEqual([0.1, 0.02, 0.02])
+    // base_link's box is untouched
+    expect(readPrimitive(after, 'base_link')?.dims).toEqual(readPrimitive(before, 'base_link')?.dims)
+    // the file still parses to the same links
+    expect(parseAssembly(after).map((i) => i.link)).toEqual(parseAssembly(before).map((i) => i.link))
+  })
+
+  it('setVisualOrigin inserts then updates the visual origin', () => {
+    const u = setVisualOrigin(base, 'base_link', [0.01, 0, 0])
+    expect(readPrimitive(u, 'base_link')?.origin).toEqual([0.01, 0, 0])
+    const u2 = setVisualOrigin(u, 'base_link', [0.02, 0, 0])
+    expect(readPrimitive(u2, 'base_link')?.origin).toEqual([0.02, 0, 0])
+    expect((u2.match(/<origin/g) || []).length).toBe(1) // not duplicated
+  })
+
+  it('setJointOrigin moves a part (patches only its joint)', () => {
+    const u = addPrimitive(base, { kind: 'box', linkBase: 'head' }).urdf
+    const moved = setJointOrigin(u, 'head', [0, 0, 0.1])
+    expect(moved).toContain('<origin xyz="0 0 0.1" rpy="0 0 0"/>')
+    expect(moved).toContain('<child link="head"/>')
+  })
+
+  it('removeLink drops the link AND its owning joint', () => {
+    const u = addPrimitive(base, { kind: 'sphere', linkBase: 'eye' }).urdf
+    const rm = removeLink(u, 'eye')
+    expect(parseAssembly(rm).map((i) => i.link)).not.toContain('eye')
+    expect(rm).not.toContain('eye_joint')
+    expect(parseAssembly(rm).map((i) => i.link)).toContain('base_link') // sibling survives
+  })
+
+  it('removeLink CASCADES a non-leaf block (no dangling joint that crashes the loader)', () => {
+    // base_link → arm → hand ; deleting arm must also drop hand + both joints.
+    let u = addPrimitive(base, { kind: 'box', linkBase: 'arm', parent: 'base_link' }).urdf
+    u = addPrimitive(u, { kind: 'box', linkBase: 'hand', parent: 'arm' }).urdf
+    const rm = removeLink(u, 'arm')
+    const links = parseAssembly(rm).map((i) => i.link)
+    expect(links).toEqual(['base_link'])
+    expect(rm).not.toContain('link="arm"') // no dangling parent/child ref
+    expect(rm).not.toMatch(/hand/)
+  })
+
+  it('setPrimitiveSize / readPrimitive ignore a sibling <collision> geometry', () => {
+    const withCollision = `<?xml version="1.0"?>\n<robot name="c">\n  <link name="base_link">\n    <visual><origin xyz="0 0 0"/><geometry><box size="0.04 0.04 0.04"/></geometry></visual>\n    <collision><geometry><box size="0.9 0.9 0.9"/></geometry></collision>\n  </link>\n</robot>\n`
+    expect(readPrimitive(withCollision, 'base_link')?.dims).toEqual([0.04, 0.04, 0.04]) // NOT the collision box
+    const resized = setPrimitiveSize(withCollision, 'base_link', [0.1, 0.04, 0.04])
+    expect(resized).toContain('<box size="0.9 0.9 0.9"/>') // collision untouched
+    expect(readPrimitive(resized, 'base_link')?.dims).toEqual([0.1, 0.04, 0.04])
+  })
+
+  it('reads a cylinder written in open/close form', () => {
+    const u = `<robot name="c"><link name="base_link"><visual><geometry><cylinder radius="0.02" length="0.06"></cylinder></geometry></visual></link></robot>`
+    expect(readPrimitive(u, 'base_link')).toEqual({ kind: 'cylinder', dims: [0.02, 0.06], origin: [0, 0, 0] })
+  })
+
+  it('preserves comments + materials across an edit', () => {
+    const withComment = `<?xml version="1.0"?>\n<!-- keep me -->\n<robot name="c">\n  <material name="steel"><color rgba="0.6 0.6 0.6 1"/></material>\n  <link name="base_link"><visual><geometry><box size="0.04 0.04 0.04"/></geometry></visual></link>\n</robot>\n`
+    const edited = setPrimitiveSize(addPrimitive(withComment, { kind: 'box' }).urdf, 'base_link', [0.08, 0.04, 0.04])
+    expect(edited).toContain('<!-- keep me -->')
+    expect(edited).toContain('<material name="steel">')
+  })
+})


### PR DESCRIPTION
Epic #309 Phase 5 (the **315a** kid-friendly half). "So easy a child can build a robot model from blocks." Closes #333.

## What
- **Floating, transparent, pinnable Build dock on the LEFT** — mirrors the breadboard library dock (edge tab, pin/auto-hide). Lists the components with a **per-item edit pencil** (view by default) + STL import.
- **＋ Box / Tube / Ball** → a primitive as a new link **fixed-jointed to the selected part** (no joint jargon).
- **Push/pull a face to resize** — Fusion-style, opposite face held put, with a **live mm measurement** — or type exact mm. **Delete cascades** the subtree.
- URDF **text stays the source of truth**: pure regex helpers (`robot-assembly.ts`) + the drag maths (`robot-build.ts`, opposite-face-fixed). Edits save into the **linked project URDF**, and the **camera is preserved across the re-parse** (no view jump — the #1 must-fix).

## Rigor
Designed and adversarially reviewed via **multi-agent workflows**: a 4-architect → 3-judge design phase (the interaction design won, verified against the urdf-loader source), then a 3-reviewer → per-finding verification pass that surfaced **12 confirmed bugs — all fixed**, including a **HIGH**: deleting a non-leaf block orphaned its children into a non-loadable URDF that was then auto-saved (now `removeLink` cascades the subtree), and a `<collision>`-block leak (edits are now visual-scoped). **17 pure unit tests** (drag maths + URDF-text round-trip, opposite-face-fixed, cascade delete, collision isolation, comment/material preservation).

## Verified in-app (Playwright)
Dock opens from the tab; **+ Box** adds a fixed-jointed block; a **push/pull face drag resizes 40→50 mm** with a live HUD and the opposite face fixed; the numeric mm form works; edits save to the linked URDF; the camera never jumps.

Gate: typecheck + lint clean, **1487 tests**, build ✅.

Follow-up **#315b** (#315): revolute/prismatic joint editor (visual axis/origin/limits) + the mimic editor. (A move tool + Fusion-style snapping points + a tool toolbar were just requested — I'll file + build those next.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
