### PR TITLE
feat: Robot joint editor — hinge/slider/wheel + axis/limits/mimic (#315)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Robot View — joint editor: hinges, sliders, wheels + mimic (#315, epic #309
+  Phase 5).** Editing a block in the Build panel now also sets **how it moves**
+  relative to its parent: pick **Fixed / Hinge / Slider / Wheel** (URDF
+  fixed / revolute / prismatic / continuous), choose the **axis** (X / Y / Z) and
+  set **limits** (degrees for a hinge, mm for a slider). A **Copies** dropdown
+  makes the joint **mimic** another with a gear ratio (× multiplier + offset) —
+  e.g. a gripper's two fingers, or a geared pair. Every change rewrites the URDF
+  and shows up **live** in the pose tool and the motion timeline, so you can
+  build a 2-link arm from blocks, make the elbow a hinge and pose it straight
+  away. Completes the #315 builder scope (primitives + push/pull + move + joints).
 - **Robot View — builder tools: a toolbar + move-with-snap (#335, epic #309
   Phase 5).** The block builder gains a floating **tool toolbar** (top-centre of
   the stage): **Pick** (select), **Push & pull** (resize a face), **Move** a

--- a/src/renderer/src/components/RobotBuildPanel.css
+++ b/src/renderer/src/components/RobotBuildPanel.css
@@ -193,9 +193,88 @@
 }
 .robotbuild__editrow {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.3rem;
   padding: 0.15rem 0.3rem 0.3rem;
+}
+.robotbuild__editmain {
+  display: flex;
+  flex-direction: column;
+  gap: 0.28rem;
+  flex: 1;
+  min-width: 0;
+}
+.robotbuild__joint {
+  display: flex;
+  flex-direction: column;
+  gap: 0.22rem;
+}
+.robotbuild__jrow {
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+  flex-wrap: wrap;
+}
+.robotbuild__jlabel {
+  font-size: 0.54rem;
+  color: var(--text-muted, #8b919b);
+  width: 2.3rem;
+  flex-shrink: 0;
+}
+.robotbuild__chip {
+  font-family: inherit;
+  font-size: 0.55rem;
+  color: var(--text-muted, #9aa0a6);
+  background: var(--bg-sunken, rgba(0, 0, 0, 0.25));
+  border: 1px solid var(--border, #34373d);
+  border-radius: 4px;
+  padding: 0.08rem 0.32rem;
+  cursor: pointer;
+}
+.robotbuild__chip--axis {
+  min-width: 1.35rem;
+  text-align: center;
+}
+.robotbuild__chip:hover:not(.is-on) {
+  color: var(--text, #cdd2d9);
+  border-color: var(--text-muted, #6b7079);
+}
+.robotbuild__chip.is-on {
+  color: #1a1c20;
+  background: #c8a24a;
+  border-color: #c8a24a;
+}
+.robotbuild__jnote,
+.robotbuild__jsel {
+  font-size: 0.55rem;
+  color: var(--text-muted, #9aa0a6);
+}
+.robotbuild__jsel {
+  font-family: inherit;
+  color: var(--text, #cdd2d9);
+  background: var(--bg-sunken, rgba(0, 0, 0, 0.3));
+  border: 1px solid var(--border, #34373d);
+  border-radius: 4px;
+  padding: 0.06rem 0.15rem;
+  max-width: 6.5rem;
+}
+.robotbuild__jratio {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.12rem;
+  font-size: 0.55rem;
+  color: var(--text-muted, #8b919b);
+}
+.robotbuild__jratio input {
+  width: 2.4rem;
+  font-family: inherit;
+  font-size: 0.58rem;
+  color: var(--text, #cdd2d9);
+  background: var(--bg-sunken, rgba(0, 0, 0, 0.3));
+  border: 1px solid var(--border, #34373d);
+  border-radius: 4px;
+  padding: 0.08rem 0.15rem;
+  text-align: center;
 }
 .robotbuild__size {
   display: flex;

--- a/src/renderer/src/components/RobotBuildPanel.tsx
+++ b/src/renderer/src/components/RobotBuildPanel.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from 'react'
-import type { AssemblyItem, PrimitiveGeom } from './robot-assembly'
-import type { PrimitiveKind } from './robot-build'
+import type { AssemblyItem, PrimitiveGeom, JointDef, JointType, JointSpec } from './robot-assembly'
+import type { PrimitiveKind, Vec3 } from './robot-build'
+import { principalAxisName } from './robot-build'
+import { toDisplay, toNative, unitLabel, type MovableType } from './robot-pose'
 import { baseName } from './robot-mesh'
 import { shouldAutoHide } from './pin-overlay'
 import './RobotBuildPanel.css'
@@ -41,6 +43,10 @@ export interface RobotBuildPanelProps {
   editGeom: PrimitiveGeom | null
   onAdd: (kind: PrimitiveKind) => void
   onSetSize: (link: string, dims: number[]) => void
+  /** The parent joint of the link being edited (null for the root), + a setter. */
+  editJoint: JointDef | null
+  jointNames: string[]
+  onSetJoint: (link: string, spec: JointSpec) => void
   onDelete: (link: string) => void
   onImportStl: () => void
   canImport: boolean
@@ -109,6 +115,198 @@ function SizeForm({
   )
 }
 
+// Kid-friendly names for the URDF joint types (jargon lives in the tooltip).
+const JOINT_KINDS: Array<{ id: JointType; label: string; hint: string }> = [
+  { id: 'fixed', label: 'Fixed', hint: 'Glued in place — no movement' },
+  { id: 'revolute', label: 'Hinge', hint: 'Rotates about an axis, within limits (revolute)' },
+  { id: 'continuous', label: 'Wheel', hint: 'Spins freely, no limits (continuous)' },
+  { id: 'prismatic', label: 'Slider', hint: 'Slides along an axis, within limits (prismatic)' }
+]
+const AXES: Array<{ id: 'x' | 'y' | 'z'; vec: Vec3 }> = [
+  { id: 'x', vec: [1, 0, 0] },
+  { id: 'y', vec: [0, 1, 0] },
+  { id: 'z', vec: [0, 0, 1] }
+]
+
+/** The joint editor (#315b): type, axis, limits and a mimic coupling. */
+function JointForm({
+  joint,
+  names,
+  onChange
+}: {
+  joint: JointDef
+  names: string[]
+  onChange: (spec: JointSpec) => void
+}): JSX.Element {
+  // The current joint as a full spec, so each edit preserves the other fields.
+  const spec = (): JointSpec => ({
+    type: joint.type,
+    axis: joint.axis ?? [0, 0, 1],
+    lower: joint.limit?.lower,
+    upper: joint.limit?.upper,
+    mimic: joint.mimic
+  })
+  const movable = joint.type !== 'fixed'
+  const bounded = joint.type === 'revolute' || joint.type === 'prismatic'
+  const mt = (movable ? joint.type : 'revolute') as MovableType
+  const activeAxis = principalAxisName(joint.axis)
+
+  // Local limit fields (display units) so typing doesn't rebuild per keystroke.
+  const disp = (n?: number): number => (n == null ? 0 : Math.round(toDisplay(mt, n) * 100) / 100)
+  const lo = disp(joint.limit?.lower)
+  const hi = disp(joint.limit?.upper)
+  const [lim, setLim] = useState<[number, number]>([lo, hi])
+  const limKey = `${joint.name}:${joint.type}:${lo}:${hi}`
+  useEffect(() => setLim([lo, hi]), [limKey]) // eslint-disable-line react-hooks/exhaustive-deps
+  const commitLim = (): void =>
+    onChange({ ...spec(), lower: toNative(mt, lim[0]), upper: toNative(mt, lim[1]) })
+
+  const others = names.filter((n) => n !== joint.name)
+  const unit = unitLabel(mt)
+
+  return (
+    <div className="robotbuild__joint">
+      <div className="robotbuild__jrow" role="group" aria-label="Joint type">
+        {JOINT_KINDS.map((k) => (
+          <button
+            key={k.id}
+            type="button"
+            className={`robotbuild__chip${joint.type === k.id ? ' is-on' : ''}`}
+            title={k.hint}
+            onClick={() => onChange({ ...spec(), type: k.id })}
+          >
+            {k.label}
+          </button>
+        ))}
+      </div>
+      {movable && (
+        <div className="robotbuild__jrow">
+          <span className="robotbuild__jlabel">Axis</span>
+          {AXES.map((a) => (
+            <button
+              key={a.id}
+              type="button"
+              className={`robotbuild__chip robotbuild__chip--axis${activeAxis === a.id ? ' is-on' : ''}`}
+              title={`Move about the ${a.id.toUpperCase()} axis`}
+              onClick={() => onChange({ ...spec(), axis: a.vec })}
+            >
+              {a.id.toUpperCase()}
+            </button>
+          ))}
+          {activeAxis === 'custom' && <span className="robotbuild__jnote">custom</span>}
+        </div>
+      )}
+      {bounded && (
+        <div className="robotbuild__jrow">
+          <span className="robotbuild__jlabel">Limits</span>
+          <label className="robotbuild__mm">
+            <span>min</span>
+            <input
+              type="number"
+              value={Number.isFinite(lim[0]) ? lim[0] : ''}
+              onChange={(e) => setLim([Number(e.target.value), lim[1]])}
+              onBlur={commitLim}
+              onKeyDown={(e) => e.key === 'Enter' && commitLim()}
+            />
+          </label>
+          <label className="robotbuild__mm">
+            <span>max</span>
+            <input
+              type="number"
+              value={Number.isFinite(lim[1]) ? lim[1] : ''}
+              onChange={(e) => setLim([lim[0], Number(e.target.value)])}
+              onBlur={commitLim}
+              onKeyDown={(e) => e.key === 'Enter' && commitLim()}
+            />
+          </label>
+          <span className="robotbuild__mm-unit">{unit}</span>
+        </div>
+      )}
+      {movable && (
+        <div className="robotbuild__jrow">
+          <span className="robotbuild__jlabel" title="This joint copies another (gear ratio)">
+            Copies
+          </span>
+          <select
+            className="robotbuild__jsel"
+            value={joint.mimic?.joint ?? ''}
+            onChange={(e) =>
+              onChange({
+                ...spec(),
+                mimic: e.target.value
+                  ? { joint: e.target.value, multiplier: joint.mimic?.multiplier ?? 1, offset: joint.mimic?.offset ?? 0 }
+                  : null
+              })
+            }
+          >
+            <option value="">— none —</option>
+            {others.map((n) => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
+          {joint.mimic && (
+            <MimicRatio
+              key={`${joint.name}:${joint.mimic.joint}`}
+              mult={joint.mimic.multiplier}
+              offset={disp(joint.mimic.offset)}
+              unit={unit}
+              onChange={(mult, offsetDisp) =>
+                onChange({
+                  ...spec(),
+                  mimic: { joint: joint.mimic!.joint, multiplier: mult, offset: toNative(mt, offsetDisp) }
+                })
+              }
+            />
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** The `× multiplier + offset` fields of a mimic coupling (local, commit on blur). */
+function MimicRatio({
+  mult,
+  offset,
+  unit,
+  onChange
+}: {
+  mult: number
+  offset: number
+  unit: string
+  onChange: (mult: number, offset: number) => void
+}): JSX.Element {
+  const [m, setM] = useState(mult)
+  const [o, setO] = useState(offset)
+  const commit = (): void => onChange(Number.isFinite(m) ? m : 1, Number.isFinite(o) ? o : 0)
+  return (
+    <span className="robotbuild__jratio">
+      <span>×</span>
+      <input
+        type="number"
+        step={0.1}
+        value={Number.isFinite(m) ? m : ''}
+        title="Gear ratio (negative to reverse)"
+        onChange={(e) => setM(Number(e.target.value))}
+        onBlur={commit}
+        onKeyDown={(e) => e.key === 'Enter' && commit()}
+      />
+      <span>+</span>
+      <input
+        type="number"
+        value={Number.isFinite(o) ? o : ''}
+        title={`Offset (${unit})`}
+        onChange={(e) => setO(Number(e.target.value))}
+        onBlur={commit}
+        onKeyDown={(e) => e.key === 'Enter' && commit()}
+      />
+      <span className="robotbuild__mm-unit">{unit}</span>
+    </span>
+  )
+}
+
 export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
   const {
     open,
@@ -123,6 +321,9 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
     editGeom,
     onAdd,
     onSetSize,
+    editJoint,
+    jointNames,
+    onSetJoint,
     onDelete,
     onImportStl,
     canImport,
@@ -233,11 +434,22 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
               </div>
               {isEdit && (
                 <div className="robotbuild__editrow">
-                  {editGeom ? (
-                    <SizeForm geom={editGeom} onChange={(d) => onSetSize(it.link, d)} />
-                  ) : (
-                    <span className="robotbuild__editnote">Grab a face in 3D to resize, or…</span>
-                  )}
+                  <div className="robotbuild__editmain">
+                    {editGeom ? (
+                      <SizeForm geom={editGeom} onChange={(d) => onSetSize(it.link, d)} />
+                    ) : (
+                      <span className="robotbuild__editnote">Grab a face in 3D to resize, or…</span>
+                    )}
+                    {editJoint ? (
+                      <JointForm
+                        joint={editJoint}
+                        names={jointNames}
+                        onChange={(spec) => onSetJoint(it.link, spec)}
+                      />
+                    ) : (
+                      <span className="robotbuild__editnote">This is the base — nothing to join to.</span>
+                    )}
+                  </div>
                   <button
                     type="button"
                     className="robotbuild__del"

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -20,13 +20,17 @@ import {
 import {
   addMeshLink,
   addPrimitive,
+  jointNames,
   parseAssembly,
   readJoint,
   readPrimitive,
   removeLink,
+  setJoint,
   setJointOrigin,
   setPrimitiveSize,
   setVisualOrigin,
+  type JointDef,
+  type JointSpec,
   type PrimitiveGeom
 } from './robot-assembly'
 import {
@@ -307,6 +311,11 @@ export function RobotView({
     () => (editLink ? readPrimitive(content, editLink) : null),
     [content, editLink]
   )
+  const editJoint: JointDef | null = useMemo(
+    () => (editLink ? readJoint(content, editLink) : null),
+    [content, editLink]
+  )
+  const allJointNames = useMemo(() => jointNames(content), [content])
 
   const setBuildPinnedPersist = (p: boolean): void => {
     setBuildPinned(p)
@@ -334,6 +343,9 @@ export function RobotView({
   }
   const handleSetSize = (link: string, dims: number[]): void => {
     commitUrdf(setPrimitiveSize(content, link, dims))
+  }
+  const handleSetJoint = (link: string, spec: JointSpec): void => {
+    commitUrdf(setJoint(content, link, spec))
   }
   const handleDeleteLink = (link: string): void => {
     commitUrdf(removeLink(content, link))
@@ -1476,8 +1488,11 @@ export function RobotView({
             editLink={editLink}
             onEdit={setEditLink}
             editGeom={editGeom}
+            editJoint={editJoint}
+            jointNames={allJointNames}
             onAdd={handleAddPrimitive}
             onSetSize={handleSetSize}
+            onSetJoint={handleSetJoint}
             onDelete={handleDeleteLink}
             onImportStl={() => void handleImportStl()}
             canImport={!!canImport}

--- a/src/renderer/src/components/robot-assembly.ts
+++ b/src/renderer/src/components/robot-assembly.ts
@@ -272,26 +272,133 @@ export function setVisualOrigin(
 
 /** Read the joint whose `<child>` is `childLink`, or null (e.g. the root link has
  *  none — the move tool uses that to refuse moving the base). */
-export function readJoint(
-  urdf: string,
-  childLink: string
-): { name: string; parent: string; type: string; xyz: Vec3; rpy: Vec3 } | null {
+/** The four joint types the builder can author (a subset of the URDF set). */
+export type JointType = 'fixed' | 'revolute' | 'continuous' | 'prismatic'
+const JOINT_TYPES: readonly string[] = ['fixed', 'revolute', 'continuous', 'prismatic']
+
+export interface JointDef {
+  name: string
+  parent: string
+  type: JointType
+  xyz: Vec3
+  rpy: Vec3
+  /** The rotation/slide axis, or null for a fixed joint (no `<axis>`). */
+  axis: Vec3 | null
+  /** Native lower/upper (rad for revolute, m for prismatic); null when absent. */
+  limit: { lower: number; upper: number } | null
+  /** A `<mimic>` coupling (`value = multiplier·master + offset`), or null. */
+  mimic: { joint: string; multiplier: number; offset: number } | null
+}
+
+/** The full definition of the joint whose CHILD is `childLink`, or null (root). */
+export function readJoint(urdf: string, childLink: string): JointDef | null {
   const re = /<joint\b([^>]*)>([\s\S]*?)<\/joint>/gi
   const childRe = new RegExp(`<child\\b[^>]*\\blink\\s*=\\s*"${escapeRe(childLink)}"`, 'i')
   let m: RegExpExecArray | null
   while ((m = re.exec(urdf))) {
     if (!childRe.test(m[2])) continue
-    const originM = /<origin\b[^>]*\bxyz\s*=\s*"([^"]+)"/i.exec(m[2])
-    const rpyM = /<origin\b[^>]*\brpy\s*=\s*"([^"]+)"/i.exec(m[2])
+    const body = m[2]
+    const originM = /<origin\b[^>]*\bxyz\s*=\s*"([^"]+)"/i.exec(body)
+    const rpyM = /<origin\b[^>]*\brpy\s*=\s*"([^"]+)"/i.exec(body)
+    const axisM = /<axis\b[^>]*\bxyz\s*=\s*"([^"]+)"/i.exec(body)
+    const limM = /<limit\b([^>]*?)\/?>/i.exec(body)
+    const lower = limM ? /\blower\s*=\s*"([^"]+)"/.exec(limM[1])?.[1] : undefined
+    const upper = limM ? /\bupper\s*=\s*"([^"]+)"/.exec(limM[1])?.[1] : undefined
+    const mimM = /<mimic\b([^>]*?)\/?>/i.exec(body)
+    const typeRaw = /\btype\s*=\s*"([^"]+)"/.exec(m[1])?.[1] ?? 'fixed'
     return {
       name: /\bname\s*=\s*"([^"]+)"/.exec(m[1])?.[1] ?? '',
-      type: /\btype\s*=\s*"([^"]+)"/.exec(m[1])?.[1] ?? 'fixed',
-      parent: /<parent\b[^>]*\blink\s*=\s*"([^"]+)"/i.exec(m[2])?.[1] ?? '',
+      type: (JOINT_TYPES.includes(typeRaw) ? typeRaw : 'fixed') as JointType,
+      parent: /<parent\b[^>]*\blink\s*=\s*"([^"]+)"/i.exec(body)?.[1] ?? '',
       xyz: originM ? parseVec3(originM[1]) : [0, 0, 0],
-      rpy: rpyM ? parseVec3(rpyM[1]) : [0, 0, 0]
+      rpy: rpyM ? parseVec3(rpyM[1]) : [0, 0, 0],
+      axis: axisM ? parseVec3(axisM[1]) : null,
+      limit: lower != null && upper != null ? { lower: Number(lower), upper: Number(upper) } : null,
+      mimic: mimM
+        ? {
+            joint: /\bjoint\s*=\s*"([^"]+)"/.exec(mimM[1])?.[1] ?? '',
+            multiplier: Number(/\bmultiplier\s*=\s*"([^"]+)"/.exec(mimM[1])?.[1] ?? '1'),
+            offset: Number(/\boffset\s*=\s*"([^"]+)"/.exec(mimM[1])?.[1] ?? '0')
+          }
+        : null
     }
   }
   return null
+}
+
+/** Names of every `<joint>` in the model (for the mimic master picker). */
+export function jointNames(urdf: string): string[] {
+  const re = /<joint\b([^>]*)>/gi
+  const out: string[] = []
+  let m: RegExpExecArray | null
+  while ((m = re.exec(urdf))) {
+    const nm = /\bname\s*=\s*"([^"]+)"/.exec(m[1])?.[1]
+    if (nm) out.push(nm)
+  }
+  return out
+}
+
+/** A sensible native limit when a joint first becomes movable. */
+export function defaultJointLimit(type: JointType): { lower: number; upper: number } {
+  return type === 'prismatic'
+    ? { lower: 0, upper: 0.05 } // 0–50 mm
+    : { lower: -Math.PI / 2, upper: Math.PI / 2 } // ±90°
+}
+
+export interface JointSpec {
+  type: JointType
+  /** Rotation/slide axis (movable joints); defaults to +Z. */
+  axis?: Vec3
+  /** Native lower/upper (rad/m) for revolute/prismatic; defaults per type. */
+  lower?: number
+  upper?: number
+  /** A `<mimic>` coupling, or null/undefined for none. */
+  mimic?: { joint: string; multiplier: number; offset: number } | null
+}
+
+/**
+ * Rewrite the joint whose child is `childLink` to a new type + axis/limit/mimic,
+ * PRESERVING its name, parent and origin. The block is regenerated wholesale
+ * (not surgically patched) so a type change can never strand a stale
+ * `<axis>`/`<limit>`/`<mimic>`. Movable joints get an `<axis>`; revolute/prismatic
+ * additionally get a `<limit>` (the URDF spec requires it), continuous a bare
+ * effort/velocity limit. Returns the URDF unchanged if the joint isn't found.
+ */
+export function setJoint(urdf: string, childLink: string, spec: JointSpec): string {
+  const re = /<joint\b[^>]*>[\s\S]*?<\/joint>/gi
+  const childRe = new RegExp(`<child\\b[^>]*\\blink\\s*=\\s*"${escapeRe(childLink)}"`, 'i')
+  let m: RegExpExecArray | null
+  while ((m = re.exec(urdf))) {
+    if (!childRe.test(m[0])) continue
+    const blk = m[0]
+    const name = /\bname\s*=\s*"([^"]+)"/.exec(blk)?.[1] ?? `${childLink}_joint`
+    const parent = /<parent\b[^>]*\blink\s*=\s*"([^"]+)"/i.exec(blk)?.[1] ?? ''
+    const oxyz = /<origin\b[^>]*\bxyz\s*=\s*"([^"]+)"/i.exec(blk)?.[1] ?? '0 0 0'
+    const orpy = /<origin\b[^>]*\brpy\s*=\s*"([^"]+)"/i.exec(blk)?.[1] ?? '0 0 0'
+    const { type } = spec
+    const movable = type !== 'fixed'
+    const axis = spec.axis ?? [0, 0, 1]
+    let inner =
+      `    <parent link="${parent}"/>\n` +
+      `    <child link="${childLink}"/>\n` +
+      `    <origin xyz="${oxyz}" rpy="${orpy}"/>\n`
+    if (movable) inner += `    <axis xyz="${fmtVec(axis)}"/>\n`
+    if (type === 'revolute' || type === 'prismatic') {
+      const def = defaultJointLimit(type)
+      const lower = spec.lower ?? def.lower
+      const upper = spec.upper ?? def.upper
+      inner += `    <limit lower="${fmtNum(lower)}" upper="${fmtNum(upper)}" effort="1" velocity="1"/>\n`
+    } else if (type === 'continuous') {
+      inner += `    <limit effort="1" velocity="1"/>\n`
+    }
+    if (movable && spec.mimic && spec.mimic.joint) {
+      const mi = spec.mimic
+      inner += `    <mimic joint="${mi.joint}" multiplier="${fmtNum(mi.multiplier)}" offset="${fmtNum(mi.offset)}"/>\n`
+    }
+    const block = `  <joint name="${name}" type="${type}">\n${inner}  </joint>`
+    return urdf.slice(0, m.index) + block + urdf.slice(m.index + m[0].length)
+  }
+  return urdf
 }
 
 /** Set the fixed-joint origin whose child is `childLink` (moves the whole part). */

