### PR TITLE
feat: Robot View — Fusion-style floating Properties dialog (#352)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Robot View — Fusion-style Properties dialog (#352).** Clicking a block's
+  **edit pencil** now opens a floating, **draggable** properties dialog on the
+  right (size + joint) instead of expanding the hierarchy row. Edits apply live to
+  the 3-D preview; **OK** keeps them, **Cancel** discards them (the URDF is
+  snapshotted on open and restored on cancel) — both close the dialog. Delete
+  moved onto the hierarchy row.
 - **Robot View — animated camera moves.** Clicking a nav-cube face/edge/corner,
   focusing a block from the hierarchy, **Home** and **Fit** now **glide** the
   camera to the destination (eased ~0.3s) instead of jumping, so you can see where

--- a/src/renderer/src/components/RobotBuildPanel.tsx
+++ b/src/renderer/src/components/RobotBuildPanel.tsx
@@ -44,13 +44,6 @@ export interface RobotBuildPanelProps {
   onSelect: (link: string | null) => void
   editLink: string | null
   onEdit: (link: string | null) => void
-  /** Geometry of the link being edited (for the size form), or null. */
-  editGeom: PrimitiveGeom | null
-  onSetSize: (link: string, dims: number[]) => void
-  /** The parent joint of the link being edited (null for the root), + a setter. */
-  editJoint: JointDef | null
-  jointNames: string[]
-  onSetJoint: (link: string, spec: JointSpec) => void
   /** The current root link, and an action to re-root the model at a link. */
   rootLink: string | null
   onMakeBase: (link: string) => void
@@ -66,7 +59,7 @@ export interface RobotBuildPanelProps {
 const mm = (m: number): number => Math.round(m * 1000)
 const toM = (millis: number): number => millis / 1000
 
-function SizeForm({
+export function SizeForm({
   geom,
   onChange
 }: {
@@ -136,7 +129,7 @@ const AXES: Array<{ id: 'x' | 'y' | 'z'; vec: Vec3 }> = [
 ]
 
 /** The joint editor (#315b): type, axis, limits and a mimic coupling. */
-function JointForm({
+export function JointForm({
   joint,
   names,
   onChange
@@ -325,11 +318,6 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
     onSelect,
     editLink,
     onEdit,
-    editGeom,
-    onSetSize,
-    editJoint,
-    jointNames,
-    onSetJoint,
     rootLink,
     onMakeBase,
     onDelete,
@@ -434,49 +422,28 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
                 )}
                 <button
                   type="button"
+                  className="robotbuild__del"
+                  disabled={it.link === rootLink}
+                  onClick={() => onDelete(it.link)}
+                  title={
+                    it.link === rootLink
+                      ? 'The base can’t be deleted — make another block the base first'
+                      : `Delete ${it.link}`
+                  }
+                  aria-label={`Delete ${it.link}`}
+                >
+                  ✕
+                </button>
+                <button
+                  type="button"
                   className={`robotbuild__edit${isEdit ? ' is-on' : ''}`}
                   onClick={() => onEdit(isEdit ? null : it.link)}
-                  title={isEdit ? 'Done editing' : 'Edit this block'}
+                  title={isEdit ? 'Close properties' : 'Edit properties'}
                   aria-label={`Edit ${it.link}`}
                 >
                   {PENCIL}
                 </button>
               </div>
-              {isEdit &&
-                (() => {
-                  const isRoot = it.link === rootLink
-                  return (
-                    <div className="robotbuild__editrow">
-                      <div className="robotbuild__editmain">
-                        {editGeom ? (
-                          <SizeForm geom={editGeom} onChange={(d) => onSetSize(it.link, d)} />
-                        ) : (
-                          <span className="robotbuild__editnote">Grab a face in 3D to resize, or…</span>
-                        )}
-                        {editJoint && (
-                          <JointForm
-                            joint={editJoint}
-                            names={jointNames}
-                            onChange={(spec) => onSetJoint(it.link, spec)}
-                          />
-                        )}
-                      </div>
-                      <button
-                        type="button"
-                        className="robotbuild__del"
-                        disabled={isRoot}
-                        onClick={() => onDelete(it.link)}
-                        title={
-                          isRoot
-                            ? 'The base can’t be deleted — make another block the base first'
-                            : `Delete ${it.link}`
-                        }
-                      >
-                        ✕
-                      </button>
-                    </div>
-                  )
-                })()}
             </li>
           )
         })}

--- a/src/renderer/src/components/RobotPropertiesDialog.css
+++ b/src/renderer/src/components/RobotPropertiesDialog.css
@@ -1,0 +1,103 @@
+/* Fusion-style floating Properties dialog (#352), docked top-right of the stage
+   by default, draggable by its title bar. Prefix robotprops__. */
+.robotprops {
+  position: absolute;
+  top: 3.2rem; /* below the nav zone */
+  right: 12px;
+  z-index: 20;
+  width: 13rem;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 8px;
+  background: rgba(20, 21, 24, 0.92);
+  backdrop-filter: blur(8px);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.5);
+  color: var(--text, #cdd2d9);
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  font-size: 0.66rem;
+}
+:root[data-theme='skeuomorph'] .robotprops {
+  background: rgba(231, 226, 211, 0.94);
+}
+.robotprops__head {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.35rem 0.5rem;
+  border-bottom: 1px solid var(--border, #3a3d44);
+  cursor: grab;
+  user-select: none;
+}
+.robotprops__head:active {
+  cursor: grabbing;
+}
+.robotprops__grip {
+  color: var(--text-muted, #8b919b);
+  letter-spacing: -1px;
+}
+.robotprops__title {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 700;
+  color: var(--accent-ink);
+}
+.robotprops__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  max-height: 60vh;
+  overflow-y: auto;
+}
+.robotprops__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+.robotprops__label {
+  font-size: 0.56rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted, #8b919b);
+}
+.robotprops__note {
+  margin: 0;
+  font-size: 0.58rem;
+  color: var(--text-muted, #8b919b);
+  font-style: italic;
+}
+.robotprops__foot {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.4rem;
+  padding: 0.4rem 0.5rem;
+  border-top: 1px solid var(--border, #3a3d44);
+}
+.robotprops__btn {
+  font-family: inherit;
+  font-size: 0.62rem;
+  color: var(--text, #cdd2d9);
+  background: var(--bg-sunken, rgba(0, 0, 0, 0.25));
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 5px;
+  padding: 0.18rem 0.7rem;
+  cursor: pointer;
+}
+.robotprops__btn:hover {
+  border-color: var(--text-muted, #6b7079);
+  color: var(--text, #f2f4f7);
+}
+.robotprops__btn--ok {
+  color: var(--accent-contrast, #15161a);
+  background: var(--accent, #d6a23f);
+  border-color: var(--accent, #d6a23f);
+  font-weight: 700;
+}
+.robotprops__btn--ok:hover {
+  color: var(--accent-contrast, #15161a);
+  filter: brightness(1.08);
+}

--- a/src/renderer/src/components/RobotPropertiesDialog.tsx
+++ b/src/renderer/src/components/RobotPropertiesDialog.tsx
@@ -1,0 +1,99 @@
+import { useRef, useState } from 'react'
+import type { JointDef, JointSpec, PrimitiveGeom } from './robot-assembly'
+import { SizeForm, JointForm } from './RobotBuildPanel'
+import './RobotPropertiesDialog.css'
+
+/**
+ * PROPERTIES DIALOG (#352, Fusion-style) — a floating, draggable dialog on the
+ * RIGHT that holds the properties of the block being edited (its size + joint).
+ * Edits apply live (so the 3-D preview updates); the footer commits (**OK**) or
+ * reverts (**Cancel**) — RobotView snapshots the URDF when it opens and restores
+ * it on Cancel. Both close edit mode.
+ */
+export interface RobotPropertiesDialogProps {
+  /** The link being edited (title). */
+  link: string
+  geom: PrimitiveGeom | null
+  joint: JointDef | null
+  jointNames: string[]
+  onSetSize: (link: string, dims: number[]) => void
+  onSetJoint: (link: string, spec: JointSpec) => void
+  onOk: () => void
+  onCancel: () => void
+}
+
+export function RobotPropertiesDialog({
+  link,
+  geom,
+  joint,
+  jointNames,
+  onSetSize,
+  onSetJoint,
+  onOk,
+  onCancel
+}: RobotPropertiesDialogProps): JSX.Element {
+  // Drag the dialog by its title bar. `pos` null = the default docked spot (CSS).
+  const [pos, setPos] = useState<{ x: number; y: number } | null>(null)
+  const drag = useRef<{ dx: number; dy: number } | null>(null)
+  const onHeadDown = (e: React.PointerEvent): void => {
+    const rect = (e.currentTarget.parentElement as HTMLElement).getBoundingClientRect()
+    drag.current = { dx: e.clientX - rect.left, dy: e.clientY - rect.top }
+    ;(e.target as HTMLElement).setPointerCapture?.(e.pointerId)
+  }
+  const onHeadMove = (e: React.PointerEvent): void => {
+    if (!drag.current) return
+    setPos({ x: e.clientX - drag.current.dx, y: e.clientY - drag.current.dy })
+  }
+  const onHeadUp = (e: React.PointerEvent): void => {
+    drag.current = null
+    ;(e.target as HTMLElement).releasePointerCapture?.(e.pointerId)
+  }
+
+  const style = pos ? { left: `${pos.x}px`, top: `${pos.y}px`, right: 'auto' } : undefined
+
+  return (
+    <aside className="robotprops" style={style} role="dialog" aria-label={`Properties — ${link}`}>
+      <div
+        className="robotprops__head"
+        onPointerDown={onHeadDown}
+        onPointerMove={onHeadMove}
+        onPointerUp={onHeadUp}
+      >
+        <span className="robotprops__grip" aria-hidden="true">
+          ⠿
+        </span>
+        <span className="robotprops__title" title={link}>
+          {link}
+        </span>
+      </div>
+      <div className="robotprops__body">
+        {geom ? (
+          <section className="robotprops__section">
+            <div className="robotprops__label">Size (mm)</div>
+            <SizeForm geom={geom} onChange={(d) => onSetSize(link, d)} />
+          </section>
+        ) : (
+          <p className="robotprops__note">This is a mesh — grab a face in 3-D to move it.</p>
+        )}
+        {joint ? (
+          <section className="robotprops__section">
+            <div className="robotprops__label">Joint</div>
+            <JointForm joint={joint} names={jointNames} onChange={(spec) => onSetJoint(link, spec)} />
+          </section>
+        ) : (
+          <p className="robotprops__note">This is the base — nothing to join to.</p>
+        )}
+      </div>
+      <div className="robotprops__foot">
+        <button type="button" className="robotprops__btn" onClick={onCancel}>
+          Cancel
+        </button>
+        <button type="button" className="robotprops__btn robotprops__btn--ok" onClick={onOk}>
+          OK
+        </button>
+      </div>
+    </aside>
+  )
+}
+
+export default RobotPropertiesDialog

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -56,6 +56,7 @@ import {
   type Vec3
 } from './robot-build'
 import { RobotBuildPanel } from './RobotBuildPanel'
+import { RobotPropertiesDialog } from './RobotPropertiesDialog'
 import { RobotToolbar } from './RobotToolbar'
 import { loadPin, savePin, PIN_KEYS } from './pin-overlay'
 import { RobotTimeline } from './RobotTimeline'
@@ -470,6 +471,26 @@ export function RobotView({
   }
   const handleMakeBase = (link: string): void => {
     commitUrdf(reRoot(content, link))
+  }
+  // Properties dialog (#352): the pencil opens it (snapshot the URDF so Cancel can
+  // revert); OK keeps the (live-applied) edits, Cancel restores the snapshot.
+  const editSnapshotRef = useRef<string | null>(null)
+  const handleOpenProps = (link: string | null): void => {
+    if (link) {
+      editSnapshotRef.current = contentRef.current
+      setSelectedLink(link)
+    }
+    setEditLink(link)
+  }
+  const handlePropsOk = (): void => {
+    editSnapshotRef.current = null
+    setEditLink(null)
+  }
+  const handlePropsCancel = (): void => {
+    const snap = editSnapshotRef.current
+    editSnapshotRef.current = null
+    if (snap != null && snap !== contentRef.current) commitUrdf(snap) // discard edits
+    setEditLink(null)
   }
 
   // Re-apply the selection outline when the picked block changes (no re-parse).
@@ -2066,19 +2087,26 @@ export function RobotView({
               if (link) zoomApiRef.current?.focusLink(link) // hierarchy click zooms to fit
             }}
             editLink={editLink}
-            onEdit={setEditLink}
-            editGeom={editGeom}
-            editJoint={editJoint}
-            jointNames={allJointNames}
+            onEdit={handleOpenProps}
             rootLink={rootName}
-            onSetSize={handleSetSize}
-            onSetJoint={handleSetJoint}
             onMakeBase={handleMakeBase}
             onDelete={handleDeleteLink}
             onImportStl={() => void handleImportStl()}
             canImport={!!canImport}
             importing={importing}
             canEdit={canEdit}
+          />
+        )}
+        {showPanel && editLink && (
+          <RobotPropertiesDialog
+            link={editLink}
+            geom={editGeom}
+            joint={editJoint}
+            jointNames={allJointNames}
+            onSetSize={handleSetSize}
+            onSetJoint={handleSetJoint}
+            onOk={handlePropsOk}
+            onCancel={handlePropsCancel}
           />
         )}
         {buildDim && (


### PR DESCRIPTION
Closes #352. First slice of the Fusion-360 redesign.

Clicking a block's **edit pencil** now opens a floating, **draggable Properties dialog on the right** (`RobotPropertiesDialog`) with the Size + Joint forms — instead of expanding inline under the hierarchy row.

- Edits **apply live** to the 3-D preview; the footer **OK** keeps them, **Cancel** discards them. RobotView snapshots the URDF when the dialog opens (`editSnapshotRef`) and restores it on Cancel; both close edit mode.
- `SizeForm`/`JointForm` are now exported from `RobotBuildPanel` and rendered by the dialog (the inline edit-row — including the joint-type buttons — is removed).
- **Delete** moved onto the hierarchy row (beside ★ make-base + ✎ edit).
- Dialog is draggable by its title bar; themed for light + dark.

## Verification
- `typecheck` · `lint` · `test` (**1521**) · `build` green.
- Smoke: pencil → dialog (title "arm"); edit L live `0.03 → 0.09`; **Cancel** reverts to `0.03` + closes; reopen, edit `→ 0.07`, **OK** keeps + closes.

Next: **#353** (servos/poses/joints as hierarchy nodes, each opening its own context dialog) and **#354** (Add Joint tool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)