### PR TITLE
fix: Robot View — make the joint-pick cross-hair directly clickable (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   timeline follow.
 
 ### Changed
+- **Robot View — Join tool: the snap target is now directly clickable (#354).** The
+  on-surface cross-hair showed exactly where a joint would land — but a click still
+  measured its own pixel distance and often dropped a raw surface point instead, so
+  the hole centre you were aiming at was frustratingly un-clickable. A click now
+  lands on **exactly the snap the cross-hair is showing** (what-you-see-is-what-you
+  -get), and the cross-hair **stays put as you move onto a hole** without needing to
+  hold Shift (Shift still force-locks for large holes). A side effect: on a
+  primitive block a joint pick always snaps to the nearest face handle
+  (corner/edge/centre) — the exact point the target marker previews.
 - **Robot View — a clearer selection highlight.** The selected block was outlined
   with a brass wireframe of every edge, which read as a see-through cage. It's now
   tinted **light blue** (keeping the material's shading, so the sides still shade

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -1916,8 +1916,12 @@ export function RobotView({
             let best = Infinity
             pts.forEach((p, i) => {
               const v = p.clone().project(camera)
+              // Reject points behind the camera / outside the depth frustum: their
+              // mirrored NDC would otherwise masquerade as a nearby on-screen snap.
+              if (!(v.z >= -1 && v.z <= 1)) return
               const sx = (v.x * 0.5 + 0.5) * rect.width
               const sy = (-v.y * 0.5 + 0.5) * rect.height
+              if (!Number.isFinite(sx) || !Number.isFinite(sy)) return
               const d = Math.hypot(sx - px, sy - py)
               if (d < best) {
                 best = d
@@ -2231,15 +2235,32 @@ export function RobotView({
           const pickJointPoint = (e: PointerEvent): void => {
             const robot = robotRef.current
             if (!robot) return
-            buildNdcFrom(e)
-            buildRay.setFromCamera(buildNdc, camera)
-            const hit = buildRay.intersectObject(robot, true).find((h) => h.face)
             const jr = jointPickRef.current
             let link: string | null = null
-            let world: THREE.Vector3
-            let worldNormal: THREE.Vector3
+            let world: THREE.Vector3 | null = null
+            let worldNormal: THREE.Vector3 | null = null
             let role = 'point'
-            if (hit) {
+            // WYSIWYG: a click lands on exactly the snap the hover cross-hair is
+            // showing (its nearest snap on the last-hovered surface). This makes the
+            // on-surface target — including a hole centre drawn over empty space —
+            // directly clickable, with no pixel-threshold gap and no need to hold
+            // SHIFT to reach it.
+            if (hoverSnaps && hoverSnaps.pts.length && robot.links[hoverSnaps.link]) {
+              const near = nearestScreen(hoverSnaps.pts, e)
+              if (near.index >= 0) {
+                link = hoverSnaps.link
+                world = hoverSnaps.pts[near.index].clone()
+                worldNormal = hoverSnaps.worldNormal.clone()
+                role = hoverSnaps.roles[near.index]
+              }
+            }
+            if (!world) {
+              // Fallback (no live hover target, e.g. a mesh face with no detectable
+              // snaps): raycast the surface under the cursor and snap if close.
+              buildNdcFrom(e)
+              buildRay.setFromCamera(buildNdc, camera)
+              const hit = buildRay.intersectObject(robot, true).find((h) => h.face)
+              if (!hit) return
               link = ownerLinkName(hit.object)
               if (!link || !robot.links[link]) return
               const mesh = hit.object as THREE.Mesh
@@ -2252,17 +2273,8 @@ export function RobotView({
                 world = th.pts[near.index].clone()
                 role = th.roles[near.index]
               }
-            } else if (e.shiftKey && hoverSnaps && hoverSnaps.pts.length) {
-              // SHIFT-locked: clicking over empty space (e.g. a hole centre, where
-              // there is no surface to hit) lands on the nearest frozen snap.
-              link = hoverSnaps.link
-              if (!robot.links[link]) return
-              const near = nearestScreen(hoverSnaps.pts, e)
-              if (near.index < 0) return
-              world = hoverSnaps.pts[near.index].clone()
-              worldNormal = hoverSnaps.worldNormal.clone()
-              role = hoverSnaps.roles[near.index]
-            } else return
+            }
+            if (!link || !world || !worldNormal) return
             // Reject a same-block pick (marker/state desync).
             if (jr.step === 'child' && jr.parentLink === link) return
             if (jr.step === 'parent' && jr.childLink === link) return
@@ -2273,6 +2285,10 @@ export function RobotView({
             const linkNormal = worldNormal.clone().applyQuaternion(lq.invert()) // face normal, link-local
             setJointMarker(world, worldNormal, jr.step === 'child')
             clearHoverMarker()
+            // Drop the consumed snaps so the NEXT pick (e.g. the child after the
+            // parent) can't reuse this surface's stale snap without a fresh hover —
+            // absent a new hover it falls through to the raycast under the cursor.
+            hoverSnaps = null
             onJointPickRef.current?.(
               link,
               [local.x, local.y, local.z],
@@ -2423,8 +2439,15 @@ export function RobotView({
               if (hit) {
                 const s = computeSnaps(hit)
                 if (s) hoverSnaps = s
-              } else if (!e.shiftKey) {
-                hoverSnaps = null // over empty space + not locking → forget the snaps
+              } else if (hoverSnaps && hoverSnaps.pts.length) {
+                // Over empty space (e.g. inside a hole). Keep the last surface's
+                // snaps while one is still near the cursor so the hole cross-hair
+                // stays put — and stays clickable — as you move onto it. SHIFT
+                // force-locks them regardless of distance (large holes).
+                const near = nearestScreen(hoverSnaps.pts, e)
+                if (!e.shiftKey && (near.index < 0 || near.distPx > 90)) hoverSnaps = null
+              } else {
+                hoverSnaps = null
               }
               if (!hoverSnaps || !hoverSnaps.pts.length) {
                 clearHandles()


### PR DESCRIPTION
## The bug
> I can see it's accurately found the hole and placed the cross-hairs around it, but it refuses to place a snap point at that point… make those centre cross-hairs clickable — the SHIFT hold isn't working.

The on-surface **cross-hair showed exactly where the joint would land**, but a click ran its *own* raycast + pixel-distance test and usually dropped a **raw surface point** instead. So the hole centre you were aiming at wasn't clickable, and the SHIFT-lock-over-empty-space workaround was fiddly.

## The fix
- **A click lands on exactly the snap the cross-hair is showing** (WYSIWYG). `pickJointPoint` now takes `hoverSnaps.pts[nearest]` — the same point the hover marker draws — instead of re-raycasting with a threshold. The raycast+snap path stays only as a **fallback** for a mesh face with no detectable snaps.
- **The cross-hair stays put as you move onto a hole** (nearest snap within ~90px), so it's clickable **without holding SHIFT**. SHIFT still force-locks for large holes.

Net effect: hover near the hole → the cross-hair snaps to its centre → click → the joint lands on the hole.

## Review follow-ups
Ran a 3-lens adversarial review (correctness / regression / edge, each finding verified by a skeptic). All confirmed findings were **LOW**; the two worth acting on are fixed here:
- **Reset `hoverSnaps` after a committed pick** so a stale parent snap can't carry into the child pick (also closes a touch-tap wrong-link path).
- **Harden `nearestScreen`** to reject behind-camera / non-finite projections, restoring the `index === -1` contract the pick now relies on.

One intentional behaviour, documented in the CHANGELOG: on a **primitive** block a joint pick always snaps to the nearest face handle (corner/edge/centre) — the exact point the target marker previews. (Free arbitrary-point picks on a bare primitive face are no longer selectable; that's the WYSIWYG trade-off.)

## Verification
- `npm run typecheck` / `lint` (only the pre-existing DriverInstallBanner warning) / `npm test` (1542) / `build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)