### PR TITLE
feat: Robot nav cube — 2× larger, edge/corner highlight, Home button (#309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   if it lands past the end, never overwriting an existing key), and a per-pair
   **mirror-invert** checkbox so a reversed-axis left↔right joint mirrors correctly
   in one click (persists to `robot.yml`).
-- **Robot View — navigation cube.** A CAD-style **ViewCube** floats at the
-  top-right of the 3-D viewer, mirroring the camera's orientation as you orbit and
-  lit from the lower-front so it reads as a solid block. **Click a face, edge or
-  corner** (26 orientations) to snap the view, **drag the cube** to orbit the
-  camera, and the region under the pointer highlights in brass. Runs in its own
-  small canvas so it never fights the viewer's orbit/zoom.
+- **Robot View — navigation cube.** A large CAD-style **ViewCube** at the
+  top-right of the 3-D viewer, mirroring the camera as you orbit and lit from the
+  lower-front so it reads as a solid block. **Click a face, edge or corner** (26
+  orientations) to snap the view, **drag the cube** to orbit, and the region under
+  the pointer highlights with a brass overlay (a plate on a face, a bar on an edge,
+  a cube on a corner). A **Home** button (revealed on hover) resets to the default
+  isometric view. Runs in its own canvas so it never fights the viewer's orbit/zoom.
 - **Robot View — new blocks & meshes arrive at the origin, not stuck to the
   selection.** Adding a block or importing an STL/DAE now drops it at the
   **workspace origin** (attached to the base), **selects it**, and **reframes** so

--- a/src/renderer/src/components/RobotView.css
+++ b/src/renderer/src/components/RobotView.css
@@ -89,14 +89,48 @@
   color: var(--text-muted, #7d838d);
 }
 
-/* Navigation cube — top-right of the stage (its own canvas is appended here). */
-.robotview__viewcube {
+/* Navigation zone — top-right of the stage: the ViewCube + a hover-revealed
+   Home button. */
+.robotview__navzone {
   position: absolute;
   right: 12px;
   top: 12px;
   z-index: 30;
-  width: 96px;
-  height: 96px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+}
+.robotview__home {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  color: var(--text, #cdd2d9);
+  background: rgba(31, 32, 36, 0.92);
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.45);
+  cursor: pointer;
+  /* Revealed only when the pointer is over the nav zone (top-right area). */
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+.robotview__navzone:hover .robotview__home {
+  opacity: 1;
+}
+.robotview__home:hover {
+  color: #c8a24a;
+  border-color: #5a606b;
+}
+:root[data-theme='skeuomorph'] .robotview__home {
+  background: rgba(231, 226, 211, 0.92);
+}
+/* The ViewCube's own canvas is appended here (2× — was 96px). */
+.robotview__viewcube {
+  width: 192px;
+  height: 192px;
   /* Shadow drops down-back, consistent with the cube being lit from lower-front. */
   filter: drop-shadow(0 5px 9px rgba(0, 0, 0, 0.5));
 }
@@ -166,7 +200,7 @@
    of the navigation cube (top-right). */
 .robotview__note {
   position: absolute;
-  right: 96px;
+  right: 216px;
   top: 0.55rem;
   max-width: 70%;
   padding: 0.3rem 0.55rem;

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -168,7 +168,13 @@ export function RobotView({
   const highlightApiRef = useRef<{ apply: (link: string | null) => void } | null>(null)
   // Imperative zoom API (the buttons live in React; the ortho camera lives in the
   // three.js effect) + the live zoom % for the readout.
-  const zoomApiRef = useRef<{ in: () => void; out: () => void; fit: () => void; toggle: () => void } | null>(null)
+  const zoomApiRef = useRef<{
+    in: () => void
+    out: () => void
+    fit: () => void
+    toggle: () => void
+    home: () => void
+  } | null>(null)
   const [zoomPct, setZoomPct] = useState(100)
   metaRef.current = jointMeta
   valuesRef.current = values
@@ -842,7 +848,7 @@ export function RobotView({
       controls.update()
     }
     const viewCube = cubeMountRef.current
-      ? createViewCube({ size: 96, onPick: snapView, onOrbit: orbitBy })
+      ? createViewCube({ size: 192, onPick: snapView, onOrbit: orbitBy })
       : null
     if (viewCube && cubeMountRef.current) cubeMountRef.current.appendChild(viewCube.dom)
 
@@ -895,7 +901,13 @@ export function RobotView({
       out: () => applyZoom(camera.zoom / 1.2),
       fit: fitView,
       // Double-clicking the % readout: 100% ↔ fit (keyed on the live zoom).
-      toggle: () => (Math.abs(camera.zoom - 1) < 0.005 ? fitView() : applyZoom(1))
+      toggle: () => (Math.abs(camera.zoom - 1) < 0.005 ? fitView() : applyZoom(1)),
+      // Home: the default isometric framing at 100%.
+      home: () => {
+        if (!robotRef.current) return
+        frameModel(robotRef.current)
+        applyZoom(1)
+      }
     }
     const onControlsChange = (): void => syncZoomPct()
     controls.addEventListener('change', onControlsChange)
@@ -1732,7 +1744,24 @@ export function RobotView({
           </div>
         )}
         {!isEmpty && !error && !compact && (
-          <div className="robotview__viewcube" ref={cubeMountRef} title="Click a face to snap the view" />
+          <div className="robotview__navzone">
+            <button
+              type="button"
+              className="robotview__home"
+              onClick={() => zoomApiRef.current?.home()}
+              title="Home — default view"
+              aria-label="Home view"
+            >
+              <svg viewBox="0 0 16 16" width="15" height="15" aria-hidden="true">
+                <path d="M2 7.5L8 2.5l6 5M3.5 6.6V13h9V6.6" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinejoin="round" strokeLinecap="round" />
+              </svg>
+            </button>
+            <div
+              className="robotview__viewcube"
+              ref={cubeMountRef}
+              title="Click a face / edge / corner to snap · drag to orbit"
+            />
+          </div>
         )}
         {!isEmpty && !error && !compact && (
           <div className="robotview__zoom" role="toolbar" aria-label="Zoom controls">

--- a/src/renderer/src/components/robot-viewcube.ts
+++ b/src/renderer/src/components/robot-viewcube.ts
@@ -24,7 +24,6 @@ export interface ViewCube {
 
 // BoxGeometry material order: +X, -X, +Y, -Y, +Z, -Z.
 const FACE_LABELS = ['RIGHT', 'LEFT', 'TOP', 'BOT', 'FRONT', 'BACK']
-const faceIndex = (axis: 0 | 1 | 2, positive: boolean): number => axis * 2 + (positive ? 0 : 1)
 
 /** A face label painted onto a canvas texture (parchment, dark-brass border). */
 function faceTexture(text: string): THREE.CanvasTexture {
@@ -46,22 +45,16 @@ function faceTexture(text: string): THREE.CanvasTexture {
   return tex
 }
 
-/** Classify a local hit point on the unit cube into its view direction (world
- *  axis) + the face material indices it touches (1 face / 2 edge / 3 corner). */
-function classify(p: THREE.Vector3): { dir: THREE.Vector3; faces: number[] } {
+/** Classify a local hit point on the unit cube into `raw` (±1/0 per axis — which
+ *  face/edge/corner) and `dir` (the normalised view direction to snap to). */
+function classify(p: THREE.Vector3): { dir: THREE.Vector3; raw: THREE.Vector3 } {
   const thr = 0.32 // within 0.18 of an edge counts as that edge/corner
-  const comp = [p.x, p.y, p.z]
-  const dir = new THREE.Vector3()
-  const faces: number[] = []
-  comp.forEach((v, ax) => {
-    if (Math.abs(v) >= thr) {
-      const positive = v >= 0
-      dir.setComponent(ax, positive ? 1 : -1)
-      faces.push(faceIndex(ax as 0 | 1 | 2, positive))
-    }
+  const raw = new THREE.Vector3()
+  ;[p.x, p.y, p.z].forEach((v, ax) => {
+    if (Math.abs(v) >= thr) raw.setComponent(ax, v >= 0 ? 1 : -1)
   })
-  if (dir.lengthSq() === 0) dir.set(0, 0, 1) // safety (shouldn't happen on a surface hit)
-  return { dir: dir.normalize(), faces }
+  if (raw.lengthSq() === 0) raw.set(0, 0, 1) // safety (shouldn't happen on a surface hit)
+  return { dir: raw.clone().normalize(), raw }
 }
 
 export function createViewCube(opts: {
@@ -85,12 +78,7 @@ export function createViewCube(opts: {
   keyLight.position.set(-0.4, -0.9, 1.4) // lower-front
   scene.add(keyLight)
 
-  const HILITE = new THREE.Color(0xc8a24a)
-  const DARK = new THREE.Color(0x000000)
-  const materials = FACE_LABELS.map(
-    (label) =>
-      new THREE.MeshLambertMaterial({ map: faceTexture(label), emissive: DARK.clone() })
-  )
+  const materials = FACE_LABELS.map((label) => new THREE.MeshLambertMaterial({ map: faceTexture(label) }))
   const geometry = new THREE.BoxGeometry(1, 1, 1)
   const cube = new THREE.Mesh(geometry, materials)
   scene.add(cube)
@@ -99,19 +87,35 @@ export function createViewCube(opts: {
   const edges = new THREE.LineSegments(edgeGeo, edgeMat)
   cube.add(edges)
 
+  // A brass overlay that snaps to the hovered face / edge / corner — a thin plate
+  // on a face, a bar along an edge, a small cube on a corner (from `raw`).
+  const hlGeo = new THREE.BoxGeometry(1, 1, 1)
+  const hlMat = new THREE.MeshBasicMaterial({ color: 0xc8a24a, transparent: true, opacity: 0.55, depthTest: false })
+  const highlight = new THREE.Mesh(hlGeo, hlMat)
+  highlight.visible = false
+  highlight.renderOrder = 3
+  cube.add(highlight)
+  const setHighlight = (raw: THREE.Vector3 | null): void => {
+    if (!raw) {
+      highlight.visible = false
+      return
+    }
+    highlight.visible = true
+    highlight.position.set(raw.x * 0.5, raw.y * 0.5, raw.z * 0.5)
+    const t = 0.12 // thin on the "extreme" axes, spanning on the free ones
+    highlight.scale.set(raw.x !== 0 ? t : 0.98, raw.y !== 0 ? t : 0.98, raw.z !== 0 ? t : 0.98)
+  }
+
   const raycaster = new THREE.Raycaster()
   const ndc = new THREE.Vector2()
-  const pick = (e: PointerEvent): { dir: THREE.Vector3; faces: number[] } | null => {
+  const pick = (e: PointerEvent): { dir: THREE.Vector3; raw: THREE.Vector3 } | null => {
     const rect = canvas.getBoundingClientRect()
     ndc.x = ((e.clientX - rect.left) / rect.width) * 2 - 1
     ndc.y = -((e.clientY - rect.top) / rect.height) * 2 + 1
     raycaster.setFromCamera(ndc, camera)
-    const hit = raycaster.intersectObject(cube, false)[0]
+    // Don't let the highlight overlay intercept the pick.
+    const hit = raycaster.intersectObject(cube, false).find((h) => h.object === cube)
     return hit ? classify(cube.worldToLocal(hit.point.clone())) : null
-  }
-
-  const setHighlight = (faces: number[]): void => {
-    materials.forEach((m, i) => m.emissive.copy(faces.includes(i) ? HILITE : DARK))
   }
 
   // Drag-to-orbit vs click-to-snap: a near-stationary press is a click.
@@ -127,12 +131,12 @@ export function createViewCube(opts: {
       if (down.moved || Math.hypot(dx, dy) > 3) {
         down.moved = true
         onOrbit(e.movementX || dx, e.movementY || dy)
-        setHighlight([])
+        setHighlight(null)
       }
       return
     }
     const r = pick(e)
-    setHighlight(r ? r.faces : [])
+    setHighlight(r ? r.raw : null)
   }
   const onPointerUp = (e: PointerEvent): void => {
     canvas.releasePointerCapture?.(e.pointerId)
@@ -144,7 +148,7 @@ export function createViewCube(opts: {
     }
   }
   const onLeave = (): void => {
-    if (!down) setHighlight([])
+    if (!down) setHighlight(null)
   }
   canvas.addEventListener('pointerdown', onPointerDown)
   canvas.addEventListener('pointermove', onPointerMove)
@@ -168,6 +172,8 @@ export function createViewCube(opts: {
       geometry.dispose()
       edgeGeo.dispose()
       edgeMat.dispose()
+      hlGeo.dispose()
+      hlMat.dispose()
       materials.forEach((m) => {
         m.map?.dispose()
         m.dispose()


### PR DESCRIPTION
Nav-cube feedback, batched.

- **2× larger** (96 → 192px).
- **Edge/corner hover highlight** — a brass overlay that snaps to the exact region under the pointer: a thin **plate** on a face, a **bar** along an edge, a small **cube** on a corner (driven by the raw ±1/0-per-axis classification), rather than tinting whole adjacent faces.
- **Home button** (⌂) above the cube, **revealed on hover** of the top-right nav zone → resets to the default isometric view at 100%.

Verification: `typecheck` · `lint` · `test` (1521) · `build` green. In-app smoke: cube size **192**; home opacity **0 → 1** on hover; clicking Home after an orbit **reset the view**; edge-hover shows the brass overlay (screenshot).

**Follow-up:** the **orthographic / perspective dropdown** (a ▾ beneath the cube) is a separate PR — it toggles the camera *type*, which branches the core resize/frame code, so I'm doing it on its own for careful testing. Tracked next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)