### PR TITLE
feat: Robot View Join tool — Add Joint dialog connects two blocks (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Robot View — Join tool (#354).** A new **Add Joint** button on the build
+  toolbar opens a floating dialog to connect two blocks: pick **Component 1**
+  (parent) and **Component 2** (child) and an **X/Y/Z offset** (mm) for the joint
+  origin, then **Add**. It re-parents the child under the chosen parent (preserving
+  the joint's type/axis/limits) or creates a fixed joint if it had none, refusing a
+  connection that would form a loop. Tune the joint's type in the Joints branch.
 - **Robot View — open a different robot (.urdf).** The docked mini viewer gains an
   **📂 Open…** button (alongside New robot / Pop out) and the pose tool's Build
   panel gains one too, so you can pick and open another robot model via the native

--- a/src/renderer/src/components/RobotPropertiesDialog.tsx
+++ b/src/renderer/src/components/RobotPropertiesDialog.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react'
-import type { JointDef, JointSpec, PrimitiveGeom } from './robot-assembly'
+import type { JointDef, JointFull, JointSpec, PrimitiveGeom } from './robot-assembly'
 import type { ServoJointBinding } from '../../../shared/robot'
 import type { NamedPoseLike } from './RobotJointPanel'
 import { normPin } from './robot-pose'
@@ -17,6 +17,7 @@ export type PropsContext =
   | { kind: 'joint'; child: string; joint: string }
   | { kind: 'servo'; pin: string }
   | { kind: 'pose'; name: string }
+  | { kind: 'addjoint' }
 
 /** A short human title for the dialog header, per context. */
 function contextTitle(ctx: PropsContext): string {
@@ -29,6 +30,8 @@ function contextTitle(ctx: PropsContext): string {
       return `Servo — GP${normPin(ctx.pin)}`
     case 'pose':
       return `Pose — ${ctx.name}`
+    case 'addjoint':
+      return 'Add Joint'
   }
 }
 
@@ -52,6 +55,14 @@ export interface RobotPropertiesDialogProps {
   onRecallPose: (pose: NamedPoseLike) => void
   onRenamePose: (oldName: string, newName: string) => void
   onDeletePose: (name: string) => void
+  // addjoint
+  /** All link names, for the Add Joint parent/child pickers. */
+  links: string[]
+  /** Every joint (to seed the offset from a child's current origin). */
+  joints: JointFull[]
+  /** Connect `child` under `parent` at joint origin `xyz` (metres). Returns
+   *  whether anything changed (false = invalid pick, e.g. would form a loop). */
+  onConnect: (parent: string, child: string, xyz: [number, number, number]) => boolean
   // footer
   onOk: () => void
   onCancel: () => void
@@ -70,8 +81,10 @@ export interface RobotPropertiesDialogProps {
 export function RobotPropertiesDialog(props: RobotPropertiesDialogProps): JSX.Element {
   const { context, onOk, onCancel } = props
 
-  // Bodies with a local draft (servo/pose) register a commit here; OK runs it.
-  const commitRef = useRef<(() => void) | null>(null)
+  // Bodies with a local draft (servo/pose/addjoint) register a commit here; OK
+  // runs it. A commit that returns `false` (an invalid Add-Joint pick) keeps the
+  // dialog open instead of closing as if it succeeded.
+  const commitRef = useRef<(() => void | boolean) | null>(null)
 
   // Drag the dialog by its title bar. `pos` null = the default docked spot (CSS).
   const [pos, setPos] = useState<{ x: number; y: number } | null>(null)
@@ -93,7 +106,7 @@ export function RobotPropertiesDialog(props: RobotPropertiesDialogProps): JSX.El
   const style = pos ? { left: `${pos.x}px`, top: `${pos.y}px`, right: 'auto' } : undefined
   const title = contextTitle(context)
   const handleOk = (): void => {
-    commitRef.current?.()
+    if (commitRef.current?.() === false) return // invalid — keep the dialog open
     onOk()
   }
 
@@ -122,6 +135,7 @@ export function RobotPropertiesDialog(props: RobotPropertiesDialogProps): JSX.El
         {context.kind === 'pose' && (
           <PoseBody {...props} name={context.name} commitRef={commitRef} />
         )}
+        {context.kind === 'addjoint' && <AddJointBody {...props} commitRef={commitRef} />}
       </div>
       <div className="robotprops__foot">
         {context.kind === 'servo' && (
@@ -162,7 +176,7 @@ export function RobotPropertiesDialog(props: RobotPropertiesDialogProps): JSX.El
           Cancel
         </button>
         <button type="button" className="robotprops__btn robotprops__btn--ok" onClick={handleOk}>
-          OK
+          {context.kind === 'addjoint' ? 'Add' : 'OK'}
         </button>
       </div>
     </aside>
@@ -214,7 +228,7 @@ function ServoBody({
   commitRef
 }: RobotPropertiesDialogProps & {
   pin: string
-  commitRef: React.MutableRefObject<(() => void) | null>
+  commitRef: React.MutableRefObject<(() => void | boolean) | null>
 }): JSX.Element {
   const [joint, setJoint] = useState(servo?.joint ?? movableJoints[0] ?? '')
   const [invert, setInvert] = useState(!!servo?.invert)
@@ -301,7 +315,7 @@ function PoseBody({
   commitRef
 }: RobotPropertiesDialogProps & {
   name: string
-  commitRef: React.MutableRefObject<(() => void) | null>
+  commitRef: React.MutableRefObject<(() => void | boolean) | null>
 }): JSX.Element {
   const [draftName, setDraftName] = useState(name)
   const trimmed = draftName.trim()
@@ -333,6 +347,122 @@ function PoseBody({
         <p className="robotprops__note">
           Captures {jointCount} joint{jointCount === 1 ? '' : 's'}. <strong>Recall</strong> applies
           it to the model.
+        </p>
+      )}
+    </>
+  )
+}
+
+/** The Add Joint body (#354): pick Component 1 (parent) + Component 2 (child) and
+ *  an X/Y/Z offset (mm) for the joint origin; commit on **Add**. */
+function AddJointBody({
+  links,
+  joints,
+  onConnect,
+  commitRef
+}: RobotPropertiesDialogProps & {
+  commitRef: React.MutableRefObject<(() => void | boolean) | null>
+}): JSX.Element {
+  const [parent, setParent] = useState(links[0] ?? '')
+  const [child, setChild] = useState(links.find((l) => l !== (links[0] ?? '')) ?? '')
+  // The child's current joint origin (metres → mm), so re-attaching without
+  // touching the offset leaves the part where it is. Re-seeded as the child changes.
+  const currentOrigin = (link: string): Record<'x' | 'y' | 'z', string> => {
+    const j = joints.find((x) => x.child === link)
+    const mm = (n: number): string => String(Math.round((n ?? 0) * 1000))
+    return j ? { x: mm(j.xyz[0]), y: mm(j.xyz[1]), z: mm(j.xyz[2]) } : { x: '0', y: '0', z: '0' }
+  }
+  // Offsets in mm (raw strings so you can clear / type a leading "-").
+  const [off, setOff] = useState<Record<'x' | 'y' | 'z', string>>(() => currentOrigin(child))
+  const [err, setErr] = useState<string | null>(null)
+  const same = !!parent && parent === child
+  const alreadyJointed = joints.some((x) => x.child === child)
+
+  commitRef.current = (): boolean => {
+    if (!parent || !child) {
+      setErr('Add another block to join to.')
+      return false
+    }
+    if (same) {
+      setErr('Pick two different blocks.')
+      return false
+    }
+    const mm = (s: string): number => {
+      const v = Number(s)
+      return Number.isFinite(v) ? v / 1000 : 0 // mm → m
+    }
+    const ok = onConnect(parent, child, [mm(off.x), mm(off.y), mm(off.z)])
+    if (!ok) {
+      setErr('Can’t connect — that would form a loop (the parent hangs off the child).')
+      return false
+    }
+    return true
+  }
+  const pickChild = (c: string): void => {
+    setChild(c)
+    setOff(currentOrigin(c)) // seed the offset from its current origin
+    setErr(null)
+  }
+  const axis = (k: 'x' | 'y' | 'z'): JSX.Element => (
+    <label className="robotprops__mm">
+      <span>{k.toUpperCase()}</span>
+      <input
+        type="number"
+        value={off[k]}
+        onChange={(e) => setOff((o) => ({ ...o, [k]: e.target.value }))}
+      />
+    </label>
+  )
+  const warn = err ?? (same ? 'Pick two different blocks.' : !child ? 'Add another block to join to.' : null)
+  return (
+    <>
+      <section className="robotprops__section">
+        <div className="robotprops__label">Component 1 (parent)</div>
+        <select
+          className="robotprops__sel"
+          value={parent}
+          onChange={(e) => {
+            const p = e.target.value
+            setParent(p)
+            setErr(null)
+            if (p === child) pickChild(links.find((l) => l !== p) ?? '') // keep child ≠ parent
+          }}
+        >
+          {links.map((l) => (
+            <option key={l} value={l}>
+              {l}
+            </option>
+          ))}
+        </select>
+      </section>
+      <section className="robotprops__section">
+        <div className="robotprops__label">Component 2 (child)</div>
+        <select className="robotprops__sel" value={child} onChange={(e) => pickChild(e.target.value)}>
+          {links
+            .filter((l) => l !== parent)
+            .map((l) => (
+              <option key={l} value={l}>
+                {l}
+              </option>
+            ))}
+        </select>
+      </section>
+      <section className="robotprops__section">
+        <div className="robotprops__label">Offset (mm)</div>
+        <div className="robotprops__row">
+          {axis('x')}
+          {axis('y')}
+          {axis('z')}
+        </div>
+      </section>
+      {warn ? (
+        <p className="robotprops__note robotprops__note--warn">{warn}</p>
+      ) : (
+        <p className="robotprops__note">
+          {alreadyJointed ? 'Re-attaches ' : 'Attaches '}
+          <strong>{child}</strong> under <strong>{parent}</strong>
+          {alreadyJointed ? ', keeping its joint type.' : ' as a fixed joint.'} Tune the type in the
+          Joints branch.
         </p>
       )}
     </>

--- a/src/renderer/src/components/RobotToolbar.tsx
+++ b/src/renderer/src/components/RobotToolbar.tsx
@@ -20,6 +20,8 @@ export interface RobotToolbarProps {
   canRedo: boolean
   onUndo: () => void
   onRedo: () => void
+  /** Open the Add Joint dialog (#354) — connect two blocks with a joint. */
+  onAddJoint: () => void
 }
 
 const MEASURE_ICON = (
@@ -69,8 +71,7 @@ const ICONS: Record<BuildTool, JSX.Element> = {
 const TOOLS: Array<{ id: BuildTool; label: string; soon?: boolean }> = [
   { id: 'select', label: 'Pick a block' },
   { id: 'pushpull', label: 'Push & pull to resize' },
-  { id: 'move', label: 'Move a block' },
-  { id: 'joint', label: 'Join two blocks (coming soon)', soon: true }
+  { id: 'move', label: 'Move a block' }
 ]
 
 const UNDO_ICON = (
@@ -94,7 +95,8 @@ export function RobotToolbar({
   canUndo,
   canRedo,
   onUndo,
-  onRedo
+  onRedo,
+  onAddJoint
 }: RobotToolbarProps): JSX.Element {
   return (
     <div className="robottool" role="toolbar" aria-label="Build tools">
@@ -129,6 +131,16 @@ export function RobotToolbar({
           </button>
         )
       })}
+      <button
+        type="button"
+        className="robottool__btn"
+        disabled={!canEdit}
+        title={canEdit ? 'Add a joint — connect two blocks' : 'Save the robot to a folder first'}
+        aria-label="Add a joint"
+        onClick={onAddJoint}
+      >
+        {ICONS.joint}
+      </button>
       <button
         type="button"
         className={`robottool__btn${measureActive ? ' is-active' : ''}`}

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -20,6 +20,7 @@ import {
 import {
   addMeshLink,
   addPrimitive,
+  connectJoint,
   jointNames,
   parseAssembly,
   readAllJoints,
@@ -539,6 +540,22 @@ export function RobotView({
   }
   const handleOpenPose = (name: string): void => {
     openContext({ kind: 'pose', name }, null)
+  }
+  // Add Joint (#354): the toolbar opens the dialog; Add commits a connectJoint.
+  const handleAddJoint = (): void => {
+    openContext({ kind: 'addjoint' }, null)
+    if (!buildOpen) setBuildOpen(true)
+  }
+  const handleConnectJoint = (
+    parent: string,
+    child: string,
+    xyz: [number, number, number]
+  ): boolean => {
+    const next = connectJoint(content, { parent, child, xyz })
+    if (next === content) return false // no-op (cycle / invalid) — tell the dialog
+    commitUrdf(next)
+    setSelectedLink(child)
+    return true
   }
   const handlePropsOk = (): void => {
     editSnapshotRef.current = null
@@ -2153,6 +2170,7 @@ export function RobotView({
             canRedo={histCanRedo(histRef.current)}
             onUndo={undoUrdf}
             onRedo={redoUrdf}
+            onAddJoint={handleAddJoint}
           />
         )}
         {showPanel && (
@@ -2194,7 +2212,9 @@ export function RobotView({
                   ? dialogCtx.joint
                   : dialogCtx.kind === 'servo'
                     ? dialogCtx.pin
-                    : dialogCtx.name
+                    : dialogCtx.kind === 'pose'
+                      ? dialogCtx.name
+                      : 'addjoint'
             }`}
             context={dialogCtx}
             geom={editGeom}
@@ -2211,6 +2231,9 @@ export function RobotView({
             onRecallPose={handleRecallPose}
             onRenamePose={handleRenamePose}
             onDeletePose={handleDeletePose}
+            links={assembly.map((a) => a.link)}
+            joints={joints}
+            onConnect={handleConnectJoint}
             onOk={handlePropsOk}
             onCancel={handlePropsCancel}
           />

--- a/src/renderer/src/components/robot-assembly.ts
+++ b/src/renderer/src/components/robot-assembly.ts
@@ -424,6 +424,107 @@ export function setJoint(urdf: string, childLink: string, spec: JointSpec): stri
   return urdf
 }
 
+/** A link + every descendant reachable through child joints (transitive). Used
+ *  by the Join tool to forbid a re-parent that would create a cycle. */
+export function subtreeOf(urdf: string, link: string): Set<string> {
+  const inside = new Set<string>([link])
+  const jointOf = (block: string, attr: 'parent' | 'child'): string | undefined =>
+    new RegExp(`<${attr}\\b[^>]*\\blink\\s*=\\s*"([^"]+)"`, 'i').exec(block)?.[1]
+  for (let changed = true; changed; ) {
+    changed = false
+    const re = /<joint\b[^>]*>[\s\S]*?<\/joint>/gi
+    let m: RegExpExecArray | null
+    while ((m = re.exec(urdf))) {
+      const parent = jointOf(m[0], 'parent')
+      const child = jointOf(m[0], 'child')
+      if (parent && child && inside.has(parent) && !inside.has(child)) {
+        inside.add(child)
+        changed = true
+      }
+    }
+  }
+  return inside
+}
+
+/** A joint name derived from `base`, made unique within the URDF. */
+function uniqueJointName(urdf: string, base: string): string {
+  const existing = new Set(jointNames(urdf))
+  if (!existing.has(base)) return base
+  let n = 2
+  while (existing.has(`${base}_${n}`)) n++
+  return `${base}_${n}`
+}
+
+/** Render a complete `<joint>` block from parsed fields — regenerated wholesale
+ *  (never surgically patched) so it's immune to open-vs-self-closing tag forms and
+ *  can't strand/duplicate a child tag. Movable joints get an `<axis>`;
+ *  revolute/prismatic additionally a `<limit>`, continuous a bare effort/velocity. */
+function renderJointBlock(j: JointFull): string {
+  const movable = j.type !== 'fixed'
+  let inner =
+    `    <parent link="${j.parent}"/>\n` +
+    `    <child link="${j.child}"/>\n` +
+    `    <origin xyz="${fmtVec(j.xyz)}" rpy="${fmtVec(j.rpy)}"/>\n`
+  if (movable) inner += `    <axis xyz="${fmtVec(j.axis ?? [0, 0, 1])}"/>\n`
+  if (j.type === 'revolute' || j.type === 'prismatic') {
+    const lim = j.limit ?? defaultJointLimit(j.type)
+    inner += `    <limit lower="${fmtNum(lim.lower)}" upper="${fmtNum(lim.upper)}" effort="1" velocity="1"/>\n`
+  } else if (j.type === 'continuous') {
+    inner += `    <limit effort="1" velocity="1"/>\n`
+  }
+  if (movable && j.mimic && j.mimic.joint) {
+    const mi = j.mimic
+    inner += `    <mimic joint="${mi.joint}" multiplier="${fmtNum(mi.multiplier)}" offset="${fmtNum(mi.offset)}"/>\n`
+  }
+  return `  <joint name="${j.name}" type="${j.type}">\n${inner}  </joint>`
+}
+
+/**
+ * The Join tool (#354): connect `child` (Component 2) under `parent` (Component 1)
+ * at joint origin `xyz`. If the child already has a parent joint it is re-parented
+ * (parent + origin rewritten, type/axis/limits preserved); otherwise a new fixed
+ * joint is created. Refuses a no-op or a re-parent that would form a cycle
+ * (parent within the child's own subtree) — returns the URDF unchanged.
+ */
+export function connectJoint(
+  urdf: string,
+  opts: { parent: string; child: string; xyz?: readonly [number, number, number] }
+): string {
+  const { parent, child } = opts
+  const xyz: Vec3 = [...(opts.xyz ?? [0, 0, 0])] as Vec3
+  if (!parent || !child || parent === child) return urdf
+  // A URDF is a tree: attaching `child` under one of its own descendants (or
+  // itself) would create a loop the loader can't build.
+  if (subtreeOf(urdf, child).has(parent)) return urdf
+  // Re-parent the child's existing joint by regenerating its block wholesale
+  // (accepts any tag form; preserves type/axis/limit/mimic + rpy).
+  const re = /<joint\b([^>]*)>([\s\S]*?)<\/joint>/gi
+  const childRe = new RegExp(`<child\\b[^>]*\\blink\\s*=\\s*"${escapeRe(child)}"`, 'i')
+  let m: RegExpExecArray | null
+  while ((m = re.exec(urdf))) {
+    if (!childRe.test(m[2])) continue
+    const j = parseJoint(m[1], m[2])
+    const block = renderJointBlock({ ...j, parent, child, xyz })
+    return urdf.slice(0, m.index) + block + urdf.slice(m.index + m[0].length)
+  }
+  // No existing joint (child is the root / an orphan) → create a fixed one.
+  const name = uniqueJointName(urdf, `${child}_joint`)
+  const block =
+    renderJointBlock({
+      name,
+      type: 'fixed',
+      parent,
+      child,
+      xyz,
+      rpy: [0, 0, 0],
+      axis: null,
+      limit: null,
+      mimic: null
+    }) + '\n'
+  const idx = urdf.lastIndexOf('</robot>')
+  return idx < 0 ? `${urdf.trimEnd()}\n${block}` : urdf.slice(0, idx) + block + urdf.slice(idx)
+}
+
 /** Set the fixed-joint origin whose child is `childLink` (moves the whole part). */
 export function setJointOrigin(
   urdf: string,

--- a/test/robotAssembly.test.ts
+++ b/test/robotAssembly.test.ts
@@ -5,7 +5,10 @@ import {
   rootLink,
   uniqueLinkName,
   addMeshLink,
-  blankUrdf
+  blankUrdf,
+  connectJoint,
+  subtreeOf,
+  readAllJoints
 } from '../src/renderer/src/components/robot-assembly'
 
 const URDF = `<?xml version="1.0"?>
@@ -73,6 +76,90 @@ describe('addMeshLink (#309)', () => {
     expect(link).toBe('x')
     expect(urdf).toContain('<link name="x">')
     expect(urdf).not.toContain('<joint')
+  })
+})
+
+describe('connectJoint — the Join tool (#354)', () => {
+  // base_link → upper → tip. Re-parent `tip` under `base_link`.
+  it('re-parents an existing child, rewriting parent + origin, keeping type', () => {
+    const out = connectJoint(URDF, { parent: 'base_link', child: 'tip', xyz: [0.01, 0, 0.02] })
+    const tipJoint = readAllJoints(out).find((j) => j.child === 'tip')!
+    expect(tipJoint.parent).toBe('base_link')
+    expect(tipJoint.type).toBe('fixed') // preserved
+    expect(tipJoint.xyz).toEqual([0.01, 0, 0.02])
+    // The other joint (base_link → upper) is untouched.
+    expect(readAllJoints(out).find((j) => j.child === 'upper')!.parent).toBe('base_link')
+  })
+
+  it('preserves a revolute joint type when re-parenting to a sibling', () => {
+    // base → armA (revolute), base → armB (fixed). Re-home armA under armB.
+    const branched = `<?xml version="1.0"?>
+<robot name="r">
+  <link name="base"/>
+  <link name="armA"/>
+  <link name="armB"/>
+  <joint name="jA" type="revolute"><parent link="base"/><child link="armA"/><axis xyz="0 0 1"/><limit lower="-1" upper="1" effort="1" velocity="1"/></joint>
+  <joint name="jB" type="fixed"><parent link="base"/><child link="armB"/></joint>
+</robot>`
+    const out = connectJoint(branched, { parent: 'armB', child: 'armA' })
+    const j = readAllJoints(out).find((x) => x.child === 'armA')!
+    expect(j.parent).toBe('armB')
+    expect(j.type).toBe('revolute')
+  })
+
+  it('refuses a cycle (parent inside the child subtree) — returns unchanged', () => {
+    // `tip` is a descendant of `upper`; attaching upper under tip would loop.
+    expect(connectJoint(URDF, { parent: 'tip', child: 'base_link' })).toBe(URDF)
+    expect(connectJoint(URDF, { parent: 'upper', child: 'base_link' })).toBe(URDF)
+  })
+
+  it('refuses a no-op (same link / empty)', () => {
+    expect(connectJoint(URDF, { parent: 'upper', child: 'upper' })).toBe(URDF)
+    expect(connectJoint(URDF, { parent: '', child: 'tip' })).toBe(URDF)
+  })
+
+  it('creates a fixed joint for an orphan child that has none', () => {
+    // Two unconnected links (no joints) — `b` is an orphan. Join it under `a`.
+    const twoRoots = `<?xml version="1.0"?>
+<robot name="r">
+  <link name="a"><visual><geometry><box size="0.1 0.1 0.1"/></geometry></visual></link>
+  <link name="b"><visual><geometry><box size="0.1 0.1 0.1"/></geometry></visual></link>
+</robot>`
+    const out = connectJoint(twoRoots, { parent: 'a', child: 'b', xyz: [0, 0, 0.05] })
+    const j = readAllJoints(out).find((x) => x.child === 'b')!
+    expect(j.parent).toBe('a')
+    expect(j.type).toBe('fixed')
+    expect(j.xyz).toEqual([0, 0, 0.05])
+  })
+
+  it('re-parents a joint authored with the OPEN <parent></parent> form (#354 review)', () => {
+    // The self-closing-only regex used to leave this parent untouched.
+    const openForm = `<?xml version="1.0"?>
+<robot name="r">
+  <link name="base_link"/>
+  <link name="arm"/>
+  <link name="wheel"/>
+  <joint name="j_arm" type="fixed"><parent link="base_link"/><child link="arm"/></joint>
+  <joint name="j_wheel" type="fixed">
+    <parent link="base_link"></parent>
+    <child link="wheel"></child>
+    <origin xyz="0 0 0" rpy="0 0 0"></origin>
+  </joint>
+</robot>`
+    const out = connectJoint(openForm, { parent: 'arm', child: 'wheel', xyz: [0.01, 0, 0] })
+    const j = readAllJoints(out).find((x) => x.child === 'wheel')!
+    expect(j.parent).toBe('arm') // actually re-parented, not just moved
+    expect(j.xyz).toEqual([0.01, 0, 0])
+    // Exactly one origin in the wheel joint (no duplicate).
+    const wheelBlock = /<joint name="j_wheel"[\s\S]*?<\/joint>/.exec(out)![0]
+    expect((wheelBlock.match(/<origin\b/g) || []).length).toBe(1)
+    expect((wheelBlock.match(/<child\b/g) || []).length).toBe(1)
+  })
+
+  it('subtreeOf collects a link + its descendants', () => {
+    expect([...subtreeOf(URDF, 'base_link')].sort()).toEqual(['base_link', 'tip', 'upper'])
+    expect([...subtreeOf(URDF, 'upper')].sort()).toEqual(['tip', 'upper'])
+    expect([...subtreeOf(URDF, 'tip')]).toEqual(['tip'])
   })
 })
 


### PR DESCRIPTION
Implements the **Join tool** — the toolbar joint button (previously "coming soon") now opens a Fusion-style **Add Joint** dialog.

## What
- **Add Joint** button on the build toolbar → floating dialog:
  - **Component 1** (parent) + **Component 2** (child) pickers
  - **X/Y/Z offset** (mm) for the joint origin
  - **Add** connects them
- `connectJoint(urdf, {parent, child, xyz})` re-parents the child's existing joint (preserving type/axis/limit/mimic) or creates a fixed joint if it had none. Refuses a no-op or a cycle (parent within the child's subtree). Tune the joint type afterwards in the **Joints** branch.

## Adversarial review (4 findings, all fixed before merge)
- **[med] Open tag form:** the re-parent used regexes that only matched self-closing `<parent .../>`, so a joint authored `<parent></parent>` moved but wasn't re-parented. Now `connectJoint` regenerates the joint block **wholesale** from parsed fields (`renderJointBlock`), immune to tag form — and never duplicates an `<origin>`. Unit-tested.
- **[med] False success:** Add closed as if it worked on an invalid pick (empty child, or a cycle). Now `onConnect` returns whether it changed; an invalid pick keeps the dialog **open with an inline warning**.
- **[low] Duplicate origin / dropped offset:** same root cause as the first — fixed by the wholesale regen.
- **[low] Silent origin reset:** the offset is now **seeded from the child's current joint origin**, and the note reflects re-attach vs new joint.

## Verification
- `npm run typecheck` / `lint` (only pre-existing DriverInstallBanner warning) / `npm test` (**1528**, +8 `connectJoint` incl. open-tag form + cycle guard) / `build` ✅
- Playwright E2E: a valid join re-parents `gripper` under `base_link` **on disk**; a cycle (parent=gripper, child=base_link) keeps the dialog open + warns; the offset seeds from the child's current origin (`0 0 0.1` → `0/0/100`mm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)