### PR TITLE
feat: Robot View — open a different robot (.urdf) from the dock + pose tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Robot View — open a different robot (.urdf).** The docked mini viewer gains an
+  **📂 Open…** button (alongside New robot / Pop out) and the pose tool's Build
+  panel gains one too, so you can pick and open another robot model via the native
+  file dialog — including when the view is popped out full-screen.
 - **Robot View — hierarchy is now a node tree with context dialogs (#353).** The
   Build panel groups the model into collapsible branches — **Blocks**, **Meshes**,
   **Joints**, **Servos** and **Poses** — each with a count. Clicking a node opens

--- a/src/main/fs/ipc.ts
+++ b/src/main/fs/ipc.ts
@@ -55,6 +55,20 @@ export function registerFsIpc(getWindow: () => BrowserWindow | undefined): void 
     })
   )
 
+  ipcMain.handle(
+    'fs:openFileDialog',
+    (_e, opts?: { filters?: { name: string; extensions: string[] }[] }) =>
+      wrap(async () => {
+        const win = getWindow()
+        const options = { properties: ['openFile' as const], filters: opts?.filters }
+        const result = win
+          ? await dialog.showOpenDialog(win, options)
+          : await dialog.showOpenDialog(options)
+        if (result.canceled || result.filePaths.length === 0) return null
+        return result.filePaths[0]
+      })
+  )
+
   ipcMain.handle('fs:saveFileDialog', (_e, defaultPath?: string) =>
     wrap(async () => {
       const win = getWindow()

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -246,6 +246,11 @@ const fs = {
   /** Show the native "open folder" dialog. Resolves to the path or null. */
   openFolderDialog: (): Promise<string | null> =>
     unwrap(ipcRenderer.invoke('fs:openFolderDialog')),
+  /** Show the native "open file" dialog (optionally filtered). Resolves to the
+   *  chosen path, or null if cancelled. */
+  openFileDialog: (opts?: {
+    filters?: { name: string; extensions: string[] }[]
+  }): Promise<string | null> => unwrap(ipcRenderer.invoke('fs:openFileDialog', opts)),
   /**
    * Show the native "save file" dialog (used for the untitled "Save As" flow).
    * `defaultName` seeds the dialog's default path. Resolves to the chosen path,

--- a/src/renderer/src/components/RobotBuildPanel.css
+++ b/src/renderer/src/components/RobotBuildPanel.css
@@ -410,9 +410,12 @@
 .robotbuild__foot {
   border-top: 1px solid var(--border, #2c2e33);
   padding-top: 0.35rem;
+  display: flex;
+  gap: 0.3rem;
 }
+.robotbuild__open,
 .robotbuild__stl {
-  width: 100%;
+  flex: 1 1 auto;
   font-family: inherit;
   font-size: 0.62rem;
   color: var(--text, #cdd2d9);
@@ -421,6 +424,10 @@
   border-radius: 5px;
   padding: 0.25rem;
   cursor: pointer;
+}
+.robotbuild__open:hover,
+.robotbuild__stl:hover:not(:disabled) {
+  border-color: var(--text-muted, #6b7079);
 }
 .robotbuild__stl:hover:not(:disabled) {
   border-color: var(--accent-ink);

--- a/src/renderer/src/components/RobotBuildPanel.tsx
+++ b/src/renderer/src/components/RobotBuildPanel.tsx
@@ -71,6 +71,8 @@ export interface RobotBuildPanelProps {
   importing: boolean
   /** Editing needs a saved project file — disables add/edit with a hint. */
   canEdit: boolean
+  /** Open a different robot `.urdf` via the native picker (works popped out). */
+  onOpenRobot: () => void
 }
 
 /** metres → integer mm (display) and back. */
@@ -467,7 +469,8 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
     onImportStl,
     canImport,
     importing,
-    canEdit
+    canEdit,
+    onOpenRobot
   } = props
   const dockRef = useRef<HTMLElement | null>(null)
   // Which tree branches are collapsed (all expanded by default).
@@ -630,6 +633,14 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
       </div>
 
       <div className="robotbuild__foot">
+        <button
+          type="button"
+          className="robotbuild__open"
+          onClick={onOpenRobot}
+          title="Open a different robot (.urdf) — works when popped out full-screen"
+        >
+          📂 Open…
+        </button>
         <button
           type="button"
           className="robotbuild__stl"

--- a/src/renderer/src/components/RobotDockPanel.tsx
+++ b/src/renderer/src/components/RobotDockPanel.tsx
@@ -67,6 +67,19 @@ export function RobotDockPanel(): JSX.Element {
     setFocus(true)
   }
 
+  // Open an existing robot model (.urdf) via the native picker, full-screen.
+  const openRobot = async (): Promise<void> => {
+    const path = await window.api.fs.openFileDialog({
+      filters: [
+        { name: 'Robot model', extensions: ['urdf', 'xacro'] },
+        { name: 'All files', extensions: ['*'] }
+      ]
+    })
+    if (!path) return
+    await openFile('local', path)
+    setFocus(true)
+  }
+
   // Create a new blank robot as a REAL FILE in the selected project folder, and
   // LINK it in robot.yml (`robot.urdf`) so it's the one project robot — reopening
   // always uses this file, and STL import + poses persist alongside it. With no
@@ -121,6 +134,14 @@ export function RobotDockPanel(): JSX.Element {
           onClick={() => void newRobot()}
         >
           ＋ New robot
+        </button>
+        <button
+          type="button"
+          className="robotdock__btn"
+          title="Open an existing robot (.urdf) full-screen"
+          onClick={() => void openRobot()}
+        >
+          📂 Open…
         </button>
         <button
           type="button"

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -131,7 +131,8 @@ export function RobotView({
   basePath,
   compact = false
 }: RobotViewProps = {}): JSX.Element {
-  const { openFiles, activeId, currentFolder, updateContent, saveFile, openBuffer } = useWorkspace()
+  const { openFiles, activeId, currentFolder, updateContent, saveFile, openBuffer, openFile } =
+    useWorkspace()
   const activeFile = openFiles.find((f) => f.id === activeId) ?? null
   const content = urdfContent ?? activeFile?.content ?? ''
   // Where to resolve mesh files from: an explicit base (docked panel) else the
@@ -480,6 +481,17 @@ export function RobotView({
     setSelectedLink(link)
     setDialogCtx({ kind: 'link', link })
     if (!buildOpen) setBuildOpen(true)
+  }
+  // Open a different robot model (.urdf) via the native file picker — lets you
+  // switch robots from the pose tool, including when it's popped out full-screen.
+  const handleOpenRobotFile = async (): Promise<void> => {
+    const path = await window.api.fs.openFileDialog({
+      filters: [
+        { name: 'Robot model', extensions: ['urdf', 'xacro'] },
+        { name: 'All files', extensions: ['*'] }
+      ]
+    })
+    if (path) await openFile('local', path)
   }
   const handleSetSize = (link: string, dims: number[]): void => {
     commitUrdf(setPrimitiveSize(content, link, dims))
@@ -2170,6 +2182,7 @@ export function RobotView({
             canImport={!!canImport}
             importing={importing}
             canEdit={canEdit}
+            onOpenRobot={() => void handleOpenRobotFile()}
           />
         )}
         {showPanel && dialogCtx && (

--- a/src/renderer/src/lib/preloadFallback.ts
+++ b/src/renderer/src/lib/preloadFallback.ts
@@ -65,6 +65,7 @@ if (!w.api) {
     },
     fs: {
       openFolderDialog: P(null),
+      openFileDialog: P(null),
       readDir: P([]),
       readFile: P(''),
       writeFile: P(undefined),


### PR DESCRIPTION
Adds an **Open robot…** capability so you can switch to a different `.urdf` — the last of the mini-viewer requests, specifically the "open files when popped out" case (the Robot workspace hides the file tree, so there was no way to open another robot while popped out).

## What
- New `fs.openFileDialog({ filters })` IPC (main + preload + preload-fallback) — a native open-file dialog, filtered to `.urdf` / `.xacro`.
- **📂 Open…** button in two places:
  - the docked mini viewer: `[+ New robot] [📂 Open…] [⤢ Pop out]`
  - the pose tool's **Build** panel footer (next to `+ STL / DAE`) — visible when popped out full-screen
- Both open the chosen model via the workspace `openFile`.

## Verification
- `npm run typecheck` / `lint` (only pre-existing DriverInstallBanner warning) / `npm test` (1521) / `build` ✅
- Playwright smoke: with the native dialog stubbed to a second robot, clicking **Open…** in the pose tool opens `arm2.urdf` and the viewer HUD switches to its name (`second_arm`); the mini dock shows all three buttons readable on the parchment skin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)