### PR TITLE
feat: Robot builder tools — toolbar + move-with-snap (#335)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Robot View — builder tools: a toolbar + move-with-snap (#335, epic #309
+  Phase 5).** The block builder gains a floating **tool toolbar** (top-centre of
+  the stage): **Pick** (select), **Push & pull** (resize a face), **Move** a
+  block, and **Join** (coming soon). The new **Move** tool slides a block around
+  with a live mm read-out and a 5 mm grid (hold **Shift** for 1 mm); hover a face
+  and Fusion-style **snap handles** appear on its corners, edge-midpoints and
+  centre, so you can drop a block with its face point landing exactly on another
+  block's corner / edge / centre (the read-out shows **snap ✓**). Moves rewrite
+  the block's fixed-joint origin in the linked URDF, and the camera never jumps.
 - **Robot View — kid-friendly block builder (#315a, epic #309 Phase 5).** Build a
   robot from blocks: a floating, transparent, pinnable **Build** panel on the left
   (like the breadboard's library dock) lists your components with a per-item edit

--- a/src/renderer/src/components/RobotBuildPanel.tsx
+++ b/src/renderer/src/components/RobotBuildPanel.tsx
@@ -154,6 +154,10 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
       tabIndex={-1}
       aria-label="Build panel"
       onBlur={(e) => {
+        // Don't auto-hide when focus moves to the tool toolbar (part of the
+        // builder, but a separate DOM subtree over the stage).
+        const rt = e.relatedTarget as Element | null
+        if (rt && typeof rt.closest === 'function' && rt.closest('.robottool')) return
         if (shouldAutoHide(pinned, dockRef.current, e.relatedTarget)) onSetOpen(false)
       }}
     >

--- a/src/renderer/src/components/RobotToolbar.css
+++ b/src/renderer/src/components/RobotToolbar.css
@@ -1,0 +1,43 @@
+/* Build tool cluster (#335) — floating pill, top-centre of the 3-D stage. */
+.robottool {
+  position: absolute;
+  top: 0.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 5;
+  display: flex;
+  gap: 0.2rem;
+  padding: 0.2rem;
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 8px;
+  background: rgba(20, 21, 24, 0.55);
+  backdrop-filter: blur(8px);
+}
+:root[data-theme='skeuomorph'] .robottool {
+  background: rgba(231, 226, 211, 0.78);
+}
+.robottool__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.85rem;
+  height: 1.85rem;
+  color: var(--text, #cdd2d9);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.robottool__btn:hover:not(:disabled) {
+  border-color: var(--border, #3a3d44);
+  color: #c8a24a;
+}
+.robottool__btn.is-active {
+  color: #c8a24a;
+  border-color: #c8a24a;
+  background: rgba(200, 162, 74, 0.18);
+}
+.robottool__btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}

--- a/src/renderer/src/components/RobotToolbar.tsx
+++ b/src/renderer/src/components/RobotToolbar.tsx
@@ -1,0 +1,78 @@
+import type { BuildTool } from './robot-build'
+import './RobotToolbar.css'
+
+/**
+ * ROBOT TOOLBAR (#335) — a small floating tool cluster (top-centre of the 3-D
+ * stage) that sets the active builder tool. Only the active tool owns the canvas
+ * pointer (RobotView gates on it). Kid-friendly labels, no jargon.
+ */
+export interface RobotToolbarProps {
+  tool: BuildTool
+  onSetTool: (t: BuildTool) => void
+  /** Editing needs a saved project file — tools disable without one. */
+  canEdit: boolean
+}
+
+const ICONS: Record<BuildTool, JSX.Element> = {
+  select: (
+    <svg viewBox="0 0 16 16" width="15" height="15" aria-hidden="true">
+      <path d="M3 2l9 4.5-3.8 1 1.9 4.2-1.6.7-1.9-4.2L3 11z" fill="currentColor" />
+    </svg>
+  ),
+  pushpull: (
+    <svg viewBox="0 0 16 16" width="15" height="15" aria-hidden="true">
+      <rect x="2" y="4" width="7" height="8" fill="none" stroke="currentColor" strokeWidth="1.3" />
+      <path d="M10 8h4M12 6l2 2-2 2" fill="none" stroke="currentColor" strokeWidth="1.3" />
+    </svg>
+  ),
+  move: (
+    <svg viewBox="0 0 16 16" width="15" height="15" aria-hidden="true">
+      <path
+        d="M8 1v14M1 8h14M8 1L6 3M8 1l2 2M8 15l-2-2M8 15l2-2M1 8l2-2M1 8l2 2M15 8l-2-2M15 8l-2 2"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.2"
+      />
+    </svg>
+  ),
+  joint: (
+    <svg viewBox="0 0 16 16" width="15" height="15" aria-hidden="true">
+      <circle cx="4" cy="8" r="2.2" fill="currentColor" />
+      <circle cx="12" cy="8" r="2.2" fill="currentColor" />
+      <path d="M6 8h4" stroke="currentColor" strokeWidth="1.4" />
+    </svg>
+  )
+}
+
+const TOOLS: Array<{ id: BuildTool; label: string; soon?: boolean }> = [
+  { id: 'select', label: 'Pick a block' },
+  { id: 'pushpull', label: 'Push & pull to resize' },
+  { id: 'move', label: 'Move a block' },
+  { id: 'joint', label: 'Join two blocks (coming soon)', soon: true }
+]
+
+export function RobotToolbar({ tool, onSetTool, canEdit }: RobotToolbarProps): JSX.Element {
+  return (
+    <div className="robottool" role="toolbar" aria-label="Build tools">
+      {TOOLS.map((t) => {
+        const disabled = t.soon || !canEdit
+        return (
+          <button
+            key={t.id}
+            type="button"
+            className={`robottool__btn${tool === t.id ? ' is-active' : ''}`}
+            aria-pressed={tool === t.id}
+            disabled={disabled}
+            title={!canEdit && !t.soon ? 'Save the robot to a folder first' : t.label}
+            aria-label={t.label}
+            onClick={() => onSetTool(t.id)}
+          >
+            {ICONS[t.id]}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+export default RobotToolbar

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -21,14 +21,26 @@ import {
   addMeshLink,
   addPrimitive,
   parseAssembly,
+  readJoint,
   readPrimitive,
   removeLink,
+  setJointOrigin,
   setPrimitiveSize,
   setVisualOrigin,
   type PrimitiveGeom
 } from './robot-assembly'
-import { classifyFace, resizeFromDrag, type FaceEdit, type PrimitiveKind } from './robot-build'
+import {
+  classifyFace,
+  faceSnapPoints,
+  movedJointOrigin,
+  resizeFromDrag,
+  type BuildTool,
+  type FaceEdit,
+  type PrimitiveKind,
+  type Vec3
+} from './robot-build'
 import { RobotBuildPanel } from './RobotBuildPanel'
+import { RobotToolbar } from './RobotToolbar'
 import { loadPin, savePin, PIN_KEYS } from './pin-overlay'
 import { RobotTimeline } from './RobotTimeline'
 import {
@@ -274,6 +286,13 @@ export function RobotView({
   const canEdit = poseUI && activeFile?.source === 'local' && !!activeFile.path
   const canEditRef = useRef(false)
   canEditRef.current = canEdit
+  const [buildTool, setBuildTool] = useState<BuildTool>('select')
+  const buildToolRef = useRef<BuildTool>('select')
+  buildToolRef.current = buildTool
+  const onSetTool = (t: BuildTool): void => {
+    setBuildTool(t)
+    setMeasureActive(false) // the two canvas interaction modes are exclusive
+  }
   // Camera state preserved across the content re-parse (so an edit never jumps
   // the view); keyed by the open file so a NEW robot still auto-frames.
   const cameraStateRef = useRef<{
@@ -1027,24 +1046,86 @@ export function RobotView({
           let drag: Drag | null = null
           let bDownX = 0
           let bDownY = 0
-          const onBuildDown = (e: PointerEvent): void => {
-            bDownX = e.clientX
-            bDownY = e.clientY
-            const editName = editLinkRef.current
-            if (!buildActive() || !canEditRef.current || !robotRef.current || !editName) return
+
+          // Snap-handle pool (Fusion-style dots on a hovered/target face). Shared
+          // geometry/materials; spheres never intercept a raycast.
+          const snapGroup = new THREE.Group()
+          scene.add(snapGroup)
+          const handleGeo = new THREE.SphereGeometry(1, 10, 10)
+          const handleMat = new THREE.MeshBasicMaterial({ color: 0xc8a24a, depthTest: false })
+          const handleMatOn = new THREE.MeshBasicMaterial({ color: 0xffffff, depthTest: false })
+          const clearHandles = (): void => {
+            snapGroup.clear()
+          }
+          const showHandles = (pts: THREE.Vector3[], activeIdx: number): void => {
+            snapGroup.clear()
+            const r = halfView * 0.02
+            pts.forEach((p, i) => {
+              const s = new THREE.Mesh(handleGeo, i === activeIdx ? handleMatOn : handleMat)
+              s.position.copy(p)
+              s.scale.setScalar(i === activeIdx ? r * 1.7 : r)
+              s.renderOrder = 999
+              s.raycast = () => {}
+              snapGroup.add(s)
+            })
+          }
+          const mmv = (m: number): number => Math.round(m * 1000)
+          const ownerLinkName = (obj: THREE.Object3D | null): string | null => {
+            let o = obj
+            while (o && !(o as unknown as { isURDFLink?: boolean }).isURDFLink) o = o.parent
+            return (o as unknown as { urdfName?: string } | null)?.urdfName ?? null
+          }
+          // Classify the hovered face + return its world snap handles.
+          const hitToHandles = (
+            hit: THREE.Intersection,
+            link: string,
+            geom: PrimitiveGeom
+          ): { pts: THREE.Vector3[]; roles: string[]; face: FaceEdit } => {
+            const linkObj = robotRef.current!.links[link]
+            const mesh = hit.object as THREE.Mesh
+            const nW = hit.face!.normal.clone().transformDirection(mesh.matrixWorld).normalize()
+            const q = new THREE.Quaternion()
+            linkObj.getWorldQuaternion(q)
+            const nL = nW.clone().applyQuaternion(q.invert())
+            const face = classifyFace([nL.x, nL.y, nL.z], geom.kind)
+            const sp = faceSnapPoints(geom, face)
+            const m = linkObj.matrixWorld
+            return {
+              pts: sp.map((s) => new THREE.Vector3(s.p[0], s.p[1], s.p[2]).applyMatrix4(m)),
+              roles: sp.map((s) => s.role),
+              face
+            }
+          }
+          const nearestScreen = (pts: THREE.Vector3[], e: PointerEvent): { index: number; distPx: number } => {
+            const rect = renderer.domElement.getBoundingClientRect()
+            const px = e.clientX - rect.left
+            const py = e.clientY - rect.top
+            let index = -1
+            let best = Infinity
+            pts.forEach((p, i) => {
+              const v = p.clone().project(camera)
+              const sx = (v.x * 0.5 + 0.5) * rect.width
+              const sy = (-v.y * 0.5 + 0.5) * rect.height
+              const d = Math.hypot(sx - px, sy - py)
+              if (d < best) {
+                best = d
+                index = i
+              }
+            })
+            return { index, distPx: best }
+          }
+
+          // ── Resize (push/pull tool) ──
+          const startResize = (e: PointerEvent): void => {
+            const editName = selectedLinkRef.current ?? editLinkRef.current
+            if (!editName || !robotRef.current) return
             const linkObj = robotRef.current.links[editName]
             const geom = readPrimitive(contentRef.current, editName)
             if (!linkObj || !geom) return
             buildNdcFrom(e)
             buildRay.setFromCamera(buildNdc, camera)
-            // Skip non-face hits (e.g. the selection outline) — we need a mesh face.
             const hit = buildRay.intersectObject(linkObj, true).find((h) => h.face)
-            if (!hit || !hit.face) return
-            // The face must belong to editName's OWN visual, not a nested child
-            // link's mesh (the link object contains its descendant subtree).
-            let owner: THREE.Object3D | null = hit.object
-            while (owner && !(owner as unknown as { isURDFLink?: boolean }).isURDFLink) owner = owner.parent
-            if ((owner as unknown as { urdfName?: string } | null)?.urdfName !== editName) return
+            if (!hit || !hit.face || ownerLinkName(hit.object) !== editName) return
             const mesh = hit.object as THREE.Mesh
             const group = mesh.parent
             if (!group) return
@@ -1054,7 +1135,6 @@ export function RobotView({
             const nLink = nWorld.clone().applyQuaternion(q.invert())
             const face = classifyFace([nLink.x, nLink.y, nLink.z], geom.kind)
             camera.getWorldDirection(camDir)
-            const plane = new THREE.Plane().setFromNormalAndCoplanarPoint(camDir, hit.point)
             drag = {
               link: editName,
               kind: geom.kind,
@@ -1064,36 +1144,143 @@ export function RobotView({
               mesh,
               group,
               nWorld,
-              plane,
+              plane: new THREE.Plane().setFromNormalAndCoplanarPoint(camDir, hit.point),
               anchor: hit.point.clone(),
               preview: null
             }
-            controls.enabled = false // orbit yields to the drag (move early-returns)
+            controls.enabled = false
             ;(e.target as HTMLElement).setPointerCapture?.(e.pointerId)
           }
+
+          // ── Move tool ──
+          type Move = {
+            link: string
+            jointObj: THREE.Object3D
+            oldXyz: THREE.Vector3
+            parentBasis: number[]
+            grab: THREE.Vector3
+            anchor: THREE.Vector3
+            plane: THREE.Plane
+            newXyz: THREE.Vector3
+          }
+          let move: Move | null = null
+          const startMove = (e: PointerEvent): void => {
+            const robot = robotRef.current
+            if (!robot) return
+            buildNdcFrom(e)
+            buildRay.setFromCamera(buildNdc, camera)
+            const hit = buildRay.intersectObject(robot, true).find((h) => h.face)
+            if (!hit || !hit.face) return
+            const link = ownerLinkName(hit.object)
+            if (!link) return
+            setSelectedLink(link)
+            const joint = readJoint(contentRef.current, link) // null for the root
+            const linkObj = robot.links[link]
+            const jointObj = linkObj?.parent
+            const geom = readPrimitive(contentRef.current, link)
+            const parentLink = jointObj?.parent
+            if (!joint || !jointObj || !linkObj || !geom || !parentLink) return
+            robot.updateMatrixWorld(true)
+            const parentBasis = [...new THREE.Matrix3().setFromMatrix4(parentLink.matrixWorld).elements]
+            const { pts } = hitToHandles(hit, link, geom)
+            const near = nearestScreen(pts, e)
+            const grab = (near.index >= 0 ? pts[near.index] : hit.point).clone()
+            camera.getWorldDirection(camDir)
+            move = {
+              link,
+              jointObj,
+              oldXyz: jointObj.position.clone(),
+              parentBasis,
+              grab,
+              anchor: hit.point.clone(),
+              plane: new THREE.Plane().setFromNormalAndCoplanarPoint(camDir, hit.point),
+              newXyz: jointObj.position.clone()
+            }
+            controls.enabled = false
+            ;(e.target as HTMLElement).setPointerCapture?.(e.pointerId)
+          }
+
+          const onBuildDown = (e: PointerEvent): void => {
+            bDownX = e.clientX
+            bDownY = e.clientY
+            if (!buildActive() || !canEditRef.current || !robotRef.current) return
+            if (buildToolRef.current === 'pushpull') startResize(e)
+            else if (buildToolRef.current === 'move') startMove(e)
+          }
+
           const onBuildMove = (e: PointerEvent): void => {
-            if (!drag) return
+            if (drag) {
+              buildNdcFrom(e)
+              buildRay.setFromCamera(buildNdc, camera)
+              const p = new THREE.Vector3()
+              if (!buildRay.ray.intersectPlane(drag.plane, p)) return
+              const delta = p.sub(drag.anchor).dot(drag.nWorld)
+              const res = resizeFromDrag(drag.dims0, drag.origin0, drag.face, delta, {
+                step: e.shiftKey ? 0.001 : 0.005
+              })
+              applyPreview(drag.kind, drag.mesh, drag.group, res.dims, res.origin)
+              drag.preview = res
+              const rect = mount.getBoundingClientRect()
+              setBuildDim({ x: e.clientX - rect.left + 14, y: e.clientY - rect.top + 14, text: dimText(drag.kind, drag.face, res.dims) })
+              return
+            }
+            if (!move || !robotRef.current) return
             buildNdcFrom(e)
             buildRay.setFromCamera(buildNdc, camera)
             const p = new THREE.Vector3()
-            if (!buildRay.ray.intersectPlane(drag.plane, p)) return
-            const delta = p.sub(drag.anchor).dot(drag.nWorld)
-            const step = e.shiftKey ? 0.001 : 0.005
-            const res = resizeFromDrag(drag.dims0, drag.origin0, drag.face, delta, { step })
-            applyPreview(drag.kind, drag.mesh, drag.group, res.dims, res.origin)
-            drag.preview = res
+            if (!buildRay.ray.intersectPlane(move.plane, p)) return
+            const freeDelta = p.clone().sub(move.anchor)
+            const movedGrab = move.grab.clone().add(freeDelta)
+            // Snap the moved grab point to a handle on ANOTHER block under the cursor.
+            let snapWorld: THREE.Vector3 | null = null
+            let snapRole: string | null = null
+            let handles: THREE.Vector3[] = []
+            let activeIdx = -1
+            const tHit = buildRay
+              .intersectObject(robotRef.current, true)
+              .filter((h) => h.face && ownerLinkName(h.object) !== move!.link)
+              .find((h) => h.face)
+            if (tHit) {
+              const tLink = ownerLinkName(tHit.object)!
+              const tGeom = readPrimitive(contentRef.current, tLink)
+              if (tGeom) {
+                const th = hitToHandles(tHit, tLink, tGeom)
+                handles = th.pts
+                const near = nearestScreen(handles, e)
+                const gp = movedGrab.clone().project(camera)
+                const hp = near.index >= 0 ? handles[near.index].clone().project(camera) : gp
+                const rect = renderer.domElement.getBoundingClientRect()
+                const dpx = Math.hypot(((hp.x - gp.x) * rect.width) / 2, ((hp.y - gp.y) * rect.height) / 2)
+                if (near.index >= 0 && dpx < 16) {
+                  snapWorld = handles[near.index]
+                  snapRole = th.roles[near.index]
+                  activeIdx = near.index
+                }
+              }
+            }
+            const worldDelta = snapWorld ? snapWorld.clone().sub(move.grab) : freeDelta
+            const nx = movedJointOrigin(
+              [move.oldXyz.x, move.oldXyz.y, move.oldXyz.z],
+              [worldDelta.x, worldDelta.y, worldDelta.z] as Vec3,
+              move.parentBasis,
+              snapWorld ? {} : { step: e.shiftKey ? 0.001 : 0.005 }
+            )
+            move.newXyz.set(nx[0], nx[1], nx[2])
+            move.jointObj.position.copy(move.newXyz)
+            showHandles(handles, activeIdx)
             const rect = mount.getBoundingClientRect()
             setBuildDim({
               x: e.clientX - rect.left + 14,
               y: e.clientY - rect.top + 14,
-              text: dimText(drag.kind, drag.face, res.dims)
+              text: snapRole ? `snap ✓ ${snapRole}` : `${mmv(nx[0])} · ${mmv(nx[1])} · ${mmv(nx[2])} mm`
             })
           }
+
           const onBuildUp = (e: PointerEvent): void => {
-            const d = drag
-            drag = null
-            controls.enabled = true
-            if (d) {
+            if (drag) {
+              const d = drag
+              drag = null
+              controls.enabled = true
               setBuildDim(null)
               if (d.preview) {
                 let next = setPrimitiveSize(contentRef.current, d.link, d.preview.dims)
@@ -1102,42 +1289,87 @@ export function RobotView({
               }
               return
             }
+            if (move) {
+              const mv = move
+              move = null
+              controls.enabled = true
+              setBuildDim(null)
+              clearHandles()
+              if (!mv.newXyz.equals(mv.oldXyz)) {
+                commitUrdfRef.current?.(
+                  setJointOrigin(contentRef.current, mv.link, [mv.newXyz.x, mv.newXyz.y, mv.newXyz.z])
+                )
+              }
+              return
+            }
+            // Select tool / plain click → pick the block under the cursor.
             if (!buildActive() || !robotRef.current) return
             if (Math.hypot(e.clientX - bDownX, e.clientY - bDownY) > 4) return
             buildNdcFrom(e)
             buildRay.setFromCamera(buildNdc, camera)
-            const hit = buildRay.intersectObject(robotRef.current, true)[0]
-            if (!hit) return
-            let o: THREE.Object3D | null = hit.object
-            while (o && !(o as unknown as { isURDFLink?: boolean }).isURDFLink) o = o.parent
-            const name = (o as unknown as { urdfName?: string } | null)?.urdfName
+            const name = ownerLinkName(buildRay.intersectObject(robotRef.current, true)[0]?.object ?? null)
             if (name) setSelectedLink(name)
           }
 
+          // Hover: show a face's snap handles when the Move tool is active + idle.
+          const onBuildHover = (e: PointerEvent): void => {
+            if (drag || move) return
+            if (!buildActive() || buildToolRef.current !== 'move' || !robotRef.current) {
+              if (snapGroup.children.length) clearHandles()
+              return
+            }
+            buildNdcFrom(e)
+            buildRay.setFromCamera(buildNdc, camera)
+            const hit = buildRay.intersectObject(robotRef.current, true).find((h) => h.face)
+            const link = hit ? ownerLinkName(hit.object) : null
+            const geom = link ? readPrimitive(contentRef.current, link) : null
+            if (!hit || !link || !geom) {
+              clearHandles()
+              return
+            }
+            const th = hitToHandles(hit, link, geom)
+            const near = nearestScreen(th.pts, e)
+            showHandles(th.pts, near.distPx < 16 ? near.index : -1)
+          }
+
           // A cancelled/interrupted drag must never strand OrbitControls disabled
-          // or leave a half-resized preview: revert to the pre-drag size.
+          // or leave a half-applied preview.
           const onBuildCancel = (): void => {
-            const d = drag
-            drag = null
             controls.enabled = true
             setBuildDim(null)
-            if (d) applyPreview(d.kind, d.mesh, d.group, d.dims0, d.origin0)
+            clearHandles()
+            if (drag) {
+              applyPreview(drag.kind, drag.mesh, drag.group, drag.dims0, drag.origin0)
+              drag = null
+            }
+            if (move) {
+              move.jointObj.position.copy(move.oldXyz)
+              move = null
+            }
           }
           renderer.domElement.addEventListener('pointerdown', onDown)
           renderer.domElement.addEventListener('pointerup', onUp)
           renderer.domElement.addEventListener('pointerdown', onBuildDown)
           renderer.domElement.addEventListener('pointermove', onBuildMove)
+          renderer.domElement.addEventListener('pointermove', onBuildHover)
           renderer.domElement.addEventListener('pointerup', onBuildUp)
           renderer.domElement.addEventListener('pointercancel', onBuildCancel)
           renderer.domElement.addEventListener('lostpointercapture', onBuildCancel)
+          renderer.domElement.addEventListener('pointerleave', clearHandles)
           teardownPose = () => {
             renderer.domElement.removeEventListener('pointerdown', onDown)
             renderer.domElement.removeEventListener('pointerup', onUp)
             renderer.domElement.removeEventListener('pointerdown', onBuildDown)
             renderer.domElement.removeEventListener('pointermove', onBuildMove)
+            renderer.domElement.removeEventListener('pointermove', onBuildHover)
             renderer.domElement.removeEventListener('pointerup', onBuildUp)
             renderer.domElement.removeEventListener('pointercancel', onBuildCancel)
             renderer.domElement.removeEventListener('lostpointercapture', onBuildCancel)
+            renderer.domElement.removeEventListener('pointerleave', clearHandles)
+            scene.remove(snapGroup)
+            handleGeo.dispose()
+            handleMat.dispose()
+            handleMatOn.dispose()
             clearMeasure()
             markerMat.dispose()
             lineMat.dispose()
@@ -1228,6 +1460,9 @@ export function RobotView({
           <div className="robotview__note" role="status">
             {meshNote}
           </div>
+        )}
+        {showPanel && buildOpen && (
+          <RobotToolbar tool={buildTool} onSetTool={onSetTool} canEdit={canEdit} />
         )}
         {showPanel && (
           <RobotBuildPanel

--- a/src/renderer/src/components/robot-assembly.ts
+++ b/src/renderer/src/components/robot-assembly.ts
@@ -4,7 +4,7 @@
  * and appending an imported mesh as a new link/joint. Regex-based (no DOM) so
  * they're cheap to unit-test in a node env.
  */
-import type { PrimitiveKind } from './robot-build'
+import type { PrimitiveKind, Vec3 } from './robot-build'
 
 /**
  * A minimal, VALID starter URDF: one `base_link` with a small box so the pose
@@ -268,6 +268,30 @@ export function setVisualOrigin(
   else visual = visual.replace(/<visual\b[^>]*>/i, (v) => `${v}\n      ${tag}`)
   const nextBody = body.slice(0, vs.start) + visual + body.slice(vs.end)
   return urdf.slice(0, span.bodyStart) + nextBody + urdf.slice(span.bodyEnd)
+}
+
+/** Read the joint whose `<child>` is `childLink`, or null (e.g. the root link has
+ *  none — the move tool uses that to refuse moving the base). */
+export function readJoint(
+  urdf: string,
+  childLink: string
+): { name: string; parent: string; type: string; xyz: Vec3; rpy: Vec3 } | null {
+  const re = /<joint\b([^>]*)>([\s\S]*?)<\/joint>/gi
+  const childRe = new RegExp(`<child\\b[^>]*\\blink\\s*=\\s*"${escapeRe(childLink)}"`, 'i')
+  let m: RegExpExecArray | null
+  while ((m = re.exec(urdf))) {
+    if (!childRe.test(m[2])) continue
+    const originM = /<origin\b[^>]*\bxyz\s*=\s*"([^"]+)"/i.exec(m[2])
+    const rpyM = /<origin\b[^>]*\brpy\s*=\s*"([^"]+)"/i.exec(m[2])
+    return {
+      name: /\bname\s*=\s*"([^"]+)"/.exec(m[1])?.[1] ?? '',
+      type: /\btype\s*=\s*"([^"]+)"/.exec(m[1])?.[1] ?? 'fixed',
+      parent: /<parent\b[^>]*\blink\s*=\s*"([^"]+)"/i.exec(m[2])?.[1] ?? '',
+      xyz: originM ? parseVec3(originM[1]) : [0, 0, 0],
+      rpy: rpyM ? parseVec3(rpyM[1]) : [0, 0, 0]
+    }
+  }
+  return null
 }
 
 /** Set the fixed-joint origin whose child is `childLink` (moves the whole part). */

--- a/src/renderer/src/components/robot-build.ts
+++ b/src/renderer/src/components/robot-build.ts
@@ -6,6 +6,10 @@
  * box `[x, y, z]`, cylinder `[radius, length]`, sphere `[radius]`.
  */
 export type PrimitiveKind = 'box' | 'cylinder' | 'sphere'
+export type Vec3 = [number, number, number]
+
+/** The active builder tool (#335). */
+export type BuildTool = 'select' | 'pushpull' | 'move' | 'joint'
 
 /** Which dimension a picked face resizes, and how. */
 export interface FaceEdit {
@@ -70,4 +74,107 @@ export function resizeFromDrag(
   d[face.dim] = newDim
   if (!face.symmetric) o[face.axis] += (face.sign * (newDim - oldDim)) / 2
   return { dims: d, origin: o }
+}
+
+// ── Snap points + move (#335) — PURE, unit-tested ───────────────────────────
+
+/** A Fusion-style snap handle on a face: a corner, edge-midpoint, or the centre. */
+export interface SnapPoint {
+  p: Vec3
+  role: 'corner' | 'edge' | 'centre'
+}
+
+/**
+ * The snap handles of a picked face, in the LINK frame (metres): a box face gives
+ * 4 corners + 4 edge-mids + centre; a cylinder cap gives a rim circle + centre;
+ * anything else gives just the primitive centre. Reaches world via
+ * `applyMatrix4(link.matrixWorld)` (rigid — no scale) in the view.
+ */
+export function faceSnapPoints(geom: { kind: PrimitiveKind; dims: number[]; origin: Vec3 }, face: FaceEdit): SnapPoint[] {
+  const o = geom.origin
+  if (geom.kind === 'box') {
+    const h = [geom.dims[0] / 2, geom.dims[1] / 2, geom.dims[2] / 2]
+    const a = face.axis
+    const [u, v] = ([0, 1, 2].filter((i) => i !== a) as [number, number])
+    const ca = o[a] + face.sign * h[a]
+    const pt = (su: number, sv: number, role: SnapPoint['role']): SnapPoint => {
+      const p: Vec3 = [0, 0, 0]
+      p[a] = ca
+      p[u] = o[u] + su * h[u]
+      p[v] = o[v] + sv * h[v]
+      return { p, role }
+    }
+    return [
+      pt(1, 1, 'corner'), pt(1, -1, 'corner'), pt(-1, 1, 'corner'), pt(-1, -1, 'corner'),
+      pt(1, 0, 'edge'), pt(-1, 0, 'edge'), pt(0, 1, 'edge'), pt(0, -1, 'edge'),
+      pt(0, 0, 'centre')
+    ]
+  }
+  if (geom.kind === 'cylinder' && face.axis === 2) {
+    const r = geom.dims[0]
+    const cz = o[2] + face.sign * (geom.dims[1] / 2)
+    const d = r / Math.SQRT2
+    return [
+      { p: [o[0], o[1], cz], role: 'centre' },
+      { p: [o[0] + r, o[1], cz], role: 'edge' }, { p: [o[0] - r, o[1], cz], role: 'edge' },
+      { p: [o[0], o[1] + r, cz], role: 'edge' }, { p: [o[0], o[1] - r, cz], role: 'edge' },
+      { p: [o[0] + d, o[1] + d, cz], role: 'corner' }, { p: [o[0] - d, o[1] + d, cz], role: 'corner' },
+      { p: [o[0] + d, o[1] - d, cz], role: 'corner' }, { p: [o[0] - d, o[1] - d, cz], role: 'corner' }
+    ]
+  }
+  return [{ p: [o[0], o[1], o[2]], role: 'centre' }]
+}
+
+/** Index of the nearest candidate point to `to` (Euclidean), or -1 if empty. */
+export function nearestIndex(cands: readonly Vec3[], to: Vec3): { index: number; dist: number } {
+  let index = -1
+  let best = Infinity
+  for (let i = 0; i < cands.length; i++) {
+    const c = cands[i]
+    const dx = c[0] - to[0]
+    const dy = c[1] - to[1]
+    const dz = c[2] - to[2]
+    const d = dx * dx + dy * dy + dz * dz
+    if (d < best) {
+      best = d
+      index = i
+    }
+  }
+  return { index, dist: index < 0 ? Infinity : Math.sqrt(best) }
+}
+
+/**
+ * Rotate a WORLD delta into the PARENT link frame (the fixed-joint origin frame).
+ * `parentBasis` is the column-major 3×3 of the parent link's world matrix
+ * (THREE.Matrix3().setFromMatrix4(parentLink.matrixWorld).elements); since link
+ * transforms are rigid, the parent-frame delta is Rᵀ·d.
+ */
+export function worldDeltaToParent(worldDelta: Vec3, parentBasis: readonly number[]): Vec3 {
+  const [dx, dy, dz] = worldDelta
+  const e = parentBasis
+  return [
+    e[0] * dx + e[1] * dy + e[2] * dz,
+    e[3] * dx + e[4] * dy + e[5] * dz,
+    e[6] * dx + e[7] * dy + e[8] * dz
+  ]
+}
+
+/** The moved fixed-joint origin: old origin + the world delta in the parent frame,
+ *  optionally grid-snapped per axis. */
+export function movedJointOrigin(
+  oldXyz: Vec3,
+  worldDelta: Vec3,
+  parentBasis: readonly number[],
+  opts: { step?: number } = {}
+): Vec3 {
+  const l = worldDeltaToParent(worldDelta, parentBasis)
+  const r: Vec3 = [oldXyz[0] + l[0], oldXyz[1] + l[1], oldXyz[2] + l[2]]
+  const s = opts.step
+  return s ? [snapDimension(r[0], s), snapDimension(r[1], s), snapDimension(r[2], s)] : r
+}
+
+/** The joint origin (in B's frame) that makes A's local point coincide with B's —
+ *  a plain subtraction (both points are in their own axis-aligned link frames). */
+export function jointOriginForCoincident(aLocal: Vec3, bLocal: Vec3): Vec3 {
+  return [bLocal[0] - aLocal[0], bLocal[1] - aLocal[1], bLocal[2] - aLocal[2]]
 }

--- a/test/robotSnap.test.ts
+++ b/test/robotSnap.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import {
+  classifyFace,
+  faceSnapPoints,
+  nearestIndex,
+  worldDeltaToParent,
+  movedJointOrigin,
+  jointOriginForCoincident,
+  type Vec3
+} from '../src/renderer/src/components/robot-build'
+import { addPrimitive, readJoint, blankUrdf } from '../src/renderer/src/components/robot-assembly'
+
+describe('faceSnapPoints (#335)', () => {
+  it('gives a box face 9 handles (4 corners, 4 edge-mids, centre) in the link frame', () => {
+    const geom = { kind: 'box' as const, dims: [0.04, 0.06, 0.02], origin: [0, 0, 0] as Vec3 }
+    const face = classifyFace([1, 0, 0], 'box') // +X
+    const pts = faceSnapPoints(geom, face)
+    expect(pts).toHaveLength(9)
+    expect(pts.filter((p) => p.role === 'corner')).toHaveLength(4)
+    expect(pts.filter((p) => p.role === 'edge')).toHaveLength(4)
+    const centre = pts.find((p) => p.role === 'centre')!
+    expect(centre.p).toEqual([0.02, 0, 0]) // face plane at +x half-extent
+    expect(pts.some((p) => p.role === 'corner' && p.p[1] === 0.03 && p.p[2] === 0.01)).toBe(true)
+  })
+  it('offsets all handles by the visual origin', () => {
+    const geom = { kind: 'box' as const, dims: [0.04, 0.04, 0.04], origin: [0.1, 0, 0] as Vec3 }
+    const c = faceSnapPoints(geom, classifyFace([1, 0, 0], 'box')).find((p) => p.role === 'centre')!
+    expect(c.p[0]).toBeCloseTo(0.12) // 0.1 origin + 0.02 half
+    expect(c.p[1]).toBe(0)
+    expect(c.p[2]).toBe(0)
+  })
+  it('gives a cylinder cap a rim circle + centre at the cap plane', () => {
+    const geom = { kind: 'cylinder' as const, dims: [0.02, 0.06], origin: [0, 0, 0] as Vec3 }
+    const pts = faceSnapPoints(geom, classifyFace([0, 0, 1], 'cylinder')) // +Z cap
+    expect(pts).toHaveLength(9)
+    expect(pts[0]).toEqual({ p: [0, 0, 0.03], role: 'centre' }) // cz = +length/2
+    expect(pts.some((p) => p.p[0] === 0.02 && p.p[2] === 0.03)).toBe(true) // rim
+  })
+  it('gives a sphere just its centre', () => {
+    const pts = faceSnapPoints({ kind: 'sphere', dims: [0.03], origin: [0, 0.05, 0] }, classifyFace([0, 1, 0], 'sphere'))
+    expect(pts).toEqual([{ p: [0, 0.05, 0], role: 'centre' }])
+  })
+})
+
+describe('nearestIndex (#335)', () => {
+  it('picks the closest candidate; empty → -1', () => {
+    const cands: Vec3[] = [[0, 0, 0], [1, 0, 0], [0, 1, 0]]
+    expect(nearestIndex(cands, [0.9, 0.1, 0]).index).toBe(1)
+    expect(nearestIndex([], [0, 0, 0])).toEqual({ index: -1, dist: Infinity })
+  })
+})
+
+describe('world → parent-frame maths (#335)', () => {
+  it('identity basis passes the delta through', () => {
+    expect(worldDeltaToParent([0.01, -0.02, 0.03], [1, 0, 0, 0, 1, 0, 0, 0, 1])).toEqual([0.01, -0.02, 0.03])
+  })
+  it('a 90° about-X basis maps world +Y to parent −Z', () => {
+    // R = Rx(90): columns [1,0,0],[0,0,1],[0,-1,0] (col-major)
+    const basis = [1, 0, 0, 0, 0, 1, 0, -1, 0]
+    const out = worldDeltaToParent([0, 1, 0], basis)
+    expect(out[0]).toBeCloseTo(0)
+    expect(out[1]).toBeCloseTo(0)
+    expect(out[2]).toBeCloseTo(-1)
+  })
+  it('movedJointOrigin adds the parent-frame delta and grid-snaps', () => {
+    const r = movedJointOrigin([0.06, 0, 0], [0.013, 0, 0], [1, 0, 0, 0, 1, 0, 0, 0, 1], { step: 0.005 })
+    expect(r[0]).toBeCloseTo(0.075) // 0.06 + 0.013 = 0.073 → snap 5mm → 0.075
+  })
+  it('jointOriginForCoincident is B − A', () => {
+    expect(jointOriginForCoincident([0.02, 0, 0], [0, 0.01, 0.03])).toEqual([-0.02, 0.01, 0.03])
+  })
+})
+
+describe('readJoint (#335)', () => {
+  it('reads a fixed joint origin/parent/type for a child; null for the root', () => {
+    const u = addPrimitive(blankUrdf('bot'), { kind: 'box', linkBase: 'arm', parent: 'base_link' }).urdf
+    const j = readJoint(u, 'arm')!
+    expect(j.parent).toBe('base_link')
+    expect(j.type).toBe('fixed')
+    expect(j.xyz).toEqual([0.06, 0, 0])
+    expect(readJoint(u, 'base_link')).toBeNull() // root has no parent joint → move refused
+    expect(readJoint(u, 'ghost')).toBeNull()
+  })
+})


### PR DESCRIPTION
Closes #335 (epic #309, Phase 5 — the Fusion-style builder).

Adds a floating **tool toolbar** to the block builder and a **Move** tool with Fusion-style snapping, so a child can slide a block into place and have it click onto another block's corner/edge/centre.

## What's new
- **Toolbar** (top-centre of the 3-D stage): **Pick** · **Push & pull** · **Move** · **Join** *(coming soon, disabled)*. The active tool owns the canvas pointer.
- **Move tool** — drag a block to rewrite its **fixed-joint origin** in the linked URDF. Live **mm read-out**, **5 mm grid** (hold **Shift** → 1 mm). Hover a face and **snap handles** appear on its corners / edge-mids / centre; release within 16 px of another block's handle and the grabbed face point drops **coincident** with it (read-out shows `snap ✓ <role>`).
- **Push & pull** now retargets to the **selected** block, so it works from the toolbar (not only the edit pencil).
- The Build panel no longer auto-hides when focus moves to the toolbar.

## Architecture
- Pure maths in `robot-build.ts` (`faceSnapPoints`, `nearestIndex`, `worldDeltaToParent` = Rᵀ·d, `movedJointOrigin`, `jointOriginForCoincident`) + `readJoint` in `robot-assembly.ts` — no three.js/React. **10 unit tests** in `test/robotSnap.test.ts`.
- The joint object's local `.position` *is* the URDF `<origin xyz>`, so the live move preview needs no frame conversion; only the world-delta→parent-frame step uses Rᵀ·d.
- Cancel/interrupt (`pointercancel`, `lostpointercapture`) reverts the preview and re-enables OrbitControls; teardown disposes the snap-handle geometry/materials and removes all listeners.

## Verification
- `npm run typecheck` · `npm run lint` · `npm test` (**1497 passing**) · `npm run build` — all green.
- In-app smoke (Playwright): toolbar renders 4 tools; Move drag moved a box `0.1 0 0.06` → `0.08 -0.03 0.05` with a live `80 · -30 · 50 mm` HUD; Push & pull via the toolbar grew the plate `…0.06` → `…0.07` with a `70 mm` HUD.

Deferred to follow-ups: the **Join** tool (add a static/moving joint by picking two snap points) is stubbed/disabled; revolute/prismatic + mimic editing is #315b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)