### PR TITLE
feat: Robot View Join tool — smart parent/child swap; verify multi-joint chains (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Robot View — Join tool: smart parent/child + multi-joint chains (#354).** You
+  no longer have to pick the two blocks in the "right" order — if the chosen order
+  would form a loop but the reverse wouldn't, the tool **swaps** parent and child
+  for you. Building a chain of joints works (each new joint keeps the earlier ones);
+  note that a joined child snaps to meet its parent, so it visibly moves.
 - **Robot View — Join tool snaps to hole centres (#354).** When you pick a joint
   point on an imported mesh (STL), the tool detects **hole centres** on the clicked
   face — an STL is just triangles, so it finds the coplanar rim-edge loops, and a

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -30,6 +30,7 @@ import {
   rootLink,
   setJoint,
   setJointOrigin,
+  orientJoint,
   setPrimitiveSize,
   setVisualOrigin,
   type JointDef,
@@ -613,20 +614,24 @@ export function RobotView({
     const jp = jointPick
     if (!jp?.parent || !jp?.child) return false
     const base = contentRef.current
+    // Intelligent parent/child (#354): if the chosen order would loop but the
+    // reverse wouldn't, orientJoint swaps them so the user needn't get it "right".
+    const o = orientJoint(base, jp.parent.link, jp.child.link)
+    const [parent, child] = o.parent === jp.parent.link ? [jp.parent, jp.child] : [jp.child, jp.parent]
     const xyz: [number, number, number] = [
-      jp.parent.local[0] - jp.child.local[0] + offsetMm[0],
-      jp.parent.local[1] - jp.child.local[1] + offsetMm[1],
-      jp.parent.local[2] - jp.child.local[2] + offsetMm[2]
+      parent.local[0] - child.local[0] + offsetMm[0],
+      parent.local[1] - child.local[1] + offsetMm[1],
+      parent.local[2] - child.local[2] + offsetMm[2]
     ]
-    let next = connectJoint(base, { parent: jp.parent.link, child: jp.child.link, xyz })
+    let next = connectJoint(base, { parent: parent.link, child: child.link, xyz })
     if (next === base) return false // cycle / invalid — keep the dialog open
-    next = setJoint(next, jp.child.link, { type }) // apply the chosen joint type
+    next = setJoint(next, child.link, { type }) // apply the chosen joint type
     // Force the joint rotation to identity (rpy 0): the origin math above assumes
     // it, and connectJoint/setJoint otherwise PRESERVE a child's old rpy — which
     // would leave the two picked points misaligned. setJointOrigin emits rpy="0 0 0".
-    next = setJointOrigin(next, jp.child.link, xyz)
+    next = setJointOrigin(next, child.link, xyz)
     commitUrdf(next)
-    setSelectedLink(jp.child.link)
+    setSelectedLink(child.link)
     return true
   }
   const handlePropsOk = (): void => {

--- a/src/renderer/src/components/robot-assembly.ts
+++ b/src/renderer/src/components/robot-assembly.ts
@@ -446,6 +446,17 @@ export function subtreeOf(urdf: string, link: string): Set<string> {
   return inside
 }
 
+/**
+ * Decide the parent/child orientation for a joint between two links (#354). A URDF
+ * tree needs the child NOT to already sit above the parent; if making `a` the
+ * parent of `b` would form a loop but the reverse wouldn't, swap them. When either
+ * order works (or neither), keep `a` as the parent.
+ */
+export function orientJoint(urdf: string, a: string, b: string): { parent: string; child: string } {
+  if (subtreeOf(urdf, b).has(a) && !subtreeOf(urdf, a).has(b)) return { parent: b, child: a }
+  return { parent: a, child: b }
+}
+
 /** A joint name derived from `base`, made unique within the URDF. */
 function uniqueJointName(urdf: string, base: string): string {
   const existing = new Set(jointNames(urdf))

--- a/test/robotAssembly.test.ts
+++ b/test/robotAssembly.test.ts
@@ -7,6 +7,7 @@ import {
   addMeshLink,
   blankUrdf,
   connectJoint,
+  orientJoint,
   subtreeOf,
   readAllJoints
 } from '../src/renderer/src/components/robot-assembly'
@@ -154,6 +155,43 @@ describe('connectJoint — the Join tool (#354)', () => {
     const wheelBlock = /<joint name="j_wheel"[\s\S]*?<\/joint>/.exec(out)![0]
     expect((wheelBlock.match(/<origin\b/g) || []).length).toBe(1)
     expect((wheelBlock.match(/<child\b/g) || []).length).toBe(1)
+  })
+
+  it('orientJoint swaps parent/child when the chosen order would loop', () => {
+    // base → upper → tip. Making `tip` the parent of `upper` would loop.
+    expect(orientJoint(URDF, 'tip', 'upper')).toEqual({ parent: 'upper', child: 'tip' })
+    // The already-valid order is kept as-is.
+    expect(orientJoint(URDF, 'base_link', 'tip')).toEqual({ parent: 'base_link', child: 'tip' })
+    // Two unrelated siblings: keep `a` as the parent (either order is fine).
+    const branched = `<?xml version="1.0"?>
+<robot name="r">
+  <link name="base"/><link name="l"/><link name="r"/>
+  <joint name="jl" type="fixed"><parent link="base"/><child link="l"/></joint>
+  <joint name="jr" type="fixed"><parent link="base"/><child link="r"/></joint>
+</robot>`
+    expect(orientJoint(branched, 'l', 'r')).toEqual({ parent: 'l', child: 'r' })
+  })
+
+  it('supports a CHAIN of joints — a second connect keeps the first (#354 IK chains)', () => {
+    // base → a, base → b, base → c (all fixed to base).
+    const flat = `<?xml version="1.0"?>
+<robot name="r">
+  <link name="base"/>
+  <link name="a"/>
+  <link name="b"/>
+  <link name="c"/>
+  <joint name="ja" type="fixed"><parent link="base"/><child link="a"/></joint>
+  <joint name="jb" type="fixed"><parent link="base"/><child link="b"/></joint>
+  <joint name="jc" type="fixed"><parent link="base"/><child link="c"/></joint>
+</robot>`
+    let out = connectJoint(flat, { parent: 'a', child: 'b' }) // b under a
+    out = connectJoint(out, { parent: 'b', child: 'c' }) // c under b (chain a→b→c)
+    const js = readAllJoints(out)
+    expect(js.find((x) => x.child === 'b')!.parent).toBe('a') // first join intact
+    expect(js.find((x) => x.child === 'c')!.parent).toBe('b') // second join
+    expect(js.find((x) => x.child === 'a')!.parent).toBe('base') // untouched
+    // Still exactly 3 joints (no dupes / drops).
+    expect(js.length).toBe(3)
   })
 
   it('subtreeOf collects a link + its descendants', () => {


### PR DESCRIPTION
Addresses the latest Join-tool report: intelligent parent/child ordering + the "second joint ignores the first" concern.

## Smart parent/child
`orientJoint(urdf, a, b)` picks the orientation: if making `a` the parent of `b` would form a loop but the reverse wouldn't, it **swaps** them. So you needn't pick the two blocks in the "right" order — `handleConnectPicked` runs the picks through `orientJoint` before connecting (swapping the local pick coords too).

## Multi-joint "ignores the first" — investigated
Could **not** reproduce a dropped joint:
- Unit: `connectJoint` chains correctly — `a→b` then `b→c` keeps all three joints.
- E2E: creating two joints in sequence (re-probing positions between) keeps both — a real `base→b1→b2→b3` chain.

The real effect: a joined child **snaps to meet its parent**, so it visibly moves. Clicking where a block *used* to be then picks the wrong block — that's what "seemed to ignore the first" was. Documented in the changelog.

## Verification
- `npm run typecheck` / `lint` / `npm test` (**1534**, +`orientJoint` + chain tests) / `build` ✅
- Playwright E2E: picking the would-loop order (`parent=b2, child=b1` on `base→b1→b2`) now **succeeds** via the swap (dialog closes, no loop warning) instead of erroring.

Still queued (earlier message): face-normal orientation + mate-the-normals + first-block transparency; rotation min/max + default angle + live rotation preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)