### PR TITLE
feat: Robot View — STL scale + dynamic near/far + hierarchy zoom + nav-cube tuning (#309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,18 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   or reopen any panel. Nothing about Robot mode is permanently changed.
 
 ### Fixed
+- **Robot View — imported meshes no longer render massive / clipped.** STLs
+  authored in millimetres loaded 1000× too big (a huge mesh pushed the camera past
+  the fixed far-plane, so only a "letterbox" sliver rendered). Imports now measure
+  the mesh and normalise the scale (mm→m via `<mesh scale>`); the camera's near/far
+  planes are also bracketed dynamically around the framed model so nothing clips at
+  any size/offset.
+- **Robot View — clicking a block in the hierarchy zooms to fit it**, and the
+  navigation cube: **lighter brass**, 25% smaller, **longer X/Y/Z axes**, a
+  **primary-button-only** guard (right/middle click no longer snaps the view), and
+  a `pointercancel`/`lostpointercapture` reset so a stolen drag can't leave it
+  orbiting on hover. A manual camera move (zoom / fit / home / focus / cube) is now
+  preserved when async meshes finish loading (previously the settle re-frame wiped it).
 - **Local Files refresh now updates expanded sub-folders too.** The refresh button
   re-read only the root listing, so files added/removed inside an already-expanded
   sub-folder didn't show up. Refresh now signals every expanded folder to re-read

--- a/src/renderer/src/components/RobotView.css
+++ b/src/renderer/src/components/RobotView.css
@@ -98,8 +98,8 @@
   right: 10px;
   top: 10px;
   z-index: 30;
-  width: 192px;
-  height: 192px;
+  width: 144px;
+  height: 144px;
 }
 .robotview__home {
   position: absolute;
@@ -132,8 +132,8 @@
 }
 /* The ViewCube's own canvas is appended here (2× — was 96px). */
 .robotview__viewcube {
-  width: 192px;
-  height: 192px;
+  width: 144px;
+  height: 144px;
   /* Shadow drops down-back, consistent with the cube being lit from lower-front. */
   filter: drop-shadow(0 5px 9px rgba(0, 0, 0, 0.5));
 }

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -174,6 +174,7 @@ export function RobotView({
     fit: () => void
     toggle: () => void
     home: () => void
+    focusLink: (name: string) => void
   } | null>(null)
   const [zoomPct, setZoomPct] = useState(100)
   // Camera projection (orthographic default; the ViewCube dropdown toggles it).
@@ -764,10 +765,26 @@ export function RobotView({
         if (res.error) setSavingLabel(`import failed: ${res.error}`)
         return
       }
+      // Normalise scale: the URDF world is metres, but STLs are commonly authored
+      // in millimetres (they'd load 1000× too big). Measure the mesh and, if its
+      // largest dimension is implausibly large for a metre-scale part, scale mm→m.
+      let scale = 1
+      if (/\.stl$/i.test(res.rel)) {
+        try {
+          const bytes = await window.api.fs.readFileBytes(`${dirname(activeFile.path)}/${res.rel}`)
+          const geo = new STLLoader().parse(bytes.buffer as ArrayBuffer)
+          geo.computeBoundingBox()
+          const size = new THREE.Vector3()
+          geo.boundingBox?.getSize(size)
+          if (Math.max(size.x, size.y, size.z) > 3) scale = 0.001
+        } catch {
+          /* leave scale 1 if the mesh can't be measured */
+        }
+      }
       // Add the mesh to the URDF (a new link + fixed joint at the origin) so it
       // renders now. Select it + reframe so the user can see + place it.
       const linkBase = res.name?.replace(/\.(stl|dae)$/i, '') ?? 'part'
-      const next = addMeshLink(content, { meshRel: res.rel, linkBase })
+      const next = addMeshLink(content, { meshRel: res.rel, linkBase, scale })
       refitNextRef.current = true
       // Route through the choke point so the import is ONE undoable step and the
       // history stays in sync (commitUrdf updates the buffer + schedules the save).
@@ -775,7 +792,7 @@ export function RobotView({
       setSelectedLink(next.link)
       setEditLink(next.link)
       if (!buildOpen) setBuildOpen(true)
-      setSavingLabel(`added ${next.link}`)
+      setSavingLabel(scale !== 1 ? `added ${next.link} (scaled mm→m)` : `added ${next.link}`)
     } catch (e) {
       setSavingLabel(`import failed: ${e instanceof Error ? e.message : 'error'}`)
     } finally {
@@ -850,6 +867,7 @@ export function RobotView({
       if (Math.abs(dir.y) > 0.9) camera.up.set(0, 0, dir.y > 0 ? -1 : 1)
       camera.position.copy(controls.target).addScaledVector(dir, dist)
       controls.update()
+      recordCamera()
     }
     // Drag the cube → orbit the camera (spherical around the target), same feel
     // as dragging the viewport.
@@ -863,9 +881,10 @@ export function RobotView({
       cubeOffset.setFromSpherical(cubeSph)
       camera.position.copy(controls.target).add(cubeOffset)
       controls.update()
+      recordCamera()
     }
     const viewCube = cubeMountRef.current
-      ? createViewCube({ size: 192, onPick: snapView, onOrbit: orbitBy })
+      ? createViewCube({ size: 144, onPick: snapView, onOrbit: orbitBy })
       : null
     if (viewCube && cubeMountRef.current) cubeMountRef.current.appendChild(viewCube.dom)
 
@@ -891,12 +910,35 @@ export function RobotView({
       camera.updateProjectionMatrix()
     }
 
+    // Bracket the near/far planes around the framed model so a large or offset
+    // model never gets sliced ("letterbox" clipping). `radius` = model half-size,
+    // `d` = camera→target distance. Fixed far=100 clipped big/scaled-off meshes.
+    const setClip = (radius: number): void => {
+      const d = camera.position.distanceTo(controls.target)
+      camera.near = Math.max(0.001, d - radius * 8)
+      camera.far = d + radius * 8 + 0.5
+      camera.updateProjectionMatrix()
+    }
+    // Snapshot the camera as the PRESERVED state so a later re-parse / async
+    // mesh-settle restores THIS view instead of re-framing the whole model. Called
+    // by manual camera actions (zoom, fit, home, focus-a-link, cube snap/orbit) so
+    // a click made while meshes are still loading isn't clobbered on settle.
+    const recordCamera = (): void => {
+      cameraStateRef.current = {
+        pos: camera.position.clone(),
+        target: controls.target.clone(),
+        zoom: camera.zoom,
+        halfView
+      }
+    }
+
     // ── Zoom controls (mirrors the node-graph viewport cluster) ──
     const syncZoomPct = (): void => setZoomPct(Math.round(camera.zoom * 100))
     const applyZoom = (z: number): void => {
       camera.zoom = Math.min(8, Math.max(0.2, z))
       camera.updateProjectionMatrix()
       syncZoomPct()
+      recordCamera()
     }
     // Zoom-to-fit: recentre on the model + size the frustum to its bounds, keeping
     // the current orbit orientation (zoom multiplier back to 1).
@@ -920,8 +962,36 @@ export function RobotView({
       camera.zoom = 1
       camera.updateProjectionMatrix()
       controls.update()
+      setClip(radius)
       resize()
       syncZoomPct()
+      recordCamera()
+    }
+    // Zoom-to-fit a SINGLE link's bounds (clicking a block in the hierarchy).
+    const focusLink = (name: string): void => {
+      const robot = robotRef.current
+      const link = robot?.links[name]
+      if (!robot || !link) return
+      robot.updateMatrixWorld(true)
+      const box = new THREE.Box3().setFromObject(link)
+      if (box.isEmpty() || !Number.isFinite(box.min.x)) return
+      const size = box.getSize(new THREE.Vector3())
+      const centre = box.getCenter(new THREE.Vector3())
+      const radius = Math.max(size.x, size.y, size.z, 0.03) * 0.5
+      halfView = radius * 1.6
+      if (camera instanceof THREE.PerspectiveCamera) {
+        const dir = camera.position.clone().sub(controls.target).normalize()
+        const dist = (radius * 1.6) / Math.sin(THREE.MathUtils.degToRad(camera.fov / 2))
+        camera.position.copy(centre).addScaledVector(dir, dist)
+      }
+      controls.target.copy(centre)
+      camera.zoom = 1
+      camera.updateProjectionMatrix()
+      controls.update()
+      setClip(radius)
+      resize()
+      syncZoomPct()
+      recordCamera()
     }
     zoomApiRef.current = {
       in: () => applyZoom(camera.zoom * 1.2),
@@ -934,7 +1004,8 @@ export function RobotView({
         if (!robotRef.current) return
         frameModel(robotRef.current)
         applyZoom(1)
-      }
+      },
+      focusLink
     }
     const onControlsChange = (): void => syncZoomPct()
     controls.addEventListener('change', onControlsChange)
@@ -970,6 +1041,7 @@ export function RobotView({
       grid = new THREE.GridHelper(gridSize, 20, 0x3a3d44, 0x27292e)
       grid.position.y = box.min.y
       scene.add(grid)
+      setClip(radius)
       resize()
     }
 
@@ -1882,7 +1954,10 @@ export function RobotView({
             onSetPinned={setBuildPinnedPersist}
             assembly={assembly}
             selected={selectedLink}
-            onSelect={setSelectedLink}
+            onSelect={(link) => {
+              setSelectedLink(link)
+              if (link) zoomApiRef.current?.focusLink(link) // hierarchy click zooms to fit
+            }}
             editLink={editLink}
             onEdit={setEditLink}
             editGeom={editGeom}

--- a/src/renderer/src/components/robot-assembly.ts
+++ b/src/renderer/src/components/robot-assembly.ts
@@ -109,7 +109,7 @@ export function uniqueLinkName(urdf: string, base: string): string {
  */
 export function addMeshLink(
   urdf: string,
-  opts: { meshRel: string; linkBase: string }
+  opts: { meshRel: string; linkBase: string; scale?: number }
 ): { urdf: string; link: string } {
   const parent = rootLink(urdf)
   const name = uniqueLinkName(urdf, opts.linkBase)
@@ -120,10 +120,12 @@ export function addMeshLink(
       `    <origin xyz="0 0 0" rpy="0 0 0"/>\n` +
       `  </joint>\n`
     : '' // first link of an empty URDF needs no joint
+  // A `scale` normalises a mesh authored in different units (e.g. mm → m).
+  const s = opts.scale && opts.scale !== 1 ? ` scale="${fmtNum(opts.scale)} ${fmtNum(opts.scale)} ${fmtNum(opts.scale)}"` : ''
   const block =
     `  <link name="${name}">\n` +
     `    <visual>\n` +
-    `      <geometry><mesh filename="${opts.meshRel}"/></geometry>\n` +
+    `      <geometry><mesh filename="${opts.meshRel}"${s}/></geometry>\n` +
     `    </visual>\n` +
     `  </link>\n` +
     joint

--- a/src/renderer/src/components/robot-viewcube.ts
+++ b/src/renderer/src/components/robot-viewcube.ts
@@ -30,14 +30,14 @@ function faceTexture(text: string): THREE.CanvasTexture {
   const c = document.createElement('canvas')
   c.width = c.height = 128
   const ctx = c.getContext('2d')!
-  // Brass faces with a soft metallic sheen (top-lit) + a darker brass border.
+  // Bright brass faces with a soft metallic sheen (top-lit) + a brass border.
   const g = ctx.createLinearGradient(0, 0, 0, 128)
-  g.addColorStop(0, '#d8b25a')
-  g.addColorStop(0.5, '#c39b45')
-  g.addColorStop(1, '#a97f2e')
+  g.addColorStop(0, '#f2dd9c')
+  g.addColorStop(0.5, '#e6c46a')
+  g.addColorStop(1, '#d0a844')
   ctx.fillStyle = g
   ctx.fillRect(0, 0, 128, 128)
-  ctx.strokeStyle = '#7a5c1e'
+  ctx.strokeStyle = '#9a7526'
   ctx.lineWidth = 6
   ctx.strokeRect(3, 3, 122, 122)
   ctx.fillStyle = '#2b2205' // dark-brass ink, readable on brass
@@ -118,9 +118,10 @@ export function createViewCube(opts: {
     { end: new THREE.Vector3(0, 0, 1), color: 0x4a78e0, label: 'Z' }
   ]
   const corner = new THREE.Vector3(-0.5, -0.5, -0.5)
+  const AXIS_LEN = 1.32 // poke ~0.32 beyond the far edge so the colour shows
   const axisDisposables: Array<{ dispose: () => void }> = []
   for (const a of AXES) {
-    const tip = corner.clone().add(a.end)
+    const tip = corner.clone().add(a.end.clone().multiplyScalar(AXIS_LEN))
     const lg = new THREE.BufferGeometry().setFromPoints([corner, tip])
     const lm = new THREE.LineBasicMaterial({ color: a.color, linewidth: 2 })
     cube.add(new THREE.Line(lg, lm))
@@ -128,7 +129,7 @@ export function createViewCube(opts: {
     const lt = axisLabelTexture(a.label, a.color)
     const sm = new THREE.SpriteMaterial({ map: lt, depthTest: false, transparent: true })
     const sprite = new THREE.Sprite(sm)
-    sprite.position.copy(corner.clone().add(a.end.clone().multiplyScalar(1.16)))
+    sprite.position.copy(corner.clone().add(a.end.clone().multiplyScalar(AXIS_LEN + 0.2)))
     sprite.scale.set(0.34, 0.34, 1)
     sprite.renderOrder = 4
     cube.add(sprite)
@@ -166,21 +167,24 @@ export function createViewCube(opts: {
     return hit ? classify(cube.worldToLocal(hit.point.clone())) : null
   }
 
-  // Drag-to-orbit vs click-to-snap: a near-stationary press is a click.
-  let down: { x: number; y: number; moved: boolean } | null = null
+  // Drag-to-orbit vs click-to-snap: a near-stationary press is a click. Orbit by
+  // the PER-MOVE delta (last→now), never `movementX` (unreliable under capture) or
+  // the total-from-down (which re-applied the whole delta each frame → wild spin).
+  let down: { x: number; y: number; lastX: number; lastY: number; moved: boolean } | null = null
   const onPointerDown = (e: PointerEvent): void => {
-    down = { x: e.clientX, y: e.clientY, moved: false }
+    if (e.button !== 0 || down) return // primary button only; ignore right/middle
+    down = { x: e.clientX, y: e.clientY, lastX: e.clientX, lastY: e.clientY, moved: false }
     canvas.setPointerCapture(e.pointerId)
   }
   const onPointerMove = (e: PointerEvent): void => {
     if (down) {
-      const dx = e.clientX - down.x
-      const dy = e.clientY - down.y
-      if (down.moved || Math.hypot(dx, dy) > 3) {
+      if (down.moved || Math.hypot(e.clientX - down.x, e.clientY - down.y) > 3) {
         down.moved = true
-        onOrbit(e.movementX || dx, e.movementY || dy)
+        onOrbit(e.clientX - down.lastX, e.clientY - down.lastY)
         setHighlight(null)
       }
+      down.lastX = e.clientX
+      down.lastY = e.clientY
       return
     }
     const r = pick(e)
@@ -198,9 +202,18 @@ export function createViewCube(opts: {
   const onLeave = (): void => {
     if (!down) setHighlight(null)
   }
+  // If the OS/browser steals the gesture (touch cancel, capture loss) it fires
+  // pointercancel, NOT pointerup — reset so a later bare hover doesn't keep orbiting.
+  const onCancel = (e: PointerEvent): void => {
+    canvas.releasePointerCapture?.(e.pointerId)
+    down = null
+    setHighlight(null)
+  }
   canvas.addEventListener('pointerdown', onPointerDown)
   canvas.addEventListener('pointermove', onPointerMove)
   canvas.addEventListener('pointerup', onPointerUp)
+  canvas.addEventListener('pointercancel', onCancel)
+  canvas.addEventListener('lostpointercapture', onCancel)
   canvas.addEventListener('pointerleave', onLeave)
   canvas.style.cursor = 'pointer'
 
@@ -216,6 +229,8 @@ export function createViewCube(opts: {
       canvas.removeEventListener('pointerdown', onPointerDown)
       canvas.removeEventListener('pointermove', onPointerMove)
       canvas.removeEventListener('pointerup', onPointerUp)
+      canvas.removeEventListener('pointercancel', onCancel)
+      canvas.removeEventListener('lostpointercapture', onCancel)
       canvas.removeEventListener('pointerleave', onLeave)
       geometry.dispose()
       edgeGeo.dispose()


### PR DESCRIPTION
Batch from user feedback, with an adversarial review of the diff (3 confirmed bugs fixed).

## Fixes
- **Imported meshes no longer render massive / clipped.** STLs in millimetres loaded 1000× too big, pushing the camera past the fixed `far=100` plane → a "letterbox" sliver. Now: measure the mesh on import and normalise scale (mm→m via `<mesh scale>`), **and** bracket the camera near/far dynamically around the framed model (`setClip`) so nothing clips at any size/offset.
- **Hierarchy click zooms-to-fit** the clicked block (`focusLink`).

## Nav cube tuning
- Lighter/brighter **brass** faces; **25% smaller** (144px); **longer X/Y/Z axes**; **drag-to-orbit** rewritten to per-move deltas (fixes the wild spinning).

## Adversarial-review fixes (all confirmed real)
1. **`pointercancel`/`lostpointercapture`** reset — a stolen drag could leave the cube orbiting on a bare hover.
2. **Primary-button-only** — right/middle click no longer snaps the view or orbits.
3. **Camera state recorded on manual moves** — a zoom/fit/home/focus/cube action made while async meshes are still loading is no longer wiped by the mesh-settle re-frame.

## Verification
- `typecheck` · `lint` · `test` (**1521**) · `build` green.
- Smokes: 100-unit STL → `<mesh scale="0.001">`, renders sensibly, **full grid (no letterbox)**; cube 144px; hierarchy click zooms; **right-click is a confirmed no-op** (identical before/after); left-click still snaps.

Known follow-ups (next): perspective scroll-zoom % readout; a 2nd-STL-click view/clip issue; animating camera transitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)