### PR TITLE
fix: Robot View — first-block-only fade, dialog drag jump, pop-out home view (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -250,6 +250,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   or reopen any panel. Nothing about Robot mode is permanently changed.
 
 ### Fixed
+- **Robot View — Join tool: only the first block fades.** Picking Component 1 faded
+  the whole robot, because its material is usually shared (everything uses "steel");
+  the fade now swaps in a transparent clone for just that block's mesh, so every
+  other object stays solid and pickable as Component 2.
+- **Robot View — the properties / Add-Joint dialog drags in place.** It jumped down
+  and right on the first drag because the pointer's viewport coordinates were applied
+  as `left`/`top` relative to the 3-D stage; the drag now converts by the stage offset.
+- **Robot View — Pop-out opens in the home view.** Popping the robot out full-screen
+  reused a preserved camera, so it wasn't fit/oriented; it now re-frames to home
+  (as if you clicked the Home button) when it goes full-screen.
 - **Robot View — deleting a joint now actually removes it (#354).** Delete used to
   re-attach the block to the base, which is a no-op for a joint that's already off
   the base — so those joints (e.g. the two fixed joints in a fresh robot) couldn't

--- a/src/renderer/src/components/RobotPropertiesDialog.tsx
+++ b/src/renderer/src/components/RobotPropertiesDialog.tsx
@@ -101,16 +101,27 @@ export function RobotPropertiesDialog(props: RobotPropertiesDialogProps): JSX.El
   const commitRef = useRef<(() => void | boolean) | null>(null)
 
   // Drag the dialog by its title bar. `pos` null = the default docked spot (CSS).
+  // `left`/`top` are relative to the dialog's positioned ancestor (the 3-D stage),
+  // NOT the viewport — so we convert the (viewport) pointer coords by the ancestor's
+  // offset; otherwise the dialog jumps by that offset on the first move.
   const [pos, setPos] = useState<{ x: number; y: number } | null>(null)
-  const drag = useRef<{ dx: number; dy: number } | null>(null)
+  const drag = useRef<{ dx: number; dy: number; ox: number; oy: number } | null>(null)
   const onHeadDown = (e: React.PointerEvent): void => {
-    const rect = (e.currentTarget.parentElement as HTMLElement).getBoundingClientRect()
-    drag.current = { dx: e.clientX - rect.left, dy: e.clientY - rect.top }
+    const aside = e.currentTarget.parentElement as HTMLElement
+    const rect = aside.getBoundingClientRect()
+    const parent = (aside.offsetParent as HTMLElement | null)?.getBoundingClientRect()
+    drag.current = {
+      dx: e.clientX - rect.left, // cursor offset within the dialog
+      dy: e.clientY - rect.top,
+      ox: parent?.left ?? 0, // the ancestor's viewport offset
+      oy: parent?.top ?? 0
+    }
     ;(e.target as HTMLElement).setPointerCapture?.(e.pointerId)
   }
   const onHeadMove = (e: React.PointerEvent): void => {
     if (!drag.current) return
-    setPos({ x: e.clientX - drag.current.dx, y: e.clientY - drag.current.dy })
+    const d = drag.current
+    setPos({ x: e.clientX - d.dx - d.ox, y: e.clientY - d.dy - d.oy })
   }
   const onHeadUp = (e: React.PointerEvent): void => {
     drag.current = null

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -6,6 +6,7 @@ import { ColladaLoader } from 'three/examples/jsm/loaders/ColladaLoader.js'
 import URDFLoader from 'urdf-loader'
 import type { URDFRobot } from 'urdf-loader'
 import { useWorkspace } from '../store/workspace'
+import { useWorkspaceLayout } from '../store/layout'
 import { baseName, dirname, meshKind } from './robot-mesh'
 import { RobotJointPanel, type NamedPoseLike } from './RobotJointPanel'
 import {
@@ -759,6 +760,16 @@ export function RobotView({
     const dim = jointPick?.parent && !jointPick?.child ? jointPick.parent.link : null
     jointPickApiRef.current?.dim(dim)
   }, [jointPick])
+
+  // Popping the robot out full-screen (the dock's Pop-out enters focus mode) should
+  // open in the HOME view — but a RobotView already mounted for this file keeps its
+  // preserved camera. Re-frame home on the transition into focus (full-screen only).
+  const { focus: layoutFocus } = useWorkspaceLayout()
+  const prevFocusRef = useRef(layoutFocus)
+  useEffect(() => {
+    if (poseUI && layoutFocus && !prevFocusRef.current) zoomApiRef.current?.home()
+    prevFocusRef.current = layoutFocus
+  }, [layoutFocus, poseUI])
 
   // ── Servo → joint binding + code-driven simulation (#313) ──────────────────
   // The KRF servo↔joint map, loaded from robot.yml. Kept in a ref for the
@@ -1994,15 +2005,21 @@ export function RobotView({
               if (l.geometry) l.geometry.dispose()
             })
           }
-          // Fusion-style: fade the first-picked block so it's obvious it's chosen
-          // (and can't be re-picked as the second). Restores the original materials.
+          // Fusion-style: fade ONLY the first-picked block (so it's obviously chosen
+          // and can't be re-picked as the second). The block's material is usually
+          // SHARED across links (e.g. everything uses "steel"), so editing it in place
+          // would fade the whole robot — instead we swap in a transparent CLONE for
+          // just this link's mesh and restore (+ dispose the clone) on un-dim.
           type DimMat = THREE.Material & { transparent: boolean; opacity: number }
-          let dimmed: { mat: DimMat; transparent: boolean; opacity: number }[] = []
+          let dimmed: {
+            mesh: THREE.Mesh
+            orig: THREE.Material | THREE.Material[]
+            clones: THREE.Material[]
+          }[] = []
           const dimLink = (link: string | null): void => {
             for (const d of dimmed) {
-              d.mat.transparent = d.transparent
-              d.mat.opacity = d.opacity
-              d.mat.needsUpdate = true
+              d.mesh.material = d.orig
+              d.clones.forEach((c) => c.dispose())
             }
             dimmed = []
             const lo = link && robotRef.current?.links[link]
@@ -2010,14 +2027,16 @@ export function RobotView({
             lo.traverse((o) => {
               const mesh = o as THREE.Mesh
               if (!mesh.isMesh || ownerLinkName(mesh) !== link) return // this link's own visual only
-              const mats = Array.isArray(mesh.material) ? mesh.material : [mesh.material]
-              for (const mat of mats) {
-                const m = mat as DimMat
-                dimmed.push({ mat: m, transparent: m.transparent, opacity: m.opacity })
-                m.transparent = true
-                m.opacity = 0.28
-                m.needsUpdate = true
+              const orig = mesh.material
+              const mk = (m: THREE.Material): THREE.Material => {
+                const c = m.clone() as DimMat
+                c.transparent = true
+                c.opacity = 0.28
+                return c
               }
+              const clones = Array.isArray(orig) ? orig.map(mk) : [mk(orig)]
+              mesh.material = Array.isArray(orig) ? clones : clones[0]
+              dimmed.push({ mesh, orig, clones })
             })
           }
           const clearJointMarkers = (): void => {


### PR DESCRIPTION
Three small Robot View bugs from recent reports.

## Only the first block fades
Picking Component 1 faded the **whole robot** — its material is usually **shared** (everything uses `steel`), so editing it in place hit every mesh. The fade now swaps in a transparent **clone** for just that link's mesh (restored + disposed on un-dim); every other object stays solid and pickable as Component 2.

## Dialog drags in place
The properties / Add-Joint dialog **jumped down-and-right** on the first drag: the pointer's *viewport* coords were written as `left`/`top`, which are relative to the dialog's positioned ancestor (the 3-D stage). The drag now subtracts the ancestor's offset, so it tracks the cursor exactly.

## Pop-out opens in the home view
Popping the robot out full-screen reused a **preserved camera** (a RobotView already mounted for that file), so it didn't open framed. It now re-frames to **home** (fit + home orientation) on the transition into focus mode — as if you hit the Home button.

## Verification
- `npm run typecheck` / `lint` / `npm test` (1542) / `build` ✅
- Playwright E2E: picking a block fades **only it** (others solid — screenshot); dragging the dialog moves it by **exactly** the drag delta `(120,80)`; after zooming to 207% and re-popping-out, the view returns to **100%** (home).

🤖 Generated with [Claude Code](https://claude.com/claude-code)