### PR TITLE
fix: Local Files refresh re-reads expanded sub-folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   or reopen any panel. Nothing about Robot mode is permanently changed.
 
 ### Fixed
+- **Local Files refresh now updates expanded sub-folders too.** The refresh button
+  re-read only the root listing, so files added/removed inside an already-expanded
+  sub-folder didn't show up. Refresh now signals every expanded folder to re-read
+  its children.
 - **Robot View accent text is readable on the parchment theme.** The Robot-View
   panels hard-coded a light gold (`#c8a24a`) for highlight/active text, which
   didn't darken for the skeuomorph (parchment) theme — gold-on-cream was hard to

--- a/src/renderer/src/components/LocalFileTree.tsx
+++ b/src/renderer/src/components/LocalFileTree.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { FsEntry } from '../../../main/fs/types'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { useWorkspace } from '../store/workspace'
@@ -85,6 +85,8 @@ interface TreeNodeProps {
   isSynced: (path: string) => boolean
   /** Tag / untag a (file) path for device sync (#178). */
   toggleSync: (path: string) => void
+  /** Bumped by the Refresh button — expanded folders re-read their children. */
+  refreshNonce: number
 }
 
 /** Recursively renders a directory entry and (when expanded) its children. */
@@ -97,7 +99,8 @@ function TreeNode({
   onChanged,
   onContextMenu,
   isSynced,
-  toggleSync
+  toggleSync,
+  refreshNonce
 }: TreeNodeProps): JSX.Element {
   const [expanded, setExpanded] = useState(false)
   const [children, setChildren] = useState<FsEntry[] | null>(null)
@@ -111,6 +114,16 @@ function TreeNode({
       setError(err instanceof Error ? err.message : String(err))
     }
   }, [entry.path])
+
+  // Refresh signal from above: re-read an EXPANDED folder's children so newly
+  // added/removed files show up (the root re-reads separately). Skip the first
+  // render — only react to actual bumps.
+  const firstNonce = useRef(refreshNonce)
+  useEffect(() => {
+    if (refreshNonce === firstNonce.current) return
+    if (expanded) void loadChildren()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [refreshNonce])
 
   const toggle = useCallback(async (): Promise<void> => {
     if (!expanded && children === null) await loadChildren()
@@ -186,6 +199,7 @@ function TreeNode({
             onContextMenu={onContextMenu}
             isSynced={isSynced}
             toggleSync={toggleSync}
+            refreshNonce={refreshNonce}
           />
         ))}
     </div>
@@ -214,8 +228,12 @@ export function LocalFileTree(): JSX.Element {
   const [error, setError] = useState<string | null>(null)
   const [menu, setMenu] = useState<MenuState | null>(null)
 
+  // Bumping this tells every EXPANDED subfolder to re-read its children too, so
+  // Refresh reflects changes anywhere in the open tree (not just the root).
+  const [refreshNonce, setRefreshNonce] = useState(0)
   const refresh = useCallback(async (): Promise<void> => {
     if (!root) return
+    setRefreshNonce((n) => n + 1)
     try {
       setEntries(await window.api.fs.readDir(root))
       setError(null)
@@ -526,6 +544,7 @@ export function LocalFileTree(): JSX.Element {
                 onContextMenu={handleContextMenu}
                 isSynced={isSynced}
                 toggleSync={toggleSync}
+                refreshNonce={refreshNonce}
               />
             ))}
           </div>


### PR DESCRIPTION
Reported: *"the local files refresh button isn't refreshing the currently opened folder contents."*

**Root cause:** the Refresh button re-read only the **root** listing (`setEntries(readDir(root))`). Each `TreeNode` caches its own `children` state, loaded once when you expand it — so a file added/removed inside an **already-expanded sub-folder** never showed up on refresh.

**Fix:** thread a `refreshNonce` down the tree. Refresh bumps it; every expanded `TreeNode` re-reads its children when it changes (an initial-render guard means it only reacts to real bumps).

**Verification (in-app smoke):** open a folder with `sub/`, expand `sub`, add `bbb.txt` to the root and `yyy.txt` to `sub/` externally, click Refresh →
- before: only `bbb.txt` appeared (sub's `yyy.txt` missing);
- after: **both** `bbb.txt` and `yyy.txt` appear.

`typecheck` · `lint` · `test` (1521) · `build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)