### PR TITLE
feat: Robot viewer — zoom controls + canonical pushpin (#309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Robot View — zoom controls + a consistent pin.** The 3-D viewer gains the
+  usual floating **zoom cluster** bottom-right (−, a live **%** readout, +, and a
+  **zoom-to-fit** button); **double-click the %** toggles 100% ↔ fit. The Build
+  panel's pin button now uses the app's standard **pushpin** icon (outline when
+  loose, filled when pinned) and accent colour, instead of a one-off gold star.
 - **Robot View — "Make base" + base protection (#309 builder).** A URDF hangs off
   its **base** link, so deleting the base used to leave an empty, unusable file.
   Now the base **can't be deleted** (its ✕ is disabled with a hint, and it shows a

--- a/src/renderer/src/components/RobotBuildPanel.css
+++ b/src/renderer/src/components/RobotBuildPanel.css
@@ -83,9 +83,13 @@
   cursor: pointer;
 }
 .robotbuild__pin.is-pinned {
-  color: #c8a24a;
+  /* Canonical pinned colour (matches WiringCanvas / BoardGraph). */
+  color: var(--accent, #34ad4f);
 }
-.robotbuild__pin:hover,
+.robotbuild__pin:hover {
+  color: var(--text, #d6dae0);
+  background: rgba(128, 128, 128, 0.18);
+}
 .robotbuild__collapse:hover {
   color: #c8a24a;
   border-color: var(--border, #3a3d44);

--- a/src/renderer/src/components/RobotBuildPanel.tsx
+++ b/src/renderer/src/components/RobotBuildPanel.tsx
@@ -15,11 +15,16 @@ import './RobotBuildPanel.css'
  * import, and — while a primitive is being edited — a numeric size form. All the
  * 3-D interaction (select, push/pull faces) lives in RobotView.
  */
-const STAR = (
+// The app-wide pushpin (canonical across WiringCanvas / BoardGraph): an outline
+// when unpinned, filled when pinned. Kept identical so the builder dock matches.
+const PinIcon = ({ pinned }: { pinned: boolean }): JSX.Element => (
   <svg viewBox="0 0 16 16" width="12" height="12" aria-hidden="true">
     <path
-      d="M8 1.6l1.9 3.9 4.3.6-3.1 3 .8 4.3L8 11.9 4.1 13.4l.8-4.3-3.1-3 4.3-.6z"
-      fill="currentColor"
+      d="M9.5 1.5l5 5-2.2.6-2.5 2.5.4 3.1-1.8-.3-2.6-2.6L2 13.6 1.4 13l3.8-3.8L2.6 6.6l-.3-1.8 3.1.4L7.9 2.7z"
+      fill={pinned ? 'currentColor' : 'none'}
+      stroke="currentColor"
+      strokeWidth="1.3"
+      strokeLinejoin="round"
     />
   </svg>
 )
@@ -375,7 +380,7 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
           title={pinned ? 'Unpin — hide when it loses focus' : 'Pin the panel open'}
           aria-label={pinned ? 'Unpin the build panel' : 'Pin the build panel open'}
         >
-          {STAR}
+          <PinIcon pinned={pinned} />
         </button>
         <span className="robotbuild__title">Build</span>
         <button

--- a/src/renderer/src/components/RobotView.css
+++ b/src/renderer/src/components/RobotView.css
@@ -89,6 +89,60 @@
   color: var(--text-muted, #7d838d);
 }
 
+/* Bottom-right zoom cluster (mirrors the node-graph viewport control). */
+.robotview__zoom {
+  position: absolute;
+  right: 0.6rem;
+  bottom: 0.55rem;
+  z-index: 6;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px;
+  border-radius: 10px;
+  background: rgba(31, 32, 36, 0.92);
+  border: 1px solid var(--border, #3a3d44);
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  backdrop-filter: blur(6px);
+  user-select: none;
+}
+:root[data-theme='skeuomorph'] .robotview__zoom {
+  background: rgba(231, 226, 211, 0.9);
+}
+.robotview__zbtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  height: 28px;
+  padding: 0 6px;
+  font-family: inherit;
+  font-size: 15px;
+  line-height: 1;
+  color: var(--text, #c2c7cf);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.robotview__zbtn:hover {
+  color: #c8a24a;
+  border-color: var(--border, #3a3d44);
+}
+.robotview__zbtn--pct {
+  min-width: 46px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+.robotview__zsep {
+  width: 1px;
+  height: 18px;
+  margin: 0 2px;
+  background: var(--border, #3d414a);
+  flex: 0 0 auto;
+}
+
 /* A non-blocking banner when one or more meshes couldn't load (#319). */
 .robotview__note {
   position: absolute;

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -153,6 +153,10 @@ export function RobotView({
   const measureActiveRef = useRef(false)
   const measureApiRef = useRef<{ clear: () => void } | null>(null)
   const highlightApiRef = useRef<{ apply: (link: string | null) => void } | null>(null)
+  // Imperative zoom API (the buttons live in React; the ortho camera lives in the
+  // three.js effect) + the live zoom % for the readout.
+  const zoomApiRef = useRef<{ in: () => void; out: () => void; fit: () => void; toggle: () => void } | null>(null)
+  const [zoomPct, setZoomPct] = useState(100)
   metaRef.current = jointMeta
   valuesRef.current = values
   overridesRef.current = overrides
@@ -714,6 +718,41 @@ export function RobotView({
       camera.bottom = -halfView
       camera.updateProjectionMatrix()
     }
+
+    // ── Zoom controls (mirrors the node-graph viewport cluster) ──
+    const syncZoomPct = (): void => setZoomPct(Math.round(camera.zoom * 100))
+    const applyZoom = (z: number): void => {
+      camera.zoom = Math.min(8, Math.max(0.2, z))
+      camera.updateProjectionMatrix()
+      syncZoomPct()
+    }
+    // Zoom-to-fit: recentre on the model + size the frustum to its bounds, keeping
+    // the current orbit orientation (zoom multiplier back to 1).
+    const fitView = (): void => {
+      const robot = robotRef.current
+      if (!robot) return
+      robot.updateMatrixWorld(true)
+      const box = new THREE.Box3().setFromObject(robot)
+      if (box.isEmpty() || !Number.isFinite(box.min.x)) return
+      const size = box.getSize(new THREE.Vector3())
+      const centre = box.getCenter(new THREE.Vector3())
+      halfView = Math.max(size.x, size.y, size.z, 0.1) * 0.5 * 1.35
+      controls.target.copy(centre)
+      camera.zoom = 1
+      camera.updateProjectionMatrix()
+      controls.update()
+      resize()
+      syncZoomPct()
+    }
+    zoomApiRef.current = {
+      in: () => applyZoom(camera.zoom * 1.2),
+      out: () => applyZoom(camera.zoom / 1.2),
+      fit: fitView,
+      // Double-clicking the % readout: 100% ↔ fit (keyed on the live zoom).
+      toggle: () => (Math.abs(camera.zoom - 1) < 0.005 ? fitView() : applyZoom(1))
+    }
+    const onControlsChange = (): void => syncZoomPct()
+    controls.addEventListener('change', onControlsChange)
 
     // Frame the model isometrically + (re)lay a ground grid under it. Called once
     // up-front (primitives) and again when async meshes arrive and grow the box.
@@ -1438,6 +1477,8 @@ export function RobotView({
       teardownPose()
       cancelAnimationFrame(raf)
       ro.disconnect()
+      controls.removeEventListener('change', onControlsChange)
+      zoomApiRef.current = null
       controls.dispose()
       scene.traverse((o) => {
         const mesh = o as THREE.Mesh
@@ -1480,6 +1521,56 @@ export function RobotView({
         {!error && meshNote && (
           <div className="robotview__note" role="status">
             {meshNote}
+          </div>
+        )}
+        {!isEmpty && !error && !compact && (
+          <div className="robotview__zoom" role="toolbar" aria-label="Zoom controls">
+            <button
+              type="button"
+              className="robotview__zbtn"
+              onClick={() => zoomApiRef.current?.out()}
+              title="Zoom out"
+              aria-label="Zoom out"
+            >
+              −
+            </button>
+            <button
+              type="button"
+              className="robotview__zbtn robotview__zbtn--pct"
+              onDoubleClick={() => zoomApiRef.current?.toggle()}
+              title="Double-click: 100% ↔ zoom to fit"
+              aria-label={`Zoom ${zoomPct}% — double-click to toggle 100% / fit`}
+            >
+              {zoomPct}%
+            </button>
+            <button
+              type="button"
+              className="robotview__zbtn"
+              onClick={() => zoomApiRef.current?.in()}
+              title="Zoom in"
+              aria-label="Zoom in"
+            >
+              +
+            </button>
+            <span className="robotview__zsep" aria-hidden="true" />
+            <button
+              type="button"
+              className="robotview__zbtn"
+              onClick={() => zoomApiRef.current?.fit()}
+              title="Zoom to fit"
+              aria-label="Zoom to fit"
+            >
+              <svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  d="M4 9V4h5M20 9V4h-5M4 15v5h5M20 15v5h-5"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </button>
           </div>
         )}
         {showPanel && buildOpen && (


### PR DESCRIPTION
Two Robot-View chrome fixes from user feedback (first two of three; the navigation cube is a follow-up PR).

## Zoom controls
The 3-D viewer gains the **usual floating zoom cluster** bottom-right of the stage, mirroring the node-graph board view:
- **−** / live **%** readout / **+** / a **zoom-to-fit** button.
- **Double-click the %** toggles **100% ↔ zoom-to-fit** (keyed on the live zoom).
- +/− step ×1.2 (clamped 0.2–8); the % tracks the orthographic `camera.zoom` live via OrbitControls' `change` event. "Fit" recentres on the model bounds keeping the current orbit orientation.
- Hidden in the compact docked mini-viewer.

## Canonical pin
The Build panel's pin button used a one-off **gold ★** (always filled). It now uses the **app-wide pushpin** (outline when loose → filled when pinned) with the standard `--accent` colour + hover treatment — identical to `WiringCanvas` / `BoardGraph`, so it's theme-consistent (green in dark, ink on parchment).

## Verification
- `typecheck` · `lint` · `test` (**1515 passing**) · `build` — all green.
- In-app smoke (Playwright): zoom `100% → +×2 → 144% → −→ 120% → dbl-click % → 100%`; the pin renders the pushpin path (`fill=none` loose → `fill=currentColor` pinned, `is-pinned` class, `--accent` colour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)