### PR TITLE
feat: edit an existing joint's offset + roll in the joint editor (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   dialog now has a **roll (°)** field alongside the X/Y/Z offset — for **Static** joints
   too — that spins the child about the joint's normal axis while keeping the mated faces
   flush, so you can orient a bracket/part however you like at the connection.
+- **Robot View — edit an existing joint's offset + roll after the fact (#354).**
+  Clicking a joint in the build panel's **Joints** list now shows an **Offset (X/Y/Z, mm)**
+  and a **Roll (°)** control in the joint editor — for **Static** joints too, not just
+  when first adding them. Nudge a connection into place or spin a part about its normal
+  without deleting and re-joining.
 - **Robot View — import parts, pick a base, articulate them into a chain (#354).**
   Imported STLs no longer stack on top of the first part at the origin. Each import
   now attaches to the base with a **movable joint** at a **staggered** position, so it

--- a/src/renderer/src/components/RobotBuildPanel.tsx
+++ b/src/renderer/src/components/RobotBuildPanel.tsx
@@ -172,11 +172,17 @@ const AXES: Array<{ id: 'x' | 'y' | 'z'; vec: Vec3 }> = [
 export function JointForm({
   joint,
   names,
-  onChange
+  onChange,
+  onSetOrigin,
+  onRoll
 }: {
   joint: JointDef
   names: string[]
   onChange: (spec: JointSpec) => void
+  /** Move the joint origin to `xyz` (metres), keeping its orientation. */
+  onSetOrigin?: (xyz: [number, number, number]) => void
+  /** Roll the joint about its own normal axis by `deltaDeg` (relative nudge). */
+  onRoll?: (deltaDeg: number) => void
 }): JSX.Element {
   // The current joint as a full spec, so each edit preserves the other fields.
   const spec = (): JointSpec => ({
@@ -201,6 +207,21 @@ export function JointForm({
   const commitLim = (): void =>
     onChange({ ...spec(), lower: toNative(mt, lim[0]), upper: toNative(mt, lim[1]) })
 
+  // Origin offset (mm, local like the size fields) + a relative roll nudge (deg)
+  // about the joint's own normal axis. Editable for every joint type (#354).
+  const off0 = joint.xyz.map(mm) as [number, number, number]
+  const [off, setOff] = useState<[number, number, number]>(off0)
+  const offKey = `${joint.name}:${off0.join(',')}`
+  useEffect(() => setOff(off0), [offKey]) // eslint-disable-line react-hooks/exhaustive-deps
+  const commitOff = (): void =>
+    onSetOrigin?.(off.map((v) => toM(Number.isFinite(v) ? v : 0)) as [number, number, number])
+  const [roll, setRoll] = useState('0')
+  const commitRoll = (): void => {
+    const d = Number(roll) || 0
+    if (d) onRoll?.(d)
+    setRoll('0') // a relative nudge — reset so the next entry rolls from here
+  }
+
   const others = names.filter((n) => n !== joint.name)
   const unit = unitLabel(mt)
 
@@ -219,6 +240,50 @@ export function JointForm({
           </button>
         ))}
       </div>
+      {onSetOrigin && (
+        <div className="robotbuild__jrow">
+          <span className="robotbuild__jlabel" title="Position of the joint, relative to its parent">
+            Offset
+          </span>
+          {(['X', 'Y', 'Z'] as const).map((ax, i) => (
+            <label className="robotbuild__mm" key={ax}>
+              <span>{ax}</span>
+              <input
+                type="number"
+                step={1}
+                value={Number.isFinite(off[i]) ? off[i] : ''}
+                onChange={(e) => {
+                  const n = [...off] as [number, number, number]
+                  n[i] = Number(e.target.value)
+                  setOff(n)
+                }}
+                onBlur={commitOff}
+                onKeyDown={(e) => e.key === 'Enter' && commitOff()}
+              />
+            </label>
+          ))}
+          <span className="robotbuild__mm-unit">mm</span>
+        </div>
+      )}
+      {onRoll && (
+        <div className="robotbuild__jrow">
+          <span className="robotbuild__jlabel" title="Rotate the joint about its own normal axis">
+            Roll
+          </span>
+          <label className="robotbuild__mm">
+            <span>by</span>
+            <input
+              type="number"
+              step={15}
+              value={roll}
+              onChange={(e) => setRoll(e.target.value)}
+              onBlur={commitRoll}
+              onKeyDown={(e) => e.key === 'Enter' && commitRoll()}
+            />
+          </label>
+          <span className="robotbuild__mm-unit">°</span>
+        </div>
+      )}
       {movable && (
         <div className="robotbuild__jrow">
           <span className="robotbuild__jlabel">Axis</span>

--- a/src/renderer/src/components/RobotPropertiesDialog.tsx
+++ b/src/renderer/src/components/RobotPropertiesDialog.tsx
@@ -51,6 +51,9 @@ export interface RobotPropertiesDialogProps {
   jointNames: string[]
   onSetSize: (link: string, dims: number[]) => void
   onSetJoint: (link: string, spec: JointSpec) => void
+  /** Reposition the joint origin (offset, mm→m) and roll it about its normal (deg). */
+  onSetJointOrigin: (child: string, xyz: [number, number, number]) => void
+  onRollJoint: (child: string, deltaDeg: number) => void
   /** Remove the joint whose child is this link (the block re-attaches to the base). */
   onDeleteJoint: (child: string) => void
   // servo
@@ -247,7 +250,9 @@ function LinkBody({
   joint,
   jointNames,
   onSetSize,
-  onSetJoint
+  onSetJoint,
+  onSetJointOrigin,
+  onRollJoint
 }: RobotPropertiesDialogProps & { context: PropsContext }): JSX.Element {
   // `link` = the block being edited, or the joint's child link (which carries it).
   const link = context.kind === 'joint' ? context.child : context.kind === 'link' ? context.link : ''
@@ -265,7 +270,13 @@ function LinkBody({
       {joint ? (
         <section className="robotprops__section">
           <div className="robotprops__label">Joint</div>
-          <JointForm joint={joint} names={jointNames} onChange={(spec) => onSetJoint(link, spec)} />
+          <JointForm
+            joint={joint}
+            names={jointNames}
+            onChange={(spec) => onSetJoint(link, spec)}
+            onSetOrigin={(xyz) => onSetJointOrigin(link, xyz)}
+            onRoll={(deltaDeg) => onRollJoint(link, deltaDeg)}
+          />
         </section>
       ) : (
         <p className="robotprops__note">This is the base — nothing to join to.</p>

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -556,6 +556,22 @@ export function RobotView({
   const handleSetJoint = (link: string, spec: JointSpec): void => {
     commitUrdf(setJoint(content, link, spec))
   }
+  // Reposition an existing joint's origin (keep its orientation) — the Offset fields
+  // on the joint editor.
+  const handleSetJointOrigin = (child: string, xyz: [number, number, number]): void => {
+    const j = readJoint(content, child)
+    if (j) commitUrdf(setJointOrigin(content, child, xyz, j.rpy))
+  }
+  // Roll an existing joint about its own normal axis (its origin's local Z) by
+  // `deltaDeg`, keeping its position — the roll field on the joint editor.
+  const handleRollJoint = (child: string, deltaDeg: number): void => {
+    const j = readJoint(content, child)
+    if (!j || !deltaDeg) return
+    const R = new THREE.Quaternion().setFromEuler(new THREE.Euler(j.rpy[0], j.rpy[1], j.rpy[2], 'ZYX'))
+    R.multiply(new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 0, 1), (deltaDeg * Math.PI) / 180))
+    const e = new THREE.Euler().setFromQuaternion(R, 'ZYX')
+    commitUrdf(setJointOrigin(content, child, j.xyz, [e.x, e.y, e.z]))
+  }
   const handleDeleteLink = (link: string): void => {
     // Deleting the base would cascade-remove the whole tree → an empty, unusable
     // URDF. The UI disables it; guard here too. (A loose, unconnected part is fine
@@ -3022,6 +3038,8 @@ export function RobotView({
             jointNames={allJointNames}
             onSetSize={handleSetSize}
             onSetJoint={handleSetJoint}
+            onSetJointOrigin={handleSetJointOrigin}
+            onRollJoint={handleRollJoint}
             onDeleteJoint={handleDeleteJoint}
             servo={dialogCtx.kind === 'servo' ? bindings.find((b) => b.pin === dialogCtx.pin) ?? null : null}
             movableJoints={movableNames}


### PR DESCRIPTION
## What

Answers the follow-up to the Join tool work: *"I can't see the angle and offset fields in the static joint dialog — should that be there too?"* — **yes**, and now they are.

Clicking a joint in the build panel's **Joints** list opened an editor that only let you change **type / axis / limits**. For a **Static** (fixed) joint there was nothing to adjust at all. You could set an offset + roll when *first adding* a joint (#389/#390), but never afterward — so a slightly-off connection meant deleting and re-joining.

## Changes

- **`JointForm` (RobotBuildPanel)** gains an **Offset (X/Y/Z, mm)** row and a **Roll (°)** nudge, rendered for **every** joint type (gated on two new optional callbacks, `onSetOrigin` / `onRoll`).
  - **Offset** moves the joint origin, keeping its orientation — local mm state, commit on blur/Enter (mirrors `SizeForm`).
  - **Roll** spins the joint about its **own normal axis** (its origin's local Z) by a *relative* amount, then resets to `0` so the next entry rolls from there.
- **`RobotView`**: `handleSetJointOrigin` (keep rpy, set xyz) + `handleRollJoint` (premultiply-free `R · spinZ(Δ)` → new rpy), both via the existing `setJointOrigin` plumbing.
- **`RobotPropertiesDialog`** threads the two handlers through `LinkBody` → `JointForm`.

The fields reuse the themed `.robotbuild__mm` / `__jrow` / `__jlabel` classes, so they read correctly in **both** the dark and skeuomorph skins with no new CSS.

## Verification

- `typecheck` ✅ · `lint` ✅ (only the pre-existing `DriverInstallBanner` warning) · **1550 tests** ✅ · `build` ✅
- Playwright smoke: seed a 2-link URDF with a **fixed** joint → open its editor → **Offset** (seeded to 50mm from the 0.05m origin) + **Roll** fields render; edit X→80mm and roll 90° → both apply, `pageerror: null`, roll resets to 0, offset persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)