### PR TITLE
feat: Robot View — perspective top-right-front default/home view (#309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   timeline follow.
 
 ### Changed
+- **Robot View — default view is the perspective "home" corner.** The viewer now
+  opens in **perspective**, framed from the cube's **top-right-front corner**
+  (+X/+Y/+Z), zoomed to fit — and that's exactly where the **Home** button returns.
 - **Robot View — blueprint-style ground grid.** The grid is now much **lighter**
   and theme-aware (subtle on both white and black backgrounds), with **major +
   minor** subdivision lines, plus **red-X / blue-Z origin lines** through the

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -177,9 +177,9 @@ export function RobotView({
     focusLink: (name: string) => void
   } | null>(null)
   const [zoomPct, setZoomPct] = useState(100)
-  // Camera projection (orthographic default; the ViewCube dropdown toggles it).
-  // Changing it rebuilds the 3-D effect with the matching camera type + re-frames.
-  const [projection, setProjection] = useState<'ortho' | 'persp'>('ortho')
+  // Camera projection — PERSPECTIVE is the default view (the ViewCube dropdown
+  // toggles it). Changing it rebuilds the 3-D effect + re-frames.
+  const [projection, setProjection] = useState<'ortho' | 'persp'>('persp')
   metaRef.current = jointMeta
   valuesRef.current = values
   overridesRef.current = overrides
@@ -1128,7 +1128,8 @@ export function RobotView({
       const size = box.getSize(new THREE.Vector3())
       const centre = box.getCenter(new THREE.Vector3())
       const radius = Math.max(size.x, size.y, size.z, 0.1) * 0.5
-      const isoDir = new THREE.Vector3(1, 0.9, 1).normalize()
+      // Home = the cube's top-right-front corner (+X right, +Y up, +Z front).
+      const isoDir = new THREE.Vector3(1, 1, 1).normalize()
       // Ortho apparent size is set by halfView, so distance is arbitrary; perspective
       // must sit back far enough that the model fits the vertical fov.
       const dist =


### PR DESCRIPTION
Reported: the top-right-front corner should be the home position + the default view, in perspective, zoomed to fit.

- **Default projection = perspective** (was orthographic).
- **frameModel iso direction = (1,1,1)** — the cube's top-right-front corner (+X right, +Y up, +Z front). The initial framing **and** the **Home** button use it, zoomed to fit.

Verification: `typecheck` · `lint` · `test` (1521) · `build` green. Smoke: default projection reads `persp`; screenshot shows the perspective top-right-front fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)