### PR TITLE
feat: Robot builder — toolbar consolidation + readable accent text (#309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   timeline follow.
 
 ### Changed
+- **Robot View builder — tidier toolbar + panel.** The **add Box / Tube / Ball**
+  buttons and the **Measure** tool moved onto the floating build toolbar (with the
+  select / push-pull / move / join tools and undo/redo). The left panel keeps the
+  hierarchy; **★ Make base** is now a one-click star on each block's row (no longer
+  hidden in edit mode). The collapsed **Build** tab is squared off and reads
+  top-to-bottom. Accent text in the builder (headings, the STL filename) uses a
+  **darker brass** (`--accent-ink`) so it's readable on the parchment theme, and
+  the toolbar's active-tool highlight is a neutral fill instead of hard-to-see gold.
 - **Robot pop-out now keeps you in Robot mode.** Instead of switching to Code
   mode, popping the robot out (or creating a new one) enters a transient *focus*:
   it hides the board, instruments and console so the URDF fills the editor, and

--- a/src/renderer/src/components/RobotBuildPanel.css
+++ b/src/renderer/src/components/RobotBuildPanel.css
@@ -7,8 +7,8 @@
   top: 0.6rem;
   left: 0;
   z-index: 4;
+  /* Vertical label reading top→bottom (no 180° flip — that read wrong-way-round). */
   writing-mode: vertical-rl;
-  transform: rotate(180deg);
   font-family: var(--font-mono, 'JetBrains Mono', monospace);
   font-size: 0.62rem;
   letter-spacing: 0.06em;
@@ -16,13 +16,13 @@
   background: rgba(20, 21, 24, 0.72);
   border: 1px solid var(--border, #3a3d44);
   border-left: none;
-  border-radius: 0 6px 6px 0;
+  border-radius: 0; /* square edge tab — no rounded corners */
   padding: 0.5rem 0.2rem;
   cursor: pointer;
 }
 .robotbuild__tab:hover {
-  color: var(--accent);
-  border-color: var(--accent);
+  color: var(--accent-ink);
+  border-color: var(--accent-ink);
 }
 
 /* Open: the glass dock, anchored left. */
@@ -67,7 +67,7 @@
 .robotbuild__title {
   flex: 1 1 auto;
   font-weight: 700;
-  color: var(--accent);
+  color: var(--accent-ink);
   letter-spacing: 0.04em;
 }
 .robotbuild__pin,
