### PR TITLE
feat: Robot View — import parts loose, pick a base, join them into a chain (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Robot View — import parts loose, pick a base, then join them into a chain (#354).**
+  Imported STLs no longer auto-weld to the first part with a hidden fixed joint (which
+  fused everything into one rigid blob). Each import now comes in as a **loose,
+  unconnected part**, listed under a new **"Not connected yet"** group with a friendly
+  hint. You **pick which part is the base** (its ☆ — the anchor everything hangs off,
+  remembered in `robot.yml`), then use **Add Joint** to build the kinematic chain; each
+  part leaves "Not connected yet" as it's joined. When several parts are loose and no
+  base is obvious, a "⭐ Pick a base part to start your robot" prompt guides you.
 - **Robot View — Join tool: SHIFT-lock snapping + an on-surface target (#354).**
   While picking a joint point, an accurate **target** is drawn on the surface (a
   circle + X/Y/Z axis triad; a **cross-hair** over a hole / loop centre) so you can

--- a/src/renderer/src/components/RobotBuildPanel.css
+++ b/src/renderer/src/components/RobotBuildPanel.css
@@ -127,6 +127,41 @@
   color: var(--text-muted, #8b919b);
 }
 
+/* "Pick a base" prompt + the loose-parts helpers (#354). Amber attention tones as
+   translucent overlays so they read on BOTH the dark and light (parchment) skins. */
+.robotbuild__basehint {
+  margin: 0 0 0.15rem;
+  padding: 0.3rem 0.4rem;
+  font-size: 0.6rem;
+  line-height: 1.3;
+  color: var(--text, #cdd2d9);
+  background: rgba(230, 160, 60, 0.14);
+  border: 1px solid rgba(230, 160, 60, 0.4);
+  border-radius: 6px;
+}
+.robotbuild__loosehint {
+  list-style: none;
+  margin: 0;
+  padding: 0.1rem 0.35rem 0.25rem;
+  font-size: 0.55rem;
+  line-height: 1.3;
+  color: var(--text-muted, #8b919b);
+}
+.robotbuild__part.is-loose {
+  border-left: 2px solid rgba(230, 160, 60, 0.5);
+}
+.robotbuild__loosebadge {
+  flex: 0 0 auto;
+  font-size: 0.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding: 0.05rem 0.3rem;
+  border-radius: 999px;
+  color: #b5651d;
+  background: rgba(230, 160, 60, 0.18);
+  border: 1px solid rgba(230, 160, 60, 0.45);
+}
+
 /* The hierarchy tree scrolls as one under the dock's max-height. */
 .robotbuild__tree {
   flex: 1 1 auto;

--- a/src/renderer/src/components/RobotBuildPanel.tsx
+++ b/src/renderer/src/components/RobotBuildPanel.tsx
@@ -373,6 +373,7 @@ function BodyRow({
   isSel,
   isEdit,
   isRoot,
+  loose = false,
   onSelect,
   onEdit,
   onMakeBase,
@@ -382,13 +383,14 @@ function BodyRow({
   isSel: boolean
   isEdit: boolean
   isRoot: boolean
+  loose?: boolean
   onSelect: (link: string) => void
   onEdit: (link: string | null) => void
   onMakeBase: (link: string) => void
   onDelete: (link: string) => void
 }): JSX.Element {
   return (
-    <li className={`robotbuild__part${isSel ? ' is-sel' : ''}`}>
+    <li className={`robotbuild__part${isSel ? ' is-sel' : ''}${loose ? ' is-loose' : ''}`}>
       <div className="robotbuild__part-row">
         {/* Action icons sit to the LEFT of the name so they never overlap long
             titles (the name button flexes to fill the rest). */}
@@ -441,6 +443,11 @@ function BodyRow({
             {it.kind === 'mesh' ? baseName(it.mesh ?? '') : it.kind}
           </span>
         </button>
+        {loose && (
+          <span className="robotbuild__loosebadge" title="Not connected — join it into the robot">
+            not connected
+          </span>
+        )}
       </div>
     </li>
   )
@@ -477,8 +484,15 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({})
   const toggle = (id: string): void => setCollapsed((c) => ({ ...c, [id]: !c[id] }))
 
-  const blocks = assembly.filter((it) => it.kind !== 'mesh')
-  const meshes = assembly.filter((it) => it.kind === 'mesh')
+  // A part is LOOSE (not connected yet) when it has no parent joint AND it isn't the
+  // chosen base — i.e. an imported part still waiting to be joined into the chain.
+  const jointChildren = new Set(joints.map((j) => j.child))
+  const isLoose = (it: AssemblyItem): boolean => !jointChildren.has(it.link) && it.link !== rootLink
+  const looseParts = assembly.filter(isLoose)
+  const blocks = assembly.filter((it) => it.kind !== 'mesh' && !isLoose(it))
+  const meshes = assembly.filter((it) => it.kind === 'mesh' && !isLoose(it))
+  // No base picked yet but parts exist → prompt the user to choose one.
+  const needsBase = rootLink === null && assembly.length > 0
   const editLink = active?.kind === 'link' ? active.link : null
 
   if (!open) {
@@ -538,6 +552,40 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
       )}
 
       <div className="robotbuild__tree">
+        {needsBase && (
+          <p className="robotbuild__basehint">
+            ⭐ Pick a <strong>base</strong> part (tap its ☆) — it&rsquo;s the anchor the
+            rest of the robot hangs off.
+          </p>
+        )}
+        {looseParts.length > 0 && (
+          <Section
+            id="loose"
+            label="Not connected yet"
+            count={looseParts.length}
+            collapsed={collapsed}
+            onToggle={toggle}
+          >
+            <li className="robotbuild__loosehint">
+              Join each of these to your robot with the Add Joint tool — or tap ☆ to make
+              one the base.
+            </li>
+            {looseParts.map((it) => (
+              <BodyRow
+                key={it.link}
+                it={it}
+                isSel={it.link === selected}
+                isEdit={it.link === editLink}
+                isRoot={false}
+                loose
+                onSelect={onSelect}
+                onEdit={onEdit}
+                onMakeBase={onMakeBase}
+                onDelete={onDelete}
+              />
+            ))}
+          </Section>
+        )}
         <Section id="blocks" label="Blocks" count={blocks.length} collapsed={collapsed} onToggle={toggle}>
           {blocks.map((it) => (
             <BodyRow

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -23,6 +23,7 @@ import {
   addPrimitive,
   connectJoint,
   jointNames,
+  looseLinks,
   parseAssembly,
   readAllJoints,
   readJoint,
@@ -41,7 +42,7 @@ import {
   type JointType,
   type PrimitiveGeom
 } from './robot-assembly'
-import { reRoot } from './robot-reroot'
+import { canReRoot, reRoot } from './robot-reroot'
 import { createViewCube } from './robot-viewcube'
 import {
   historyInit,
@@ -340,6 +341,9 @@ export function RobotView({
     loadPin(window.localStorage, PIN_KEYS.builder, true)
   )
   const [selectedLink, setSelectedLink] = useState<string | null>(null)
+  // The link the user designated as the base (root) of the chain, from robot.yml.
+  // Distinguishes the intended base from other still-unconnected imported parts (#354).
+  const [chosenBase, setChosenBase] = useState<string | null>(null)
   // The hierarchy node whose context dialog (#353) is open — a block/mesh, a
   // joint, a servo binding or a pose. `editLink` (the block whose URDF is being
   // edited + highlighted in 3-D) is DERIVED from it (link + joint contexts).
@@ -432,7 +436,17 @@ export function RobotView({
     [content, editLink]
   )
   const allJointNames = useMemo(() => jointNames(content), [content])
-  const rootName = useMemo(() => rootLink(content) ?? null, [content])
+  // The effective base for the hierarchy's ★ marker: the user's chosen base if it's
+  // still a root, else the sole root of a single-tree robot, else null — meaning
+  // several loose parts and no base picked yet (the panel then prompts to pick one).
+  const effectiveBaseLink = useMemo(() => {
+    const roots = looseLinks(content) // every childless link
+    if (chosenBase && roots.includes(chosenBase)) return chosenBase
+    if (roots.length === 1) return roots[0] // a single-tree robot: its sole root
+    // Several roots + no explicit choice: honour the conventional `base_link` (the
+    // new-robot starter's base) if present, else prompt the user to pick one.
+    return roots.includes('base_link') ? 'base_link' : null
+  }, [content, chosenBase])
 
   const setBuildPinnedPersist = (p: boolean): void => {
     setBuildPinned(p)
@@ -553,14 +567,30 @@ export function RobotView({
     commitUrdf(setJoint(content, link, spec))
   }
   const handleDeleteLink = (link: string): void => {
-    // Deleting the root would cascade-remove the whole tree → an empty, unusable
-    // URDF. The UI disables it; guard here too. Re-root onto a keeper first.
-    if (link === rootLink(content)) return
+    // Deleting the base would cascade-remove the whole tree → an empty, unusable
+    // URDF. The UI disables it; guard here too. (A loose, unconnected part is fine
+    // to delete — it just removes that one link.)
+    if (link === effectiveBaseLink) return
     commitUrdf(removeLink(content, link))
     setSelectedLink(null)
     setDialogCtx(null)
   }
   const handleMakeBase = (link: string): void => {
+    // A link can become the base only if it's already a root (a loose part) or it can
+    // be re-rooted up to the current root. A link stuck in a SEPARATE, still-detached
+    // sub-assembly can't yet — persisting it would leave robot.yml pointing at a base
+    // the UI will never honour. Guide the user to connect it first instead.
+    const isRoot = looseLinks(content).includes(link)
+    if (!isRoot && !canReRoot(content, link)) {
+      setSavingLabel('connect this part to the rest first to make it the base')
+      return
+    }
+    // Record the choice in robot.yml AND re-root the tree onto it (a no-op flip when
+    // the link is already a loose root; flips the joint chain when it isn't).
+    setChosenBase(link)
+    void persist((m) => {
+      m.baseLink = link
+    })
     commitUrdf(reRoot(content, link))
   }
   // Properties dialog (#352 / #353): clicking a node opens its context here. For a
@@ -1078,8 +1108,9 @@ export function RobotView({
           /* leave scale 1 if the mesh can't be measured */
         }
       }
-      // Add the mesh to the URDF (a new link + fixed joint at the origin) so it
-      // renders now. Select it + reframe so the user can see + place it.
+      // Add the mesh as a LOOSE link (no joint) so it renders now but stays an
+      // unconnected part — the user picks the base + joins it into the chain. Select
+      // it + reframe so the user can see + place it.
       const linkBase = res.name?.replace(/\.(stl|dae)$/i, '') ?? 'part'
       const next = addMeshLink(content, { meshRel: res.rel, linkBase, scale })
       refitNextRef.current = true
@@ -1089,7 +1120,11 @@ export function RobotView({
       setSelectedLink(next.link)
       setDialogCtx({ kind: 'link', link: next.link })
       if (!buildOpen) setBuildOpen(true)
-      setSavingLabel(scale !== 1 ? `added ${next.link} (scaled mm→m)` : `added ${next.link}`)
+      setSavingLabel(
+        scale !== 1
+          ? `added ${next.link} (scaled mm→m) — now join it to your robot`
+          : `added ${next.link} — now join it to your robot`
+      )
     } catch (e) {
       setSavingLabel(`import failed: ${e instanceof Error ? e.message : 'error'}`)
     } finally {
@@ -1614,6 +1649,7 @@ export function RobotView({
               if (disposed || !robotRef.current) return
               defRef.current = def
               const model = def.robot ?? {}
+              setChosenBase(typeof model.baseLink === 'string' ? model.baseLink : null)
               const ov = (model.joints ?? {}) as Record<string, { min?: number; max?: number }>
               const dp = model.defaultPose ?? {}
               const nv = { ...initial }
@@ -2840,7 +2876,7 @@ export function RobotView({
             onOpenJoint={handleOpenJoint}
             onOpenServo={handleOpenServo}
             onOpenPose={handleOpenPose}
-            rootLink={rootName}
+            rootLink={effectiveBaseLink}
             onMakeBase={handleMakeBase}
             onDelete={handleDeleteLink}
             onImportStl={() => void handleImportStl()}

--- a/src/renderer/src/components/robot-assembly.ts
+++ b/src/renderer/src/components/robot-assembly.ts
@@ -1,15 +1,15 @@
 /**
  * ROBOT ASSEMBLY HELPERS (epic #309) — pure text utilities for the pose tool's
  * assembly panel + STL import: reading a URDF's links + the mesh files they use,
- * and appending an imported mesh as a new link/joint. Regex-based (no DOM) so
- * they're cheap to unit-test in a node env.
+ * and appending an imported mesh as a new (loose, unconnected) link. Regex-based
+ * (no DOM) so they're cheap to unit-test in a node env.
  */
 import type { PrimitiveKind, Vec3 } from './robot-build'
 
 /**
  * A minimal, VALID starter URDF: one `base_link` with a small box so the pose
- * tool renders something and an imported STL (via `addMeshLink`) has a root to
- * attach to. `name` is sanitised to a URDF-safe robot name.
+ * tool renders something out of the box. Imported STLs come in as loose parts the
+ * user joins explicitly. `name` is sanitised to a URDF-safe robot name.
  */
 export function blankUrdf(name = 'my_robot'): string {
   const safe = name.replace(/[^A-Za-z0-9_]+/g, '_').replace(/^_+|_+$/g, '') || 'my_robot'
@@ -102,24 +102,18 @@ export function uniqueLinkName(urdf: string, base: string): string {
 }
 
 /**
- * Append an imported mesh to a URDF as a new link (+ a fixed joint onto the root
- * link) so it shows in the model immediately. `meshRel` is the mesh path
- * relative to the URDF folder (e.g. `meshes/wheel.stl`). Returns the new URDF
- * text and the created link name.
+ * Append an imported mesh to a URDF as a new **loose** link — no joint, so it
+ * comes in as an unconnected part (a root) the user then designates as the base
+ * or joins into the chain with the Add Joint tool. (Auto-welding every import to
+ * the root with a fixed joint fused the whole assembly into one rigid blob.)
+ * `meshRel` is the mesh path relative to the URDF folder (e.g. `meshes/wheel.stl`).
+ * Returns the new URDF text and the created link name.
  */
 export function addMeshLink(
   urdf: string,
   opts: { meshRel: string; linkBase: string; scale?: number }
 ): { urdf: string; link: string } {
-  const parent = rootLink(urdf)
   const name = uniqueLinkName(urdf, opts.linkBase)
-  const joint = parent
-    ? `  <joint name="${name}_joint" type="fixed">\n` +
-      `    <parent link="${parent}"/>\n` +
-      `    <child link="${name}"/>\n` +
-      `    <origin xyz="0 0 0" rpy="0 0 0"/>\n` +
-      `  </joint>\n`
-    : '' // first link of an empty URDF needs no joint
   // A `scale` normalises a mesh authored in different units (e.g. mm → m).
   const s = opts.scale && opts.scale !== 1 ? ` scale="${fmtNum(opts.scale)} ${fmtNum(opts.scale)} ${fmtNum(opts.scale)}"` : ''
   const block =
@@ -127,11 +121,24 @@ export function addMeshLink(
     `    <visual>\n` +
     `      <geometry><mesh filename="${opts.meshRel}"${s}/></geometry>\n` +
     `    </visual>\n` +
-    `  </link>\n` +
-    joint
+    `  </link>\n`
   const idx = urdf.lastIndexOf('</robot>')
   const next = idx < 0 ? `${urdf.trimEnd()}\n${block}` : urdf.slice(0, idx) + block + urdf.slice(idx)
   return { urdf: next, link: name }
+}
+
+/**
+ * The **unconnected** links: every link that is a root (never a joint's `<child>`)
+ * EXCEPT the chosen base. These are parts imported but not yet joined into the
+ * chain. `base` is the designated base link (from robot.yml, or the sole root).
+ */
+export function looseLinks(urdf: string, base?: string | null): string[] {
+  const links = parseAssembly(urdf).map((i) => i.link)
+  const children = new Set<string>()
+  const re = /<child\b[^>]*\blink\s*=\s*"([^"]+)"/gi
+  let m: RegExpExecArray | null
+  while ((m = re.exec(urdf))) children.add(m[1])
+  return links.filter((l) => !children.has(l) && l !== base)
 }
 
 // ── Primitive builder (#315a) ────────────────────────────────────────────────

--- a/src/shared/krf.ts
+++ b/src/shared/krf.ts
@@ -159,6 +159,7 @@ export function sanitiseRobotModel(raw: unknown): RobotModel | undefined {
   const model: RobotModel = { version: KRF_VERSION }
 
   if (isStr(r.urdf) && r.urdf.trim()) model.urdf = r.urdf.trim()
+  if (isStr(r.baseLink) && r.baseLink.trim()) model.baseLink = r.baseLink.trim()
 
   if (Array.isArray(r.servoJointMap)) {
     const map = r.servoJointMap.map(sanitiseBinding).filter((b): b is ServoJointBinding => b !== null)

--- a/src/shared/robot.ts
+++ b/src/shared/robot.ts
@@ -53,6 +53,10 @@ export interface RobotModel {
   version?: number
   /** Path to the `.urdf` file, relative to the project root (e.g. `urdf/arm.urdf`). */
   urdf?: string
+  /** The link the user designated as the base (root) of the kinematic tree — the
+   *  anchor every other part hangs off. Distinguishes the intended base from other
+   *  as-yet-unconnected imported parts (#354). */
+  baseLink?: string
   /** Servo pin ↔ URDF joint bindings with angle calibration (Phase 3). */
   servoJointMap?: ServoJointBinding[]
   /** Per-joint limit / calibration overrides edited in-app (Phase 2). */

--- a/test/robotAssembly.test.ts
+++ b/test/robotAssembly.test.ts
@@ -5,6 +5,7 @@ import {
   rootLink,
   uniqueLinkName,
   addMeshLink,
+  looseLinks,
   blankUrdf,
   connectJoint,
   orientJoint,
@@ -57,18 +58,19 @@ describe('rootLink + uniqueLinkName (#309)', () => {
   })
 })
 
-describe('addMeshLink (#309)', () => {
-  it('appends a link + fixed joint before </robot>, parented to the root', () => {
+describe('addMeshLink (#354 — loose import)', () => {
+  it('appends a LOOSE link (no joint) before </robot>', () => {
     const { urdf, link } = addMeshLink(URDF, { meshRel: 'meshes/wheel.stl', linkBase: 'wheel' })
     expect(link).toBe('wheel')
     expect(urdf).toContain('<mesh filename="meshes/wheel.stl"/>')
-    expect(urdf).toContain('<joint name="wheel_joint" type="fixed">')
-    expect(urdf).toContain('<parent link="base_link"/>')
-    expect(urdf.indexOf('wheel_joint')).toBeLessThan(urdf.indexOf('</robot>'))
-    // the new link now parses back out
+    // No auto fixed-joint any more — the part comes in unconnected.
+    expect(urdf).not.toContain('wheel_joint')
+    expect(urdf.indexOf('<link name="wheel">')).toBeLessThan(urdf.indexOf('</robot>'))
+    // the new link now parses back out, and is a loose root (never a joint child)
     expect(parseAssembly(urdf).some((i) => i.link === 'wheel' && i.mesh === 'meshes/wheel.stl')).toBe(
       true
     )
+    expect(looseLinks(urdf, 'base_link')).toContain('wheel')
   })
   it('avoids a name collision', () => {
     const { link } = addMeshLink(URDF, { meshRel: 'meshes/upper.stl', linkBase: 'upper' })
@@ -80,6 +82,20 @@ describe('addMeshLink (#309)', () => {
     expect(link).toBe('x')
     expect(urdf).toContain('<link name="x">')
     expect(urdf).not.toContain('<joint')
+  })
+})
+
+describe('looseLinks (#354)', () => {
+  it('returns roots that are not the base (unconnected parts)', () => {
+    // URDF: base_link → upper → tip is one chain; add two loose imports.
+    let u = addMeshLink(URDF, { meshRel: 'meshes/a.stl', linkBase: 'a' }).urdf
+    u = addMeshLink(u, { meshRel: 'meshes/b.stl', linkBase: 'b' }).urdf
+    // base_link is the chosen base; upper/tip are jointed; a + b are loose.
+    expect(looseLinks(u, 'base_link').sort()).toEqual(['a', 'b'])
+  })
+  it('with no base, every root is loose', () => {
+    const u = `<robot name="r"><link name="p1"/><link name="p2"/></robot>`
+    expect(looseLinks(u).sort()).toEqual(['p1', 'p2'])
   })
 })
 
@@ -261,9 +277,11 @@ describe('blankUrdf — new robot starter', () => {
     expect(a).toEqual([{ link: 'base_link', kind: 'box' }])
     expect(rootLink(u)).toBe('base_link')
   })
-  it('an imported mesh attaches to its base_link', () => {
+  it('imports a mesh as a loose part (unconnected to base_link)', () => {
     const { urdf, link } = addMeshLink(blankUrdf(), { meshRel: 'meshes/w.stl', linkBase: 'w' })
     expect(link).toBe('w')
-    expect(urdf).toContain('<parent link="base_link"/>')
+    expect(urdf).toContain('<link name="w">')
+    expect(urdf).not.toContain('<joint') // no auto-weld; the user joins it explicitly
+    expect(looseLinks(urdf, 'base_link')).toEqual(['w'])
   })
 })

--- a/test/robotYaml.test.ts
+++ b/test/robotYaml.test.ts
@@ -87,6 +87,18 @@ describe('KRF robot model round-trips (#312)', () => {
     expect(round.robot?.poses).toEqual([{ name: 'home', values: { shoulder: 0, elbow: 20 } }])
   })
 
+  it('round-trips the chosen baseLink (#354)', () => {
+    const def: RobotDefinition = {
+      parts: [],
+      connections: [],
+      robot: { version: 1, urdf: 'urdf/arm.urdf', baseLink: 'base_link' }
+    }
+    expect(robotFromYaml(robotToYaml(def)).robot?.baseLink).toBe('base_link')
+    // A blank / whitespace baseLink is dropped by the sanitiser.
+    const blank = robotFromYaml(robotToYaml({ parts: [], connections: [], robot: { baseLink: '  ' } }))
+    expect(blank.robot?.baseLink).toBeUndefined()
+  })
+
   it('a wiring-only robot.yml stays free of a robot: section', () => {
     const yaml = robotToYaml({ parts: [], connections: [] })
     expect(yaml).not.toMatch(/\brobot:/)


### PR DESCRIPTION
Reworks STL import to match the natural assembly workflow the user asked for: **bring parts in as loose pieces → designate one as the base → join them with the Add Joint tool to form the kinematic chain.**

## Why
`addMeshLink` auto-appended a hidden `<joint type="fixed">` welding every import to the current root — fusing the whole assembly into one rigid blob and giving no control over the base. (It's also why two parts could end up feeling like "one link".)

## URDF answer
A base link isn't fundamental at the *file* level — a `<robot>` may hold several `<link>`s with zero `<joint>`s, and `urdf-loader` renders them. What's fundamental is that a **valid, complete robot is a single tree with one root**. So imports sit as **loose roots** while editing, and the URDF collapses to one valid tree as joints are added. `robot.yml` records the chosen base.

## Changes
- **Loose import** — `addMeshLink` emits a bare `<link>`, no joint. New pure helper `looseLinks(urdf, base?)`.
- **`robot.yml.baseLink`** — added to `RobotModel` + `sanitiseRobotModel` (round-trips; never clobbers a legacy wiring-only file).
- **Base resolution** — `effectiveBaseLink` = chosen base (if still a root) → sole root → conventional `base_link` → else `null` (prompt). `handleMakeBase` persists + re-roots, **guarded by `canReRoot`** so it can't record a base it can't actually reach.
- **Hierarchy** — a **"Not connected yet"** section lists loose parts (badge + hint); Blocks/Meshes exclude them so every part appears once; a **"⭐ Pick a base part"** banner when none is chosen.

## Review + verification
- 3-lens adversarial review (base logic / panel partition / persist-regress). Confirmed: 1 **MED** (make-base persisting an unreachable base → fixed with the `canReRoot` guard + user feedback) and 1 **LOW** (stale doc comments → fixed). No other real defects.
- Unit tests: loose import (no joint), `looseLinks`, `baseLink` round-trip.
- `npm run typecheck` / `lint` (only pre-existing warning) / `npm test` (1545) / `build` ✅

Follow-up (not here): the panel's visual redesign (Fusion-style rows, trashcan/right-click menu, anchor base icon) and auto-splitting an existing "one link, two meshes" file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)