### PR TITLE
feat: joint editor — live offset/roll + a remembered, absolute roll (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   dialog now has a **roll (°)** field alongside the X/Y/Z offset — for **Static** joints
   too — that spins the child about the joint's normal axis while keeping the mated faces
   flush, so you can orient a bracket/part however you like at the connection.
-- **Robot View — edit an existing joint's offset + roll after the fact (#354).**
-  Clicking a joint in the build panel's **Joints** list now shows an **Offset (X/Y/Z, mm)**
-  and a **Roll (°)** control in the joint editor — for **Static** joints too, not just
-  when first adding them. Nudge a connection into place or spin a part about its normal
-  without deleting and re-joining.
+- **Robot View — edit an existing joint's offset + roll, live (#354).** Clicking a
+  joint in the build panel's **Joints** list now shows an **Offset (X/Y/Z, mm)** and a
+  **Roll (°)** control in the joint editor — for **Static** joints too, not just when
+  first adding them. Both apply **immediately** as you type or nudge the spinner (no
+  Enter needed), and the **roll is an absolute value that's remembered** — reopen the
+  joint and it still reads the angle you set (instead of snapping back to 0), so you can
+  fine-tune it or return it to 0 yourself. Nudge a connection into place or spin a part
+  about its normal without deleting and re-joining.
 - **Robot View — import parts, pick a base, articulate them into a chain (#354).**
   Imported STLs no longer stack on top of the first part at the origin. Each import
   now attaches to the base with a **movable joint** at a **staggered** position, so it

--- a/src/renderer/src/components/RobotBuildPanel.tsx
+++ b/src/renderer/src/components/RobotBuildPanel.tsx
@@ -172,17 +172,20 @@ const AXES: Array<{ id: 'x' | 'y' | 'z'; vec: Vec3 }> = [
 export function JointForm({
   joint,
   names,
+  jointRoll,
   onChange,
   onSetOrigin,
   onRoll
 }: {
   joint: JointDef
   names: string[]
+  /** The joint's current absolute roll (deg) about its normal — seeds the Roll field. */
+  jointRoll?: number
   onChange: (spec: JointSpec) => void
-  /** Move the joint origin to `xyz` (metres), keeping its orientation. */
+  /** Move the joint origin to `xyz` (metres), keeping its orientation (applied live). */
   onSetOrigin?: (xyz: [number, number, number]) => void
-  /** Roll the joint about its own normal axis by `deltaDeg` (relative nudge). */
-  onRoll?: (deltaDeg: number) => void
+  /** Set the joint's ABSOLUTE roll about its own normal axis, in degrees (applied live). */
+  onRoll?: (absDeg: number) => void
 }): JSX.Element {
   // The current joint as a full spec, so each edit preserves the other fields.
   const spec = (): JointSpec => ({
@@ -207,19 +210,30 @@ export function JointForm({
   const commitLim = (): void =>
     onChange({ ...spec(), lower: toNative(mt, lim[0]), upper: toNative(mt, lim[1]) })
 
-  // Origin offset (mm, local like the size fields) + a relative roll nudge (deg)
-  // about the joint's own normal axis. Editable for every joint type (#354).
+  // Origin offset (mm, local like the size fields) + an ABSOLUTE roll (deg) about the
+  // joint's own normal axis. Both apply LIVE as the field changes (#354). Editable for
+  // every joint type. The offset re-seeds from the model on an external change (a 3-D
+  // drag) — but NOT while the field is focused, so live typing isn't clobbered by the
+  // URDF's 0.1 mm rounding. The roll seeds from its remembered absolute value.
   const off0 = joint.xyz.map(mm) as [number, number, number]
   const [off, setOff] = useState<[number, number, number]>(off0)
+  const offEditing = useRef(false)
   const offKey = `${joint.name}:${off0.join(',')}`
-  useEffect(() => setOff(off0), [offKey]) // eslint-disable-line react-hooks/exhaustive-deps
-  const commitOff = (): void =>
-    onSetOrigin?.(off.map((v) => toM(Number.isFinite(v) ? v : 0)) as [number, number, number])
-  const [roll, setRoll] = useState('0')
-  const commitRoll = (): void => {
-    const d = Number(roll) || 0
-    if (d) onRoll?.(d)
-    setRoll('0') // a relative nudge — reset so the next entry rolls from here
+  useEffect(() => {
+    if (!offEditing.current) setOff(off0)
+  }, [offKey]) // eslint-disable-line react-hooks/exhaustive-deps
+  const toXyz = (v: number[]): [number, number, number] =>
+    v.map((n) => toM(Number.isFinite(n) ? n : 0)) as [number, number, number]
+  const pushOff = (n: [number, number, number]): void => {
+    setOff(n)
+    if (n.every((v) => Number.isFinite(v))) onSetOrigin?.(toXyz(n)) // live
+  }
+  const commitOff = (): void => onSetOrigin?.(toXyz(off))
+  const [roll, setRoll] = useState(String(jointRoll ?? 0))
+  const setRollLive = (v: string): void => {
+    setRoll(v)
+    const n = Number(v)
+    if (v.trim() !== '' && Number.isFinite(n)) onRoll?.(n) // absolute, live
   }
 
   const others = names.filter((n) => n !== joint.name)
@@ -252,12 +266,16 @@ export function JointForm({
                 type="number"
                 step={1}
                 value={Number.isFinite(off[i]) ? off[i] : ''}
+                onFocus={() => (offEditing.current = true)}
                 onChange={(e) => {
                   const n = [...off] as [number, number, number]
                   n[i] = Number(e.target.value)
-                  setOff(n)
+                  pushOff(n)
                 }}
-                onBlur={commitOff}
+                onBlur={() => {
+                  offEditing.current = false
+                  commitOff()
+                }}
                 onKeyDown={(e) => e.key === 'Enter' && commitOff()}
               />
             </label>
@@ -267,19 +285,11 @@ export function JointForm({
       )}
       {onRoll && (
         <div className="robotbuild__jrow">
-          <span className="robotbuild__jlabel" title="Rotate the joint about its own normal axis">
+          <span className="robotbuild__jlabel" title="Absolute roll about the joint's own normal axis">
             Roll
           </span>
           <label className="robotbuild__mm">
-            <span>by</span>
-            <input
-              type="number"
-              step={15}
-              value={roll}
-              onChange={(e) => setRoll(e.target.value)}
-              onBlur={commitRoll}
-              onKeyDown={(e) => e.key === 'Enter' && commitRoll()}
-            />
+            <input type="number" step={15} value={roll} onChange={(e) => setRollLive(e.target.value)} />
           </label>
           <span className="robotbuild__mm-unit">°</span>
         </div>

--- a/src/renderer/src/components/RobotPropertiesDialog.tsx
+++ b/src/renderer/src/components/RobotPropertiesDialog.tsx
@@ -51,9 +51,12 @@ export interface RobotPropertiesDialogProps {
   jointNames: string[]
   onSetSize: (link: string, dims: number[]) => void
   onSetJoint: (link: string, spec: JointSpec) => void
-  /** Reposition the joint origin (offset, mm→m) and roll it about its normal (deg). */
+  /** Reposition the joint origin (offset, mm→m) and set its ABSOLUTE roll about its
+   *  own normal axis (deg) — both applied live as the field changes. */
   onSetJointOrigin: (child: string, xyz: [number, number, number]) => void
-  onRollJoint: (child: string, deltaDeg: number) => void
+  onRollJoint: (child: string, absDeg: number) => void
+  /** The open joint's current absolute roll (deg), for seeding the Roll field. */
+  jointRoll?: number
   /** Remove the joint whose child is this link (the block re-attaches to the base). */
   onDeleteJoint: (child: string) => void
   // servo
@@ -252,7 +255,8 @@ function LinkBody({
   onSetSize,
   onSetJoint,
   onSetJointOrigin,
-  onRollJoint
+  onRollJoint,
+  jointRoll
 }: RobotPropertiesDialogProps & { context: PropsContext }): JSX.Element {
   // `link` = the block being edited, or the joint's child link (which carries it).
   const link = context.kind === 'joint' ? context.child : context.kind === 'link' ? context.link : ''
@@ -273,9 +277,10 @@ function LinkBody({
           <JointForm
             joint={joint}
             names={jointNames}
+            jointRoll={jointRoll}
             onChange={(spec) => onSetJoint(link, spec)}
             onSetOrigin={(xyz) => onSetJointOrigin(link, xyz)}
-            onRoll={(deltaDeg) => onRollJoint(link, deltaDeg)}
+            onRoll={(absDeg) => onRollJoint(link, absDeg)}
           />
         </section>
       ) : (

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -177,6 +177,7 @@ export function RobotView({
   const valuesRef = useRef<Record<string, number>>({})
   const overridesRef = useRef<Record<string, { min?: number; max?: number }>>({})
   const defaultPoseRef = useRef<Record<string, number>>({}) // native, non-mimic
+  const jointRollRef = useRef<Record<string, number>>({}) // joint name → absolute roll (deg)
   const measureActiveRef = useRef(false)
   const measureApiRef = useRef<{ clear: () => void } | null>(null)
   const highlightApiRef = useRef<{ apply: (link: string | null) => void } | null>(null)
@@ -562,13 +563,23 @@ export function RobotView({
     const j = readJoint(content, child)
     if (j) commitUrdf(setJointOrigin(content, child, xyz, j.rpy))
   }
-  // Roll an existing joint about its own normal axis (its origin's local Z) by
-  // `deltaDeg`, keeping its position — the roll field on the joint editor.
-  const handleRollJoint = (child: string, deltaDeg: number): void => {
+  // Set an existing joint's ABSOLUTE roll about its own normal axis (its origin's
+  // local Z), keeping its position — the roll field on the joint editor. The URDF
+  // rpy bakes the roll in (so it can't be decoded back out unambiguously), so the
+  // absolute value is remembered in robot.yml and applied as a DELTA on the rpy —
+  // that keeps geometry exact while letting the field show the stored roll on reopen.
+  const setJointRoll = (child: string, absDeg: number): void => {
     const j = readJoint(content, child)
-    if (!j || !deltaDeg) return
+    if (!j) return
+    const prev = jointRollRef.current[j.name] ?? 0
+    jointRollRef.current = { ...jointRollRef.current, [j.name]: absDeg }
+    void persist((m) => {
+      m.jointRoll = { ...(m.jointRoll ?? {}), [j.name]: absDeg }
+    })
+    const delta = absDeg - prev
+    if (!delta) return
     const R = new THREE.Quaternion().setFromEuler(new THREE.Euler(j.rpy[0], j.rpy[1], j.rpy[2], 'ZYX'))
-    R.multiply(new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 0, 1), (deltaDeg * Math.PI) / 180))
+    R.multiply(new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 0, 1), (delta * Math.PI) / 180))
     const e = new THREE.Euler().setFromQuaternion(R, 'ZYX')
     commitUrdf(setJointOrigin(content, child, j.xyz, [e.x, e.y, e.z]))
   }
@@ -765,17 +776,24 @@ export function RobotView({
     }
     commitUrdf(next)
     setSelectedLink(child.link)
+    const jn = readJoint(next, child.link)?.name
+    // Remember the roll baked in at creation so the joint editor's Roll field shows it
+    // (and edits from it) — always write it, so a freshly re-joined link overwrites any
+    // stale roll left from a previous joint that reused this name (#354).
+    if (jn) {
+      jointRollRef.current = { ...jointRollRef.current, [jn]: angleDeg }
+      void persist((m) => {
+        m.jointRoll = { ...(m.jointRoll ?? {}), [jn]: angleDeg }
+      })
+    }
     // Rotation default angle: persist it to the robot.yml defaultPose (keyed by the
     // joint's actual name, in display degrees) so the joint loads at that angle —
     // and it seeds the pose slider for interactive preview of the swing.
-    if (rotation && type === 'revolute' && rotation.defaultDeg) {
-      const jn = readJoint(next, child.link)?.name
-      if (jn) {
-        const dd = rotation.defaultDeg
-        void persist((m) => {
-          m.defaultPose = { ...(m.defaultPose ?? {}), [jn]: dd }
-        })
-      }
+    if (jn && rotation && type === 'revolute' && rotation.defaultDeg) {
+      const dd = rotation.defaultDeg
+      void persist((m) => {
+        m.defaultPose = { ...(m.defaultPose ?? {}), [jn]: dd }
+      })
     }
     return true
   }
@@ -1760,6 +1778,7 @@ export function RobotView({
                 robot.setJointValue(m.name, nv[m.name])
               }
               defaultPoseRef.current = { ...nv } // "Reset" returns to the saved default
+              jointRollRef.current = { ...(model.jointRoll ?? {}) } // remembered joint rolls
               setOverrides(ov)
               setPoses(Array.isArray(model.poses) ? model.poses : [])
               setValues(nv)
@@ -3039,7 +3058,8 @@ export function RobotView({
             onSetSize={handleSetSize}
             onSetJoint={handleSetJoint}
             onSetJointOrigin={handleSetJointOrigin}
-            onRollJoint={handleRollJoint}
+            onRollJoint={setJointRoll}
+            jointRoll={editJoint ? jointRollRef.current[editJoint.name] ?? 0 : 0}
             onDeleteJoint={handleDeleteJoint}
             servo={dialogCtx.kind === 'servo' ? bindings.find((b) => b.pin === dialogCtx.pin) ?? null : null}
             movableJoints={movableNames}

--- a/src/shared/krf.ts
+++ b/src/shared/krf.ts
@@ -181,6 +181,9 @@ export function sanitiseRobotModel(raw: unknown): RobotModel | undefined {
   const def = sanitiseNumberMap(r.defaultPose)
   if (Object.keys(def).length) model.defaultPose = def
 
+  const roll = sanitiseNumberMap(r.jointRoll)
+  if (Object.keys(roll).length) model.jointRoll = roll
+
   if (Array.isArray(r.poses)) {
     const poses = r.poses
       .map((p): NamedPose | null => {

--- a/src/shared/robot.ts
+++ b/src/shared/robot.ts
@@ -61,6 +61,11 @@ export interface RobotModel {
   servoJointMap?: ServoJointBinding[]
   /** Per-joint limit / calibration overrides edited in-app (Phase 2). */
   joints?: Record<string, JointConfig>
+  /** Per-joint absolute roll about its own normal axis, in DEGREES (#354). The URDF
+   *  `<origin rpy>` already bakes this in; it's remembered here so the joint editor
+   *  can show the current roll and edit it absolutely (deltas re-applied to the rpy),
+   *  instead of the field resetting to 0 each time the dialog reopens. */
+  jointRoll?: Record<string, number>
   /** The default pose applied on load: joint name → value (deg / mm). */
   defaultPose?: Record<string, number>
   /** Saved named poses (Phase 2). */


### PR DESCRIPTION
## What

Follow-up to the joint-editor work: *"changing the rotation angle should change immediately… and it makes more sense for the dialog to keep the angle offset rather than being applied and reset to zero."*

Two problems with the roll field:
1. It applied on **Enter/blur** and **reset to 0** — reopening a joint always showed 0, even after you'd rolled it, and there was no way to see or fine-tune the roll you'd set.
2. Nothing applied **live** as you changed the value.

## Changes

- **Roll is now absolute + remembered.** The URDF `<origin rpy>` bakes the roll in and can't be decoded back out unambiguously (it's *mating-rotation ∘ roll*), so the absolute roll is stored per joint in **`robot.yml`** (new `RobotModel.jointRoll`, sanitised in `krf`) and applied to the rpy as a **delta** — geometry stays exact, and the field shows the stored angle on reopen. `handleConnectPicked` seeds it with the roll baked in at creation (always, so a re-joined link overwrites any stale entry).
- **`setJointRoll(child, absDeg)`** — persist the absolute value + apply the delta to the rpy.
- **Live editing.** `JointForm` seeds the Roll field from the stored value and applies **on change**; the **Offset (X/Y/Z)** applies on change too, with its model re-seed suppressed while the field is focused so the URDF's 0.1 mm rounding can't clobber live typing.

Fields reuse the themed `.robotbuild__mm` / `__jrow` / `__jlabel` classes → both skins, no new CSS.

## Verification

- `typecheck` ✅ · `lint` ✅ (only the pre-existing `DriverInstallBanner` warning) · **1550 tests** ✅ · `build` ✅
- Playwright smoke: set roll **live** (fill 90, no Enter) → close + reopen the joint → still reads **90°** (not 0); offset persists at **80 mm**; `robot.yml` carries `jointRoll: { j1: 90 }`; `pageerror` null throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)