### PR TITLE
feat: Robot View Join tool — snap to hole centres on imported meshes (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Robot View — Join tool snaps to hole centres (#354).** When you pick a joint
+  point on an imported mesh (STL), the tool detects **hole centres** on the clicked
+  face — an STL is just triangles, so it finds the coplanar rim-edge loops, and a
+  roughly-circular loop's centre becomes a snap point (plus the face outline centre
+  and midpoints of long edges as alignment guides). Hover reveals the snaps.
 - **Robot View — Join tool (#354).** A new **Add Joint** button on the build
   toolbar opens a floating dialog, then you **click a point on each block in 3-D**
   to connect them: Component 1 (parent) then Component 2 (child), each snapping to a

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -59,6 +59,7 @@ import {
   type Vec3
 } from './robot-build'
 import { RobotBuildPanel } from './RobotBuildPanel'
+import { detectSnapCentres } from './robot-holes'
 import { RobotPropertiesDialog, type PropsContext } from './RobotPropertiesDialog'
 import { RobotToolbar } from './RobotToolbar'
 import { loadPin, savePin, PIN_KEYS } from './pin-overlay'
@@ -1901,6 +1902,33 @@ export function RobotView({
             drawFrom(jp?.parent ?? null, false)
             drawFrom(jp?.child ?? null, true)
           }
+          // Detect hole / loop / edge snap centres on the face of a MESH the pointer
+          // hit (an STL has no primitive face handles). Cached per mesh+plane — a
+          // pass over the triangles is cheap but not per-hover-pixel cheap.
+          const holeCache = new Map<string, { pts: THREE.Vector3[]; roles: string[] }>()
+          const meshSnapCentres = (hit: THREE.Intersection): { pts: THREE.Vector3[]; roles: string[] } => {
+            const mesh = hit.object as THREE.Mesh
+            const geo = mesh.geometry as THREE.BufferGeometry
+            const posAttr = geo.attributes.position
+            if (!hit.face || !posAttr) return { pts: [], roles: [] }
+            const nLocal = hit.face.normal.clone().normalize()
+            const pLocal = mesh.worldToLocal(hit.point.clone())
+            const key = `${mesh.uuid}:${Math.round(nLocal.x * 50)},${Math.round(nLocal.y * 50)},${Math.round(nLocal.z * 50)}:${Math.round(pLocal.dot(nLocal) * 2000)}`
+            const cached = holeCache.get(key)
+            if (cached) return cached
+            const centres = detectSnapCentres(
+              posAttr.array as ArrayLike<number>,
+              geo.index ? (geo.index.array as ArrayLike<number>) : null,
+              { point: [pLocal.x, pLocal.y, pLocal.z], normal: [nLocal.x, nLocal.y, nLocal.z] }
+            )
+            const result = {
+              pts: centres.map((c) => mesh.localToWorld(new THREE.Vector3(c.p[0], c.p[1], c.p[2]))),
+              roles: centres.map((c) => c.kind)
+            }
+            holeCache.set(key, result)
+            return result
+          }
+
           const pickJointPoint = (e: PointerEvent): void => {
             const robot = robotRef.current
             if (!robot) return
@@ -1917,13 +1945,20 @@ export function RobotView({
             if (jr.step === 'parent' && jr.childLink === link) return
             let world = hit.point.clone()
             let role = 'point'
-            // Snap to a face corner/edge/centre for a primitive; a mesh has none, so
-            // the raw hit point stands in.
             const geom = readPrimitive(contentRef.current, link)
             if (geom) {
+              // Primitive: snap to a face corner / edge / centre.
               const th = hitToHandles(hit, link, geom)
               const near = nearestScreen(th.pts, e)
               if (near.index >= 0 && near.distPx < 24) {
+                world = th.pts[near.index].clone()
+                role = th.roles[near.index]
+              }
+            } else {
+              // Mesh: snap to a detected hole / loop centre or edge midpoint.
+              const th = meshSnapCentres(hit)
+              const near = nearestScreen(th.pts, e)
+              if (near.index >= 0 && near.distPx < 28) {
                 world = th.pts[near.index].clone()
                 role = th.roles[near.index]
               }
@@ -2066,14 +2101,23 @@ export function RobotView({
             buildRay.setFromCamera(buildNdc, camera)
             const hit = buildRay.intersectObject(robotRef.current, true).find((h) => h.face)
             const link = hit ? ownerLinkName(hit.object) : null
-            const geom = link ? readPrimitive(contentRef.current, link) : null
-            if (!hit || !link || !geom) {
+            if (!hit || !link) {
               clearHandles()
               return
             }
-            const th = hitToHandles(hit, link, geom)
-            const near = nearestScreen(th.pts, e)
-            showHandles(th.pts, near.distPx < 16 ? near.index : -1)
+            const geom = readPrimitive(contentRef.current, link)
+            if (geom) {
+              const th = hitToHandles(hit, link, geom)
+              const near = nearestScreen(th.pts, e)
+              showHandles(th.pts, near.distPx < 16 ? near.index : -1)
+            } else if (jointPickRef.current.active) {
+              // Mesh + Join picking: reveal detected hole / loop / edge snaps.
+              const th = meshSnapCentres(hit)
+              if (th.pts.length) {
+                const near = nearestScreen(th.pts, e)
+                showHandles(th.pts, near.distPx < 20 ? near.index : -1)
+              } else clearHandles()
+            } else clearHandles()
           }
 
           // A cancelled/interrupted drag must never strand OrbitControls disabled

--- a/src/renderer/src/components/robot-holes.ts
+++ b/src/renderer/src/components/robot-holes.ts
@@ -1,0 +1,164 @@
+/**
+ * HOLE / LOOP SNAP DETECTION (#354c) — find snappable centres on the flat face a
+ * user clicked on a mesh (an STL is just a triangle soup). A bolt hole shows up in
+ * the mesh as a ring of triangle edges where the flat face meets the cylindrical
+ * bore; its centre is a natural place to attach a joint.
+ *
+ * The approach is pure + dependency-free (arrays in, points out) so it unit-tests
+ * without three.js:
+ *  1. keep only triangles COPLANAR with the clicked face (all verts on the plane +
+ *     normal parallel),
+ *  2. an edge used by exactly ONE coplanar triangle is a RIM edge (the border of
+ *     the flat region — its outer outline or a hole),
+ *  3. chain rim edges into closed loops,
+ *  4. each loop's centroid is a snap centre; a roughly-circular loop is tagged a
+ *     hole, and the largest loop is the face OUTLINE.
+ * Also emits midpoints of long straight rim edges as alignment guides.
+ */
+export type Vec3 = [number, number, number]
+
+export interface SnapCentre {
+  /** Centre point, in the mesh's LOCAL frame. */
+  p: Vec3
+  /** Mean radius of the loop (metres). */
+  radius: number
+  kind: 'hole' | 'outline' | 'edge'
+}
+
+const sub = (a: Vec3, b: Vec3): Vec3 => [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+const cross = (a: Vec3, b: Vec3): Vec3 => [
+  a[1] * b[2] - a[2] * b[1],
+  a[2] * b[0] - a[0] * b[2],
+  a[0] * b[1] - a[1] * b[0]
+]
+const dot = (a: Vec3, b: Vec3): number => a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+const len = (a: Vec3): number => Math.hypot(a[0], a[1], a[2])
+const norm = (a: Vec3): Vec3 => {
+  const l = len(a) || 1
+  return [a[0] / l, a[1] / l, a[2] / l]
+}
+
+/** Quantise a point to a grid so shared triangle vertices collapse to one key. */
+function keyOf(p: Vec3, q = 1e5): string {
+  return `${Math.round(p[0] * q)},${Math.round(p[1] * q)},${Math.round(p[2] * q)}`
+}
+
+/**
+ * Find snap centres on the plane the user clicked, from a triangle mesh.
+ *
+ * @param positions flat [x,y,z, …] vertex positions in the mesh's local frame.
+ * @param index     triangle vertex indices (3 per tri), or null for a non-indexed
+ *                  soup (positions taken 3 verts at a time).
+ * @param plane     the clicked face: a point on it + its (unit-ish) normal, local.
+ */
+export function detectSnapCentres(
+  positions: ArrayLike<number>,
+  index: ArrayLike<number> | null,
+  plane: { point: Vec3; normal: Vec3 },
+  opts?: { planeEps?: number; circleTol?: number; minLoop?: number }
+): SnapCentre[] {
+  const n = norm(plane.normal)
+  const planeEps = opts?.planeEps ?? 5e-4 // 0.5 mm on-plane tolerance
+  const circleTol = opts?.circleTol ?? 0.18 // radius stddev / mean below this = circle
+  const minLoop = opts?.minLoop ?? 3
+  const triCount = index ? Math.floor(index.length / 3) : Math.floor(positions.length / 9)
+  const vAt = (i: number): Vec3 => [positions[i * 3], positions[i * 3 + 1], positions[i * 3 + 2]]
+  const idx = (t: number, k: number): number => (index ? index[t * 3 + k] : t * 3 + k)
+  const dist = (p: Vec3): number => dot(sub(p, plane.point), n)
+
+  // 1) coplanar triangles → 2) rim edges (used by exactly one coplanar triangle).
+  const edgeCount = new Map<string, { a: Vec3; b: Vec3; count: number }>()
+  const edgeKey = (ka: string, kb: string): string => (ka < kb ? `${ka}|${kb}` : `${kb}|${ka}`)
+  for (let t = 0; t < triCount; t++) {
+    const a = vAt(idx(t, 0))
+    const b = vAt(idx(t, 1))
+    const c = vAt(idx(t, 2))
+    if (Math.abs(dist(a)) > planeEps || Math.abs(dist(b)) > planeEps || Math.abs(dist(c)) > planeEps) {
+      continue // not on the plane
+    }
+    const tn = norm(cross(sub(b, a), sub(c, a)))
+    if (Math.abs(dot(tn, n)) < 0.98) continue // not parallel to the face
+    const verts: Vec3[] = [a, b, c]
+    const keys = verts.map((v) => keyOf(v))
+    for (let e = 0; e < 3; e++) {
+      const va = verts[e]
+      const vb = verts[(e + 1) % 3]
+      const k = edgeKey(keys[e], keys[(e + 1) % 3])
+      const cur = edgeCount.get(k)
+      if (cur) cur.count++
+      else edgeCount.set(k, { a: va, b: vb, count: 1 })
+    }
+  }
+  const rim = [...edgeCount.values()].filter((e) => e.count === 1)
+  if (rim.length < minLoop) return []
+
+  // 3) chain rim edges into closed loops (each rim vertex should have degree 2).
+  const adj = new Map<string, { to: string; p: Vec3 }[]>()
+  const posByKey = new Map<string, Vec3>()
+  for (const e of rim) {
+    const ka = keyOf(e.a)
+    const kb = keyOf(e.b)
+    posByKey.set(ka, e.a)
+    posByKey.set(kb, e.b)
+    ;(adj.get(ka) ?? adj.set(ka, []).get(ka)!).push({ to: kb, p: e.b })
+    ;(adj.get(kb) ?? adj.set(kb, []).get(kb)!).push({ to: ka, p: e.a })
+  }
+  const seen = new Set<string>()
+  const loops: Vec3[][] = []
+  for (const start of adj.keys()) {
+    if (seen.has(start)) continue
+    const loop: Vec3[] = []
+    let cur = start
+    let prev = ''
+    let ok = true
+    for (let guard = 0; guard < adj.size + 2; guard++) {
+      seen.add(cur)
+      loop.push(posByKey.get(cur)!)
+      const nbrs = adj.get(cur) ?? []
+      const next = nbrs.find((e) => e.to !== prev && !(loop.length > 2 && e.to === start))
+      const back = nbrs.find((e) => e.to === start && loop.length > 2)
+      if (back && !next) break // closed the loop
+      if (!next) {
+        ok = false
+        break
+      }
+      prev = cur
+      cur = next.to
+      if (cur === start) break
+    }
+    if (ok && loop.length >= minLoop) loops.push(loop)
+  }
+  if (loops.length === 0) return []
+
+  // 4) centroid + circularity per loop; largest loop = the face outline.
+  const centres: SnapCentre[] = loops.map((loop) => {
+    const c: Vec3 = [0, 0, 0]
+    for (const p of loop) {
+      c[0] += p[0]
+      c[1] += p[1]
+      c[2] += p[2]
+    }
+    c[0] /= loop.length
+    c[1] /= loop.length
+    c[2] /= loop.length
+    const radii = loop.map((p) => len(sub(p, c)))
+    const mean = radii.reduce((s, r) => s + r, 0) / radii.length
+    const variance = radii.reduce((s, r) => s + (r - mean) * (r - mean), 0) / radii.length
+    const std = Math.sqrt(variance)
+    const circular = mean > 0 && std / mean < circleTol
+    return { p: c, radius: mean, kind: circular ? ('hole' as const) : ('outline' as const) }
+  })
+  // The loop with the biggest radius is the outer outline, not a hole.
+  let outer = 0
+  for (let i = 1; i < centres.length; i++) if (centres[i].radius > centres[outer].radius) outer = i
+  centres[outer] = { ...centres[outer], kind: 'outline' }
+
+  // Alignment guides: midpoints of the longest few rim edges (between two edges).
+  const edgeMids: SnapCentre[] = rim
+    .map((e) => ({ mid: [(e.a[0] + e.b[0]) / 2, (e.a[1] + e.b[1]) / 2, (e.a[2] + e.b[2]) / 2] as Vec3, l: len(sub(e.a, e.b)) }))
+    .sort((x, y) => y.l - x.l)
+    .slice(0, 4)
+    .map((e) => ({ p: e.mid, radius: e.l / 2, kind: 'edge' as const }))
+
+  return [...centres, ...edgeMids]
+}

--- a/test/robotHoles.test.ts
+++ b/test/robotHoles.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { detectSnapCentres, type Vec3 } from '../src/renderer/src/components/robot-holes'
+
+/** A flat washer in the z=0 plane: an annulus between an outer + inner circle,
+ *  triangulated (non-indexed). The inner circle is a "hole"; the outer is the
+ *  face outline. Optionally offset the whole thing so the centroid isn't (0,0,0). */
+function washer(R: number, r: number, N = 24, offset: Vec3 = [0, 0, 0]): number[] {
+  const outer: Vec3[] = []
+  const inner: Vec3[] = []
+  for (let i = 0; i < N; i++) {
+    const a = (i / N) * 2 * Math.PI
+    outer.push([offset[0] + R * Math.cos(a), offset[1] + R * Math.sin(a), offset[2]])
+    inner.push([offset[0] + r * Math.cos(a), offset[1] + r * Math.sin(a), offset[2]])
+  }
+  const pos: number[] = []
+  for (let i = 0; i < N; i++) {
+    const j = (i + 1) % N
+    pos.push(...outer[i], ...outer[j], ...inner[i]) // tri 1
+    pos.push(...outer[j], ...inner[j], ...inner[i]) // tri 2
+  }
+  return pos
+}
+
+describe('detectSnapCentres — hole/loop snapping (#354c)', () => {
+  const plane = { point: [0, 0, 0] as Vec3, normal: [0, 0, 1] as Vec3 }
+
+  it('finds the hole centre + the outline centre of a washer', () => {
+    const centres = detectSnapCentres(washer(0.05, 0.02), null, plane)
+    const hole = centres.find((c) => c.kind === 'hole')
+    const outline = centres.find((c) => c.kind === 'outline')
+    expect(hole).toBeTruthy()
+    expect(outline).toBeTruthy()
+    // Both concentric at the origin.
+    expect(hole!.p.map((v) => Math.round(v * 1000) + 0)).toEqual([0, 0, 0])
+    expect(outline!.p.map((v) => Math.round(v * 1000) + 0)).toEqual([0, 0, 0])
+    // Radii match the geometry (±1 mm).
+    expect(Math.abs(hole!.radius - 0.02)).toBeLessThan(0.001)
+    expect(Math.abs(outline!.radius - 0.05)).toBeLessThan(0.001)
+  })
+
+  it('locates an OFF-centre hole centroid', () => {
+    const centres = detectSnapCentres(washer(0.04, 0.015, 24, [0.1, -0.05, 0.02]), null, {
+      point: [0, 0, 0.02],
+      normal: [0, 0, 1]
+    })
+    const hole = centres.find((c) => c.kind === 'hole')
+    expect(hole).toBeTruthy()
+    expect(hole!.p.map((v) => Math.round(v * 1000) + 0)).toEqual([100, -50, 20])
+  })
+
+  it('ignores triangles that are not coplanar with the clicked face', () => {
+    // A washer at z=0 + a stray triangle standing up at z=0.1 (a wall).
+    const pos = washer(0.05, 0.02)
+    pos.push(0.2, 0, 0, 0.2, 0.01, 0, 0.2, 0, 0.1) // off-plane triangle
+    const centres = detectSnapCentres(pos, null, plane)
+    // Still exactly the two washer loops (the wall triangle is filtered out).
+    const loops = centres.filter((c) => c.kind === 'hole' || c.kind === 'outline')
+    expect(loops.length).toBe(2)
+  })
+
+  it('returns nothing for a plane with no coplanar rim loops', () => {
+    const centres = detectSnapCentres(washer(0.05, 0.02), null, {
+      point: [0, 0, 1],
+      normal: [0, 0, 1]
+    }) // plane 1 m away — no coplanar triangles
+    expect(centres).toEqual([])
+  })
+})


### PR DESCRIPTION
The first of the requested Join enhancements: **hole-center snapping** on imported STL meshes.

## How
An STL is a triangle soup, so `robot-holes.ts` (pure, dependency-free, unit-tested) finds snap centres on the face you clicked:
1. keep triangles **coplanar** with the clicked face (verts on the plane + normal parallel),
2. an edge used by exactly **one** coplanar triangle is a **rim** edge — the flat region's outline or a hole,
3. chain rim edges into closed **loops**; a roughly-circular loop's centroid is a **hole**, the largest is the face **outline**,
4. plus midpoints of the longest rim edges as **alignment guides**.

Wired into the 3-D picker: a mesh hit runs `detectSnapCentres` (cached per mesh+plane), converts centres geometry-local → world, and snaps the pick to the nearest within a screen threshold. Hover reveals the snaps during Join picking.

## Verification
- `npm run typecheck` / `lint` / `npm test` (**1532**, +4 `robot-holes`: hole centre, off-centre hole, coplanar filtering, no-loop) / `build` ✅
- Playwright E2E on a thick washer STL: rim-edge + centre snaps appear at the correct screen locations while Add-Joint picking (a concentric washer's hole centre coincides with its outline centre; an off-centre hole is tagged `hole`, covered by the unit test).

## Notes / limits
Hole detection is a heuristic (coplanar rim-loop). It needs a real flat face around the hole and a plate thicker than the on-plane tolerance (~0.5 mm); a zero-thickness or non-manifold mesh won't yield rim loops.

Still queued from the same message: face-normal orientation + mate-the-normals + first-block transparency; rotation min/max + default angle + live rotation preview. And from the latest message: intelligent parent/child swap + a multi-joint bug to investigate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)