### PR TITLE
feat: Robot View hierarchy node tree + per-node context dialogs (#353)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Robot View — hierarchy is now a node tree with context dialogs (#353).** The
+  Build panel groups the model into collapsible branches — **Blocks**, **Meshes**,
+  **Joints**, **Servos** and **Poses** — each with a count. Clicking a node opens
+  a Fusion-style floating dialog on the right tailored to it: a **joint** shows its
+  type/axis/limits/mimic; a **servo** shows its joint mapping, servo/joint ranges,
+  invert and a delete; a **pose** shows rename, **Recall** and delete; a
+  **block/mesh** (edit pencil) shows size + joint. Block/joint edits apply live and
+  **Cancel** reverts them; servo/pose edits are held until **OK**.
 - **Robot View — Fusion-style Properties dialog (#352).** Clicking a block's
   **edit pencil** now opens a floating, **draggable** properties dialog on the
   right (size + joint) instead of expanding the hierarchy row. Edits apply live to

--- a/src/renderer/src/components/RobotBuildPanel.css
+++ b/src/renderer/src/components/RobotBuildPanel.css
@@ -127,19 +127,89 @@
   color: var(--text-muted, #8b919b);
 }
 
-.robotbuild__parts {
+/* The hierarchy tree scrolls as one under the dock's max-height. */
+.robotbuild__tree {
   flex: 1 1 auto;
-  min-height: 0; /* allow the list to shrink + scroll under the dock's max-height */
+  min-height: 0;
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+.robotbuild__section {
+  display: flex;
+  flex-direction: column;
+}
+/* A branch header: disclosure caret + label + a muted count. */
+.robotbuild__branch {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-family: inherit;
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--text-muted, #9aa0a6);
+  background: transparent;
+  border: none;
+  padding: 0.22rem 0.2rem 0.12rem;
+  cursor: pointer;
+  text-align: left;
+}
+.robotbuild__branch:hover {
+  color: var(--accent-ink);
+}
+.robotbuild__caret {
+  flex: 0 0 auto;
+  width: 0.7rem;
+  font-size: 0.6rem;
+}
+.robotbuild__branch-label {
+  flex: 1 1 auto;
+}
+.robotbuild__branch-count {
+  flex: 0 0 auto;
+  font-weight: 400;
+  /* Lean on the AA-tuned muted token directly — fading it with opacity dropped it
+     below AA on the parchment theme. */
+  color: var(--text-muted, #9aa0a6);
+}
+.robotbuild__parts {
   list-style: none;
   margin: 0;
-  padding: 0;
+  padding: 0 0 0 0.35rem;
   display: flex;
   flex-direction: column;
   gap: 0.12rem;
 }
 .robotbuild__part {
   border-radius: 5px;
+}
+/* A leaf node that opens a context dialog (joint / servo / pose). */
+.robotbuild__node {
+  width: 100%;
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.3rem;
+  font-family: inherit;
+  font-size: 0.72rem;
+  color: var(--text, #cdd2d9);
+  background: transparent;
+  border: none;
+  border-radius: 5px;
+  padding: 0.2rem 0.3rem;
+  cursor: pointer;
+  text-align: left;
+}
+.robotbuild__node:hover {
+  background: rgba(128, 128, 128, 0.14);
+}
+.robotbuild__node.is-on {
+  background: rgba(200, 162, 74, 0.18);
+  outline: 1px solid rgba(200, 162, 74, 0.5);
 }
 .robotbuild__part.is-sel {
   background: rgba(200, 162, 74, 0.18);

--- a/src/renderer/src/components/RobotBuildPanel.tsx
+++ b/src/renderer/src/components/RobotBuildPanel.tsx
@@ -1,10 +1,20 @@
 import { useEffect, useRef, useState } from 'react'
-import type { AssemblyItem, PrimitiveGeom, JointDef, JointType, JointSpec } from './robot-assembly'
+import type {
+  AssemblyItem,
+  PrimitiveGeom,
+  JointDef,
+  JointFull,
+  JointType,
+  JointSpec
+} from './robot-assembly'
 import type { Vec3 } from './robot-build'
 import { principalAxisName } from './robot-build'
-import { toDisplay, toNative, unitLabel, type MovableType } from './robot-pose'
+import { toDisplay, toNative, unitLabel, normPin, type MovableType } from './robot-pose'
 import { baseName } from './robot-mesh'
 import { shouldAutoHide } from './pin-overlay'
+import type { ServoJointBinding } from '../../../shared/robot'
+import type { NamedPoseLike } from './RobotJointPanel'
+import type { PropsContext } from './RobotPropertiesDialog'
 import './RobotBuildPanel.css'
 
 /**
@@ -40,10 +50,18 @@ export interface RobotBuildPanelProps {
   onSetOpen: (open: boolean) => void
   onSetPinned: (pinned: boolean) => void
   assembly: AssemblyItem[]
+  /** The model's joints, servo bindings and named poses — extra tree branches. */
+  joints: JointFull[]
+  servos: ServoJointBinding[]
+  poses: NamedPoseLike[]
   selected: string | null
   onSelect: (link: string | null) => void
-  editLink: string | null
+  /** The node whose context dialog is open (highlighted in the tree). */
+  active: PropsContext | null
   onEdit: (link: string | null) => void
+  onOpenJoint: (child: string, joint: string) => void
+  onOpenServo: (pin: string) => void
+  onOpenPose: (name: string) => void
   /** The current root link, and an action to re-root the model at a link. */
   rootLink: string | null
   onMakeBase: (link: string) => void
@@ -307,6 +325,125 @@ function MimicRatio({
   )
 }
 
+/** Kid-friendly label for a joint type (matches the joint editor's chips). */
+function jointTypeLabel(type: JointType): string {
+  return JOINT_KINDS.find((k) => k.id === type)?.label ?? type
+}
+
+/** A collapsible branch of the hierarchy tree (disclosure ▸/▾ + label + count). */
+function Section({
+  id,
+  label,
+  count,
+  collapsed,
+  onToggle,
+  children
+}: {
+  id: string
+  label: string
+  count: number
+  collapsed: Record<string, boolean>
+  onToggle: (id: string) => void
+  children: React.ReactNode
+}): JSX.Element {
+  const isCollapsed = !!collapsed[id]
+  return (
+    <div className="robotbuild__section">
+      <button
+        type="button"
+        className="robotbuild__branch"
+        aria-expanded={!isCollapsed}
+        onClick={() => onToggle(id)}
+      >
+        <span className="robotbuild__caret">{isCollapsed ? '▸' : '▾'}</span>
+        <span className="robotbuild__branch-label">{label}</span>
+        <span className="robotbuild__branch-count">{count}</span>
+      </button>
+      {!isCollapsed && <ul className="robotbuild__parts">{children}</ul>}
+    </div>
+  )
+}
+
+/** A block / mesh row: base marker (☆/★), edit pencil, delete, and the name
+ *  (click selects + zooms). Shared by the Blocks + Meshes branches. */
+function BodyRow({
+  it,
+  isSel,
+  isEdit,
+  isRoot,
+  onSelect,
+  onEdit,
+  onMakeBase,
+  onDelete
+}: {
+  it: AssemblyItem
+  isSel: boolean
+  isEdit: boolean
+  isRoot: boolean
+  onSelect: (link: string) => void
+  onEdit: (link: string | null) => void
+  onMakeBase: (link: string) => void
+  onDelete: (link: string) => void
+}): JSX.Element {
+  return (
+    <li className={`robotbuild__part${isSel ? ' is-sel' : ''}`}>
+      <div className="robotbuild__part-row">
+        {/* Action icons sit to the LEFT of the name so they never overlap long
+            titles (the name button flexes to fill the rest). */}
+        {isRoot ? (
+          <span className="robotbuild__rowbase is-base" title="This is the base — every block hangs off it">
+            ★
+          </span>
+        ) : (
+          <button
+            type="button"
+            className="robotbuild__rowbase"
+            onClick={() => onMakeBase(it.link)}
+            title="Make this the base"
+            aria-label={`Make ${it.link} the base`}
+          >
+            ☆
+          </button>
+        )}
+        <button
+          type="button"
+          className={`robotbuild__edit${isEdit ? ' is-on' : ''}`}
+          onClick={() => onEdit(isEdit ? null : it.link)}
+          title={isEdit ? 'Close properties' : 'Edit properties'}
+          aria-label={`Edit ${it.link}`}
+        >
+          {PENCIL}
+        </button>
+        <button
+          type="button"
+          className="robotbuild__del"
+          disabled={isRoot}
+          onClick={() => onDelete(it.link)}
+          title={
+            isRoot
+              ? 'The base can’t be deleted — make another block the base first'
+              : `Delete ${it.link}`
+          }
+          aria-label={`Delete ${it.link}`}
+        >
+          ✕
+        </button>
+        <button
+          type="button"
+          className="robotbuild__part-name"
+          title={it.link}
+          onClick={() => onSelect(it.link)}
+        >
+          <span className="robotbuild__part-label">{it.link}</span>
+          <span className={`robotbuild__part-geo${it.kind === 'mesh' ? ' is-mesh' : ''}`}>
+            {it.kind === 'mesh' ? baseName(it.mesh ?? '') : it.kind}
+          </span>
+        </button>
+      </div>
+    </li>
+  )
+}
+
 export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
   const {
     open,
@@ -314,10 +451,16 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
     onSetOpen,
     onSetPinned,
     assembly,
+    joints,
+    servos,
+    poses,
     selected,
     onSelect,
-    editLink,
+    active,
     onEdit,
+    onOpenJoint,
+    onOpenServo,
+    onOpenPose,
     rootLink,
     onMakeBase,
     onDelete,
@@ -327,6 +470,13 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
     canEdit
   } = props
   const dockRef = useRef<HTMLElement | null>(null)
+  // Which tree branches are collapsed (all expanded by default).
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({})
+  const toggle = (id: string): void => setCollapsed((c) => ({ ...c, [id]: !c[id] }))
+
+  const blocks = assembly.filter((it) => it.kind !== 'mesh')
+  const meshes = assembly.filter((it) => it.kind === 'mesh')
+  const editLink = active?.kind === 'link' ? active.link : null
 
   if (!open) {
     return (
@@ -384,73 +534,100 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
         <p className="robotbuild__hint">Save this robot to a folder to build.</p>
       )}
 
-      <ul className="robotbuild__parts">
-        {assembly.map((it) => {
-          const isSel = it.link === selected
-          const isEdit = it.link === editLink
-          return (
-            <li
-              className={`robotbuild__part${isSel ? ' is-sel' : ''}`}
+      <div className="robotbuild__tree">
+        <Section id="blocks" label="Blocks" count={blocks.length} collapsed={collapsed} onToggle={toggle}>
+          {blocks.map((it) => (
+            <BodyRow
               key={it.link}
-            >
-              <div className="robotbuild__part-row">
-                {/* Action icons sit to the LEFT of the name so they never overlap
-                    long titles (the name button flexes to fill the rest). */}
-                {it.link === rootLink ? (
-                  <span className="robotbuild__rowbase is-base" title="This is the base — every block hangs off it">
-                    ★
-                  </span>
-                ) : (
-                  <button
-                    type="button"
-                    className="robotbuild__rowbase"
-                    onClick={() => onMakeBase(it.link)}
-                    title="Make this the base"
-                    aria-label={`Make ${it.link} the base`}
-                  >
-                    ☆
-                  </button>
-                )}
+              it={it}
+              isSel={it.link === selected}
+              isEdit={it.link === editLink}
+              isRoot={it.link === rootLink}
+              onSelect={onSelect}
+              onEdit={onEdit}
+              onMakeBase={onMakeBase}
+              onDelete={onDelete}
+            />
+          ))}
+          {blocks.length === 0 && <li className="robotbuild__empty">No blocks yet — add one above.</li>}
+        </Section>
+
+        <Section id="meshes" label="Meshes" count={meshes.length} collapsed={collapsed} onToggle={toggle}>
+          {meshes.map((it) => (
+            <BodyRow
+              key={it.link}
+              it={it}
+              isSel={it.link === selected}
+              isEdit={it.link === editLink}
+              isRoot={it.link === rootLink}
+              onSelect={onSelect}
+              onEdit={onEdit}
+              onMakeBase={onMakeBase}
+              onDelete={onDelete}
+            />
+          ))}
+          {meshes.length === 0 && <li className="robotbuild__empty">No imported meshes.</li>}
+        </Section>
+
+        <Section id="joints" label="Joints" count={joints.length} collapsed={collapsed} onToggle={toggle}>
+          {joints.map((j) => {
+            const on = active?.kind === 'joint' && active.joint === j.name
+            return (
+              <li className="robotbuild__part" key={j.name}>
                 <button
                   type="button"
-                  className={`robotbuild__edit${isEdit ? ' is-on' : ''}`}
-                  onClick={() => onEdit(isEdit ? null : it.link)}
-                  title={isEdit ? 'Close properties' : 'Edit properties'}
-                  aria-label={`Edit ${it.link}`}
+                  className={`robotbuild__node${on ? ' is-on' : ''}`}
+                  title={`Edit joint ${j.name}`}
+                  onClick={() => onOpenJoint(j.child, j.name)}
                 >
-                  {PENCIL}
+                  <span className="robotbuild__part-label">{j.name}</span>
+                  <span className="robotbuild__part-geo">{jointTypeLabel(j.type)}</span>
                 </button>
+              </li>
+            )
+          })}
+          {joints.length === 0 && <li className="robotbuild__empty">No joints.</li>}
+        </Section>
+
+        <Section id="servos" label="Servos" count={servos.length} collapsed={collapsed} onToggle={toggle}>
+          {servos.map((b) => {
+            const on = active?.kind === 'servo' && normPin(active.pin) === normPin(b.pin)
+            return (
+              <li className="robotbuild__part" key={b.pin}>
                 <button
                   type="button"
-                  className="robotbuild__del"
-                  disabled={it.link === rootLink}
-                  onClick={() => onDelete(it.link)}
-                  title={
-                    it.link === rootLink
-                      ? 'The base can’t be deleted — make another block the base first'
-                      : `Delete ${it.link}`
-                  }
-                  aria-label={`Delete ${it.link}`}
+                  className={`robotbuild__node${on ? ' is-on' : ''}`}
+                  title={`Edit servo GP${normPin(b.pin)}`}
+                  onClick={() => onOpenServo(b.pin)}
                 >
-                  ✕
+                  <span className="robotbuild__part-label">GP{normPin(b.pin)}</span>
+                  <span className="robotbuild__part-geo">→ {b.joint || '—'}</span>
                 </button>
+              </li>
+            )
+          })}
+          {servos.length === 0 && <li className="robotbuild__empty">No servos mapped.</li>}
+        </Section>
+
+        <Section id="poses" label="Poses" count={poses.length} collapsed={collapsed} onToggle={toggle}>
+          {poses.map((p) => {
+            const on = active?.kind === 'pose' && active.name === p.name
+            return (
+              <li className="robotbuild__part" key={p.name}>
                 <button
                   type="button"
-                  className="robotbuild__part-name"
-                  title={it.link}
-                  onClick={() => onSelect(it.link)}
+                  className={`robotbuild__node${on ? ' is-on' : ''}`}
+                  title={`Edit pose ${p.name}`}
+                  onClick={() => onOpenPose(p.name)}
                 >
-                  <span className="robotbuild__part-label">{it.link}</span>
-                  <span className={`robotbuild__part-geo${it.kind === 'mesh' ? ' is-mesh' : ''}`}>
-                    {it.kind === 'mesh' ? baseName(it.mesh ?? '') : it.kind}
-                  </span>
+                  <span className="robotbuild__part-label">{p.name}</span>
                 </button>
-              </div>
-            </li>
-          )
-        })}
-        {assembly.length === 0 && <li className="robotbuild__empty">No blocks yet — add one above.</li>}
-      </ul>
+              </li>
+            )
+          })}
+          {poses.length === 0 && <li className="robotbuild__empty">No saved poses.</li>}
+        </Section>
+      </div>
 
       <div className="robotbuild__foot">
         <button

--- a/src/renderer/src/components/RobotPropertiesDialog.css
+++ b/src/renderer/src/components/RobotPropertiesDialog.css
@@ -70,12 +70,58 @@
   color: var(--text-muted, #8b919b);
   font-style: italic;
 }
+/* Servo / pose form controls. */
+.robotprops__row {
+  display: flex;
+  gap: 0.4rem;
+}
+.robotprops__mm {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.58rem;
+  color: var(--text-muted, #8b919b);
+}
+.robotprops__mm input {
+  width: 3.2rem;
+  font-family: inherit;
+  font-size: 0.62rem;
+  color: var(--text, #cdd2d9);
+  background: var(--bg-sunken, rgba(0, 0, 0, 0.25));
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 4px;
+  padding: 0.12rem 0.25rem;
+}
+.robotprops__sel,
+.robotprops__text {
+  width: 100%;
+  box-sizing: border-box;
+  font-family: inherit;
+  font-size: 0.64rem;
+  color: var(--text, #cdd2d9);
+  background: var(--bg-sunken, rgba(0, 0, 0, 0.25));
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 5px;
+  padding: 0.2rem 0.3rem;
+}
+.robotprops__check {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.6rem;
+  color: var(--text-muted, #8b919b);
+  cursor: pointer;
+}
 .robotprops__foot {
   display: flex;
+  align-items: center;
   justify-content: flex-end;
   gap: 0.4rem;
   padding: 0.4rem 0.5rem;
   border-top: 1px solid var(--border, #3a3d44);
+}
+.robotprops__foot-spacer {
+  flex: 1 1 auto;
 }
 .robotprops__btn {
   font-family: inherit;
@@ -100,4 +146,12 @@
 .robotprops__btn--ok:hover {
   color: var(--accent-contrast, #15161a);
   filter: brightness(1.08);
+}
+.robotprops__btn--danger {
+  color: var(--danger);
+}
+.robotprops__btn--danger:hover {
+  color: #fff;
+  background: var(--danger);
+  border-color: var(--danger);
 }

--- a/src/renderer/src/components/RobotPropertiesDialog.tsx
+++ b/src/renderer/src/components/RobotPropertiesDialog.tsx
@@ -1,37 +1,76 @@
 import { useRef, useState } from 'react'
 import type { JointDef, JointSpec, PrimitiveGeom } from './robot-assembly'
+import type { ServoJointBinding } from '../../../shared/robot'
+import type { NamedPoseLike } from './RobotJointPanel'
+import { normPin } from './robot-pose'
 import { SizeForm, JointForm } from './RobotBuildPanel'
 import './RobotPropertiesDialog.css'
 
 /**
- * PROPERTIES DIALOG (#352, Fusion-style) — a floating, draggable dialog on the
- * RIGHT that holds the properties of the block being edited (its size + joint).
- * Edits apply live (so the 3-D preview updates); the footer commits (**OK**) or
- * reverts (**Cancel**) — RobotView snapshots the URDF when it opens and restores
- * it on Cancel. Both close edit mode.
+ * The thing the Properties dialog is editing (#353). A block/mesh shows its size
+ * + joint; a joint shows just the joint form; a servo shows its binding editor;
+ * a pose shows recall / rename / delete. Clicking any hierarchy node opens the
+ * matching context here (Fusion-style), on the right.
  */
+export type PropsContext =
+  | { kind: 'link'; link: string }
+  | { kind: 'joint'; child: string; joint: string }
+  | { kind: 'servo'; pin: string }
+  | { kind: 'pose'; name: string }
+
+/** A short human title for the dialog header, per context. */
+function contextTitle(ctx: PropsContext): string {
+  switch (ctx.kind) {
+    case 'link':
+      return ctx.link
+    case 'joint':
+      return ctx.joint
+    case 'servo':
+      return `Servo — GP${normPin(ctx.pin)}`
+    case 'pose':
+      return `Pose — ${ctx.name}`
+  }
+}
+
 export interface RobotPropertiesDialogProps {
-  /** The link being edited (title). */
-  link: string
+  context: PropsContext
+  // link / joint
   geom: PrimitiveGeom | null
   joint: JointDef | null
   jointNames: string[]
   onSetSize: (link: string, dims: number[]) => void
   onSetJoint: (link: string, spec: JointSpec) => void
+  // servo
+  servo: ServoJointBinding | null
+  movableJoints: string[]
+  onSetServo: (pin: string, patch: Partial<ServoJointBinding>) => void
+  onDeleteServo: (pin: string) => void
+  // pose
+  pose: NamedPoseLike | null
+  onRecallPose: (pose: NamedPoseLike) => void
+  onRenamePose: (oldName: string, newName: string) => void
+  onDeletePose: (name: string) => void
+  // footer
   onOk: () => void
   onCancel: () => void
 }
 
-export function RobotPropertiesDialog({
-  link,
-  geom,
-  joint,
-  jointNames,
-  onSetSize,
-  onSetJoint,
-  onOk,
-  onCancel
-}: RobotPropertiesDialogProps): JSX.Element {
+/**
+ * PROPERTIES DIALOG (#352 / #353, Fusion-style) — a floating, draggable dialog on
+ * the RIGHT holding the properties of the hierarchy node being edited. For a
+ * block/mesh/joint, edits apply live to the 3-D preview and the footer commits
+ * (**OK**) or reverts (**Cancel**) via a URDF snapshot RobotView takes on open.
+ * Servo + pose edits are held locally and only committed on **OK** (a `commitRef`
+ * the body registers), so **Cancel** simply discards them.
+ *
+ * Mounted with a per-node `key` so switching nodes gives fresh local state.
+ */
+export function RobotPropertiesDialog(props: RobotPropertiesDialogProps): JSX.Element {
+  const { context, onOk, onCancel } = props
+
+  // Bodies with a local draft (servo/pose) register a commit here; OK runs it.
+  const commitRef = useRef<(() => void) | null>(null)
+
   // Drag the dialog by its title bar. `pos` null = the default docked spot (CSS).
   const [pos, setPos] = useState<{ x: number; y: number } | null>(null)
   const drag = useRef<{ dx: number; dy: number } | null>(null)
@@ -50,9 +89,14 @@ export function RobotPropertiesDialog({
   }
 
   const style = pos ? { left: `${pos.x}px`, top: `${pos.y}px`, right: 'auto' } : undefined
+  const title = contextTitle(context)
+  const handleOk = (): void => {
+    commitRef.current?.()
+    onOk()
+  }
 
   return (
-    <aside className="robotprops" style={style} role="dialog" aria-label={`Properties — ${link}`}>
+    <aside className="robotprops" style={style} role="dialog" aria-label={`Properties — ${title}`}>
       <div
         className="robotprops__head"
         onPointerDown={onHeadDown}
@@ -62,37 +106,223 @@ export function RobotPropertiesDialog({
         <span className="robotprops__grip" aria-hidden="true">
           ⠿
         </span>
-        <span className="robotprops__title" title={link}>
-          {link}
+        <span className="robotprops__title" title={title}>
+          {title}
         </span>
       </div>
       <div className="robotprops__body">
-        {geom ? (
+        {(context.kind === 'link' || context.kind === 'joint') && (
+          <LinkBody {...props} context={context} />
+        )}
+        {context.kind === 'servo' && (
+          <ServoBody {...props} pin={context.pin} commitRef={commitRef} />
+        )}
+        {context.kind === 'pose' && (
+          <PoseBody {...props} name={context.name} commitRef={commitRef} />
+        )}
+      </div>
+      <div className="robotprops__foot">
+        {context.kind === 'servo' && (
+          <button
+            type="button"
+            className="robotprops__btn robotprops__btn--danger"
+            onClick={() => {
+              props.onDeleteServo(context.pin)
+              onOk()
+            }}
+          >
+            Delete
+          </button>
+        )}
+        {context.kind === 'pose' && (
+          <>
+            <button
+              type="button"
+              className="robotprops__btn"
+              onClick={() => props.pose && props.onRecallPose(props.pose)}
+            >
+              Recall
+            </button>
+            <button
+              type="button"
+              className="robotprops__btn robotprops__btn--danger"
+              onClick={() => {
+                props.onDeletePose(context.name)
+                onOk()
+              }}
+            >
+              Delete
+            </button>
+          </>
+        )}
+        <span className="robotprops__foot-spacer" />
+        <button type="button" className="robotprops__btn" onClick={onCancel}>
+          Cancel
+        </button>
+        <button type="button" className="robotprops__btn robotprops__btn--ok" onClick={handleOk}>
+          OK
+        </button>
+      </div>
+    </aside>
+  )
+}
+
+/** The block / mesh / joint body: size (primitives) + the joint form. Edits are
+ *  applied live (URDF); RobotView reverts via snapshot on Cancel. */
+function LinkBody({
+  context,
+  geom,
+  joint,
+  jointNames,
+  onSetSize,
+  onSetJoint
+}: RobotPropertiesDialogProps & { context: PropsContext }): JSX.Element {
+  // `link` = the block being edited, or the joint's child link (which carries it).
+  const link = context.kind === 'joint' ? context.child : context.kind === 'link' ? context.link : ''
+  return (
+    <>
+      {context.kind === 'link' &&
+        (geom ? (
           <section className="robotprops__section">
             <div className="robotprops__label">Size (mm)</div>
             <SizeForm geom={geom} onChange={(d) => onSetSize(link, d)} />
           </section>
         ) : (
           <p className="robotprops__note">This is a mesh — grab a face in 3-D to move it.</p>
-        )}
-        {joint ? (
-          <section className="robotprops__section">
-            <div className="robotprops__label">Joint</div>
-            <JointForm joint={joint} names={jointNames} onChange={(spec) => onSetJoint(link, spec)} />
-          </section>
-        ) : (
-          <p className="robotprops__note">This is the base — nothing to join to.</p>
-        )}
-      </div>
-      <div className="robotprops__foot">
-        <button type="button" className="robotprops__btn" onClick={onCancel}>
-          Cancel
-        </button>
-        <button type="button" className="robotprops__btn robotprops__btn--ok" onClick={onOk}>
-          OK
-        </button>
-      </div>
-    </aside>
+        ))}
+      {joint ? (
+        <section className="robotprops__section">
+          <div className="robotprops__label">Joint</div>
+          <JointForm joint={joint} names={jointNames} onChange={(spec) => onSetJoint(link, spec)} />
+        </section>
+      ) : (
+        <p className="robotprops__note">This is the base — nothing to join to.</p>
+      )}
+    </>
+  )
+}
+
+/** The servo binding body: joint mapping + servo/joint ranges + invert. Held in
+ *  local draft state, committed on OK via `commitRef` (so Cancel discards). */
+function ServoBody({
+  pin,
+  servo,
+  movableJoints,
+  onSetServo,
+  commitRef
+}: RobotPropertiesDialogProps & {
+  pin: string
+  commitRef: React.MutableRefObject<(() => void) | null>
+}): JSX.Element {
+  const [draft, setDraft] = useState<ServoJointBinding>(() => ({
+    pin,
+    joint: servo?.joint ?? movableJoints[0] ?? '',
+    servoMin: servo?.servoMin ?? 0,
+    servoMax: servo?.servoMax ?? 180,
+    jointMin: servo?.jointMin ?? 0,
+    jointMax: servo?.jointMax ?? 0,
+    invert: servo?.invert ?? false
+  }))
+  // OK commits the whole draft as a patch.
+  commitRef.current = () => onSetServo(pin, draft)
+  const set = (patch: Partial<ServoJointBinding>): void => setDraft((d) => ({ ...d, ...patch }))
+  // Include the current joint even if it's no longer movable, so it's not dropped.
+  const options =
+    !draft.joint || movableJoints.includes(draft.joint) ? movableJoints : [draft.joint, ...movableJoints]
+
+  const num = (
+    label: string,
+    key: 'servoMin' | 'servoMax' | 'jointMin' | 'jointMax'
+  ): JSX.Element => (
+    <label className="robotprops__mm">
+      <span>{label}</span>
+      <input
+        type="number"
+        value={Number.isFinite(draft[key] as number) ? (draft[key] as number) : 0}
+        onChange={(e) => set({ [key]: Number(e.target.value) })}
+      />
+    </label>
+  )
+
+  return (
+    <>
+      <section className="robotprops__section">
+        <div className="robotprops__label">Drives joint</div>
+        <select
+          className="robotprops__sel"
+          value={draft.joint}
+          onChange={(e) => set({ joint: e.target.value })}
+        >
+          {options.length === 0 && <option value="">— no movable joints —</option>}
+          {options.map((j) => (
+            <option key={j} value={j}>
+              {j}
+            </option>
+          ))}
+        </select>
+      </section>
+      <section className="robotprops__section">
+        <div className="robotprops__label">Servo (°)</div>
+        <div className="robotprops__row">
+          {num('min', 'servoMin')}
+          {num('max', 'servoMax')}
+        </div>
+      </section>
+      <section className="robotprops__section">
+        <div className="robotprops__label">Joint range</div>
+        <div className="robotprops__row">
+          {num('min', 'jointMin')}
+          {num('max', 'jointMax')}
+        </div>
+      </section>
+      <label className="robotprops__check">
+        <input
+          type="checkbox"
+          checked={!!draft.invert}
+          onChange={(e) => set({ invert: e.target.checked })}
+        />
+        <span>Invert (servo min → joint max)</span>
+      </label>
+    </>
+  )
+}
+
+/** The pose body: rename (commit on OK) + a count; Recall / Delete live in the
+ *  footer. */
+function PoseBody({
+  name,
+  pose,
+  onRenamePose,
+  commitRef
+}: RobotPropertiesDialogProps & {
+  name: string
+  commitRef: React.MutableRefObject<(() => void) | null>
+}): JSX.Element {
+  const [draftName, setDraftName] = useState(name)
+  // OK renames the pose if the name changed to something non-empty.
+  commitRef.current = () => {
+    const next = draftName.trim()
+    if (next && next !== name) onRenamePose(name, next)
+  }
+  const jointCount = pose ? Object.keys(pose.values).length : 0
+  return (
+    <>
+      <section className="robotprops__section">
+        <div className="robotprops__label">Name</div>
+        <input
+          className="robotprops__text"
+          value={draftName}
+          onChange={(e) => setDraftName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') (e.currentTarget as HTMLInputElement).blur()
+          }}
+        />
+      </section>
+      <p className="robotprops__note">
+        Captures {jointCount} joint{jointCount === 1 ? '' : 's'}. <strong>Recall</strong> applies it
+        to the model.
+      </p>
+    </>
   )
 }
 

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -22,6 +22,7 @@ import {
   addPrimitive,
   jointNames,
   parseAssembly,
+  readAllJoints,
   readJoint,
   readPrimitive,
   removeLink,
@@ -56,7 +57,7 @@ import {
   type Vec3
 } from './robot-build'
 import { RobotBuildPanel } from './RobotBuildPanel'
-import { RobotPropertiesDialog } from './RobotPropertiesDialog'
+import { RobotPropertiesDialog, type PropsContext } from './RobotPropertiesDialog'
 import { RobotToolbar } from './RobotToolbar'
 import { loadPin, savePin, PIN_KEYS } from './pin-overlay'
 import { RobotTimeline } from './RobotTimeline'
@@ -272,6 +273,19 @@ export function RobotView({
     })
   }
 
+  // Rename a pose (#353 pose dialog): keep its captured values, drop the old + any
+  // clashing name. (Committed on the dialog's OK, which then closes it.)
+  const handleRenamePose = (oldName: string, newName: string): void => {
+    const target = newName.trim()
+    const pose = poses.find((p) => p.name === oldName)
+    if (!pose || !target || target === oldName) return
+    const next = [...poses.filter((p) => p.name !== oldName && p.name !== target), { name: target, values: pose.values }]
+    setPoses(next)
+    void persist((m) => {
+      m.poses = next
+    })
+  }
+
   const handleResetPose = (): void => {
     const dp = defaultPoseRef.current
     const nv = { ...valuesRef.current }
@@ -286,6 +300,8 @@ export function RobotView({
 
   // The model's links + meshes, for the assembly panel.
   const assembly = useMemo(() => parseAssembly(content), [content])
+  // The model's joints, for the hierarchy's Joints branch (#353).
+  const joints = useMemo(() => readAllJoints(content), [content])
   // Import is only possible for a saved local `.urdf` (a file we can edit).
   const canImport = poseUI && activeFile?.source === 'local' && !!activeFile.path
   const [importing, setImporting] = useState(false)
@@ -310,7 +326,12 @@ export function RobotView({
     loadPin(window.localStorage, PIN_KEYS.builder, true)
   )
   const [selectedLink, setSelectedLink] = useState<string | null>(null)
-  const [editLink, setEditLink] = useState<string | null>(null)
+  // The hierarchy node whose context dialog (#353) is open — a block/mesh, a
+  // joint, a servo binding or a pose. `editLink` (the block whose URDF is being
+  // edited + highlighted in 3-D) is DERIVED from it (link + joint contexts).
+  const [dialogCtx, setDialogCtx] = useState<PropsContext | null>(null)
+  const editLink =
+    dialogCtx?.kind === 'link' ? dialogCtx.link : dialogCtx?.kind === 'joint' ? dialogCtx.child : null
   const [buildDim, setBuildDim] = useState<{ x: number; y: number; text: string } | null>(null)
   // Refs the three.js pointer callbacks read (avoids re-subscribing on each edit).
   const buildOpenRef = useRef(false)
@@ -452,7 +473,7 @@ export function RobotView({
     const { urdf, link } = addPrimitive(content, { kind, jointXyz: [0, 0, 0] })
     commitUrdf(urdf)
     setSelectedLink(link)
-    setEditLink(link)
+    setDialogCtx({ kind: 'link', link })
     if (!buildOpen) setBuildOpen(true)
   }
   const handleSetSize = (link: string, dims: number[]): void => {
@@ -467,30 +488,46 @@ export function RobotView({
     if (link === rootLink(content)) return
     commitUrdf(removeLink(content, link))
     setSelectedLink(null)
-    setEditLink(null)
+    setDialogCtx(null)
   }
   const handleMakeBase = (link: string): void => {
     commitUrdf(reRoot(content, link))
   }
-  // Properties dialog (#352): the pencil opens it (snapshot the URDF so Cancel can
-  // revert); OK keeps the (live-applied) edits, Cancel restores the snapshot.
+  // Properties dialog (#352 / #353): clicking a node opens its context here. For a
+  // block/mesh/joint we snapshot the URDF so Cancel can revert the live edits; OK
+  // keeps them. Servo/pose contexts hold their own drafts (committed on OK).
   const editSnapshotRef = useRef<string | null>(null)
   const handleOpenProps = (link: string | null): void => {
     if (link) {
       editSnapshotRef.current = contentRef.current
       setSelectedLink(link)
+      setDialogCtx({ kind: 'link', link })
+    } else {
+      setDialogCtx(null)
     }
-    setEditLink(link)
+  }
+  const handleOpenJoint = (child: string, joint: string): void => {
+    editSnapshotRef.current = contentRef.current
+    setSelectedLink(child) // highlight the joint's child block in 3-D
+    setDialogCtx({ kind: 'joint', child, joint })
+  }
+  const handleOpenServo = (pin: string): void => {
+    editSnapshotRef.current = null // servo edits are drafted in the dialog, not URDF
+    setDialogCtx({ kind: 'servo', pin })
+  }
+  const handleOpenPose = (name: string): void => {
+    editSnapshotRef.current = null
+    setDialogCtx({ kind: 'pose', name })
   }
   const handlePropsOk = (): void => {
     editSnapshotRef.current = null
-    setEditLink(null)
+    setDialogCtx(null)
   }
   const handlePropsCancel = (): void => {
     const snap = editSnapshotRef.current
     editSnapshotRef.current = null
     if (snap != null && snap !== contentRef.current) commitUrdf(snap) // discard edits
-    setEditLink(null)
+    setDialogCtx(null)
   }
 
   // Re-apply the selection outline when the picked block changes (no re-parse).
@@ -814,7 +851,7 @@ export function RobotView({
       // history stays in sync (commitUrdf updates the buffer + schedules the save).
       commitUrdf(next.urdf)
       setSelectedLink(next.link)
-      setEditLink(next.link)
+      setDialogCtx({ kind: 'link', link: next.link })
       if (!buildOpen) setBuildOpen(true)
       setSavingLabel(scale !== 1 ? `added ${next.link} (scaled mm→m)` : `added ${next.link}`)
     } catch (e) {
@@ -2084,13 +2121,19 @@ export function RobotView({
             onSetOpen={setBuildOpen}
             onSetPinned={setBuildPinnedPersist}
             assembly={assembly}
+            joints={joints}
+            servos={bindings}
+            poses={poses}
             selected={selectedLink}
             onSelect={(link) => {
               setSelectedLink(link)
               if (link) zoomApiRef.current?.focusLink(link) // hierarchy click zooms to fit
             }}
-            editLink={editLink}
+            active={dialogCtx}
             onEdit={handleOpenProps}
+            onOpenJoint={handleOpenJoint}
+            onOpenServo={handleOpenServo}
+            onOpenPose={handleOpenPose}
             rootLink={rootName}
             onMakeBase={handleMakeBase}
             onDelete={handleDeleteLink}
@@ -2100,14 +2143,31 @@ export function RobotView({
             canEdit={canEdit}
           />
         )}
-        {showPanel && editLink && (
+        {showPanel && dialogCtx && (
           <RobotPropertiesDialog
-            link={editLink}
+            key={`${dialogCtx.kind}:${
+              dialogCtx.kind === 'link'
+                ? dialogCtx.link
+                : dialogCtx.kind === 'joint'
+                  ? dialogCtx.joint
+                  : dialogCtx.kind === 'servo'
+                    ? dialogCtx.pin
+                    : dialogCtx.name
+            }`}
+            context={dialogCtx}
             geom={editGeom}
             joint={editJoint}
             jointNames={allJointNames}
             onSetSize={handleSetSize}
             onSetJoint={handleSetJoint}
+            servo={dialogCtx.kind === 'servo' ? bindings.find((b) => b.pin === dialogCtx.pin) ?? null : null}
+            movableJoints={movableNames}
+            onSetServo={handleUpdateBinding}
+            onDeleteServo={handleDeleteBinding}
+            pose={dialogCtx.kind === 'pose' ? poses.find((p) => p.name === dialogCtx.name) ?? null : null}
+            onRecallPose={handleRecallPose}
+            onRenamePose={handleRenamePose}
+            onDeletePose={handleDeletePose}
             onOk={handlePropsOk}
             onCancel={handlePropsCancel}
           />


### PR DESCRIPTION
Turns the Robot View **Build** panel into a Fusion-style node tree and gives every node its own right-side context dialog.

## Tree
Collapsible branches, each with a count:
- **Blocks** — primitive links (box/cylinder/sphere), with the base/edit/delete controls + click-to-zoom
- **Meshes** — imported STL/DAE links
- **Joints** — every joint (name + kid-friendly type)
- **Servos** — each servo→joint binding (`GP0 → arm_joint`)
- **Poses** — each saved pose

## Context dialogs (click a node)
The single-purpose `editLink` Properties dialog is generalised into a `PropsContext` union (`link | joint | servo | pose`):
- **joint** → type / axis / limits / mimic (keyed on the joint's child link)
- **servo** → drives-joint dropdown + servo/joint ranges + invert + **Delete**
- **pose** → rename + **Recall** + **Delete**
- **block/mesh** (edit pencil) → size + joint, as before

Block/joint edits apply live and **Cancel** reverts them via a URDF snapshot; servo/pose edits are drafted locally and committed on **OK** (a `commitRef` the dialog body registers). The dialog is mounted with a per-node `key` so switching nodes gives fresh state.

## Verification
- `npm run typecheck` / `lint` (only the pre-existing DriverInstallBanner warning) / `npm test` (1521) / `build` ✅
- Playwright smoke in **both** dark + skeuomorph themes: all five branches (counts 2·1·2·1·2) and all four dialog contexts render and open correctly, below the nav cube.
- Adversarial multi-agent review (state / React / UX dimensions) found **no correctness bugs**; fixed the two theme-readability nits it caught — the Delete button (`#e06c6c` → `var(--danger)`) and the branch count (opacity → `var(--text-muted)`), both now readable on parchment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)