### PR TITLE
feat: order-independent Join tool + nudge freed parts aside on detach (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -310,14 +310,22 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   or reopen any panel. Nothing about Robot mode is permanently changed.
 
 ### Fixed
+- **Robot View — the Join tool respects the existing structure whichever part you pick
+  first (#354).** Picking the two parts in the "wrong" order used to re-home the part
+  that was *already* built into the chain onto the loose one — so the established part
+  jumped away and looked disconnected from the base. Joining is now **order-independent**:
+  the loose / less-established part — the one closer to the base (then with fewer
+  descendants) — is always the one that moves onto the other, so your existing structure
+  stays put no matter which you click as Component 1 (a gripper mounts onto the arm tip,
+  never the reverse).
 - **Robot View — removing a joint no longer fuses the freed part into the base (#354).**
   Deleting a joint used to leave its part *rootless*, and the loader collapses every
   rootless part into the base's single scene node — so the base and every freed part
   **highlighted together** and you couldn't pick just one to re-join it (which also made
   a follow-up joint look "ignored"). Deleting a joint now **re-attaches the part to the
-  base as a loose part** at exactly where it was (its sub-assembly comes with it and
-  stays put) — so each part stays independently selectable and you can articulate a new
-  chain from it.
+  base as a loose part**, nudged to a clear spot beside the base (like a fresh import)
+  so it's off its old parent and easy to pick — its sub-assembly relocates with it — and
+  each part stays independently selectable so you can articulate a new chain from it.
 - **Robot View — adding a joint no longer blanks the view (#354).** After a joint was
   added the selected block's highlight was re-applied during the scene rebuild, but the
   helper it needed was declared *later* in the same setup — a temporal-dead-zone crash

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -36,6 +36,7 @@ import {
   setJoint,
   setJointOrigin,
   orientJoint,
+  subtreeOf,
   setPrimitiveSize,
   setVisualOrigin,
   type JointDef,
@@ -726,9 +727,18 @@ export function RobotView({
     const jp = jointPick
     if (!jp?.parent || !jp?.child) return false
     const base = contentRef.current
-    // Intelligent parent/child (#354): if the chosen order would loop but the
-    // reverse wouldn't, orientJoint swaps them so the user needn't get it "right".
-    const o = orientJoint(base, jp.parent.link, jp.child.link)
+    // Intelligent parent/child (#354): orientJoint re-homes the less-established part
+    // regardless of pick order, so the existing structure stays put. It's base-agnostic
+    // and measures depth within each part's OWN root, so in a multi-root URDF it can't
+    // tell a loose separate-root import from the base's structure. Guard it here: the
+    // base's connected structure must NEVER be re-homed onto a part disconnected from the
+    // base (a loose import / the base itself) — if the chosen child is on the base but the
+    // parent isn't, flip so the disconnected part is the one that moves.
+    const baseTree = effectiveBaseLink ? subtreeOf(base, effectiveBaseLink) : new Set<string>()
+    let o = orientJoint(base, jp.parent.link, jp.child.link)
+    if (o.child !== o.parent && baseTree.has(o.child) && !baseTree.has(o.parent)) {
+      o = { parent: o.child, child: o.parent }
+    }
     const [parent, child] = o.parent === jp.parent.link ? [jp.parent, jp.child] : [jp.child, jp.parent]
     // The mating ROTATION (rotate the child so its picked face meets the parent's
     // flush, then roll it about the joint normal by `angleDeg`). The origin is handled
@@ -797,12 +807,12 @@ export function RobotView({
     return true
   }
   // Delete a joint (#354): detach the child from its parent, then RE-ATTACH it to the
-  // base as a LOOSE fixed joint at its current world pose. It must NOT be left rootless
-  // — the loader collapses every rootless link into the base's single scene node, so
-  // freed parts would co-highlight and you couldn't pick one to re-join it. Its whole
-  // sub-assembly comes with it and stays put, because the child's own link frame (and
-  // thus its visual + descendant joints, all relative to it) is preserved by placing
-  // the new base→child joint at the child's former world pose.
+  // base as a LOOSE fixed joint — NUDGED to a clear, staggered spot beside the base
+  // (like a fresh import), not left on top of its old parent where it's hard to pick.
+  // It must NOT be left rootless — the loader collapses every rootless link into the
+  // base's single scene node, so freed parts would co-highlight and you couldn't pick
+  // one to re-join it. Its whole sub-assembly comes with it (descendant joints are
+  // relative to the child link, so the freed part relocates as a unit).
   const handleDeleteJoint = (child: string): void => {
     const before = content
     const base = effectiveBaseLink
@@ -810,37 +820,35 @@ export function RobotView({
       setDialogCtx(null) // can't detach the base itself
       return
     }
-    // The child's transform relative to the base (which loads at the origin).
-    const robot = robotRef.current
-    let relM = new THREE.Matrix4()
-    if (robot?.links[child] && robot.links[base]) {
-      robot.updateMatrixWorld(true)
-      relM = new THREE.Matrix4()
-        .copy(robot.links[base].matrixWorld)
-        .invert()
-        .multiply(robot.links[child].matrixWorld)
-    }
-    const p = new THREE.Vector3()
-    const q = new THREE.Quaternion()
-    relM.decompose(p, q, new THREE.Vector3())
-    const e = new THREE.Euler().setFromQuaternion(q, 'ZYX') // URDF rpy convention
-    const relXyz: [number, number, number] = [p.x, p.y, p.z]
-    const relRpy: [number, number, number] = [e.x, e.y, e.z]
+    const oldJointName = readJoint(before, child)?.name
     let next = removeJoint(before, child)
     if (next === before) {
       setDialogCtx(null) // no such joint
       return
     }
-    // Re-attach to the base (fresh fixed joint) at the former world pose.
-    next = connectJoint(next, { parent: base, child, xyz: relXyz })
-    next = setJointOrigin(next, child, relXyz, relRpy)
+    // A clear loose spot BEYOND every part already parked directly on the base, along X —
+    // so successive detaches (which don't change the link count) don't stack on the same
+    // spot. Placed just past the current max so it's off its old parent, upright + pickable.
+    const baseChildX = readAllJoints(next)
+      .filter((j) => j.parent === base)
+      .map((j) => j.xyz[0])
+    const looseXyz: [number, number, number] = [Math.max(0, ...baseChildX) + 0.08, 0, 0]
+    next = connectJoint(next, { parent: base, child, xyz: looseXyz })
+    next = setJointOrigin(next, child, looseXyz, [0, 0, 0])
     commitUrdf(next)
-    // Fresh loose attachment → its orientation is the new zero-roll baseline.
+    // Fresh loose attachment → its orientation is the new zero-roll baseline. Drop the
+    // old joint's remembered roll (its name is gone) so the map doesn't accrete cruft.
     const jn = readJoint(next, child)?.name
-    if (jn) {
-      jointRollRef.current = { ...jointRollRef.current, [jn]: 0 }
+    if (jn || oldJointName) {
+      const roll = { ...jointRollRef.current }
+      if (oldJointName) delete roll[oldJointName]
+      if (jn) roll[jn] = 0
+      jointRollRef.current = roll
       void persist((m) => {
-        m.jointRoll = { ...(m.jointRoll ?? {}), [jn]: 0 }
+        const mr = { ...(m.jointRoll ?? {}) }
+        if (oldJointName) delete mr[oldJointName]
+        if (jn) mr[jn] = 0
+        m.jointRoll = mr
       })
     }
     setDialogCtx(null)

--- a/src/renderer/src/components/robot-assembly.ts
+++ b/src/renderer/src/components/robot-assembly.ts
@@ -514,15 +514,65 @@ export function subtreeOf(urdf: string, link: string): Set<string> {
   return inside
 }
 
+/** How many joints from `link` up to its root (0 for a root). Walks parent joints,
+ *  cycle-guarded. Used to tell a loose stub near the base from a deep chain link. */
+export function depthFromRoot(urdf: string, link: string): number {
+  const parentOf = (child: string): string | undefined => {
+    const re = /<joint\b[^>]*>[\s\S]*?<\/joint>/gi
+    let m: RegExpExecArray | null
+    while ((m = re.exec(urdf))) {
+      const c = /<child\b[^>]*\blink\s*=\s*"([^"]+)"/i.exec(m[0])?.[1]
+      if (c === child) return /<parent\b[^>]*\blink\s*=\s*"([^"]+)"/i.exec(m[0])?.[1]
+    }
+    return undefined
+  }
+  const seen = new Set<string>()
+  let cur: string | undefined = link
+  let depth = 0
+  while (cur && !seen.has(cur)) {
+    seen.add(cur)
+    const p = parentOf(cur)
+    if (!p) break
+    depth++
+    cur = p
+  }
+  return depth
+}
+
 /**
- * Decide the parent/child orientation for a joint between two links (#354). A URDF
- * tree needs the child NOT to already sit above the parent; if making `a` the
- * parent of `b` would form a loop but the reverse wouldn't, swap them. When either
- * order works (or neither), keep `a` as the parent.
+ * Decide the parent/child orientation for a joint between two links (#354), so the
+ * SAME pair joins the same way no matter which the user picked first.
+ *
+ * 1. A URDF tree needs the child NOT to already sit above the parent — if one link
+ *    is in the other's subtree, the ancestor MUST be the parent (else a loop).
+ * 2. Otherwise (independent parts) the child is the one that gets re-homed onto the
+ *    parent, so re-home the LESS-established part and leave the deeper structure put.
+ *    Pick as child the link CLOSER to the base (a loose stub / freshly-added part, over
+ *    a deep chain link — e.g. a gripper mounts onto an arm tip, not the reverse), then
+ *    the one with FEWER descendants (a leaf over a sub-assembly root). A true tie falls
+ *    back to a deterministic name order, so the result never depends on pick order.
+ *
+ * Depth is measured within each link's OWN root, so it tracks "loose-ness" only within a
+ * single tree (the normal single-root robot). It is base-AGNOSTIC: in a multi-root URDF
+ * the caller must refuse to re-home anything connected to the designated base onto a
+ * disconnected part (a separate-root loose import) — see handleConnectPicked.
  */
 export function orientJoint(urdf: string, a: string, b: string): { parent: string; child: string } {
-  if (subtreeOf(urdf, b).has(a) && !subtreeOf(urdf, a).has(b)) return { parent: b, child: a }
-  return { parent: a, child: b }
+  if (a === b) return { parent: a, child: b }
+  const subA = subtreeOf(urdf, a)
+  const subB = subtreeOf(urdf, b)
+  // (1) Cycle avoidance — the ancestor has to be the parent.
+  if (subB.has(a) && !subA.has(b)) return { parent: b, child: a }
+  if (subA.has(b) && !subB.has(a)) return { parent: a, child: b }
+  // (2) Independent parts — re-home the less-established one (the child): shallower
+  // first (closer to base), then fewer descendants, then a stable name tie-break.
+  const depthA = depthFromRoot(urdf, a)
+  const depthB = depthFromRoot(urdf, b)
+  if (depthA !== depthB) return depthA > depthB ? { parent: a, child: b } : { parent: b, child: a }
+  const descA = subA.size - 1
+  const descB = subB.size - 1
+  if (descA !== descB) return descA < descB ? { parent: b, child: a } : { parent: a, child: b }
+  return a < b ? { parent: a, child: b } : { parent: b, child: a }
 }
 
 /** A joint name derived from `base`, made unique within the URDF. */

--- a/test/robotAssembly.test.ts
+++ b/test/robotAssembly.test.ts
@@ -10,6 +10,7 @@ import {
   blankUrdf,
   connectJoint,
   orientJoint,
+  depthFromRoot,
   subtreeOf,
   readAllJoints,
   removeJoint,
@@ -212,6 +213,75 @@ describe('connectJoint — the Join tool (#354)', () => {
   <joint name="jr" type="fixed"><parent link="base"/><child link="r"/></joint>
 </robot>`
     expect(orientJoint(branched, 'l', 'r')).toEqual({ parent: 'l', child: 'r' })
+  })
+
+  it('orientJoint is order-independent: re-homes the loose part, keeps the structure (#354)', () => {
+    // base → a → b (a has a subtree), plus a loose c fixed to base.
+    const chainC = `<?xml version="1.0"?>
+<robot name="r">
+  <link name="base"/><link name="a"/><link name="b"/><link name="c"/>
+  <joint name="ja" type="fixed"><parent link="base"/><child link="a"/></joint>
+  <joint name="jb" type="fixed"><parent link="a"/><child link="b"/></joint>
+  <joint name="jc" type="fixed"><parent link="base"/><child link="c"/></joint>
+</robot>`
+    // Joining a (has descendant b) with loose leaf c: c is ALWAYS the child, whichever
+    // the user picks first — so a's subtree stays put and c re-homes onto it.
+    expect(orientJoint(chainC, 'c', 'a')).toEqual({ parent: 'a', child: 'c' })
+    expect(orientJoint(chainC, 'a', 'c')).toEqual({ parent: 'a', child: 'c' })
+
+    // base → a → b → c (deep chain), plus a loose l. Both c and l are leaves (0 desc),
+    // so the tie breaks on depth: the shallow stub l re-homes onto the deep end c.
+    const deepChain = `<?xml version="1.0"?>
+<robot name="r">
+  <link name="base"/><link name="a"/><link name="b"/><link name="c"/><link name="l"/>
+  <joint name="ja" type="fixed"><parent link="base"/><child link="a"/></joint>
+  <joint name="jb" type="fixed"><parent link="a"/><child link="b"/></joint>
+  <joint name="jc" type="fixed"><parent link="b"/><child link="c"/></joint>
+  <joint name="jl" type="fixed"><parent link="base"/><child link="l"/></joint>
+</robot>`
+    expect(orientJoint(deepChain, 'l', 'c')).toEqual({ parent: 'c', child: 'l' })
+    expect(orientJoint(deepChain, 'c', 'l')).toEqual({ parent: 'c', child: 'l' })
+    // Cycle rule still wins over the heuristic: an ancestor must stay the parent.
+    expect(orientJoint(deepChain, 'c', 'a')).toEqual({ parent: 'a', child: 'c' })
+    expect(depthFromRoot(deepChain, 'c')).toBe(3)
+    expect(depthFromRoot(deepChain, 'l')).toBe(1)
+    expect(depthFromRoot(deepChain, 'base')).toBe(0)
+  })
+
+  it('orientJoint mounts a shallow sub-assembly onto a deep leaf, not vice-versa (#354)', () => {
+    // Arm base→shoulder→elbow→wrist→tip (tip is a deep LEAF, 0 descendants), plus a
+    // loose gripper gbase→f1,f2 (gbase is shallow but HAS descendants).
+    const armGripper = `<?xml version="1.0"?>
+<robot name="r">
+  <link name="base"/><link name="shoulder"/><link name="elbow"/><link name="wrist"/><link name="tip"/>
+  <link name="gbase"/><link name="f1"/><link name="f2"/>
+  <joint name="js" type="fixed"><parent link="base"/><child link="shoulder"/></joint>
+  <joint name="je" type="fixed"><parent link="shoulder"/><child link="elbow"/></joint>
+  <joint name="jw" type="fixed"><parent link="elbow"/><child link="wrist"/></joint>
+  <joint name="jt" type="fixed"><parent link="wrist"/><child link="tip"/></joint>
+  <joint name="jg" type="fixed"><parent link="base"/><child link="gbase"/></joint>
+  <joint name="jf1" type="fixed"><parent link="gbase"/><child link="f1"/></joint>
+  <joint name="jf2" type="fixed"><parent link="gbase"/><child link="f2"/></joint>
+</robot>`
+    // The gripper (shallow, depth 1) mounts onto the arm tip (deep, depth 4) — NOT the
+    // arm tip re-homed onto the gripper. Descendant count must NOT override depth here.
+    expect(orientJoint(armGripper, 'tip', 'gbase')).toEqual({ parent: 'tip', child: 'gbase' })
+    expect(orientJoint(armGripper, 'gbase', 'tip')).toEqual({ parent: 'tip', child: 'gbase' })
+  })
+
+  it('orientJoint is order-independent even on a true tie — two loose leaves (#354)', () => {
+    const twoLoose = `<?xml version="1.0"?>
+<robot name="r">
+  <link name="base"/><link name="xx"/><link name="yy"/>
+  <joint name="jx" type="fixed"><parent link="base"/><child link="xx"/></joint>
+  <joint name="jy" type="fixed"><parent link="base"/><child link="yy"/></joint>
+</robot>`
+    // Equal depth (1) AND equal descendants (0) — a deterministic name tie-break makes
+    // BOTH pick orders resolve identically (the common "join two fresh imports" case).
+    const forward = orientJoint(twoLoose, 'xx', 'yy')
+    const reverse = orientJoint(twoLoose, 'yy', 'xx')
+    expect(forward).toEqual(reverse)
+    expect(forward).toEqual({ parent: 'xx', child: 'yy' })
   })
 
   it('supports a CHAIN of joints — a second connect keeps the first (#354 IK chains)', () => {


### PR DESCRIPTION
Two Robot View improvements, hardened by **two rounds of adversarial review** (a workflow surfaced 9 findings in round 1 and 1 in round 2; all confirmed ones are fixed here).

## 1. Order-independent joining

Picking the two parts in the "wrong" order used to re-home the part *already* built into the chain onto the loose one — the established part jumped away and looked disconnected from the base. `orientJoint` now decides parent/child by **structure**, not pick order:

1. `a === b` guard.
2. **Cycle avoidance** — an ancestor must be the parent.
3. **Independent parts** — the child (the part that moves) is the **shallower** one (closer to the base = the loose/addable part, so a gripper mounts onto an arm tip, *never* the reverse — depth beats descendant count), then **fewer descendants**, then a **lexicographic name tie-break** so two loose parts resolve identically whichever is picked first.

`depthFromRoot()` added. Since `orientJoint` is base-agnostic and measures depth per-root, `handleConnectPicked` guards the multi-root case: the base's connected structure is never re-homed onto a part disconnected from the base (this subsumes the old "never re-home the base itself" guard).

## 2. Nudge freed parts aside on detach

Deleting a joint now relocates the freed part (and its sub-assembly) to a **clear loose spot beside the base** — placed just past every part already parked on the base along X, so **successive detaches don't stack** on the same spot (the link count is invariant across a detach, so the naïve `0.08*N` collided). It's off its old parent and upright, so it's easy to pick and re-join. Also drops the old joint's remembered roll so `robot.yml` doesn't accrete stale entries.

## Verification

- **30 robot-assembly unit tests** — order-independence both directions, the gripper-onto-arm-tip case, the two-loose tie, the cycle rule.
- Driven Playwright smokes — order-independent end-to-end (both pick orders → identical tree); consecutive detaches land at **distinct** spots (240 / 320, off the parent at 160); single root preserved throughout; `pageerror` null.
- `typecheck` ✅ · `lint` ✅ (only the pre-existing `DriverInstallBanner` warning) · **1553 tests** ✅ · `build` ✅

### Review findings addressed
- orientJoint order-dependent on the common two-loose-parts tie → deterministic name tie-break.
- "Fewer descendants" re-homed a deep leaf onto a shallow sub-assembly → **depth-primary**.
- Consecutive detaches stacked on one spot → occupancy-based placement.
- Base re-rooted / base-connected structure re-homed in multi-root URDFs → base-tree guard.
- Stale `jointRoll` entry on a renamed joint → cleanup on detach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)