### PR TITLE
fix: Robot View — Move tool moves imported meshes + larger hierarchy text (#309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   or reopen any panel. Nothing about Robot mode is permanently changed.
 
 ### Fixed
+- **Robot View — the Move tool now moves imported meshes.** It bailed on any link
+  without primitive geometry, so STL/DAE parts couldn't be dragged; meshes now
+  move (grabbing the hit point; primitives still get the face snap points). The
+  Build hierarchy text is also a little larger (matching the breadboard browser).
 - **Robot View readouts are readable in light mode.** The 3-D viewer's info/hint
   HUD (also the docked mini-viewer's text) used a dark pill, so its text was
   dark-on-dark on the parchment theme; it now uses a parchment pill with brass

--- a/src/renderer/src/components/RobotBuildPanel.css
+++ b/src/renderer/src/components/RobotBuildPanel.css
@@ -155,11 +155,12 @@
   justify-content: space-between;
   gap: 0.3rem;
   font-family: inherit;
-  font-size: 0.64rem;
+  /* Match the breadboard library "Browser" list text (a touch larger). */
+  font-size: 0.72rem;
   color: var(--text, #cdd2d9);
   background: transparent;
   border: none;
-  padding: 0.15rem 0.3rem;
+  padding: 0.2rem 0.3rem;
   cursor: pointer;
   text-align: left;
 }
@@ -170,7 +171,7 @@
 }
 .robotbuild__part-geo {
   flex: 0 0 auto;
-  font-size: 0.54rem;
+  font-size: 0.6rem;
   color: var(--text-muted, #8b919b);
 }
 .robotbuild__part-geo.is-mesh {

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -1653,14 +1653,19 @@ export function RobotView({
             const joint = readJoint(contentRef.current, link) // null for the root
             const linkObj = robot.links[link]
             const jointObj = linkObj?.parent
-            const geom = readPrimitive(contentRef.current, link)
+            const geom = readPrimitive(contentRef.current, link) // null for mesh links
             const parentLink = jointObj?.parent
-            if (!joint || !jointObj || !linkObj || !geom || !parentLink) return
+            // A mesh has no primitive geometry → no face snap points, but it can
+            // still be moved (grab the hit point). Only the ROOT (no joint) is barred.
+            if (!joint || !jointObj || !linkObj || !parentLink) return
             robot.updateMatrixWorld(true)
             const parentBasis = [...new THREE.Matrix3().setFromMatrix4(parentLink.matrixWorld).elements]
-            const { pts } = hitToHandles(hit, link, geom)
-            const near = nearestScreen(pts, e)
-            const grab = (near.index >= 0 ? pts[near.index] : hit.point).clone()
+            let grab = hit.point.clone()
+            if (geom) {
+              const { pts } = hitToHandles(hit, link, geom)
+              const near = nearestScreen(pts, e)
+              if (near.index >= 0) grab = pts[near.index].clone()
+            }
             camera.getWorldDirection(camDir)
             move = {
               link,


### PR DESCRIPTION
- **Move tool now moves imported meshes.** `startMove` bailed on any link without primitive geometry (`readPrimitive` → null), so STL/DAE parts couldn't be dragged. Meshes now move (grabbing the hit point; the primitive-only face snap points are simply skipped). Only the **root** link (no parent joint) is still barred.
- **Larger hierarchy text** (0.64 → 0.72rem) to match the breadboard library browser.

Verification: `typecheck` · `lint` · `test` (**1521**) · `build` green. Smoke: focus an imported mesh, select **Move**, drag → its joint origin changed `0.05 0 0.02 → 0.055 0.01 0.025`.

This is the first slice of the larger Fusion-360 request; next up: the floating **Properties dialog** (edit pencil → right-side dialog with OK/Cancel, #352), **hierarchy nodes** for meshes/joints/poses (#353), and the **Add Joint** tool + dialog (#354).

🤖 Generated with [Claude Code](https://claude.com/claude-code)