### PR TITLE
feat: Robot base object — Make base (re-root) + protect the base from deletion (#309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Robot View — "Make base" + base protection (#309 builder).** A URDF hangs off
+  its **base** link, so deleting the base used to leave an empty, unusable file.
+  Now the base **can't be deleted** (its ✕ is disabled with a hint, and it shows a
+  "★ This is the base" badge), and every other block gains a **★ Make base** button
+  that re-roots the whole model onto it — reversing the joint chain up to the old
+  base (origins inverted exactly, off-path sub-trees left untouched). So you can
+  bless a new base mid-build and then delete the old one. Fixed joints re-root
+  perfectly; a movable joint that happens to sit on the reversed path keeps its
+  axis/limits (best effort).
 - **Robot View — joint editor: hinges, sliders, wheels + mimic (#315, epic #309
   Phase 5).** Editing a block in the Build panel now also sets **how it moves**
   relative to its parent: pick **Fixed / Hinge / Slider / Wheel** (URDF

--- a/src/renderer/src/components/RobotBuildPanel.css
+++ b/src/renderer/src/components/RobotBuildPanel.css
@@ -318,9 +318,33 @@
   padding: 0 0.35rem;
   cursor: pointer;
 }
-.robotbuild__del:hover {
+.robotbuild__del:hover:not(:disabled) {
   color: #b4544e;
   border-color: #b4544e;
+}
+.robotbuild__del:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+.robotbuild__makebase {
+  align-self: flex-start;
+  font-family: inherit;
+  font-size: 0.55rem;
+  color: var(--text-muted, #9aa0a6);
+  background: transparent;
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 4px;
+  padding: 0.08rem 0.4rem;
+  cursor: pointer;
+}
+.robotbuild__makebase:hover {
+  color: #c8a24a;
+  border-color: #c8a24a;
+}
+.robotbuild__basebadge {
+  align-self: flex-start;
+  font-size: 0.55rem;
+  color: #c8a24a;
 }
 .robotbuild__empty {
   color: var(--text-muted, #8b919b);

--- a/src/renderer/src/components/RobotBuildPanel.tsx
+++ b/src/renderer/src/components/RobotBuildPanel.tsx
@@ -47,6 +47,9 @@ export interface RobotBuildPanelProps {
   editJoint: JointDef | null
   jointNames: string[]
   onSetJoint: (link: string, spec: JointSpec) => void
+  /** The current root link, and an action to re-root the model at a link. */
+  rootLink: string | null
+  onMakeBase: (link: string) => void
   onDelete: (link: string) => void
   onImportStl: () => void
   canImport: boolean
@@ -324,6 +327,8 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
     editJoint,
     jointNames,
     onSetJoint,
+    rootLink,
+    onMakeBase,
     onDelete,
     onImportStl,
     canImport,
@@ -432,34 +437,55 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
                   {PENCIL}
                 </button>
               </div>
-              {isEdit && (
-                <div className="robotbuild__editrow">
-                  <div className="robotbuild__editmain">
-                    {editGeom ? (
-                      <SizeForm geom={editGeom} onChange={(d) => onSetSize(it.link, d)} />
-                    ) : (
-                      <span className="robotbuild__editnote">Grab a face in 3D to resize, or…</span>
-                    )}
-                    {editJoint ? (
-                      <JointForm
-                        joint={editJoint}
-                        names={jointNames}
-                        onChange={(spec) => onSetJoint(it.link, spec)}
-                      />
-                    ) : (
-                      <span className="robotbuild__editnote">This is the base — nothing to join to.</span>
-                    )}
-                  </div>
-                  <button
-                    type="button"
-                    className="robotbuild__del"
-                    onClick={() => onDelete(it.link)}
-                    title={`Delete ${it.link}`}
-                  >
-                    ✕
-                  </button>
-                </div>
-              )}
+              {isEdit &&
+                (() => {
+                  const isRoot = it.link === rootLink
+                  return (
+                    <div className="robotbuild__editrow">
+                      <div className="robotbuild__editmain">
+                        {editGeom ? (
+                          <SizeForm geom={editGeom} onChange={(d) => onSetSize(it.link, d)} />
+                        ) : (
+                          <span className="robotbuild__editnote">Grab a face in 3D to resize, or…</span>
+                        )}
+                        {editJoint && (
+                          <JointForm
+                            joint={editJoint}
+                            names={jointNames}
+                            onChange={(spec) => onSetJoint(it.link, spec)}
+                          />
+                        )}
+                        {isRoot ? (
+                          <span className="robotbuild__basebadge" title="Every other block hangs off the base">
+                            ★ This is the base
+                          </span>
+                        ) : (
+                          <button
+                            type="button"
+                            className="robotbuild__makebase"
+                            onClick={() => onMakeBase(it.link)}
+                            title="Make this the base — the whole model re-hangs off this block"
+                          >
+                            ★ Make base
+                          </button>
+                        )}
+                      </div>
+                      <button
+                        type="button"
+                        className="robotbuild__del"
+                        disabled={isRoot}
+                        onClick={() => onDelete(it.link)}
+                        title={
+                          isRoot
+                            ? 'The base can’t be deleted — make another block the base first'
+                            : `Delete ${it.link}`
+                        }
+                      >
+                        ✕
+                      </button>
+                    </div>
+                  )
+                })()}
             </li>
           )
         })}

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -25,6 +25,7 @@ import {
   readJoint,
   readPrimitive,
   removeLink,
+  rootLink,
   setJoint,
   setJointOrigin,
   setPrimitiveSize,
@@ -33,6 +34,7 @@ import {
   type JointSpec,
   type PrimitiveGeom
 } from './robot-assembly'
+import { reRoot } from './robot-reroot'
 import {
   classifyFace,
   faceSnapPoints,
@@ -316,6 +318,7 @@ export function RobotView({
     [content, editLink]
   )
   const allJointNames = useMemo(() => jointNames(content), [content])
+  const rootName = useMemo(() => rootLink(content) ?? null, [content])
 
   const setBuildPinnedPersist = (p: boolean): void => {
     setBuildPinned(p)
@@ -348,9 +351,15 @@ export function RobotView({
     commitUrdf(setJoint(content, link, spec))
   }
   const handleDeleteLink = (link: string): void => {
+    // Deleting the root would cascade-remove the whole tree → an empty, unusable
+    // URDF. The UI disables it; guard here too. Re-root onto a keeper first.
+    if (link === rootLink(content)) return
     commitUrdf(removeLink(content, link))
     setSelectedLink(null)
     setEditLink(null)
+  }
+  const handleMakeBase = (link: string): void => {
+    commitUrdf(reRoot(content, link))
   }
 
   // Re-apply the selection outline when the picked block changes (no re-parse).
@@ -1490,9 +1499,11 @@ export function RobotView({
             editGeom={editGeom}
             editJoint={editJoint}
             jointNames={allJointNames}
+            rootLink={rootName}
             onAdd={handleAddPrimitive}
             onSetSize={handleSetSize}
             onSetJoint={handleSetJoint}
+            onMakeBase={handleMakeBase}
             onDelete={handleDeleteLink}
             onImportStl={() => void handleImportStl()}
             canImport={!!canImport}

--- a/src/renderer/src/components/robot-assembly.ts
+++ b/src/renderer/src/components/robot-assembly.ts
@@ -290,40 +290,61 @@ export interface JointDef {
   mimic: { joint: string; multiplier: number; offset: number } | null
 }
 
+/** A joint definition that also carries its child link (from `readAllJoints`). */
+export interface JointFull extends JointDef {
+  child: string
+}
+
+/** Parse one `<joint>` from its opening attrs + inner body. */
+function parseJoint(attrs: string, body: string): JointFull {
+  const originM = /<origin\b[^>]*\bxyz\s*=\s*"([^"]+)"/i.exec(body)
+  const rpyM = /<origin\b[^>]*\brpy\s*=\s*"([^"]+)"/i.exec(body)
+  const axisM = /<axis\b[^>]*\bxyz\s*=\s*"([^"]+)"/i.exec(body)
+  const limM = /<limit\b([^>]*?)\/?>/i.exec(body)
+  const lower = limM ? /\blower\s*=\s*"([^"]+)"/.exec(limM[1])?.[1] : undefined
+  const upper = limM ? /\bupper\s*=\s*"([^"]+)"/.exec(limM[1])?.[1] : undefined
+  const mimM = /<mimic\b([^>]*?)\/?>/i.exec(body)
+  const typeRaw = /\btype\s*=\s*"([^"]+)"/.exec(attrs)?.[1] ?? 'fixed'
+  return {
+    name: /\bname\s*=\s*"([^"]+)"/.exec(attrs)?.[1] ?? '',
+    type: (JOINT_TYPES.includes(typeRaw) ? typeRaw : 'fixed') as JointType,
+    parent: /<parent\b[^>]*\blink\s*=\s*"([^"]+)"/i.exec(body)?.[1] ?? '',
+    child: /<child\b[^>]*\blink\s*=\s*"([^"]+)"/i.exec(body)?.[1] ?? '',
+    xyz: originM ? parseVec3(originM[1]) : [0, 0, 0],
+    rpy: rpyM ? parseVec3(rpyM[1]) : [0, 0, 0],
+    axis: axisM ? parseVec3(axisM[1]) : null,
+    limit: lower != null && upper != null ? { lower: Number(lower), upper: Number(upper) } : null,
+    mimic: mimM
+      ? {
+          joint: /\bjoint\s*=\s*"([^"]+)"/.exec(mimM[1])?.[1] ?? '',
+          multiplier: Number(/\bmultiplier\s*=\s*"([^"]+)"/.exec(mimM[1])?.[1] ?? '1'),
+          offset: Number(/\boffset\s*=\s*"([^"]+)"/.exec(mimM[1])?.[1] ?? '0')
+        }
+      : null
+  }
+}
+
 /** The full definition of the joint whose CHILD is `childLink`, or null (root). */
 export function readJoint(urdf: string, childLink: string): JointDef | null {
   const re = /<joint\b([^>]*)>([\s\S]*?)<\/joint>/gi
   const childRe = new RegExp(`<child\\b[^>]*\\blink\\s*=\\s*"${escapeRe(childLink)}"`, 'i')
   let m: RegExpExecArray | null
   while ((m = re.exec(urdf))) {
-    if (!childRe.test(m[2])) continue
-    const body = m[2]
-    const originM = /<origin\b[^>]*\bxyz\s*=\s*"([^"]+)"/i.exec(body)
-    const rpyM = /<origin\b[^>]*\brpy\s*=\s*"([^"]+)"/i.exec(body)
-    const axisM = /<axis\b[^>]*\bxyz\s*=\s*"([^"]+)"/i.exec(body)
-    const limM = /<limit\b([^>]*?)\/?>/i.exec(body)
-    const lower = limM ? /\blower\s*=\s*"([^"]+)"/.exec(limM[1])?.[1] : undefined
-    const upper = limM ? /\bupper\s*=\s*"([^"]+)"/.exec(limM[1])?.[1] : undefined
-    const mimM = /<mimic\b([^>]*?)\/?>/i.exec(body)
-    const typeRaw = /\btype\s*=\s*"([^"]+)"/.exec(m[1])?.[1] ?? 'fixed'
-    return {
-      name: /\bname\s*=\s*"([^"]+)"/.exec(m[1])?.[1] ?? '',
-      type: (JOINT_TYPES.includes(typeRaw) ? typeRaw : 'fixed') as JointType,
-      parent: /<parent\b[^>]*\blink\s*=\s*"([^"]+)"/i.exec(body)?.[1] ?? '',
-      xyz: originM ? parseVec3(originM[1]) : [0, 0, 0],
-      rpy: rpyM ? parseVec3(rpyM[1]) : [0, 0, 0],
-      axis: axisM ? parseVec3(axisM[1]) : null,
-      limit: lower != null && upper != null ? { lower: Number(lower), upper: Number(upper) } : null,
-      mimic: mimM
-        ? {
-            joint: /\bjoint\s*=\s*"([^"]+)"/.exec(mimM[1])?.[1] ?? '',
-            multiplier: Number(/\bmultiplier\s*=\s*"([^"]+)"/.exec(mimM[1])?.[1] ?? '1'),
-            offset: Number(/\boffset\s*=\s*"([^"]+)"/.exec(mimM[1])?.[1] ?? '0')
-          }
-        : null
-    }
+    if (childRe.test(m[2])) return parseJoint(m[1], m[2])
   }
   return null
