### PR TITLE
feat: Robot nav cube — brass, perspective, XYZ axes + themed viewer background (#309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Robot View — themed background + a richer navigation cube.** The 3-D viewer
+  background now follows the theme (**white** in light, **black** in dark). The
+  ViewCube is **brass**, always drawn in **perspective** (independent of the view's
+  projection), sits tight in the top-right, shows **X/Y/Z axes** (red/green/blue
+  with labels) along its base, and uses a pointer cursor so corner picks aren't
+  hidden by the hand cursor.
 - **Robot View — orthographic / perspective toggle.** A dropdown beneath the
   navigation cube switches the camera between **Orthographic** (default, no
   distortion — best for building) and **Perspective** (a natural, lens-like view).

--- a/src/renderer/src/components/RobotView.css
+++ b/src/renderer/src/components/RobotView.css
@@ -91,22 +91,25 @@
 
 /* Navigation zone — top-right of the stage: the ViewCube + a hover-revealed
    Home button. */
+/* The cube sits tight in the top-right corner; the Home button + projection
+   dropdown are positioned around it so they don't push it down. */
 .robotview__navzone {
   position: absolute;
-  right: 12px;
-  top: 12px;
+  right: 10px;
+  top: 10px;
   z-index: 30;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 6px;
+  width: 192px;
+  height: 192px;
 }
 .robotview__home {
+  position: absolute;
+  top: 3px;
+  left: 3px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 30px;
-  height: 30px;
+  width: 28px;
+  height: 28px;
   color: var(--text, #cdd2d9);
   background: rgba(31, 32, 36, 0.92);
   border: 1px solid var(--border, #3a3d44);
@@ -139,7 +142,9 @@
 }
 /* Projection dropdown beneath the cube's bottom-right. */
 .robotview__proj {
-  align-self: flex-end;
+  position: absolute;
+  top: calc(100% + 2px);
+  right: 0;
   font-family: inherit;
   font-size: 0.6rem;
   color: var(--text, #cdd2d9);

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -803,7 +803,18 @@ export function RobotView({
     }
 
     const scene = new THREE.Scene()
-    scene.background = new THREE.Color(0x191a1d)
+    // Background follows the theme: white in light mode, black in dark. Decide from
+    // the --text luminance (light themes use dark text) so it's robust to any skin.
+    const applyBg = (): void => {
+      const text = getComputedStyle(document.documentElement).getPropertyValue('--text').trim()
+      const m = /#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})/i.exec(text)
+      const lum = m ? 0.299 * parseInt(m[1], 16) + 0.587 * parseInt(m[2], 16) + 0.114 * parseInt(m[3], 16) : 200
+      const lightMode = lum < 128 // dark text ⇒ light theme ⇒ white background
+      scene.background = new THREE.Color(lightMode ? 0xffffff : 0x000000)
+    }
+    applyBg()
+    const themeObserver = new MutationObserver(applyBg)
+    themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] })
 
     // Isometric ORTHOGRAPHIC camera (#320) — the three axes foreshorten equally
     // and there's no perspective distortion, which reads cleaner for poses. Its
@@ -1715,6 +1726,7 @@ export function RobotView({
       teardownPose()
       cancelAnimationFrame(raf)
       ro.disconnect()
+      themeObserver.disconnect()
       controls.removeEventListener('change', onControlsChange)
       zoomApiRef.current = null
       if (viewCube) {

--- a/src/renderer/src/components/robot-viewcube.ts
+++ b/src/renderer/src/components/robot-viewcube.ts
@@ -30,16 +30,36 @@ function faceTexture(text: string): THREE.CanvasTexture {
   const c = document.createElement('canvas')
   c.width = c.height = 128
   const ctx = c.getContext('2d')!
-  ctx.fillStyle = '#e7e2d3'
+  // Brass faces with a soft metallic sheen (top-lit) + a darker brass border.
+  const g = ctx.createLinearGradient(0, 0, 0, 128)
+  g.addColorStop(0, '#d8b25a')
+  g.addColorStop(0.5, '#c39b45')
+  g.addColorStop(1, '#a97f2e')
+  ctx.fillStyle = g
   ctx.fillRect(0, 0, 128, 128)
-  ctx.strokeStyle = '#8a6a2a'
+  ctx.strokeStyle = '#7a5c1e'
   ctx.lineWidth = 6
   ctx.strokeRect(3, 3, 122, 122)
-  ctx.fillStyle = '#34373d'
+  ctx.fillStyle = '#2b2205' // dark-brass ink, readable on brass
   ctx.font = 'bold 22px sans-serif'
   ctx.textAlign = 'center'
   ctx.textBaseline = 'middle'
   ctx.fillText(text, 64, 66)
+  const tex = new THREE.CanvasTexture(c)
+  tex.anisotropy = 4
+  return tex
+}
+
+/** A coloured axis letter (X/Y/Z) on a transparent canvas for a billboard sprite. */
+function axisLabelTexture(text: string, colorHex: number): THREE.CanvasTexture {
+  const c = document.createElement('canvas')
+  c.width = c.height = 64
+  const ctx = c.getContext('2d')!
+  ctx.fillStyle = `#${colorHex.toString(16).padStart(6, '0')}`
+  ctx.font = 'bold 46px sans-serif'
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'middle'
+  ctx.fillText(text, 32, 34)
   const tex = new THREE.CanvasTexture(c)
   tex.anisotropy = 4
   return tex
@@ -69,8 +89,10 @@ export function createViewCube(opts: {
   renderer.setSize(size, size)
 
   const scene = new THREE.Scene()
-  const camera = new THREE.OrthographicCamera(-1.5, 1.5, 1.5, -1.5, 0.1, 10)
-  camera.position.set(0, 0, 4)
+  // A PERSPECTIVE nav camera so the cube always looks 3-D (independent of the main
+  // viewer's ortho/perspective mode).
+  const camera = new THREE.PerspectiveCamera(32, 1, 0.1, 20)
+  camera.position.set(0, 0, 4.6)
   camera.lookAt(0, 0, 0)
   // Lit from the lower-front so the cube looks like a solid, shaded block.
   scene.add(new THREE.HemisphereLight(0xffffff, 0x6b6b6b, 0.9))
@@ -87,10 +109,36 @@ export function createViewCube(opts: {
   const edges = new THREE.LineSegments(edgeGeo, edgeMat)
   cube.add(edges)
 
-  // A brass overlay that snaps to the hovered face / edge / corner — a thin plate
+  // X/Y/Z orientation axes from the bottom-back-left corner along the three edges
+  // meeting there (X red, Y green, Z blue), with a labelled tip. Children of the
+  // cube so they track its orientation; occluded naturally (depthTest on).
+  const AXES = [
+    { end: new THREE.Vector3(1, 0, 0), color: 0xe0483a, label: 'X' },
+    { end: new THREE.Vector3(0, 1, 0), color: 0x40b04a, label: 'Y' },
+    { end: new THREE.Vector3(0, 0, 1), color: 0x4a78e0, label: 'Z' }
+  ]
+  const corner = new THREE.Vector3(-0.5, -0.5, -0.5)
+  const axisDisposables: Array<{ dispose: () => void }> = []
+  for (const a of AXES) {
+    const tip = corner.clone().add(a.end)
+    const lg = new THREE.BufferGeometry().setFromPoints([corner, tip])
+    const lm = new THREE.LineBasicMaterial({ color: a.color, linewidth: 2 })
+    cube.add(new THREE.Line(lg, lm))
+    axisDisposables.push(lg, lm)
+    const lt = axisLabelTexture(a.label, a.color)
+    const sm = new THREE.SpriteMaterial({ map: lt, depthTest: false, transparent: true })
+    const sprite = new THREE.Sprite(sm)
+    sprite.position.copy(corner.clone().add(a.end.clone().multiplyScalar(1.16)))
+    sprite.scale.set(0.34, 0.34, 1)
+    sprite.renderOrder = 4
+    cube.add(sprite)
+    axisDisposables.push(lt, sm)
+  }
+
+  // A bright overlay that snaps to the hovered face / edge / corner — a thin plate
   // on a face, a bar along an edge, a small cube on a corner (from `raw`).
   const hlGeo = new THREE.BoxGeometry(1, 1, 1)
-  const hlMat = new THREE.MeshBasicMaterial({ color: 0xc8a24a, transparent: true, opacity: 0.55, depthTest: false })
+  const hlMat = new THREE.MeshBasicMaterial({ color: 0xfff0c0, transparent: true, opacity: 0.5, depthTest: false })
   const highlight = new THREE.Mesh(hlGeo, hlMat)
   highlight.visible = false
   highlight.renderOrder = 3
@@ -154,7 +202,7 @@ export function createViewCube(opts: {
   canvas.addEventListener('pointermove', onPointerMove)
   canvas.addEventListener('pointerup', onPointerUp)
   canvas.addEventListener('pointerleave', onLeave)
-  canvas.style.cursor = 'grab'
+  canvas.style.cursor = 'pointer'
 
   const inv = new THREE.Quaternion()
   return {
@@ -172,6 +220,7 @@ export function createViewCube(opts: {
       geometry.dispose()
       edgeGeo.dispose()
       edgeMat.dispose()
+      axisDisposables.forEach((d) => d.dispose())
       hlGeo.dispose()
       hlMat.dispose()
       materials.forEach((m) => {


### PR DESCRIPTION
Nav-cube + viewer feedback, batched.

**Navigation cube**
- **Brass faces** (metallic gradient, dark-brass labels).
- Always drawn in **perspective** — its own perspective nav camera, independent of the main view's ortho/perspective mode.
- **Pointer cursor** (was the grab hand, which hid corner picks).
- **X / Y / Z axes** along the bottom edges from the back-left corner (X red, Y green, Z blue) with labelled tips; they track the cube's orientation.
- **Tight top-right** position again — the Home button overlays the corner (revealed on hover) and the projection dropdown sits just beneath, so neither pushes the cube down.
- Brighter hover overlay so the face/edge/corner highlight reads on brass.

**Viewer**
- The 3-D **background follows the theme**: **white** in light, **black** in dark — decided from the `--text` luminance (robust to any skin) and updated live via a `MutationObserver` on `data-theme` (disconnected on teardown).

Verification: `typecheck` · `lint` · `test` (1521) · `build` green. In-app smoke: cube 10px from top/right; cursor `pointer`; light theme → **white bg** + brass cube; flipping `data-theme=dark` live → **black bg**; screenshots show the brass perspective cube with red/green/blue **X/Y/Z** labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)