### PR TITLE
fix: Robot View keeps its camera across editor-tab switches (#399)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -332,6 +332,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   or reopen any panel. Nothing about Robot mode is permanently changed.
 
 ### Fixed
+- **Robot View — the 3-D view keeps its camera when you switch editor tabs (#399).**
+  Flipping to another file tab and back used to reset the robot to the default framing,
+  losing your orbit. Two causes: orbiting/panning wasn't recorded (only the zoom/home/fit
+  buttons were), and the view fully unmounts when you leave its tab. Now every camera move
+  is remembered per-file in a cache that survives the unmount, so you come back to exactly
+  the view you left.
 - **Robot View — editing a joint's Roll turns it about the mating normal, not the
   wrong axis (#354).** The Roll field on an existing joint spun the part about the joint's
   local Z, which usually isn't the axis the two faces are joined on — so the part rotated

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -98,6 +98,13 @@ import './RobotView.css'
 /** An empty motion clip (2 s, ease-in-out, looping). */
 const EMPTY_TIMELINE: MotionTimeline = { duration: 2, easing: 'easeInOut', loop: true, fps: 20, tracks: [] }
 
+// Camera view per robot, kept at MODULE scope so it survives the RobotView unmounting
+// when you switch to a non-URDF editor tab — otherwise the orbit is lost and the view
+// resets to the default framing on return (#399). Keyed by the same `frameKey` the
+// in-run preservation uses (the active file, or the base link for the compact viewer).
+type CamState = { pos: THREE.Vector3; target: THREE.Vector3; zoom: number; halfView: number }
+const cameraCache = new Map<string, CamState>()
+
 /**
  * ROBOT VIEW (#311, epic #309) — a 3D panel that renders a URDF robot.
  * =============================================================================
@@ -1573,16 +1580,28 @@ export function RobotView({
       camera.far = d + radius * 8 + 0.5
       camera.updateProjectionMatrix()
     }
-    // Snapshot the camera as the PRESERVED state so a later re-parse / async
-    // mesh-settle restores THIS view instead of re-framing the whole model. Called
-    // by manual camera actions (zoom, fit, home, focus-a-link, cube snap/orbit) so
-    // a click made while meshes are still loading isn't clobbered on settle.
+    // The camera-preservation key: the active file (or the base link for the compact
+    // dock viewer). Defined early so the orbit/record handlers can key the module cache.
+    const frameKey = compact ? effectiveBase : activeFile?.id ?? ''
+    // Snapshot the camera as the PRESERVED state so a later re-parse / async mesh-settle
+    // restores THIS view instead of re-framing the whole model — and stash it in the
+    // MODULE cache so it also survives the view unmounting on an editor-tab switch (#399).
+    // Called by manual camera actions (zoom, fit, home, focus, cube) AND on orbit/pan end.
     const recordCamera = (): void => {
-      cameraStateRef.current = {
+      const state: CamState = {
         pos: camera.position.clone(),
         target: controls.target.clone(),
         zoom: camera.zoom,
         halfView
+      }
+      cameraStateRef.current = state
+      if (frameKey) {
+        cameraCache.set(frameKey, {
+          pos: state.pos.clone(),
+          target: state.target.clone(),
+          zoom: state.zoom,
+          halfView: state.halfView
+        })
       }
     }
 
@@ -1710,7 +1729,13 @@ export function RobotView({
       },
       focusLink
     }
-    const onControlsChange = (): void => syncZoomPct()
+    // Every camera change (orbit / pan / wheel-zoom) updates the % readout AND records
+    // the view, so an orbited view survives an editor-tab switch (#399) — not just the
+    // discrete zoom/home/fit/cube actions.
+    const onControlsChange = (): void => {
+      syncZoomPct()
+      recordCamera()
+    }
     controls.addEventListener('change', onControlsChange)
     // A user grabbing the viewport cancels any in-flight camera animation (else
     // the tween and OrbitControls fight over the camera).
@@ -1754,12 +1779,9 @@ export function RobotView({
     }
 
     // Frame a NEW robot isometrically, but PRESERVE the camera when the same file
-    // is just re-parsed after a build edit (#315a must-fix — no view jump). The grid
-    // is refreshed to the new bounds either way. The mini/compact viewer's content
-    // comes from `urdfContent` (the dock's demo-arm → project robot), NOT the
-    // workspace's active file — so key it on the robot's base folder, else it keeps
-    // the demo-arm camera and the real robot loads tiny + off-centre.
-    const frameKey = compact ? effectiveBase : (activeFile?.id ?? '')
+    // is just re-parsed after a build edit (#315a must-fix — no view jump), or when the
+    // view remounts after an editor-tab switch (#399, via the module cache). The grid
+    // is refreshed to the new bounds either way. `frameKey` is defined above.
     const relayGrid = (robot: URDFRobot): void => {
       robot.updateMatrixWorld(true)
       const box = new THREE.Box3().setFromObject(robot)
@@ -1777,13 +1799,17 @@ export function RobotView({
         cameraStateRef.current = null
         return
       }
-      if (saved && framedKeyRef.current === frameKey) {
-        halfView = saved.halfView
-        camera.position.copy(saved.pos)
-        controls.target.copy(saved.target)
-        camera.zoom = saved.zoom
+      // Restore the preserved view — either the in-run snapshot (re-parse/mesh-settle),
+      // or, on a fresh mount after a tab switch, the module-cached view for this file.
+      const restore = saved && framedKeyRef.current === frameKey ? saved : cameraCache.get(frameKey)
+      if (restore) {
+        halfView = restore.halfView
+        camera.position.copy(restore.pos)
+        controls.target.copy(restore.target)
+        camera.zoom = restore.zoom
         camera.updateProjectionMatrix()
         controls.update()
+        framedKeyRef.current = frameKey
         relayGrid(robot)
         resize()
       } else {


### PR DESCRIPTION
Epic item (#399): _"The URDF editor doesn't always home correctly when switching between tabs — it loses the current view and resets to a front view."_

## Cause

Two things:
1. **Orbiting/panning never recorded the camera** — `onControlsChange` only synced the zoom %. Only the discrete zoom / home / fit / cube actions recorded it, so a hand-orbited view was never saved.
2. **RobotView unmounts when you leave its tab** — it's conditionally rendered (`showRobot ? <RobotView/> : <MonacoEditor/>`), so its component-level `cameraStateRef` is dropped, and on return the effect re-frames from scratch.

## Fix

- Record the camera on **every** `controls` `change` (orbit / pan / wheel), not just the discrete actions.
- Persist it in a **module-level cache** keyed by the same `frameKey` (active file / base link) so it **survives the unmount**; `framePreservingCamera` restores from that cache on a fresh mount. (`frameKey` moved above `recordCamera` so the orbit handler can key the cache without a TDZ reference.)

## Verification

Driven Playwright smoke: orbit the view (camera moves + is recorded), switch to a `.py` tab (**Monaco replaces RobotView — a genuine unmount**), switch back → the camera returns to the **exact orbited position** `[0,0.18,0]`, not the default `[-0.11,0.11,0.11]`.

`typecheck` ✅ · `lint` ✅ (only the pre-existing `DriverInstallBanner` warning) · **1556 tests** ✅ · `build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)