+}
+
+/** Every `<joint>` in the model (with its child link), in document order. */
+export function readAllJoints(urdf: string): JointFull[] {
+  const re = /<joint\b([^>]*)>([\s\S]*?)<\/joint>/gi
+  const out: JointFull[] = []
+  let m: RegExpExecArray | null
+  while ((m = re.exec(urdf))) {
+    const j = parseJoint(m[1], m[2])
+    if (j.child) out.push(j)
+  }
+  return out
 }
 
 /** Names of every `<joint>` in the model (for the mimic master picker). */

--- a/src/renderer/src/components/robot-reroot.ts
+++ b/src/renderer/src/components/robot-reroot.ts
@@ -1,0 +1,101 @@
+/**
+ * RE-ROOTING a URDF (#309 builder) — "bless" another link as the base.
+ *
+ * A URDF is a tree that hangs off its ROOT link; every other link is reached by
+ * a chain of `<joint>`s. To make some other link the root we reverse every joint
+ * on the path from the old root down to the new one: swap its parent/child and
+ * invert its origin transform. Links NOT on that path keep their parent, so their
+ * sub-trees hang unchanged. This lets the user delete the old base (once another
+ * block is the base) without stranding the rest of the model.
+ *
+ * The origin inversion uses three.js with the SAME Euler order urdf-loader applies
+ * (`'ZYX'`), so a re-rooted model renders identically. For the builder's own
+ * joints (origin `rpy = 0`) this is just negating the translation. Movable joints
+ * that happen to sit on the reversed path keep their axis/limits as-is (best
+ * effort — correct for the common all-fixed structural path).
+ */
+import * as THREE from 'three'
+import { readAllJoints, rootLink, type JointFull } from './robot-assembly'
+import type { Vec3 } from './robot-build'
+
+const fmtNum = (n: number): string => (Math.round(n * 1e4) / 1e4).toString()
+const fmtVec = (v: readonly number[]): string => v.map(fmtNum).join(' ')
+const escapeRe = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+/** Invert an origin transform (child←parent becomes parent←child). */
+function invertOrigin(xyz: Vec3, rpy: Vec3): { xyz: Vec3; rpy: Vec3 } {
+  const m = new THREE.Matrix4().compose(
+    new THREE.Vector3(xyz[0], xyz[1], xyz[2]),
+    new THREE.Quaternion().setFromEuler(new THREE.Euler(rpy[0], rpy[1], rpy[2], 'ZYX')),
+    new THREE.Vector3(1, 1, 1)
+  )
+  m.invert()
+  const p = new THREE.Vector3()
+  const q = new THREE.Quaternion()
+  const s = new THREE.Vector3()
+  m.decompose(p, q, s)
+  const e = new THREE.Euler().setFromQuaternion(q, 'ZYX')
+  // Snap tiny float dust to zero so an rpy=0 joint stays clean text.
+  const z = (n: number): number => (Math.abs(n) < 1e-9 ? 0 : n)
+  return { xyz: [z(p.x), z(p.y), z(p.z)], rpy: [z(e.x), z(e.y), z(e.z)] }
+}
+
+/** Regenerate a joint block from a (possibly reversed) definition. */
+function emitJoint(j: JointFull): string {
+  let inner =
+    `    <parent link="${j.parent}"/>\n` +
+    `    <child link="${j.child}"/>\n` +
+    `    <origin xyz="${fmtVec(j.xyz)}" rpy="${fmtVec(j.rpy)}"/>\n`
+  if (j.axis) inner += `    <axis xyz="${fmtVec(j.axis)}"/>\n`
+  if (j.limit) inner += `    <limit lower="${fmtNum(j.limit.lower)}" upper="${fmtNum(j.limit.upper)}" effort="1" velocity="1"/>\n`
+  else if (j.type === 'continuous') inner += `    <limit effort="1" velocity="1"/>\n`
+  if (j.mimic)
+    inner += `    <mimic joint="${j.mimic.joint}" multiplier="${fmtNum(j.mimic.multiplier)}" offset="${fmtNum(j.mimic.offset)}"/>\n`
+  return `  <joint name="${j.name}" type="${j.type}">\n${inner}  </joint>`
+}
+
+/** Replace the `<joint name="name">…</joint>` block in the text. */
+function replaceJointByName(urdf: string, name: string, block: string): string {
+  const re = new RegExp(`<joint\\b[^>]*\\bname\\s*=\\s*"${escapeRe(name)}"[^>]*>[\\s\\S]*?</joint>`, 'i')
+  return urdf.replace(re, block)
+}
+
+/** The chain of joints from `newRoot` up to the current root, or null if there
+ *  is no such path (not in the tree / a cycle / already the root). */
+function pathToRoot(urdf: string, newRoot: string): JointFull[] | null {
+  const root = rootLink(urdf)
+  if (!root || newRoot === root) return null
+  const byChild = new Map(readAllJoints(urdf).map((j) => [j.child, j]))
+  const path: JointFull[] = []
+  const seen = new Set<string>()
+  let cur = newRoot
+  while (cur !== root) {
+    const j = byChild.get(cur)
+    if (!j || seen.has(cur)) return null // detached or a cycle
+    seen.add(cur)
+    path.push(j)
+    cur = j.parent
+  }
+  return path
+}
+
+/** True when `link` exists, isn't already the root, and reaches the root. */
+export function canReRoot(urdf: string, link: string): boolean {
+  return pathToRoot(urdf, link) !== null
+}
+
+/**
+ * Re-root the model at `newRoot` (make it the base). Returns the URDF unchanged
+ * if `newRoot` is already the root or can't be reached from it.
+ */
+export function reRoot(urdf: string, newRoot: string): string {
+  const path = pathToRoot(urdf, newRoot)
+  if (!path) return urdf
+  let out = urdf
+  for (const j of path) {
+    const inv = invertOrigin(j.xyz, j.rpy)
+    const reversed: JointFull = { ...j, parent: j.child, child: j.parent, xyz: inv.xyz, rpy: inv.rpy }
+    out = replaceJointByName(out, j.name, emitJoint(reversed))
+  }
+  return out
+}

