### PR TITLE
fix: Robot View — Join tool: holes are sticky, easier to grab (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -290,6 +290,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   or reopen any panel. Nothing about Robot mode is permanently changed.
 
 ### Fixed
+- **Robot View — Join tool: holes are easier to grab (#354).** Snapping a joint point
+  onto a hole was fiddly — an edge that was a touch closer would win, so the cross-hair
+  flicked off the hole as you moved to click. A **hole / loop centre now sticks** when
+  the cursor is within a generous radius (it wins over a marginally-closer edge), so the
+  cross-hair stays on the hole and the click lands there.
 - **Robot View — Join tool: the hinge pivots at the joint, not the part's middle (#354).**
   A rotation joint rotated the child about its *own centre* instead of the point you
   picked, so a hinge ended up "halfway along the part". The joint origin now sits **on

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -2022,10 +2022,12 @@ export function RobotView({
             })
             return { index, distPx: best }
           }
-          // Hole/loop centres are a joint's natural target but hard to hit dead-on (they
-          // sit over empty space). Bias toward one within a generous radius so it STICKS
-          // even when an edge midpoint is marginally closer — otherwise the target flicks
-          // off the hole as you move to click it. Falls back to the plain nearest.
+          // A HOLE centre is a joint's natural target but hard to hit dead-on (it sits
+          // over empty space). Bias toward one within a generous radius so it STICKS even
+          // when an edge midpoint is marginally closer — otherwise the target flicks off
+          // the hole as you move to click it. Only role 'hole' is magnetised (NOT the
+          // 'outline' = face centroid every mesh face has, which would swallow edge picks
+          // on small faces). Falls back to the plain nearest.
           const HOLE_CATCH_PX = 48
           const nearestSnap = (
             pts: THREE.Vector3[],
@@ -2045,9 +2047,7 @@ export function RobotView({
               if (!Number.isFinite(sx) || !Number.isFinite(sy)) return
               const d = Math.hypot(sx - px, sy - py)
               if (d < best.distPx) best = { index: i, distPx: d }
-              if ((roles[i] === 'hole' || roles[i] === 'outline') && d < hole.distPx) {
-                hole = { index: i, distPx: d }
-              }
+              if (roles[i] === 'hole' && d < hole.distPx) hole = { index: i, distPx: d }
             })
             return hole.index >= 0 && hole.distPx <= HOLE_CATCH_PX ? hole : best
           }
@@ -2445,7 +2445,7 @@ export function RobotView({
               const geom = readPrimitive(contentRef.current, link)
               const th = geom ? hitToHandles(hit, link, geom) : meshSnapCentres(hit)
               const near = nearestSnap(th.pts, th.roles, e)
-              const isHole = near.index >= 0 && (th.roles[near.index] === 'hole' || th.roles[near.index] === 'outline')
+              const isHole = near.index >= 0 && th.roles[near.index] === 'hole'
               if (near.index >= 0 && near.distPx < (isHole ? HOLE_CATCH_PX : geom ? 24 : 28)) {
                 world = th.pts[near.index].clone()
                 role = th.roles[near.index]

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -2022,6 +2022,35 @@ export function RobotView({
             })
             return { index, distPx: best }
           }
+          // Hole/loop centres are a joint's natural target but hard to hit dead-on (they
+          // sit over empty space). Bias toward one within a generous radius so it STICKS
+          // even when an edge midpoint is marginally closer — otherwise the target flicks
+          // off the hole as you move to click it. Falls back to the plain nearest.
+          const HOLE_CATCH_PX = 48
+          const nearestSnap = (
+            pts: THREE.Vector3[],
+            roles: string[],
+            e: PointerEvent
+          ): { index: number; distPx: number } => {
+            const rect = renderer.domElement.getBoundingClientRect()
+            const px = e.clientX - rect.left
+            const py = e.clientY - rect.top
+            let best = { index: -1, distPx: Infinity }
+            let hole = { index: -1, distPx: Infinity }
+            pts.forEach((p, i) => {
+              const v = p.clone().project(camera)
+              if (!(v.z >= -1 && v.z <= 1)) return
+              const sx = (v.x * 0.5 + 0.5) * rect.width
+              const sy = (-v.y * 0.5 + 0.5) * rect.height
+              if (!Number.isFinite(sx) || !Number.isFinite(sy)) return
+              const d = Math.hypot(sx - px, sy - py)
+              if (d < best.distPx) best = { index: i, distPx: d }
+              if ((roles[i] === 'hole' || roles[i] === 'outline') && d < hole.distPx) {
+                hole = { index: i, distPx: d }
+              }
+            })
+            return hole.index >= 0 && hole.distPx <= HOLE_CATCH_PX ? hole : best
+          }
 
           // ── Resize (push/pull tool) ──
           const startResize = (e: PointerEvent): void => {
@@ -2393,7 +2422,7 @@ export function RobotView({
             // directly clickable, with no pixel-threshold gap and no need to hold
             // SHIFT to reach it.
             if (hoverSnaps && hoverSnaps.pts.length && robot.links[hoverSnaps.link]) {
-              const near = nearestScreen(hoverSnaps.pts, e)
+              const near = nearestSnap(hoverSnaps.pts, hoverSnaps.roles, e)
               if (near.index >= 0) {
                 link = hoverSnaps.link
                 world = hoverSnaps.pts[near.index].clone()
@@ -2415,8 +2444,9 @@ export function RobotView({
               world = hit.point.clone()
               const geom = readPrimitive(contentRef.current, link)
               const th = geom ? hitToHandles(hit, link, geom) : meshSnapCentres(hit)
-              const near = nearestScreen(th.pts, e)
-              if (near.index >= 0 && near.distPx < (geom ? 24 : 28)) {
+              const near = nearestSnap(th.pts, th.roles, e)
+              const isHole = near.index >= 0 && (th.roles[near.index] === 'hole' || th.roles[near.index] === 'outline')
+              if (near.index >= 0 && near.distPx < (isHole ? HOLE_CATCH_PX : geom ? 24 : 28)) {
                 world = th.pts[near.index].clone()
                 role = th.roles[near.index]
               }
@@ -2606,7 +2636,7 @@ export function RobotView({
                 clearHoverMarker()
                 return
               }
-              const near = nearestScreen(hoverSnaps.pts, e)
+              const near = nearestSnap(hoverSnaps.pts, hoverSnaps.roles, e)
               showHandles(hoverSnaps.pts, near.index, hoverSnaps.worldNormal)
               if (near.index >= 0) {
                 setHoverMarker(hoverSnaps.pts[near.index], hoverSnaps.worldNormal, hoverSnaps.roles[near.index])


### PR DESCRIPTION
> it's still tricky to select a snap point over a hole, even though a cross hair identifies this.

## Cause
The snap target was chosen by **pure screen distance** (`nearestScreen`), so an edge midpoint or outline point a touch closer than the hole centre would win. The cross-hair identified the hole, but as you moved the cursor to click, the target flicked onto a nearer edge.

## Fix
New `nearestSnap()` **biases hole / loop centres**: within a generous radius (48px) the nearest hole wins over a marginally-closer edge, so the cross-hair **sticks on the hole** and the click lands there. Used for the joint hover target + the WYSIWYG pick (they stay consistent); the plain `nearestScreen` is kept for the SHIFT keep-alive and the Move tool.

## Verification
- `typecheck` / `lint` / `test` (1549) / `build` ✅
- Interactive (holes need a washer STL): relies on this review + live testing. The change only re-ranks which snap is chosen (prefer a near hole), so it can't place a joint anywhere a snap didn't already exist.

Adversarial review pending before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)