### PR TITLE
fix: make the Join tool predictable — you control parent/child (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -310,14 +310,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   or reopen any panel. Nothing about Robot mode is permanently changed.
 
 ### Fixed
-- **Robot View — the Join tool respects the existing structure whichever part you pick
-  first (#354).** Picking the two parts in the "wrong" order used to re-home the part
-  that was *already* built into the chain onto the loose one — so the established part
-  jumped away and looked disconnected from the base. Joining is now **order-independent**:
-  the loose / less-established part — the one closer to the base (then with fewer
-  descendants) — is always the one that moves onto the other, so your existing structure
-  stays put no matter which you click as Component 1 (a gripper mounts onto the arm tip,
-  never the reverse).
+- **Robot View — the Join tool is now predictable: you control the hierarchy (#354).**
+  The tool used to *guess* which of the two picked parts was the parent, using descendant
+  count — so joining a part that already had something attached (e.g. an arm with a servo)
+  would wrongly make **it** the parent and flip your chain, and you could never build
+  `base → shoulder → arm → servo`. Now **Component 1 is the parent (the anchor that stays
+  put) and Component 2 is the child (it attaches onto Component 1)** — the tool only
+  auto-swaps to prevent a loop, and never re-homes the base. A **⇅ swap** button in the
+  Add Joint dialog flips parent ↔ child if you picked them the wrong way round, and the
+  labels/hints spell out which part moves. Build a chain by picking parent-then-child.
 - **Robot View — removing a joint no longer fuses the freed part into the base (#354).**
   Deleting a joint used to leave its part *rootless*, and the loader collapses every
   rootless part into the base's single scene node — so the base and every freed part

--- a/src/renderer/src/components/RobotPropertiesDialog.css
+++ b/src/renderer/src/components/RobotPropertiesDialog.css
@@ -160,6 +160,30 @@
 .robotprops__pick-hint {
   color: var(--text-muted, #8b919b);
 }
+/* Swap parent ↔ child — sits between the two pick slots. */
+.robotprops__swaprow {
+  display: flex;
+  justify-content: center;
+  margin: -0.15rem 0;
+}
+.robotprops__swap {
+  font-family: inherit;
+  font-size: 0.58rem;
+  color: var(--text-muted, #8b919b);
+  background: var(--bg-sunken, rgba(0, 0, 0, 0.25));
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 5px;
+  padding: 0.1rem 0.5rem;
+  cursor: pointer;
+}
+.robotprops__swap:hover:not(:disabled) {
+  color: var(--text, #f2f4f7);
+  border-color: var(--text-muted, #6b7079);
+}
+.robotprops__swap:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
 /* Joint-type chips (Static / Rotation / Linear). */
 .robotprops__chip {
   flex: 1 1 auto;

--- a/src/renderer/src/components/RobotPropertiesDialog.tsx
+++ b/src/renderer/src/components/RobotPropertiesDialog.tsx
@@ -85,6 +85,8 @@ export interface RobotPropertiesDialogProps {
   jointPick: JointPickView | null
   /** Arm the picker for a component again (the next 3-D click re-picks it). */
   onRepick: (step: 'parent' | 'child') => void
+  /** Swap which pick is the parent vs the child (flip the hierarchy). */
+  onSwapPicks: () => void
   /** Create the joint from the two picks + chosen type + offset (mm) + a roll angle
    *  (degrees) about the joint normal. Returns false (keeps the dialog open) if the
    *  picks are incomplete / would loop. */
@@ -588,6 +590,7 @@ const ADDJOINT_KINDS: Array<{ id: JointType; label: string; hint: string }> = [
 function AddJointBody({
   jointPick,
   onRepick,
+  onSwapPicks,
   onConnectPicked,
   commitRef
 }: RobotPropertiesDialogProps & {
@@ -667,11 +670,25 @@ function AddJointBody({
   return (
     <>
       <section className="robotprops__section">
-        <div className="robotprops__label">Component 1 (parent)</div>
+        <div className="robotprops__label">Component 1 · parent (stays put)</div>
         {slot('parent', parent)}
       </section>
+      <div className="robotprops__swaprow">
+        <button
+          type="button"
+          className="robotprops__swap"
+          onClick={() => {
+            onSwapPicks()
+            setErr(null)
+          }}
+          disabled={!parent || !child}
+          title="Swap parent ↔ child — flip which part stays put and which attaches"
+        >
+          ⇅ swap
+        </button>
+      </div>
       <section className="robotprops__section">
-        <div className="robotprops__label">Component 2 (child)</div>
+        <div className="robotprops__label">Component 2 · child (attaches onto Component 1)</div>
         {slot('child', child)}
       </section>
       <section className="robotprops__section">
@@ -740,10 +757,10 @@ function AddJointBody({
       ) : (
         <p className="robotprops__note">
           {!parent || !child
-            ? 'Click a point on each block (snaps to corners / edges / hole centres). Hold Shift to lock a snap onto a hole.'
+            ? 'Pick a point on the PARENT first, then the CHILD (snaps to corners / edges / hole centres). Hold Shift to lock a snap onto a hole.'
             : type === 'revolute'
-              ? 'Component 2 mates to Component 1; after Add, drag the joint in the pose panel to preview the swing.'
-              : 'Component 2 will snap so its point meets Component 1’s point.'}
+              ? 'The parent (1) stays put; the child (2) attaches onto it — use ⇅ swap to flip. After Add, pose the joint to preview the swing.'
+              : 'The child (2) moves so its point meets the parent (1) — use ⇅ swap if you picked them the wrong way round.'}
         </p>
       )}
     </>

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -714,6 +714,11 @@ export function RobotView({
         : jp
     )
   }
+  // Swap which pick is the parent vs the child (the dialog's ⇅ button) — so you can
+  // flip the hierarchy without re-picking both points.
+  const handleSwapPicks = (): void => {
+    setJointPick((jp) => (jp && jp.parent && jp.child ? { ...jp, parent: jp.child, child: jp.parent } : jp))
+  }
   // Add: mate the child's picked face against the parent's, re-parent it, set the
   // type — and put the joint origin (the PIVOT) AT the mating point by re-origining
   // the child link onto its picked point (so a hinge rotates about the joint, not the
@@ -727,13 +732,11 @@ export function RobotView({
     const jp = jointPick
     if (!jp?.parent || !jp?.child) return false
     const base = contentRef.current
-    // Intelligent parent/child (#354): orientJoint re-homes the less-established part
-    // regardless of pick order, so the existing structure stays put. It's base-agnostic
-    // and measures depth within each part's OWN root, so in a multi-root URDF it can't
-    // tell a loose separate-root import from the base's structure. Guard it here: the
+    // Parent/child (#354): orientJoint honours the pick order — Component 1 is the parent,
+    // Component 2 the child — and only swaps to avoid a loop. One safety override: the
     // base's connected structure must NEVER be re-homed onto a part disconnected from the
-    // base (a loose import / the base itself) — if the chosen child is on the base but the
-    // parent isn't, flip so the disconnected part is the one that moves.
+    // base (a stray separate-root import), which would float it off the base — if the
+    // chosen child is on the base but the parent isn't, flip so the loose part moves.
     const baseTree = effectiveBaseLink ? subtreeOf(base, effectiveBaseLink) : new Set<string>()
     let o = orientJoint(base, jp.parent.link, jp.child.link)
     if (o.child !== o.parent && baseTree.has(o.child) && !baseTree.has(o.parent)) {
@@ -3093,6 +3096,7 @@ export function RobotView({
               }
             }
             onRepick={handleRepick}
+            onSwapPicks={handleSwapPicks}
             onConnectPicked={handleConnectPicked}
             onOk={handlePropsOk}
             onCancel={handlePropsCancel}

--- a/src/renderer/src/components/robot-assembly.ts
+++ b/src/renderer/src/components/robot-assembly.ts
@@ -514,65 +514,27 @@ export function subtreeOf(urdf: string, link: string): Set<string> {
   return inside
 }
 
-/** How many joints from `link` up to its root (0 for a root). Walks parent joints,
- *  cycle-guarded. Used to tell a loose stub near the base from a deep chain link. */
-export function depthFromRoot(urdf: string, link: string): number {
-  const parentOf = (child: string): string | undefined => {
-    const re = /<joint\b[^>]*>[\s\S]*?<\/joint>/gi
-    let m: RegExpExecArray | null
-    while ((m = re.exec(urdf))) {
-      const c = /<child\b[^>]*\blink\s*=\s*"([^"]+)"/i.exec(m[0])?.[1]
-      if (c === child) return /<parent\b[^>]*\blink\s*=\s*"([^"]+)"/i.exec(m[0])?.[1]
-    }
-    return undefined
-  }
-  const seen = new Set<string>()
-  let cur: string | undefined = link
-  let depth = 0
-  while (cur && !seen.has(cur)) {
-    seen.add(cur)
-    const p = parentOf(cur)
-    if (!p) break
-    depth++
-    cur = p
-  }
-  return depth
-}
-
 /**
- * Decide the parent/child orientation for a joint between two links (#354), so the
- * SAME pair joins the same way no matter which the user picked first.
+ * Decide the parent/child orientation for a joint between two links (#354).
  *
- * 1. A URDF tree needs the child NOT to already sit above the parent — if one link
- *    is in the other's subtree, the ancestor MUST be the parent (else a loop).
- * 2. Otherwise (independent parts) the child is the one that gets re-homed onto the
- *    parent, so re-home the LESS-established part and leave the deeper structure put.
- *    Pick as child the link CLOSER to the base (a loose stub / freshly-added part, over
- *    a deep chain link — e.g. a gripper mounts onto an arm tip, not the reverse), then
- *    the one with FEWER descendants (a leaf over a sub-assembly root). A true tie falls
- *    back to a deterministic name order, so the result never depends on pick order.
+ * PREDICTABLE by pick order: `a` (Component 1) is the parent — the anchor that stays
+ * put — and `b` (Component 2) is the child that attaches onto it. The ONLY automatic
+ * change is to avoid a cycle: if making `a` the parent would loop (because `b` is
+ * already an ANCESTOR of `a`), the two are swapped. The user drives the hierarchy;
+ * the tool never re-flips it behind their back (the old descendant/depth heuristic
+ * guessed wrong for common chains — e.g. a part with a servo attached would wrongly
+ * win the "parent" role over the link you were extending).
  *
- * Depth is measured within each link's OWN root, so it tracks "loose-ness" only within a
- * single tree (the normal single-root robot). It is base-AGNOSTIC: in a multi-root URDF
- * the caller must refuse to re-home anything connected to the designated base onto a
- * disconnected part (a separate-root loose import) — see handleConnectPicked.
+ * It is base-AGNOSTIC: in a multi-root URDF the caller must still refuse to re-home
+ * anything connected to the designated base onto a disconnected part — see
+ * handleConnectPicked.
  */
 export function orientJoint(urdf: string, a: string, b: string): { parent: string; child: string } {
   if (a === b) return { parent: a, child: b }
-  const subA = subtreeOf(urdf, a)
-  const subB = subtreeOf(urdf, b)
-  // (1) Cycle avoidance — the ancestor has to be the parent.
-  if (subB.has(a) && !subA.has(b)) return { parent: b, child: a }
-  if (subA.has(b) && !subB.has(a)) return { parent: a, child: b }
-  // (2) Independent parts — re-home the less-established one (the child): shallower
-  // first (closer to base), then fewer descendants, then a stable name tie-break.
-  const depthA = depthFromRoot(urdf, a)
-  const depthB = depthFromRoot(urdf, b)
-  if (depthA !== depthB) return depthA > depthB ? { parent: a, child: b } : { parent: b, child: a }
-  const descA = subA.size - 1
-  const descB = subB.size - 1
-  if (descA !== descB) return descA < descB ? { parent: b, child: a } : { parent: a, child: b }
-  return a < b ? { parent: a, child: b } : { parent: b, child: a }
+  // Swap only when `b` sits ABOVE `a` (making a→b would loop) and `a` doesn't sit
+  // above `b`; otherwise honour the pick order (a = parent, b = child).
+  if (subtreeOf(urdf, b).has(a) && !subtreeOf(urdf, a).has(b)) return { parent: b, child: a }
+  return { parent: a, child: b }
 }
 
 /** A joint name derived from `base`, made unique within the URDF. */

--- a/test/robotAssembly.test.ts
+++ b/test/robotAssembly.test.ts
@@ -10,7 +10,6 @@ import {
   blankUrdf,
   connectJoint,
   orientJoint,
-  depthFromRoot,
   subtreeOf,
   readAllJoints,
   removeJoint,
@@ -200,12 +199,12 @@ describe('connectJoint — the Join tool (#354)', () => {
     expect((wheelBlock.match(/<child\b/g) || []).length).toBe(1)
   })
 
-  it('orientJoint swaps parent/child when the chosen order would loop', () => {
-    // base → upper → tip. Making `tip` the parent of `upper` would loop.
+  it('orientJoint swaps parent/child ONLY when the chosen order would loop', () => {
+    // base → upper → tip. Making `tip` the parent of `upper` would loop → swap.
     expect(orientJoint(URDF, 'tip', 'upper')).toEqual({ parent: 'upper', child: 'tip' })
     // The already-valid order is kept as-is.
     expect(orientJoint(URDF, 'base_link', 'tip')).toEqual({ parent: 'base_link', child: 'tip' })
-    // Two unrelated siblings: keep `a` as the parent (either order is fine).
+    // Two unrelated siblings: `a` (Component 1) is the parent — pick order stands.
     const branched = `<?xml version="1.0"?>
 <robot name="r">
   <link name="base"/><link name="l"/><link name="r"/>
@@ -213,75 +212,27 @@ describe('connectJoint — the Join tool (#354)', () => {
   <joint name="jr" type="fixed"><parent link="base"/><child link="r"/></joint>
 </robot>`
     expect(orientJoint(branched, 'l', 'r')).toEqual({ parent: 'l', child: 'r' })
+    expect(orientJoint(branched, 'r', 'l')).toEqual({ parent: 'r', child: 'l' }) // predictable
   })
 
-  it('orientJoint is order-independent: re-homes the loose part, keeps the structure (#354)', () => {
-    // base → a → b (a has a subtree), plus a loose c fixed to base.
-    const chainC = `<?xml version="1.0"?>
+  it('orientJoint honours pick order — Component 1 is the parent, no inversion (#354)', () => {
+    // The reported bug: base → shoulder, base → arm → servo (the arm has the servo
+    // attached). Extending the chain by joining the arm onto the shoulder must NOT be
+    // inverted just because the arm has a descendant (the OLD heuristic made the arm the
+    // parent here, so you could never build base → shoulder → arm → servo).
+    const rig = `<?xml version="1.0"?>
 <robot name="r">
-  <link name="base"/><link name="a"/><link name="b"/><link name="c"/>
-  <joint name="ja" type="fixed"><parent link="base"/><child link="a"/></joint>
-  <joint name="jb" type="fixed"><parent link="a"/><child link="b"/></joint>
-  <joint name="jc" type="fixed"><parent link="base"/><child link="c"/></joint>
-</robot>`
-    // Joining a (has descendant b) with loose leaf c: c is ALWAYS the child, whichever
-    // the user picks first — so a's subtree stays put and c re-homes onto it.
-    expect(orientJoint(chainC, 'c', 'a')).toEqual({ parent: 'a', child: 'c' })
-    expect(orientJoint(chainC, 'a', 'c')).toEqual({ parent: 'a', child: 'c' })
-
-    // base → a → b → c (deep chain), plus a loose l. Both c and l are leaves (0 desc),
-    // so the tie breaks on depth: the shallow stub l re-homes onto the deep end c.
-    const deepChain = `<?xml version="1.0"?>
-<robot name="r">
-  <link name="base"/><link name="a"/><link name="b"/><link name="c"/><link name="l"/>
-  <joint name="ja" type="fixed"><parent link="base"/><child link="a"/></joint>
-  <joint name="jb" type="fixed"><parent link="a"/><child link="b"/></joint>
-  <joint name="jc" type="fixed"><parent link="b"/><child link="c"/></joint>
-  <joint name="jl" type="fixed"><parent link="base"/><child link="l"/></joint>
-</robot>`
-    expect(orientJoint(deepChain, 'l', 'c')).toEqual({ parent: 'c', child: 'l' })
-    expect(orientJoint(deepChain, 'c', 'l')).toEqual({ parent: 'c', child: 'l' })
-    // Cycle rule still wins over the heuristic: an ancestor must stay the parent.
-    expect(orientJoint(deepChain, 'c', 'a')).toEqual({ parent: 'a', child: 'c' })
-    expect(depthFromRoot(deepChain, 'c')).toBe(3)
-    expect(depthFromRoot(deepChain, 'l')).toBe(1)
-    expect(depthFromRoot(deepChain, 'base')).toBe(0)
-  })
-
-  it('orientJoint mounts a shallow sub-assembly onto a deep leaf, not vice-versa (#354)', () => {
-    // Arm base→shoulder→elbow→wrist→tip (tip is a deep LEAF, 0 descendants), plus a
-    // loose gripper gbase→f1,f2 (gbase is shallow but HAS descendants).
-    const armGripper = `<?xml version="1.0"?>
-<robot name="r">
-  <link name="base"/><link name="shoulder"/><link name="elbow"/><link name="wrist"/><link name="tip"/>
-  <link name="gbase"/><link name="f1"/><link name="f2"/>
+  <link name="base"/><link name="shoulder"/><link name="arm"/><link name="servo"/>
   <joint name="js" type="fixed"><parent link="base"/><child link="shoulder"/></joint>
-  <joint name="je" type="fixed"><parent link="shoulder"/><child link="elbow"/></joint>
-  <joint name="jw" type="fixed"><parent link="elbow"/><child link="wrist"/></joint>
-  <joint name="jt" type="fixed"><parent link="wrist"/><child link="tip"/></joint>
-  <joint name="jg" type="fixed"><parent link="base"/><child link="gbase"/></joint>
-  <joint name="jf1" type="fixed"><parent link="gbase"/><child link="f1"/></joint>
-  <joint name="jf2" type="fixed"><parent link="gbase"/><child link="f2"/></joint>
+  <joint name="ja" type="fixed"><parent link="base"/><child link="arm"/></joint>
+  <joint name="jv" type="fixed"><parent link="arm"/><child link="servo"/></joint>
 </robot>`
-    // The gripper (shallow, depth 1) mounts onto the arm tip (deep, depth 4) — NOT the
-    // arm tip re-homed onto the gripper. Descendant count must NOT override depth here.
-    expect(orientJoint(armGripper, 'tip', 'gbase')).toEqual({ parent: 'tip', child: 'gbase' })
-    expect(orientJoint(armGripper, 'gbase', 'tip')).toEqual({ parent: 'tip', child: 'gbase' })
-  })
-
-  it('orientJoint is order-independent even on a true tie — two loose leaves (#354)', () => {
-    const twoLoose = `<?xml version="1.0"?>
-<robot name="r">
-  <link name="base"/><link name="xx"/><link name="yy"/>
-  <joint name="jx" type="fixed"><parent link="base"/><child link="xx"/></joint>
-  <joint name="jy" type="fixed"><parent link="base"/><child link="yy"/></joint>
-</robot>`
-    // Equal depth (1) AND equal descendants (0) — a deterministic name tie-break makes
-    // BOTH pick orders resolve identically (the common "join two fresh imports" case).
-    const forward = orientJoint(twoLoose, 'xx', 'yy')
-    const reverse = orientJoint(twoLoose, 'yy', 'xx')
-    expect(forward).toEqual(reverse)
-    expect(forward).toEqual({ parent: 'xx', child: 'yy' })
+    // Pick the shoulder first (parent): it stays put; the arm (+servo) attaches under it.
+    expect(orientJoint(rig, 'shoulder', 'arm')).toEqual({ parent: 'shoulder', child: 'arm' })
+    // Pick the arm first (parent): the exact reverse — the user drives it, no re-flip.
+    expect(orientJoint(rig, 'arm', 'shoulder')).toEqual({ parent: 'arm', child: 'shoulder' })
+    // A cycle would still be prevented: servo is arm's child, so arm stays the parent.
+    expect(orientJoint(rig, 'servo', 'arm')).toEqual({ parent: 'arm', child: 'servo' })
   })
 
   it('supports a CHAIN of joints — a second connect keeps the first (#354 IK chains)', () => {


### PR DESCRIPTION
Diagnosed from a real user's robot (4 imported STLs) — they couldn't build a multi-part IK chain, and the parts looked disconnected from the base.

## Root cause

**The auto-orientation heuristic guessed wrong.** The "order-independent" join logic decided parent vs child by **descendant count**, so joining a part that already had something attached (an arm with a servo) made the **arm** the parent and flipped the chain. Extending `base → shoulder` with the arm always inverted to `arm → shoulder`. Confirmed: both pick orders returned `{parent: arm, child: shoulder}`, so there was no way to build `base → shoulder → arm → servo`.

(Separately, their assembly *looked* detached because the `base → firstPart` joint kept a **0.24 m loose stagger offset** — topologically connected, geometrically 240 mm off the base. Their local file has been re-anchored + its stale pose joint-name fixed; those are untracked user files, not in this PR.)

## The fix — predictable, user-driven

- `orientJoint` now **honours pick order**: **Component 1 = parent** (the anchor that stays put), **Component 2 = child** (it attaches onto Component 1). The only automatic change is a **cycle swap** (if Component 2 is already an ancestor of Component 1). Removed `depthFromRoot` + the descendant/depth heuristic.
- The call-site **base guard** stays — a multi-root safety net so the base's connected structure is never re-homed onto a disconnected part.
- **Add Joint dialog**: a **⇅ swap** button flips parent ↔ child without re-picking, and the slot labels + hints spell out which part stays vs moves.

Build a chain by picking parent-then-child. Joining the arm(+servo) onto the shoulder now keeps `base → shoulder → arm → servo`.

## Verification

- Unit tests updated for the predictable behaviour: pick order honoured, **no inversion** on the arm+servo case, cycle-swap only.
- Driven Playwright smoke: join `shoulder(1) + arm(2)` → `shoulder → arm` (not inverted), servo stays under arm, single root, swap button present, `pageerror` null.
- `typecheck` ✅ · `lint` ✅ (only the pre-existing `DriverInstallBanner` warning) · tests ✅ · `build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)