### PR TITLE
fix: Robot View nav/layout bugs (home click, first-fit clip, dialog + hierarchy layout)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   or reopen any panel. Nothing about Robot mode is permanently changed.
 
 ### Fixed
+- **Robot View — a batch of navigation / layout fixes.** The **Home** button now
+  responds to clicks (it sat under the cube canvas — it's raised above it and only
+  captures clicks while the nav zone is hovered, so the cube corner stays pickable)
+  and orients to the **top-left-front** corner. The first **Fit / 100%** no longer
+  clips the model (the near plane was bracketed off the *far* end of the glide;
+  it now uses the nearer end). The Properties dialog opens **comfortably below the
+  nav cube** instead of behind it. In the Build hierarchy, the ☆/✎/✕ icons moved to
+  the **left of the block name** so they no longer overlap long titles, and the
+  panel now **sizes to its contents** (scrolling if needed) so it no longer covers
+  the Help hint in the bottom-left.
 - **Robot View — the Move tool now moves imported meshes.** It bailed on any link
   without primitive geometry, so STL/DAE parts couldn't be dragged; meshes now
   move (grabbing the hit point; primitives still get the face snap points). The

--- a/src/renderer/src/components/RobotBuildPanel.css
+++ b/src/renderer/src/components/RobotBuildPanel.css
@@ -30,7 +30,9 @@
   position: absolute;
   top: 0.5rem;
   left: 0.5rem;
-  bottom: 0.5rem;
+  /* Size to fit its contents (capped), so it never overlaps the Help hint in the
+     bottom-left; the parts list scrolls if the robot has more blocks than fit. */
+  max-height: calc(100% - 1rem);
   z-index: 4;
   width: 12.5rem;
   display: flex;
