### PR TITLE
feat: Robot builder — add at origin + reveal; match app zoom controls (#309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,18 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Robot View — new blocks & meshes arrive at the origin, not stuck to the
+  selection.** Adding a block or importing an STL/DAE now drops it at the
+  **workspace origin** (attached to the base), **selects it**, and **reframes** so
+  it's actually in view — instead of auto-joining it to the selected part with an
+  offset (a placement that can't be guessed). Selecting a block in the Build list
+  highlights it in 3-D, meshes included (re-applied once an async mesh loads).
 - **Robot View — zoom controls + a consistent pin.** The 3-D viewer gains the
   usual floating **zoom cluster** bottom-right (−, a live **%** readout, +, and a
-  **zoom-to-fit** button); **double-click the %** toggles 100% ↔ fit. The Build
-  panel's pin button now uses the app's standard **pushpin** icon (outline when
-  loose, filled when pinned) and accent colour, instead of a one-off gold star.
+  **zoom-to-fit** button), styled identically to the node-graph control;
+  **double-click the %** toggles 100% ↔ fit. The Build panel's pin button now uses
+  the app's standard **pushpin** icon (outline when loose, filled when pinned) and
+  accent colour, instead of a one-off gold star.
 - **Robot View — "Make base" + base protection (#309 builder).** A URDF hangs off
   its **base** link, so deleting the base used to leave an empty, unusable file.
   Now the base **can't be deleted** (its ✕ is disabled with a hint, and it shows a

--- a/src/renderer/src/components/RobotView.css
+++ b/src/renderer/src/components/RobotView.css
@@ -89,57 +89,61 @@
   color: var(--text-muted, #7d838d);
 }
 
-/* Bottom-right zoom cluster (mirrors the node-graph viewport control). */
+/* Bottom-right zoom cluster — identical to the node-graph viewport control
+   (.boardgraph__viewport-ctl) so every zoom control in the app matches. */
 .robotview__zoom {
   position: absolute;
-  right: 0.6rem;
-  bottom: 0.55rem;
-  z-index: 6;
+  right: 16px;
+  bottom: 16px;
+  z-index: 30;
   display: flex;
   align-items: center;
   gap: 4px;
-  padding: 4px;
-  border-radius: 10px;
+  padding: 5px;
+  border-radius: 12px;
   background: rgba(31, 32, 36, 0.92);
-  border: 1px solid var(--border, #3a3d44);
-  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  border: 1px solid #3a3d44;
+  box-shadow:
+    0 8px 22px rgba(0, 0, 0, 0.5),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
   backdrop-filter: blur(6px);
   user-select: none;
-}
-:root[data-theme='skeuomorph'] .robotview__zoom {
-  background: rgba(231, 226, 211, 0.9);
 }
 .robotview__zbtn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 28px;
-  height: 28px;
+  min-width: 32px;
+  height: 32px;
   padding: 0 6px;
-  font-family: inherit;
-  font-size: 15px;
+  font-family: var(--font-mono), 'JetBrains Mono', monospace;
+  font-size: 17px;
   line-height: 1;
-  color: var(--text, #c2c7cf);
-  background: transparent;
-  border: 1px solid transparent;
-  border-radius: 6px;
+  color: #c2c7cf;
+  background: linear-gradient(180deg, #2c2f35, #232529);
+  border: 1px solid #3d414a;
+  border-radius: 8px;
   cursor: pointer;
 }
 .robotview__zbtn:hover {
-  color: #c8a24a;
-  border-color: var(--border, #3a3d44);
+  color: #fff;
+  border-color: #5a606b;
+  background: linear-gradient(180deg, #34373e, #292b30);
+}
+.robotview__zbtn:active {
+  background: #202227;
 }
 .robotview__zbtn--pct {
-  min-width: 46px;
-  font-size: 11px;
+  min-width: 48px;
+  font-size: 12px;
   font-weight: 700;
   letter-spacing: 0.02em;
 }
 .robotview__zsep {
   width: 1px;
-  height: 18px;
+  height: 22px;
   margin: 0 2px;
-  background: var(--border, #3d414a);
+  background: #3d414a;
   flex: 0 0 auto;
 }
 

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -312,6 +312,9 @@ export function RobotView({
     halfView: number
   } | null>(null)
   const framedKeyRef = useRef<string | null>(null)
+  // Set before an ADD (primitive / STL) so the next re-parse RE-FRAMES to reveal
+  // the new object at the origin, instead of preserving the camera like an edit.
+  const refitNextRef = useRef(false)
 
   const editGeom: PrimitiveGeom | null = useMemo(
     () => (editLink ? readPrimitive(content, editLink) : null),
@@ -342,7 +345,11 @@ export function RobotView({
 
   const handleAddPrimitive = (kind: PrimitiveKind): void => {
     if (!canEdit) return // needs a saved project file — don't set a phantom selection
-    const { urdf, link } = addPrimitive(content, { kind, parent: selectedLink ?? undefined })
+    // Bring a new block in at the WORKSPACE ORIGIN, attached to the base (never
+    // auto-stuck onto the selected part — that placement can't be guessed). The
+    // user then moves/joins it. Reframe so it's actually in view.
+    refitNextRef.current = true
+    const { urdf, link } = addPrimitive(content, { kind, jointXyz: [0, 0, 0] })
     commitUrdf(urdf)
     setSelectedLink(link)
     setEditLink(link)
@@ -640,14 +647,19 @@ export function RobotView({
         if (res.error) setSavingLabel(`import failed: ${res.error}`)
         return
       }
-      // Add the mesh to the URDF (a new link + fixed joint) so it renders now.
+      // Add the mesh to the URDF (a new link + fixed joint at the origin) so it
+      // renders now. Select it + reframe so the user can see + place it.
       const linkBase = res.name?.replace(/\.(stl|dae)$/i, '') ?? 'part'
       const next = addMeshLink(content, { meshRel: res.rel, linkBase })
+      refitNextRef.current = true
       // Update the buffer (RobotView re-renders + the tab reflects it), then let
       // an effect persist it once the store state is fresh (saveFile() called
       // here would write the stale pre-edit content).
       updateContent(activeFile.id, next.urdf)
       pendingSaveRef.current = activeFile.id
+      setSelectedLink(next.link)
+      setEditLink(next.link)
+      if (!buildOpen) setBuildOpen(true)
       setSavingLabel(`added ${next.link}`)
     } catch (e) {
       setSavingLabel(`import failed: ${e instanceof Error ? e.message : 'error'}`)
@@ -802,6 +814,14 @@ export function RobotView({
     }
     const framePreservingCamera = (robot: URDFRobot): void => {
       const saved = cameraStateRef.current
+      if (refitNextRef.current) {
+        // A just-added object: reframe so it's actually in view (once).
+        refitNextRef.current = false
+        frameModel(robot)
+        framedKeyRef.current = frameKey
+        cameraStateRef.current = null
+        return
+      }
       if (saved && framedKeyRef.current === frameKey) {
         halfView = saved.halfView
         camera.position.copy(saved.pos)
@@ -833,6 +853,9 @@ export function RobotView({
     const finalize = (): void => {
       if (disposed || !ready || pending > 0 || !robot) return
       framePreservingCamera(robot)
+      // A mesh that finished loading async isn't outlined yet — re-apply the
+      // selection highlight now that its geometry exists.
+      highlightApiRef.current?.apply(selectedLinkRef.current)
       if (failed.length) {
         const shown = failed.slice(0, 3).join(', ')
         const more = failed.length > 3 ? ` +${failed.length - 3} more` : ''


### PR DESCRIPTION
Robot builder/viewer refinements from user feedback.

## New blocks & meshes arrive at the origin (not stuck to the selection)
Reported: *"added an STL, I can see it listed but can't actually see it"* + *"stop sticking new objects together — they can never be placed automatically."*
- Adding a block or importing an STL/DAE now drops it at the **workspace origin**, attached to the **base** (not auto-joined to the selected part with a `[0.06,0,0]` offset).
- The new object is **selected** and the view **reframes** to reveal it — previously the same-file re-parse *preserved* the camera (the #315a "no view jump" behaviour), leaving a freshly-added object off-screen.
- Selecting a block in the Build list **highlights it in 3-D**, meshes included — the outline is re-applied once an async mesh finishes loading.

## Zoom controls match the app exactly
Reported: *"the zoom controls need to match the colour/size/icon placement/behaviour of all the other zoom controls."* The cluster now uses the **identical** styling to the node-graph `.boardgraph__viewport-ctl` (dark gradient buttons, 32px sizes, white hover, 16px inset) instead of the parchment/gold variant.

## Verification
- `typecheck` · `lint` · `test` (**1515 passing**) · `build` — all green.
- In-app smoke: with `arm` selected, adding a **Box** created `box_joint` with **parent `base_link`** (root, not `arm`) at **`xyz="0 0 0"`**, selected the box, and reframed so it's visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)