### PR TITLE
feat: Robot View — delete a joint from the Joints branch (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Robot View — delete a joint (#354).** Clicking a joint in the **Joints** branch
+  already opened its editor (type / axis / limits); it now also has a **Delete**
+  button that removes the joint and re-attaches the block to the base, keeping its
+  current position so it doesn't jump.
 - **Robot View — Join tool: smart parent/child + multi-joint chains (#354).** You
   no longer have to pick the two blocks in the "right" order — if the chosen order
   would form a loop but the reverse wouldn't, the tool **swaps** parent and child

--- a/src/renderer/src/components/RobotPropertiesDialog.tsx
+++ b/src/renderer/src/components/RobotPropertiesDialog.tsx
@@ -43,6 +43,8 @@ export interface RobotPropertiesDialogProps {
   jointNames: string[]
   onSetSize: (link: string, dims: number[]) => void
   onSetJoint: (link: string, spec: JointSpec) => void
+  /** Remove the joint whose child is this link (the block re-attaches to the base). */
+  onDeleteJoint: (child: string) => void
   // servo
   servo: ServoJointBinding | null
   movableJoints: string[]
@@ -146,6 +148,19 @@ export function RobotPropertiesDialog(props: RobotPropertiesDialogProps): JSX.El
         {context.kind === 'addjoint' && <AddJointBody {...props} commitRef={commitRef} />}
       </div>
       <div className="robotprops__foot">
+        {context.kind === 'joint' && (
+          <button
+            type="button"
+            className="robotprops__btn robotprops__btn--danger"
+            title="Remove this joint — the block re-attaches to the base"
+            onClick={() => {
+              props.onDeleteJoint(context.child)
+              onOk()
+            }}
+          >
+            Delete
+          </button>
+        )}
         {context.kind === 'servo' && (
           <button
             type="button"

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -634,6 +634,28 @@ export function RobotView({
     setSelectedLink(child.link)
     return true
   }
+  // Delete a joint (#354): detach its child from the current parent by re-attaching
+  // it to the base, KEEPING its current world position (so the part doesn't jump).
+  const handleDeleteJoint = (child: string): void => {
+    const root = rootLink(content)
+    if (!root || child === root) return
+    let xyz: [number, number, number] = [0, 0, 0]
+    const robot = robotRef.current
+    if (robot?.links[child] && robot.links[root]) {
+      robot.updateMatrixWorld(true)
+      const rel = new THREE.Matrix4()
+        .copy(robot.links[root].matrixWorld)
+        .invert()
+        .multiply(robot.links[child].matrixWorld)
+      const pos = new THREE.Vector3().setFromMatrixPosition(rel)
+      xyz = [pos.x, pos.y, pos.z]
+    }
+    let next = connectJoint(content, { parent: root, child, xyz })
+    next = setJoint(next, child, { type: 'fixed' })
+    next = setJointOrigin(next, child, xyz)
+    if (next !== content) commitUrdf(next)
+    setDialogCtx(null)
+  }
   const handlePropsOk = (): void => {
     editSnapshotRef.current = null
     setDialogCtx(null)
@@ -2438,6 +2460,7 @@ export function RobotView({
             jointNames={allJointNames}
             onSetSize={handleSetSize}
             onSetJoint={handleSetJoint}
+            onDeleteJoint={handleDeleteJoint}
             servo={dialogCtx.kind === 'servo' ? bindings.find((b) => b.pin === dialogCtx.pin) ?? null : null}
             movableJoints={movableNames}
             onSetServo={handleUpdateBinding}


### PR DESCRIPTION
Adds the missing **delete** for joints (editing already worked — clicking a joint in the **Joints** branch opens its type/axis/limits form).

## What
The joint dialog gains a **Delete** button. It removes the joint by re-attaching the child to the **base**, computing the child's current world position from the live 3-D transforms so the part **keeps its place** instead of jumping to the origin.

## Verification
- `npm run typecheck` / `lint` / `npm test` (1534) / `build` ✅
- Playwright E2E: deleting `j2` (b2 under b1) re-parents `b2` to `base` (verified on disk).

Next (from the same message): draw the pick markers **on the face** in 3-D (a circle + axis triad at the joint origin) and orient joints by the **local face normal** so mating faces line up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)