### PR TITLE
feat: Robot View Join tool — pick two points in 3-D to connect blocks (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 - **Robot View — Join tool (#354).** A new **Add Joint** button on the build
-  toolbar opens a floating dialog to connect two blocks: pick **Component 1**
-  (parent) and **Component 2** (child) and an **X/Y/Z offset** (mm) for the joint
-  origin, then **Add**. It re-parents the child under the chosen parent (preserving
-  the joint's type/axis/limits) or creates a fixed joint if it had none, refusing a
-  connection that would form a loop. Tune the joint's type in the Joints branch.
+  toolbar opens a floating dialog, then you **click a point on each block in 3-D**
+  to connect them: Component 1 (parent) then Component 2 (child), each snapping to a
+  face corner / edge / centre. Choose the joint type (**Static / Rotation / Linear**)
+  and an optional X/Y/Z offset, then **Add** — the child snaps so its picked point
+  meets the parent's, is re-parented under it, and the new joint appears in the
+  **Joints** branch. Refuses a connection that would form a loop.
 - **Robot View — open a different robot (.urdf).** The docked mini viewer gains an
   **📂 Open…** button (alongside New robot / Pop out) and the pose tool's Build
   panel gains one too, so you can pick and open another robot model via the native

--- a/src/renderer/src/components/RobotPropertiesDialog.css
+++ b/src/renderer/src/components/RobotPropertiesDialog.css
@@ -119,6 +119,60 @@
   color: var(--text-muted, #8b919b);
   cursor: pointer;
 }
+/* Add Joint — the pick slot for Component 1 / 2 (filled by a 3-D click). */
+.robotprops__pick {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.4rem;
+  width: 100%;
+  box-sizing: border-box;
+  font-family: inherit;
+  font-size: 0.64rem;
+  color: var(--text, #cdd2d9);
+  background: var(--bg-sunken, rgba(0, 0, 0, 0.25));
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 5px;
+  padding: 0.2rem 0.4rem;
+  cursor: pointer;
+  text-align: left;
+}
+.robotprops__pick.is-arming {
+  border-color: var(--accent, #d6a23f);
+  box-shadow: 0 0 0 1px var(--accent, #d6a23f) inset;
+}
+.robotprops__pick-link {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 700;
+}
+.robotprops__pick-role {
+  flex: 0 0 auto;
+  font-size: 0.56rem;
+  color: var(--text-muted, #8b919b);
+}
+.robotprops__pick-hint {
+  color: var(--text-muted, #8b919b);
+}
+/* Joint-type chips (Static / Rotation / Linear). */
+.robotprops__chip {
+  flex: 1 1 auto;
+  font-family: inherit;
+  font-size: 0.6rem;
+  color: var(--text, #cdd2d9);
+  background: var(--bg-sunken, rgba(0, 0, 0, 0.25));
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 5px;
+  padding: 0.18rem 0.2rem;
+  cursor: pointer;
+}
+.robotprops__chip.is-on {
+  color: var(--accent-contrast, #15161a);
+  background: var(--accent, #d6a23f);
+  border-color: var(--accent, #d6a23f);
+  font-weight: 700;
+}
 .robotprops__foot {
   display: flex;
   align-items: center;

--- a/src/renderer/src/components/RobotPropertiesDialog.tsx
+++ b/src/renderer/src/components/RobotPropertiesDialog.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react'
-import type { JointDef, JointFull, JointSpec, PrimitiveGeom } from './robot-assembly'
+import type { JointDef, JointType, JointSpec, PrimitiveGeom } from './robot-assembly'
 import type { ServoJointBinding } from '../../../shared/robot'
 import type { NamedPoseLike } from './RobotJointPanel'
 import { normPin } from './robot-pose'
@@ -55,17 +55,25 @@ export interface RobotPropertiesDialogProps {
   onRecallPose: (pose: NamedPoseLike) => void
   onRenamePose: (oldName: string, newName: string) => void
   onDeletePose: (name: string) => void
-  // addjoint
-  /** All link names, for the Add Joint parent/child pickers. */
-  links: string[]
-  /** Every joint (to seed the offset from a child's current origin). */
-  joints: JointFull[]
-  /** Connect `child` under `parent` at joint origin `xyz` (metres). Returns
-   *  whether anything changed (false = invalid pick, e.g. would form a loop). */
-  onConnect: (parent: string, child: string, xyz: [number, number, number]) => boolean
+  // addjoint (#354 — pick two points in 3-D)
+  /** The Add Joint pick state (which block/point is Component 1 / 2), driven by
+   *  clicks in the 3-D view. */
+  jointPick: JointPickView | null
+  /** Arm the picker for a component again (the next 3-D click re-picks it). */
+  onRepick: (step: 'parent' | 'child') => void
+  /** Create the joint from the two picks + chosen type + offset (mm). Returns
+   *  false (keeps the dialog open) if the picks are incomplete / would loop. */
+  onConnectPicked: (type: JointType, offsetMm: [number, number, number]) => boolean
   // footer
   onOk: () => void
   onCancel: () => void
+}
+
+/** A component picked in 3-D for the Join tool: its link + the snap role. */
+export interface JointPickView {
+  step: 'parent' | 'child'
+  parent: { link: string; role: string } | null
+  child: { link: string; role: string } | null
 }
 
 /**
@@ -353,55 +361,49 @@ function PoseBody({
   )
 }
 
-/** The Add Joint body (#354): pick Component 1 (parent) + Component 2 (child) and
- *  an X/Y/Z offset (mm) for the joint origin; commit on **Add**. */
+// Kid-friendly joint kinds offered by the Join tool (a subset of the URDF set).
+const ADDJOINT_KINDS: Array<{ id: JointType; label: string; hint: string }> = [
+  { id: 'fixed', label: 'Static', hint: 'Glued in place — no movement' },
+  { id: 'revolute', label: 'Rotation', hint: 'Rotates about an axis, within limits (revolute)' },
+  { id: 'prismatic', label: 'Linear', hint: 'Slides along an axis (prismatic)' }
+]
+
+/**
+ * The Add Joint body (#354): pick a point on TWO blocks in the 3-D view (Component
+ * 1 = parent, Component 2 = child), choose the joint type + an X/Y/Z offset, then
+ * **Add**. The picks come from clicks in the 3-D stage (snapping to face
+ * corners/edges/centres); this body just reflects them + collects type/offset.
+ */
 function AddJointBody({
-  links,
-  joints,
-  onConnect,
+  jointPick,
+  onRepick,
+  onConnectPicked,
   commitRef
 }: RobotPropertiesDialogProps & {
   commitRef: React.MutableRefObject<(() => void | boolean) | null>
 }): JSX.Element {
-  const [parent, setParent] = useState(links[0] ?? '')
-  const [child, setChild] = useState(links.find((l) => l !== (links[0] ?? '')) ?? '')
-  // The child's current joint origin (metres → mm), so re-attaching without
-  // touching the offset leaves the part where it is. Re-seeded as the child changes.
-  const currentOrigin = (link: string): Record<'x' | 'y' | 'z', string> => {
-    const j = joints.find((x) => x.child === link)
-    const mm = (n: number): string => String(Math.round((n ?? 0) * 1000))
-    return j ? { x: mm(j.xyz[0]), y: mm(j.xyz[1]), z: mm(j.xyz[2]) } : { x: '0', y: '0', z: '0' }
-  }
-  // Offsets in mm (raw strings so you can clear / type a leading "-").
-  const [off, setOff] = useState<Record<'x' | 'y' | 'z', string>>(() => currentOrigin(child))
+  const [type, setType] = useState<JointType>('fixed')
+  const [off, setOff] = useState<Record<'x' | 'y' | 'z', string>>({ x: '0', y: '0', z: '0' })
   const [err, setErr] = useState<string | null>(null)
-  const same = !!parent && parent === child
-  const alreadyJointed = joints.some((x) => x.child === child)
+  const parent = jointPick?.parent ?? null
+  const child = jointPick?.child ?? null
+  const step = jointPick?.step ?? 'parent'
 
   commitRef.current = (): boolean => {
     if (!parent || !child) {
-      setErr('Add another block to join to.')
-      return false
-    }
-    if (same) {
-      setErr('Pick two different blocks.')
+      setErr('Pick a point on both blocks first.')
       return false
     }
     const mm = (s: string): number => {
       const v = Number(s)
       return Number.isFinite(v) ? v / 1000 : 0 // mm → m
     }
-    const ok = onConnect(parent, child, [mm(off.x), mm(off.y), mm(off.z)])
+    const ok = onConnectPicked(type, [mm(off.x), mm(off.y), mm(off.z)])
     if (!ok) {
       setErr('Can’t connect — that would form a loop (the parent hangs off the child).')
       return false
     }
     return true
-  }
-  const pickChild = (c: string): void => {
-    setChild(c)
-    setOff(currentOrigin(c)) // seed the offset from its current origin
-    setErr(null)
   }
   const axis = (k: 'x' | 'y' | 'z'): JSX.Element => (
     <label className="robotprops__mm">
@@ -413,39 +415,57 @@ function AddJointBody({
       />
     </label>
   )
-  const warn = err ?? (same ? 'Pick two different blocks.' : !child ? 'Add another block to join to.' : null)
+  const slot = (which: 'parent' | 'child', pick: { link: string; role: string } | null): JSX.Element => {
+    const arming = step === which && !pick
+    return (
+      <button
+        type="button"
+        className={`robotprops__pick${arming ? ' is-arming' : ''}`}
+        onClick={() => {
+          onRepick(which)
+          setErr(null)
+        }}
+        title="Click, then pick a point on the block in the 3-D view"
+      >
+        {pick ? (
+          <>
+            <span className="robotprops__pick-link">{pick.link}</span>
+            <span className="robotprops__pick-role">{pick.role}</span>
+          </>
+        ) : (
+          <span className="robotprops__pick-hint">
+            {arming ? '● Click a point in 3-D…' : 'Click to pick'}
+          </span>
+        )}
+      </button>
+    )
+  }
+
   return (
     <>
       <section className="robotprops__section">
         <div className="robotprops__label">Component 1 (parent)</div>
-        <select
-          className="robotprops__sel"
-          value={parent}
-          onChange={(e) => {
-            const p = e.target.value
-            setParent(p)
-            setErr(null)
-            if (p === child) pickChild(links.find((l) => l !== p) ?? '') // keep child ≠ parent
-          }}
-        >
-          {links.map((l) => (
-            <option key={l} value={l}>
-              {l}
-            </option>
-          ))}
-        </select>
+        {slot('parent', parent)}
       </section>
       <section className="robotprops__section">
         <div className="robotprops__label">Component 2 (child)</div>
-        <select className="robotprops__sel" value={child} onChange={(e) => pickChild(e.target.value)}>
-          {links
-            .filter((l) => l !== parent)
-            .map((l) => (
-              <option key={l} value={l}>
-                {l}
-              </option>
-            ))}
-        </select>
+        {slot('child', child)}
+      </section>
+      <section className="robotprops__section">
+        <div className="robotprops__label">Joint type</div>
+        <div className="robotprops__row">
+          {ADDJOINT_KINDS.map((k) => (
+            <button
+              key={k.id}
+              type="button"
+              className={`robotprops__chip${type === k.id ? ' is-on' : ''}`}
+              title={k.hint}
+              onClick={() => setType(k.id)}
+            >
+              {k.label}
+            </button>
+          ))}
+        </div>
       </section>
       <section className="robotprops__section">
         <div className="robotprops__label">Offset (mm)</div>
@@ -455,14 +475,13 @@ function AddJointBody({
           {axis('z')}
         </div>
       </section>
-      {warn ? (
-        <p className="robotprops__note robotprops__note--warn">{warn}</p>
+      {err ? (
+        <p className="robotprops__note robotprops__note--warn">{err}</p>
       ) : (
         <p className="robotprops__note">
-          {alreadyJointed ? 'Re-attaches ' : 'Attaches '}
-          <strong>{child}</strong> under <strong>{parent}</strong>
-          {alreadyJointed ? ', keeping its joint type.' : ' as a fixed joint.'} Tune the type in the
-          Joints branch.
+          {parent && child
+            ? 'Component 2 will snap so its point meets Component 1’s point.'
+            : 'Click a point on each block in the 3-D view (snaps to corners / edges / centres).'}
         </p>
       )}
     </>

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -34,6 +34,7 @@ import {
   setVisualOrigin,
   type JointDef,
   type JointSpec,
+  type JointType,
   type PrimitiveGeom
 } from './robot-assembly'
 import { reRoot } from './robot-reroot'
@@ -340,10 +341,40 @@ export function RobotView({
   const editLink =
     dialogCtx?.kind === 'link' ? dialogCtx.link : dialogCtx?.kind === 'joint' ? dialogCtx.child : null
   const [buildDim, setBuildDim] = useState<{ x: number; y: number; text: string } | null>(null)
+  // Join tool (#354): the two points picked in 3-D. Non-null = pick mode is armed.
+  type JointPickPt = { link: string; local: [number, number, number]; role: string }
+  const [jointPick, setJointPick] = useState<{
+    step: 'parent' | 'child'
+    parent: JointPickPt | null
+    child: JointPickPt | null
+  } | null>(null)
   // Refs the three.js pointer callbacks read (avoids re-subscribing on each edit).
   const buildOpenRef = useRef(false)
   const selectedLinkRef = useRef<string | null>(null)
   const editLinkRef = useRef<string | null>(null)
+  // Join-tool bridges: pick mode state for the effect, the pick callback, + a
+  // handle to clear the 3-D pick markers. `parentLink`/`childLink` let the pick
+  // handler reject a same-block pick BEFORE it draws a marker.
+  const jointPickRef = useRef<{
+    active: boolean
+    step: 'parent' | 'child'
+    parentLink: string | null
+    childLink: string | null
+  }>({ active: false, step: 'parent', parentLink: null, childLink: null })
+  jointPickRef.current = {
+    active: !!jointPick,
+    step: jointPick?.step ?? 'parent',
+    parentLink: jointPick?.parent?.link ?? null,
+    childLink: jointPick?.child?.link ?? null
+  }
+  // The full pick state (with local coords) for the effect to REDRAW markers after
+  // a rebuild mid-pick (deps change) — otherwise the dialog shows picks but 3-D is bare.
+  const jointPickStateRef = useRef(jointPick)
+  jointPickStateRef.current = jointPick
+  const onJointPickRef = useRef<
+    ((link: string, local: [number, number, number], role: string) => void) | null
+  >(null)
+  const jointPickApiRef = useRef<{ clear: () => void } | null>(null)
   buildOpenRef.current = buildOpen && poseUI
   selectedLinkRef.current = selectedLink
   editLinkRef.current = editLink
@@ -522,6 +553,10 @@ export function RobotView({
   const openContext = (ctx: PropsContext | null, snapshot: string | null): void => {
     editSnapshotRef.current = snapshot
     setDialogCtx(ctx)
+    if (ctx?.kind !== 'addjoint') {
+      setJointPick(null) // leaving the Join tool disarms picking + clears markers
+      jointPickApiRef.current?.clear()
+    }
   }
   const handleOpenProps = (link: string | null): void => {
     if (link) {
@@ -541,31 +576,71 @@ export function RobotView({
   const handleOpenPose = (name: string): void => {
     openContext({ kind: 'pose', name }, null)
   }
-  // Add Joint (#354): the toolbar opens the dialog; Add commits a connectJoint.
+  // Add Joint (#354): the toolbar opens the dialog + ARMS picking. The user clicks
+  // a point on each block in 3-D (onJointPick), picks a type + offset, then Add.
   const handleAddJoint = (): void => {
+    setMeasureActive(false) // picking + measuring both own clicks — don't double-fire
+    jointPickApiRef.current?.clear()
+    setJointPick({ step: 'parent', parent: null, child: null })
     openContext({ kind: 'addjoint' }, null)
     if (!buildOpen) setBuildOpen(true)
   }
-  const handleConnectJoint = (
-    parent: string,
-    child: string,
-    xyz: [number, number, number]
-  ): boolean => {
-    const next = connectJoint(content, { parent, child, xyz })
-    if (next === content) return false // no-op (cycle / invalid) — tell the dialog
+  // A 3-D pick landed (the effect resolved the click → link + local snap point).
+  const onJointPick = (link: string, local: [number, number, number], role: string): void => {
+    setJointPick((jp) => {
+      if (!jp) return jp
+      const pt: JointPickPt = { link, local, role }
+      if (jp.step === 'parent') return { ...jp, parent: pt, step: 'child' }
+      if (jp.parent && link === jp.parent.link) return jp // can't join a block to itself
+      return { ...jp, child: pt }
+    })
+  }
+  onJointPickRef.current = onJointPick
+  // Re-arm picking for one component (its 3-D marker is replaced on the next click).
+  const handleRepick = (which: 'parent' | 'child'): void => {
+    setJointPick((jp) =>
+      jp
+        ? which === 'parent'
+          ? { ...jp, step: 'parent', parent: null }
+          : { ...jp, step: 'child', child: null }
+        : jp
+    )
+  }
+  // Add: place the child so its picked point meets the parent's picked point
+  // (origin = parentLocal − childLocal + offset), re-parent it, and set the type.
+  const handleConnectPicked = (type: JointType, offsetMm: [number, number, number]): boolean => {
+    const jp = jointPick
+    if (!jp?.parent || !jp?.child) return false
+    const base = contentRef.current
+    const xyz: [number, number, number] = [
+      jp.parent.local[0] - jp.child.local[0] + offsetMm[0],
+      jp.parent.local[1] - jp.child.local[1] + offsetMm[1],
+      jp.parent.local[2] - jp.child.local[2] + offsetMm[2]
+    ]
+    let next = connectJoint(base, { parent: jp.parent.link, child: jp.child.link, xyz })
+    if (next === base) return false // cycle / invalid — keep the dialog open
+    next = setJoint(next, jp.child.link, { type }) // apply the chosen joint type
+    // Force the joint rotation to identity (rpy 0): the origin math above assumes
+    // it, and connectJoint/setJoint otherwise PRESERVE a child's old rpy — which
+    // would leave the two picked points misaligned. setJointOrigin emits rpy="0 0 0".
+    next = setJointOrigin(next, jp.child.link, xyz)
     commitUrdf(next)
-    setSelectedLink(child)
+    setSelectedLink(jp.child.link)
     return true
   }
   const handlePropsOk = (): void => {
     editSnapshotRef.current = null
     setDialogCtx(null)
+    setJointPick(null)
+    jointPickApiRef.current?.clear()
   }
   const handlePropsCancel = (): void => {
     const snap = editSnapshotRef.current
     editSnapshotRef.current = null
     if (snap != null && snap !== contentRef.current) commitUrdf(snap) // discard edits
     setDialogCtx(null)
+    setJointPick(null)
+    jointPickApiRef.current?.clear()
   }
 
   // Re-apply the selection outline when the picked block changes (no re-parse).
@@ -1781,9 +1856,87 @@ export function RobotView({
             ;(e.target as HTMLElement).setPointerCapture?.(e.pointerId)
           }
 
+          // ── Join tool (#354): click a point on two blocks to connect them ──
+          const jointMarkerMat = new THREE.MeshBasicMaterial({ color: 0x4ea1ff, depthTest: false }) // parent
+          const jointMarkerMatChild = new THREE.MeshBasicMaterial({ color: 0x34ad4f, depthTest: false }) // child
+          let parentMarker: THREE.Mesh | null = null
+          let childMarker: THREE.Mesh | null = null
+          const clearJointMarkers = (): void => {
+            for (const mk of [parentMarker, childMarker]) {
+              if (mk) {
+                scene.remove(mk)
+                mk.geometry.dispose()
+              }
+            }
+            parentMarker = null
+            childMarker = null
+          }
+          jointPickApiRef.current = { clear: clearJointMarkers }
+          const setJointMarker = (world: THREE.Vector3, isChild: boolean): void => {
+            const prev = isChild ? childMarker : parentMarker
+            if (prev) {
+              scene.remove(prev)
+              prev.geometry.dispose()
+            }
+            const mk = new THREE.Mesh(
+              new THREE.SphereGeometry(halfView * 0.03 + 0.002, 12, 12),
+              isChild ? jointMarkerMatChild : jointMarkerMat
+            )
+            mk.position.copy(world)
+            mk.renderOrder = 999
+            mk.raycast = () => {}
+            scene.add(mk)
+            if (isChild) childMarker = mk
+            else parentMarker = mk
+          }
+          // Redraw markers for any picks that survived an effect rebuild mid-pick
+          // (the state persists in jointPickStateRef; the old scene objects didn't).
+          {
+            const jp = jointPickStateRef.current
+            const drawFrom = (p: { link: string; local: [number, number, number] } | null, child: boolean): void => {
+              const lo = p && robotRef.current?.links[p.link]
+              if (p && lo) setJointMarker(lo.localToWorld(new THREE.Vector3(...p.local)), child)
+            }
+            robotRef.current?.updateMatrixWorld(true)
+            drawFrom(jp?.parent ?? null, false)
+            drawFrom(jp?.child ?? null, true)
+          }
+          const pickJointPoint = (e: PointerEvent): void => {
+            const robot = robotRef.current
+            if (!robot) return
+            buildNdcFrom(e)
+            buildRay.setFromCamera(buildNdc, camera)
+            const hit = buildRay.intersectObject(robot, true).find((h) => h.face)
+            if (!hit) return
+            const link = ownerLinkName(hit.object)
+            if (!link || !robot.links[link]) return
+            // Reject a same-block pick BEFORE drawing a marker (else the marker moves
+            // but the dialog state rejects the pick → visual/state desync).
+            const jr = jointPickRef.current
+            if (jr.step === 'child' && jr.parentLink === link) return
+            if (jr.step === 'parent' && jr.childLink === link) return
+            let world = hit.point.clone()
+            let role = 'point'
+            // Snap to a face corner/edge/centre for a primitive; a mesh has none, so
+            // the raw hit point stands in.
+            const geom = readPrimitive(contentRef.current, link)
+            if (geom) {
+              const th = hitToHandles(hit, link, geom)
+              const near = nearestScreen(th.pts, e)
+              if (near.index >= 0 && near.distPx < 24) {
+                world = th.pts[near.index].clone()
+                role = th.roles[near.index]
+              }
+            }
+            const local = robot.links[link].worldToLocal(world.clone())
+            setJointMarker(world, jr.step === 'child')
+            onJointPickRef.current?.(link, [local.x, local.y, local.z], role)
+          }
+
           const onBuildDown = (e: PointerEvent): void => {
             bDownX = e.clientX
             bDownY = e.clientY
+            if (jointPickRef.current.active) return // pick mode owns clicks (no move/resize)
             if (!buildActive() || !canEditRef.current || !robotRef.current) return
             if (buildToolRef.current === 'pushpull') startResize(e)
             else if (buildToolRef.current === 'move') startMove(e)
@@ -1858,6 +2011,14 @@ export function RobotView({
           }
 
           const onBuildUp = (e: PointerEvent): void => {
+            // Join tool: a near-stationary click picks a point (drags orbit). Skip
+            // if measuring (that tool consumes the click via its own handler).
+            if (jointPickRef.current.active) {
+              if (!measureActiveRef.current && Math.hypot(e.clientX - bDownX, e.clientY - bDownY) <= 4) {
+                pickJointPoint(e)
+              }
+              return
+            }
             if (drag) {
               const d = drag
               drag = null
@@ -1892,10 +2053,12 @@ export function RobotView({
             if (name) setSelectedLink(name)
           }
 
-          // Hover: show a face's snap handles when the Move tool is active + idle.
+          // Hover: show a face's snap handles when the Move tool OR the Join picker
+          // is active + idle, so the user sees the corner/edge/centre snaps.
           const onBuildHover = (e: PointerEvent): void => {
             if (drag || move) return
-            if (!buildActive() || buildToolRef.current !== 'move' || !robotRef.current) {
+            const wantHandles = buildToolRef.current === 'move' || jointPickRef.current.active
+            if (!buildActive() || !wantHandles || !robotRef.current) {
               if (snapGroup.children.length) clearHandles()
               return
             }
@@ -1956,8 +2119,12 @@ export function RobotView({
             lineMat.dispose()
             if (outline) outline.geometry.dispose()
             accentLineMat.dispose()
+            clearJointMarkers()
+            jointMarkerMat.dispose()
+            jointMarkerMatChild.dispose()
             measureApiRef.current = null
             highlightApiRef.current = null
+            jointPickApiRef.current = null
           }
         }
       }
@@ -2231,9 +2398,21 @@ export function RobotView({
             onRecallPose={handleRecallPose}
             onRenamePose={handleRenamePose}
             onDeletePose={handleDeletePose}
-            links={assembly.map((a) => a.link)}
-            joints={joints}
-            onConnect={handleConnectJoint}
+            jointPick={
+              jointPick && {
+                step: jointPick.step,
+                parent: jointPick.parent && {
+                  link: jointPick.parent.link,
+                  role: jointPick.parent.role
+                },
+                child: jointPick.child && {
+                  link: jointPick.child.link,
+                  role: jointPick.child.role
+                }
+              }
+            }
+            onRepick={handleRepick}
+            onConnectPicked={handleConnectPicked}
             onOk={handlePropsOk}
             onCancel={handlePropsCancel}
           />


### PR DESCRIPTION
Reworks **Add Joint** into the Fusion-style interactive flow the request asked for.

## Flow
1. Toolbar **Add Joint** → dialog opens, picking armed.
2. **Click a point on the first block** → snaps to a face corner/edge/centre, fills **Component 1 (parent)** + drops a blue marker.
3. **Click a point on the second block** → fills **Component 2 (child)** + green marker.
4. Choose the joint type — **Static / Rotation / Linear**.
5. Optional X/Y/Z offset (mm).
6. **Add** → child snaps so its point meets the parent's (`origin = parentLocal − childLocal + offset`), re-parents under the parent, sets the type; the joint shows in the **Joints** branch.

Snap handles appear on hover during picking (reusing the move-tool snap infra).

## Adversarial review — 7 findings, all fixed before merge
- **[HIGH]** Origin math assumed identity rotation, but `connectJoint`/`setJoint` preserve a child's existing `rpy` → a rotated child's picked points would miss. Now forces `rpy=0` via `setJointOrigin`.
- **[MED×2]** Marker drawn *before* validation → a same-block click moved the marker while the dialog rejected it. Now rejects same-block picks (both steps) before drawing, via parent/child links added to the ref.
- **[MED]** Effect rebuild mid-pick orphaned the markers → now redrawn from persisted pick state.
- **[LOW×2]** Parent step lacked a different-block guard (misleading loop error) → guarded symmetrically.
- **[LOW]** A measure-tool click could double-fire as a pick → Add Joint disables measure + the pick branch skips while measuring.

## Verification
- `npm run typecheck` / `lint` / `npm test` (1528) / `build` ✅
- Playwright E2E: click `blockL` → parent, `blockR` → child, **Rotation**, **Add** → `jR` becomes `type="revolute"` re-parented under `blockL` with an `<axis>` and a picked-corner origin; dialog closes.

Follow-ups already requested (next PR): snap flat on the face + orient the joint by the face **normal**, mate the second normal to the first, make the first block transparent, **hole-center** snapping for meshes, live **rotation preview**, and revolute **min/max + default angle**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)