### PR TITLE
fix: Robot View — readable highlight text via var(--accent) (#309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   or reopen any panel. Nothing about Robot mode is permanently changed.
 
 ### Fixed
+- **Robot View accent text is readable on the parchment theme.** The Robot-View
+  panels hard-coded a light gold (`#c8a24a`) for highlight/active text, which
+  didn't darken for the skeuomorph (parchment) theme — gold-on-cream was hard to
+  read. They now use the theme-aware `var(--accent)` brass token (dark-brass on
+  parchment, gold on dark), like the rest of the app. (3-D selection outlines /
+  snap handles stay gold — the canvas is always dark.)
 - **Files panel now always reopens from the toolbar button / activity icon.** A
   workspace switch (or the Robot pop-out) could leave the panel visually
   collapsed while the store thought it was open, so the next toggle click called

--- a/src/renderer/src/components/RobotBuildPanel.css
+++ b/src/renderer/src/components/RobotBuildPanel.css
@@ -21,8 +21,8 @@
   cursor: pointer;
 }
 .robotbuild__tab:hover {
-  color: #c8a24a;
-  border-color: #c8a24a;
+  color: var(--accent);
+  border-color: var(--accent);
 }
 
 /* Open: the glass dock, anchored left. */
@@ -67,7 +67,7 @@
 .robotbuild__title {
   flex: 1 1 auto;
   font-weight: 700;
-  color: #c8a24a;
+  color: var(--accent);
   letter-spacing: 0.04em;
 }
 .robotbuild__pin,
