### PR TITLE
feat: Robot View — Fusion-style build hierarchy (anchor base, right-click menu, rename) (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- **Robot View — a cleaner, Fusion-style build hierarchy (#354).** The panel is
+  **wider** so long STL names have room, and it drops its solid slab — each line now
+  sits on its own **subtle off-white card** so it reads over the 3-D canvas. Per-row
+  clutter is gone: the base is marked with an **anchor** (not a star), and **Rename /
+  Make base / Delete** moved to a **right-click menu** (renaming a part updates it
+  everywhere it's referenced). Mesh rows show a compact `stl`/`dae` tag instead of
+  repeating the filename.
+
 ### Added
 - **Robot View — import parts loose, pick a base, then join them into a chain (#354).**
   Imported STLs no longer auto-weld to the first part with a hidden fixed joint (which

--- a/src/renderer/src/components/RobotBuildPanel.css
+++ b/src/renderer/src/components/RobotBuildPanel.css
@@ -34,29 +34,23 @@
      bottom-left; the parts list scrolls if the robot has more blocks than fit. */
   max-height: calc(100% - 1rem);
   z-index: 4;
-  width: 12.5rem;
+  width: 15.5rem;
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
   padding: 0.4rem 0.45rem;
   box-sizing: border-box;
-  border: 1px solid var(--border, #3a3d44);
+  border: none;
   border-radius: 8px;
-  /* Transparent glassy fill (the "floating browser" look). */
-  background: rgba(20, 21, 24, 0.55);
-  backdrop-filter: blur(8px);
+  /* Fully floating (Fusion-style): no panel slab — each tree line carries its own
+     subtle backing (below) so it reads over the 3-D canvas. */
+  background: transparent;
   color: var(--text, #cdd2d9);
   font-family: var(--font-mono, 'JetBrains Mono', monospace);
   font-size: 0.66rem;
   outline: none;
 }
-.robotbuild__dock--overlay {
-  box-shadow: 14px 0 28px -16px rgba(0, 0, 0, 0.55);
-}
 /* Light skin: a warm translucent parchment instead of dark glass. */
-:root[data-theme='skeuomorph'] .robotbuild__dock {
-  background: rgba(231, 226, 211, 0.72);
-}
 :root[data-theme='skeuomorph'] .robotbuild__tab {
   background: rgba(231, 226, 211, 0.85);
 }
@@ -102,24 +96,19 @@
 }
 
 /* Per-row base marker: ☆ makes this the base, ★ marks the current base. */
+/* A fixed-width slot on the left of every row: the ANCHOR on the base link, empty
+   otherwise (keeps the names aligned). */
 .robotbuild__rowbase {
   flex: 0 0 auto;
+  width: 0.95rem;
   display: inline-flex;
   align-items: center;
-  font-size: 0.72rem;
+  justify-content: center;
   line-height: 1;
   color: var(--text-muted, #8b919b);
-  background: transparent;
-  border: none;
-  padding: 0.1rem 0.15rem;
-  cursor: pointer;
-}
-.robotbuild__rowbase:hover {
-  color: var(--accent-ink);
 }
 .robotbuild__rowbase.is-base {
   color: var(--accent-ink);
-  cursor: default;
 }
 .robotbuild__hint {
   margin: 0;
@@ -148,18 +137,7 @@
   color: var(--text-muted, #8b919b);
 }
 .robotbuild__part.is-loose {
-  border-left: 2px solid rgba(230, 160, 60, 0.5);
-}
-.robotbuild__loosebadge {
-  flex: 0 0 auto;
-  font-size: 0.5rem;
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-  padding: 0.05rem 0.3rem;
-  border-radius: 999px;
-  color: #b5651d;
-  background: rgba(230, 160, 60, 0.18);
-  border: 1px solid rgba(230, 160, 60, 0.45);
+  border-left: 2px solid rgba(230, 160, 60, 0.6);
 }
 
 /* The hierarchy tree scrolls as one under the dock's max-height. */
@@ -186,14 +164,18 @@
   letter-spacing: 0.03em;
   text-transform: uppercase;
   color: var(--text-muted, #9aa0a6);
-  background: transparent;
+  background: rgba(24, 26, 30, 0.62);
   border: none;
-  padding: 0.22rem 0.2rem 0.12rem;
+  border-radius: 5px;
+  padding: 0.22rem 0.35rem 0.2rem;
   cursor: pointer;
   text-align: left;
 }
 .robotbuild__branch:hover {
   color: var(--accent-ink);
+}
+:root[data-theme='skeuomorph'] .robotbuild__branch {
+  background: rgba(246, 242, 232, 0.82);
 }
 .robotbuild__caret {
   flex: 0 0 auto;
@@ -220,6 +202,11 @@
 }
 .robotbuild__part {
   border-radius: 5px;
+  /* Each row is its own subtle line over the canvas (Fusion-style). */
+  background: rgba(28, 30, 35, 0.62);
+}
+:root[data-theme='skeuomorph'] .robotbuild__part {
+  background: rgba(250, 247, 240, 0.82);
 }
 /* A leaf node that opens a context dialog (joint / servo / pose). */
 .robotbuild__node {
@@ -273,12 +260,16 @@
   text-align: left;
 }
 .robotbuild__part-label {
+  flex: 1 1 auto;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 .robotbuild__part-geo {
   flex: 0 0 auto;
+  white-space: nowrap;
+  padding-left: 0.3rem;
   font-size: 0.6rem;
   color: var(--text-muted, #8b919b);
 }
@@ -291,15 +282,14 @@
   align-items: center;
   color: var(--text-muted, #8b919b);
   background: transparent;
-  border: 1px solid transparent;
+  border: none;
   border-radius: 4px;
-  padding: 0.15rem 0.25rem;
+  padding: 0.12rem 0.15rem;
   cursor: pointer;
 }
 .robotbuild__edit:hover,
 .robotbuild__edit.is-on {
   color: var(--accent-ink);
-  border-color: var(--border, #3a3d44);
 }
 .robotbuild__editrow {
   display: flex;
@@ -418,23 +408,6 @@
   font-size: 0.56rem;
   color: var(--text-muted, #8b919b);
   font-style: italic;
-}
-.robotbuild__del {
-  margin-left: auto;
-  color: var(--text-muted, #9aa0a6);
-  background: transparent;
-  border: 1px solid var(--border, #3a3d44);
-  border-radius: 4px;
-  padding: 0 0.35rem;
-  cursor: pointer;
-}
-.robotbuild__del:hover:not(:disabled) {
-  color: #b4544e;
-  border-color: #b4544e;
-}
-.robotbuild__del:disabled {
-  opacity: 0.35;
-  cursor: default;
 }
 .robotbuild__empty {
   color: var(--text-muted, #8b919b);

--- a/src/renderer/src/components/RobotBuildPanel.tsx
+++ b/src/renderer/src/components/RobotBuildPanel.tsx
@@ -415,7 +415,9 @@ function BodyRow({
         <span
           className={`robotbuild__rowbase${isRoot ? ' is-base' : ''}`}
           title={isRoot ? 'This is the base — everything hangs off it' : undefined}
-          aria-hidden={!isRoot}
+          role={isRoot ? 'img' : undefined}
+          aria-label={isRoot ? 'Base — everything hangs off it' : undefined}
+          aria-hidden={isRoot ? undefined : true}
         >
           {isRoot ? ANCHOR : null}
         </span>

--- a/src/renderer/src/components/RobotBuildPanel.tsx
+++ b/src/renderer/src/components/RobotBuildPanel.tsx
@@ -10,11 +10,12 @@ import type {
 import type { Vec3 } from './robot-build'
 import { principalAxisName } from './robot-build'
 import { toDisplay, toNative, unitLabel, normPin, type MovableType } from './robot-pose'
-import { baseName } from './robot-mesh'
 import { shouldAutoHide } from './pin-overlay'
 import type { ServoJointBinding } from '../../../shared/robot'
 import type { NamedPoseLike } from './RobotJointPanel'
 import type { PropsContext } from './RobotPropertiesDialog'
+import { ContextMenu, type ContextMenuItem, type ContextMenuPosition } from './ContextMenu'
+import { usePrompt } from './PromptModal'
 import './RobotBuildPanel.css'
 
 /**
@@ -43,6 +44,20 @@ const PENCIL = (
     <path d="M11.5 1.5l3 3L5 14l-3.5.5L2 11z" fill="none" stroke="currentColor" strokeWidth="1.4" />
   </svg>
 )
+// An anchor marks the base link (Fusion-style) — the part everything hangs off.
+const ANCHOR = (
+  <svg viewBox="0 0 16 16" width="12" height="12" aria-hidden="true">
+    <circle cx="8" cy="3" r="1.8" fill="none" stroke="currentColor" strokeWidth="1.3" />
+    <path
+      d="M8 4.8V14M4 8H2.4c0 3 2.4 4.8 5.6 4.8S13.6 11 13.6 8H12M4.8 10.2L8 13l3.2-2.8"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+)
 
 export interface RobotBuildPanelProps {
   open: boolean
@@ -65,6 +80,7 @@ export interface RobotBuildPanelProps {
   /** The current root link, and an action to re-root the model at a link. */
   rootLink: string | null
   onMakeBase: (link: string) => void
+  onRename: (link: string, to: string) => void
   onDelete: (link: string) => void
   onImportStl: () => void
   canImport: boolean
@@ -366,8 +382,9 @@ function Section({
   )
 }
 
-/** A block / mesh row: base marker (☆/★), edit pencil, delete, and the name
- *  (click selects + zooms). Shared by the Blocks + Meshes branches. */
+/** A block / mesh row: an anchor on the base + an edit pencil to the left, then the
+ *  name (click selects + zooms). Rename / Make base / Delete live on the right-click
+ *  menu (Fusion-style). Shared by the Blocks / Meshes / Not-connected branches. */
 function BodyRow({
   it,
   isSel,
@@ -376,8 +393,7 @@ function BodyRow({
   loose = false,
   onSelect,
   onEdit,
-  onMakeBase,
-  onDelete
+  onContextMenu
 }: {
   it: AssemblyItem
   isSel: boolean
@@ -386,29 +402,23 @@ function BodyRow({
   loose?: boolean
   onSelect: (link: string) => void
   onEdit: (link: string | null) => void
-  onMakeBase: (link: string) => void
-  onDelete: (link: string) => void
+  onContextMenu: (e: React.MouseEvent, link: string) => void
 }): JSX.Element {
   return (
-    <li className={`robotbuild__part${isSel ? ' is-sel' : ''}${loose ? ' is-loose' : ''}`}>
+    <li
+      className={`robotbuild__part${isSel ? ' is-sel' : ''}${loose ? ' is-loose' : ''}`}
+      onContextMenu={(e) => onContextMenu(e, it.link)}
+    >
       <div className="robotbuild__part-row">
-        {/* Action icons sit to the LEFT of the name so they never overlap long
-            titles (the name button flexes to fill the rest). */}
-        {isRoot ? (
-          <span className="robotbuild__rowbase is-base" title="This is the base — every block hangs off it">
-            ★
-          </span>
-        ) : (
-          <button
-            type="button"
-            className="robotbuild__rowbase"
-            onClick={() => onMakeBase(it.link)}
-            title="Make this the base"
-            aria-label={`Make ${it.link} the base`}
-          >
-            ☆
-          </button>
-        )}
+        {/* Icons sit to the LEFT of the name (Fusion-style); the name button flexes
+            to fill the rest so long mesh filenames get room to breathe. */}
+        <span
+          className={`robotbuild__rowbase${isRoot ? ' is-base' : ''}`}
+          title={isRoot ? 'This is the base — everything hangs off it' : undefined}
+          aria-hidden={!isRoot}
+        >
+          {isRoot ? ANCHOR : null}
+        </span>
         <button
           type="button"
           className={`robotbuild__edit${isEdit ? ' is-on' : ''}`}
@@ -420,34 +430,18 @@ function BodyRow({
         </button>
         <button
           type="button"
-          className="robotbuild__del"
-          disabled={isRoot}
-          onClick={() => onDelete(it.link)}
-          title={
-            isRoot
-              ? 'The base can’t be deleted — make another block the base first'
-              : `Delete ${it.link}`
-          }
-          aria-label={`Delete ${it.link}`}
-        >
-          ✕
-        </button>
-        <button
-          type="button"
           className="robotbuild__part-name"
-          title={it.link}
+          title={`${it.link} — right-click for rename / base / delete`}
           onClick={() => onSelect(it.link)}
+          onContextMenu={(e) => onContextMenu(e, it.link)}
         >
           <span className="robotbuild__part-label">{it.link}</span>
           <span className={`robotbuild__part-geo${it.kind === 'mesh' ? ' is-mesh' : ''}`}>
-            {it.kind === 'mesh' ? baseName(it.mesh ?? '') : it.kind}
+            {/* A compact type tag — for a mesh the file extension, so the (long) link
+                name gets the row's width instead of repeating the filename. */}
+            {it.kind === 'mesh' ? (it.mesh?.match(/\.(\w+)$/)?.[1]?.toLowerCase() ?? 'mesh') : it.kind}
           </span>
         </button>
-        {loose && (
-          <span className="robotbuild__loosebadge" title="Not connected — join it into the robot">
-            not connected
-          </span>
-        )}
       </div>
     </li>
   )
@@ -472,6 +466,7 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
     onOpenPose,
     rootLink,
     onMakeBase,
+    onRename,
     onDelete,
     onImportStl,
     canImport,
@@ -480,9 +475,46 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
     onOpenRobot
   } = props
   const dockRef = useRef<HTMLElement | null>(null)
+  const prompt = usePrompt()
   // Which tree branches are collapsed (all expanded by default).
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({})
   const toggle = (id: string): void => setCollapsed((c) => ({ ...c, [id]: !c[id] }))
+  // Right-click menu (Fusion-style): rename / make base / delete a part.
+  const [menu, setMenu] = useState<{ pos: ContextMenuPosition; link: string } | null>(null)
+  const openMenu = (e: React.MouseEvent, link: string): void => {
+    if (!canEdit) return
+    e.preventDefault()
+    e.stopPropagation()
+    setMenu({ pos: { x: e.clientX, y: e.clientY }, link })
+  }
+  const menuItems = (link: string): ContextMenuItem[] => {
+    const isBase = link === rootLink
+    return [
+      {
+        key: 'rename',
+        label: 'Rename…',
+        onSelect: () => {
+          void (async () => {
+            const to = await prompt('Rename part', link)
+            if (to && to.trim() && to.trim() !== link) onRename(link, to.trim())
+          })()
+        }
+      },
+      {
+        key: 'base',
+        label: isBase ? 'Base (already)' : 'Make base',
+        disabled: isBase,
+        onSelect: () => onMakeBase(link)
+      },
+      {
+        key: 'delete',
+        label: 'Delete',
+        danger: true,
+        disabled: isBase,
+        onSelect: () => onDelete(link)
+      }
+    ]
+  }
 
   // A part is LOOSE (not connected yet) when it has no parent joint AND it isn't the
   // chosen base — i.e. an imported part still waiting to be joined into the chain.
@@ -554,8 +586,8 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
       <div className="robotbuild__tree">
         {needsBase && (
           <p className="robotbuild__basehint">
-            ⭐ Pick a <strong>base</strong> part (tap its ☆) — it&rsquo;s the anchor the
-            rest of the robot hangs off.
+            ⭐ Pick a <strong>base</strong> part (right-click → <em>Make base</em>) — it&rsquo;s
+            the anchor the rest of the robot hangs off.
           </p>
         )}
         {looseParts.length > 0 && (
@@ -567,8 +599,8 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
             onToggle={toggle}
           >
             <li className="robotbuild__loosehint">
-              Join each of these to your robot with the Add Joint tool — or tap ☆ to make
-              one the base.
+              Join each of these to your robot with the Add Joint tool — or right-click →
+              <em> Make base</em>.
             </li>
             {looseParts.map((it) => (
               <BodyRow
@@ -580,8 +612,7 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
                 loose
                 onSelect={onSelect}
                 onEdit={onEdit}
-                onMakeBase={onMakeBase}
-                onDelete={onDelete}
+                onContextMenu={openMenu}
               />
             ))}
           </Section>
@@ -596,8 +627,7 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
               isRoot={it.link === rootLink}
               onSelect={onSelect}
               onEdit={onEdit}
-              onMakeBase={onMakeBase}
-              onDelete={onDelete}
+              onContextMenu={openMenu}
             />
           ))}
           {blocks.length === 0 && <li className="robotbuild__empty">No blocks yet — add one above.</li>}
@@ -613,8 +643,7 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
               isRoot={it.link === rootLink}
               onSelect={onSelect}
               onEdit={onEdit}
-              onMakeBase={onMakeBase}
-              onDelete={onDelete}
+              onContextMenu={openMenu}
             />
           ))}
           {meshes.length === 0 && <li className="robotbuild__empty">No imported meshes.</li>}
@@ -699,6 +728,9 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
           {importing ? 'Importing…' : '+ STL / DAE'}
         </button>
       </div>
+      {menu && (
+        <ContextMenu position={menu.pos} items={menuItems(menu.link)} onClose={() => setMenu(null)} />
+      )}
     </aside>
   )
 }

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -31,6 +31,7 @@ import {
   readVisualOrigin,
   removeJoint,
   removeLink,
+  renameLink,
   rootLink,
   setJoint,
   setJointOrigin,
@@ -592,6 +593,19 @@ export function RobotView({
       m.baseLink = link
     })
     commitUrdf(reRoot(content, link))
+  }
+  const handleRenameLink = (link: string, to: string): void => {
+    const { urdf, name } = renameLink(content, link, to)
+    if (name === link) return // unchanged / no-op
+    commitUrdf(urdf)
+    if (selectedLink === link) setSelectedLink(name)
+    // Follow the rename through the base bookkeeping so the ★ + robot.yml stay in sync.
+    if (chosenBase === link) {
+      setChosenBase(name)
+      void persist((m) => {
+        m.baseLink = name
+      })
+    }
   }
   // Properties dialog (#352 / #353): clicking a node opens its context here. For a
   // block/mesh/joint we snapshot the URDF so Cancel can revert the live edits; OK
@@ -2878,6 +2892,7 @@ export function RobotView({
             onOpenPose={handleOpenPose}
             rootLink={effectiveBaseLink}
             onMakeBase={handleMakeBase}
+            onRename={handleRenameLink}
             onDelete={handleDeleteLink}
             onImportStl={() => void handleImportStl()}
             canImport={!!canImport}

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -599,13 +599,21 @@ export function RobotView({
     if (name === link) return // unchanged / no-op
     commitUrdf(urdf)
     if (selectedLink === link) setSelectedLink(name)
-    // Follow the rename through the base bookkeeping so the ★ + robot.yml stay in sync.
-    if (chosenBase === link) {
+    // Follow the rename through the base bookkeeping so the anchor + robot.yml stay in
+    // sync — keyed on the EFFECTIVE base (which may be the implicit `base_link` fallback,
+    // with chosenBase still null) so renaming the base never silently loses it.
+    if (link === effectiveBaseLink || chosenBase === link) {
       setChosenBase(name)
       void persist((m) => {
         m.baseLink = name
       })
     }
+    // Follow it through an open properties dialog so it doesn't orphan onto the old name.
+    setDialogCtx((c) => {
+      if (c?.kind === 'link' && c.link === link) return { kind: 'link', link: name }
+      if (c?.kind === 'joint' && c.child === link) return { ...c, child: name }
+      return c
+    })
   }
   // Properties dialog (#352 / #353): clicking a node opens its context here. For a
   // block/mesh/joint we snapshot the URDF so Cancel can revert the live edits; OK

--- a/src/renderer/src/components/robot-assembly.ts
+++ b/src/renderer/src/components/robot-assembly.ts
@@ -141,6 +141,28 @@ export function looseLinks(urdf: string, base?: string | null): string[] {
   return links.filter((l) => !children.has(l) && l !== base)
 }
 
+/**
+ * Rename a link everywhere it's referenced: its `<link name="…">` and every
+ * joint's `<parent link="…">` / `<child link="…">`. `to` is sanitised to an
+ * XML-safe name, made unique (a collision with another link bumps a suffix); a
+ * rename to the same name is a no-op. Returns the new URDF + the final name.
+ */
+export function renameLink(urdf: string, from: string, to: string): { urdf: string; name: string } {
+  const safe = to.replace(/[^A-Za-z0-9_]+/g, '_').replace(/^_+|_+$/g, '') || 'part'
+  if (safe === from) return { urdf, name: from }
+  const existing = new Set(parseAssembly(urdf).map((i) => i.link))
+  existing.delete(from)
+  let name = safe
+  let n = 2
+  while (existing.has(name)) name = `${safe}_${n++}`
+  const e = escapeRe(from)
+  const out = urdf
+    .replace(new RegExp(`(<link\\b[^>]*\\bname\\s*=\\s*")${e}(")`, 'g'), `$1${name}$2`)
+    .replace(new RegExp(`(<parent\\b[^>]*\\blink\\s*=\\s*")${e}(")`, 'gi'), `$1${name}$2`)
+    .replace(new RegExp(`(<child\\b[^>]*\\blink\\s*=\\s*")${e}(")`, 'gi'), `$1${name}$2`)
+  return { urdf: out, name }
+}
+
 // ── Primitive builder (#315a) ────────────────────────────────────────────────
 
 /** A primitive link's geometry, read from / written to the URDF. Sizes in metres:

--- a/src/renderer/src/components/robot-assembly.ts
+++ b/src/renderer/src/components/robot-assembly.ts
@@ -155,11 +155,13 @@ export function renameLink(urdf: string, from: string, to: string): { urdf: stri
   let name = safe
   let n = 2
   while (existing.has(name)) name = `${safe}_${n++}`
+  // URDF link references are case-SENSITIVE — match the link def + its joint refs
+  // with the same case so a rename can't rewrite a different-cased link's joints.
   const e = escapeRe(from)
   const out = urdf
     .replace(new RegExp(`(<link\\b[^>]*\\bname\\s*=\\s*")${e}(")`, 'g'), `$1${name}$2`)
-    .replace(new RegExp(`(<parent\\b[^>]*\\blink\\s*=\\s*")${e}(")`, 'gi'), `$1${name}$2`)
-    .replace(new RegExp(`(<child\\b[^>]*\\blink\\s*=\\s*")${e}(")`, 'gi'), `$1${name}$2`)
+    .replace(new RegExp(`(<parent\\b[^>]*\\blink\\s*=\\s*")${e}(")`, 'g'), `$1${name}$2`)
+    .replace(new RegExp(`(<child\\b[^>]*\\blink\\s*=\\s*")${e}(")`, 'g'), `$1${name}$2`)
   return { urdf: out, name }
 }
 

--- a/test/robotAssembly.test.ts
+++ b/test/robotAssembly.test.ts
@@ -6,6 +6,7 @@ import {
   uniqueLinkName,
   addMeshLink,
   looseLinks,
+  renameLink,
   blankUrdf,
   connectJoint,
   orientJoint,
@@ -96,6 +97,23 @@ describe('looseLinks (#354)', () => {
   it('with no base, every root is loose', () => {
     const u = `<robot name="r"><link name="p1"/><link name="p2"/></robot>`
     expect(looseLinks(u).sort()).toEqual(['p1', 'p2'])
+  })
+})
+
+describe('renameLink (#354)', () => {
+  it('renames the link + every joint parent/child reference', () => {
+    const { urdf, name } = renameLink(URDF, 'upper', 'arm')
+    expect(name).toBe('arm')
+    expect(urdf).toContain('<link name="arm">')
+    expect(urdf).not.toContain('<link name="upper">')
+    expect(urdf).toContain('<child link="arm"/>') // j1's child
+    expect(urdf).toContain('<parent link="arm"/>') // j2's parent
+    expect(urdf).not.toContain('link="upper"')
+  })
+  it('sanitises + de-collides the new name; same-name is a no-op', () => {
+    expect(renameLink(URDF, 'tip', 'my tip!').name).toBe('my_tip') // XML-safe
+    expect(renameLink(URDF, 'tip', 'base_link').name).toBe('base_link_2') // collision bump
+    expect(renameLink(URDF, 'tip', 'tip')).toEqual({ urdf: URDF, name: 'tip' }) // no-op
   })
 })
 


### PR DESCRIPTION
Reworks the build hierarchy per feedback: STL names looked garbled, the delete ✕ had a heavy border, and each action needed its own inline icon.

## Changes
- **Wider panel + no slab.** The solid panel background is gone; each tree **line** (section header + row) has its own **subtle off-white card** so it reads over the 3-D canvas (Fusion-style).
- **Right-click menu** (reusing `ContextMenu`): **Rename / Make base / Delete**. The inline **star + delete icons are removed**.
- **Anchor** marks the base link (Fusion-style), replacing the star.
- **`renameLink`** — new pure helper: renames a link + every joint `parent`/`child` reference (XML-safe, de-colliding, same-name no-op). `handleRenameLink` follows the rename through the current selection + the `robot.yml` `baseLink`.
- **Mesh rows** show a compact `stl`/`dae` tag; the long link name gets the row width and truncates with an ellipsis (full name on hover).

## Verification
- Unit tests for `renameLink` (rename refs, sanitise + de-collide, no-op).
- Playwright smoke in **light + dark** skins: anchor on the base, "Not connected yet" section, right-click menu = Rename/Make base/Delete. Screenshots confirm names now breathe.
- `typecheck` / `lint` (only pre-existing warning) / `test` (1547) / `build` ✅

Adversarial review pending before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)