### PR TITLE
fix: Robot View — adding a joint crashed the view (ownerLinkName TDZ) (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -300,6 +300,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   or reopen any panel. Nothing about Robot mode is permanently changed.
 
 ### Fixed
+- **Robot View — adding a joint no longer blanks the view (#354).** After a joint was
+  added the selected block's highlight was re-applied during the scene rebuild, but the
+  helper it needed was declared *later* in the same setup — a temporal-dead-zone crash
+  that blanked the whole Robot View (intermittent, since it only fired once the block's
+  mesh had finished loading — which is why "the 3rd joint vanished"). The helper is now
+  declared before it's used, so chaining any number of joints is solid.
 - **Robot View — the Add Joint dialog's buttons are always clickable (#354).** The
   properties dialog sat *below* the zoom controls, so when it grew tall enough to reach
   the bottom-right the zoom toolbar covered its **Add** button — clicks landed on "Zoom

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -1873,6 +1873,14 @@ export function RobotView({
           const buildRay = new THREE.Raycaster()
           const buildNdc = new THREE.Vector2()
           const camDir = new THREE.Vector3()
+          // The URDF link an object belongs to (walk up to the marked URDFLink). Declared
+          // HERE — before applyHighlight uses it below — so re-selecting on an effect
+          // re-run (e.g. after adding a joint) can't hit a temporal-dead-zone crash.
+          const ownerLinkName = (obj: THREE.Object3D | null): string | null => {
+            let o = obj
+            while (o && !(o as unknown as { isURDFLink?: boolean }).isURDFLink) o = o.parent
+            return (o as unknown as { urdfName?: string } | null)?.urdfName ?? null
+          }
           // Selection highlight: tint the one selected block LIGHT BLUE, keeping the
           // material's shading (so the sides still shade rather than going flat). Only
           // ever ONE block is highlighted — clearHighlight() restores the previous one
@@ -2004,11 +2012,6 @@ export function RobotView({
             })
           }
           const mmv = (m: number): number => Math.round(m * 1000)
-          const ownerLinkName = (obj: THREE.Object3D | null): string | null => {
-            let o = obj
-            while (o && !(o as unknown as { isURDFLink?: boolean }).isURDFLink) o = o.parent
-            return (o as unknown as { urdfName?: string } | null)?.urdfName ?? null
-          }
           // Classify the hovered face + return its world snap handles.
           const hitToHandles = (
             hit: THREE.Intersection,


### PR DESCRIPTION
The **real** cause of "linking more than two items ignores the 3rd joint" (my earlier z-index PR #389 was a red herring — the assembly logic and the Add button were both fine).

## Root cause — a temporal-dead-zone crash
`handleConnectPicked` marks the child as selected, the 3-D `useEffect` re-runs to rebuild the scene, and near the top it calls `applyHighlight(selectedLinkRef.current)` to survive the re-parse. But `applyHighlight` calls **`ownerLinkName`, a `const` declared ~120 lines *later*** in the same effect body → **`Cannot access 'ownerLinkName' before initialization`**, which **blanks the entire Robot View**.

**Why it looked like "the 3rd joint":** `applyHighlight` only reaches `ownerLinkName` when the selected block has a *loaded mesh* to traverse. A primitive-only robot never crashed; a mesh robot crashed on whichever joint landed *after* its STL finished loading — so it felt intermittent ("2 work, the 3rd vanishes").

## Fix
Declare `ownerLinkName` **before** `applyHighlight` uses it.

## Verification
Driven Playwright smoke chaining **3 joints**: before the fix the view goes blank after the first mesh-joint (`pageerror: Cannot access 'ownerLinkName' before initialization`, toolbar gone). After the fix: the toolbar survives all 3, **no page error**.

Screenshots + the reproduction trace made this unambiguous. (The separate roll-angle field and the edit-dialog offset/roll are follow-ups.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)