### PR TITLE
fix: Robot View — deleting a joint now actually removes it, without moving anything (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   or reopen any panel. Nothing about Robot mode is permanently changed.
 
 ### Fixed
+- **Robot View — deleting a joint now actually removes it (#354).** Delete used to
+  re-attach the block to the base, which is a no-op for a joint that's already off
+  the base — so those joints (e.g. the two fixed joints in a fresh robot) couldn't
+  be removed. Delete now strips the joint outright; the block becomes free-standing
+  and stays where it was (its position is baked into its visual origin so it doesn't
+  jump).
 - **Robot View — nav + mini-viewer polish.** The projection dropdown under the
   navigation cube no longer vanishes when you reach for it (it sat just outside the
   nav zone's hover box, so moving the pointer down dropped the hover; the zone now

--- a/src/renderer/src/components/RobotPropertiesDialog.tsx
+++ b/src/renderer/src/components/RobotPropertiesDialog.tsx
@@ -156,7 +156,7 @@ export function RobotPropertiesDialog(props: RobotPropertiesDialogProps): JSX.El
           <button
             type="button"
             className="robotprops__btn robotprops__btn--danger"
-            title="Remove this joint — the block re-attaches to the base"
+            title="Remove this joint — the part is freed and kept where it is"
             onClick={() => {
               props.onDeleteJoint(context.child)
               onOk()

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -26,6 +26,8 @@ import {
   readAllJoints,
   readJoint,
   readPrimitive,
+  readVisualOrigin,
+  removeJoint,
   removeLink,
   rootLink,
   setJoint,
@@ -677,27 +679,59 @@ export function RobotView({
     }
     return true
   }
-  // Delete a joint (#354): detach its child from the current parent by re-attaching
-  // it to the base, KEEPING its current world position (so the part doesn't jump).
+  // Delete a joint (#354): strip it so the child becomes a free-standing root, and
+  // keep the whole sub-assembly EXACTLY where it is. Because a root has no frame
+  // transform, moving the child frame to the origin is compensated two ways: the
+  // child's own visual origin is baked with its full world transform, and each of
+  // the child's DIRECT-child joints is pre-multiplied by that same transform (so
+  // descendants — which hang off those joints — don't teleport). Handles rotation
+  // (full rel matrix → rpy), meshes (readVisualOrigin), and dangling mimics.
   const handleDeleteJoint = (child: string): void => {
-    const root = rootLink(content)
-    if (!root || child === root) return
-    let xyz: [number, number, number] = [0, 0, 0]
+    const before = content
+    const root = rootLink(before)
+    if (!root || child === root) {
+      setDialogCtx(null)
+      return
+    }
+    const stripped = removeJoint(before, child)
+    if (stripped === before) {
+      setDialogCtx(null) // no such joint
+      return
+    }
+    // The child's full transform relative to the base (which loads at the origin).
     const robot = robotRef.current
+    let relM = new THREE.Matrix4()
     if (robot?.links[child] && robot.links[root]) {
       robot.updateMatrixWorld(true)
-      const rel = new THREE.Matrix4()
+      relM = new THREE.Matrix4()
         .copy(robot.links[root].matrixWorld)
         .invert()
         .multiply(robot.links[child].matrixWorld)
-      const pos = new THREE.Vector3().setFromMatrixPosition(rel)
-      xyz = [pos.x, pos.y, pos.z]
     }
-    let next = connectJoint(content, { parent: root, child, xyz })
-    next = setJoint(next, child, { type: 'fixed' })
-    next = setJointOrigin(next, child, xyz)
-    if (next !== content) commitUrdf(next)
+    const toMat = (xyz: readonly number[], rpy: readonly number[]): THREE.Matrix4 =>
+      new THREE.Matrix4()
+        .makeRotationFromEuler(new THREE.Euler(rpy[0], rpy[1], rpy[2], 'ZYX'))
+        .setPosition(xyz[0], xyz[1], xyz[2])
+    const fromMat = (m: THREE.Matrix4): { xyz: [number, number, number]; rpy: [number, number, number] } => {
+      const p = new THREE.Vector3()
+      const q = new THREE.Quaternion()
+      m.decompose(p, q, new THREE.Vector3())
+      const e = new THREE.Euler().setFromQuaternion(q, 'ZYX') // URDF rpy convention
+      return { xyz: [p.x, p.y, p.z], rpy: [e.x, e.y, e.z] }
+    }
+    // Bake the child's own visual so it stays put.
+    const ov = readVisualOrigin(before, child) ?? { xyz: [0, 0, 0], rpy: [0, 0, 0] }
+    const nv = fromMat(relM.clone().multiply(toMat(ov.xyz, ov.rpy)))
+    let next = setVisualOrigin(stripped, child, nv.xyz, nv.rpy)
+    // Re-base the child's direct-child joints so the subtree keeps its world pose.
+    for (const j of readAllJoints(before)) {
+      if (j.parent !== child) continue
+      const nj = fromMat(relM.clone().multiply(toMat(j.xyz, j.rpy)))
+      next = setJointOrigin(next, j.child, nj.xyz, nj.rpy)
+    }
+    commitUrdf(next)
     setDialogCtx(null)
+    setSelectedLink(child)
   }
   const handlePropsOk = (): void => {
     editSnapshotRef.current = null

--- a/src/renderer/src/components/robot-assembly.ts
+++ b/src/renderer/src/components/robot-assembly.ts
@@ -253,20 +253,41 @@ export function setPrimitiveSize(urdf: string, link: string, dims: readonly numb
   return urdf.slice(0, span.bodyStart) + nextBody + urdf.slice(span.bodyEnd)
 }
 
-/** Insert-or-replace a link's `<visual><origin xyz>` (keeps the opposite face put). */
+/** Read a link's `<visual><origin>` (xyz + rpy), for ANY geometry (mesh included),
+ *  or null when the link has no visual. */
+export function readVisualOrigin(
+  urdf: string,
+  link: string
+): { xyz: [number, number, number]; rpy: [number, number, number] } | null {
+  const span = linkSpan(urdf, link)
+  if (!span) return null
+  const body = urdf.slice(span.bodyStart, span.bodyEnd)
+  const vs = visualSlice(body)
+  if (!vs) return null
+  const visual = body.slice(vs.start, vs.end)
+  const x = /<origin\b[^>]*\bxyz\s*=\s*"([^"]+)"/i.exec(visual)
+  const r = /<origin\b[^>]*\brpy\s*=\s*"([^"]+)"/i.exec(visual)
+  return { xyz: x ? parseVec3(x[1]) : [0, 0, 0], rpy: r ? parseVec3(r[1]) : [0, 0, 0] }
+}
+
+/** Insert-or-replace a link's `<visual><origin>` (keeps the opposite face put).
+ *  `rpy` defaults to zero; pass it to also orient the visual. Handles both the
+ *  self-closing and open `<origin>…</origin>` tag forms. */
 export function setVisualOrigin(
   urdf: string,
   link: string,
-  xyz: readonly [number, number, number]
+  xyz: readonly [number, number, number],
+  rpy: readonly [number, number, number] = [0, 0, 0]
 ): string {
   const span = linkSpan(urdf, link)
   if (!span) return urdf
   const body = urdf.slice(span.bodyStart, span.bodyEnd)
   const vs = visualSlice(body)
   if (!vs) return urdf
-  const tag = `<origin xyz="${fmtVec(xyz)}" rpy="0 0 0"/>`
+  const tag = `<origin xyz="${fmtVec(xyz)}" rpy="${fmtVec(rpy)}"/>`
+  const originRe = /<origin\b[^>]*\/>|<origin\b[^>]*>[\s\S]*?<\/origin>/i
   let visual = body.slice(vs.start, vs.end)
-  if (/<origin\b[^>]*\/>/i.test(visual)) visual = visual.replace(/<origin\b[^>]*\/>/i, tag)
+  if (originRe.test(visual)) visual = visual.replace(originRe, tag)
   else visual = visual.replace(/<visual\b[^>]*>/i, (v) => `${v}\n      ${tag}`)
   const nextBody = body.slice(0, vs.start) + visual + body.slice(vs.end)
   return urdf.slice(0, span.bodyStart) + nextBody + urdf.slice(span.bodyEnd)
@@ -598,6 +619,31 @@ export function addPrimitive(
   const idx = urdf.lastIndexOf('</robot>')
   const next = idx < 0 ? `${urdf.trimEnd()}\n${block}` : urdf.slice(0, idx) + block + urdf.slice(idx)
   return { urdf: ensureMaterial(next, 'steel'), link: name }
+}
+
+/**
+ * Remove the `<joint>` whose child is `childLink` (leaves the child a detached
+ * root — the caller keeps it in place / re-homes it). Returns the URDF unchanged
+ * when no such joint exists. Handles any joint-tag / attribute layout.
+ */
+export function removeJoint(urdf: string, childLink: string): string {
+  const re = /\s*<joint\b[^>]*>[\s\S]*?<\/joint>/gi
+  const childRe = new RegExp(`<child\\b[^>]*\\blink\\s*=\\s*"${escapeRe(childLink)}"`, 'i')
+  let removedName: string | undefined
+  let out = urdf.replace(re, (block) => {
+    if (!childRe.test(block)) return block
+    removedName = /\bname\s*=\s*"([^"]+)"/.exec(block)?.[1]
+    return '\n'
+  })
+  // A joint that MIMICKED the removed one now dangles — drop the stale <mimic>.
+  if (removedName) {
+    const mimicRe = new RegExp(
+      `\\s*<mimic\\b[^>]*\\bjoint\\s*=\\s*"${escapeRe(removedName)}"[^>]*\\/?>`,
+      'gi'
+    )
+    out = out.replace(mimicRe, '')
+  }
+  return out
 }
 
 /**

--- a/test/robotAssembly.test.ts
+++ b/test/robotAssembly.test.ts
@@ -9,7 +9,10 @@ import {
   connectJoint,
   orientJoint,
   subtreeOf,
-  readAllJoints
+  readAllJoints,
+  removeJoint,
+  readVisualOrigin,
+  setVisualOrigin
 } from '../src/renderer/src/components/robot-assembly'
 
 const URDF = `<?xml version="1.0"?>
@@ -192,6 +195,55 @@ describe('connectJoint — the Join tool (#354)', () => {
     expect(js.find((x) => x.child === 'a')!.parent).toBe('base') // untouched
     // Still exactly 3 joints (no dupes / drops).
     expect(js.length).toBe(3)
+  })
+
+  it('removeJoint removes the joint whose child matches — incl. a TOP-LEVEL joint', () => {
+    // The reported bug: a joint straight off the base couldn't be deleted.
+    const flat = `<?xml version="1.0"?>
+<robot name="r">
+  <link name="base_link"/>
+  <link name="partA"/>
+  <link name="partB"/>
+  <joint name="jA" type="fixed"><parent link="base_link"/><child link="partA"/><origin xyz="0 0 0.1"/></joint>
+  <joint name="jB" type="fixed"><parent link="base_link"/><child link="partB"/></joint>
+</robot>`
+    const out = removeJoint(flat, 'partA')
+    expect(out).not.toContain('name="jA"') // the joint is gone
+    expect(readAllJoints(out).map((j) => j.child)).toEqual(['partB']) // only jB remains
+    expect(out).toContain('<link name="partA"/>') // the link itself is kept (now a root)
+  })
+
+  it('removeJoint is a no-op when no joint has that child', () => {
+    expect(removeJoint(URDF, 'base_link')).toBe(URDF) // the root has no parent joint
+    expect(removeJoint(URDF, 'nope')).toBe(URDF)
+  })
+
+  it('removeJoint strips a dangling <mimic> reference to the removed joint', () => {
+    const withMimic = `<?xml version="1.0"?>
+<robot name="r">
+  <link name="base"/><link name="a"/><link name="b"/>
+  <joint name="j_master" type="revolute"><parent link="base"/><child link="a"/><axis xyz="0 0 1"/><limit lower="-1" upper="1" effort="1" velocity="1"/></joint>
+  <joint name="j_follow" type="revolute"><parent link="base"/><child link="b"/><axis xyz="0 0 1"/><limit lower="-1" upper="1" effort="1" velocity="1"/><mimic joint="j_master" multiplier="1" offset="0"/></joint>
+</robot>`
+    const out = removeJoint(withMimic, 'a') // removes j_master
+    expect(out).not.toContain('name="j_master"')
+    expect(out).not.toContain('<mimic') // the follower's dangling mimic is gone
+    expect(readAllJoints(out).map((j) => j.child)).toEqual(['b'])
+  })
+
+  it('readVisualOrigin reads a mesh link visual origin (xyz + rpy)', () => {
+    const u = `<?xml version="1.0"?>
+<robot name="r">
+  <link name="m"><visual><origin xyz="0.02 0 0.01" rpy="0 1.5708 0"/><geometry><mesh filename="x.stl"/></geometry></visual></link>
+</robot>`
+    const vo = readVisualOrigin(u, 'm')!
+    expect(vo.xyz).toEqual([0.02, 0, 0.01])
+    expect(vo.rpy.map((v) => Math.round(v * 1e4) / 1e4)).toEqual([0, 1.5708, 0])
+    // setVisualOrigin round-trips xyz + rpy.
+    const w = setVisualOrigin(u, 'm', [0.1, 0.2, 0.3], [0.5, 0, 0])
+    const vo2 = readVisualOrigin(w, 'm')!
+    expect(vo2.xyz).toEqual([0.1, 0.2, 0.3])
+    expect(vo2.rpy).toEqual([0.5, 0, 0])
   })
 
   it('subtreeOf collects a link + its descendants', () => {


### PR DESCRIPTION
**Bug:** you couldn't delete the two pre-existing fixed joints — Delete re-attached the child to the base, which is a no-op for a joint already off the base, so the joint stayed.

**Fix:** Delete now **strips the joint** (the child becomes a free-standing root) and keeps the whole sub-assembly exactly in place — the child's visual origin is baked with its full world transform, and each of the child's **direct-child joints** is pre-multiplied by that transform so descendants don't teleport.

## Adversarial review of the first attempt caught 5 issues (all fixed)
- **[HIGH]** a child *with a subtree* teleported its descendants (a root has no frame) → direct-child joints are re-based so the subtree keeps its world pose.
- **[HIGH]** the bake dropped rotation (translation-only, rpy=0) → full rel matrix composed + decomposed to xyz+rpy; `setVisualOrigin` gained an `rpy` arg.
- **[MED]** a mesh link's existing visual origin was lost (`readPrimitive` is null for meshes) → new `readVisualOrigin` reads it for any geometry.
- **[MED]** removing a `<mimic>` master left a dangling reference (loader crash) → `removeJoint` strips `<mimic joint="removed">` from followers.
- **[LOW]** the Delete tooltip was stale.

## Verification
- `npm run typecheck` / `lint` / `npm test` (**1542**, + removeJoint/mimic + readVisualOrigin round-trip) / `build` ✅
- Playwright E2E: deleting a top-level fixed joint removes it and keeps the block; deleting a joint whose child has a subtree removes it and keeps both the block and its descendant in place (visual baked, child joint re-based).

Next (your latest messages): SHIFT-lock snap + on-surface hover target + hole cross-hair/circle; and the new selected-item highlight (light blue + shadow + black outline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)