### PR TITLE
fix: Robot View — mini 3D viewer zooms to fit the robot on load (#320)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -290,6 +290,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   or reopen any panel. Nothing about Robot mode is permanently changed.
 
 ### Fixed
+- **Robot View — the mini 3-D viewer zooms to fit the robot on load (#320).** The dock
+  viewer starts on the demo arm and swaps to your project robot once it resolves, but it
+  kept the demo arm's camera — so your robot loaded tiny and off-centre. It now re-frames
+  when the robot changes, filling the mini view.
 - **Robot View — Join tool: holes are easier to grab (#354).** Snapping a joint point
   onto a hole was fiddly — an edge that was a touch closer would win, so the cross-hair
   flicked off the hole as you moved to click. A **hole / loop centre now sticks** when

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -1536,9 +1536,12 @@ export function RobotView({
     }
 
     // Frame a NEW robot isometrically, but PRESERVE the camera when the same file
-    // is just re-parsed after a build edit (#315a must-fix — no view jump). The
-    // grid is refreshed to the new bounds either way.
-    const frameKey = activeFile?.id ?? ''
+    // is just re-parsed after a build edit (#315a must-fix — no view jump). The grid
+    // is refreshed to the new bounds either way. The mini/compact viewer's content
+    // comes from `urdfContent` (the dock's demo-arm → project robot), NOT the
+    // workspace's active file — so key it on the robot's base folder, else it keeps
+    // the demo-arm camera and the real robot loads tiny + off-centre.
+    const frameKey = compact ? effectiveBase : (activeFile?.id ?? '')
     const relayGrid = (robot: URDFRobot): void => {
       robot.updateMatrixWorld(true)
       const box = new THREE.Box3().setFromObject(robot)
@@ -2786,7 +2789,7 @@ export function RobotView({
       renderer.dispose()
       if (renderer.domElement.parentNode === mount) mount.removeChild(renderer.domElement)
     }
-  }, [content, effectiveBase, isEmpty, poseUI, currentFolder, activeFile?.id, projection])
+  }, [content, effectiveBase, isEmpty, poseUI, compact, currentFolder, activeFile?.id, projection])
 
   const showPanel = poseUI && !error && !isEmpty
   const showTimeline = poseUI && !error && !isEmpty && movableNames.length > 0


### PR DESCRIPTION
> the mini-urdf view needs to be zoomed to fit when loading the robot mode view.

## Cause
The dock's compact viewer starts on the bundled **demo arm** and swaps to your **project robot** once `robot.yml` resolves. But `RobotView` reads `activeFile` from the store even in compact mode, so its **frame key was the workspace's active file id** — which doesn't change across that demo→real content swap. So it took the "preserve camera" path and **restored the demo arm's camera**, leaving the real robot tiny + off-centre.

## Fix
Key the **compact** viewer on `effectiveBase` (the robot's folder) instead of the active file, so a newly-resolved robot re-frames. The full-screen view is **unchanged** (still `activeFile?.id`).

## Verification
Before/after Playwright screenshots: the project robot went from three tiny cubes low in the frame to filling the mini view. `typecheck` / `lint` / `test` (1549) / `build` ✅. The non-compact path is byte-for-byte unchanged, so no risk to the main view's camera preservation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)