### PR TITLE
feat: Robot View — navigation cube upgrade (#309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   **mirror-invert** checkbox so a reversed-axis left↔right joint mirrors correctly
   in one click (persists to `robot.yml`).
 - **Robot View — navigation cube.** A CAD-style **ViewCube** floats at the
-  top-right of the 3-D viewer, mirroring the camera's orientation as you orbit;
-  **click a face** (Front / Back / Left / Right / Top / Bottom) to snap the view
-  to that straight-on orthographic angle. Runs in its own small canvas so it never
-  fights the viewer's orbit/zoom.
+  top-right of the 3-D viewer, mirroring the camera's orientation as you orbit and
+  lit from the lower-front so it reads as a solid block. **Click a face, edge or
+  corner** (26 orientations) to snap the view, **drag the cube** to orbit the
+  camera, and the region under the pointer highlights in brass. Runs in its own
+  small canvas so it never fights the viewer's orbit/zoom.
 - **Robot View — new blocks & meshes arrive at the origin, not stuck to the
   selection.** Adding a block or importing an STL/DAE now drops it at the
   **workspace origin** (attached to the base), **selects it**, and **reframes** so

--- a/src/renderer/src/components/RobotView.css
+++ b/src/renderer/src/components/RobotView.css
@@ -95,9 +95,10 @@
   right: 12px;
   top: 12px;
   z-index: 30;
-  width: 72px;
-  height: 72px;
-  filter: drop-shadow(0 4px 10px rgba(0, 0, 0, 0.45));
+  width: 96px;
+  height: 96px;
+  /* Shadow drops down-back, consistent with the cube being lit from lower-front. */
+  filter: drop-shadow(0 5px 9px rgba(0, 0, 0, 0.5));
 }
 .robotview__viewcube canvas {
   display: block;

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -828,7 +828,22 @@ export function RobotView({
       camera.position.copy(controls.target).addScaledVector(dir, dist)
       controls.update()
     }
-    const viewCube = cubeMountRef.current ? createViewCube({ size: 72, onPick: snapView }) : null
+    // Drag the cube → orbit the camera (spherical around the target), same feel
+    // as dragging the viewport.
+    const cubeSph = new THREE.Spherical()
+    const cubeOffset = new THREE.Vector3()
+    const orbitBy = (dxPx: number, dyPx: number): void => {
+      cubeOffset.copy(camera.position).sub(controls.target)
+      cubeSph.setFromVector3(cubeOffset)
+      cubeSph.theta -= dxPx * 0.01
+      cubeSph.phi = Math.max(0.01, Math.min(Math.PI - 0.01, cubeSph.phi - dyPx * 0.01))
+      cubeOffset.setFromSpherical(cubeSph)
+      camera.position.copy(controls.target).add(cubeOffset)
+      controls.update()
+    }
+    const viewCube = cubeMountRef.current
+      ? createViewCube({ size: 96, onPick: snapView, onOrbit: orbitBy })
+      : null
     if (viewCube && cubeMountRef.current) cubeMountRef.current.appendChild(viewCube.dom)
 
     // Half-height of the ortho frustum (updated by frameModel as bounds change).

--- a/src/renderer/src/components/robot-viewcube.ts
+++ b/src/renderer/src/components/robot-viewcube.ts
@@ -1,13 +1,15 @@
 /**
- * NAVIGATION CUBE (#309) — a small CAD-style ViewCube floating in the corner of
- * the 3-D viewer. It mirrors the main camera's orientation each frame, and
- * clicking a face snaps the camera to that orthographic view (front/back/…/top).
+ * NAVIGATION CUBE (#309) — a CAD-style ViewCube in the corner of the 3-D viewer.
+ *
+ * It mirrors the main camera's orientation each frame. You can:
+ *  - CLICK a face / edge / corner (26 regions) to snap to that orthographic view,
+ *  - DRAG the cube to orbit the camera,
+ *  - and the region under the pointer highlights in brass.
  *
  * It runs in its OWN tiny canvas + WebGL context so its pointer handling can't
- * fight the main viewer's OrbitControls. The host calls `sync()` + `render()`
- * each frame and handles `onPick(dir)` by moving the main camera to look at the
- * model FROM `dir` (a world-space unit direction). The scene is three's Y-up
- * (the URDF loader rotates Z-up models into Y-up), so +Y = top, +Z = front.
+ * fight the main viewer's OrbitControls. The scene is three's Y-up (the URDF
+ * loader rotates Z-up models into Y-up), so +Y = top, +Z = front. Faces are lit
+ * from the lower-front so the block reads as solid.
  */
 import * as THREE from 'three'
 
@@ -20,27 +22,22 @@ export interface ViewCube {
   dispose: () => void
 }
 
-const FACES: Array<{ label: string; normal: [number, number, number] }> = [
-  { label: 'RIGHT', normal: [1, 0, 0] }, // +X  (BoxGeometry material order)
-  { label: 'LEFT', normal: [-1, 0, 0] }, // -X
-  { label: 'TOP', normal: [0, 1, 0] }, // +Y
-  { label: 'BOT', normal: [0, -1, 0] }, // -Y
-  { label: 'FRONT', normal: [0, 0, 1] }, // +Z
-  { label: 'BACK', normal: [0, 0, -1] } // -Z
-]
+// BoxGeometry material order: +X, -X, +Y, -Y, +Z, -Z.
+const FACE_LABELS = ['RIGHT', 'LEFT', 'TOP', 'BOT', 'FRONT', 'BACK']
+const faceIndex = (axis: 0 | 1 | 2, positive: boolean): number => axis * 2 + (positive ? 0 : 1)
 
-/** A face label painted onto a canvas texture (parchment-brass, readable). */
+/** A face label painted onto a canvas texture (parchment, dark-brass border). */
 function faceTexture(text: string): THREE.CanvasTexture {
   const c = document.createElement('canvas')
   c.width = c.height = 128
   const ctx = c.getContext('2d')!
   ctx.fillStyle = '#e7e2d3'
   ctx.fillRect(0, 0, 128, 128)
-  ctx.strokeStyle = '#b07d1e'
-  ctx.lineWidth = 7
-  ctx.strokeRect(4, 4, 120, 120)
+  ctx.strokeStyle = '#8a6a2a'
+  ctx.lineWidth = 6
+  ctx.strokeRect(3, 3, 122, 122)
   ctx.fillStyle = '#34373d'
-  ctx.font = 'bold 24px sans-serif'
+  ctx.font = 'bold 22px sans-serif'
   ctx.textAlign = 'center'
   ctx.textBaseline = 'middle'
   ctx.fillText(text, 64, 66)
@@ -49,66 +46,125 @@ function faceTexture(text: string): THREE.CanvasTexture {
   return tex
 }
 
+/** Classify a local hit point on the unit cube into its view direction (world
+ *  axis) + the face material indices it touches (1 face / 2 edge / 3 corner). */
+function classify(p: THREE.Vector3): { dir: THREE.Vector3; faces: number[] } {
+  const thr = 0.32 // within 0.18 of an edge counts as that edge/corner
+  const comp = [p.x, p.y, p.z]
+  const dir = new THREE.Vector3()
+  const faces: number[] = []
+  comp.forEach((v, ax) => {
+    if (Math.abs(v) >= thr) {
+      const positive = v >= 0
+      dir.setComponent(ax, positive ? 1 : -1)
+      faces.push(faceIndex(ax as 0 | 1 | 2, positive))
+    }
+  })
+  if (dir.lengthSq() === 0) dir.set(0, 0, 1) // safety (shouldn't happen on a surface hit)
+  return { dir: dir.normalize(), faces }
+}
+
 export function createViewCube(opts: {
   size: number
   onPick: (dir: THREE.Vector3) => void
+  onOrbit: (dxPx: number, dyPx: number) => void
 }): ViewCube {
-  const { size, onPick } = opts
+  const { size, onPick, onOrbit } = opts
   const canvas = document.createElement('canvas')
   const renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: true })
   renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2))
   renderer.setSize(size, size)
 
   const scene = new THREE.Scene()