@@ -91,7 +91,7 @@
   background: rgba(128, 128, 128, 0.18);
 }
 .robotbuild__collapse:hover {
-  color: var(--accent);
+  color: var(--accent-ink);
   border-color: var(--border, #3a3d44);
 }
 .robotbuild__collapse {
@@ -99,27 +99,24 @@
   line-height: 1;
 }
 
-.robotbuild__add {
-  display: flex;
-  gap: 0.25rem;
-}
-.robotbuild__add button {
-  flex: 1 1 0;
-  font-family: inherit;
-  font-size: 0.62rem;
-  color: var(--text, #cdd2d9);
-  background: var(--bg-sunken, rgba(0, 0, 0, 0.25));
-  border: 1px solid var(--border, #3a3d44);
-  border-radius: 5px;
-  padding: 0.25rem 0.1rem;
+/* Per-row base marker: ☆ makes this the base, ★ marks the current base. */
+.robotbuild__rowbase {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.72rem;
+  line-height: 1;
+  color: var(--text-muted, #8b919b);
+  background: transparent;
+  border: none;
+  padding: 0.1rem 0.15rem;
   cursor: pointer;
 }
-.robotbuild__add button:hover:not(:disabled) {
-  border-color: var(--accent);
-  color: var(--accent);
+.robotbuild__rowbase:hover {
+  color: var(--accent-ink);
 }
-.robotbuild__add button:disabled {
-  opacity: 0.45;
+.robotbuild__rowbase.is-base {
+  color: var(--accent-ink);
   cursor: default;
 }
 .robotbuild__hint {
@@ -177,7 +174,7 @@
   color: var(--text-muted, #8b919b);
 }
 .robotbuild__part-geo.is-mesh {
-  color: var(--accent);
+  color: var(--accent-ink);
 }
 .robotbuild__edit {
   flex: 0 0 auto;
@@ -192,7 +189,7 @@
 }
 .robotbuild__edit:hover,
 .robotbuild__edit.is-on {
-  color: var(--accent);
+  color: var(--accent-ink);
   border-color: var(--border, #3a3d44);
 }
 .robotbuild__editrow {
@@ -246,7 +243,7 @@
 .robotbuild__chip.is-on {
   color: #1a1c20;
   background: var(--accent);
-  border-color: var(--accent);
+  border-color: var(--accent-ink);
 }
 .robotbuild__jnote,
 .robotbuild__jsel {
@@ -330,26 +327,6 @@
   opacity: 0.35;
   cursor: default;
 }
-.robotbuild__makebase {
-  align-self: flex-start;
-  font-family: inherit;
-  font-size: 0.55rem;
-  color: var(--text-muted, #9aa0a6);
-  background: transparent;
-  border: 1px solid var(--border, #3a3d44);
-  border-radius: 4px;
-  padding: 0.08rem 0.4rem;
-  cursor: pointer;
-}
-.robotbuild__makebase:hover {
-  color: var(--accent);
-  border-color: var(--accent);
-}
-.robotbuild__basebadge {
-  align-self: flex-start;
-  font-size: 0.55rem;
-  color: var(--accent);
-}
 .robotbuild__empty {
   color: var(--text-muted, #8b919b);
   font-size: 0.6rem;
@@ -372,7 +349,7 @@
   cursor: pointer;
 }
 .robotbuild__stl:hover:not(:disabled) {
-  border-color: var(--accent);
+  border-color: var(--accent-ink);
 }
 .robotbuild__stl:disabled {
   opacity: 0.45;

--- a/src/renderer/src/components/RobotBuildPanel.tsx
+++ b/src/renderer/src/components/RobotBuildPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import type { AssemblyItem, PrimitiveGeom, JointDef, JointType, JointSpec } from './robot-assembly'
-import type { PrimitiveKind, Vec3 } from './robot-build'
+import type { Vec3 } from './robot-build'
 import { principalAxisName } from './robot-build'
 import { toDisplay, toNative, unitLabel, type MovableType } from './robot-pose'
 import { baseName } from './robot-mesh'
@@ -46,7 +46,6 @@ export interface RobotBuildPanelProps {
   onEdit: (link: string | null) => void
   /** Geometry of the link being edited (for the size form), or null. */
   editGeom: PrimitiveGeom | null
-  onAdd: (kind: PrimitiveKind) => void
   onSetSize: (link: string, dims: number[]) => void
   /** The parent joint of the link being edited (null for the root), + a setter. */
   editJoint: JointDef | null
@@ -327,7 +326,6 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
     editLink,
     onEdit,
     editGeom,
-    onAdd,
     onSetSize,
     editJoint,
     jointNames,
@@ -394,22 +392,9 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
         </button>
       </div>
 
-      <div className="robotbuild__add" role="group" aria-label="Add a block">
-        {(['box', 'cylinder', 'sphere'] as const).map((k) => (
-          <button
-            key={k}
-            type="button"
-            disabled={!canEdit}
-            onClick={() => onAdd(k)}
-            title={canEdit ? `Add a ${k}` : 'Save the robot to a project folder first'}
-          >
-            {k === 'box' ? '▦ Box' : k === 'cylinder' ? '⬭ Tube' : '● Ball'}
-          </button>
-        ))}
-      </div>
-      <p className="robotbuild__hint">
-        {canEdit ? 'A new block sticks to the part you picked.' : 'Save this robot to a folder to build.'}
-      </p>
+      {!canEdit && (
+        <p className="robotbuild__hint">Save this robot to a folder to build.</p>
+      )}
 
       <ul className="robotbuild__parts">
         {assembly.map((it) => {
@@ -432,6 +417,21 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
                     {it.kind === 'mesh' ? baseName(it.mesh ?? '') : it.kind}
                   </span>
                 </button>
+                {it.link === rootLink ? (
+                  <span className="robotbuild__rowbase is-base" title="This is the base — every block hangs off it">
+                    ★
+                  </span>
+                ) : (
+                  <button
+                    type="button"
+                    className="robotbuild__rowbase"
+                    onClick={() => onMakeBase(it.link)}
+                    title="Make this the base"
+                    aria-label={`Make ${it.link} the base`}
+                  >
+                    ☆
+                  </button>
+                )}
                 <button
                   type="button"
                   className={`robotbuild__edit${isEdit ? ' is-on' : ''}`}
@@ -459,20 +459,6 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
                             names={jointNames}
                             onChange={(spec) => onSetJoint(it.link, spec)}
                           />
-                        )}
-                        {isRoot ? (
-                          <span className="robotbuild__basebadge" title="Every other block hangs off the base">
-                            ★ This is the base
-                          </span>
-                        ) : (
-                          <button
-                            type="button"
-                            className="robotbuild__makebase"
-                            onClick={() => onMakeBase(it.link)}
-                            title="Make this the base — the whole model re-hangs off this block"
-                          >
-                            ★ Make base
-                          </button>
                         )}
                       </div>
                       <button

--- a/src/renderer/src/components/RobotJointPanel.tsx
+++ b/src/renderer/src/components/RobotJointPanel.tsx
@@ -32,8 +32,8 @@ export interface RobotJointPanelProps {
   onRecallPose: (pose: NamedPoseLike) => void
   onDeletePose: (name: string) => void
   onResetPose: () => void
+  /** True while the measure tool (in the toolbar) is active — shows the readout. */
   measureActive: boolean
-  onToggleMeasure: () => void
   /** Point-to-point distance in mm, or null when fewer than 2 points are set. */
   measureDistance: number | null
   /** Whether the current pose has been persisted (for a subtle saved hint). */
@@ -68,7 +68,6 @@ export function RobotJointPanel({
   onDeletePose,
   onResetPose,
   measureActive,
-  onToggleMeasure,
   measureDistance,
   savingLabel,
   assembly,
@@ -388,25 +387,20 @@ export function RobotJointPanel({
         )}
       </section>
 
-      <section className="robotpanel__section">
-        <div className="robotpanel__section-head">
-          <span>Measure</span>
-        </div>
-        <button
-          type="button"
-          className={`robotpanel__btn robotpanel__measure${measureActive ? ' is-on' : ''}`}
-          onClick={onToggleMeasure}
-        >
-          {measureActive ? 'Measuring — click 2 points' : 'Measure distance'}
-        </button>
-        {measureDistance != null && (
-          <div className="robotpanel__measure-out">
-            {measureDistance < 1000
-              ? `${measureDistance.toFixed(1)} mm`
-              : `${(measureDistance / 1000).toFixed(3)} m`}
+      {measureActive && (
+        <section className="robotpanel__section">
+          <div className="robotpanel__section-head">
+            <span>Measure</span>
           </div>
-        )}
-      </section>
+          <div className="robotpanel__measure-out">
+            {measureDistance == null
+              ? 'Click two points…'
+              : measureDistance < 1000
+                ? `${measureDistance.toFixed(1)} mm`
+                : `${(measureDistance / 1000).toFixed(3)} m`}
+          </div>
+        </section>
+      )}
     </aside>
   )
 }

--- a/src/renderer/src/components/RobotToolbar.css
+++ b/src/renderer/src/components/RobotToolbar.css
@@ -30,12 +30,19 @@
 }
 .robottool__btn:hover:not(:disabled) {
   border-color: var(--border, #3a3d44);
-  color: var(--accent);
+  color: var(--text, #cdd2d9);
+  background: rgba(128, 128, 128, 0.18);
 }
+/* Active tool: a neutral filled state (no brass) — brighter text on a subtle
+   sunken fill so it reads without the hard-to-see orange highlight. */
 .robottool__btn.is-active {
-  color: var(--accent);
-  border-color: var(--accent);
-  background: rgba(200, 162, 74, 0.18);
+  color: var(--text, #f2f4f7);
+  border-color: var(--text-muted, #6b7079);
+  background: rgba(128, 128, 128, 0.28);
+}
+.robottool__btn--add {
+  font-size: 1rem;
+  line-height: 1;
 }
 .robottool__btn:disabled {
   opacity: 0.4;

--- a/src/renderer/src/components/RobotToolbar.tsx
+++ b/src/renderer/src/components/RobotToolbar.tsx
@@ -1,21 +1,39 @@
-import type { BuildTool } from './robot-build'
+import type { BuildTool, PrimitiveKind } from './robot-build'
 import './RobotToolbar.css'
 
 /**
  * ROBOT TOOLBAR (#335) — a small floating tool cluster (top-centre of the 3-D
- * stage) that sets the active builder tool. Only the active tool owns the canvas
- * pointer (RobotView gates on it). Kid-friendly labels, no jargon.
+ * stage): add a block, set the active builder tool, and undo/redo. Only the
+ * active tool owns the canvas pointer (RobotView gates on it).
  */
 export interface RobotToolbarProps {
   tool: BuildTool
   onSetTool: (t: BuildTool) => void
   /** Editing needs a saved project file — tools disable without one. */
   canEdit: boolean
+  /** Add a primitive at the workspace origin. */
+  onAdd: (kind: PrimitiveKind) => void
+  /** Point-to-point measure tool (toggle). */
+  measureActive: boolean
+  onToggleMeasure: () => void
   canUndo: boolean
   canRedo: boolean
   onUndo: () => void
   onRedo: () => void
 }
+
+const MEASURE_ICON = (
+  <svg viewBox="0 0 16 16" width="15" height="15" aria-hidden="true">
+    <rect x="1.5" y="5" width="13" height="6" rx="1" fill="none" stroke="currentColor" strokeWidth="1.3" />
+    <path d="M4 5v2.5M6.5 5v3.5M9 5v2.5M11.5 5v3.5" fill="none" stroke="currentColor" strokeWidth="1.1" />
+  </svg>
+)
+
+const ADD: Array<{ kind: PrimitiveKind; glyph: string; label: string }> = [
+  { kind: 'box', glyph: '▦', label: 'Add a box' },
+  { kind: 'cylinder', glyph: '⬭', label: 'Add a tube' },
+  { kind: 'sphere', glyph: '●', label: 'Add a ball' }
+]
 
 const ICONS: Record<BuildTool, JSX.Element> = {
   select: (
@@ -70,6 +88,9 @@ export function RobotToolbar({
   tool,
   onSetTool,
   canEdit,
+  onAdd,
+  measureActive,
+  onToggleMeasure,
   canUndo,
   canRedo,
   onUndo,
@@ -77,6 +98,20 @@ export function RobotToolbar({
 }: RobotToolbarProps): JSX.Element {
   return (
     <div className="robottool" role="toolbar" aria-label="Build tools">
+      {ADD.map((a) => (
+        <button
+          key={a.kind}
+          type="button"
+          className="robottool__btn robottool__btn--add"
+          disabled={!canEdit}
+          title={canEdit ? a.label : 'Save the robot to a folder first'}
+          aria-label={a.label}
+          onClick={() => onAdd(a.kind)}
+        >
+          {a.glyph}
+        </button>
+      ))}
+      <span className="robottool__sep" aria-hidden="true" />
       {TOOLS.map((t) => {
         const disabled = t.soon || !canEdit
         return (
@@ -94,6 +129,16 @@ export function RobotToolbar({
           </button>
         )
       })}
+      <button
+        type="button"
+        className={`robottool__btn${measureActive ? ' is-active' : ''}`}
+        aria-pressed={measureActive}
+        title="Measure distance (click two points)"
+        aria-label="Measure distance"
+        onClick={onToggleMeasure}
+      >
+        {MEASURE_ICON}
+      </button>
       <span className="robottool__sep" aria-hidden="true" />
       <button
         type="button"

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -1731,6 +1731,9 @@ export function RobotView({
             tool={buildTool}
             onSetTool={onSetTool}
             canEdit={canEdit}
+            onAdd={handleAddPrimitive}
+            measureActive={measureActive}
+            onToggleMeasure={() => setMeasureActive((a) => !a)}
             canUndo={histCanUndo(histRef.current)}
             canRedo={histCanRedo(histRef.current)}
             onUndo={undoUrdf}
@@ -1752,7 +1755,6 @@ export function RobotView({
             editJoint={editJoint}
             jointNames={allJointNames}
             rootLink={rootName}
-            onAdd={handleAddPrimitive}
             onSetSize={handleSetSize}
             onSetJoint={handleSetJoint}
             onMakeBase={handleMakeBase}
@@ -1782,7 +1784,6 @@ export function RobotView({
           onDeletePose={handleDeletePose}
           onResetPose={handleResetPose}
           measureActive={measureActive}
-          onToggleMeasure={() => setMeasureActive((a) => !a)}
           measureDistance={measureDist}
           savingLabel={savingLabel}
           assembly={assembly}

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -43,6 +43,7 @@
   --text-muted: #9aa0aa;
 
   --accent: #d6a23f; /* brass — active/selected/links */
+  --accent-ink: #d6a23f; /* brass for TEXT — readable on the dark chrome */
   --accent-2: #3fae5a; /* green — connected / run / saved */
   --accent-contrast: #15161a;
   --danger: #e3624f;
@@ -100,6 +101,7 @@
   --text-muted: #5c616a;
 
   --accent: #b07d1e; /* brass — active/selected/links */
+  --accent-ink: #5c3f0c; /* DARK brass for TEXT — readable on the parchment */
   --accent-2: #1c7a34; /* green — connected / run / saved */
   --accent-contrast: #fffdf6;
   --danger: #c4301f;


### PR DESCRIPTION
Builder-UI feedback from Kevin, batched.

## Toolbar consolidation
- **Add Box / Tube / Ball** and the **Measure** tool now live on the floating build toolbar (with select / push-pull / move / join + undo/redo). Removed from the left panel / pose panel. The pose panel shows the measure **readout** while measuring.

## Readability (parchment theme)
- New theme-aware **`--accent-ink`** token — **dark brass** (`#5c3f0c`) on the skeuomorph/parchment theme, brass on dark. The builder's accent **text** (panel headings, the **STL filename**) uses it, so it's no longer washed-out gold on cream.
- The toolbar's **active-tool** highlight is a neutral fill instead of the hard-to-read gold.

## Build panel affordances
- **★ Make base** is now a one-click star on each block's row (`☆` = make this the base, `★` = the current base) — no longer hidden behind the edit pencil.
- The collapsed **"Build" tab** is squared off (no rounded corners) and reads top-to-bottom (dropped the 180° flip that read wrong-way-round).

## Verification
- `typecheck` · `lint` · `test` (**1521 passing**) · `build` — all green.
- In-app smoke: add-via-toolbar grows the link count; row stars render (1 `is-base`); the old panel add-group is gone; toolbar shows add glyphs + tools + measure + undo/redo.

Part of the larger Fusion-360-style Robot-View direction (context panel + hierarchy relationships + interactive Join are being scoped as follow-up issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)