### PR TITLE
feat: Robot View — light-mode HUD + nav-cube polish + pinned build menu (#309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   timeline follow.
 
 ### Changed
+- **Robot View polish.** The **build menu defaults to pinned-open**; the
+  navigation cube is **brighter brass** with its X/Y/Z labels **occluded** by the
+  cube (no longer showing through); and the ortho/perspective dropdown collapses to
+  just its ▾ arrow, revealed (like the Home button) only when the pointer is over
+  the top-right nav zone.
 - **Robot View — clearer measure tool.** Measuring now draws a **dashed line**
   between the two picked points with the distance shown in a **floating pill on
   the model** (mm / m), so you read it in context. Clears on re-measure or when
@@ -177,6 +182,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   or reopen any panel. Nothing about Robot mode is permanently changed.
 
 ### Fixed
+- **Robot View readouts are readable in light mode.** The 3-D viewer's info/hint
+  HUD (also the docked mini-viewer's text) used a dark pill, so its text was
+  dark-on-dark on the parchment theme; it now uses a parchment pill with brass
+  emphasis in light mode.
 - **Robot View — imported meshes no longer render massive / clipped.** STLs
   authored in millimetres loaded 1000× too big (a huge mesh pushed the camera past
   the fixed far-plane, so only a "letterbox" sliver rendered). Imports now measure

--- a/src/renderer/src/components/RobotView.css
+++ b/src/renderer/src/components/RobotView.css
@@ -82,8 +82,12 @@
   color: var(--text, #cdd2d9);
   pointer-events: none;
 }
+/* Light theme: parchment pill so the (dark) text is readable, not black-on-dark. */
+:root[data-theme='skeuomorph'] .robotview__hud {
+  background: rgba(231, 226, 211, 0.86);
+}
 .robotview__hud strong {
-  color: var(--accent);
+  color: var(--accent-ink);
 }
 .robotview__hud-hint {
   color: var(--text-muted, #7d838d);
@@ -140,20 +144,29 @@
 .robotview__viewcube canvas {
   display: block;
 }
-/* Projection dropdown beneath the cube's bottom-right. */
+/* Projection dropdown beneath the cube's bottom-right. Collapsed to just the ▾
+   arrow (the value text is clipped by the narrow width); revealed on nav-zone
+   hover like the Home button; clicking opens the full native option list. */
 .robotview__proj {
   position: absolute;
   top: calc(100% + 2px);
   right: 0;
+  width: 26px;
   font-family: inherit;
   font-size: 0.6rem;
   color: var(--text, #cdd2d9);
   background: rgba(31, 32, 36, 0.92);
   border: 1px solid var(--border, #3a3d44);
   border-radius: 6px;
-  padding: 0.12rem 0.3rem;
+  padding: 0.12rem 0.1rem;
   cursor: pointer;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+.robotview__navzone:hover .robotview__proj,
+.robotview__proj:focus {
+  opacity: 1;
 }
 :root[data-theme='skeuomorph'] .robotview__proj {
   background: rgba(231, 226, 211, 0.92);

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -301,9 +301,12 @@ export function RobotView({
   }, [content, saveFile])
 
   // ── Block builder (#315a) ──────────────────────────────────────────────────
-  const [buildOpen, setBuildOpen] = useState(false)
+  // The build menu defaults to PINNED OPEN (first run / no stored preference).
   const [buildPinned, setBuildPinned] = useState(() =>
-    loadPin(window.localStorage, PIN_KEYS.builder, false)
+    loadPin(window.localStorage, PIN_KEYS.builder, true)
+  )
+  const [buildOpen, setBuildOpen] = useState(() =>
+    loadPin(window.localStorage, PIN_KEYS.builder, true)
   )
   const [selectedLink, setSelectedLink] = useState<string | null>(null)
   const [editLink, setEditLink] = useState<string | null>(null)

--- a/src/renderer/src/components/robot-viewcube.ts
+++ b/src/renderer/src/components/robot-viewcube.ts
@@ -30,14 +30,15 @@ function faceTexture(text: string): THREE.CanvasTexture {
   const c = document.createElement('canvas')
   c.width = c.height = 128
   const ctx = c.getContext('2d')!
-  // Bright brass faces with a soft metallic sheen (top-lit) + a brass border.
+  // Bright brass faces (matching the lightest part of the panel/instrument
+  // buttons) with a soft metallic sheen + a brass border.
   const g = ctx.createLinearGradient(0, 0, 0, 128)
-  g.addColorStop(0, '#f2dd9c')
-  g.addColorStop(0.5, '#e6c46a')
-  g.addColorStop(1, '#d0a844')
+  g.addColorStop(0, '#fbf1cf')
+  g.addColorStop(0.5, '#f0d68a')
+  g.addColorStop(1, '#e0bd5e')
   ctx.fillStyle = g
   ctx.fillRect(0, 0, 128, 128)
-  ctx.strokeStyle = '#9a7526'
+  ctx.strokeStyle = '#a9822f'
   ctx.lineWidth = 6
   ctx.strokeRect(3, 3, 122, 122)
   ctx.fillStyle = '#2b2205' // dark-brass ink, readable on brass
@@ -127,11 +128,12 @@ export function createViewCube(opts: {
     cube.add(new THREE.Line(lg, lm))
     axisDisposables.push(lg, lm)
     const lt = axisLabelTexture(a.label, a.color)
-    const sm = new THREE.SpriteMaterial({ map: lt, depthTest: false, transparent: true })
+    // depthTest on → labels are occluded by the cube when behind it (they looked
+    // odd showing through). transparent so the letter's alpha reads cleanly.
+    const sm = new THREE.SpriteMaterial({ map: lt, transparent: true })
     const sprite = new THREE.Sprite(sm)
     sprite.position.copy(corner.clone().add(a.end.clone().multiplyScalar(AXIS_LEN + 0.2)))
     sprite.scale.set(0.34, 0.34, 1)
-    sprite.renderOrder = 4
     cube.add(sprite)
     axisDisposables.push(lt, sm)
   }


### PR DESCRIPTION
Polish + a light-mode readability fix, from user feedback.

- **Light-mode readouts** — the 3-D viewer's info/hint **HUD** (and the docked **mini-3D viewer** text) used a dark pill, so its text was dark-on-dark on the parchment theme. It now uses a parchment pill (brass emphasis) in light mode.
- **Brighter nav cube** — faces match the lightest panel/instrument brass; **X/Y/Z axis labels are occluded** by the cube (depth-tested) instead of showing through.
- **Collapsed projection dropdown** — shows just its ▾ arrow, revealed on nav-zone hover like the Home button (was always visible with the full word).
- **Build menu defaults to pinned-open.**

Verification: `typecheck` · `lint` · `test` (**1521**) · `build` green. Smoke: fresh load → build **dock open + pinned**; HUD bg `rgba(231,226,211,…)` (parchment) in light; projection dropdown opacity **0 → 1** on hover; screenshot shows the brighter cube + readable HUD.

Also saved a project memory: **every new UI element must have both a dark and a light theme variant** (this class of bug keeps recurring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)