-  // Fixed ortho camera looking straight at the cube; the CUBE rotates.
   const camera = new THREE.OrthographicCamera(-1.5, 1.5, 1.5, -1.5, 0.1, 10)
   camera.position.set(0, 0, 4)
   camera.lookAt(0, 0, 0)
-  scene.add(new THREE.HemisphereLight(0xffffff, 0x555555, 1.2))
+  // Lit from the lower-front so the cube looks like a solid, shaded block.
+  scene.add(new THREE.HemisphereLight(0xffffff, 0x6b6b6b, 0.9))
+  const keyLight = new THREE.DirectionalLight(0xffffff, 0.75)
+  keyLight.position.set(-0.4, -0.9, 1.4) // lower-front
+  scene.add(keyLight)
 
-  const materials = FACES.map((f) => {
-    const map = faceTexture(f.label)
-    return new THREE.MeshBasicMaterial({ map })
-  })
+  const HILITE = new THREE.Color(0xc8a24a)
+  const DARK = new THREE.Color(0x000000)
+  const materials = FACE_LABELS.map(
+    (label) =>
+      new THREE.MeshLambertMaterial({ map: faceTexture(label), emissive: DARK.clone() })
+  )
   const geometry = new THREE.BoxGeometry(1, 1, 1)
   const cube = new THREE.Mesh(geometry, materials)
   scene.add(cube)
-  // Crisp edges so the cube reads as a solid block.
   const edgeGeo = new THREE.EdgesGeometry(geometry)
