### PR TITLE
fix: Robot View — joint pivot sits at the mating point, not the part's centre (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -290,6 +290,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   or reopen any panel. Nothing about Robot mode is permanently changed.
 
 ### Fixed
+- **Robot View — Join tool: the hinge pivots at the joint, not the part's middle (#354).**
+  A rotation joint rotated the child about its *own centre* instead of the point you
+  picked, so a hinge ended up "halfway along the part". The joint origin now sits **on
+  the mating point**, and the child is re-origined onto its picked point (its mesh — and
+  any parts hanging off it — stay exactly put), so a hinge swings about the joint.
 - **Robot View — Join tool: the second block is now always selectable (#354).**
   After picking Component 1 it fades — but the faded mesh still hit-tested, so when it
   sat in front of the camera it stole every click and Component 2 "went dark and

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -736,7 +736,9 @@ export function RobotView({
     ]
     const ov = readVisualOrigin(base, child.link) ?? { xyz: [0, 0, 0], rpy: [0, 0, 0] }
     next = setVisualOrigin(next, child.link, shift(ov.xyz), ov.rpy as [number, number, number])
-    for (const j of readAllJoints(base)) {
+    // Read the child's own sub-joints from `next` (connectJoint only re-parented the
+    // child itself, never these) and shift each so descendants stay put too.
+    for (const j of readAllJoints(next)) {
       if (j.parent === child.link) next = setJointOrigin(next, j.child, shift(j.xyz), j.rpy)
     }
     commitUrdf(next)

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -684,8 +684,10 @@ export function RobotView({
         : jp
     )
   }
-  // Add: place the child so its picked point meets the parent's picked point
-  // (origin = parentLocal − childLocal + offset), re-parent it, and set the type.
+  // Add: mate the child's picked face against the parent's, re-parent it, set the
+  // type — and put the joint origin (the PIVOT) AT the mating point by re-origining
+  // the child link onto its picked point (so a hinge rotates about the joint, not the
+  // child's centre).
   const handleConnectPicked = (
     type: JointType,
     offsetMm: [number, number, number],
@@ -698,15 +700,22 @@ export function RobotView({
     // reverse wouldn't, orientJoint swaps them so the user needn't get it "right".
     const o = orientJoint(base, jp.parent.link, jp.child.link)
     const [parent, child] = o.parent === jp.parent.link ? [jp.parent, jp.child] : [jp.child, jp.parent]
-    // Orient the joint from the two picked FACE NORMALS: rotate the child so its
-    // face mates flush against the parent's and the picked points coincide.
-    const { xyz, rpy } = jointFromPicks(
+    // The mating ROTATION (rotate the child so its picked face meets the parent's
+    // flush). The origin is handled separately below so the pivot lands on the joint.
+    const { rpy } = jointFromPicks(
       parent.local,
       parent.normal,
       child.local,
       child.normal,
       offsetMm
     )
+    // Joint origin — the PIVOT — at the mating point (parent's picked point + offset).
+    // Exact because we re-origin the child onto its picked point below.
+    const xyz: [number, number, number] = [
+      parent.local[0] + offsetMm[0],
+      parent.local[1] + offsetMm[1],
+      parent.local[2] + offsetMm[2]
+    ]
     let next = connectJoint(base, { parent: parent.link, child: child.link, xyz })
     if (next === base) return false // cycle / invalid — keep the dialog open
     const rad = (d: number): number => (d * Math.PI) / 180
@@ -716,6 +725,20 @@ export function RobotView({
         ? setJoint(next, child.link, { type, lower: rad(rotation.minDeg), upper: rad(rotation.maxDeg) })
         : setJoint(next, child.link, { type })
     next = setJointOrigin(next, child.link, xyz, rpy) // xyz + the mating rotation
+    // Re-origin the child onto its picked point: shift its mesh (+ any of its own
+    // child-joints) by −childLocal so the geometry stays exactly put while the link
+    // origin (the pivot) lands on the mating point.
+    const cl = child.local
+    const shift = (v: readonly number[]): [number, number, number] => [
+      v[0] - cl[0],
+      v[1] - cl[1],
+      v[2] - cl[2]
+    ]
+    const ov = readVisualOrigin(base, child.link) ?? { xyz: [0, 0, 0], rpy: [0, 0, 0] }
+    next = setVisualOrigin(next, child.link, shift(ov.xyz), ov.rpy as [number, number, number])
+    for (const j of readAllJoints(base)) {
+      if (j.parent === child.link) next = setJointOrigin(next, j.child, shift(j.xyz), j.rpy)
+    }
     commitUrdf(next)
     setSelectedLink(child.link)
     // Rotation default angle: persist it to the robot.yml defaultPose (keyed by the

--- a/test/robotJointFrame.test.ts
+++ b/test/robotJointFrame.test.ts
@@ -37,3 +37,39 @@ describe('jointFromPicks — mate two picked faces (#354)', () => {
     check([0.1, -0.05, 0.2], [0.3, 0.6, 0.74], [-0.02, 0.04, 0.01], [-0.5, 0.5, 0.707])
   })
 })
+
+// handleConnectPicked puts the PIVOT at the mating point (not the child's centre) by
+// using jointOrigin = parentLocal + offset and re-origining the child onto its picked
+// point (shift its visual + child-joints by −childLocal). This locks that geometry:
+// the mesh stays exactly put, but the link origin (pivot) lands on the joint.
+describe('pivot-at-mate re-origin (#354)', () => {
+  const mat = (R: THREE.Quaternion, t: THREE.Vector3): THREE.Matrix4 =>
+    new THREE.Matrix4().compose(t, R, new THREE.Vector3(1, 1, 1))
+
+  it('mesh world-position is unchanged; pivot + picked point sit on the mating point', () => {
+    const pL: Vec3 = [0.05, 0, 0.02]
+    const pN: Vec3 = [1, 0, 0]
+    const cL: Vec3 = [0, 0.03, -0.04] // picked point, offset from the child's link origin
+    const cN: Vec3 = [0, 1, 0]
+    const off: Vec3 = [0, 0, 0.01]
+    const { xyz: xyzOld, rpy } = jointFromPicks(pL, pN, cL, cN, off)
+    const R = rotOf(rpy)
+    // Old link frame (pivot at the child's centre) vs new (pivot at the mating point).
+    const Told = mat(R, v(xyzOld))
+    const xyzNew = v(pL).add(v(off)) // parentLocal + offset
+    const Tnew = mat(R, xyzNew)
+    const shift = v(cL).negate() // −childLocal
+
+    // 1) pivot (new link origin) IS the mating point.
+    expect(near(xyzNew, v(pL).add(v(off)))).toBe(true)
+    // 2) the picked point (now at the link origin after the shift) is on the pivot.
+    const pickedNew = v(cL).add(shift).applyQuaternion(R).add(xyzNew)
+    expect(near(pickedNew, xyzNew)).toBe(true)
+    // 3) an arbitrary mesh point keeps its world position: Told·p == Tnew·(p − childLocal).
+    for (const p of [v([0.1, -0.2, 0.05]), v([0, 0, 0]), v(cL)]) {
+      const worldOld = p.clone().applyMatrix4(Told)
+      const worldNew = p.clone().add(shift).applyMatrix4(Tnew)
+      expect(near(worldOld, worldNew)).toBe(true)
+    }
+  })
+})


### PR DESCRIPTION
> the hinge (the rotation point) isn't at the joint, it's half way along the part; the joint should obviously be the pivot point.

## Cause
`jointFromPicks` placed the joint origin at `parentLocal − R·childLocal + offset` — the child's **old link frame** — which is displaced from the mating point by the child's pick offset. Since a revolute joint pivots about the joint origin, the hinge ended up at the child's centre ("halfway along the part") instead of the picked hole.

## Fix (`handleConnectPicked`)
- Put the joint origin (the **pivot**) **at the mating point** (`parentLocal + offset`).
- **Re-origin the child onto its picked point**: shift its visual origin — and any of its *own* child-joints (for a mid-chain part) — by `−childLocal`, so the geometry stays **exactly** put while the link origin (the pivot) lands on the joint.

The mating (faces flush + picked points coincident) is unchanged; only the pivot moves. Verified with a concrete bar-picked-at-its-end example.

## Verification
- New unit test locks the geometry: the mesh's world position is invariant (`T_old·p == T_new·(p−childLocal)`), and both the pivot and the picked point land on the mating point.
- `typecheck` / `lint` / `test` (1549) / `build` ✅

Adversarial review pending before merge (edge cases: mid-chain parts with descendants, pre-existing visual origins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)