### PR TITLE
feat: movable joints rotate/slide about the mated normal, not a guessed Z (#399)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Robot View — a hinge rotates about the mated normal, Fusion-style (#399).** A new
+  Rotation/Linear joint now takes its **axis from the two faces you mated** — it turns (or
+  slides) about the normal through the joint, the same axis its Roll uses — instead of a
+  guessed `Z`. So a servo horn spins on its mounting face without you hunting for the right
+  axis. (You can still override the axis in the joint editor.)
 - **Robot View — Add Joint previews the mate live (#399).** As soon as you pick the
   second point, the child snaps onto the parent **in the 3-D view** — so you see the
   result and can tell whether it needs a roll **before** pressing Add. Changing the type,

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -866,10 +866,19 @@ export function RobotView({
     let next = connectJoint(base, { parent: parent.link, child: child.link, xyz })
     if (next === base) return null // cycle / invalid
     const rad = (d: number): number => (d * Math.PI) / 180
+    // Fusion-style single axis (#399): a movable joint rotates/slides about the MATED
+    // NORMAL, so the user needn't guess. In the joint (child) frame that IS the child's
+    // picked face normal — the same axis the roll turns about. (Fixed joints have none.)
+    const cnv = new THREE.Vector3(child.normal[0], child.normal[1], child.normal[2])
+    if (cnv.lengthSq() > 1e-9) cnv.normalize()
+    else cnv.set(0, 0, 1)
+    const axis: [number, number, number] = [cnv.x, cnv.y, cnv.z]
     next =
-      rotation && type === 'revolute'
-        ? setJoint(next, child.link, { type, lower: rad(rotation.minDeg), upper: rad(rotation.maxDeg) })
-        : setJoint(next, child.link, { type })
+      type === 'fixed'
+        ? setJoint(next, child.link, { type })
+        : rotation && type === 'revolute'
+          ? setJoint(next, child.link, { type, axis, lower: rad(rotation.minDeg), upper: rad(rotation.maxDeg) })
+          : setJoint(next, child.link, { type, axis })
     next = setJointOrigin(next, child.link, xyz, rpy)
     // Re-origin the child onto its picked point so the geometry stays put while the link
     // origin (the pivot) lands on the mating point; shift its own sub-joints to match.


### PR DESCRIPTION
Epic item (#399): _"The axis rotation in Fusion 360 only has one axis rotation on joints — around the mated normal; do that rather than have the user guess which axis."_

## Change

Creating a **Rotation / Linear** joint now sets its `<axis>` to the **mating normal** instead of defaulting to `[0 0 1]`. In the joint (child) frame the mated normal *is* the child's picked face normal, so `computeMate` passes that as the axis for every movable joint (fixed joints have none). It's the exact axis the **Roll** already turns about, so a joint's rotation and its roll now agree — a servo horn spins on its mounting face, no axis-hunting.

The joint editor still lets you override the axis (X/Y/Z chips) if you want something else.

## Verification

Driven Playwright smoke: mating on a side face (child picked normal `[-1,0,0]`) creates a revolute joint whose `<axis>` is `[-1,0,0]` — the mated normal, **not** the default `Z`.

`typecheck` ✅ · `lint` ✅ (only the pre-existing `DriverInstallBanner` warning) · **1556 tests** ✅ · `build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)