### PR TITLE
fix: Robot View nav dropdown reachability + mini-viewer light-mode buttons + mini Home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   or reopen any panel. Nothing about Robot mode is permanently changed.
 
 ### Fixed
+- **Robot View — nav + mini-viewer polish.** The projection dropdown under the
+  navigation cube no longer vanishes when you reach for it (it sat just outside the
+  nav zone's hover box, so moving the pointer down dropped the hover; the zone now
+  extends to contain it, and the target is a touch larger). The docked mini-viewer's
+  **New robot** / **Pop out** buttons are readable in the light skin (they hard-coded
+  a dark fill, so the dark label was dark-on-dark) and now use theme tokens. The mini
+  viewer also gains a **Home** button (top-right) that flies back to the fitted
+  default view.
 - **Robot View — hierarchy dialog follow-ups (#353).** Renaming a pose onto an
   existing pose's name no longer silently destroys that pose (the rename is refused
   with an inline warning). The servo dialog's number fields hold raw text while you

--- a/src/renderer/src/components/RobotView.css
+++ b/src/renderer/src/components/RobotView.css
@@ -103,7 +103,10 @@
   top: 10px;
   z-index: 30;
   width: 144px;
-  height: 144px;
+  /* Taller than the 144px cube so the projection dropdown below it lives INSIDE
+     the hover box — otherwise moving the pointer down to click it exits the zone,
+     :hover drops, and the dropdown vanishes before the click lands. */
+  height: 178px;
 }
 .robotview__home {
   position: absolute;
@@ -138,6 +141,31 @@
 :root[data-theme='skeuomorph'] .robotview__home {
   background: rgba(231, 226, 211, 0.92);
 }
+/* Compact (mini dock) home button — top-right, clear of the New/Pop-out actions
+   on the left. Always visible (the mini view has no hover nav zone). */
+.robotview__minihome {
+  position: absolute;
+  top: 0.35rem;
+  right: 0.35rem;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  color: var(--text, #cdd2d9);
+  background: rgba(20, 21, 24, 0.78);
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 5px;
+  cursor: pointer;
+}
+:root[data-theme='skeuomorph'] .robotview__minihome {
+  background: rgba(231, 226, 211, 0.9);
+}
+.robotview__minihome:hover {
+  color: var(--accent-ink);
+  border-color: var(--accent-ink);
+}
 /* The ViewCube's own canvas is appended here (2× — was 96px). */
 .robotview__viewcube {
   width: 144px;
@@ -153,16 +181,18 @@
    hover like the Home button; clicking opens the full native option list. */
 .robotview__proj {
   position: absolute;
-  top: calc(100% + 2px);
+  /* Just below the 144px cube, but WITHIN the (178px) nav-zone box so the hover
+     region is continuous from cube → dropdown. */
+  top: 148px;
   right: 0;
-  width: 26px;
+  width: 30px;
   font-family: inherit;
   font-size: 0.6rem;
   color: var(--text, #cdd2d9);
   background: rgba(31, 32, 36, 0.92);
   border: 1px solid var(--border, #3a3d44);
   border-radius: 6px;
-  padding: 0.12rem 0.1rem;
+  padding: 0.22rem 0.15rem;
   cursor: pointer;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
   opacity: 0;

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -2026,6 +2026,26 @@ export function RobotView({
             {meshNote}
           </div>
         )}
+        {!isEmpty && !error && compact && (
+          <button
+            type="button"
+            className="robotview__minihome"
+            onClick={() => zoomApiRef.current?.home()}
+            title="Home — reset to the fitted default view"
+            aria-label="Home view"
+          >
+            <svg viewBox="0 0 16 16" width="13" height="13" aria-hidden="true">
+              <path
+                d="M2 7.5L8 2.5l6 5M3.5 6.6V13h9V6.6"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.4"
+                strokeLinejoin="round"
+                strokeLinecap="round"
+              />
+            </svg>
+          </button>
+        )}
         {!isEmpty && !error && !compact && (
           <div className="robotview__navzone">
             <button

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -2162,26 +2162,32 @@ body {
   font-family: var(--font-mono);
   font-size: 0.6rem;
   color: var(--text, #cdd2d9);
+  /* Dark glass by default; a light parchment in the skeuomorph skin so the
+     (dark) label isn't dark-on-dark. */
   background: rgba(20, 21, 24, 0.78);
   border: 1px solid var(--border, #3a3d44);
   border-radius: 5px;
   padding: 0.15rem 0.4rem;
   cursor: pointer;
 }
+:root[data-theme='skeuomorph'] .robotdock__btn {
+  background: rgba(231, 226, 211, 0.9);
+}
 .robotdock__btn:hover {
-  border-color: #c8a24a;
-  color: #c8a24a;
+  border-color: var(--accent-ink);
+  color: var(--accent-ink);
 }
 /* Highlight "New robot" when there's no project robot yet (the demo is a stand-in). */
 .robotdock__btn--cta {
-  color: #191a1d;
-  background: #c8a24a;
-  border-color: #c8a24a;
+  color: var(--accent-contrast, #191a1d);
+  background: var(--accent, #c8a24a);
+  border-color: var(--accent, #c8a24a);
   font-weight: 700;
 }
 .robotdock__btn--cta:hover {
-  color: #191a1d;
-  background: #d8b45c;
+  color: var(--accent-contrast, #191a1d);
+  background: var(--accent, #c8a24a);
+  filter: brightness(1.08);
 }
 
 .activitybar {


### PR DESCRIPTION
Three Robot View polish items.

## Fixes
1. **Projection dropdown vanished on click.** The ortho/perspective `<select>` sat `top: calc(100% + 2px)` — just **outside** the 144px nav-zone box, revealed on `.robotview__navzone:hover`. Moving the pointer down to click it crossed the 2px gap, dropping `:hover` → the dropdown hid (opacity 0 + pointer-events none) before the click landed. The nav zone is now **178px tall** so the dropdown lives *inside* the hover box (continuous region), and the target is slightly larger.
2. **Mini-viewer buttons unreadable in light mode.** `.robotdock__btn` (New robot / Pop out) hard-coded `background: rgba(20,21,24,.78)` while `color: var(--text)` is dark on parchment → dark-on-dark. They now get a parchment fill in the skeuomorph skin and use theme tokens (`var(--accent-ink)` / `var(--accent)` / `var(--accent-contrast)`) for hover + the CTA.
3. **Mini-viewer Home button.** The docked mini viewer gains a **Home** button (top-right, clear of New/Pop-out on the left) that flies back to the fitted default view, reusing the same `home()` that zooms-to-fit and orients to the home corner. (The full-view Home already zooms-to-fit + rotates — verified 207%/164% → 100% after button/wheel zoom + orbit, in both projections.)

## Verification
- `npm run typecheck` / `lint` (only pre-existing DriverInstallBanner warning) / `npm test` (1521) / `build` ✅
- Playwright smoke: the dropdown stays visible + `pointer-events: auto` when you move onto it; the dock buttons compute to light-text/dark-fill in dark and dark-text/parchment in skeuomorph; the mini Home button renders in the Robot workspace dock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)