### PR TITLE
feat: explicit kinematic Chain view + parent picker (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Robot View — an explicit kinematic Chain view + a parent picker (#354).** The build
+  panel now shows the robot as an indented **Chain** — `Base → Shoulder → Arm → Servo` —
+  so the parent→child structure is always visible (a part nested under the wrong parent
+  is obvious at a glance), with the connecting joint type on each row and a **⚠ loose**
+  tag for parts not yet in the chain. Editing a part now has an **"Attaches to"** dropdown:
+  pick its parent explicitly from the existing structure instead of relying on 3-D
+  pick-order. Re-parenting **keeps the part exactly where it is** (world pose preserved) and
+  can't form a loop — so you can build a chain reliably, and repair a tangled one (move the
+  arm under the shoulder, the servo under the arm) without deleting and re-mating. The 3-D
+  Add Joint tool stays, now purely for geometry (where parts meet + orientation).
+
 ### Changed
 - **Robot View — the pose sidebar is retired; posing moves to a popup (#312).** The
   old right-hand pose panel duplicated the build panel (assembly, servos, poses). It's

--- a/src/renderer/src/components/RobotBuildPanel.css
+++ b/src/renderer/src/components/RobotBuildPanel.css
@@ -252,6 +252,54 @@
 .robotbuild__part-geo.is-mesh {
   color: var(--accent-ink);
 }
+/* Chain tree (#354): indent connector, the clickable joint-type chip, and the
+   "loose / not connected" markers. Colours come from theme tokens (both skins). */
+.robotbuild__chain-elbow {
+  flex: 0 0 auto;
+  color: var(--text-muted, #8b919b);
+  opacity: 0.55;
+  margin-right: 0.05rem;
+  font-size: 0.7rem;
+  line-height: 1;
+}
+.robotbuild__jtype {
+  flex: 0 0 auto;
+  white-space: nowrap;
+  margin-left: 0.25rem;
+  padding: 0.05rem 0.32rem;
+  font-family: inherit;
+  font-size: 0.56rem;
+  color: var(--text-muted, #8b919b);
+  background: var(--bg-sunken, rgba(0, 0, 0, 0.22));
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 999px;
+  cursor: pointer;
+}
+.robotbuild__jtype:hover,
+.robotbuild__jtype.is-on {
+  color: var(--accent-contrast, #15161a);
+  background: var(--accent, #d6a23f);
+  border-color: var(--accent, #d6a23f);
+}
+.robotbuild__loose-tag {
+  flex: 0 0 auto;
+  white-space: nowrap;
+  margin-left: 0.25rem;
+  font-size: 0.56rem;
+  color: var(--accent);
+}
+.robotbuild__chain--loose .robotbuild__part-label {
+  font-style: italic;
+  opacity: 0.85;
+}
+.robotbuild__loose-head {
+  list-style: none;
+  padding: 0.25rem 0.4rem 0.1rem;
+  font-size: 0.56rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted, #8b919b);
+}
 .robotbuild__edit {
   flex: 0 0 auto;
   display: inline-flex;

--- a/src/renderer/src/components/RobotBuildPanel.tsx
+++ b/src/renderer/src/components/RobotBuildPanel.tsx
@@ -1,12 +1,14 @@
-import { useEffect, useRef, useState } from 'react'
+import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
 import type {
   AssemblyItem,
+  ChainNode,
   PrimitiveGeom,
   JointDef,
   JointFull,
   JointType,
   JointSpec
 } from './robot-assembly'
+import { buildChainTree } from './robot-assembly'
 import type { Vec3 } from './robot-build'
 import { principalAxisName } from './robot-build'
 import { toDisplay, toNative, unitLabel, normPin, type MovableType } from './robot-pose'
@@ -461,66 +463,82 @@ function Section({
   )
 }
 
-/** A block / mesh row: an anchor on the base + an edit pencil to the left, then the
- *  name (click selects + zooms). Rename / Make base / Delete live on the right-click
- *  menu (Fusion-style). Shared by the Blocks / Meshes / Not-connected branches. */
-function BodyRow({
-  it,
+const INDENT = 14 // px of indent per depth level in the chain tree
+
+/** One row of the kinematic Chain tree (#354): the part name (indented by depth), the
+ *  joint type that connects it to its parent, and a "loose" flag for unconnected parts. */
+function ChainRow({
+  node,
   isSel,
   isEdit,
-  isRoot,
+  activeJoint,
   onSelect,
   onEdit,
+  onOpenJoint,
   onContextMenu
 }: {
-  it: AssemblyItem
+  node: ChainNode
   isSel: boolean
   isEdit: boolean
-  isRoot: boolean
+  activeJoint: string | null
   onSelect: (link: string) => void
   onEdit: (link: string | null) => void
+  onOpenJoint: (child: string, joint: string) => void
   onContextMenu: (e: React.MouseEvent, link: string) => void
 }): JSX.Element {
+  const geo = node.kind === 'mesh' ? node.mesh?.match(/\.(\w+)$/)?.[1]?.toLowerCase() ?? 'mesh' : node.kind
   return (
     <li
-      className={`robotbuild__part${isSel ? ' is-sel' : ''}`}
-      onContextMenu={(e) => onContextMenu(e, it.link)}
+      className={`robotbuild__part${isSel ? ' is-sel' : ''}${node.loose ? ' robotbuild__chain--loose' : ''}`}
+      style={{ paddingLeft: node.depth * INDENT }}
+      onContextMenu={(e) => onContextMenu(e, node.link)}
     >
       <div className="robotbuild__part-row">
-        {/* Icons sit to the LEFT of the name (Fusion-style); the name button flexes
-            to fill the rest so long mesh filenames get room to breathe. */}
+        {node.depth > 0 && (
+          <span className="robotbuild__chain-elbow" aria-hidden="true">
+            └
+          </span>
+        )}
         <span
-          className={`robotbuild__rowbase${isRoot ? ' is-base' : ''}`}
-          title={isRoot ? 'This is the base — everything hangs off it' : undefined}
-          role={isRoot ? 'img' : undefined}
-          aria-label={isRoot ? 'Base — everything hangs off it' : undefined}
-          aria-hidden={isRoot ? undefined : true}
+          className={`robotbuild__rowbase${node.isBase ? ' is-base' : ''}`}
+          title={node.isBase ? 'This is the base — everything hangs off it' : undefined}
+          aria-hidden={node.isBase ? undefined : true}
         >
-          {isRoot ? ANCHOR : null}
+          {node.isBase ? ANCHOR : null}
         </span>
         <button
           type="button"
           className={`robotbuild__edit${isEdit ? ' is-on' : ''}`}
-          onClick={() => onEdit(isEdit ? null : it.link)}
+          onClick={() => onEdit(isEdit ? null : node.link)}
           title={isEdit ? 'Close properties' : 'Edit properties'}
-          aria-label={`Edit ${it.link}`}
+          aria-label={`Edit ${node.link}`}
         >
           {PENCIL}
         </button>
         <button
           type="button"
           className="robotbuild__part-name"
-          title={`${it.link} — right-click for rename / base / delete`}
-          onClick={() => onSelect(it.link)}
-          onContextMenu={(e) => onContextMenu(e, it.link)}
+          title={`${node.link} — right-click for rename / base / delete / attach`}
+          onClick={() => onSelect(node.link)}
+          onContextMenu={(e) => onContextMenu(e, node.link)}
         >
-          <span className="robotbuild__part-label">{it.link}</span>
-          <span className={`robotbuild__part-geo${it.kind === 'mesh' ? ' is-mesh' : ''}`}>
-            {/* A compact type tag — for a mesh the file extension, so the (long) link
-                name gets the row's width instead of repeating the filename. */}
-            {it.kind === 'mesh' ? (it.mesh?.match(/\.(\w+)$/)?.[1]?.toLowerCase() ?? 'mesh') : it.kind}
-          </span>
+          <span className="robotbuild__part-label">{node.link}</span>
+          <span className={`robotbuild__part-geo${node.kind === 'mesh' ? ' is-mesh' : ''}`}>{geo}</span>
         </button>
+        {node.joint ? (
+          <button
+            type="button"
+            className={`robotbuild__jtype${activeJoint === node.joint.name ? ' is-on' : ''}`}
+            title={`${node.joint.name} — click to edit (parent: ${node.joint.parent})`}
+            onClick={() => onOpenJoint(node.link, node.joint!.name)}
+          >
+            {jointTypeLabel(node.joint.type)}
+          </button>
+        ) : node.loose ? (
+          <span className="robotbuild__loose-tag" title="Not connected to the base — open it and pick a parent">
+            ⚠ loose
+          </span>
+        ) : null}
       </div>
     </li>
   )
@@ -597,9 +615,14 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
     ]
   }
 
-  const blocks = assembly.filter((it) => it.kind !== 'mesh')
-  const meshes = assembly.filter((it) => it.kind === 'mesh')
-  const editLink = active?.kind === 'link' ? active.link : null
+  // The kinematic chain, flattened for an indented list: base's subtree first, then any
+  // loose (unconnected) parts. This replaces the flat Blocks/Meshes/Joints lists so the
+  // parent→child structure is always visible.
+  const tree = useMemo(() => buildChainTree(assembly, joints, rootLink), [assembly, joints, rootLink])
+  const activeLink =
+    active?.kind === 'link' ? active.link : active?.kind === 'joint' ? active.child : null
+  const activeJoint = active?.kind === 'joint' ? active.joint : null
+  const looseStart = tree.findIndex((n) => n.loose)
 
   if (!open) {
     return (
@@ -658,59 +681,33 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
       )}
 
       <div className="robotbuild__tree">
-        {blocks.length > 0 && (
-          <Section id="blocks" label="Blocks" count={blocks.length} collapsed={collapsed} onToggle={toggle}>
-            {blocks.map((it) => (
-              <BodyRow
-                key={it.link}
-                it={it}
-                isSel={it.link === selected}
-                isEdit={it.link === editLink}
-                isRoot={it.link === rootLink}
-                onSelect={onSelect}
-                onEdit={onEdit}
-                onContextMenu={openMenu}
-              />
+        {tree.length > 0 && (
+          <Section id="chain" label="Chain" count={tree.length} collapsed={collapsed} onToggle={toggle}>
+            {tree.map((node, i) => (
+              <Fragment key={node.link}>
+                {i === looseStart && looseStart > 0 && (
+                  <li className="robotbuild__loose-head" aria-hidden="true">
+                    Not connected
+                  </li>
+                )}
+                <ChainRow
+                  node={node}
+                  isSel={node.link === selected}
+                  isEdit={node.link === activeLink}
+                  activeJoint={activeJoint}
+                  onSelect={onSelect}
+                  onEdit={onEdit}
+                  onOpenJoint={onOpenJoint}
+                  onContextMenu={openMenu}
+                />
+              </Fragment>
             ))}
           </Section>
         )}
-
-        {meshes.length > 0 && (
-          <Section id="meshes" label="Meshes" count={meshes.length} collapsed={collapsed} onToggle={toggle}>
-            {meshes.map((it) => (
-              <BodyRow
-                key={it.link}
-                it={it}
-                isSel={it.link === selected}
-                isEdit={it.link === editLink}
-                isRoot={it.link === rootLink}
-                onSelect={onSelect}
-                onEdit={onEdit}
-                onContextMenu={openMenu}
-              />
-            ))}
-          </Section>
-        )}
-
-        {joints.length > 0 && (
-        <Section id="joints" label="Joints" count={joints.length} collapsed={collapsed} onToggle={toggle}>
-          {joints.map((j) => {
-            const on = active?.kind === 'joint' && active.joint === j.name
-            return (
-              <li className="robotbuild__part" key={j.name}>
-                <button
-                  type="button"
-                  className={`robotbuild__node${on ? ' is-on' : ''}`}
-                  title={`Edit joint ${j.name}`}
-                  onClick={() => onOpenJoint(j.child, j.name)}
-                >
-                  <span className="robotbuild__part-label">{j.name}</span>
-                  <span className="robotbuild__part-geo">{jointTypeLabel(j.type)}</span>
-                </button>
-              </li>
-            )
-          })}
-        </Section>
+        {rootLink === null && assembly.length > 1 && (
+          <p className="robotbuild__hint">
+            Several parts, no base yet — right-click a part ▸ <b>Make base</b> to start the chain.
+          </p>
         )}
 
         {canEdit && joints.some((j) => j.type !== 'fixed') && (

--- a/src/renderer/src/components/RobotPropertiesDialog.tsx
+++ b/src/renderer/src/components/RobotPropertiesDialog.tsx
@@ -57,6 +57,14 @@ export interface RobotPropertiesDialogProps {
   onRollJoint: (child: string, absDeg: number) => void
   /** The open joint's current absolute roll (deg), for seeding the Roll field. */
   jointRoll?: number
+  /** Valid parents for the open part (every link except itself + its descendants). */
+  parentOptions: string[]
+  /** The part's current parent link (null for the base / a loose root). */
+  currentParent: string | null
+  /** True when the open part is the base (no parent — the picker is hidden). */
+  isBase: boolean
+  /** Re-home the part under a new parent — keeps it where it is, only moves it in the chain. */
+  onSetParent: (child: string, parent: string) => void
   /** Remove the joint whose child is this link (the block re-attaches to the base). */
   onDeleteJoint: (child: string) => void
   // servo
@@ -258,7 +266,11 @@ function LinkBody({
   onSetJoint,
   onSetJointOrigin,
   onRollJoint,
-  jointRoll
+  jointRoll,
+  parentOptions,
+  currentParent,
+  isBase,
+  onSetParent
 }: RobotPropertiesDialogProps & { context: PropsContext }): JSX.Element {
   // `link` = the block being edited, or the joint's child link (which carries it).
   const link = context.kind === 'joint' ? context.child : context.kind === 'link' ? context.link : ''
@@ -273,6 +285,34 @@ function LinkBody({
         ) : (
           <p className="robotprops__note">This is a mesh — grab a face in 3-D to move it.</p>
         ))}
+      {!isBase && parentOptions.length > 0 && (
+        <section className="robotprops__section">
+          <div className="robotprops__label" title="Which part this connects to in the chain">
+            Attaches to
+          </div>
+          <select
+            className="robotprops__sel"
+            value={currentParent ?? ''}
+            onChange={(e) => e.target.value && onSetParent(link, e.target.value)}
+          >
+            {currentParent === null && (
+              <option value="" disabled>
+                — choose a parent —
+              </option>
+            )}
+            {parentOptions.map((p) => (
+              <option key={p} value={p}>
+                {p}
+              </option>
+            ))}
+          </select>
+          <p className="robotprops__note">
+            {currentParent === null
+              ? 'This part isn’t in the chain yet — pick where it connects.'
+              : 'Changing the parent keeps this part where it is — it only moves it in the chain.'}
+          </p>
+        </section>
+      )}
       {joint ? (
         <section className="robotprops__section">
           <div className="robotprops__label">Joint</div>
@@ -285,9 +325,9 @@ function LinkBody({
             onRoll={(absDeg) => onRollJoint(link, absDeg)}
           />
         </section>
-      ) : (
-        <p className="robotprops__note">This is the base — nothing to join to.</p>
-      )}
+      ) : isBase ? (
+        <p className="robotprops__note">This is the base — everything hangs off it.</p>
+      ) : null}
     </>
   )
 }

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -428,6 +428,15 @@ export function RobotView({
     [content, editLink]
   )
   const allJointNames = useMemo(() => jointNames(content), [content])
+  // Valid parents for the part being edited: every link EXCEPT itself and its own
+  // descendants (attaching onto its own branch would loop) — the "Attaches to" picker.
+  const parentOptions = useMemo(() => {
+    if (!editLink) return []
+    const banned = subtreeOf(content, editLink) // includes editLink itself
+    return parseAssembly(content)
+      .map((i) => i.link)
+      .filter((l) => !banned.has(l))
+  }, [content, editLink])
   // The effective base for the hierarchy's ★ marker: the user's chosen base if it's
   // still a root, else the sole root of a single-tree robot, else null — meaning
   // several loose parts and no base picked yet (the panel then prompts to pick one).
@@ -563,6 +572,83 @@ export function RobotView({
   const handleSetJointOrigin = (child: string, xyz: [number, number, number]): void => {
     const j = readJoint(content, child)
     if (j) commitUrdf(setJointOrigin(content, child, xyz, j.rpy))
+  }
+  // Explicit re-parent (#354): move `child` under `newParent` in the chain WITHOUT
+  // moving it on screen (topology only). Keeps the joint TYPE/axis/limit (connectJoint
+  // preserves them) and computes a REST-pose-preserving origin. The origin is derived
+  // by PURE forward-kinematics over the authored joint origins (not the live/articulated
+  // matrixWorld) — so re-parenting while the robot is posed can't bake a transient
+  // articulation into the saved rest pose. The base has no parent (use Make base).
+  const handleReparent = (child: string, newParent: string): void => {
+    if (!child || !newParent || child === newParent || child === effectiveBaseLink) return
+    if (subtreeOf(content, child).has(newParent)) return // would form a loop
+    const old = readJoint(content, child) // null for a loose/rootless part
+    if (old && old.parent === newParent) return // already there
+    const joints = readAllJoints(content)
+    const parentJointOf = new Map(joints.map((j) => [j.child, j]))
+    // A link's REST world transform = product of authored joint origins from the root
+    // down to it. Pose-independent; the robot's root rotation is a common prefix that
+    // cancels in the newParent⁻¹·old relative, so we can ignore it. Cycle-guarded.
+    const restWorld = (link: string): THREE.Matrix4 => {
+      const chain: JointDef[] = []
+      const seen = new Set<string>()
+      let cur: string | undefined = link
+      while (cur && parentJointOf.has(cur) && !seen.has(cur)) {
+        seen.add(cur)
+        const j = parentJointOf.get(cur)!
+        chain.push(j)
+        cur = j.parent
+      }
+      const m = new THREE.Matrix4()
+      for (let i = chain.length - 1; i >= 0; i--) {
+        const j = chain[i]
+        m.multiply(
+          new THREE.Matrix4().compose(
+            new THREE.Vector3(j.xyz[0], j.xyz[1], j.xyz[2]),
+            new THREE.Quaternion().setFromEuler(new THREE.Euler(j.rpy[0], j.rpy[1], j.rpy[2], 'ZYX')),
+            new THREE.Vector3(1, 1, 1)
+          )
+        )
+      }
+      return m
+    }
+    // The child's authored origin frame in the robot frame (rest). For a loose part its
+    // own link frame IS that frame (restWorld walks no joints → identity/its position).
+    const childRestWorld = old ? restWorld(old.parent).multiply(
+      new THREE.Matrix4().compose(
+        new THREE.Vector3(old.xyz[0], old.xyz[1], old.xyz[2]),
+        new THREE.Quaternion().setFromEuler(new THREE.Euler(old.rpy[0], old.rpy[1], old.rpy[2], 'ZYX')),
+        new THREE.Vector3(1, 1, 1)
+      )
+    ) : restWorld(child)
+    const local = restWorld(newParent).invert().multiply(childRestWorld)
+    const p = new THREE.Vector3()
+    const q = new THREE.Quaternion()
+    local.decompose(p, q, new THREE.Vector3())
+    const e = new THREE.Euler().setFromQuaternion(q, 'ZYX') // URDF rpy order
+    const xyz: [number, number, number] = [p.x, p.y, p.z]
+    const rpy: [number, number, number] = [e.x, e.y, e.z]
+    let next = connectJoint(content, { parent: newParent, child, xyz })
+    if (next === content) return // refused (cycle / no-op) — backstop to the guard above
+    next = setJointOrigin(next, child, xyz, rpy) // connectJoint keeps the OLD rpy; set ours
+    commitUrdf(next)
+    setSelectedLink(child)
+    // The stored mating normal lived in the OLD parent frame → now stale. Reset the roll
+    // baseline to 0 and drop the normal (mirrors handleDeleteJoint); the world-preserving
+    // rpy already holds the real orientation, so nothing moves — only the roll baseline.
+    const jn = readJoint(next, child)?.name
+    if (jn) {
+      jointRollRef.current = { ...jointRollRef.current, [jn]: 0 }
+      const norm = { ...jointNormalRef.current }
+      delete norm[jn]
+      jointNormalRef.current = norm
+      void persist((m) => {
+        m.jointRoll = { ...(m.jointRoll ?? {}), [jn]: 0 }
+        const mn = { ...(m.jointNormal ?? {}) }
+        delete mn[jn]
+        m.jointNormal = mn
+      })
+    }
   }
   // Set an existing joint's ABSOLUTE roll about the MATING NORMAL — the same axis the
   // Add-Joint mate rolled about (the parent's picked face normal, stored per joint since
@@ -3101,6 +3187,10 @@ export function RobotView({
             onSetJointOrigin={handleSetJointOrigin}
             onRollJoint={setJointRoll}
             jointRoll={editJoint ? jointRollRef.current[editJoint.name] ?? 0 : 0}
+            parentOptions={parentOptions}
+            currentParent={editJoint?.parent ?? null}
+            isBase={editLink === effectiveBaseLink}
+            onSetParent={handleReparent}
             onDeleteJoint={handleDeleteJoint}
             servo={dialogCtx.kind === 'servo' ? bindings.find((b) => b.pin === dialogCtx.pin) ?? null : null}
             movableJoints={movableNames}

--- a/src/renderer/src/components/robot-assembly.ts
+++ b/src/renderer/src/components/robot-assembly.ts
@@ -417,6 +417,72 @@ export function readAllJoints(urdf: string): JointFull[] {
   return out
 }
 
+/** One row of the kinematic chain view (#354): a link, its depth in the tree, and
+ *  the joint that attaches it to its parent (null for the base / a loose root). */
+export interface ChainNode {
+  link: string
+  depth: number
+  kind: AssemblyItem['kind']
+  mesh?: string
+  /** The joint connecting this link to its parent — null for the base / a loose root. */
+  joint: JointFull | null
+  isBase: boolean
+  /** Not reachable from the base — a stray import / detached sub-assembly. */
+  loose: boolean
+  childCount: number
+}
+
+/**
+ * Flatten the kinematic hierarchy for the build panel (#354): the base's subtree
+ * first (base at depth 0, children indented via child joints, document order among
+ * siblings), then every DETACHED part/sub-assembly as its own depth-0 root marked
+ * `loose`. Pure — derived from the parsed links + joints, so it's cheap to test and
+ * cycle-safe (a malformed loop can't recurse forever).
+ */
+export function buildChainTree(
+  assembly: AssemblyItem[],
+  joints: JointFull[],
+  base: string | null
+): ChainNode[] {
+  const info = new Map(assembly.map((it) => [it.link, it]))
+  const kids = new Map<string, JointFull[]>() // parent link → its child joints (doc order)
+  const isChild = new Set<string>()
+  for (const j of joints) {
+    const list = kids.get(j.parent)
+    if (list) list.push(j)
+    else kids.set(j.parent, [j])
+    isChild.add(j.child)
+  }
+  const out: ChainNode[] = []
+  const seen = new Set<string>()
+  const walk = (link: string, depth: number, joint: JointFull | null, loose: boolean): void => {
+    if (seen.has(link)) return // guard: a broken cycle never recurses forever
+    seen.add(link)
+    const it = info.get(link)
+    const children = kids.get(link) ?? []
+    out.push({
+      link,
+      depth,
+      kind: it?.kind ?? 'none',
+      mesh: it?.mesh,
+      joint,
+      isBase: link === base && !loose,
+      loose,
+      childCount: children.length
+    })
+    for (const j of children) walk(j.child, depth + 1, j, loose)
+  }
+  // 1) the connected robot, rooted at the base.
+  if (base && info.has(base)) walk(base, 0, null, false)
+  // 2) loose sub-assemblies: an unseen link that is nobody's child is a loose root.
+  for (const it of assembly) {
+    if (!seen.has(it.link) && !isChild.has(it.link)) walk(it.link, 0, null, true)
+  }
+  // 3) safety net — anything still unseen (part of a cycle) is listed flat, loose.
+  for (const it of assembly) if (!seen.has(it.link)) walk(it.link, 0, null, true)
+  return out
+}
+
 /** Names of every `<joint>` in the model (for the mimic master picker). */
 export function jointNames(urdf: string): string[] {
   const re = /<joint\b([^>]*)>/gi

--- a/test/robotAssembly.test.ts
+++ b/test/robotAssembly.test.ts
@@ -10,6 +10,7 @@ import {
   blankUrdf,
   connectJoint,
   orientJoint,
+  buildChainTree,
   subtreeOf,
   readAllJoints,
   removeJoint,
@@ -328,5 +329,70 @@ describe('blankUrdf — new robot starter', () => {
     expect(urdf).toContain('<joint name="w_joint" type="fixed">')
     expect(urdf).toContain('<parent link="base_link"/>')
     expect(looseLinks(urdf, 'base_link')).toEqual([]) // it's a joint child, not a loose root
+  })
+})
+
+describe('buildChainTree — the explicit chain view (#354)', () => {
+  const parse = (urdf: string) => ({ a: parseAssembly(urdf), j: readAllJoints(urdf) })
+  it('flattens a linear chain with increasing depth', () => {
+    const urdf = `<?xml version="1.0"?>
+<robot name="r">
+  <link name="base"/><link name="shoulder"/><link name="arm"/><link name="servo"/>
+  <joint name="js" type="revolute"><parent link="base"/><child link="shoulder"/></joint>
+  <joint name="ja" type="fixed"><parent link="shoulder"/><child link="arm"/></joint>
+  <joint name="jv" type="fixed"><parent link="arm"/><child link="servo"/></joint>
+</robot>`
+    const { a, j } = parse(urdf)
+    const tree = buildChainTree(a, j, 'base')
+    expect(tree.map((n) => [n.link, n.depth])).toEqual([
+      ['base', 0],
+      ['shoulder', 1],
+      ['arm', 2],
+      ['servo', 3]
+    ])
+    expect(tree[0].isBase).toBe(true)
+    expect(tree.every((n) => !n.loose)).toBe(true)
+    // The connecting joint rides on each row (base has none).
+    expect(tree[0].joint).toBeNull()
+    expect(tree[1].joint?.name).toBe('js')
+  })
+  it('makes the "servo is a parent of arm" mistake visible (nested under servo)', () => {
+    // base -> shoulder, base -> servo -> arm (the reported tangle).
+    const urdf = `<?xml version="1.0"?>
+<robot name="r">
+  <link name="base"/><link name="shoulder"/><link name="servo"/><link name="arm"/>
+  <joint name="js" type="revolute"><parent link="base"/><child link="shoulder"/></joint>
+  <joint name="jv" type="fixed"><parent link="base"/><child link="servo"/></joint>
+  <joint name="ja" type="fixed"><parent link="servo"/><child link="arm"/></joint>
+</robot>`
+    const { a, j } = parse(urdf)
+    const tree = buildChainTree(a, j, 'base')
+    const byLink = Object.fromEntries(tree.map((n) => [n.link, n]))
+    expect(byLink.servo.depth).toBe(1)
+    expect(byLink.arm.depth).toBe(2) // arm nested UNDER servo — the bug is now visible
+    expect(byLink.servo.childCount).toBe(1)
+  })
+  it('lists a stray imported mesh as a loose depth-0 node', () => {
+    const urdf = `<?xml version="1.0"?>
+<robot name="r">
+  <link name="base"/><link name="arm"/><link name="stray"/>
+  <joint name="ja" type="fixed"><parent link="base"/><child link="arm"/></joint>
+</robot>`
+    const { a, j } = parse(urdf)
+    const tree = buildChainTree(a, j, 'base')
+    const stray = tree.find((n) => n.link === 'stray')!
+    expect(stray.loose).toBe(true)
+    expect(stray.depth).toBe(0)
+    expect(stray.joint).toBeNull()
+    expect(tree.find((n) => n.link === 'arm')!.loose).toBe(false)
+  })
+  it('puts everything in the loose group when no base is chosen', () => {
+    const urdf = `<?xml version="1.0"?>
+<robot name="r">
+  <link name="a"/><link name="b"/>
+</robot>`
+    const { a, j } = parse(urdf)
+    const tree = buildChainTree(a, j, null)
+    expect(tree.every((n) => n.loose)).toBe(true)
   })
 })


### PR DESCRIPTION
Every recurring Robot-View failure this week traced to **one root cause**: the parent→child chain was invisible and implied, so users couldn't see or control it. A user aiming for `base → shoulder → arm → servo` instead built `base → servo → arm` (servo a *parent* of arm); rolling the servo then rotated servo+arm (correct physics) and looked like a bug. This makes the topology **explicit** — the user's own proposal.

Designed via a **multi-agent workflow** (three design facets + synthesis) and hardened by an **adversarial review** (5 findings; the two that mattered are fixed here).

## What's new

- **Chain view.** The flat Blocks/Meshes/Joints lists collapse into one **indented Chain tree** — `Base → Shoulder → Arm → Servo` — each row tagged with its joint type, plus a **⚠ loose** marker + "Not connected" divider for parts outside the chain. A part nested under the wrong parent is now obvious at a glance. (`buildChainTree` — pure, unit-tested.)
- **Parent picker.** The part editor gains an **"Attaches to"** dropdown (valid parents = every link except itself + its descendants → no loops). `handleReparent` moves the part in the chain while **preserving its pose**, and `connectJoint` keeps the joint type/axis/limit + name, so poses/servos/timeline survive. You can now **build a chain reliably and repair a tangled one** (move the arm under the shoulder, the servo under the arm) without deleting + re-mating.
- The 3-D Add Joint tool is unchanged — now purely for **geometry** (mating + roll).

## Adversarial-review fixes

- **HIGH — posed re-parent corrupted the saved rest pose.** The origin was computed from the live/articulated `matrixWorld`, so re-parenting a posed robot baked a transient articulation into the persisted rest pose. Rewrote it as **pure rest-forward-kinematics over the authored joint origins** — pose-independent by construction (reads only the URDF).
- **MEDIUM — the picker was hidden for loose parts** (and they were mislabelled "nothing to join to"). Now it shows for jointless parts with a "choose a parent" placeholder; the base is excluded via an explicit `isBase` flag. This is the "add a part, pick where it connects" flow.
- Two LOW findings (roll/normal reset not on the URDF undo stack; a persist/reload race) are pre-existing patterns shared with `handleDeleteJoint` — accepted for parity.

## Verification

- **32 robot-assembly unit tests** incl. `buildChainTree` (linear-chain depths, the servo-parent-of-arm tangle made visible, a loose mesh, no-base).
- Driven Playwright smokes: fixes the exact tangle to `base → shoulder → arm → servo` with **every world position UNCHANGED**; attaches a truly-rootless part via the picker (`shoulder → gadget`).
- `typecheck` ✅ · `lint` ✅ (only the pre-existing `DriverInstallBanner` warning) · **1556 tests** ✅ · `build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)