### PR TITLE
fix: joint Roll turns about the mating normal, not local Z (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -310,6 +310,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   or reopen any panel. Nothing about Robot mode is permanently changed.
 
 ### Fixed
+- **Robot View — editing a joint's Roll turns it about the mating normal, not the
+  wrong axis (#354).** The Roll field on an existing joint spun the part about the joint's
+  local Z, which usually isn't the axis the two faces are joined on — so the part rotated
+  the wrong way. Roll now turns about the **mating normal** (the same axis the Add-Joint
+  mate used), which is captured + remembered per joint (it can't be recovered from a
+  finished joint afterward). Joints mated before this update fall back to the old axis —
+  **re-run Add Joint on them once** to capture their normal.
 - **Robot View — the Join tool is now predictable: you control the hierarchy (#354).**
   The tool used to *guess* which of the two picked parts was the parent, using descendant
   count — so joining a part that already had something attached (e.g. an arm with a servo)

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -178,6 +178,7 @@ export function RobotView({
   const overridesRef = useRef<Record<string, { min?: number; max?: number }>>({})
   const defaultPoseRef = useRef<Record<string, number>>({}) // native, non-mimic
   const jointRollRef = useRef<Record<string, number>>({}) // joint name → absolute roll (deg)
+  const jointNormalRef = useRef<Record<string, [number, number, number]>>({}) // joint → mating normal (parent frame)
   const measureActiveRef = useRef(false)
   const measureApiRef = useRef<{ clear: () => void } | null>(null)
   const highlightApiRef = useRef<{ apply: (link: string | null) => void } | null>(null)
@@ -563,11 +564,13 @@ export function RobotView({
     const j = readJoint(content, child)
     if (j) commitUrdf(setJointOrigin(content, child, xyz, j.rpy))
   }
-  // Set an existing joint's ABSOLUTE roll about its own normal axis (its origin's
-  // local Z), keeping its position — the roll field on the joint editor. The URDF
-  // rpy bakes the roll in (so it can't be decoded back out unambiguously), so the
-  // absolute value is remembered in robot.yml and applied as a DELTA on the rpy —
-  // that keeps geometry exact while letting the field show the stored roll on reopen.
+  // Set an existing joint's ABSOLUTE roll about the MATING NORMAL — the same axis the
+  // Add-Joint mate rolled about (the parent's picked face normal, stored per joint since
+  // it can't be recovered from the finished rpy). Keeps position; applied as a DELTA on
+  // the rpy (pre-multiply, in the parent frame, to match jointFromPicks). The absolute
+  // value is remembered in robot.yml so the field shows the stored roll on reopen. A
+  // joint with no stored normal (mated before this shipped) falls back to its local Z —
+  // re-run Add Joint on it to capture the normal.
   const setJointRoll = (child: string, absDeg: number): void => {
     const j = readJoint(content, child)
     if (!j) return
@@ -579,7 +582,17 @@ export function RobotView({
     const delta = absDeg - prev
     if (!delta) return
     const R = new THREE.Quaternion().setFromEuler(new THREE.Euler(j.rpy[0], j.rpy[1], j.rpy[2], 'ZYX'))
-    R.multiply(new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 0, 1), (delta * Math.PI) / 180))
+    const spin = new THREE.Quaternion()
+    const n = jointNormalRef.current[j.name]
+    if (n) {
+      // Roll about the mating normal in the PARENT frame → pre-multiply (matches the mate).
+      spin.setFromAxisAngle(new THREE.Vector3(n[0], n[1], n[2]).normalize(), (delta * Math.PI) / 180)
+      R.premultiply(spin)
+    } else {
+      // No stored normal — fall back to the joint's local Z (post-multiply).
+      spin.setFromAxisAngle(new THREE.Vector3(0, 0, 1), (delta * Math.PI) / 180)
+      R.multiply(spin)
+    }
     const e = new THREE.Euler().setFromQuaternion(R, 'ZYX')
     commitUrdf(setJointOrigin(content, child, j.xyz, [e.x, e.y, e.z]))
   }
@@ -789,13 +802,17 @@ export function RobotView({
     commitUrdf(next)
     setSelectedLink(child.link)
     const jn = readJoint(next, child.link)?.name
-    // Remember the roll baked in at creation so the joint editor's Roll field shows it
-    // (and edits from it) — always write it, so a freshly re-joined link overwrites any
-    // stale roll left from a previous joint that reused this name (#354).
+    // Remember the roll baked in at creation, AND the mating normal it turns about (the
+    // parent's picked face normal, in the parent frame) — this axis can't be recovered
+    // from the finished rpy, so the joint editor's Roll uses it to spin the child about
+    // the SAME axis the mate did. Always overwrite, so a re-join replaces stale values.
     if (jn) {
+      const pn = parent.normal as [number, number, number]
       jointRollRef.current = { ...jointRollRef.current, [jn]: angleDeg }
+      jointNormalRef.current = { ...jointNormalRef.current, [jn]: pn }
       void persist((m) => {
         m.jointRoll = { ...(m.jointRoll ?? {}), [jn]: angleDeg }
+        m.jointNormal = { ...(m.jointNormal ?? {}), [jn]: pn }
       })
     }
     // Rotation default angle: persist it to the robot.yml defaultPose (keyed by the
@@ -840,18 +857,35 @@ export function RobotView({
     next = setJointOrigin(next, child, looseXyz, [0, 0, 0])
     commitUrdf(next)
     // Fresh loose attachment → its orientation is the new zero-roll baseline. Drop the
-    // old joint's remembered roll (its name is gone) so the map doesn't accrete cruft.
+    // old joint's remembered roll + mating normal (its name is gone, and the loose fixed
+    // joint has no mate) so the maps don't accrete cruft.
     const jn = readJoint(next, child)?.name
     if (jn || oldJointName) {
       const roll = { ...jointRollRef.current }
-      if (oldJointName) delete roll[oldJointName]
-      if (jn) roll[jn] = 0
+      const norm = { ...jointNormalRef.current }
+      if (oldJointName) {
+        delete roll[oldJointName]
+        delete norm[oldJointName]
+      }
+      if (jn) {
+        roll[jn] = 0
+        delete norm[jn]
+      }
       jointRollRef.current = roll
+      jointNormalRef.current = norm
       void persist((m) => {
         const mr = { ...(m.jointRoll ?? {}) }
-        if (oldJointName) delete mr[oldJointName]
-        if (jn) mr[jn] = 0
+        const mn = { ...(m.jointNormal ?? {}) }
+        if (oldJointName) {
+          delete mr[oldJointName]
+          delete mn[oldJointName]
+        }
+        if (jn) {
+          mr[jn] = 0
+          delete mn[jn]
+        }
         m.jointRoll = mr
+        m.jointNormal = mn
       })
     }
     setDialogCtx(null)
@@ -1785,6 +1819,7 @@ export function RobotView({
               }
               defaultPoseRef.current = { ...nv } // "Reset" returns to the saved default
               jointRollRef.current = { ...(model.jointRoll ?? {}) } // remembered joint rolls
+              jointNormalRef.current = { ...(model.jointNormal ?? {}) } // remembered mating normals
               setOverrides(ov)
               setPoses(Array.isArray(model.poses) ? model.poses : [])
               setValues(nv)

--- a/src/shared/krf.ts
+++ b/src/shared/krf.ts
@@ -148,6 +148,19 @@ function sanitiseNumberMap(raw: unknown): Record<string, number> {
   return out
 }
 
+/** A map of joint name → a finite 3-vector (drops anything malformed). */
+function sanitiseVec3Map(raw: unknown): Record<string, [number, number, number]> {
+  const out: Record<string, [number, number, number]> = {}
+  if (raw && typeof raw === 'object') {
+    for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+      if (Array.isArray(v) && v.length === 3 && v.every(isFiniteNum)) {
+        out[k] = [v[0], v[1], v[2]]
+      }
+    }
+  }
+  return out
+}
+
 /**
  * Validate the robot-model section, corruption-safe: unknown/legacy shapes and
  * bad fields are dropped, never thrown. Returns `undefined` when there's no
@@ -183,6 +196,9 @@ export function sanitiseRobotModel(raw: unknown): RobotModel | undefined {
 
   const roll = sanitiseNumberMap(r.jointRoll)
   if (Object.keys(roll).length) model.jointRoll = roll
+
+  const normals = sanitiseVec3Map(r.jointNormal)
+  if (Object.keys(normals).length) model.jointNormal = normals
 
   if (Array.isArray(r.poses)) {
     const poses = r.poses

--- a/src/shared/robot.ts
+++ b/src/shared/robot.ts
@@ -66,6 +66,11 @@ export interface RobotModel {
    *  can show the current roll and edit it absolutely (deltas re-applied to the rpy),
    *  instead of the field resetting to 0 each time the dialog reopens. */
   jointRoll?: Record<string, number>
+  /** Per-joint mating normal (the parent's picked face normal, in the PARENT frame)
+   *  captured when the joint was mated (#354). It's the axis the roll turns about —
+   *  it can't be recovered from a finished joint's `rpy`, so it's stored here so the
+   *  editor's Roll rotates the child about the same axis the Add-Joint mate used. */
+  jointNormal?: Record<string, [number, number, number]>
   /** The default pose applied on load: joint name → value (deg / mm). */
   defaultPose?: Record<string, number>
   /** Saved named poses (Phase 2). */

--- a/test/robotJointFrame.test.ts
+++ b/test/robotJointFrame.test.ts
@@ -50,6 +50,26 @@ describe('jointFromPicks — mate two picked faces (#354)', () => {
     const spin = new THREE.Quaternion().setFromAxisAngle(v(pN).normalize(), Math.PI / 2)
     expect(Math.abs(Math.abs(diff.dot(spin)) - 1)).toBeLessThan(1e-6)
   })
+  it('editing the roll about the stored mating normal matches the Add-time roll (#354)', () => {
+    // Arbitrary mate with a non-axis-aligned normal (where local Z != the mating normal).
+    const pL: Vec3 = [0.05, 0, 0.02]
+    const pN: Vec3 = [0.3, 0.6, 0.74] // parent-frame mating normal (the stored axis)
+    const cL: Vec3 = [0, 0.03, 0]
+    const cN: Vec3 = [-0.5, 0.5, 0.707]
+    const angle = 40
+    // Add-time: the roll is baked straight into the mate.
+    const added = jointFromPicks(pL, pN, cL, cN, [0, 0, 0], angle)
+    // Edit-time: start from the un-rolled mate, then roll about the STORED normal (pN),
+    // pre-multiplied in the parent frame — exactly what setJointRoll does.
+    const mate = jointFromPicks(pL, pN, cL, cN, [0, 0, 0], 0)
+    const R = rotOf(mate.rpy)
+    R.premultiply(new THREE.Quaternion().setFromAxisAngle(v(pN).normalize(), (angle * Math.PI) / 180))
+    // Same orientation as the Add-time roll (quaternions equal up to sign).
+    const qAdd = rotOf(added.rpy)
+    expect(Math.abs(Math.abs(qAdd.dot(R)) - 1)).toBeLessThan(1e-6)
+    // And the face is still flush after the edit roll.
+    expect(near(v(cN).normalize().applyQuaternion(R), v(pN).normalize().negate())).toBe(true)
+  })
 })
 
 // handleConnectPicked puts the PIVOT at the mating point (not the child's centre) by


### PR DESCRIPTION
The **Roll** field on an existing joint spun the child about the joint's **local Z** axis, which generally isn't the axis the two faces are joined on (e.g. a joint with `rpy="0 1.5708 0"` has local Z pointing along world X) — so editing the roll rotated the part about the **wrong axis**. The Add-Joint dialog's roll was already correct (about the parent's picked face normal, pre-multiplied), so the two controls disagreed.

## Why it needs stored data

The mating normal **can't be recovered** from a finished joint's `rpy` — many (parent-face, child-face) pairs produce the same rotation. So capture it at mate time and remember it.

## Changes

- **`RobotModel.jointNormal`** — the parent-frame mating normal per joint (sanitised in `krf`). `handleConnectPicked` stores `parent.normal` alongside `jointRoll`; cleared on detach.
- **`setJointRoll`** now rolls about the stored normal by **pre-multiplying** the rpy (parent frame) — the exact axis + convention `jointFromPicks` uses — so Add-time and edit-time roll agree. A joint with **no stored normal** (mated before this) falls back to local Z; **re-run Add Joint on it once** to capture its normal.

## Verification

- A new `robotJointFrame` unit test proves the edit-roll reconstruction (un-rolled mate → pre-multiply about the stored normal) equals the Add-time roll **exactly** (quaternions match to 1e-6) and keeps the faces flush.
- A driven Playwright smoke confirms a real non-zero normal (`[0,0,1]`) is written to `robot.yml` on mate, and editing the roll applies with no error.
- `typecheck` ✅ · `lint` ✅ (only the pre-existing `DriverInstallBanner` warning) · tests ✅ · `build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)