### PR TITLE
fix: Robot View — imports attach to base (no fusion) + movable + hide empty sections (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   repeating the filename.
 
 ### Added
-- **Robot View — import parts loose, pick a base, then join them into a chain (#354).**
-  Imported STLs no longer auto-weld to the first part with a hidden fixed joint (which
-  fused everything into one rigid blob). Each import now comes in as a **loose,
-  unconnected part**, listed under a new **"Not connected yet"** group with a friendly
-  hint. You **pick which part is the base** (its ☆ — the anchor everything hangs off,
-  remembered in `robot.yml`), then use **Add Joint** to build the kinematic chain; each
-  part leaves "Not connected yet" as it's joined. When several parts are loose and no
-  base is obvious, a "⭐ Pick a base part to start your robot" prompt guides you.
+- **Robot View — import parts, pick a base, articulate them into a chain (#354).**
+  Imported STLs no longer stack on top of the first part at the origin. Each import
+  now attaches to the base with a **movable joint** at a **staggered** position, so it
+  lands beside the base as its **own** part — drag it to place, then use **Add Joint**
+  to articulate the kinematic chain. You **pick which part is the base** (right-click →
+  **Make base** — the anchor everything hangs off, remembered in `robot.yml`). Every
+  part is independently selectable + movable (a part with no joint of its own would
+  collapse into the base's scene node and co-select — so each gets its own joint).
+- **Robot View — the build hierarchy hides empty sections.** Blocks / Meshes / Joints
+  / Servos / Poses only appear when they actually have something in them, so the tree
+  stays focused on what your robot has.
 - **Robot View — Join tool: SHIFT-lock snapping + an on-surface target (#354).**
   While picking a joint point, an accurate **target** is drawn on the surface (a
   circle + X/Y/Z axis triad; a **cross-hair** over a hole / loop centre) so you can

--- a/src/renderer/src/components/RobotBuildPanel.css
+++ b/src/renderer/src/components/RobotBuildPanel.css
@@ -116,30 +116,6 @@
   color: var(--text-muted, #8b919b);
 }
 
-/* "Pick a base" prompt + the loose-parts helpers (#354). Amber attention tones as
-   translucent overlays so they read on BOTH the dark and light (parchment) skins. */
-.robotbuild__basehint {
-  margin: 0 0 0.15rem;
-  padding: 0.3rem 0.4rem;
-  font-size: 0.6rem;
-  line-height: 1.3;
-  color: var(--text, #cdd2d9);
-  background: rgba(230, 160, 60, 0.14);
-  border: 1px solid rgba(230, 160, 60, 0.4);
-  border-radius: 6px;
-}
-.robotbuild__loosehint {
-  list-style: none;
-  margin: 0;
-  padding: 0.1rem 0.35rem 0.25rem;
-  font-size: 0.55rem;
-  line-height: 1.3;
-  color: var(--text-muted, #8b919b);
-}
-.robotbuild__part.is-loose {
-  border-left: 2px solid rgba(230, 160, 60, 0.6);
-}
-
 /* The hierarchy tree scrolls as one under the dock's max-height. */
 .robotbuild__tree {
   flex: 1 1 auto;

--- a/src/renderer/src/components/RobotBuildPanel.css
+++ b/src/renderer/src/components/RobotBuildPanel.css
@@ -385,11 +385,6 @@
   color: var(--text-muted, #8b919b);
   font-style: italic;
 }
-.robotbuild__empty {
-  color: var(--text-muted, #8b919b);
-  font-size: 0.6rem;
-  padding: 0.3rem;
-}
 
 .robotbuild__foot {
   border-top: 1px solid var(--border, #2c2e33);

--- a/src/renderer/src/components/RobotBuildPanel.tsx
+++ b/src/renderer/src/components/RobotBuildPanel.tsx
@@ -390,7 +390,6 @@ function BodyRow({
   isSel,
   isEdit,
   isRoot,
-  loose = false,
   onSelect,
   onEdit,
   onContextMenu
@@ -399,14 +398,13 @@ function BodyRow({
   isSel: boolean
   isEdit: boolean
   isRoot: boolean
-  loose?: boolean
   onSelect: (link: string) => void
   onEdit: (link: string | null) => void
   onContextMenu: (e: React.MouseEvent, link: string) => void
 }): JSX.Element {
   return (
     <li
-      className={`robotbuild__part${isSel ? ' is-sel' : ''}${loose ? ' is-loose' : ''}`}
+      className={`robotbuild__part${isSel ? ' is-sel' : ''}`}
       onContextMenu={(e) => onContextMenu(e, it.link)}
     >
       <div className="robotbuild__part-row">
@@ -518,15 +516,8 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
     ]
   }
 
-  // A part is LOOSE (not connected yet) when it has no parent joint AND it isn't the
-  // chosen base — i.e. an imported part still waiting to be joined into the chain.
-  const jointChildren = new Set(joints.map((j) => j.child))
-  const isLoose = (it: AssemblyItem): boolean => !jointChildren.has(it.link) && it.link !== rootLink
-  const looseParts = assembly.filter(isLoose)
-  const blocks = assembly.filter((it) => it.kind !== 'mesh' && !isLoose(it))
-  const meshes = assembly.filter((it) => it.kind === 'mesh' && !isLoose(it))
-  // No base picked yet but parts exist → prompt the user to choose one.
-  const needsBase = rootLink === null && assembly.length > 0
+  const blocks = assembly.filter((it) => it.kind !== 'mesh')
+  const meshes = assembly.filter((it) => it.kind === 'mesh')
   const editLink = active?.kind === 'link' ? active.link : null
 
   if (!open) {
@@ -586,32 +577,15 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
       )}
 
       <div className="robotbuild__tree">
-        {needsBase && (
-          <p className="robotbuild__basehint">
-            ⭐ Pick a <strong>base</strong> part (right-click → <em>Make base</em>) — it&rsquo;s
-            the anchor the rest of the robot hangs off.
-          </p>
-        )}
-        {looseParts.length > 0 && (
-          <Section
-            id="loose"
-            label="Not connected yet"
-            count={looseParts.length}
-            collapsed={collapsed}
-            onToggle={toggle}
-          >
-            <li className="robotbuild__loosehint">
-              Join each of these to your robot with the Add Joint tool — or right-click →
-              <em> Make base</em>.
-            </li>
-            {looseParts.map((it) => (
+        {blocks.length > 0 && (
+          <Section id="blocks" label="Blocks" count={blocks.length} collapsed={collapsed} onToggle={toggle}>
+            {blocks.map((it) => (
               <BodyRow
                 key={it.link}
                 it={it}
                 isSel={it.link === selected}
                 isEdit={it.link === editLink}
-                isRoot={false}
-                loose
+                isRoot={it.link === rootLink}
                 onSelect={onSelect}
                 onEdit={onEdit}
                 onContextMenu={openMenu}
@@ -619,38 +593,25 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
             ))}
           </Section>
         )}
-        <Section id="blocks" label="Blocks" count={blocks.length} collapsed={collapsed} onToggle={toggle}>
-          {blocks.map((it) => (
-            <BodyRow
-              key={it.link}
-              it={it}
-              isSel={it.link === selected}
-              isEdit={it.link === editLink}
-              isRoot={it.link === rootLink}
-              onSelect={onSelect}
-              onEdit={onEdit}
-              onContextMenu={openMenu}
-            />
-          ))}
-          {blocks.length === 0 && <li className="robotbuild__empty">No blocks yet — add one above.</li>}
-        </Section>
 
-        <Section id="meshes" label="Meshes" count={meshes.length} collapsed={collapsed} onToggle={toggle}>
-          {meshes.map((it) => (
-            <BodyRow
-              key={it.link}
-              it={it}
-              isSel={it.link === selected}
-              isEdit={it.link === editLink}
-              isRoot={it.link === rootLink}
-              onSelect={onSelect}
-              onEdit={onEdit}
-              onContextMenu={openMenu}
-            />
-          ))}
-          {meshes.length === 0 && <li className="robotbuild__empty">No imported meshes.</li>}
-        </Section>
+        {meshes.length > 0 && (
+          <Section id="meshes" label="Meshes" count={meshes.length} collapsed={collapsed} onToggle={toggle}>
+            {meshes.map((it) => (
+              <BodyRow
+                key={it.link}
+                it={it}
+                isSel={it.link === selected}
+                isEdit={it.link === editLink}
+                isRoot={it.link === rootLink}
+                onSelect={onSelect}
+                onEdit={onEdit}
+                onContextMenu={openMenu}
+              />
+            ))}
+          </Section>
+        )}
 
+        {joints.length > 0 && (
         <Section id="joints" label="Joints" count={joints.length} collapsed={collapsed} onToggle={toggle}>
           {joints.map((j) => {
             const on = active?.kind === 'joint' && active.joint === j.name
@@ -668,9 +629,10 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
               </li>
             )
           })}
-          {joints.length === 0 && <li className="robotbuild__empty">No joints.</li>}
         </Section>
+        )}
 
+        {servos.length > 0 && (
         <Section id="servos" label="Servos" count={servos.length} collapsed={collapsed} onToggle={toggle}>
           {servos.map((b) => {
             const on = active?.kind === 'servo' && normPin(active.pin) === normPin(b.pin)
@@ -688,9 +650,10 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
               </li>
             )
           })}
-          {servos.length === 0 && <li className="robotbuild__empty">No servos mapped.</li>}
         </Section>
+        )}
 
+        {poses.length > 0 && (
         <Section id="poses" label="Poses" count={poses.length} collapsed={collapsed} onToggle={toggle}>
           {poses.map((p) => {
             const on = active?.kind === 'pose' && active.name === p.name
@@ -707,8 +670,11 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
               </li>
             )
           })}
-          {poses.length === 0 && <li className="robotbuild__empty">No saved poses.</li>}
         </Section>
+        )}
+        {assembly.length === 0 && (
+          <p className="robotbuild__hint">Add a block or import an STL to start building.</p>
+        )}
       </div>
 
       <div className="robotbuild__foot">

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -1133,7 +1133,12 @@ export function RobotView({
       // Add the mesh attached to the base with a movable joint, staggered so it lands
       // beside the base (not on top of it). Select it + reframe so the user can see it.
       const linkBase = res.name?.replace(/\.(stl|dae)$/i, '') ?? 'part'
-      const next = addMeshLink(content, { meshRel: res.rel, linkBase, scale })
+      const next = addMeshLink(content, {
+        meshRel: res.rel,
+        linkBase,
+        scale,
+        parent: effectiveBaseLink ?? undefined
+      })
       refitNextRef.current = true
       // Route through the choke point so the import is ONE undoable step and the
       // history stays in sync (commitUrdf updates the buffer + schedules the save).

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -1130,9 +1130,8 @@ export function RobotView({
           /* leave scale 1 if the mesh can't be measured */
         }
       }
-      // Add the mesh as a LOOSE link (no joint) so it renders now but stays an
-      // unconnected part — the user picks the base + joins it into the chain. Select
-      // it + reframe so the user can see + place it.
+      // Add the mesh attached to the base with a movable joint, staggered so it lands
+      // beside the base (not on top of it). Select it + reframe so the user can see it.
       const linkBase = res.name?.replace(/\.(stl|dae)$/i, '') ?? 'part'
       const next = addMeshLink(content, { meshRel: res.rel, linkBase, scale })
       refitNextRef.current = true
@@ -1144,8 +1143,8 @@ export function RobotView({
       if (!buildOpen) setBuildOpen(true)
       setSavingLabel(
         scale !== 1
-          ? `added ${next.link} (scaled mm→m) — now join it to your robot`
-          : `added ${next.link} — now join it to your robot`
+          ? `added ${next.link} (scaled mm→m) — drag to place, or Add Joint to articulate`
+          : `added ${next.link} — drag to place, or Add Joint to articulate`
       )
     } catch (e) {
       setSavingLabel(`import failed: ${e instanceof Error ? e.message : 'error'}`)

--- a/src/renderer/src/components/robot-assembly.ts
+++ b/src/renderer/src/components/robot-assembly.ts
@@ -113,9 +113,11 @@ export function uniqueLinkName(urdf: string, base: string): string {
  */
 export function addMeshLink(
   urdf: string,
-  opts: { meshRel: string; linkBase: string; scale?: number }
+  opts: { meshRel: string; linkBase: string; scale?: number; parent?: string }
 ): { urdf: string; link: string } {
-  const parent = rootLink(urdf)
+  // Attach under the UI's chosen base if given (it can differ from the doc-first
+  // root in a transitional multi-root URDF); else the sole/first root.
+  const parent = opts.parent ?? rootLink(urdf)
   const name = uniqueLinkName(urdf, opts.linkBase)
   // A `scale` normalises a mesh authored in different units (e.g. mm → m).
   const s = opts.scale && opts.scale !== 1 ? ` scale="${fmtNum(opts.scale)} ${fmtNum(opts.scale)} ${fmtNum(opts.scale)}"` : ''

--- a/src/renderer/src/components/robot-assembly.ts
+++ b/src/renderer/src/components/robot-assembly.ts
@@ -102,35 +102,49 @@ export function uniqueLinkName(urdf: string, base: string): string {
 }
 
 /**
- * Append an imported mesh to a URDF as a new **loose** link — no joint, so it
- * comes in as an unconnected part (a root) the user then designates as the base
- * or joins into the chain with the Add Joint tool. (Auto-welding every import to
- * the root with a fixed joint fused the whole assembly into one rigid blob.)
- * `meshRel` is the mesh path relative to the URDF folder (e.g. `meshes/wheel.stl`).
- * Returns the new URDF text and the created link name.
+ * Append an imported mesh to a URDF as a new link, attached to the current base
+ * with a **fixed (but movable) joint** at a **staggered** origin so it doesn't pile
+ * onto the base at the origin. The joint gives it its OWN scene-graph identity —
+ * urdf-loader collapses ALL rootless links into one node (they'd co-select /
+ * "fuse"), so every part except the single base root must be a joint child. The
+ * part is freely re-homable (drag it, or re-joint it into the chain). The very
+ * first link of an empty URDF becomes the root (no joint). `meshRel` is relative
+ * to the URDF folder. Returns the new URDF text + the created link name.
  */
 export function addMeshLink(
   urdf: string,
   opts: { meshRel: string; linkBase: string; scale?: number }
 ): { urdf: string; link: string } {
+  const parent = rootLink(urdf)
   const name = uniqueLinkName(urdf, opts.linkBase)
   // A `scale` normalises a mesh authored in different units (e.g. mm → m).
   const s = opts.scale && opts.scale !== 1 ? ` scale="${fmtNum(opts.scale)} ${fmtNum(opts.scale)} ${fmtNum(opts.scale)}"` : ''
+  // Stagger each new part along X (by the current link count) so imports land beside
+  // the base rather than co-located at (0,0,0) where they'd look fused.
+  const stagger = fmtNum(0.08 * parseAssembly(urdf).length)
+  const joint = parent
+    ? `  <joint name="${name}_joint" type="fixed">\n` +
+      `    <parent link="${parent}"/>\n` +
+      `    <child link="${name}"/>\n` +
+      `    <origin xyz="${stagger} 0 0" rpy="0 0 0"/>\n` +
+      `  </joint>\n`
+    : '' // first link of an empty URDF is the root — no joint
   const block =
     `  <link name="${name}">\n` +
     `    <visual>\n` +
     `      <geometry><mesh filename="${opts.meshRel}"${s}/></geometry>\n` +
     `    </visual>\n` +
-    `  </link>\n`
+    `  </link>\n` +
+    joint
   const idx = urdf.lastIndexOf('</robot>')
   const next = idx < 0 ? `${urdf.trimEnd()}\n${block}` : urdf.slice(0, idx) + block + urdf.slice(idx)
   return { urdf: next, link: name }
 }
 
 /**
- * The **unconnected** links: every link that is a root (never a joint's `<child>`)
- * EXCEPT the chosen base. These are parts imported but not yet joined into the
- * chain. `base` is the designated base link (from robot.yml, or the sole root).
+ * The **root** links (never a joint's `<child>`), optionally excluding `base`. A
+ * well-formed robot has exactly one root (the base); this enumerates them so the UI
+ * can find the base / detect a stray extra root.
  */
 export function looseLinks(urdf: string, base?: string | null): string[] {
   const links = parseAssembly(urdf).map((i) => i.link)

--- a/test/robotAssembly.test.ts
+++ b/test/robotAssembly.test.ts
@@ -59,25 +59,28 @@ describe('rootLink + uniqueLinkName (#309)', () => {
   })
 })
 
-describe('addMeshLink (#354 — loose import)', () => {
-  it('appends a LOOSE link (no joint) before </robot>', () => {
+describe('addMeshLink (#354 — attach to base, staggered)', () => {
+  it('appends a link + a movable fixed joint to the base, staggered off the origin', () => {
     const { urdf, link } = addMeshLink(URDF, { meshRel: 'meshes/wheel.stl', linkBase: 'wheel' })
     expect(link).toBe('wheel')
     expect(urdf).toContain('<mesh filename="meshes/wheel.stl"/>')
-    // No auto fixed-joint any more — the part comes in unconnected.
-    expect(urdf).not.toContain('wheel_joint')
-    expect(urdf.indexOf('<link name="wheel">')).toBeLessThan(urdf.indexOf('</robot>'))
-    // the new link now parses back out, and is a loose root (never a joint child)
+    // A per-part joint gives it its OWN scene identity (else urdf-loader collapses
+    // rootless links into one node → they co-select). Attached to the root base_link.
+    expect(urdf).toContain('<joint name="wheel_joint" type="fixed">')
+    expect(urdf).toContain('<parent link="base_link"/>')
+    // Staggered origin (URDF has 3 links → 0.08 * 3 = 0.24 m) so it doesn't stack.
+    expect(urdf).toContain('xyz="0.24 0 0"')
     expect(parseAssembly(urdf).some((i) => i.link === 'wheel' && i.mesh === 'meshes/wheel.stl')).toBe(
       true
     )
-    expect(looseLinks(urdf, 'base_link')).toContain('wheel')
+    // It's a joint child now → NOT a loose root.
+    expect(looseLinks(urdf)).not.toContain('wheel')
   })
   it('avoids a name collision', () => {
     const { link } = addMeshLink(URDF, { meshRel: 'meshes/upper.stl', linkBase: 'upper' })
     expect(link).toBe('upper_2')
   })
-  it('adds just a link (no joint) to an empty robot', () => {
+  it('adds just a link (no joint) to an empty robot — the first link is the root', () => {
     const empty = `<robot name="e"></robot>`
     const { urdf, link } = addMeshLink(empty, { meshRel: 'meshes/x.stl', linkBase: 'x' })
     expect(link).toBe('x')
@@ -87,14 +90,12 @@ describe('addMeshLink (#354 — loose import)', () => {
 })
 
 describe('looseLinks (#354)', () => {
-  it('returns roots that are not the base (unconnected parts)', () => {
-    // URDF: base_link → upper → tip is one chain; add two loose imports.
-    let u = addMeshLink(URDF, { meshRel: 'meshes/a.stl', linkBase: 'a' }).urdf
-    u = addMeshLink(u, { meshRel: 'meshes/b.stl', linkBase: 'b' }).urdf
-    // base_link is the chosen base; upper/tip are jointed; a + b are loose.
-    expect(looseLinks(u, 'base_link').sort()).toEqual(['a', 'b'])
+  it('returns roots that are not the base', () => {
+    const u = `<robot name="r"><link name="base"/><link name="p1"/><link name="p2"/><joint name="j" type="fixed"><parent link="base"/><child link="p1"/></joint></robot>`
+    // roots = base, p2 (p1 is a joint child). Excluding the base → [p2].
+    expect(looseLinks(u, 'base')).toEqual(['p2'])
   })
-  it('with no base, every root is loose', () => {
+  it('with no base, every root is returned', () => {
     const u = `<robot name="r"><link name="p1"/><link name="p2"/></robot>`
     expect(looseLinks(u).sort()).toEqual(['p1', 'p2'])
   })
@@ -295,11 +296,12 @@ describe('blankUrdf — new robot starter', () => {
     expect(a).toEqual([{ link: 'base_link', kind: 'box' }])
     expect(rootLink(u)).toBe('base_link')
   })
-  it('imports a mesh as a loose part (unconnected to base_link)', () => {
+  it('imports a mesh attached to base_link (its own joint → its own identity)', () => {
     const { urdf, link } = addMeshLink(blankUrdf(), { meshRel: 'meshes/w.stl', linkBase: 'w' })
     expect(link).toBe('w')
     expect(urdf).toContain('<link name="w">')
-    expect(urdf).not.toContain('<joint') // no auto-weld; the user joins it explicitly
-    expect(looseLinks(urdf, 'base_link')).toEqual(['w'])
+    expect(urdf).toContain('<joint name="w_joint" type="fixed">')
+    expect(urdf).toContain('<parent link="base_link"/>')
+    expect(looseLinks(urdf, 'base_link')).toEqual([]) // it's a joint child, not a loose root
   })
 })

--- a/test/robotAssembly.test.ts
+++ b/test/robotAssembly.test.ts
@@ -76,6 +76,10 @@ describe('addMeshLink (#354 — attach to base, staggered)', () => {
     // It's a joint child now → NOT a loose root.
     expect(looseLinks(urdf)).not.toContain('wheel')
   })
+  it('attaches under an explicit parent (the chosen base) when given', () => {
+    const { urdf } = addMeshLink(URDF, { meshRel: 'meshes/w.stl', linkBase: 'w', parent: 'tip' })
+    expect(urdf).toContain('<parent link="tip"/>')
+  })
   it('avoids a name collision', () => {
     const { link } = addMeshLink(URDF, { meshRel: 'meshes/upper.stl', linkBase: 'upper' })
     expect(link).toBe('upper_2')


### PR DESCRIPTION
Fixes the "clicking one unconnected mesh highlights both / they're fused" bug, makes imported parts movable, and hides empty hierarchy sections.

## Root cause (confirmed in urdf-loader source)
The "loose" (jointless) import model from the previous change hit a hard `urdf-loader` limitation: `URDFLoader.js:324-325` marks any link with no `<child>` reference as a **root**, and **every** root reuses the one shared `URDFRobot` scene node instead of getting its own `URDFLink` (`470-480`). So the base **and** every loose part collapsed into a single node with one identity — `ownerLinkName` returned the same name for all of them, so selecting/highlighting one hit them all. Not overlap — literally the same node.

## Fix (user-approved "attach to base, movable")
- **`addMeshLink`** now attaches each import to the base with a **movable fixed joint** at a **staggered** origin (`0.08 m × link-count` along X). The per-part joint gives each its own `URDFLink` identity → independently selectable, highlightable, and **draggable** (the Move tool moves its joint origin). The first link of an empty URDF stays the root.
- **Removed the "Not connected yet" staging** (loose section, "pick a base" banner, `is-loose` styling) — every part is now a real, connected, movable part. Base-picking (anchor, **Make base**, `robot.yml` `baseLink`) stays.
- **Hierarchy hides empty sections** — Blocks / Meshes / Joints / Servos / Poses show only when populated; an empty tree shows a start hint.

## Verification
- Unit tests: import emits a staggered joint to the base (not a loose root).
- Playwright smoke (screenshots): selecting one part highlights **only** it (co-highlight gone), parts are spread apart, `Meshes/Servos/Poses` hidden when empty, anchor on the base.
- `typecheck` / `lint` / `test` (1547) / `build` ✅

Adversarial review pending before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)