### PR TITLE
feat: Robot View Join tool — rotation joints get min/max + a default angle (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Robot View — rotation joints get min/max + a default angle (#354).** When you
+  choose **Rotation** in the Add Joint dialog, min / max angle limits and a default
+  angle (degrees) appear; **Add** writes the joint's `<limit>` and saves the default
+  to the robot's default pose. The joint is then movable — drag it in the pose
+  panel to preview the swing, and it loads at the default angle.
 - **Robot View — Join tool fades the first-picked block (#354).** After you pick a
   point on the first block, that block goes semi-transparent (Fusion-style) so it's
   obviously chosen — and can't be picked as the second component. It restores when

--- a/src/renderer/src/components/RobotPropertiesDialog.tsx
+++ b/src/renderer/src/components/RobotPropertiesDialog.tsx
@@ -65,7 +65,11 @@ export interface RobotPropertiesDialogProps {
   onRepick: (step: 'parent' | 'child') => void
   /** Create the joint from the two picks + chosen type + offset (mm). Returns
    *  false (keeps the dialog open) if the picks are incomplete / would loop. */
-  onConnectPicked: (type: JointType, offsetMm: [number, number, number]) => boolean
+  onConnectPicked: (
+    type: JointType,
+    offsetMm: [number, number, number],
+    rotation?: { minDeg: number; maxDeg: number; defaultDeg: number }
+  ) => boolean
   // footer
   onOk: () => void
   onCancel: () => void
@@ -399,6 +403,12 @@ function AddJointBody({
 }): JSX.Element {
   const [type, setType] = useState<JointType>('fixed')
   const [off, setOff] = useState<Record<'x' | 'y' | 'z', string>>({ x: '0', y: '0', z: '0' })
+  // Rotation (revolute) limits + default angle, in DEGREES (raw strings).
+  const [rot, setRot] = useState<{ min: string; max: string; def: string }>({
+    min: '-90',
+    max: '90',
+    def: '0'
+  })
   const [err, setErr] = useState<string | null>(null)
   const parent = jointPick?.parent ?? null
   const child = jointPick?.child ?? null
@@ -413,7 +423,11 @@ function AddJointBody({
       const v = Number(s)
       return Number.isFinite(v) ? v / 1000 : 0 // mm → m
     }
-    const ok = onConnectPicked(type, [mm(off.x), mm(off.y), mm(off.z)])
+    const rotation =
+      type === 'revolute'
+        ? { minDeg: Number(rot.min) || 0, maxDeg: Number(rot.max) || 0, defaultDeg: Number(rot.def) || 0 }
+        : undefined
+    const ok = onConnectPicked(type, [mm(off.x), mm(off.y), mm(off.z)], rotation)
     if (!ok) {
       setErr('Can’t connect — that would form a loop (the parent hangs off the child).')
       return false
@@ -482,6 +496,37 @@ function AddJointBody({
           ))}
         </div>
       </section>
+      {type === 'revolute' && (
+        <section className="robotprops__section">
+          <div className="robotprops__label">Rotation limits (°)</div>
+          <div className="robotprops__row">
+            <label className="robotprops__mm">
+              <span>min</span>
+              <input
+                type="number"
+                value={rot.min}
+                onChange={(e) => setRot((r) => ({ ...r, min: e.target.value }))}
+              />
+            </label>
+            <label className="robotprops__mm">
+              <span>max</span>
+              <input
+                type="number"
+                value={rot.max}
+                onChange={(e) => setRot((r) => ({ ...r, max: e.target.value }))}
+              />
+            </label>
+            <label className="robotprops__mm">
+              <span>default</span>
+              <input
+                type="number"
+                value={rot.def}
+                onChange={(e) => setRot((r) => ({ ...r, def: e.target.value }))}
+              />
+            </label>
+          </div>
+        </section>
+      )}
       <section className="robotprops__section">
         <div className="robotprops__label">Offset (mm)</div>
         <div className="robotprops__row">
@@ -494,9 +539,11 @@ function AddJointBody({
         <p className="robotprops__note robotprops__note--warn">{err}</p>
       ) : (
         <p className="robotprops__note">
-          {parent && child
-            ? 'Component 2 will snap so its point meets Component 1’s point.'
-            : 'Click a point on each block in the 3-D view (snaps to corners / edges / centres).'}
+          {!parent || !child
+            ? 'Click a point on each block in the 3-D view (snaps to corners / edges / centres).'
+            : type === 'revolute'
+              ? 'Component 2 mates to Component 1; after Add, drag the joint in the pose panel to preview the swing.'
+              : 'Component 2 will snap so its point meets Component 1’s point.'}
         </p>
       )}
     </>

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -631,7 +631,11 @@ export function RobotView({
   }
   // Add: place the child so its picked point meets the parent's picked point
   // (origin = parentLocal − childLocal + offset), re-parent it, and set the type.
-  const handleConnectPicked = (type: JointType, offsetMm: [number, number, number]): boolean => {
+  const handleConnectPicked = (
+    type: JointType,
+    offsetMm: [number, number, number],
+    rotation?: { minDeg: number; maxDeg: number; defaultDeg: number }
+  ): boolean => {
     const jp = jointPick
     if (!jp?.parent || !jp?.child) return false
     const base = contentRef.current
@@ -650,10 +654,27 @@ export function RobotView({
     )
     let next = connectJoint(base, { parent: parent.link, child: child.link, xyz })
     if (next === base) return false // cycle / invalid — keep the dialog open
-    next = setJoint(next, child.link, { type }) // apply the chosen joint type
+    const rad = (d: number): number => (d * Math.PI) / 180
+    // A Rotation joint carries its min/max limits (native rad); else just the type.
+    next =
+      rotation && type === 'revolute'
+        ? setJoint(next, child.link, { type, lower: rad(rotation.minDeg), upper: rad(rotation.maxDeg) })
+        : setJoint(next, child.link, { type })
     next = setJointOrigin(next, child.link, xyz, rpy) // xyz + the mating rotation
     commitUrdf(next)
     setSelectedLink(child.link)
+    // Rotation default angle: persist it to the robot.yml defaultPose (keyed by the
+    // joint's actual name, in display degrees) so the joint loads at that angle —
+    // and it seeds the pose slider for interactive preview of the swing.
+    if (rotation && type === 'revolute' && rotation.defaultDeg) {
+      const jn = readJoint(next, child.link)?.name
+      if (jn) {
+        const dd = rotation.defaultDeg
+        void persist((m) => {
+          m.defaultPose = { ...(m.defaultPose ?? {}), [jn]: dd }
+        })
+      }
+    }
     return true
   }
   // Delete a joint (#354): detach its child from the current parent by re-attaching


### PR DESCRIPTION
The last queued Join enhancement: **rotation limits + default angle** (with an interactive preview).

## What
Choosing **Rotation** in the Add Joint dialog reveals **min / max** angle limits and a **default** angle (degrees). On **Add**:
- limits → the joint's `<limit lower/upper>` (converted deg→rad),
- default → the robot.yml `defaultPose` (keyed by the joint's actual name, in display degrees), so it loads at that angle.

The new joint is **revolute/movable**, so it shows in the pose-panel sliders — **drag it to preview the swing**. The dialog note calls this out.

## Verification
- `npm run typecheck` / `lint` / `npm test` (1538) / `build` ✅
- Playwright E2E: Rotation with min=-45 / max=120 / default=30 writes `<limit lower="-0.7854" upper="2.0944">` and `robot.yml defaultPose: jR: 30`.

This completes the requested Join-tool enhancements (hole snapping, parent/child swap, delete/edit joints, on-face markers, local-normal mating, first-block fade, and rotation limits/preview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)