### PR TITLE
fix: pose slider layout + editable value; detaching a joint no longer collapses (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Robot View — the pose sidebar is retired; posing moves to a popup (#312).** The
   old right-hand pose panel duplicated the build panel (assembly, servos, poses). It's
   gone: **pose the robot in a popup** — the build panel's **Poses → ＋ New pose** (or
-  clicking a pose) opens an editor with a **slider per joint**; drag to pose, name it,
-  **Save**. Servos got a **＋ Bind a servo** in the build panel, and the save-status /
-  measure readouts moved to small floating pills. The Timeline still animates.
+  clicking a pose) opens an editor with a **full-width slider per joint** (its own row,
+  no longer squashed beside the joint name) and a **directly-editable value** so you can
+  type an exact angle; drag to pose, name it, **Save**. Servos got a **＋ Bind a servo**
+  in the build panel, and the save-status / measure readouts moved to small floating
+  pills. The Timeline still animates.
 - **Robot View — a cleaner, Fusion-style build hierarchy (#354).** The panel is
   **wider** so long STL names have room, and it drops its solid slab — each line now
   sits on its own **subtle off-white card** so it reads over the 3-D canvas. Per-row
@@ -308,6 +310,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   or reopen any panel. Nothing about Robot mode is permanently changed.
 
 ### Fixed
+- **Robot View — removing a joint no longer fuses the freed part into the base (#354).**
+  Deleting a joint used to leave its part *rootless*, and the loader collapses every
+  rootless part into the base's single scene node — so the base and every freed part
+  **highlighted together** and you couldn't pick just one to re-join it (which also made
+  a follow-up joint look "ignored"). Deleting a joint now **re-attaches the part to the
+  base as a loose part** at exactly where it was (its sub-assembly comes with it and
+  stays put) — so each part stays independently selectable and you can articulate a new
+  chain from it.
 - **Robot View — adding a joint no longer blanks the view (#354).** After a joint was
   added the selected block's highlight was re-applied during the scene rebuild, but the
   helper it needed was declared *later* in the same setup — a temporal-dead-zone crash

--- a/src/renderer/src/components/RobotPropertiesDialog.css
+++ b/src/renderer/src/components/RobotPropertiesDialog.css
@@ -237,13 +237,23 @@
   overflow-y: auto;
   margin: 0.15rem 0 0.35rem;
 }
+/* Each joint: a head row (name + editable value) then a FULL-WIDTH slider below, so
+   the slider isn't squashed into a sliver by the narrow dialog (#312). */
 .robotprops__poj {
-  display: grid;
-  grid-template-columns: 6.5rem 1fr 3rem;
-  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.1rem 0;
+}
+.robotprops__poj-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
   gap: 0.4rem;
 }
 .robotprops__poj-name {
+  flex: 1 1 auto;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -254,7 +264,31 @@
   width: 100%;
   accent-color: var(--accent, #d6a23f);
 }
+.robotprops__poj-valwrap {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: baseline;
+  gap: 0.15rem;
+}
+.robotprops__poj-num {
+  width: 3rem;
+  box-sizing: border-box;
+  text-align: right;
+  font-family: inherit;
+  font-size: 0.6rem;
+  color: var(--text, #cdd2d9);
+  background: var(--bg-sunken, rgba(0, 0, 0, 0.25));
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 4px;
+  padding: 0.08rem 0.2rem;
+  font-variant-numeric: tabular-nums;
+}
+.robotprops__poj-unit {
+  font-size: 0.56rem;
+  color: var(--text-muted, #9aa0a6);
+}
 .robotprops__poj-val {
+  flex: 0 0 auto;
   text-align: right;
   font-size: 0.6rem;
   color: var(--text-muted, #9aa0a6);

--- a/src/renderer/src/components/RobotPropertiesDialog.tsx
+++ b/src/renderer/src/components/RobotPropertiesDialog.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { JointDef, JointType, JointSpec, PrimitiveGeom } from './robot-assembly'
 import type { ServoJointBinding } from '../../../shared/robot'
 import {
@@ -379,6 +379,52 @@ function ServoBody({
 
 const fmtDeg = (v: number): string => (Math.abs(v) < 10 ? v.toFixed(1) : Math.round(v).toString())
 
+/** A directly-editable joint value (display units), paired with the pose slider so the
+ *  user can type an exact angle/offset. Applies LIVE as it changes; re-seeds from the
+ *  slider's value when it moves — but not while the field is focused, so typing isn't
+ *  clobbered by rounding. Clamped to the joint's limits on commit. */
+function PoseNum({
+  value,
+  min,
+  max,
+  step,
+  onCommit
+}: {
+  value: number
+  min: number
+  max: number
+  step: number
+  onCommit: (v: number) => void
+}): JSX.Element {
+  const [v, setV] = useState(fmtDeg(value))
+  const editing = useRef(false)
+  useEffect(() => {
+    if (!editing.current) setV(fmtDeg(value))
+  }, [value])
+  const clamp = (n: number): number => Math.min(Math.max(n, min), max)
+  return (
+    <input
+      className="robotprops__poj-num"
+      type="number"
+      min={min}
+      max={max}
+      step={step}
+      value={v}
+      onFocus={() => (editing.current = true)}
+      onChange={(e) => {
+        setV(e.target.value)
+        const n = Number(e.target.value)
+        if (e.target.value.trim() !== '' && Number.isFinite(n)) onCommit(clamp(n))
+      }}
+      onBlur={() => {
+        editing.current = false
+        const n = Number(v)
+        onCommit(Number.isFinite(n) ? clamp(n) : value)
+      }}
+    />
+  )
+}
+
 /** The pose editor (#312 — the retired pose sidebar's controls moved here): a name,
  *  a live joint SLIDER per movable joint (drag to pose the robot), and Save / Reset.
  *  Recall / Delete + the OK rename live in the footer. Opening an existing pose recalls
@@ -458,10 +504,22 @@ function PoseBody({
               const dVal = toDisplay(j.type, values[j.name] ?? 0)
               const step = j.type === 'prismatic' ? 0.5 : 1
               return (
-                <label className="robotprops__poj" key={j.name}>
-                  <span className="robotprops__poj-name" title={j.name}>
-                    {j.name}
-                  </span>
+                <div className="robotprops__poj" key={j.name}>
+                  <div className="robotprops__poj-head">
+                    <span className="robotprops__poj-name" title={j.name}>
+                      {j.name}
+                    </span>
+                    <span className="robotprops__poj-valwrap">
+                      <PoseNum
+                        value={dVal}
+                        min={dLower}
+                        max={dUpper}
+                        step={step}
+                        onCommit={(v) => onJointChange(j.name, toNative(j.type, v))}
+                      />
+                      <span className="robotprops__poj-unit">{unitLabel(j.type)}</span>
+                    </span>
+                  </div>
                   <input
                     className="robotprops__poj-slider"
                     type="range"
@@ -472,25 +530,23 @@ function PoseBody({
                     value={Math.min(Math.max(dVal, dLower), dUpper)}
                     onChange={(e) => onJointChange(j.name, toNative(j.type, Number(e.target.value)))}
                   />
-                  <span className="robotprops__poj-val">
-                    {fmtDeg(dVal)}
-                    {unitLabel(j.type)}
-                  </span>
-                </label>
+                </div>
               )
             })}
             {mimics.map((j) => {
               const dVal = toDisplay(j.type, mimicValue(j, values[j.master ?? ''] ?? 0))
               return (
                 <div className="robotprops__poj robotprops__poj--mimic" key={j.name}>
-                  <span className="robotprops__poj-name" title={j.name}>
-                    {j.name}
-                  </span>
+                  <div className="robotprops__poj-head">
+                    <span className="robotprops__poj-name" title={j.name}>
+                      {j.name}
+                    </span>
+                    <span className="robotprops__poj-val">
+                      {fmtDeg(dVal)}
+                      {unitLabel(j.type)}
+                    </span>
+                  </div>
                   <span className="robotprops__poj-mimic">follows {j.master}</span>
-                  <span className="robotprops__poj-val">
-                    {fmtDeg(dVal)}
-                    {unitLabel(j.type)}
-                  </span>
                 </div>
               )
             })}

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -33,7 +33,6 @@ import {
   removeJoint,
   removeLink,
   renameLink,
-  rootLink,
   setJoint,
   setJointOrigin,
   orientJoint,
@@ -797,57 +796,53 @@ export function RobotView({
     }
     return true
   }
-  // Delete a joint (#354): strip it so the child becomes a free-standing root, and
-  // keep the whole sub-assembly EXACTLY where it is. Because a root has no frame
-  // transform, moving the child frame to the origin is compensated two ways: the
-  // child's own visual origin is baked with its full world transform, and each of
-  // the child's DIRECT-child joints is pre-multiplied by that same transform (so
-  // descendants — which hang off those joints — don't teleport). Handles rotation
-  // (full rel matrix → rpy), meshes (readVisualOrigin), and dangling mimics.
+  // Delete a joint (#354): detach the child from its parent, then RE-ATTACH it to the
+  // base as a LOOSE fixed joint at its current world pose. It must NOT be left rootless
+  // — the loader collapses every rootless link into the base's single scene node, so
+  // freed parts would co-highlight and you couldn't pick one to re-join it. Its whole
+  // sub-assembly comes with it and stays put, because the child's own link frame (and
+  // thus its visual + descendant joints, all relative to it) is preserved by placing
+  // the new base→child joint at the child's former world pose.
   const handleDeleteJoint = (child: string): void => {
     const before = content
-    const root = rootLink(before)
-    if (!root || child === root) {
-      setDialogCtx(null)
+    const base = effectiveBaseLink
+    if (!base || child === base) {
+      setDialogCtx(null) // can't detach the base itself
       return
     }
-    const stripped = removeJoint(before, child)
-    if (stripped === before) {
-      setDialogCtx(null) // no such joint
-      return
-    }
-    // The child's full transform relative to the base (which loads at the origin).
+    // The child's transform relative to the base (which loads at the origin).
     const robot = robotRef.current
     let relM = new THREE.Matrix4()
-    if (robot?.links[child] && robot.links[root]) {
+    if (robot?.links[child] && robot.links[base]) {
       robot.updateMatrixWorld(true)
       relM = new THREE.Matrix4()
-        .copy(robot.links[root].matrixWorld)
+        .copy(robot.links[base].matrixWorld)
         .invert()
         .multiply(robot.links[child].matrixWorld)
     }
-    const toMat = (xyz: readonly number[], rpy: readonly number[]): THREE.Matrix4 =>
-      new THREE.Matrix4()
-        .makeRotationFromEuler(new THREE.Euler(rpy[0], rpy[1], rpy[2], 'ZYX'))
-        .setPosition(xyz[0], xyz[1], xyz[2])
-    const fromMat = (m: THREE.Matrix4): { xyz: [number, number, number]; rpy: [number, number, number] } => {
-      const p = new THREE.Vector3()
-      const q = new THREE.Quaternion()
-      m.decompose(p, q, new THREE.Vector3())
-      const e = new THREE.Euler().setFromQuaternion(q, 'ZYX') // URDF rpy convention
-      return { xyz: [p.x, p.y, p.z], rpy: [e.x, e.y, e.z] }
+    const p = new THREE.Vector3()
+    const q = new THREE.Quaternion()
+    relM.decompose(p, q, new THREE.Vector3())
+    const e = new THREE.Euler().setFromQuaternion(q, 'ZYX') // URDF rpy convention
+    const relXyz: [number, number, number] = [p.x, p.y, p.z]
+    const relRpy: [number, number, number] = [e.x, e.y, e.z]
+    let next = removeJoint(before, child)
+    if (next === before) {
+      setDialogCtx(null) // no such joint
+      return
     }
-    // Bake the child's own visual so it stays put.
-    const ov = readVisualOrigin(before, child) ?? { xyz: [0, 0, 0], rpy: [0, 0, 0] }
-    const nv = fromMat(relM.clone().multiply(toMat(ov.xyz, ov.rpy)))
-    let next = setVisualOrigin(stripped, child, nv.xyz, nv.rpy)
-    // Re-base the child's direct-child joints so the subtree keeps its world pose.
-    for (const j of readAllJoints(before)) {
-      if (j.parent !== child) continue
-      const nj = fromMat(relM.clone().multiply(toMat(j.xyz, j.rpy)))
-      next = setJointOrigin(next, j.child, nj.xyz, nj.rpy)
-    }
+    // Re-attach to the base (fresh fixed joint) at the former world pose.
+    next = connectJoint(next, { parent: base, child, xyz: relXyz })
+    next = setJointOrigin(next, child, relXyz, relRpy)
     commitUrdf(next)
+    // Fresh loose attachment → its orientation is the new zero-roll baseline.
+    const jn = readJoint(next, child)?.name
+    if (jn) {
+      jointRollRef.current = { ...jointRollRef.current, [jn]: 0 }
+      void persist((m) => {
+        m.jointRoll = { ...(m.jointRoll ?? {}), [jn]: 0 }
+      })
+    }
     setDialogCtx(null)
     setSelectedLink(child)
   }


### PR DESCRIPTION
Three Robot View issues reported together.

## 1. Pose slider was squashed + value not editable

In the narrow (13 rem) pose popup the slider shared a row with the joint name, leaving it a ~2 rem sliver that was almost impossible to drag. Now each joint has a **head row (name + value)** with a **full-width slider on its own line below**, and the value is a **directly-editable number** — type an exact angle and the slider follows (live, focus-guarded so rounding can't clobber mid-type). New `PoseNum` component + reworked `.robotprops__poj` CSS.

## 2. Deleting a joint fused the freed part into the base

Deleting a joint left its part **rootless**, and urdf-loader collapses every rootless link into the base's single scene node — so the base and all freed parts **co-highlighted**, and you couldn't pick just one to re-join it. `handleDeleteJoint` now **re-attaches the part to the base as a loose fixed joint** at its former world pose (its sub-assembly comes with it and stays put, because the child link frame is preserved). Never rootless → every part stays a distinct, selectable node (single-root invariant holds).

## 3. "3rd joint not respected"

A downstream symptom of #2: once parts collapsed, picks landed on the shared node and `connectJoint` no-op'd. Fixed by #2 — chaining a 3rd joint, and re-joining after a delete, both work.

## Verification

Driven Playwright smokes:
- Chain `base→A`, `B→A`, `C→B` — all respected (final chain correct).
- Delete a joint (loose **and** chained) → distinct scene-node ids (`{base:350, A:353, B:356, C:359}` — **no collapse**), freed part re-parented to base.
- Re-connect after delete works (picks resolve, part re-parents).
- Pose slider measures **190px** wide with an **editable value** that drives the slider (typed 45 → slider = 45).

`typecheck` ✅ · `lint` ✅ (only the pre-existing `DriverInstallBanner` warning) · **1550 tests** ✅ · `build` ✅ · `pageerror` null throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)