--- a/test/robotReroot.test.ts
+++ b/test/robotReroot.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+import { addPrimitive, blankUrdf, rootLink, readJoint, readAllJoints } from '../src/renderer/src/components/robot-assembly'
+import { reRoot, canReRoot } from '../src/renderer/src/components/robot-reroot'
+
+/** base_link → arm → hand (a 3-link chain of fixed joints). */
+function chain(): string {
+  let u = addPrimitive(blankUrdf('bot'), { kind: 'box', linkBase: 'arm', parent: 'base_link' }).urdf
+  u = addPrimitive(u, { kind: 'box', linkBase: 'hand', parent: 'arm' }).urdf
+  return u
+}
+
+describe('reRoot (#309 base object)', () => {
+  it('makes a child the root, reversing the joint + negating its origin', () => {
+    const u = reRoot(chain(), 'arm')
+    expect(rootLink(u)).toBe('arm')
+    const j = readAllJoints(u).find((x) => x.name === 'arm_joint')!
+    expect(j.parent).toBe('arm') // was base_link → arm
+    expect(j.child).toBe('base_link')
+    expect(j.xyz).toEqual([-0.06, 0, 0]) // origin negated (rpy=0)
+  })
+
+  it('re-roots the deepest link, reversing the whole chain', () => {
+    const u = reRoot(chain(), 'hand')
+    expect(rootLink(u)).toBe('hand')
+    const byName = new Map(readAllJoints(u).map((j) => [j.name, j]))
+    expect(byName.get('hand_joint')!.parent).toBe('hand') // hand → arm
+    expect(byName.get('hand_joint')!.child).toBe('arm')
+    expect(byName.get('arm_joint')!.parent).toBe('arm') // arm → base_link
+    expect(byName.get('arm_joint')!.child).toBe('base_link')
+  })
+
+  it('leaves off-path sub-trees hanging where they were', () => {
+    // base_link has TWO children: arm and leg. Re-root at arm.
+    const two = addPrimitive(chain(), { kind: 'box', linkBase: 'leg', parent: 'base_link' }).urdf
+    const u = reRoot(two, 'arm')
+    expect(rootLink(u)).toBe('arm')
+    const byName = new Map(readAllJoints(u).map((j) => [j.name, j]))
+    expect(byName.get('leg_joint')!.parent).toBe('base_link') // untouched
+    expect(byName.get('hand_joint')!.parent).toBe('arm') // untouched (already below arm)
+  })
+
+  it('keeps a movable joint on the path movable (type/axis/limit survive)', () => {
+    const j0 = readJoint(chain(), 'arm')! // fixed
+    let u = chain()
+    // Make arm_joint a hinge, then re-root at arm.
+    u = u.replace(
+      '<joint name="arm_joint" type="fixed">',
+      '<joint name="arm_joint" type="revolute">'
+    ).replace('</joint>', '  <axis xyz="0 0 1"/>\n    <limit lower="-1" upper="1" effort="1" velocity="1"/>\n  </joint>')
+    const r = readAllJoints(reRoot(u, 'arm')).find((x) => x.name === 'arm_joint')!
+    expect(j0.type).toBe('fixed')
+    expect(r.type).toBe('revolute')
+    expect(r.axis).toEqual([0, 0, 1])
+    expect(r.limit).toEqual({ lower: -1, upper: 1 })
+  })
+
+  it('round-trips a joint with a non-zero rpy (three.js inversion is exact)', () => {
+    const urdf = `<robot name="r"><link name="a"/><link name="b"/>
+      <joint name="j" type="fixed"><parent link="a"/><child link="b"/>
+        <origin xyz="0.1 0.2 0.3" rpy="0.1 -0.2 0.35"/></joint></robot>`
+    const back = reRoot(reRoot(urdf, 'b'), 'a') // there and back
+    const j = readJoint(back, 'b')!
+    expect(j.xyz[0]).toBeCloseTo(0.1, 4)
+    expect(j.xyz[1]).toBeCloseTo(0.2, 4)
+    expect(j.xyz[2]).toBeCloseTo(0.3, 4)
+    expect(j.rpy[0]).toBeCloseTo(0.1, 4)
+    expect(j.rpy[1]).toBeCloseTo(-0.2, 4)
+    expect(j.rpy[2]).toBeCloseTo(0.35, 4)
+  })
+
+  it('canReRoot / reRoot are no-ops for the root, unknown links and cycles', () => {
+    const u = chain()
+    expect(canReRoot(u, 'base_link')).toBe(false) // already the root
+    expect(canReRoot(u, 'ghost')).toBe(false)
+    expect(canReRoot(u, 'arm')).toBe(true)
+    expect(reRoot(u, 'base_link')).toBe(u)
+    expect(reRoot(u, 'ghost')).toBe(u)
+  })
+})