-  const edgeMat = new THREE.LineBasicMaterial({ color: 0x8a6a2a })
+  const edgeMat = new THREE.LineBasicMaterial({ color: 0x6b5220 })
   const edges = new THREE.LineSegments(edgeGeo, edgeMat)
   cube.add(edges)
 
   const raycaster = new THREE.Raycaster()
   const ndc = new THREE.Vector2()
-
-  const onClick = (e: MouseEvent): void => {
+  const pick = (e: PointerEvent): { dir: THREE.Vector3; faces: number[] } | null => {
     const rect = canvas.getBoundingClientRect()
     ndc.x = ((e.clientX - rect.left) / rect.width) * 2 - 1
     ndc.y = -((e.clientY - rect.top) / rect.height) * 2 + 1
     raycaster.setFromCamera(ndc, camera)
     const hit = raycaster.intersectObject(cube, false)[0]
-    if (!hit || !hit.face) return
-    // The clicked face's LOCAL normal is the world axis it represents (the cube's
-    // local axes map 1:1 to world axes; the rotation only faces it at the viewer).
-    const n = hit.face.normal
-    onPick(new THREE.Vector3(Math.round(n.x), Math.round(n.y), Math.round(n.z)))
+    return hit ? classify(cube.worldToLocal(hit.point.clone())) : null
   }
-  canvas.addEventListener('click', onClick)
-  canvas.style.cursor = 'pointer'
+
+  const setHighlight = (faces: number[]): void => {
+    materials.forEach((m, i) => m.emissive.copy(faces.includes(i) ? HILITE : DARK))
+  }
+
+  // Drag-to-orbit vs click-to-snap: a near-stationary press is a click.
+  let down: { x: number; y: number; moved: boolean } | null = null
+  const onPointerDown = (e: PointerEvent): void => {
+    down = { x: e.clientX, y: e.clientY, moved: false }
+    canvas.setPointerCapture(e.pointerId)
+  }
+  const onPointerMove = (e: PointerEvent): void => {
+    if (down) {
+      const dx = e.clientX - down.x
+      const dy = e.clientY - down.y
+      if (down.moved || Math.hypot(dx, dy) > 3) {
+        down.moved = true
+        onOrbit(e.movementX || dx, e.movementY || dy)
+        setHighlight([])
+      }
+      return
+    }
+    const r = pick(e)
+    setHighlight(r ? r.faces : [])
+  }
+  const onPointerUp = (e: PointerEvent): void => {
+    canvas.releasePointerCapture?.(e.pointerId)
+    const wasClick = down && !down.moved
+    down = null
+    if (wasClick) {
+      const r = pick(e)
+      if (r) onPick(r.dir)
+    }
+  }
+  const onLeave = (): void => {
+    if (!down) setHighlight([])
+  }
+  canvas.addEventListener('pointerdown', onPointerDown)
+  canvas.addEventListener('pointermove', onPointerMove)
+  canvas.addEventListener('pointerup', onPointerUp)
+  canvas.addEventListener('pointerleave', onLeave)
+  canvas.style.cursor = 'grab'
 
   const inv = new THREE.Quaternion()
   return {
     dom: canvas,
     sync: (q) => {
-      // Cube orientation = inverse of the camera's world orientation, so the face
-      // toward the viewer is the world direction the camera looks along.
       inv.copy(q).invert()
       cube.quaternion.copy(inv)
     },
     render: () => renderer.render(scene, camera),
     dispose: () => {
-      canvas.removeEventListener('click', onClick)
+      canvas.removeEventListener('pointerdown', onPointerDown)
+      canvas.removeEventListener('pointermove', onPointerMove)
+      canvas.removeEventListener('pointerup', onPointerUp)
+      canvas.removeEventListener('pointerleave', onLeave)
       geometry.dispose()
       edgeGeo.dispose()
       edgeMat.dispose()


### PR DESCRIPTION
Upgrades the ViewCube from user feedback: *"larger, draggable to change the view; faces, edges and corners clickable; brass hover highlight; lit from the lower-front."*

- **Larger** (72 → 96px).
- **Drag to orbit** — dragging the cube rotates the main camera (spherical around the target), same feel as dragging the viewport. A near-stationary press is still a click.
- **Faces, edges & corners** (26 regions) are all clickable → snap to that orthographic view. The region is classified from the local hit point (how many axes are at the extreme → 1 face / 2 edge / 3 corner).
- **Brass hover highlight** on the region under the pointer (emissive on the touched face materials).
- **Lit from the lower-front** — faces are `MeshLambert` with a hemisphere + a lower-front directional light, so the cube reads as a solid shaded block; grab cursor + a down-back drop shadow.

Verification: `typecheck` · `lint` · `test` (1521) · `build` green. In-app smoke: size 96; **drag changed the view**; face + corner clicks each snapped the camera (screenshots confirm the shaded cube).

🤖 Generated with [Claude Code](https://claude.com/claude-code)