### PR TITLE
feat: Robot View — navigation cube (CAD-style ViewCube) (#309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Robot View — navigation cube.** A CAD-style **ViewCube** floats at the
+  top-right of the 3-D viewer, mirroring the camera's orientation as you orbit;
+  **click a face** (Front / Back / Left / Right / Top / Bottom) to snap the view
+  to that straight-on orthographic angle. Runs in its own small canvas so it never
+  fights the viewer's orbit/zoom.
 - **Robot View — new blocks & meshes arrive at the origin, not stuck to the
   selection.** Adding a block or importing an STL/DAE now drops it at the
   **workspace origin** (attached to the base), **selects it**, and **reframes** so

--- a/src/renderer/src/components/RobotView.css
+++ b/src/renderer/src/components/RobotView.css
@@ -89,6 +89,20 @@
   color: var(--text-muted, #7d838d);
 }
 
+/* Navigation cube — top-right of the stage (its own canvas is appended here). */
+.robotview__viewcube {
+  position: absolute;
+  right: 12px;
+  top: 12px;
+  z-index: 30;
+  width: 72px;
+  height: 72px;
+  filter: drop-shadow(0 4px 10px rgba(0, 0, 0, 0.45));
+}
+.robotview__viewcube canvas {
+  display: block;
+}
+
 /* Bottom-right zoom cluster — identical to the node-graph viewport control
    (.boardgraph__viewport-ctl) so every zoom control in the app matches. */
 .robotview__zoom {
@@ -147,10 +161,11 @@
   flex: 0 0 auto;
 }
 
-/* A non-blocking banner when one or more meshes couldn't load (#319). */
+/* A non-blocking banner when one or more meshes couldn't load (#319). Sits left
+   of the navigation cube (top-right). */
 .robotview__note {
   position: absolute;
-  right: 0.6rem;
+  right: 96px;
   top: 0.55rem;
   max-width: 70%;
   padding: 0.3rem 0.55rem;

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -35,6 +35,7 @@ import {
   type PrimitiveGeom
 } from './robot-assembly'
 import { reRoot } from './robot-reroot'
+import { createViewCube } from './robot-viewcube'
 import {
   classifyFace,
   faceSnapPoints,
@@ -126,6 +127,7 @@ export function RobotView({
     basePath ?? (activeFile && activeFile.source === 'local' ? dirname(activeFile.path) : '')
 
   const mountRef = useRef<HTMLDivElement>(null)
+  const cubeMountRef = useRef<HTMLDivElement>(null)
   const [error, setError] = useState<string | null>(null)
   const [info, setInfo] = useState<{ name: string; joints: number; links: number } | null>(null)
   const [meshNote, setMeshNote] = useState<string | null>(null)
@@ -711,6 +713,19 @@ export function RobotView({
     const fill = new THREE.DirectionalLight(0x9fb4d0, 0.35)
     fill.position.set(-1.5, 1, -1.2)
     scene.add(fill)
+
+    // Navigation cube (top-right): mirrors the camera; a face-click snaps the
+    // view to that orthographic direction. Its own canvas → no OrbitControls clash.
+    const snapView = (dir: THREE.Vector3): void => {
+      const dist = camera.position.distanceTo(controls.target) || 1
+      // Keep "up" sane for straight top/bottom views (else the view is degenerate).
+      camera.up.set(0, 1, 0)
+      if (Math.abs(dir.y) > 0.9) camera.up.set(0, 0, dir.y > 0 ? -1 : 1)
+      camera.position.copy(controls.target).addScaledVector(dir, dist)
+      controls.update()
+    }
+    const viewCube = cubeMountRef.current ? createViewCube({ size: 72, onPick: snapView }) : null
+    if (viewCube && cubeMountRef.current) cubeMountRef.current.appendChild(viewCube.dom)
 
     // Half-height of the ortho frustum (updated by frameModel as bounds change).
     let halfView = 1
@@ -1482,6 +1497,10 @@ export function RobotView({
     const tick = (): void => {
       controls.update()
       renderer.render(scene, camera)
+      if (viewCube) {
+        viewCube.sync(camera.quaternion)
+        viewCube.render()
+      }
       raf = requestAnimationFrame(tick)
     }
     tick()
@@ -1502,6 +1521,10 @@ export function RobotView({
       ro.disconnect()
       controls.removeEventListener('change', onControlsChange)
       zoomApiRef.current = null
+      if (viewCube) {
+        viewCube.dom.remove()
+        viewCube.dispose()
+      }
       controls.dispose()
       scene.traverse((o) => {
         const mesh = o as THREE.Mesh
@@ -1545,6 +1568,9 @@ export function RobotView({
           <div className="robotview__note" role="status">
             {meshNote}
           </div>
+        )}
+        {!isEmpty && !error && !compact && (
+          <div className="robotview__viewcube" ref={cubeMountRef} title="Click a face to snap the view" />
         )}
         {!isEmpty && !error && !compact && (
           <div className="robotview__zoom" role="toolbar" aria-label="Zoom controls">

--- a/src/renderer/src/components/robot-viewcube.ts
+++ b/src/renderer/src/components/robot-viewcube.ts
@@ -1,0 +1,122 @@
+/**
+ * NAVIGATION CUBE (#309) — a small CAD-style ViewCube floating in the corner of
+ * the 3-D viewer. It mirrors the main camera's orientation each frame, and
+ * clicking a face snaps the camera to that orthographic view (front/back/…/top).
+ *
+ * It runs in its OWN tiny canvas + WebGL context so its pointer handling can't
+ * fight the main viewer's OrbitControls. The host calls `sync()` + `render()`
+ * each frame and handles `onPick(dir)` by moving the main camera to look at the
+ * model FROM `dir` (a world-space unit direction). The scene is three's Y-up
+ * (the URDF loader rotates Z-up models into Y-up), so +Y = top, +Z = front.
+ */
+import * as THREE from 'three'
+
+export interface ViewCube {
+  /** The cube's canvas — append it where you want the widget (top-right). */
+  readonly dom: HTMLCanvasElement
+  /** Orient the cube to match the main camera (call each frame before render). */
+  sync: (cameraQuaternion: THREE.Quaternion) => void
+  render: () => void
+  dispose: () => void
+}
+
+const FACES: Array<{ label: string; normal: [number, number, number] }> = [
+  { label: 'RIGHT', normal: [1, 0, 0] }, // +X  (BoxGeometry material order)
+  { label: 'LEFT', normal: [-1, 0, 0] }, // -X
+  { label: 'TOP', normal: [0, 1, 0] }, // +Y
+  { label: 'BOT', normal: [0, -1, 0] }, // -Y
+  { label: 'FRONT', normal: [0, 0, 1] }, // +Z
+  { label: 'BACK', normal: [0, 0, -1] } // -Z
+]
+
+/** A face label painted onto a canvas texture (parchment-brass, readable). */
+function faceTexture(text: string): THREE.CanvasTexture {
+  const c = document.createElement('canvas')
+  c.width = c.height = 128
+  const ctx = c.getContext('2d')!
+  ctx.fillStyle = '#e7e2d3'
+  ctx.fillRect(0, 0, 128, 128)
+  ctx.strokeStyle = '#b07d1e'
+  ctx.lineWidth = 7
+  ctx.strokeRect(4, 4, 120, 120)
+  ctx.fillStyle = '#34373d'
+  ctx.font = 'bold 24px sans-serif'
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'middle'
+  ctx.fillText(text, 64, 66)
+  const tex = new THREE.CanvasTexture(c)
+  tex.anisotropy = 4
+  return tex
+}
+
+export function createViewCube(opts: {
+  size: number
+  onPick: (dir: THREE.Vector3) => void
+}): ViewCube {
+  const { size, onPick } = opts
+  const canvas = document.createElement('canvas')
+  const renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: true })
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2))
+  renderer.setSize(size, size)
+
+  const scene = new THREE.Scene()
+  // Fixed ortho camera looking straight at the cube; the CUBE rotates.
+  const camera = new THREE.OrthographicCamera(-1.5, 1.5, 1.5, -1.5, 0.1, 10)
+  camera.position.set(0, 0, 4)
+  camera.lookAt(0, 0, 0)
+  scene.add(new THREE.HemisphereLight(0xffffff, 0x555555, 1.2))
+
+  const materials = FACES.map((f) => {
+    const map = faceTexture(f.label)
+    return new THREE.MeshBasicMaterial({ map })
+  })
+  const geometry = new THREE.BoxGeometry(1, 1, 1)
+  const cube = new THREE.Mesh(geometry, materials)
+  scene.add(cube)
+  // Crisp edges so the cube reads as a solid block.
+  const edgeGeo = new THREE.EdgesGeometry(geometry)
+  const edgeMat = new THREE.LineBasicMaterial({ color: 0x8a6a2a })
+  const edges = new THREE.LineSegments(edgeGeo, edgeMat)
+  cube.add(edges)
+
+  const raycaster = new THREE.Raycaster()
+  const ndc = new THREE.Vector2()
+
+  const onClick = (e: MouseEvent): void => {
+    const rect = canvas.getBoundingClientRect()
+    ndc.x = ((e.clientX - rect.left) / rect.width) * 2 - 1
+    ndc.y = -((e.clientY - rect.top) / rect.height) * 2 + 1
+    raycaster.setFromCamera(ndc, camera)
+    const hit = raycaster.intersectObject(cube, false)[0]
+    if (!hit || !hit.face) return
+    // The clicked face's LOCAL normal is the world axis it represents (the cube's
+    // local axes map 1:1 to world axes; the rotation only faces it at the viewer).
+    const n = hit.face.normal
+    onPick(new THREE.Vector3(Math.round(n.x), Math.round(n.y), Math.round(n.z)))
+  }
+  canvas.addEventListener('click', onClick)
+  canvas.style.cursor = 'pointer'
+
+  const inv = new THREE.Quaternion()
+  return {
+    dom: canvas,
+    sync: (q) => {
+      // Cube orientation = inverse of the camera's world orientation, so the face
+      // toward the viewer is the world direction the camera looks along.
+      inv.copy(q).invert()
+      cube.quaternion.copy(inv)
+    },
+    render: () => renderer.render(scene, camera),
+    dispose: () => {
+      canvas.removeEventListener('click', onClick)
+      geometry.dispose()
+      edgeGeo.dispose()
+      edgeMat.dispose()
+      materials.forEach((m) => {
+        m.map?.dispose()
+        m.dispose()
+      })
+      renderer.dispose()
+    }
+  }
+}


### PR DESCRIPTION
The third of the requested viewer-chrome improvements (after the pin icon + zoom controls). A CAD-style **ViewCube** floats at the top-right of the 3-D viewer.

## What it does
- **Mirrors the camera**: as you orbit, the cube rotates in lockstep, so you always see which way is up/front.
- **Click a face** (Front / Back / Left / Right / Top / Bottom) to **snap** the view to that straight-on orthographic angle.

## Design
- `robot-viewcube.ts` is a **self-contained widget** with its **own canvas + WebGL context + click handling**, so it can never fight the main viewer's OrbitControls (the reason for a second context rather than a scissored corner viewport). A labelled `BoxGeometry` (parchment/brass faces to match the theme), synced via `cube.quaternion = camera.quaternion.invert()`; a click raycasts the cube and the hit face's **local normal is the world direction to view from**.
- `RobotView` creates/appends the cube in the 3-D effect, `sync()`+`render()`s it in the tick loop, and `snapView()` repositions the orthographic camera (with a sane up-vector for straight top/bottom views). Disposed on teardown; hidden in the compact docked mini-viewer; the mesh-load banner shifts left to clear it.

> Note: `/Users/kev/Micropython/buddy` turned out not to contain a nav cube (just a plain three.js + OrbitControls viewer), so this is built from scratch.

## Verification
- `typecheck` · `lint` · `test` (**1515 passing**) · `build` — all green.
- In-app smoke: cube renders top-right (72×72), tracks the iso camera, and a face-click snaps the main view to a straight-on orthographic angle (canvas pixels change; screenshots confirm the iso→face-on snap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)