--- a/src/renderer/src/components/robot-build.ts
+++ b/src/renderer/src/components/robot-build.ts
@@ -178,3 +178,17 @@ export function movedJointOrigin(
 export function jointOriginForCoincident(aLocal: Vec3, bLocal: Vec3): Vec3 {
   return [bLocal[0] - aLocal[0], bLocal[1] - aLocal[1], bLocal[2] - aLocal[2]]
 }
+
+/**
+ * Which principal axis a joint's `<axis>` vector points along, so the editor can
+ * highlight the right X/Y/Z button. `'custom'` = an off-axis vector, `'none'` =
+ * no axis (a fixed joint). Sign is ignored (X and −X both read as `'x'`).
+ */
+export function principalAxisName(axis: Vec3 | null): 'x' | 'y' | 'z' | 'custom' | 'none' {
+  if (!axis) return 'none'
+  const [x, y, z] = axis.map((n) => Math.abs(n))
+  if (x > 0 && y === 0 && z === 0) return 'x'
+  if (y > 0 && x === 0 && z === 0) return 'y'
+  if (z > 0 && x === 0 && y === 0) return 'z'
+  return 'custom'
+}

--- a/test/robotJoint.test.ts
+++ b/test/robotJoint.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest'
+import {
+  addPrimitive,
+  blankUrdf,
+  readJoint,
+  setJoint,
+  jointNames,
+  defaultJointLimit
+} from '../src/renderer/src/components/robot-assembly'
+import { principalAxisName, type Vec3 } from '../src/renderer/src/components/robot-build'
+
+/** A 2-link arm: base_link + `arm` joined by its (fixed) `arm_joint`. */
+function arm(): string {
+  return addPrimitive(blankUrdf('bot'), { kind: 'box', linkBase: 'arm', parent: 'base_link' }).urdf
+}
+
+describe('setJoint — type changes (#315b)', () => {
+  it('fixed → revolute adds an <axis> and a <limit>, keeping origin/parent', () => {
+    const u = setJoint(arm(), 'arm', { type: 'revolute' })
+    const j = readJoint(u, 'arm')!
+    expect(j.type).toBe('revolute')
+    expect(j.parent).toBe('base_link')
+    expect(j.xyz).toEqual([0.06, 0, 0]) // origin preserved
+    expect(j.axis).toEqual([0, 0, 1]) // default +Z
+    expect(j.limit!.lower).toBeCloseTo(-Math.PI / 2, 3) // written at 4dp
+    expect(j.limit!.upper).toBeCloseTo(Math.PI / 2, 3)
+    expect(u).toMatch(/effort="1" velocity="1"/) // spec-required attrs
+  })
+
+  it('honours an explicit axis + native limits', () => {
+    const u = setJoint(arm(), 'arm', { type: 'revolute', axis: [0, 1, 0], lower: -1, upper: 2 })
+    const j = readJoint(u, 'arm')!
+    expect(j.axis).toEqual([0, 1, 0])
+    expect(j.limit).toEqual({ lower: -1, upper: 2 })
+  })
+
+  it('prismatic carries a limit; continuous has an axis but no lower/upper', () => {
+    const p = readJoint(setJoint(arm(), 'arm', { type: 'prismatic' }), 'arm')!
+    expect(p.type).toBe('prismatic')
+    expect(p.limit).toEqual({ lower: 0, upper: 0.05 })
+    const c = readJoint(setJoint(arm(), 'arm', { type: 'continuous', axis: [1, 0, 0] }), 'arm')!
+    expect(c.type).toBe('continuous')
+    expect(c.axis).toEqual([1, 0, 0])
+    expect(c.limit).toBeNull() // effort/velocity only, no bounds
+  })
+
+  it('revolute → fixed strips axis, limit and mimic', () => {
+    let u = setJoint(arm(), 'arm', { type: 'revolute', mimic: { joint: 'x', multiplier: 1, offset: 0 } })
+    u = setJoint(u, 'arm', { type: 'fixed' })
+    const j = readJoint(u, 'arm')!
+    expect(j.type).toBe('fixed')
+    expect(j.axis).toBeNull()
+    expect(j.limit).toBeNull()
+    expect(j.mimic).toBeNull()
+    expect(u).not.toMatch(/<axis|<limit|<mimic/)
+  })
+
+  it('preserves a non-default origin through a type change', () => {
+    const moved = setJoint(arm(), 'arm', { type: 'fixed' }).replace('xyz="0.06 0 0"', 'xyz="0.1 0 0.06"')
+    const j = readJoint(setJoint(moved, 'arm', { type: 'revolute' }), 'arm')!
+    expect(j.xyz).toEqual([0.1, 0, 0.06])
+  })
+
+  it('leaves the URDF untouched when the child has no joint', () => {
+    const u = arm()
+    expect(setJoint(u, 'base_link', { type: 'revolute' })).toBe(u) // root has no parent joint
+    expect(setJoint(u, 'ghost', { type: 'revolute' })).toBe(u)
+  })
+})
+
+describe('setJoint — mimic (#315b)', () => {
+  it('adds a <mimic> and reads it back; null clears it', () => {
+    let u = setJoint(arm(), 'arm', { type: 'revolute', mimic: { joint: 'lead', multiplier: -0.5, offset: 0.1 } })
+    expect(readJoint(u, 'arm')!.mimic).toEqual({ joint: 'lead', multiplier: -0.5, offset: 0.1 })
+    u = setJoint(u, 'arm', { type: 'revolute', mimic: null })
+    expect(readJoint(u, 'arm')!.mimic).toBeNull()
+  })
+
+  it('ignores a mimic on a fixed joint (nothing to drive)', () => {
+    const u = setJoint(arm(), 'arm', { type: 'fixed', mimic: { joint: 'lead', multiplier: 1, offset: 0 } })
+    expect(readJoint(u, 'arm')!.mimic).toBeNull()
+  })
+})
+
+describe('readJoint / jointNames / defaults (#315b)', () => {
+  it('reads a hand-written revolute joint (axis, limit, mimic)', () => {
+    const urdf = `<robot name="r">
+      <link name="a"/><link name="b"/>
+      <joint name="b_joint" type="revolute">
+        <parent link="a"/><child link="b"/>
+        <origin xyz="0 0 0.1" rpy="0 0 0"/>
+        <axis xyz="0 1 0"/>
+        <limit lower="-0.5" upper="0.5" effort="1" velocity="1"/>
+        <mimic joint="a_joint" multiplier="2" offset="0"/>
+      </joint>
+    </robot>`
+    const j = readJoint(urdf, 'b')!
+    expect(j.type).toBe('revolute')
+    expect(j.axis).toEqual([0, 1, 0])
+    expect(j.limit).toEqual({ lower: -0.5, upper: 0.5 })
+    expect(j.mimic).toEqual({ joint: 'a_joint', multiplier: 2, offset: 0 })
+  })
+
+  it('lists every joint name for the mimic picker', () => {
+    const two = addPrimitive(arm(), { kind: 'box', linkBase: 'hand', parent: 'arm' }).urdf
+    expect(jointNames(two).sort()).toEqual(['arm_joint', 'hand_joint'])
+  })
+
+  it('defaultJointLimit: ±90° for angular, 0–50 mm for prismatic', () => {
+    expect(defaultJointLimit('revolute')).toEqual({ lower: -Math.PI / 2, upper: Math.PI / 2 })
+    expect(defaultJointLimit('prismatic')).toEqual({ lower: 0, upper: 0.05 })
+  })
+})
+
+describe('principalAxisName (#315b)', () => {
+  it('classifies principal axes, custom vectors, and no-axis', () => {
+    expect(principalAxisName([1, 0, 0])).toBe('x')
+    expect(principalAxisName([0, -1, 0] as Vec3)).toBe('y') // sign ignored
+    expect(principalAxisName([0, 0, 1])).toBe('z')
+    expect(principalAxisName([1, 1, 0])).toBe('custom')
+    expect(principalAxisName(null)).toBe('none')
+  })
+})


### PR DESCRIPTION
Completes the **#315** builder scope (epic #309, Phase 5). Every builder block already gets a parent joint (fixed); this adds an editor for **how it moves**, so you can build a 2-link arm from blocks, make the elbow a **hinge**, and pose it immediately.

## What's new
In the Build panel's edit row (pencil → a block), below the size form:
- **Type** — **Fixed / Hinge / Slider / Wheel** (URDF `fixed` / `revolute` / `prismatic` / `continuous`), kid-friendly labels with the URDF term in the tooltip.
- **Axis** — **X / Y / Z** (the active axis is highlighted; off-axis vectors read as "custom").
- **Limits** — min / max, in **degrees** for a hinge / **mm** for a slider (hidden for Fixed/Wheel).
- **Copies** — a **mimic** coupling: pick a master joint + a gear ratio (`× multiplier + offset`), e.g. a gripper's two fingers or a geared pair.

Every change rewrites the URDF and is reflected **live** in the pose tool and the motion timeline (they re-parse `robot.joints`).

## Architecture
- Pure logic in `robot-assembly.ts`: `readJoint` now parses `axis`/`limit`/`mimic`; **`setJoint`** regenerates the joint block **wholesale** (preserving name/parent/origin) so a type change can't strand a stale `<axis>`/`<limit>`/`<mimic>`; `jointNames()` (mimic picker) + `defaultJointLimit()`. `principalAxisName()` in `robot-build.ts`.
- **12 unit tests** in `test/robotJoint.test.ts` (type changes, mimic add/clear, origin preservation, root-guard, read-back, defaults, axis classification).

## Verification
- `typecheck` · `lint` · `test` (**1509 passing**) · `build` — all green.
- In-app smoke (Playwright): editing `arm` → **Hinge** wrote `type="revolute"` + `<axis xyz="0 0 1">` + `<limit … effort="1" velocity="1">`; **axis X** → `<axis xyz="1 0 0">`; the pose tool gained a live `arm_joint` slider (was "no movable joints").

🤖 Generated with [Claude Code](https://claude.com/claude-code)