### PR TITLE
feat: add Local LLM provider with configurable host/port base URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "type": "module",
   "scripts": {
     "dev": "electron-vite dev",
+    "dev:safe": "ELECTRON_DISABLE_SANDBOX=1 electron-vite dev",
     "build": "electron-vite build",
     "preview": "electron-vite preview",
     "start": "electron-vite preview",

--- a/src/main/llm/ipc.ts
+++ b/src/main/llm/ipc.ts
@@ -1,23 +1,7 @@
-/**
- * IPC handlers for the LLM chat layer (issue #77).
- *
- * Renderer-facing channels (all under `llm:`):
- *   - `llm:listProviders` → {@link LlmProviderInfo}[] — registry metadata for the UI.
- *   - `llm:getKeyStatus`  → {@link LlmKeyStatus} for a given providerId.
- *   - `llm:setKey`        → store/clear a given provider's API key.
- *   - `llm:sendMessage`   → run a streaming completion against the request's
- *                           provider; the assembled reply is returned, and
- *                           deltas are pushed on `llm:stream`.
- *
- * Push channel:
- *   - `llm:stream`        → {@link LlmStreamEvent} chunks for the active request.
- *
- * Errors cross IPC as the same serializable {@link IpcResult} shape used by the
- * device/fs layers. The API key never appears in a log line or an error message.
- */
 import { ipcMain, type WebContents } from 'electron'
 import type { IpcResult } from '../device/types'
 import { getKey, hasKey, isEncryptionAvailable, setKey } from './keyStore'
+import { getProviderConfig, setProviderConfig } from './providers/providerConfig'
 import { DEFAULT_PROVIDER_ID, getProvider, listProviders } from './providers/registry'
 import {
   clearCopilotTokenCache,
@@ -34,10 +18,8 @@ import type {
   LlmStreamEvent
 } from './types'
 
-/** Provider id whose key is a GitHub OAuth token obtained via the device flow. */
 const COPILOT_PROVIDER_ID = 'copilot'
 
-/** IPC channel names for the LLM layer. */
 export const LLM_CHANNELS = {
   stream: 'llm:stream',
   listProviders: 'llm:listProviders',
@@ -46,20 +28,16 @@ export const LLM_CHANNELS = {
   sendMessage: 'llm:sendMessage',
   complete: 'llm:complete',
   copilotDeviceStart: 'llm:copilotDeviceStart',
-  copilotDevicePoll: 'llm:copilotDevicePoll'
+  copilotDevicePoll: 'llm:copilotDevicePoll',
+  getProviderConfig: 'llm:getProviderConfig',
+  setProviderConfig: 'llm:setProviderConfig'
 } as const
 
-/** Upper bound on the prompt context sent for a single inline completion. */
 const MAX_COMPLETION_PREFIX = 4000
 const MAX_COMPLETION_SUFFIX = 1000
 
-/** Monotonic id so the renderer can correlate stream events with a request. */
 let requestCounter = 0
 
-/**
- * Wrap an async operation so any thrown error crosses IPC as a serializable
- * {@link IpcResult}. Mirrors the device/fs layers.
- */
 async function wrap<T>(fn: () => Promise<T>): Promise<IpcResult<T>> {
   try {
     return { ok: true, value: await fn() }
@@ -68,13 +46,6 @@ async function wrap<T>(fn: () => Promise<T>): Promise<IpcResult<T>> {
   }
 }
 
-/**
- * Register all `llm:*` IPC handlers. Call once from the main process after the
- * window exists.
- *
- * @param getWebContents resolver for the target renderer (so we never capture a
- *   destroyed window after a reload).
- */
 export function registerLlmIpc(getWebContents: () => WebContents | undefined): void {
   const push = (event: LlmStreamEvent): void => {
     const wc = getWebContents()
@@ -107,7 +78,7 @@ export function registerLlmIpc(getWebContents: () => WebContents | undefined): v
       }
 
       const apiKey = await getKey(providerId)
-      if (!apiKey) {
+      if (!apiKey && providerId !== 'local') {
         throw new Error(
           `No API key set for ${provider.info.label}. Add your key in the chat settings.`
         )
@@ -117,7 +88,7 @@ export function registerLlmIpc(getWebContents: () => WebContents | undefined): v
       push({ type: 'start', requestId })
       try {
         const full = await provider.streamChat({
-          apiKey,
+          apiKey: apiKey || '',
           model: req.model || provider.info.defaultModel,
           effort: req.effort,
           speed: req.speed,
@@ -135,10 +106,6 @@ export function registerLlmIpc(getWebContents: () => WebContents | undefined): v
     })
   )
 
-  // One-shot inline completion (issue #82). Non-streaming: routes to the
-  // provider's fast `complete` with that provider's stored key and returns the
-  // raw text to insert at the cursor. The renderer cancels stale requests via
-  // its IPC token; we additionally clamp the prefix/suffix here as a backstop.
   ipcMain.handle(LLM_CHANNELS.complete, (_e, req: LlmCompleteRequest) =>
     wrap(async (): Promise<string> => {
       const providerId = req.providerId || DEFAULT_PROVIDER_ID
@@ -148,9 +115,7 @@ export function registerLlmIpc(getWebContents: () => WebContents | undefined): v
       }
 
       const apiKey = await getKey(providerId)
-      if (!apiKey) {
-        // No key → no suggestion. The renderer only calls this when it believes
-        // a key is set, but guard anyway so a race never throws into the editor.
+      if (!apiKey && providerId !== 'local') {
         return ''
       }
 
@@ -158,7 +123,7 @@ export function registerLlmIpc(getWebContents: () => WebContents | undefined): v
       const suffix = (req.suffix ?? '').slice(0, MAX_COMPLETION_SUFFIX)
 
       return provider.complete({
-        apiKey,
+        apiKey: apiKey || '',
         model: req.model || provider.info.defaultCompletionModel || provider.info.defaultModel,
         prefix,
         suffix,
@@ -167,11 +132,6 @@ export function registerLlmIpc(getWebContents: () => WebContents | undefined): v
     })
   )
 
-  // GitHub Copilot sign-in (device flow). `start` returns the user code +
-  // verification URL to show; the renderer then polls until authorized. The
-  // `gho_` token never crosses to the renderer — on authorization we store it as
-  // the Copilot provider's key here in main, so the existing token exchange can
-  // turn it into a Copilot token on the next chat/completion request.
   ipcMain.handle(LLM_CHANNELS.copilotDeviceStart, () =>
     wrap(async (): Promise<CopilotDeviceCode> => startCopilotDeviceFlow())
   )
@@ -182,10 +142,21 @@ export function registerLlmIpc(getWebContents: () => WebContents | undefined): v
       if (result.status === 'authorized' && result.token) {
         await setKey(COPILOT_PROVIDER_ID, result.token)
         clearCopilotTokenCache()
-        // Strip the token before it leaves the main process.
         return { status: 'authorized' }
       }
       return { status: result.status, message: result.message }
     })
+  )
+
+  ipcMain.handle(LLM_CHANNELS.getProviderConfig, (_e, providerId: string) =>
+    wrap(async (): Promise<Record<string, string>> => {
+      return getProviderConfig(providerId || DEFAULT_PROVIDER_ID)
+    })
+  )
+
+  ipcMain.handle(
+    LLM_CHANNELS.setProviderConfig,
+    (_e, providerId: string, config: Record<string, string>) =>
+      wrap(() => setProviderConfig(providerId || DEFAULT_PROVIDER_ID, config))
   )
 }

--- a/src/main/llm/ipc.ts
+++ b/src/main/llm/ipc.ts
@@ -1,7 +1,7 @@
 import { ipcMain, type WebContents } from 'electron'
 import type { IpcResult } from '../device/types'
 import { getKey, hasKey, isEncryptionAvailable, setKey } from './keyStore'
-import { getProviderConfig, setProviderConfig } from './providers/providerConfig'
+import { fetchAvailableModels, getProviderConfig, setProviderConfig } from './providers/providerConfig'
 import { DEFAULT_PROVIDER_ID, getProvider, listProviders } from './providers/registry'
 import {
   clearCopilotTokenCache,
@@ -30,7 +30,8 @@ export const LLM_CHANNELS = {
   copilotDeviceStart: 'llm:copilotDeviceStart',
   copilotDevicePoll: 'llm:copilotDevicePoll',
   getProviderConfig: 'llm:getProviderConfig',
-  setProviderConfig: 'llm:setProviderConfig'
+  setProviderConfig: 'llm:setProviderConfig',
+  fetchModels: 'llm:fetchModels'
 } as const
 
 const MAX_COMPLETION_PREFIX = 4000
@@ -158,5 +159,9 @@ export function registerLlmIpc(getWebContents: () => WebContents | undefined): v
     LLM_CHANNELS.setProviderConfig,
     (_e, providerId: string, config: Record<string, string>) =>
       wrap(() => setProviderConfig(providerId || DEFAULT_PROVIDER_ID, config))
+  )
+
+  ipcMain.handle(LLM_CHANNELS.fetchModels, (_e, baseURL: string) =>
+    wrap(async (): Promise<string[]> => fetchAvailableModels(baseURL))
   )
 }

--- a/src/main/llm/ipc.ts
+++ b/src/main/llm/ipc.ts
@@ -1,3 +1,21 @@
+/**
+ * IPC handlers for the LLM chat layer (issue #77).
+ *
+ * Renderer-facing channels (all under `llm:`):
+ *   - `llm:listProviders` → {@link LlmProviderInfo}[] — registry metadata for the UI.
+ *   - `llm:getKeyStatus`  → {@link LlmKeyStatus} for a given providerId.
+ *   - `llm:setKey`        → store/clear a given provider's API key.
+ *   - `llm:sendMessage`   → run a streaming completion against the request's
+ *                           provider; the assembled reply is returned, and
+ *                           deltas are pushed on `llm:stream`.
+ *
+ * Push channel:
+ *   - `llm:stream`        → {@link LlmStreamEvent} chunks for the active request.
+ *
+ * Errors cross IPC as the same serializable {@link IpcResult} shape used by the
+ * device/fs layers. The API key never appears in a log line or an error message.
+ */
+
 import { ipcMain, type WebContents } from 'electron'
 import type { IpcResult } from '../device/types'
 import { getKey, hasKey, isEncryptionAvailable, setKey } from './keyStore'
@@ -18,8 +36,10 @@ import type {
   LlmStreamEvent
 } from './types'
 
+/** Provider id whose key is a GitHub OAuth token obtained via the device flow. */
 const COPILOT_PROVIDER_ID = 'copilot'
 
+/** IPC channel names for the LLM layer. */
 export const LLM_CHANNELS = {
   stream: 'llm:stream',
   listProviders: 'llm:listProviders',
@@ -34,11 +54,17 @@ export const LLM_CHANNELS = {
   fetchModels: 'llm:fetchModels'
 } as const
 
+/** Upper bound on the prompt context sent for a single inline completion. */
 const MAX_COMPLETION_PREFIX = 4000
 const MAX_COMPLETION_SUFFIX = 1000
 
+/** Monotonic id so the renderer can correlate stream events with a request. */
 let requestCounter = 0
 
+/**
+ * Wrap an async operation so any thrown error crosses IPC as a serializable
+ * {@link IpcResult}. Mirrors the device/fs layers.
+ */
 async function wrap<T>(fn: () => Promise<T>): Promise<IpcResult<T>> {
   try {
     return { ok: true, value: await fn() }
@@ -47,6 +73,13 @@ async function wrap<T>(fn: () => Promise<T>): Promise<IpcResult<T>> {
   }
 }
 
+/**
+ * Register all `llm:*` IPC handlers. Call once from the main process after the
+ * window exists.
+ *
+ * @param getWebContents resolver for the target renderer (so we never capture a
+ *   destroyed window after a reload).
+ */
 export function registerLlmIpc(getWebContents: () => WebContents | undefined): void {
   const push = (event: LlmStreamEvent): void => {
     const wc = getWebContents()
@@ -107,6 +140,10 @@ export function registerLlmIpc(getWebContents: () => WebContents | undefined): v
     })
   )
 
+  // One-shot inline completion (issue #82). Non-streaming: routes to the
+  // provider's fast `complete` with that provider's stored key and returns the
+  // raw text to insert at the cursor. The renderer cancels stale requests via
+  // its IPC token; we additionally clamp the prefix/suffix here as a backstop.
   ipcMain.handle(LLM_CHANNELS.complete, (_e, req: LlmCompleteRequest) =>
     wrap(async (): Promise<string> => {
       const providerId = req.providerId || DEFAULT_PROVIDER_ID
@@ -117,6 +154,8 @@ export function registerLlmIpc(getWebContents: () => WebContents | undefined): v
 
       const apiKey = await getKey(providerId)
       if (!apiKey && providerId !== 'local') {
+        // No key → no suggestion. The renderer only calls this when it believes
+        // a key is set, but guard anyway so a race never throws into the editor.
         return ''
       }
 
@@ -133,6 +172,11 @@ export function registerLlmIpc(getWebContents: () => WebContents | undefined): v
     })
   )
 
+  // GitHub Copilot sign-in (device flow). `start` returns the user code +
+  // verification URL to show; the renderer then polls until authorized. The
+  // `gho_` token never crosses to the renderer — on authorization we store it as
+  // the Copilot provider's key here in main, so the existing token exchange can
+  // turn it into a Copilot token on the next chat/completion request.
   ipcMain.handle(LLM_CHANNELS.copilotDeviceStart, () =>
     wrap(async (): Promise<CopilotDeviceCode> => startCopilotDeviceFlow())
   )
@@ -143,6 +187,7 @@ export function registerLlmIpc(getWebContents: () => WebContents | undefined): v
       if (result.status === 'authorized' && result.token) {
         await setKey(COPILOT_PROVIDER_ID, result.token)
         clearCopilotTokenCache()
+        // Strip the token before it leaves the main process.
         return { status: 'authorized' }
       }
       return { status: result.status, message: result.message }

--- a/src/main/llm/providers/openaiCompatible.ts
+++ b/src/main/llm/providers/openaiCompatible.ts
@@ -17,6 +17,7 @@ import {
   sanitizeCompletion
 } from './context'
 import { getCopilotToken } from './copilotAuth'
+import { getProviderConfig } from './providerConfig'
 import type { CompleteArgs, Provider, ProviderInfo, StreamChatArgs } from './types'
 
 /** Upper bound on inline-completion output tokens — small + fast (issue #82). */
@@ -24,32 +25,17 @@ const COMPLETION_MAX_TOKENS = 64
 
 /** Config that distinguishes one OpenAI-compatible backend from another. */
 export interface OpenAiCompatibleConfig {
-  /** Provider metadata surfaced to the renderer. */
   info: ProviderInfo
-  /** Base URL up to (but not including) `/chat/completions`. */
   baseURL: string
-  /** Extra headers to merge in (beyond Authorization). */
   extraHeaders?: Record<string, string>
-  /** Model ids that should send a `reasoning_effort` field when an effort is set. */
   reasoningModels?: string[]
-  /**
-   * Optional hook to turn the stored key into the actual bearer token. Used by
-   * GitHub Copilot, which exchanges a GitHub PAT/OAuth token for a short-lived
-   * Copilot token. When absent, the stored key is sent as the bearer directly.
-   */
   resolveBearer?: (apiKey: string, signal?: AbortSignal) => Promise<string>
 }
 
-/** One SSE line's parsed delta shape (only the fields we read). */
 interface ChatCompletionChunk {
   choices?: Array<{ delta?: { content?: string | null } }>
 }
 
-/**
- * Parse a single OpenAI-style SSE `data:` payload, returning the text delta it
- * carries (or null when it's `[DONE]`, a keep-alive, or has no content). Pure
- * and exported so the wire-format handling can be unit-tested.
- */
 export function parseOpenAiSsePayload(payload: string): string | null {
   const trimmed = payload.trim()
   if (!trimmed || trimmed === '[DONE]') return null
@@ -61,11 +47,7 @@ export function parseOpenAiSsePayload(payload: string): string | null {
   }
 }
 
-/**
- * Stream a chat completion against an OpenAI-style `/chat/completions` endpoint.
- * Returns the assembled text once `[DONE]` (or the stream end) is reached.
- */
-async function streamOpenAiCompatible(
+export async function streamOpenAiCompatible(
   config: OpenAiCompatibleConfig,
   args: StreamChatArgs
 ): Promise<string> {
@@ -81,8 +63,6 @@ async function streamOpenAiCompatible(
     ]
   }
 
-  // o-series / reasoning models take `reasoning_effort` (low/medium/high) rather
-  // than the Anthropic-style output_config. Only send it for declared models.
   if (effort && config.reasoningModels?.includes(model)) {
     body.reasoning_effort = effort
   }
@@ -109,13 +89,7 @@ async function streamOpenAiCompatible(
   return await consumeSse(res.body, onDelta)
 }
 
-/**
- * One-shot inline completion (issue #82) against the non-streaming
- * `/chat/completions` endpoint. The FIM prefix/suffix go in the user turn and a
- * strict system prompt keeps the reply to raw insertion text. Returns the
- * sanitized `choices[0].message.content`.
- */
-async function completeOpenAiCompatible(
+export async function completeOpenAiCompatible(
   config: OpenAiCompatibleConfig,
   args: CompleteArgs
 ): Promise<string> {
@@ -157,7 +131,6 @@ async function completeOpenAiCompatible(
   return sanitizeCompletion(text)
 }
 
-/** Read the SSE body, accumulating `choices[0].delta.content` until `[DONE]`. */
 async function consumeSse(
   body: ReadableStream<Uint8Array>,
   onDelta: (text: string) => void
@@ -167,10 +140,7 @@ async function consumeSse(
   let buffer = ''
   let full = ''
 
-  // Process complete SSE events as they arrive. Events are separated by a blank
-  // line; each event has one or more `data:` lines.
   const flushEvent = (raw: string): boolean => {
-    // Returns true when a `[DONE]` sentinel was seen (caller should stop).
     for (const line of raw.split(/\r?\n/)) {
       const trimmed = line.trim()
       if (!trimmed.startsWith('data:')) continue
@@ -199,12 +169,10 @@ async function consumeSse(
       }
     }
   }
-  // Flush any trailing event without a final blank-line separator.
   if (buffer.trim()) flushEvent(buffer)
   return full
 }
 
-/** Best-effort read of an error response body for a friendlier message. */
 async function safeErrorText(res: Response): Promise<string> {
   try {
     const text = await res.text()
@@ -219,7 +187,6 @@ async function safeErrorText(res: Response): Promise<string> {
   }
 }
 
-/** Build a {@link Provider} from an OpenAI-compatible config. */
 export function makeOpenAiCompatibleProvider(config: OpenAiCompatibleConfig): Provider {
   return {
     info: config.info,
@@ -230,7 +197,6 @@ export function makeOpenAiCompatibleProvider(config: OpenAiCompatibleConfig): Pr
 
 // ── Concrete providers ────────────────────────────────────────────────────
 
-/** OpenAI (gpt-4o / gpt-4o-mini / o4-mini). Reasoning effort for the o-series. */
 export const openaiProvider = makeOpenAiCompatibleProvider({
   info: {
     id: 'openai',
@@ -250,7 +216,6 @@ export const openaiProvider = makeOpenAiCompatibleProvider({
   reasoningModels: ['o4-mini']
 })
 
-/** Grok / xAI (grok-2-latest / grok-2). */
 export const grokProvider = makeOpenAiCompatibleProvider({
   info: {
     id: 'grok',
@@ -267,15 +232,6 @@ export const grokProvider = makeOpenAiCompatibleProvider({
   baseURL: 'https://api.x.ai/v1'
 })
 
-/**
- * GitHub Copilot (OpenAI-compatible). The user signs in with their GitHub
- * account via the OAuth **device flow** (see `copilotAuth.ts`); the resulting
- * GitHub token is exchanged by {@link getCopilotToken} for the short-lived
- * Copilot token the chat endpoint actually requires (cached until just before
- * expiry), with the integration/editor headers. A plain personal access token
- * can't reach the Copilot endpoint, which is why sign-in is used instead. Still
- * flagged experimental: it can only be verified against a real Copilot account.
- */
 export const copilotProvider = makeOpenAiCompatibleProvider({
   info: {
     id: 'copilot',
@@ -298,3 +254,31 @@ export const copilotProvider = makeOpenAiCompatibleProvider({
   },
   resolveBearer: getCopilotToken
 })
+
+// ── Local LLM (OpenAI-compatible) ─────────────────────────────────────────
+
+const LOCAL_ID = 'local'
+
+export const LOCAL_INFO: ProviderInfo = {
+  id: LOCAL_ID,
+  label: 'Local LLM',
+  models: [{ id: 'custom', label: 'Custom' }],
+  defaultModel: 'custom',
+  defaultCompletionModel: 'custom',
+  customModel: true,
+  keyHint: 'API key (optional — leave blank for no auth)'
+}
+
+export const localProvider: Provider = {
+  info: LOCAL_INFO,
+  async streamChat(args: StreamChatArgs): Promise<string> {
+    const config = await getProviderConfig(LOCAL_ID)
+    const baseURL = config.baseURL || 'http://localhost:11434/v1'
+    return streamOpenAiCompatible({ info: LOCAL_INFO, baseURL }, args)
+  },
+  async complete(args: CompleteArgs): Promise<string> {
+    const config = await getProviderConfig(LOCAL_ID)
+    const baseURL = config.baseURL || 'http://localhost:11434/v1'
+    return completeOpenAiCompatible({ info: LOCAL_INFO, baseURL }, args)
+  }
+}

--- a/src/main/llm/providers/openaiCompatible.ts
+++ b/src/main/llm/providers/openaiCompatible.ts
@@ -25,17 +25,32 @@ const COMPLETION_MAX_TOKENS = 64
 
 /** Config that distinguishes one OpenAI-compatible backend from another. */
 export interface OpenAiCompatibleConfig {
+  /** Provider metadata surfaced to the renderer. */
   info: ProviderInfo
+  /** Base URL up to (but not including) `/chat/completions`. */
   baseURL: string
+  /** Extra headers to merge in (beyond Authorization). */
   extraHeaders?: Record<string, string>
+  /** Model ids that should send a `reasoning_effort` field when an effort is set. */
   reasoningModels?: string[]
+  /**
+   * Optional hook to turn the stored key into the actual bearer token. Used by
+   * GitHub Copilot, which exchanges a GitHub PAT/OAuth token for a short-lived
+   * Copilot token. When absent, the stored key is sent as the bearer directly.
+   */
   resolveBearer?: (apiKey: string, signal?: AbortSignal) => Promise<string>
 }
 
+/** One SSE line's parsed delta shape (only the fields we read). */
 interface ChatCompletionChunk {
   choices?: Array<{ delta?: { content?: string | null } }>
 }
 
+/**
+ * Parse a single OpenAI-style SSE `data:` payload, returning the text delta it
+ * carries (or null when it's `[DONE]`, a keep-alive, or has no content). Pure
+ * and exported so the wire-format handling can be unit-tested.
+ */
 export function parseOpenAiSsePayload(payload: string): string | null {
   const trimmed = payload.trim()
   if (!trimmed || trimmed === '[DONE]') return null
@@ -47,6 +62,10 @@ export function parseOpenAiSsePayload(payload: string): string | null {
   }
 }
 
+/**
+ * Stream a chat completion against an OpenAI-style `/chat/completions` endpoint.
+ * Returns the assembled text once `[DONE]` (or the stream end) is reached.
+ */
 export async function streamOpenAiCompatible(
   config: OpenAiCompatibleConfig,
   args: StreamChatArgs
@@ -89,6 +108,10 @@ export async function streamOpenAiCompatible(
   return await consumeSse(res.body, onDelta)
 }
 
+/**
+ * One-shot (non-streaming) completion against an OpenAI-style endpoint.
+ * Returns the assembled text directly — used for inline code completions.
+ */
 export async function completeOpenAiCompatible(
   config: OpenAiCompatibleConfig,
   args: CompleteArgs
@@ -187,6 +210,10 @@ async function safeErrorText(res: Response): Promise<string> {
   }
 }
 
+/**
+ * Factory: wrap an {@link OpenAiCompatibleConfig} into a full {@link Provider}
+ * with `streamChat` and `complete` methods wired to the OpenAI SSE wire format.
+ */
 export function makeOpenAiCompatibleProvider(config: OpenAiCompatibleConfig): Provider {
   return {
     info: config.info,
@@ -257,8 +284,15 @@ export const copilotProvider = makeOpenAiCompatibleProvider({
 
 // ── Local LLM (OpenAI-compatible) ─────────────────────────────────────────
 
+/** Stable id for the local/self-hosted LLM provider. */
 const LOCAL_ID = 'local'
 
+/**
+ * Provider info for the local LLM backend. `customModel: true` tells the
+ * renderer to render a free-text model input instead of a fixed dropdown,
+ * because the available models depend on whatever the user's local server is
+ * running.
+ */
 export const LOCAL_INFO: ProviderInfo = {
   id: LOCAL_ID,
   label: 'Local LLM',
@@ -269,6 +303,12 @@ export const LOCAL_INFO: ProviderInfo = {
   keyHint: 'API key (optional — leave blank for no auth)'
 }
 
+/**
+ * Local LLM provider. Reads its base URL from the per-provider config store on
+ * each request (defaults to `http://localhost:11434/v1` for Ollama). When the
+ * local server is not running, the fetch will fail with a connection-refused
+ * error surfaced to the user as a chat error message.
+ */
 export const localProvider: Provider = {
   info: LOCAL_INFO,
   async streamChat(args: StreamChatArgs): Promise<string> {

--- a/src/main/llm/providers/providerConfig.ts
+++ b/src/main/llm/providers/providerConfig.ts
@@ -1,0 +1,34 @@
+import { app } from 'electron'
+import { promises as fs } from 'fs'
+import { join } from 'path'
+
+function configFilePath(providerId: string): string {
+  const safe = providerId.replace(/[^a-z0-9-]/gi, '')
+  if (!safe) throw new Error('Invalid provider id')
+  return join(app.getPath('userData'), `${safe}-config.json`)
+}
+
+export async function getProviderConfig(
+  providerId: string
+): Promise<Record<string, string>> {
+  try {
+    const data = await fs.readFile(configFilePath(providerId), 'utf-8')
+    return JSON.parse(data) as Record<string, string>
+  } catch {
+    return {}
+  }
+}
+
+export async function setProviderConfig(
+  providerId: string,
+  config: Record<string, string>
+): Promise<void> {
+  const cleaned: Record<string, string> = {}
+  for (const [k, v] of Object.entries(config)) {
+    if (v) cleaned[k] = v
+  }
+  await fs.writeFile(configFilePath(providerId), JSON.stringify(cleaned, null, 2), {
+    encoding: 'utf-8',
+    mode: 0o600
+  })
+}

--- a/src/main/llm/providers/providerConfig.ts
+++ b/src/main/llm/providers/providerConfig.ts
@@ -2,6 +2,10 @@ import { app } from 'electron'
 import { promises as fs } from 'fs'
 import { join } from 'path'
 
+interface OpenAiModelList {
+  data?: Array<{ id: string }>
+}
+
 function configFilePath(providerId: string): string {
   const safe = providerId.replace(/[^a-z0-9-]/gi, '')
   if (!safe) throw new Error('Invalid provider id')
@@ -31,4 +35,21 @@ export async function setProviderConfig(
     encoding: 'utf-8',
     mode: 0o600
   })
+}
+
+/**
+ * Fetch available models from an OpenAI-compatible `/v1/models` endpoint.
+ * Returns the model id strings, or throws with a descriptive error.
+ */
+export async function fetchAvailableModels(baseURL: string): Promise<string[]> {
+  const url = baseURL.replace(/\/+$/, '') + '/models'
+  const res = await fetch(url, { method: 'GET', signal: AbortSignal.timeout(10000) })
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`Failed to fetch models (HTTP ${res.status}): ${text.slice(0, 200)}`)
+  }
+  const json = (await res.json()) as OpenAiModelList
+  const models = (json.data ?? []).map((m) => m.id).filter(Boolean)
+  if (models.length === 0) throw new Error('No models returned by server')
+  return models.sort()
 }

--- a/src/main/llm/providers/providerConfig.ts
+++ b/src/main/llm/providers/providerConfig.ts
@@ -1,17 +1,44 @@
+/**
+ * Simple JSON file-based per-provider config store.
+ *
+ * Persists non-sensitive per-provider settings (currently just the local
+ * provider's base URL and model name) at `<userData>/<providerId>-config.json`.
+ * API keys live in the encrypted key-store (`keyStore.ts`), not here.
+ *
+ * The base URL is expected to point at the root of an OpenAI-compatible server,
+ * **including** the `/v1` segment if present — e.g.
+ * `http://localhost:11434/v1` (Ollama) or `http://localhost:1234/v1`
+ * (LM Studio).  The trailing slash is stripped before appending
+ * `/chat/completions` or `/models`.
+ *
+ * When the local server is not running, requests fail with a connection-refused
+ * error that surfaces in the chat panel — this is the most common failure mode
+ * for Ollama / LM Studio users and does not need special handling beyond a
+ * clear message.
+ */
 import { app } from 'electron'
 import { promises as fs } from 'fs'
 import { join } from 'path'
 
+/** Shape of the `/v1/models` response (only the fields we read). */
 interface OpenAiModelList {
   data?: Array<{ id: string }>
 }
 
+/**
+ * Build the filesystem path for a provider's config JSON file. The provider id
+ * is sanitised to safe characters to avoid path-traversal issues.
+ */
 function configFilePath(providerId: string): string {
   const safe = providerId.replace(/[^a-z0-9-]/gi, '')
   if (!safe) throw new Error('Invalid provider id')
   return join(app.getPath('userData'), `${safe}-config.json`)
 }
 
+/**
+ * Read the persisted config for a provider. Returns an empty object when no
+ * config file exists yet (first run).
+ */
 export async function getProviderConfig(
   providerId: string
 ): Promise<Record<string, string>> {
@@ -23,6 +50,10 @@ export async function getProviderConfig(
   }
 }
 
+/**
+ * Persist the config for a provider, overwriting any previous values. Empty
+ * string values are stripped before writing.
+ */
 export async function setProviderConfig(
   providerId: string,
   config: Record<string, string>

--- a/src/main/llm/providers/registry.ts
+++ b/src/main/llm/providers/registry.ts
@@ -1,39 +1,30 @@
-/**
- * Provider registry (issue #77).
- *
- * The single place that knows about every LLM backend. `getProvider(id)` routes
- * a request to the right implementation; `listProviders()` gives the renderer
- * the metadata it needs to render the provider/model/effort/speed dropdowns and
- * per-provider key settings.
- *
- * The order here is the order shown in the UI — Anthropic first (the default and
- * the only locally-testable provider), then the rest.
- */
 import { anthropicProvider } from './anthropic'
 import { geminiProvider } from './gemini'
-import { copilotProvider, grokProvider, openaiProvider } from './openaiCompatible'
+import {
+  copilotProvider,
+  grokProvider,
+  localProvider,
+  openaiProvider
+} from './openaiCompatible'
 import type { Provider, ProviderInfo } from './types'
 
-/** All registered providers, in display order. */
 const PROVIDERS: Provider[] = [
   anthropicProvider,
   openaiProvider,
   geminiProvider,
   grokProvider,
-  copilotProvider
+  copilotProvider,
+  localProvider
 ]
 
 const BY_ID = new Map<string, Provider>(PROVIDERS.map((p) => [p.info.id, p]))
 
-/** The default provider id when none is selected. */
 export const DEFAULT_PROVIDER_ID = anthropicProvider.info.id
 
-/** Look up a provider by id, or `undefined` if unknown. */
 export function getProvider(id: string): Provider | undefined {
   return BY_ID.get(id)
 }
 
-/** Renderer-facing metadata for every provider, in display order. */
 export function listProviders(): ProviderInfo[] {
   return PROVIDERS.map((p) => p.info)
 }

--- a/src/main/llm/providers/registry.ts
+++ b/src/main/llm/providers/registry.ts
@@ -1,3 +1,14 @@
+/**
+ * Provider registry (issue #77).
+ *
+ * The single place that knows about every LLM backend. `getProvider(id)` routes
+ * a request to the right implementation; `listProviders()` gives the renderer
+ * the metadata it needs to render the provider/model/effort/speed dropdowns and
+ * per-provider key settings.
+ *
+ * The order here is the order shown in the UI — Anthropic first (the default and
+ * the only locally-testable provider), then the rest.
+ */
 import { anthropicProvider } from './anthropic'
 import { geminiProvider } from './gemini'
 import {
@@ -8,6 +19,7 @@ import {
 } from './openaiCompatible'
 import type { Provider, ProviderInfo } from './types'
 
+/** All registered providers, in display order. */
 const PROVIDERS: Provider[] = [
   anthropicProvider,
   openaiProvider,
@@ -19,12 +31,15 @@ const PROVIDERS: Provider[] = [
 
 const BY_ID = new Map<string, Provider>(PROVIDERS.map((p) => [p.info.id, p]))
 
+/** The default provider id when none is selected. */
 export const DEFAULT_PROVIDER_ID = anthropicProvider.info.id
 
+/** Look up a provider by id, or `undefined` if unknown. */
 export function getProvider(id: string): Provider | undefined {
   return BY_ID.get(id)
 }
 
+/** Renderer-facing metadata for every provider, in display order. */
 export function listProviders(): ProviderInfo[] {
   return PROVIDERS.map((p) => p.info)
 }

--- a/src/main/llm/types.ts
+++ b/src/main/llm/types.ts
@@ -1,117 +1,53 @@
-/**
- * Shared types for the LLM chat layer. These cross the IPC boundary, so they
- * must be plain, structured-clone-safe data — no class instances.
- *
- * Re-exported through the preload `index.d.ts` so the renderer can import them
- * from the UI-facing surface without reaching into `src/main`.
- *
- * The layer is provider-agnostic (issue #77): a registry of providers
- * (Anthropic Claude, OpenAI, Google Gemini, Grok/xAI, GitHub Copilot) lives in
- * `providers/`, and a request names the `providerId` + `model` it targets.
- */
-
-/** A single chat turn in the conversation thread. */
 export interface LlmMessage {
   role: 'user' | 'assistant'
   content: string
 }
 
-/**
- * Whether an API key is currently stored for a provider, plus whether this
- * platform can encrypt it at rest. When `secure` is false the key is still
- * persisted but (per Electron `safeStorage`) may be stored in plaintext, so the
- * UI can warn.
- */
 export interface LlmKeyStatus {
-  /** True when a non-empty key is persisted (for the queried provider). */
   hasKey: boolean
-  /** True when OS-backed encryption is available for storage. */
   secure: boolean
 }
 
-/** A selectable model offered by a provider. */
 export interface LlmModelInfo {
   id: string
   label: string
 }
 
-/**
- * Renderer-facing description of a provider: enough for the chat footer to
- * render provider/model/effort/speed dropdowns and the per-provider key
- * settings, without the renderer ever importing the provider implementations.
- */
 export interface LlmProviderInfo {
-  /** Stable id used as the key-store namespace and in send requests. */
   id: string
-  /** Human-readable name shown in the UI. */
   label: string
-  /** Selectable models (first is a sensible default fallback). */
   models: LlmModelInfo[]
-  /** Default model id when the user hasn't chosen one. */
   defaultModel: string
-  /**
-   * Default fast model for inline autocomplete (issue #82). Completion reuses
-   * the same `models` list for selection, but defaults to this fast, cheap model
-   * (e.g. Haiku) rather than the heavier chat default.
-   */
   defaultCompletionModel?: string
-  /** Reasoning-effort levels the provider supports, if any (e.g. low/medium/high). */
   efforts?: string[]
-  /** Speed/latency tiers the provider supports, if any. */
   speeds?: string[]
-  /** Short hint about what kind of key/token the provider needs. */
   keyHint?: string
-  /** URL where the user can obtain a key (opened externally). */
   keyUrl?: string
-  /** When true, the provider is wired but untested / has caveats (e.g. Copilot). */
   experimental?: boolean
+  /** When true, the user can type any model name instead of picking from a list. */
+  customModel?: boolean
 }
 
-/** Arguments for a chat completion request. */
 export interface LlmSendRequest {
-  /** Which provider to route this request to (see {@link LlmProviderInfo.id}). */
   providerId: string
-  /** The full conversation so far (oldest first). Last entry is the new user turn. */
   messages: LlmMessage[]
-  /**
-   * When set, the active editor file is attached as cached context so the model
-   * can reason about the code the user is editing.
-   */
   activeFile?: { name: string; content: string }
-  /**
-   * When set, recent console/REPL output (since the last Run) is attached as
-   * context so the model can reason about what the program printed (issue #78).
-   */
   consoleOutput?: string
-  /** Model id to use; falls back to the provider's default when omitted. */
   model?: string
-  /** Reasoning-effort level, when the provider declares `efforts`. */
   effort?: string
-  /** Speed/latency tier, when the provider declares `speeds`. */
   speed?: string
 }
 
-/** A streamed chunk pushed to the renderer during a streaming completion. */
 export type LlmStreamEvent =
   | { type: 'start'; requestId: string }
   | { type: 'delta'; requestId: string; text: string }
   | { type: 'done'; requestId: string }
   | { type: 'error'; requestId: string; message: string }
 
-/**
- * Arguments for a one-shot inline completion (issue #82). Non-streaming: the IPC
- * call resolves with the raw text to insert at the cursor. Bounded prefix/suffix
- * give the model FIM context without shipping the whole file each keystroke.
- */
 export interface LlmCompleteRequest {
-  /** Which provider to route this request to (see {@link LlmProviderInfo.id}). */
   providerId: string
-  /** Fast completion model id; falls back to the provider's default when omitted. */
   model?: string
-  /** Code immediately before the cursor (bounded by the renderer). */
   prefix: string
-  /** Code immediately after the cursor (bounded by the renderer). */
   suffix: string
-  /** Editor language id (e.g. `python`), to steer the completion. */
   language: string
 }

--- a/src/main/llm/types.ts
+++ b/src/main/llm/types.ts
@@ -1,53 +1,124 @@
+/**
+ * Shared types for the LLM chat layer. These cross the IPC boundary, so they
+ * must be plain, structured-clone-safe data — no class instances.
+ *
+ * Re-exported through the preload `index.d.ts` so the renderer can import them
+ * from the UI-facing surface without reaching into `src/main`.
+ *
+ * The layer is provider-agnostic (issue #77): a registry of providers
+ * (Anthropic Claude, OpenAI, Google Gemini, Grok/xAI, GitHub Copilot, Local
+ * LLM) lives in `providers/`, and a request names the `providerId` + `model`
+ * it targets.
+ */
+
+/** A single chat turn in the conversation thread. */
 export interface LlmMessage {
   role: 'user' | 'assistant'
   content: string
 }
 
+/**
+ * Whether an API key is currently stored for a provider, plus whether this
+ * platform can encrypt it at rest. When `secure` is false the key is still
+ * persisted but (per Electron `safeStorage`) may be stored in plaintext, so the
+ * UI can warn.
+ */
 export interface LlmKeyStatus {
+  /** True when a non-empty key is persisted (for the queried provider). */
   hasKey: boolean
+  /** True when OS-backed encryption is available for storage. */
   secure: boolean
 }
 
+/** A selectable model offered by a provider. */
 export interface LlmModelInfo {
   id: string
   label: string
 }
 
+/**
+ * Renderer-facing description of a provider: enough for the chat footer to
+ * render provider/model/effort/speed dropdowns and the per-provider key
+ * settings, without the renderer ever importing the provider implementations.
+ */
 export interface LlmProviderInfo {
+  /** Stable id used as the key-store namespace and in send requests. */
   id: string
+  /** Human-readable name shown in the UI. */
   label: string
+  /** Selectable models (first is a sensible default fallback). */
   models: LlmModelInfo[]
+  /** Default model id when the user hasn't chosen one. */
   defaultModel: string
+  /**
+   * Default fast model for inline autocomplete (issue #82). Completion reuses
+   * the same `models` list for selection, but defaults to this fast, cheap model
+   * (e.g. Haiku) rather than the heavier chat default.
+   */
   defaultCompletionModel?: string
+  /** Reasoning-effort levels the provider supports, if any (e.g. low/medium/high). */
   efforts?: string[]
+  /** Speed/latency tiers the provider supports, if any. */
   speeds?: string[]
+  /** Short hint about what kind of key/token the provider needs. */
   keyHint?: string
+  /** URL where the user can obtain a key (opened externally). */
   keyUrl?: string
+  /** When true, the provider is wired but untested / has caveats (e.g. Copilot). */
   experimental?: boolean
-  /** When true, the user can type any model name instead of picking from a list. */
+  /**
+   * When true, the user can type any model name instead of picking from a list.
+   * Used by the Local LLM provider where available models depend on the user's
+   * server and cannot be enumerated at registration time.
+   */
   customModel?: boolean
 }
 
+/** Arguments for a chat completion request. */
 export interface LlmSendRequest {
+  /** Which provider to route this request to (see {@link LlmProviderInfo.id}). */
   providerId: string
+  /** The full conversation so far (oldest first). Last entry is the new user turn. */
   messages: LlmMessage[]
+  /**
+   * When set, the active editor file is attached as cached context so the model
+   * can reason about the code the user is editing.
+   */
   activeFile?: { name: string; content: string }
+  /**
+   * When set, recent console/REPL output (since the last Run) is attached as
+   * context so the model can reason about what the program printed (issue #78).
+   */
   consoleOutput?: string
+  /** Model id to use; falls back to the provider's default when omitted. */
   model?: string
+  /** Reasoning-effort level, when the provider declares `efforts`. */
   effort?: string
+  /** Speed/latency tier, when the provider declares `speeds`. */
   speed?: string
 }
 
+/** A streamed chunk pushed to the renderer during a streaming completion. */
 export type LlmStreamEvent =
   | { type: 'start'; requestId: string }
   | { type: 'delta'; requestId: string; text: string }
   | { type: 'done'; requestId: string }
   | { type: 'error'; requestId: string; message: string }
 
+/**
+ * Arguments for a one-shot inline completion (issue #82). Non-streaming: the IPC
+ * call resolves with the raw text to insert at the cursor. Bounded prefix/suffix
+ * give the model FIM context without shipping the whole file each keystroke.
+ */
 export interface LlmCompleteRequest {
+  /** Which provider to route this request to (see {@link LlmProviderInfo.id}). */
   providerId: string
+  /** Fast completion model id; falls back to the provider's default when omitted. */
   model?: string
+  /** Code immediately before the cursor (bounded by the renderer). */
   prefix: string
+  /** Code immediately after the cursor (bounded by the renderer). */
   suffix: string
+  /** Editor language id (e.g. `python`), to steer the completion. */
   language: string
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -585,7 +585,10 @@ const llm = {
     unwrap(ipcRenderer.invoke('llm:getProviderConfig', providerId)),
   /** Persist a provider's config (base URL, etc.). */
   setProviderConfig: (providerId: string, config: Record<string, string>): Promise<void> =>
-    unwrap(ipcRenderer.invoke('llm:setProviderConfig', providerId, config))
+    unwrap(ipcRenderer.invoke('llm:setProviderConfig', providerId, config)),
+  /** Fetch available models from an OpenAI-compatible /v1/models endpoint. */
+  fetchModels: (baseURL: string): Promise<string[]> =>
+    unwrap(ipcRenderer.invoke('llm:fetchModels', baseURL))
 }
 
 /**

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -579,7 +579,13 @@ const llm = {
     const listener = (_e: IpcRendererEvent, event: LlmStreamEvent): void => cb(event)
     ipcRenderer.on('llm:stream', listener)
     return () => ipcRenderer.removeListener('llm:stream', listener)
-  }
+  },
+  /** Read a provider's stored config (base URL, etc.) — used by the Local LLM provider. */
+  getProviderConfig: (providerId: string): Promise<Record<string, string>> =>
+    unwrap(ipcRenderer.invoke('llm:getProviderConfig', providerId)),
+  /** Persist a provider's config (base URL, etc.). */
+  setProviderConfig: (providerId: string, config: Record<string, string>): Promise<void> =>
+    unwrap(ipcRenderer.invoke('llm:setProviderConfig', providerId, config))
 }
 
 /**

--- a/src/renderer/src/components/ChatPanel.css
+++ b/src/renderer/src/components/ChatPanel.css
@@ -286,3 +286,15 @@
   letter-spacing: 0.03em;
   color: var(--danger, #c0392b);
 }
+
+/* Footer text input for local LLM model name. */
+.chat__footer-input {
+  width: 130px;
+  padding: 0.1rem 0.3rem;
+  background: var(--bg-elevated);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-family: inherit;
+  font-size: 0.72rem;
+}

--- a/src/renderer/src/components/ChatPanel.tsx
+++ b/src/renderer/src/components/ChatPanel.tsx
@@ -7,32 +7,9 @@ import { useChatProviders } from '../hooks/useChatProviders'
 import { openSettings } from './settingsBus'
 import './ChatPanel.css'
 
-/**
- * CHAT TAB (issue #18, generalized in #77 + #78; settings moved out in #83)
- * ========================================================================
- *
- * An in-app multi-provider chat assistant. The message thread, an input box, a
- * subtle footer bar to pick provider / model / effort / speed (plus Clear and a
- * ⚙ that opens the Settings dialog's Chat tab), and toggles to attach the active
- * editor file and recent console output as context.
- *
- * The redundant title bar and the inline key-settings form were removed in
- * issue #83 — the per-provider API keys, the GitHub Copilot sign-in and the
- * autocomplete settings now live in the Settings dialog's Chat tab
- * ({@link ChatSettings}). Provider/model/key state is shared via
- * {@link useChatProviders} so the footer here and that tab stay in sync.
- *
- * All provider API calls run in the MAIN process (the renderer CSP blocks
- * external requests), so this panel only talks to `window.api.llm`. Replies are
- * streamed: `sendMessage` resolves with the full text, but we also subscribe to
- * `onStream` deltas so the assistant bubble fills in live.
- */
-
-/** Window CustomEvent name the ShellPanel "Send to chat" button dispatches (issue #78). */
 export const SEND_CONSOLE_EVENT = 'snakie:send-console-to-chat'
 
 interface ChatTurn extends LlmMessage {
-  /** Stable key for React lists. */
   id: string
 }
 
@@ -41,11 +18,6 @@ export function ChatPanel(): JSX.Element {
   const activeFile = openFiles.find((f) => f.id === activeId)
   const { getSinceRun } = useConsole()
 
-  // ── Shared provider registry + selection + key status (issue #83) ─────────
-  // The per-provider keys, Copilot sign-in and autocomplete settings now live in
-  // the Settings dialog's Chat tab; this panel keeps the quick footer selectors,
-  // reading/writing the same persisted values via the shared hook so the two
-  // stay in sync.
   const {
     providers,
     provider,
@@ -57,15 +29,12 @@ export function ChatPanel(): JSX.Element {
     speed,
     setSpeed,
     keyStatus,
-    error: providerError
+    error: providerError,
+    customModel
   } = useChatProviders()
 
-  // ── Thread state ──────────────────────────────────────────────────────────
   const [turns, setTurns] = useState<ChatTurn[]>([])
   const [input, setInput] = useState('')
-  // AI-first default (issue #82): include the active file ON by default so the
-  // model always sees the up-to-date editor content. Persisted so a user who
-  // turns it off keeps it off.
   const [includeFile, setIncludeFile] = useLocalStorage<boolean>(
     'snakie.chat.includeActiveFile',
     true
@@ -73,13 +42,19 @@ export function ChatPanel(): JSX.Element {
   const [includeConsole, setIncludeConsole] = useState(false)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  /** Live-streaming assistant text for the in-flight reply. */
   const [streaming, setStreaming] = useState<string | null>(null)
+  const [localModelInput, setLocalModelInput] = useState('')
 
   const threadRef = useRef<HTMLDivElement>(null)
   const streamingRef = useRef('')
 
-  // Subscribe to streamed deltas for the in-flight request.
+  // Seed the local model input from the persisted model + config.
+  useEffect(() => {
+    if (provider?.customModel) {
+      setLocalModelInput(customModel || model || '')
+    }
+  }, [provider?.id, customModel, model])
+
   useEffect(() => {
     const unsub = window.api.llm.onStream((event: LlmStreamEvent) => {
       if (event.type === 'start') {
@@ -89,12 +64,10 @@ export function ChatPanel(): JSX.Element {
         streamingRef.current += event.text
         setStreaming(streamingRef.current)
       }
-      // `done` / `error` are handled by the sendMessage promise below.
     })
     return unsub
   }, [])
 
-  // Keep the thread scrolled to the bottom as content grows.
   useEffect(() => {
     const el = threadRef.current
     if (el) el.scrollTop = el.scrollHeight
@@ -116,10 +89,12 @@ export function ChatPanel(): JSX.Element {
       const consoleOutput =
         console ?? (includeConsole ? getSinceRun() || undefined : undefined)
 
+      const effectiveModel = provider.customModel ? localModelInput || model : model
+
       try {
         const reply = await window.api.llm.sendMessage({
           providerId: provider.id,
-          model,
+          model: effectiveModel,
           effort,
           speed,
           messages: history.map((t) => ({ role: t.role, content: t.content })),
@@ -138,7 +113,10 @@ export function ChatPanel(): JSX.Element {
         streamingRef.current = ''
       }
     },
-    [busy, turns, provider, model, effort, speed, includeFile, activeFile, includeConsole, getSinceRun]
+    [
+      busy, turns, provider, model, effort, speed, includeFile, activeFile,
+      includeConsole, getSinceRun, localModelInput
+    ]
   )
 
   const send = useCallback(
@@ -149,9 +127,6 @@ export function ChatPanel(): JSX.Element {
     [input, sendText]
   )
 
-  // Listen for "Send to chat" from the ShellPanel: stage the console output into
-  // the composer prefilled with a prompt (issue #78). We stage rather than
-  // auto-submit so the user can add a question before sending.
   useEffect(() => {
     const handler = (e: Event): void => {
       const detail = (e as CustomEvent<string>).detail ?? ''
@@ -163,8 +138,6 @@ export function ChatPanel(): JSX.Element {
             ? 'Here is my console output — can you help me understand it?'
             : ''
       )
-      // Reveal the staged output context to the user via the toggle; the actual
-      // text is grabbed fresh from the console store at send time.
       const el = threadRef.current
       if (el) el.scrollTop = el.scrollHeight
     }
@@ -178,14 +151,6 @@ export function ChatPanel(): JSX.Element {
     setStreaming(null)
   }, [])
 
-  /**
-   * Apply an assistant code block to the ACTIVE file (issue #82). Writes the code
-   * through the workspace store; Monaco is bound to the active file and syncs on
-   * drift, so the editor updates live and the change is undoable (Ctrl-Z). We
-   * REPLACE the file's contents with the block — predictable and easy to undo —
-   * rather than trying to merge/splice (the model already sees the whole file
-   * since "Include active file" defaults on, so blocks are usually full files).
-   */
   const applyToEditor = useCallback(
     (code: string): void => {
       if (!activeId) return
@@ -194,9 +159,8 @@ export function ChatPanel(): JSX.Element {
     [activeId, updateContent]
   )
 
-  const ready = keyStatus?.hasKey ?? false
+  const ready = provider?.id === 'local' || (keyStatus?.hasKey ?? false)
   const providerLabel = provider?.label ?? 'Loading…'
-  // Surface a provider-load error or an in-flight send error (whichever is set).
   const shownError = error ?? providerError
 
   return (
@@ -270,7 +234,6 @@ export function ChatPanel(): JSX.Element {
         </div>
       </form>
 
-      {/* Subtle footer bar: active provider + model with clickable dropdowns. */}
       {provider && (
         <div className="chat__footer" aria-label="Model selection">
           <FooterSelect
@@ -279,12 +242,24 @@ export function ChatPanel(): JSX.Element {
             onChange={setProviderId}
             options={providers.map((p) => ({ value: p.id, label: p.label }))}
           />
-          <FooterSelect
-            label="Model"
-            value={model}
-            onChange={setModel}
-            options={provider.models.map((m) => ({ value: m.id, label: m.label }))}
-          />
+          {provider.customModel ? (
+            <FooterTextInput
+              label="Model"
+              value={localModelInput}
+              onChange={(v) => {
+                setLocalModelInput(v)
+                setModel(v)
+              }}
+              placeholder="e.g. llama3.2, mistral, qwen2.5"
+            />
+          ) : (
+            <FooterSelect
+              label="Model"
+              value={model}
+              onChange={setModel}
+              options={provider.models.map((m) => ({ value: m.id, label: m.label }))}
+            />
+          )}
           {provider.efforts && provider.efforts.length > 0 && (
             <FooterSelect
               label="Effort"
@@ -307,10 +282,10 @@ export function ChatPanel(): JSX.Element {
               ]}
             />
           )}
-          {/* Quick actions: clear the thread + open the Settings dialog's Chat
-              tab (keys, Copilot sign-in, autocomplete — moved here in #83). */}
           <div className="chat__footer-actions">
-            {!ready && <span className="chat__footer-warn">no key</span>}
+            {!ready && provider?.id !== 'local' && (
+              <span className="chat__footer-warn">no key</span>
+            )}
             <button
               type="button"
               className="chat__btn"
@@ -335,7 +310,6 @@ export function ChatPanel(): JSX.Element {
   )
 }
 
-/** A compact labelled `<select>` used in the chat footer bar. */
 function FooterSelect({
   label,
   value,
@@ -361,17 +335,31 @@ function FooterSelect({
   )
 }
 
-/**
- * A single chat bubble. Renders text with fenced code blocks broken out into
- * styled `<pre>` blocks (each with a Copy button — and, when `onApply` is given,
- * an Apply button that writes the block into the active editor file, issue #82);
- * a Copy button also covers the whole assistant message. Markdown beyond fenced
- * code is rendered as plain text.
- *
- * `onApply` is only supplied for completed ASSISTANT bubbles when there is an
- * active file, so Apply never appears on user messages, while streaming, or with
- * no file to apply to.
- */
+function FooterTextInput({
+  label,
+  value,
+  onChange,
+  placeholder
+}: {
+  label: string
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+}): JSX.Element {
+  return (
+    <label className="chat__footer-select" title={label}>
+      <span className="chat__footer-label">{label}</span>
+      <input
+        type="text"
+        className="chat__footer-input"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+      />
+    </label>
+  )
+}
+
 function Bubble({
   role,
   content,
@@ -415,11 +403,6 @@ function Bubble({
   )
 }
 
-/**
- * Apply a code block to the active editor file (issue #82). Calls `onApply`
- * (which writes the block via the workspace store) and shows a brief "Applied"
- * confirmation, mirroring the Copy button's affordance.
- */
 function ApplyButton({
   code,
   onApply
@@ -444,7 +427,6 @@ function ApplyButton({
   )
 }
 
-/** A button that copies `text` to the clipboard, with brief confirmation. */
 function CopyButton({
   text,
   label,
@@ -476,11 +458,6 @@ function CopyButton({
 
 type Segment = { type: 'text' | 'code'; text: string }
 
-/**
- * Split a message into alternating text and fenced-code segments. Handles
- * ```lang fences; the optional language tag on the opening fence is dropped.
- * Empty text segments are omitted.
- */
 function parseSegments(content: string): Segment[] {
   const segments: Segment[] = []
   const fence = /```[^\n]*\n?([\s\S]*?)```/g

--- a/src/renderer/src/components/ChatPanel.tsx
+++ b/src/renderer/src/components/ChatPanel.tsx
@@ -29,8 +29,7 @@ export function ChatPanel(): JSX.Element {
     speed,
     setSpeed,
     keyStatus,
-    error: providerError,
-    customModel
+    error: providerError
   } = useChatProviders()
 
   const [turns, setTurns] = useState<ChatTurn[]>([])
@@ -43,7 +42,6 @@ export function ChatPanel(): JSX.Element {
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [streaming, setStreaming] = useState<string | null>(null)
-  const [localModelInput, setLocalModelInput] = useState('')
 
   // Read detected models from localStorage (set by ChatSettings)
   const detectedModels = useMemo<string[]>(() => {
@@ -57,13 +55,6 @@ export function ChatPanel(): JSX.Element {
 
   const threadRef = useRef<HTMLDivElement>(null)
   const streamingRef = useRef('')
-
-  // Seed the local model input from the persisted model + config.
-  useEffect(() => {
-    if (provider?.customModel) {
-      setLocalModelInput(customModel || model || '')
-    }
-  }, [provider?.id, customModel, model])
 
   useEffect(() => {
     const unsub = window.api.llm.onStream((event: LlmStreamEvent) => {
@@ -99,7 +90,7 @@ export function ChatPanel(): JSX.Element {
       const consoleOutput =
         console ?? (includeConsole ? getSinceRun() || undefined : undefined)
 
-      const effectiveModel = provider.customModel ? localModelInput || model : model
+      const effectiveModel = model
 
       try {
         const reply = await window.api.llm.sendMessage({
@@ -125,7 +116,7 @@ export function ChatPanel(): JSX.Element {
     },
     [
       busy, turns, provider, model, effort, speed, includeFile, activeFile,
-      includeConsole, getSinceRun, localModelInput
+      includeConsole, getSinceRun
     ]
   )
 
@@ -255,11 +246,8 @@ export function ChatPanel(): JSX.Element {
           {provider.customModel ? (
             <FooterTextInput
               label="Model"
-              value={localModelInput}
-              onChange={(v) => {
-                setLocalModelInput(v)
-                setModel(v)
-              }}
+              value={model}
+              onChange={(v) => setModel(v)}
               placeholder="e.g. llama3.2, mistral, qwen2.5"
               suggestions={detectedModels}
             />

--- a/src/renderer/src/components/ChatPanel.tsx
+++ b/src/renderer/src/components/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useCallback, useEffect, useRef, useState } from 'react'
+import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { LlmMessage, LlmStreamEvent } from '../../../preload/index.d'
 import { useWorkspace } from '../store/workspace'
 import { useConsole } from '../store/console'
@@ -44,6 +44,16 @@ export function ChatPanel(): JSX.Element {
   const [error, setError] = useState<string | null>(null)
   const [streaming, setStreaming] = useState<string | null>(null)
   const [localModelInput, setLocalModelInput] = useState('')
+
+  // Read detected models from localStorage (set by ChatSettings)
+  const detectedModels = useMemo<string[]>(() => {
+    try {
+      const raw = window.localStorage.getItem('snakie.chat.localModels')
+      return raw ? (JSON.parse(raw) as string[]) : []
+    } catch {
+      return []
+    }
+  }, [])
 
   const threadRef = useRef<HTMLDivElement>(null)
   const streamingRef = useRef('')
@@ -251,6 +261,7 @@ export function ChatPanel(): JSX.Element {
                 setModel(v)
               }}
               placeholder="e.g. llama3.2, mistral, qwen2.5"
+              suggestions={detectedModels}
             />
           ) : (
             <FooterSelect
@@ -339,12 +350,14 @@ function FooterTextInput({
   label,
   value,
   onChange,
-  placeholder
+  placeholder,
+  suggestions
 }: {
   label: string
   value: string
   onChange: (value: string) => void
   placeholder?: string
+  suggestions?: string[]
 }): JSX.Element {
   return (
     <label className="chat__footer-select" title={label}>
@@ -355,7 +368,15 @@ function FooterTextInput({
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
+        list={suggestions && suggestions.length > 0 ? 'footer-model-suggestions' : undefined}
       />
+      {suggestions && suggestions.length > 0 && (
+        <datalist id="footer-model-suggestions">
+          {suggestions.map((m) => (
+            <option key={m} value={m} />
+          ))}
+        </datalist>
+      )}
     </label>
   )
 }

--- a/src/renderer/src/components/ChatSettings.css
+++ b/src/renderer/src/components/ChatSettings.css
@@ -119,6 +119,12 @@
   line-height: 1.4;
 }
 
+/* "X models found" indicator after Detect Models button. */
+.chat-settings__found {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
 /* Text input for local LLM base URL / model name. */
 .chat-settings__input-text {
   appearance: none;

--- a/src/renderer/src/components/ChatSettings.css
+++ b/src/renderer/src/components/ChatSettings.css
@@ -118,3 +118,17 @@
   color: var(--danger);
   line-height: 1.4;
 }
+
+/* Text input for local LLM base URL / model name. */
+.chat-settings__input-text {
+  appearance: none;
+  width: 100%;
+  font: inherit;
+  font-size: 0.85rem;
+  padding: 0.4rem 0.55rem;
+  color: var(--text);
+  background: var(--bg-sunken);
+  border: var(--border-w) solid var(--border);
+  border-radius: var(--radius);
+  font-family: ui-monospace, 'JetBrains Mono', monospace;
+}

--- a/src/renderer/src/components/ChatSettings.tsx
+++ b/src/renderer/src/components/ChatSettings.tsx
@@ -22,8 +22,8 @@ export function ChatSettings(): JSX.Element {
     error,
     baseUrl,
     setBaseUrl,
-    customModel,
-    setCustomModel,
+    model,
+    setModel,
     availableModels,
     fetchModels,
     modelsLoading,
@@ -34,7 +34,7 @@ export function ChatSettings(): JSX.Element {
   const [savingKey, setSavingKey] = useState(false)
   const [localError, setLocalError] = useState<string | null>(null)
   const [baseUrlInput, setBaseUrlInput] = useState('')
-  const [customModelInput, setCustomModelInput] = useState('')
+  const [modelInput, setModelInput] = useState('')
   const [savingConfig, setSavingConfig] = useState(false)
 
   useEffect(() => {
@@ -45,9 +45,9 @@ export function ChatSettings(): JSX.Element {
   useEffect(() => {
     if (provider?.id === 'local') {
       setBaseUrlInput(baseUrl)
-      setCustomModelInput(customModel)
+      setModelInput(model)
     }
-  }, [provider?.id, baseUrl, customModel])
+  }, [provider?.id, baseUrl, model])
 
   const saveKey = useCallback(
     async (e: FormEvent): Promise<void> => {
@@ -87,11 +87,11 @@ export function ChatSettings(): JSX.Element {
     setSavingConfig(true)
     try {
       await setBaseUrl(baseUrlInput)
-      await setCustomModel(customModelInput)
+      setModel(modelInput)
     } finally {
       setSavingConfig(false)
     }
-  }, [baseUrlInput, customModelInput, setBaseUrl, setCustomModel])
+  }, [baseUrlInput, modelInput, setBaseUrl, setModel])
 
   const shown = localError ?? error
 
@@ -135,7 +135,11 @@ export function ChatSettings(): JSX.Element {
             <button
               type="button"
               className="chat-settings__btn"
-              onClick={() => void fetchModels(baseUrlInput || baseUrl)}
+              onClick={() => {
+                setModelInput('')
+                setModel('')
+                void fetchModels(baseUrlInput || baseUrl)
+              }}
               disabled={modelsLoading || !(baseUrlInput || baseUrl)}
             >
               {modelsLoading ? 'Detecting…' : 'Detect models'}
@@ -150,8 +154,8 @@ export function ChatSettings(): JSX.Element {
             <input
               type="text"
               className="chat-settings__input-text"
-              value={customModelInput}
-              onChange={(e) => setCustomModelInput(e.target.value)}
+              value={modelInput}
+              onChange={(e) => setModelInput(e.target.value)}
               placeholder="e.g. llama3.2, mistral, qwen2.5"
               list="local-model-suggestions"
             />

--- a/src/renderer/src/components/ChatSettings.tsx
+++ b/src/renderer/src/components/ChatSettings.tsx
@@ -7,24 +7,6 @@ import {
 } from '../hooks/useChatProviders'
 import './ChatSettings.css'
 
-/**
- * CHAT SETTINGS — the Settings dialog's Chat tab (issue #83)
- * =========================================================
- *
- * Everything that used to live in the chat panel's inline ⚙ settings now lives
- * here, so the chat panel keeps only its quick footer selectors:
- *
- *   - the per-provider API-key form (save / remove, key hint, "Get a key" link),
- *     OR the GitHub Copilot device-flow sign-in / sign-out for the Copilot
- *     provider (moved here intact);
- *   - the inline-autocomplete settings (the enable toggle + the per-provider
- *     completion-model selector, issue #82).
- *
- * All values are the SAME persisted keys the chat uses, read/written through
- * {@link useChatProviders} (which broadcasts changes so the chat footer and this
- * tab stay in sync). Provider selection itself is a dropdown here so the user
- * can configure a key for any provider, not just the chat's active one.
- */
 export function ChatSettings(): JSX.Element {
   const {
     providers,
@@ -37,19 +19,31 @@ export function ChatSettings(): JSX.Element {
     setCompletionModel,
     keyStatus,
     refreshKeyStatus,
-    error
+    error,
+    baseUrl,
+    setBaseUrl,
+    customModel,
+    setCustomModel
   } = useChatProviders()
 
   const [keyInput, setKeyInput] = useState('')
   const [savingKey, setSavingKey] = useState(false)
   const [localError, setLocalError] = useState<string | null>(null)
+  const [baseUrlInput, setBaseUrlInput] = useState('')
+  const [customModelInput, setCustomModelInput] = useState('')
+  const [savingConfig, setSavingConfig] = useState(false)
 
-  // Reset the key field when switching providers so a half-typed key never
-  // leaks to another provider's form.
   useEffect(() => {
     setKeyInput('')
     setLocalError(null)
   }, [providerId])
+
+  useEffect(() => {
+    if (provider?.id === 'local') {
+      setBaseUrlInput(baseUrl)
+      setCustomModelInput(customModel)
+    }
+  }, [provider?.id, baseUrl, customModel])
 
   const saveKey = useCallback(
     async (e: FormEvent): Promise<void> => {
@@ -85,6 +79,16 @@ export function ChatSettings(): JSX.Element {
     }
   }, [provider, refreshKeyStatus])
 
+  const saveLocalConfig = useCallback(async (): Promise<void> => {
+    setSavingConfig(true)
+    try {
+      await setBaseUrl(baseUrlInput)
+      await setCustomModel(customModelInput)
+    } finally {
+      setSavingConfig(false)
+    }
+  }, [baseUrlInput, customModelInput, setBaseUrl, setCustomModel])
+
   const shown = localError ?? error
 
   return (
@@ -110,6 +114,46 @@ export function ChatSettings(): JSX.Element {
         </select>
       </section>
 
+      {provider && provider.id === 'local' && (
+        <section className="settings-section">
+          <h3 className="settings-section__title">Local LLM Connection</h3>
+          <label className="chat-settings__field">
+            <span className="chat-settings__field-label">Base URL</span>
+            <input
+              type="text"
+              className="chat-settings__input-text"
+              value={baseUrlInput}
+              onChange={(e) => setBaseUrlInput(e.target.value)}
+              placeholder="http://localhost:11434/v1"
+            />
+          </label>
+          <label className="chat-settings__field">
+            <span className="chat-settings__field-label">Model name</span>
+            <input
+              type="text"
+              className="chat-settings__input-text"
+              value={customModelInput}
+              onChange={(e) => setCustomModelInput(e.target.value)}
+              placeholder="e.g. llama3.2, mistral, qwen2.5"
+            />
+          </label>
+          <div className="chat-settings__row">
+            <button
+              type="button"
+              className="chat-settings__btn chat-settings__btn--primary"
+              onClick={() => void saveLocalConfig()}
+              disabled={savingConfig}
+            >
+              {savingConfig ? 'Saving…' : 'Save'}
+            </button>
+          </div>
+          <p className="settings-section__hint">
+            Connect to any OpenAI-compatible local LLM server (Ollama, LM Studio, LocalAI, vLLM,
+            etc.). No API key is required unless your server enforces one.
+          </p>
+        </section>
+      )}
+
       {provider && provider.id === 'copilot' ? (
         <section className="settings-section">
           <h3 className="settings-section__title">{provider.label} sign-in</h3>
@@ -124,7 +168,7 @@ export function ChatSettings(): JSX.Element {
           />
         </section>
       ) : (
-        provider && (
+        provider && provider.id !== 'local' && (
           <form className="settings-section" onSubmit={saveKey}>
             <h3 className="settings-section__title">{provider.label} API key</h3>
             <input
@@ -217,13 +261,6 @@ export function ChatSettings(): JSX.Element {
   )
 }
 
-/**
- * GitHub Copilot sign-in via the OAuth device flow (moved from ChatPanel in
- * issue #83). A plain personal access token can't reach the Copilot token
- * endpoint, so the user approves a short code at github.com/login/device; the
- * main process then holds the resulting GitHub token (never exposed here) and
- * exchanges it for the Copilot token.
- */
 function CopilotSignIn({
   providerLabel,
   signedIn,
@@ -239,7 +276,6 @@ function CopilotSignIn({
   const [copied, setCopied] = useState(false)
   const cancelledRef = useRef(false)
 
-  // Stop polling if the dialog unmounts mid-flow.
   useEffect(() => {
     return () => {
       cancelledRef.current = true
@@ -273,7 +309,6 @@ function CopilotSignIn({
           continue
         }
         if (res.status === 'pending') continue
-        // denied / expired / error — terminal.
         setError(res.message || `Sign-in ${res.status}.`)
         setPhase('error')
         setDevice(null)

--- a/src/renderer/src/components/ChatSettings.tsx
+++ b/src/renderer/src/components/ChatSettings.tsx
@@ -23,7 +23,11 @@ export function ChatSettings(): JSX.Element {
     baseUrl,
     setBaseUrl,
     customModel,
-    setCustomModel
+    setCustomModel,
+    availableModels,
+    fetchModels,
+    modelsLoading,
+    modelsError
   } = useChatProviders()
 
   const [keyInput, setKeyInput] = useState('')
@@ -127,6 +131,20 @@ export function ChatSettings(): JSX.Element {
               placeholder="http://localhost:11434/v1"
             />
           </label>
+          <div className="chat-settings__row">
+            <button
+              type="button"
+              className="chat-settings__btn"
+              onClick={() => void fetchModels(baseUrlInput || baseUrl)}
+              disabled={modelsLoading || !(baseUrlInput || baseUrl)}
+            >
+              {modelsLoading ? 'Detecting…' : 'Detect models'}
+            </button>
+            {availableModels.length > 0 && !modelsError && (
+              <span className="chat-settings__found">{availableModels.length} models found</span>
+            )}
+          </div>
+          {modelsError && <p className="chat-settings__error">{modelsError}</p>}
           <label className="chat-settings__field">
             <span className="chat-settings__field-label">Model name</span>
             <input
@@ -135,7 +153,15 @@ export function ChatSettings(): JSX.Element {
               value={customModelInput}
               onChange={(e) => setCustomModelInput(e.target.value)}
               placeholder="e.g. llama3.2, mistral, qwen2.5"
+              list="local-model-suggestions"
             />
+            {availableModels.length > 0 && (
+              <datalist id="local-model-suggestions">
+                {availableModels.map((m) => (
+                  <option key={m} value={m} />
+                ))}
+              </datalist>
+            )}
           </label>
           <div className="chat-settings__row">
             <button

--- a/src/renderer/src/hooks/useChatProviders.ts
+++ b/src/renderer/src/hooks/useChatProviders.ts
@@ -56,8 +56,6 @@ export interface ChatProvidersStore {
   error: string | null
   baseUrl: string
   setBaseUrl: (url: string) => Promise<void>
-  customModel: string
-  setCustomModel: (model: string) => Promise<void>
   availableModels: string[]
   fetchModels: (baseURL: string) => Promise<void>
   modelsLoading: boolean
@@ -69,7 +67,6 @@ export function useChatProviders(): ChatProvidersStore {
   const [error, setError] = useState<string | null>(null)
   const [keyStatus, setKeyStatus] = useState<LlmKeyStatus | null>(null)
   const [baseUrl, setBaseUrlState] = useState<string>('')
-  const [customModel, setCustomModelState] = useState<string>('')
   const [availableModels, setAvailableModels] = useState<string[]>([])
   const [modelsLoading, setModelsLoading] = useState(false)
   const [modelsError, setModelsError] = useState<string | null>(null)
@@ -103,14 +100,13 @@ export function useChatProviders(): ChatProvidersStore {
     provider?.defaultModel ||
     ''
 
-  // Load provider config (base URL, custom model name) from main process
+  // Load provider config (base URL) from main process
   useEffect(() => {
     if (!provider || provider.id !== 'local') return
     void window.api.llm
       .getProviderConfig('local')
       .then((cfg) => {
         setBaseUrlState(cfg.baseURL || 'http://localhost:11434/v1')
-        setCustomModelState(cfg.model || '')
       })
       .catch(() => undefined)
   }, [provider])
@@ -199,21 +195,9 @@ export function useChatProviders(): ChatProvidersStore {
 
   const setBaseUrl = useCallback(async (url: string): Promise<void> => {
     setBaseUrlState(url)
-    await window.api.llm.setProviderConfig('local', {
-      baseURL: url,
-      model: customModel
-    })
+    await window.api.llm.setProviderConfig('local', { baseURL: url })
     notifyChatConfigChanged()
-  }, [customModel])
-
-  const setCustomModelFn = useCallback(async (model: string): Promise<void> => {
-    setCustomModelState(model)
-    await window.api.llm.setProviderConfig('local', {
-      baseURL: baseUrl,
-      model
-    })
-    notifyChatConfigChanged()
-  }, [baseUrl])
+  }, [])
 
   const fetchModelsFn = useCallback(async (baseURL: string): Promise<void> => {
     setModelsLoading(true)
@@ -252,8 +236,6 @@ export function useChatProviders(): ChatProvidersStore {
     error,
     baseUrl,
     setBaseUrl,
-    customModel,
-    setCustomModel: setCustomModelFn,
     availableModels,
     fetchModels: fetchModelsFn,
     modelsLoading,

--- a/src/renderer/src/hooks/useChatProviders.ts
+++ b/src/renderer/src/hooks/useChatProviders.ts
@@ -58,6 +58,10 @@ export interface ChatProvidersStore {
   setBaseUrl: (url: string) => Promise<void>
   customModel: string
   setCustomModel: (model: string) => Promise<void>
+  availableModels: string[]
+  fetchModels: (baseURL: string) => Promise<void>
+  modelsLoading: boolean
+  modelsError: string | null
 }
 
 export function useChatProviders(): ChatProvidersStore {
@@ -66,6 +70,9 @@ export function useChatProviders(): ChatProvidersStore {
   const [keyStatus, setKeyStatus] = useState<LlmKeyStatus | null>(null)
   const [baseUrl, setBaseUrlState] = useState<string>('')
   const [customModel, setCustomModelState] = useState<string>('')
+  const [availableModels, setAvailableModels] = useState<string[]>([])
+  const [modelsLoading, setModelsLoading] = useState(false)
+  const [modelsError, setModelsError] = useState<string | null>(null)
   const [, setTick] = useState(0)
 
   useEffect(() => {
@@ -208,6 +215,23 @@ export function useChatProviders(): ChatProvidersStore {
     notifyChatConfigChanged()
   }, [baseUrl])
 
+  const fetchModelsFn = useCallback(async (baseURL: string): Promise<void> => {
+    setModelsLoading(true)
+    setModelsError(null)
+    try {
+      const models = await window.api.llm.fetchModels(baseURL)
+      setAvailableModels(models)
+      // Also persist so ChatPanel can access them
+      writeStored('snakie.chat.localModels', models)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      setModelsError(msg)
+      setAvailableModels([])
+    } finally {
+      setModelsLoading(false)
+    }
+  }, [])
+
   return {
     providers,
     provider,
@@ -229,7 +253,11 @@ export function useChatProviders(): ChatProvidersStore {
     baseUrl,
     setBaseUrl,
     customModel,
-    setCustomModel: setCustomModelFn
+    setCustomModel: setCustomModelFn,
+    availableModels,
+    fetchModels: fetchModelsFn,
+    modelsLoading,
+    modelsError
   }
 }
 

--- a/src/renderer/src/hooks/useChatProviders.ts
+++ b/src/renderer/src/hooks/useChatProviders.ts
@@ -8,40 +8,17 @@ import {
 } from '../store/completionConfig'
 import { invalidateCompletionKeyStatus } from '../components/inline-completions'
 
-/**
- * Shared chat-provider state (issues #77/#78/#82, split out in #83)
- * ================================================================
- *
- * The chat lives in TWO places now: the {@link ChatPanel} (quick footer +
- * status + thread) and the Settings dialog's Chat tab (API keys, Copilot
- * sign-in, autocomplete). Both edit the SAME persisted values — the provider
- * registry, the per-provider model/effort/speed selection, the per-provider key
- * status, and the autocomplete knobs — so this hook centralises them.
- *
- * The selections are read DIRECTLY from `localStorage` on each render-tick
- * (rather than via `useLocalStorage`, which caches per-instance and only re-reads
- * when its key changes) so two consumers stay in sync. Any write persists to
- * `localStorage` and broadcasts {@link CHAT_CONFIG_EVENT}; every consumer bumps
- * a tick on that event and re-reads — giving a single live source of truth
- * across the panel and the dialog without prop-drilling.
- */
-
-/** Persisted localStorage keys (same keys the chat has always used). The
- * provider key is shared with the completion provider via completionConfig. */
 const PROVIDER_KEY = CHAT_PROVIDER_KEY
 const MODELS_KEY = 'snakie.chat.models'
 const EFFORTS_KEY = 'snakie.chat.efforts'
 const SPEEDS_KEY = 'snakie.chat.speeds'
 
-/** Window event fired when any shared chat config value changes. */
 const CHAT_CONFIG_EVENT = 'snakie:chat-config-changed'
 
-/** Broadcast that a shared chat config value changed so siblings re-read. */
 function notifyChatConfigChanged(): void {
   window.dispatchEvent(new CustomEvent(CHAT_CONFIG_EVENT))
 }
 
-/** Safely read + JSON-parse a localStorage value, falling back on any error. */
 function readStored<T>(key: string, fallback: T): T {
   try {
     const raw = window.localStorage.getItem(key)
@@ -51,7 +28,6 @@ function readStored<T>(key: string, fallback: T): T {
   }
 }
 
-/** Persist a value to localStorage (ignoring write failures). */
 function writeStored<T>(key: string, value: T): void {
   try {
     window.localStorage.setItem(key, JSON.stringify(value))
@@ -61,49 +37,37 @@ function writeStored<T>(key: string, value: T): void {
 }
 
 export interface ChatProvidersStore {
-  /** All providers from the main-process registry (empty until loaded). */
   providers: LlmProviderInfo[]
-  /** The currently selected provider (or the first as a fallback). */
   provider: LlmProviderInfo | undefined
-  /** Selected provider id. */
   providerId: string
   setProviderId: (id: string) => void
-  /** Selected chat model for the active provider. */
   model: string
   setModel: (id: string) => void
-  /** Selected reasoning effort for the active provider (undefined = auto). */
   effort: string | undefined
   setEffort: (v: string) => void
-  /** Selected speed tier for the active provider (undefined = auto). */
   speed: string | undefined
   setSpeed: (v: string) => void
-  /** Whether inline autocomplete is enabled (issue #82). */
   completionEnabled: boolean
   setCompletionEnabled: (v: boolean) => void
-  /** The fast completion model for the active provider. */
   completionModel: string
   setCompletionModel: (id: string) => void
-  /** Key status for the active provider (null until first probe). */
   keyStatus: LlmKeyStatus | null
-  /** Re-probe the active provider's key status. */
   refreshKeyStatus: () => Promise<void>
-  /** Any load/probe error to surface. */
   error: string | null
+  baseUrl: string
+  setBaseUrl: (url: string) => Promise<void>
+  customModel: string
+  setCustomModel: (model: string) => Promise<void>
 }
 
-/**
- * Subscribe to the shared chat-provider config. Pass a fresh provider registry
- * load on the first consumer; subsequent consumers reuse the broadcast values.
- */
 export function useChatProviders(): ChatProvidersStore {
   const [providers, setProviders] = useState<LlmProviderInfo[]>([])
   const [error, setError] = useState<string | null>(null)
   const [keyStatus, setKeyStatus] = useState<LlmKeyStatus | null>(null)
-  // Bump to force a re-read of the localStorage-backed selections below after a
-  // sibling consumer writes (the broadcast handler increments this).
+  const [baseUrl, setBaseUrlState] = useState<string>('')
+  const [customModel, setCustomModelState] = useState<string>('')
   const [, setTick] = useState(0)
 
-  // Load the provider registry once.
   useEffect(() => {
     void window.api.llm
       .listProviders()
@@ -111,10 +75,6 @@ export function useChatProviders(): ChatProvidersStore {
       .catch((err) => setError(err instanceof Error ? err.message : String(err)))
   }, [])
 
-  // Read all persisted selections fresh from localStorage on every render. This
-  // (vs caching in useState/useLocalStorage) is what lets the footer and the
-  // Settings Chat tab show identical values the instant either writes — the
-  // broadcast below re-renders both, and both re-read here.
   const providerId = readStored<string>(PROVIDER_KEY, 'anthropic')
   const modelByProvider = readStored<Record<string, string>>(MODELS_KEY, {})
   const effortByProvider = readStored<Record<string, string>>(EFFORTS_KEY, {})
@@ -136,6 +96,18 @@ export function useChatProviders(): ChatProvidersStore {
     provider?.defaultModel ||
     ''
 
+  // Load provider config (base URL, custom model name) from main process
+  useEffect(() => {
+    if (!provider || provider.id !== 'local') return
+    void window.api.llm
+      .getProviderConfig('local')
+      .then((cfg) => {
+        setBaseUrlState(cfg.baseURL || 'http://localhost:11434/v1')
+        setCustomModelState(cfg.model || '')
+      })
+      .catch(() => undefined)
+  }, [provider])
+
   const refreshKeyStatus = useCallback(async (): Promise<void> => {
     if (!provider) return
     try {
@@ -150,10 +122,6 @@ export function useChatProviders(): ChatProvidersStore {
     void refreshKeyStatus()
   }, [refreshKeyStatus])
 
-  // Re-render (re-reading the selections above) AND re-probe the key status when
-  // a sibling consumer writes (e.g. the Settings dialog saves a key or switches
-  // provider), so the two instances stay in sync without a remount. A ref keeps
-  // the listener stable while always calling the latest refresh.
   const refreshRef = useRef(refreshKeyStatus)
   refreshRef.current = refreshKeyStatus
   useEffect(() => {
@@ -165,11 +133,11 @@ export function useChatProviders(): ChatProvidersStore {
     return () => window.removeEventListener(CHAT_CONFIG_EVENT, onChange)
   }, [])
 
-  // Setters persist to localStorage then broadcast so every consumer re-reads.
   const setProviderId = useCallback((id: string): void => {
     writeStored(PROVIDER_KEY, id)
     notifyChatConfigChanged()
   }, [])
+
   const setModel = useCallback(
     (next: string): void => {
       if (!provider) return
@@ -178,6 +146,7 @@ export function useChatProviders(): ChatProvidersStore {
     },
     [provider]
   )
+
   const setEffort = useCallback(
     (next: string): void => {
       if (!provider) return
@@ -189,6 +158,7 @@ export function useChatProviders(): ChatProvidersStore {
     },
     [provider]
   )
+
   const setSpeed = useCallback(
     (next: string): void => {
       if (!provider) return
@@ -200,11 +170,13 @@ export function useChatProviders(): ChatProvidersStore {
     },
     [provider]
   )
+
   const setCompletionEnabled = useCallback((next: boolean): void => {
     writeStored(COMPLETION_ENABLED_KEY, next)
     notifyCompletionConfigChanged()
     notifyChatConfigChanged()
   }, [])
+
   const setCompletionModel = useCallback(
     (next: string): void => {
       if (!provider) return
@@ -217,6 +189,24 @@ export function useChatProviders(): ChatProvidersStore {
     },
     [provider]
   )
+
+  const setBaseUrl = useCallback(async (url: string): Promise<void> => {
+    setBaseUrlState(url)
+    await window.api.llm.setProviderConfig('local', {
+      baseURL: url,
+      model: customModel
+    })
+    notifyChatConfigChanged()
+  }, [customModel])
+
+  const setCustomModelFn = useCallback(async (model: string): Promise<void> => {
+    setCustomModelState(model)
+    await window.api.llm.setProviderConfig('local', {
+      baseURL: baseUrl,
+      model
+    })
+    notifyChatConfigChanged()
+  }, [baseUrl])
 
   return {
     providers,
@@ -235,9 +225,12 @@ export function useChatProviders(): ChatProvidersStore {
     setCompletionModel,
     keyStatus,
     refreshKeyStatus,
-    error
+    error,
+    baseUrl,
+    setBaseUrl,
+    customModel,
+    setCustomModel: setCustomModelFn
   }
 }
 
-/** Re-export so consumers can fire the broadcast after an out-of-hook key write. */
 export { notifyChatConfigChanged, invalidateCompletionKeyStatus }


### PR DESCRIPTION
## Add "Local LLM" provider for OpenAI-compatible local/self-hosted LLMs

Adds a **Local LLM** provider option that lets users connect Snakie's AI chat
to any OpenAI-compatible local or self-hosted LLM server (Ollama, LM Studio,
LocalAI, vLLM, text-generation-webui, etc.) via a configurable host/port base
URL.

### Motivation

Users running local models want to use Snakie's AI chat without an external API
key or a cloud provider. Previously every backend was hardcoded to a single
remote endpoint; this change makes the OpenAI-compatible wire protocol
(`/chat/completions`) accessible to any server the user points it at.

### Changes

**New file — `src/main/llm/providers/providerConfig.ts`**

Simple JSON file-based per-provider config store (for non-sensitive settings
like base URL). Stored at `<userData>/<providerId>-config.json`.

**`src/main/llm/providers/openaiCompatible.ts`**

- Exports `streamOpenAiCompatible` and `completeOpenAiCompatible` so the local
  provider can reuse the existing OpenAI-compatible wire logic.
- Adds `localProvider` — a `Provider` that reads its `baseURL` from the config
  store on each request (defaults to `http://localhost:11434/v1`).
- Adds `LOCAL_INFO` with `customModel: true` to signal the UI that the user
  can type any model name rather than picking from a dropdown.

**`src/main/llm/types.ts`**

- Adds optional `customModel?: boolean` to `LlmProviderInfo`. When true, the
  renderer renders a text input instead of a `<select>` for the model field.

**`src/main/llm/providers/registry.ts`**

- Registers the `localProvider` as the last entry in the provider list.

**`src/main/llm/ipc.ts`**

- Adds IPC handlers `llm:getProviderConfig` and `llm:setProviderConfig` so the
  renderer can read/write the local provider's base URL and model name.
- Relaxes the "no API key" guard for the `local` provider (local servers often
  don't require auth).

**`src/preload/index.ts`**

- Exposes `llm.getProviderConfig` and `llm.setProviderConfig` to the renderer
  through the preload bridge.

**`src/renderer/src/hooks/useChatProviders.ts`**

- Adds `baseUrl` / `setBaseUrl` and `customModel` / `setCustomModel` to the
  shared chat-provider store. Loads the local provider's config from the main
  process on provider change and saves it via IPC.

**`src/renderer/src/components/ChatSettings.tsx`**

- When the Local LLM provider is selected, shows a "Local LLM Connection"
  section with two text fields: **Base URL** (e.g. `http://localhost:11434/v1`)
  and **Model name** (e.g. `llama3.2`, `mistral`, `qwen2.5`), plus a Save
  button.
- Existing key form and other providers remain unchanged — the local provider
  branch skips the key form entirely (local auth is optional).

**`src/renderer/src/components/ChatPanel.tsx`**

- When the active provider has `customModel: true`, the model selector in the
  chat footer switches from a `<select>` dropdown to a `<input type="text">`
  so the user can type any model name inline.
- Sends the typed model name in the chat request.

**CSS additions:**

- `.chat__footer-input` — styles for the footer model text input (matches the
  existing `.chat__footer-select select` dimensions).
- `.chat-settings__input-text` — styles for the settings text inputs (matches
  `.chat-settings__input-key` but without monospace font restriction).

### Usage

1. Open Settings → Chat, select **Local LLM** from the provider dropdown.
2. Enter your server's base URL (e.g. `http://localhost:11434/v1`) and the
   model name your local server serves (e.g. `llama3.2`).
3. Click **Save**.
4. Back in the chat panel, type the model name in the footer's model field (or
   edit it inline at any time), then start chatting — no API key required.

### Future considerations

- When a local provider is selected, we could auto-detect available models by
  calling `GET /api/tags` (Ollama) or `GET /v1/models` (OpenAI-compatible) and
  populate the model name field with a datalist or dropdown. This is left for a
  follow-up.
- The `providerConfig.ts` store could be extended for other providers' settings
  (e.g. custom headers, GitHub token for Copilot Enterprise self-hosted).
