### PR TITLE
feat: Robot View Join tool — mate faces by local normals + on-face 3-D markers (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Robot View — Join tool mates faces by their normals + on-face markers (#354).**
+  Picking a point now captures the **face normal**, drawn as a **circle laid flat on
+  the face** with an **X/Y/Z axis triad** (blue = parent, green = child) — it sits in
+  3-D on the surface instead of facing the camera, so it reads accurately from any
+  angle. The joint is oriented from those **local** face normals: the child rotates
+  so its face meets the parent's flush (its normal anti-parallel to the parent's) and
+  the two picked points coincide.
 - **Robot View — delete a joint (#354).** Clicking a joint in the **Joints** branch
   already opened its editor (type / axis / limits); it now also has a **Delete**
   button that removes the joint and re-attaches the block to the base, keeping its

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -61,6 +61,7 @@ import {
 } from './robot-build'
 import { RobotBuildPanel } from './RobotBuildPanel'
 import { detectSnapCentres } from './robot-holes'
+import { jointFromPicks } from './robot-joint-frame'
 import { RobotPropertiesDialog, type PropsContext } from './RobotPropertiesDialog'
 import { RobotToolbar } from './RobotToolbar'
 import { loadPin, savePin, PIN_KEYS } from './pin-overlay'
@@ -344,7 +345,13 @@ export function RobotView({
     dialogCtx?.kind === 'link' ? dialogCtx.link : dialogCtx?.kind === 'joint' ? dialogCtx.child : null
   const [buildDim, setBuildDim] = useState<{ x: number; y: number; text: string } | null>(null)
   // Join tool (#354): the two points picked in 3-D. Non-null = pick mode is armed.
-  type JointPickPt = { link: string; local: [number, number, number]; role: string }
+  // `local` + `normal` are in the link's LOCAL frame (the point + its face normal).
+  type JointPickPt = {
+    link: string
+    local: [number, number, number]
+    normal: [number, number, number]
+    role: string
+  }
   const [jointPick, setJointPick] = useState<{
     step: 'parent' | 'child'
     parent: JointPickPt | null
@@ -374,7 +381,13 @@ export function RobotView({
   const jointPickStateRef = useRef(jointPick)
   jointPickStateRef.current = jointPick
   const onJointPickRef = useRef<
-    ((link: string, local: [number, number, number], role: string) => void) | null
+    | ((
+        link: string,
+        local: [number, number, number],
+        normal: [number, number, number],
+        role: string
+      ) => void)
+    | null
   >(null)
   const jointPickApiRef = useRef<{ clear: () => void } | null>(null)
   buildOpenRef.current = buildOpen && poseUI
@@ -587,11 +600,16 @@ export function RobotView({
     openContext({ kind: 'addjoint' }, null)
     if (!buildOpen) setBuildOpen(true)
   }
-  // A 3-D pick landed (the effect resolved the click → link + local snap point).
-  const onJointPick = (link: string, local: [number, number, number], role: string): void => {
+  // A 3-D pick landed (the effect resolved the click → link + local snap point + face normal).
+  const onJointPick = (
+    link: string,
+    local: [number, number, number],
+    normal: [number, number, number],
+    role: string
+  ): void => {
     setJointPick((jp) => {
       if (!jp) return jp
-      const pt: JointPickPt = { link, local, role }
+      const pt: JointPickPt = { link, local, normal, role }
       if (jp.step === 'parent') return { ...jp, parent: pt, step: 'child' }
       if (jp.parent && link === jp.parent.link) return jp // can't join a block to itself
       return { ...jp, child: pt }
@@ -618,18 +636,19 @@ export function RobotView({
     // reverse wouldn't, orientJoint swaps them so the user needn't get it "right".
     const o = orientJoint(base, jp.parent.link, jp.child.link)
     const [parent, child] = o.parent === jp.parent.link ? [jp.parent, jp.child] : [jp.child, jp.parent]
-    const xyz: [number, number, number] = [
-      parent.local[0] - child.local[0] + offsetMm[0],
-      parent.local[1] - child.local[1] + offsetMm[1],
-      parent.local[2] - child.local[2] + offsetMm[2]
-    ]
+    // Orient the joint from the two picked FACE NORMALS: rotate the child so its
+    // face mates flush against the parent's and the picked points coincide.
+    const { xyz, rpy } = jointFromPicks(
+      parent.local,
+      parent.normal,
+      child.local,
+      child.normal,
+      offsetMm
+    )
     let next = connectJoint(base, { parent: parent.link, child: child.link, xyz })
     if (next === base) return false // cycle / invalid — keep the dialog open
     next = setJoint(next, child.link, { type }) // apply the chosen joint type
-    // Force the joint rotation to identity (rpy 0): the origin math above assumes
-    // it, and connectJoint/setJoint otherwise PRESERVE a child's old rpy — which
-    // would leave the two picked points misaligned. setJointOrigin emits rpy="0 0 0".
-    next = setJointOrigin(next, child.link, xyz)
+    next = setJointOrigin(next, child.link, xyz, rpy) // xyz + the mating rotation
     commitUrdf(next)
     setSelectedLink(child.link)
     return true
@@ -1885,47 +1904,85 @@ export function RobotView({
           }
 
           // ── Join tool (#354): click a point on two blocks to connect them ──
-          const jointMarkerMat = new THREE.MeshBasicMaterial({ color: 0x4ea1ff, depthTest: false }) // parent
-          const jointMarkerMatChild = new THREE.MeshBasicMaterial({ color: 0x34ad4f, depthTest: false }) // child
-          let parentMarker: THREE.Mesh | null = null
-          let childMarker: THREE.Mesh | null = null
-          const clearJointMarkers = (): void => {
-            for (const mk of [parentMarker, childMarker]) {
-              if (mk) {
-                scene.remove(mk)
-                mk.geometry.dispose()
-              }
+          // Markers are a CIRCLE laid flat on the picked face + an X/Y/Z axis triad
+          // (Z = the face normal) so the pick reads accurately in 3-D from any angle.
+          const jointMatParent = new THREE.LineBasicMaterial({ color: 0x4ea1ff, depthTest: false })
+          const jointMatChild = new THREE.LineBasicMaterial({ color: 0x34ad4f, depthTest: false })
+          const axisMatX = new THREE.LineBasicMaterial({ color: 0xff5566, depthTest: false })
+          const axisMatY = new THREE.LineBasicMaterial({ color: 0x55dd66, depthTest: false })
+          const axisMatZ = new THREE.LineBasicMaterial({ color: 0x5599ff, depthTest: false })
+          const circlePts = (r: number): THREE.Vector3[] => {
+            const a: THREE.Vector3[] = []
+            for (let i = 0; i <= 40; i++) {
+              const t = (i / 40) * Math.PI * 2
+              a.push(new THREE.Vector3(Math.cos(t) * r, Math.sin(t) * r, 0))
             }
+            return a
+          }
+          let parentMarker: THREE.Group | null = null
+          let childMarker: THREE.Group | null = null
+          const disposeMarker = (g: THREE.Group | null): void => {
+            if (!g) return
+            scene.remove(g)
+            g.traverse((o) => {
+              const l = o as THREE.Line
+              if (l.geometry) l.geometry.dispose()
+            })
+          }
+          const clearJointMarkers = (): void => {
+            disposeMarker(parentMarker)
+            disposeMarker(childMarker)
             parentMarker = null
             childMarker = null
           }
           jointPickApiRef.current = { clear: clearJointMarkers }
-          const setJointMarker = (world: THREE.Vector3, isChild: boolean): void => {
-            const prev = isChild ? childMarker : parentMarker
-            if (prev) {
-              scene.remove(prev)
-              prev.geometry.dispose()
-            }
-            const mk = new THREE.Mesh(
-              new THREE.SphereGeometry(halfView * 0.03 + 0.002, 12, 12),
-              isChild ? jointMarkerMatChild : jointMarkerMat
+          const setJointMarker = (world: THREE.Vector3, normal: THREE.Vector3, isChild: boolean): void => {
+            disposeMarker(isChild ? childMarker : parentMarker)
+            const g = new THREE.Group()
+            const r = halfView * 0.11
+            const ax = halfView * 0.16
+            const circle = new THREE.LineLoop(
+              new THREE.BufferGeometry().setFromPoints(circlePts(r)),
+              isChild ? jointMatChild : jointMatParent
             )
-            mk.position.copy(world)
-            mk.renderOrder = 999
-            mk.raycast = () => {}
-            scene.add(mk)
-            if (isChild) childMarker = mk
-            else parentMarker = mk
+            const line = (dir: THREE.Vector3, mat: THREE.LineBasicMaterial): THREE.Line => {
+              const l = new THREE.Line(
+                new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(), dir.clone().multiplyScalar(ax)]),
+                mat
+              )
+              l.renderOrder = 999
+              l.raycast = () => {}
+              return l
+            }
+            circle.renderOrder = 999
+            circle.raycast = () => {}
+            g.add(
+              circle,
+              line(new THREE.Vector3(1, 0, 0), axisMatX),
+              line(new THREE.Vector3(0, 1, 0), axisMatY),
+              line(new THREE.Vector3(0, 0, 1), axisMatZ)
+            )
+            g.position.copy(world)
+            // Orient so the marker's +Z (the triad's blue axis + circle normal) points
+            // along the picked face normal — the circle then lies flat on the face.
+            g.quaternion.setFromUnitVectors(new THREE.Vector3(0, 0, 1), normal.clone().normalize())
+            scene.add(g)
+            if (isChild) childMarker = g
+            else parentMarker = g
           }
           // Redraw markers for any picks that survived an effect rebuild mid-pick
           // (the state persists in jointPickStateRef; the old scene objects didn't).
           {
             const jp = jointPickStateRef.current
-            const drawFrom = (p: { link: string; local: [number, number, number] } | null, child: boolean): void => {
-              const lo = p && robotRef.current?.links[p.link]
-              if (p && lo) setJointMarker(lo.localToWorld(new THREE.Vector3(...p.local)), child)
-            }
             robotRef.current?.updateMatrixWorld(true)
+            const drawFrom = (p: JointPickPt | null, child: boolean): void => {
+              const lo = p && robotRef.current?.links[p.link]
+              if (!p || !lo) return
+              const q = new THREE.Quaternion()
+              lo.getWorldQuaternion(q)
+              const wn = new THREE.Vector3(p.normal[0], p.normal[1], p.normal[2]).applyQuaternion(q)
+              setJointMarker(lo.localToWorld(new THREE.Vector3(p.local[0], p.local[1], p.local[2])), wn, child)
+            }
             drawFrom(jp?.parent ?? null, false)
             drawFrom(jp?.child ?? null, true)
           }
@@ -1972,6 +2029,13 @@ export function RobotView({
             if (jr.step === 'parent' && jr.childLink === link) return
             let world = hit.point.clone()
             let role = 'point'
+            // The picked FACE normal (world) — the point stays ON this face even when
+            // it snaps to a corner/edge/centre/hole, so the face normal still holds.
+            const mesh = hit.object as THREE.Mesh
+            const worldNormal = hit
+              .face!.normal.clone()
+              .transformDirection(mesh.matrixWorld)
+              .normalize()
             const geom = readPrimitive(contentRef.current, link)
             if (geom) {
               // Primitive: snap to a face corner / edge / centre.
@@ -1990,9 +2054,18 @@ export function RobotView({
                 role = th.roles[near.index]
               }
             }
-            const local = robot.links[link].worldToLocal(world.clone())
-            setJointMarker(world, jr.step === 'child')
-            onJointPickRef.current?.(link, [local.x, local.y, local.z], role)
+            const linkObj = robot.links[link]
+            const local = linkObj.worldToLocal(world.clone())
+            const lq = new THREE.Quaternion()
+            linkObj.getWorldQuaternion(lq)
+            const linkNormal = worldNormal.clone().applyQuaternion(lq.invert()) // face normal, link-local
+            setJointMarker(world, worldNormal, jr.step === 'child')
+            onJointPickRef.current?.(
+              link,
+              [local.x, local.y, local.z],
+              [linkNormal.x, linkNormal.y, linkNormal.z],
+              role
+            )
           }
 
           const onBuildDown = (e: PointerEvent): void => {
@@ -2191,8 +2264,11 @@ export function RobotView({
             if (outline) outline.geometry.dispose()
             accentLineMat.dispose()
             clearJointMarkers()
-            jointMarkerMat.dispose()
-            jointMarkerMatChild.dispose()
+            jointMatParent.dispose()
+            jointMatChild.dispose()
+            axisMatX.dispose()
+            axisMatY.dispose()
+            axisMatZ.dispose()
             measureApiRef.current = null
             highlightApiRef.current = null
             jointPickApiRef.current = null

--- a/src/renderer/src/components/robot-assembly.ts
+++ b/src/renderer/src/components/robot-assembly.ts
@@ -536,20 +536,23 @@ export function connectJoint(
   return idx < 0 ? `${urdf.trimEnd()}\n${block}` : urdf.slice(0, idx) + block + urdf.slice(idx)
 }
 
-/** Set the fixed-joint origin whose child is `childLink` (moves the whole part). */
+/** Set the joint origin whose child is `childLink` (moves/orients the whole part).
+ *  `rpy` defaults to zero (a plain translation); pass it to orient the joint. */
 export function setJointOrigin(
   urdf: string,
   childLink: string,
-  xyz: readonly [number, number, number]
+  xyz: readonly [number, number, number],
+  rpy: readonly [number, number, number] = [0, 0, 0]
 ): string {
   const re = /<joint\b[^>]*>[\s\S]*?<\/joint>/gi
   const childRe = new RegExp(`<child\\b[^>]*\\blink\\s*=\\s*"${escapeRe(childLink)}"`, 'i')
+  const originRe = /<origin\b[^>]*\/>|<origin\b[^>]*>[\s\S]*?<\/origin>/i
   let m: RegExpExecArray | null
   while ((m = re.exec(urdf))) {
     if (!childRe.test(m[0])) continue
-    const tag = `<origin xyz="${fmtVec(xyz)}" rpy="0 0 0"/>`
-    const block = /<origin\b[^>]*\/>/i.test(m[0])
-      ? m[0].replace(/<origin\b[^>]*\/>/i, tag)
+    const tag = `<origin xyz="${fmtVec(xyz)}" rpy="${fmtVec(rpy)}"/>`
+    const block = originRe.test(m[0])
+      ? m[0].replace(originRe, tag)
       : m[0].replace(/<\/joint>/i, `  ${tag}\n  </joint>`)
     return urdf.slice(0, m.index) + block + urdf.slice(m.index + m[0].length)
   }

--- a/src/renderer/src/components/robot-joint-frame.ts
+++ b/src/renderer/src/components/robot-joint-frame.ts
@@ -1,0 +1,37 @@
+/**
+ * JOINT FRAME FROM TWO PICKS (#354) — compute a joint's origin (xyz + rpy) so the
+ * child block's picked FACE mates against the parent's: the child is rotated so
+ * its picked normal is anti-parallel to the parent's (the faces meet flush) and
+ * its picked point lands on the parent's picked point (+ an optional offset).
+ *
+ * All inputs are in the respective link's LOCAL frame (parent point/normal in the
+ * parent frame, child point/normal in the child frame). The returned rpy is in the
+ * URDF convention (fixed-axis roll-pitch-yaw = intrinsic Z·Y·X), so it round-trips
+ * through a `<joint><origin rpy>`.
+ */
+import * as THREE from 'three'
+import type { Vec3 } from './robot-build'
+
+export function jointFromPicks(
+  parentLocal: Vec3,
+  parentNormal: Vec3,
+  childLocal: Vec3,
+  childNormal: Vec3,
+  offset: Vec3 = [0, 0, 0]
+): { xyz: Vec3; rpy: Vec3 } {
+  const pn = new THREE.Vector3(parentNormal[0], parentNormal[1], parentNormal[2]).normalize()
+  const cn = new THREE.Vector3(childNormal[0], childNormal[1], childNormal[2]).normalize()
+  // Rotate the child so its picked normal faces OPPOSITE the parent's (flush mate).
+  const q = new THREE.Quaternion().setFromUnitVectors(cn, pn.clone().negate())
+  // origin so the rotated child point lands on the parent point (+ offset):
+  //   origin + R·childLocal = parentLocal + offset
+  const rc = new THREE.Vector3(childLocal[0], childLocal[1], childLocal[2]).applyQuaternion(q)
+  const xyz: Vec3 = [
+    parentLocal[0] - rc.x + offset[0],
+    parentLocal[1] - rc.y + offset[1],
+    parentLocal[2] - rc.z + offset[2]
+  ]
+  // URDF rpy is fixed-axis XYZ ≡ intrinsic ZYX; three's Euler order 'ZYX' matches.
+  const e = new THREE.Euler().setFromQuaternion(q, 'ZYX')
+  return { xyz, rpy: [e.x, e.y, e.z] }
+}

--- a/test/robotJointFrame.test.ts
+++ b/test/robotJointFrame.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import * as THREE from 'three'
+import { jointFromPicks } from '../src/renderer/src/components/robot-joint-frame'
+import type { Vec3 } from '../src/renderer/src/components/robot-build'
+
+/** Reconstruct the joint rotation from a URDF rpy (fixed-axis XYZ ≡ intrinsic ZYX). */
+const rotOf = (rpy: Vec3): THREE.Quaternion =>
+  new THREE.Quaternion().setFromEuler(new THREE.Euler(rpy[0], rpy[1], rpy[2], 'ZYX'))
+
+const v = (a: Vec3): THREE.Vector3 => new THREE.Vector3(a[0], a[1], a[2])
+const near = (a: THREE.Vector3, b: THREE.Vector3): boolean => a.distanceTo(b) < 1e-6
+
+describe('jointFromPicks — mate two picked faces (#354)', () => {
+  const check = (pL: Vec3, pN: Vec3, cL: Vec3, cN: Vec3, off: Vec3 = [0, 0, 0]): void => {
+    const { xyz, rpy } = jointFromPicks(pL, pN, cL, cN, off)
+    const R = rotOf(rpy)
+    // 1) the child's picked normal, rotated, faces OPPOSITE the parent's.
+    const mated = v(cN).normalize().applyQuaternion(R)
+    expect(near(mated, v(pN).normalize().negate())).toBe(true)
+    // 2) the child's picked point, rotated + translated, lands on the parent's (+off).
+    const landed = v(cL).applyQuaternion(R).add(v(xyz))
+    expect(near(landed, v(pL).add(v(off)))).toBe(true)
+  }
+
+  it('mates two upward faces (needs a 180° flip)', () => {
+    check([0, 0, 0], [0, 0, 1], [0, 0, 0], [0, 0, 1])
+  })
+  it('is identity when the child already faces the parent', () => {
+    const { rpy } = jointFromPicks([0, 0, 0], [0, 0, 1], [0, 0, 0], [0, 0, -1])
+    expect(rpy.map((x) => Math.round(x * 1000))).toEqual([0, 0, 0])
+    check([0, 0, 0], [0, 0, 1], [0, 0, 0], [0, 0, -1])
+  })
+  it('mates perpendicular faces + meets offset points', () => {
+    check([0.05, 0, 0.02], [1, 0, 0], [0, 0.03, 0], [0, 1, 0], [0, 0, 0.01])
+  })
+  it('handles an arbitrary pick', () => {
+    check([0.1, -0.05, 0.2], [0.3, 0.6, 0.74], [-0.02, 0.04, 0.01], [-0.5, 0.5, 0.707])
+  })
+})


### PR DESCRIPTION
Two of the requested Join enhancements: **on-face 3-D markers** and **local face-normal** joint orientation.

## On-face markers
Each pick captures the **face normal**. The marker is now a **circle laid flat on the face** + an **X/Y/Z axis triad** (Z = the normal; **blue** = parent, **green** = child) — it lives in 3-D on the surface instead of billboarding to the camera, so it reads accurately as you orbit. It's redrawn from the stored local normal if the scene rebuilds mid-pick.

## Mate by local normals
`jointFromPicks()` rotates the child so its picked face normal is **anti-parallel** to the parent's (the faces meet flush) and the two picked points coincide:
- `origin = parentLocal − R·childLocal + offset`
- `rpy = Euler(R, 'ZYX')` (URDF fixed-axis XYZ convention)

Normals are captured **local to each link** (world normal inverse-rotated by the link quaternion), not a single world normal. `setJointOrigin` gained an optional `rpy` (and now handles both `<origin/>` tag forms).

## Verification
- `npm run typecheck` / `lint` / `npm test` (**1538**, +4 `robot-joint-frame`: mate, points-meet, rpy round-trip) / `build` ✅
- Playwright E2E: joining two same-facing block faces writes `rpy="3.1416 0 3.1416"` (child flips to mate); a clipped screenshot shows the blue/green circles flat on the faces with axis triads.
- Adversarial review (frames + markers) — **0 findings**.

Still queued: first-block **transparency** while picking; rotation **min/max + default angle + live preview**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)