@@ -91,7 +91,7 @@
   background: rgba(128, 128, 128, 0.18);
 }
 .robotbuild__collapse:hover {
-  color: #c8a24a;
+  color: var(--accent);
   border-color: var(--border, #3a3d44);
 }
 .robotbuild__collapse {
@@ -115,8 +115,8 @@
   cursor: pointer;
 }
 .robotbuild__add button:hover:not(:disabled) {
-  border-color: #c8a24a;
-  color: #c8a24a;
+  border-color: var(--accent);
+  color: var(--accent);
 }
 .robotbuild__add button:disabled {
   opacity: 0.45;
@@ -177,7 +177,7 @@
   color: var(--text-muted, #8b919b);
 }
 .robotbuild__part-geo.is-mesh {
-  color: #c8a24a;
+  color: var(--accent);
 }
 .robotbuild__edit {
   flex: 0 0 auto;
@@ -192,7 +192,7 @@
 }
 .robotbuild__edit:hover,
 .robotbuild__edit.is-on {
-  color: #c8a24a;
+  color: var(--accent);
   border-color: var(--border, #3a3d44);
 }
 .robotbuild__editrow {
@@ -245,8 +245,8 @@
 }
 .robotbuild__chip.is-on {
   color: #1a1c20;
-  background: #c8a24a;
-  border-color: #c8a24a;
+  background: var(--accent);
+  border-color: var(--accent);
 }
 .robotbuild__jnote,
 .robotbuild__jsel {
@@ -342,13 +342,13 @@
   cursor: pointer;
 }
 .robotbuild__makebase:hover {
-  color: #c8a24a;
-  border-color: #c8a24a;
+  color: var(--accent);
+  border-color: var(--accent);
 }
 .robotbuild__basebadge {
   align-self: flex-start;
   font-size: 0.55rem;
-  color: #c8a24a;
+  color: var(--accent);
 }
 .robotbuild__empty {
   color: var(--text-muted, #8b919b);
@@ -372,7 +372,7 @@
   cursor: pointer;
 }
 .robotbuild__stl:hover:not(:disabled) {
-  border-color: #c8a24a;
+  border-color: var(--accent);
 }
 .robotbuild__stl:disabled {
   opacity: 0.45;
@@ -387,7 +387,7 @@
   font-family: var(--font-mono, 'JetBrains Mono', monospace);
   font-size: 0.66rem;
   color: #191a1d;
-  background: #c8a24a;
+  background: var(--accent);
   border-radius: 4px;
   padding: 0.1rem 0.35rem;
   white-space: nowrap;

--- a/src/renderer/src/components/RobotJointPanel.css
+++ b/src/renderer/src/components/RobotJointPanel.css
@@ -27,7 +27,7 @@
 .robotpanel__title {
   font-size: 0.8rem;
   font-weight: 700;
-  color: #c8a24a;
+  color: var(--accent);
   letter-spacing: 0.04em;
 }
 .robotpanel__empty {
@@ -46,7 +46,7 @@
   cursor: pointer;
 }
 .robotpanel__btn:hover {
-  border-color: #c8a24a;
+  border-color: var(--accent);
 }
 .robotpanel__btn:disabled {
   opacity: 0.45;
@@ -75,7 +75,7 @@
   white-space: nowrap;
 }
 .robotpanel__joint-val {
-  color: #c8a24a;
+  color: var(--accent);
   font-variant-numeric: tabular-nums;
   flex: 0 0 auto;
 }
@@ -87,7 +87,7 @@
 .robotpanel__slider {
   flex: 1 1 auto;
   min-width: 0;
-  accent-color: #c8a24a;
+  accent-color: var(--accent);
   cursor: pointer;
 }
 .robotpanel__limit {
@@ -172,7 +172,7 @@
   cursor: pointer;
 }
 .robotpanel__pose-recall:hover {
-  border-color: #c8a24a;
+  border-color: var(--accent);
 }
 .robotpanel__pose-del {
   flex: 0 0 auto;
@@ -219,7 +219,7 @@
   font-size: 0.58rem;
 }
 .robotpanel__part-geo.is-mesh {
-  color: #c8a24a;
+  color: var(--accent);
 }
 
 /* Servo → joint bindings (#313). */
@@ -244,7 +244,7 @@
   gap: 0.3rem;
 }
 .robotpanel__servo-pin {
-  color: #c8a24a;
+  color: var(--accent);
   font-weight: 700;
   flex: 0 0 auto;
 }
@@ -318,12 +318,12 @@
 }
 
 .robotpanel__measure.is-on {
-  border-color: #c8a24a;
-  color: #c8a24a;
+  border-color: var(--accent);
+  color: var(--accent);
 }
 .robotpanel__measure-out {
   font-size: 0.72rem;
-  color: #c8a24a;
+  color: var(--accent);
   font-variant-numeric: tabular-nums;
   text-align: center;
   padding: 0.2rem;

--- a/src/renderer/src/components/RobotTimeline.css
+++ b/src/renderer/src/components/RobotTimeline.css
@@ -29,7 +29,7 @@
   white-space: nowrap;
 }
 .robottimeline__btn:hover:not(:disabled) {
-  border-color: #c8a24a;
+  border-color: var(--accent);
 }
 .robottimeline__btn:disabled {
   opacity: 0.45;
@@ -37,8 +37,8 @@
 }
 .robottimeline__btn.is-on {
   color: #191a1d;
-  background: #c8a24a;
-  border-color: #c8a24a;
+  background: var(--accent);
+  border-color: var(--accent);
 }
 .robottimeline__btn--del:hover:not(:disabled) {
   border-color: #b4544e;
@@ -63,12 +63,12 @@
 .robottimeline__scrub {
   flex: 1 1 auto;
   min-width: 4rem;
-  accent-color: #c8a24a;
+  accent-color: var(--accent);
   cursor: pointer;
 }
 .robottimeline__time {
   flex: 0 0 auto;
-  color: #c8a24a;
+  color: var(--accent);
   font-variant-numeric: tabular-nums;
   min-width: 3.2rem;
   text-align: right;
@@ -112,7 +112,7 @@
   bottom: 0;
   width: 2px;
   margin-left: 6.5rem; /* line up with the track start (after the name column) */
-  background: #c8a24a;
+  background: var(--accent);
   pointer-events: none;
   z-index: 3;
 }
@@ -146,7 +146,7 @@
   width: 9px;
   height: 9px;
   transform: translate(-50%, -50%) rotate(45deg);
-  background: #c8a24a;
+  background: var(--accent);
   border: 1px solid #191a1d;
   border-radius: 2px;
   padding: 0;

--- a/src/renderer/src/components/RobotToolbar.css
+++ b/src/renderer/src/components/RobotToolbar.css
@@ -30,11 +30,11 @@
 }
 .robottool__btn:hover:not(:disabled) {
   border-color: var(--border, #3a3d44);
-  color: #c8a24a;
+  color: var(--accent);
 }
 .robottool__btn.is-active {
-  color: #c8a24a;
-  border-color: #c8a24a;
+  color: var(--accent);
+  border-color: var(--accent);
   background: rgba(200, 162, 74, 0.18);
 }
 .robottool__btn:disabled {

--- a/src/renderer/src/components/RobotView.css
+++ b/src/renderer/src/components/RobotView.css
@@ -83,7 +83,7 @@
   pointer-events: none;
 }
 .robotview__hud strong {
-  color: #c8a24a;
+  color: var(--accent);
 }
 .robotview__hud-hint {
   color: var(--text-muted, #7d838d);


### PR DESCRIPTION
Reported: *"there is an orange highlight colour in the URDF editor and it's very hard to read — stop using that for text."*

**Root cause:** the Robot-View panels hard-coded a light gold `#c8a24a` for highlight/active text. The app's `--accent` token is brass **and theme-aware** (`#d6a23f` on dark, `#b07d1e` on the skeuomorph/parchment theme) — but the hard-coded gold never darkened for parchment, so gold-on-cream text was low-contrast.

**Fix:** replace every hard-coded `#c8a24a` in `RobotBuildPanel/JointPanel/Timeline/Toolbar/View.css` (36 occurrences) with `var(--accent)`, so accents read clearly on both themes and match the rest of the app. The three.js accents in `RobotView.tsx` (`0xc8a24a` selection outline, snap handles, measure markers) intentionally stay gold — the 3-D canvas is always dark and they aren't text.

Verified: `--accent` resolves to `#b07d1e` on skeuomorph; screenshot confirms the joint chips / axis / "Make base" text now read as dark brass on parchment. `build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)