### PR TITLE
feat: Robot View — joint roll angle (all types) + fix Add button hidden by zoom controls (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   repeating the filename.
 
 ### Added
+- **Robot View — Join tool: a roll angle on every joint type (#354).** The Add Joint
+  dialog now has a **roll (°)** field alongside the X/Y/Z offset — for **Static** joints
+  too — that spins the child about the joint's normal axis while keeping the mated faces
+  flush, so you can orient a bracket/part however you like at the connection.
 - **Robot View — import parts, pick a base, articulate them into a chain (#354).**
   Imported STLs no longer stack on top of the first part at the origin. Each import
   now attaches to the base with a **movable joint** at a **staggered** position, so it
@@ -296,6 +300,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   or reopen any panel. Nothing about Robot mode is permanently changed.
 
 ### Fixed
+- **Robot View — the Add Joint dialog's buttons are always clickable (#354).** The
+  properties dialog sat *below* the zoom controls, so when it grew tall enough to reach
+  the bottom-right the zoom toolbar covered its **Add** button — clicks landed on "Zoom
+  to fit" and the joint was silently not added (looked like the 3rd joint "vanished").
+  The dialog now floats above the 3-D chrome and caps its height so the footer stays
+  reachable.
 - **Robot View — the mini 3-D viewer zooms to fit the robot on load (#320).** The dock
   viewer starts on the demo arm and swaps to your project robot once it resolves, but it
   kept the demo arm's camera — so your robot loaded tiny and off-centre. It now re-frames

--- a/src/renderer/src/components/RobotPropertiesDialog.css
+++ b/src/renderer/src/components/RobotPropertiesDialog.css
@@ -4,8 +4,13 @@
   position: absolute;
   top: 190px; /* comfortably below the 144px nav cube + its projection dropdown */
   right: 12px;
-  z-index: 20;
+  /* Above the zoom controls + nav cube (z-index 30): a tall dialog reaches the
+     bottom-right, and if it sat below them the zoom toolbar covered its Add/OK
+     button so clicks landed on "Zoom to fit" instead (a joint silently not added). */
+  z-index: 40;
   width: 13rem;
+  /* Never grow past the stage; scroll the body so the footer stays reachable. */
+  max-height: calc(100% - 202px);
   display: flex;
   flex-direction: column;
   border: 1px solid var(--border, #3a3d44);

--- a/src/renderer/src/components/RobotPropertiesDialog.tsx
+++ b/src/renderer/src/components/RobotPropertiesDialog.tsx
@@ -79,12 +79,14 @@ export interface RobotPropertiesDialogProps {
   jointPick: JointPickView | null
   /** Arm the picker for a component again (the next 3-D click re-picks it). */
   onRepick: (step: 'parent' | 'child') => void
-  /** Create the joint from the two picks + chosen type + offset (mm). Returns
-   *  false (keeps the dialog open) if the picks are incomplete / would loop. */
+  /** Create the joint from the two picks + chosen type + offset (mm) + a roll angle
+   *  (degrees) about the joint normal. Returns false (keeps the dialog open) if the
+   *  picks are incomplete / would loop. */
   onConnectPicked: (
     type: JointType,
     offsetMm: [number, number, number],
-    rotation?: { minDeg: number; maxDeg: number; defaultDeg: number }
+    rotation?: { minDeg: number; maxDeg: number; defaultDeg: number },
+    angleDeg?: number
   ) => boolean
   // footer
   onOk: () => void
@@ -521,6 +523,8 @@ function AddJointBody({
 }): JSX.Element {
   const [type, setType] = useState<JointType>('fixed')
   const [off, setOff] = useState<Record<'x' | 'y' | 'z', string>>({ x: '0', y: '0', z: '0' })
+  // Roll of the child ABOUT the joint normal (degrees) — for every joint type.
+  const [angle, setAngle] = useState('0')
   // Rotation (revolute) limits + default angle, in DEGREES (raw strings).
   const [rot, setRot] = useState<{ min: string; max: string; def: string }>({
     min: '-90',
@@ -545,7 +549,7 @@ function AddJointBody({
       type === 'revolute'
         ? { minDeg: Number(rot.min) || 0, maxDeg: Number(rot.max) || 0, defaultDeg: Number(rot.def) || 0 }
         : undefined
-    const ok = onConnectPicked(type, [mm(off.x), mm(off.y), mm(off.z)], rotation)
+    const ok = onConnectPicked(type, [mm(off.x), mm(off.y), mm(off.z)], rotation, Number(angle) || 0)
     if (!ok) {
       setErr('Can’t connect — that would form a loop (the parent hangs off the child).')
       return false
@@ -651,6 +655,12 @@ function AddJointBody({
           {axis('x')}
           {axis('y')}
           {axis('z')}
+        </div>
+        <div className="robotprops__row">
+          <label className="robotprops__mm" title="Rotate the child about the joint's normal axis">
+            <span>roll °</span>
+            <input type="number" value={angle} onChange={(e) => setAngle(e.target.value)} />
+          </label>
         </div>
       </section>
       {err ? (

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -694,7 +694,8 @@ export function RobotView({
   const handleConnectPicked = (
     type: JointType,
     offsetMm: [number, number, number],
-    rotation?: { minDeg: number; maxDeg: number; defaultDeg: number }
+    rotation?: { minDeg: number; maxDeg: number; defaultDeg: number },
+    angleDeg = 0
   ): boolean => {
     const jp = jointPick
     if (!jp?.parent || !jp?.child) return false
@@ -704,13 +705,15 @@ export function RobotView({
     const o = orientJoint(base, jp.parent.link, jp.child.link)
     const [parent, child] = o.parent === jp.parent.link ? [jp.parent, jp.child] : [jp.child, jp.parent]
     // The mating ROTATION (rotate the child so its picked face meets the parent's
-    // flush). The origin is handled separately below so the pivot lands on the joint.
+    // flush, then roll it about the joint normal by `angleDeg`). The origin is handled
+    // separately below so the pivot lands on the joint.
     const { rpy } = jointFromPicks(
       parent.local,
       parent.normal,
       child.local,
       child.normal,
-      offsetMm
+      offsetMm,
+      angleDeg
     )
     // Joint origin — the PIVOT — at the mating point (parent's picked point + offset).
     // Exact because we re-origin the child onto its picked point below.

--- a/src/renderer/src/components/robot-joint-frame.ts
+++ b/src/renderer/src/components/robot-joint-frame.ts
@@ -17,12 +17,20 @@ export function jointFromPicks(
   parentNormal: Vec3,
   childLocal: Vec3,
   childNormal: Vec3,
-  offset: Vec3 = [0, 0, 0]
+  offset: Vec3 = [0, 0, 0],
+  /** Extra spin (degrees) of the child ABOUT the mating normal — the shared axis
+   *  through the joint. Keeps the faces flush; just rolls the child around it. */
+  angleDeg = 0
 ): { xyz: Vec3; rpy: Vec3 } {
   const pn = new THREE.Vector3(parentNormal[0], parentNormal[1], parentNormal[2]).normalize()
   const cn = new THREE.Vector3(childNormal[0], childNormal[1], childNormal[2]).normalize()
   // Rotate the child so its picked normal faces OPPOSITE the parent's (flush mate).
   const q = new THREE.Quaternion().setFromUnitVectors(cn, pn.clone().negate())
+  // Then roll it about the shared normal (through the joint) by `angleDeg`.
+  if (angleDeg) {
+    const spin = new THREE.Quaternion().setFromAxisAngle(pn, (angleDeg * Math.PI) / 180)
+    q.premultiply(spin)
+  }
   // origin so the rotated child point lands on the parent point (+ offset):
   //   origin + R·childLocal = parentLocal + offset
   const rc = new THREE.Vector3(childLocal[0], childLocal[1], childLocal[2]).applyQuaternion(q)

--- a/test/robotJointFrame.test.ts
+++ b/test/robotJointFrame.test.ts
@@ -36,6 +36,20 @@ describe('jointFromPicks — mate two picked faces (#354)', () => {
   it('handles an arbitrary pick', () => {
     check([0.1, -0.05, 0.2], [0.3, 0.6, 0.74], [-0.02, 0.04, 0.01], [-0.5, 0.5, 0.707])
   })
+  it('rolls the child about the mating normal, keeping the faces flush (#354)', () => {
+    const pN: Vec3 = [0, 0, 1]
+    const cN: Vec3 = [0, 0, 1]
+    const r0 = jointFromPicks([0, 0, 0], pN, [0, 0, 0], cN, [0, 0, 0], 0)
+    const r90 = jointFromPicks([0, 0, 0], pN, [0, 0, 0], cN, [0, 0, 0], 90)
+    const R0 = rotOf(r0.rpy)
+    const R90 = rotOf(r90.rpy)
+    // Mate still holds: the child's normal faces OPPOSITE the parent's.
+    expect(near(v(cN).normalize().applyQuaternion(R90), v(pN).normalize().negate())).toBe(true)
+    // R90 differs from R0 by exactly a 90° spin about the normal.
+    const diff = R90.clone().multiply(R0.clone().invert())
+    const spin = new THREE.Quaternion().setFromAxisAngle(v(pN).normalize(), Math.PI / 2)
+    expect(Math.abs(Math.abs(diff.dot(spin)) - 1)).toBeLessThan(1e-6)
+  })
 })
 
 // handleConnectPicked puts the PIVOT at the mating point (not the child's centre) by


### PR DESCRIPTION
Two Add-Joint issues from your feedback.

## 1. The "3rd joint gets ignored" bug — root cause found
The properties dialog was `z-index: 20`, **below** the zoom controls (`z-index: 30`). When the dialog grew tall enough to reach the bottom-right, the **zoom toolbar covered its Add button** — so clicks there landed on "Zoom to fit" and the joint was silently not committed.

Confirmed with a driven Playwright smoke: clicking Add *through* the overlay is intercepted by the zoom button; clicking it directly runs `handleConnectPicked` and `connectJoint changed=true`. The assembly logic was never the problem (a chain of 3+ joints builds fine).

**Fix:** dialog `z-index: 40` (above the 3-D chrome) + a `max-height` so the already-scrolling body keeps the footer reachable.

## 2. Roll angle on every joint type (incl. Static)
`jointFromPicks` gains an `angleDeg` that **spins the child about the mating normal** (the shared axis through the joint), keeping the faces flush. The Add Joint dialog shows a **roll (°)** field next to the X/Y/Z **offset** — for **Static** joints too — and `handleConnectPicked` threads it through. (The offset fields were already there for all types.)

## Verification
- Unit test locks the roll geometry: the mate is preserved and the result is exactly a 90° spin about the normal.
- Screenshots confirm the roll field renders (its own line under the offset) and the dialog now floats above the zoom controls.
- `typecheck` / `lint` / `test` (1550) / `build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)