@@ -127,6 +129,7 @@
 
 .robotbuild__parts {
   flex: 1 1 auto;
+  min-height: 0; /* allow the list to shrink + scroll under the dock's max-height */
   overflow-y: auto;
   list-style: none;
   margin: 0;

--- a/src/renderer/src/components/RobotBuildPanel.tsx
+++ b/src/renderer/src/components/RobotBuildPanel.tsx
@@ -394,17 +394,8 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
               key={it.link}
             >
               <div className="robotbuild__part-row">
-                <button
-                  type="button"
-                  className="robotbuild__part-name"
-                  title={it.link}
-                  onClick={() => onSelect(it.link)}
-                >
-                  <span className="robotbuild__part-label">{it.link}</span>
-                  <span className={`robotbuild__part-geo${it.kind === 'mesh' ? ' is-mesh' : ''}`}>
-                    {it.kind === 'mesh' ? baseName(it.mesh ?? '') : it.kind}
-                  </span>
-                </button>
+                {/* Action icons sit to the LEFT of the name so they never overlap
+                    long titles (the name button flexes to fill the rest). */}
                 {it.link === rootLink ? (
                   <span className="robotbuild__rowbase is-base" title="This is the base — every block hangs off it">
                     ★
@@ -422,6 +413,15 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
                 )}
                 <button
                   type="button"
+                  className={`robotbuild__edit${isEdit ? ' is-on' : ''}`}
+                  onClick={() => onEdit(isEdit ? null : it.link)}
+                  title={isEdit ? 'Close properties' : 'Edit properties'}
+                  aria-label={`Edit ${it.link}`}
+                >
+                  {PENCIL}
+                </button>
+                <button
+                  type="button"
                   className="robotbuild__del"
                   disabled={it.link === rootLink}
                   onClick={() => onDelete(it.link)}
@@ -436,12 +436,14 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
                 </button>
                 <button
                   type="button"
-                  className={`robotbuild__edit${isEdit ? ' is-on' : ''}`}
-                  onClick={() => onEdit(isEdit ? null : it.link)}
-                  title={isEdit ? 'Close properties' : 'Edit properties'}
-                  aria-label={`Edit ${it.link}`}
+                  className="robotbuild__part-name"
+                  title={it.link}
+                  onClick={() => onSelect(it.link)}
                 >
-                  {PENCIL}
+                  <span className="robotbuild__part-label">{it.link}</span>
+                  <span className={`robotbuild__part-geo${it.kind === 'mesh' ? ' is-mesh' : ''}`}>
+                    {it.kind === 'mesh' ? baseName(it.mesh ?? '') : it.kind}
+                  </span>
                 </button>
               </div>
             </li>

--- a/src/renderer/src/components/RobotPropertiesDialog.css
+++ b/src/renderer/src/components/RobotPropertiesDialog.css
@@ -2,7 +2,7 @@
    by default, draggable by its title bar. Prefix robotprops__. */
 .robotprops {
   position: absolute;
-  top: 3.2rem; /* below the nav zone */
+  top: 190px; /* comfortably below the 144px nav cube + its projection dropdown */
   right: 12px;
   z-index: 20;
   width: 13rem;

--- a/src/renderer/src/components/RobotView.css
+++ b/src/renderer/src/components/RobotView.css
@@ -109,6 +109,7 @@
   position: absolute;
   top: 3px;
   left: 3px;
+  z-index: 2; /* above the cube canvas, so clicks land on the button */
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -120,12 +121,15 @@
   border-radius: 8px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.45);
   cursor: pointer;
-  /* Revealed only when the pointer is over the nav zone (top-right area). */
+  /* Revealed + clickable only on nav-zone hover; click-through otherwise so it
+     doesn't block the cube corner it overlaps. */
   opacity: 0;
+  pointer-events: none;
   transition: opacity 0.15s ease;
 }
 .robotview__navzone:hover .robotview__home {
   opacity: 1;
+  pointer-events: auto;
 }
 .robotview__home:hover {
   color: #c8a24a;
@@ -162,11 +166,13 @@
   cursor: pointer;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
   opacity: 0;
+  pointer-events: none;
   transition: opacity 0.15s ease;
 }
 .robotview__navzone:hover .robotview__proj,
 .robotview__proj:focus {
   opacity: 1;
+  pointer-events: auto;
 }
 :root[data-theme='skeuomorph'] .robotview__proj {
   background: rgba(231, 226, 211, 0.92);

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -1025,10 +1025,13 @@ export function RobotView({
       dur: number
     } | null = null
     const flyTo = (toP: THREE.Vector3, toT: THREE.Vector3, toZoom: number, toHV: number, clipRadius: number): void => {
-      // Bracket near/far around BOTH ends of the flight so nothing clips mid-move.
-      const maxD = Math.max(camera.position.distanceTo(controls.target), toP.distanceTo(toT))
-      camera.near = Math.max(0.001, maxD - clipRadius * 10)
-      camera.far = maxD + clipRadius * 10 + 0.5
+      // Bracket near/far around BOTH ends of the flight so nothing clips. NEAR must
+      // use the CLOSEST distance (min) — using max clipped the model when flying in
+      // from a far view (near plane ended up beyond the model → first-fit clipping).
+      const dFrom = camera.position.distanceTo(controls.target)
+      const dTo = toP.distanceTo(toT)
+      camera.near = Math.max(0.001, Math.min(dFrom, dTo) - clipRadius * 4)
+      camera.far = Math.max(dFrom, dTo) + clipRadius * 4 + 0.5
       camera.updateProjectionMatrix()
       anim = {
         fromP: camera.position.clone(),
@@ -1149,8 +1152,8 @@ export function RobotView({
       const size = box.getSize(new THREE.Vector3())
       const centre = box.getCenter(new THREE.Vector3())
       const radius = Math.max(size.x, size.y, size.z, 0.1) * 0.5
-      // Home = the cube's top-right-front corner (+X right, +Y up, +Z front).
-      const isoDir = new THREE.Vector3(1, 1, 1).normalize()
+      // Home = the top-LEFT-front corner (−X left, +Y up, +Z front) facing us.
+      const isoDir = new THREE.Vector3(-1, 1, 1).normalize()
       // Ortho apparent size is set by halfView, so distance is arbitrary; perspective
       // must sit back far enough that the model fits the vertical fov.
       const dist =


### PR DESCRIPTION
Five targeted fixes to the Robot View, reported together.

## Fixes
1. **Home button responds to clicks.** It was painted *under* the nav-cube canvas (a later DOM sibling), so clicks landed on the cube. It's now raised above the canvas (`z-index`) and only captures pointer events while the nav zone is hovered — so the cube corner it overlaps stays pickable when the button is hidden. Home now orients to the **top-left-front** corner.
2. **First Fit / 100% no longer clips.** `flyTo` bracketed the near plane off the **far** end of the glide, so flying in from a far view left the near plane beyond the model (clipped on the first fit; the second fit — now close — corrected it). Near now uses the **nearer** of the two distances (`min`), so nothing clips on the first fit.
3. **Properties dialog opens below the nav cube** (was behind it) — `top: 190px`, comfortably clear of the 144px cube + its projection dropdown.
4. **Hierarchy icons moved left of the name.** The ☆/★ (base), ✎ (edit) and ✕ (delete) icons now sit to the **left** of the block name, so they no longer overlap long titles (the name button flexes to fill the rest).
5. **Build dock sizes to its contents.** The dock was full-height (`top`+`bottom`) and covered the Help hint in the bottom-left; it now uses `max-height` and the parts list scrolls, so it never overlaps Help.

## Verification
- `npm run typecheck` ✅
- `npm run lint` ✅ (only the pre-existing DriverInstallBanner warning)
- `npm test` ✅ 1521 passing
- `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)