### PR DESCRIPTION
Two related fixes for the robot builder's **base** (root) link, from user reports.

## Problems
1. **Deleting the base corrupted the file.** A URDF is a tree hanging off its root; deleting the base cascade-removed the whole model, leaving an empty, unusable `.urdf`.
2. **No way to re-root.** Because everything hangs off the base, you couldn't promote another block to be the base once you'd started building.

## What's new
- **The base can't be deleted** — its ✕ is disabled with a hint, and it wears a **"★ This is the base"** badge in the edit row.
- **Every other block gets a "★ Make base" button** that re-roots the whole model onto it: reverse every joint on the path from the old base down to the new one (swap parent/child, invert the origin), leaving off-path sub-trees untouched.
- So the flow the user asked for works: **bless a new base mid-build, then delete the old one.**

## Architecture
- `robot-reroot.ts`: **`reRoot(urdf, newRoot)`** + `canReRoot()`. Origin inversion uses **three.js `Matrix4`** with urdf-loader's Euler order (**`'ZYX'`**), so it's exact for any `rpy` and reduces to negating `xyz` when `rpy=0` (the builder's own joints). Guards the root / detached links / cycles (no-op).
- `robot-assembly.ts`: factored out `parseJoint()`; added `readAllJoints()` + the `JointFull` type.
- `RobotView` also guards `handleDeleteLink` against the root (belt-and-suspenders).

**Limitation (flagged):** fixed joints re-root perfectly; a *movable* joint that happens to sit on the reversed path keeps its axis/limits as-is (best effort — correct for the common all-fixed structural path).

## Verification
- `typecheck` · `lint` · `test` (**1515 passing**, 6 new) · `build` — all green.
- Unit test includes a **non-zero-`rpy` there-and-back round-trip** proving the inversion is exact.
- In-app smoke (Playwright): editing the base shows the disabled ✕ + badge; **Make base** on a mid-chain block re-roots (root → that block, its joint reversed); the old base then **deletes cleanly**, leaving a valid `arm → hand` model.

Addresses the base-object reports on the epic #309 builder. (Undo for all builder actions is tracked separately in #338.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)