### PR TITLE
feat: colour a Robot View part — primitives + STL meshes (#405)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Robot View — colour an individual part (#399).** The link Properties panel gains a
+  **Colour** control — the same colour well + one-click "used colours" swatches as the Part
+  Editor — right beside **Size (mm)**. It works for **primitive** parts (box/cylinder/sphere)
+  **and imported STL meshes**, so a multi-part robot no longer has to be a flat grey blob —
+  colour it to match your real hardware. Pick a colour and only that part recolours, live;
+  every other part keeps its colour. The colour is stored in the model's URDF `<material>`,
+  so it round-trips on reload and is covered by undo/redo. (Selecting a part still tints it
+  blue, but now over its own colour, so the change is visible while it's selected. DAE/Collada
+  meshes keep their own baked-in materials, so they show the "grab a face in 3-D" note
+  instead.)
 - **Robot View — a hinge rotates about the mated normal, Fusion-style (#399).** A new
   Rotation/Linear joint now takes its **axis from the two faces you mated** — it turns (or
   slides) about the normal through the joint, the same axis its Roll uses — instead of a

--- a/src/renderer/src/components/PartEditor.css
+++ b/src/renderer/src/components/PartEditor.css
@@ -728,35 +728,7 @@
   resize: vertical;
 }
 
-/* --- Colour well + used-colour quick-pick swatches --- */
-.pe__swatchpick {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  min-width: 0;
-}
-
-.pe__swatches {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.2rem;
-}
-
-.pe__swatch {
-  width: 1rem;
-  height: 1rem;
-  padding: 0;
-  border: none;
-  border-radius: 3px;
-  cursor: pointer;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.2);
-}
-
-.pe__swatch:hover {
-  box-shadow:
-    inset 0 0 0 1px rgba(255, 255, 255, 0.2),
-    0 0 0 2px var(--text-muted, #8b919b);
-}
+/* Colour well + swatches moved to the shared SwatchPicker component (#405). */
 
 /* --- Text-style toggle row (bold / italic / underline, align, wrap) --- */
 .pe__tbtns {

--- a/src/renderer/src/components/PartEditor.tsx
+++ b/src/renderer/src/components/PartEditor.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState, type CSSProperties, type JSX } from 'react'
 import { useHistory } from './use-history'
 import { PartSchematicView } from './PartSchematicView'
+import { SwatchPicker } from './SwatchPicker'
 import {
   PartCanvas,
   DEFAULT_LAYERS,
@@ -1399,48 +1400,6 @@ function SliderField({
         />
       </div>
     </label>
-  )
-}
-
-/** A native colour input plus a quick-pick grid of the colours already used in
- *  the part — shared by every colour well in the Properties panel. */
-function SwatchPicker({
-  value,
-  fallback,
-  used,
-  onChange,
-  ariaLabel
-}: {
-  value?: string
-  fallback: string
-  used: string[]
-  onChange: (c: string) => void
-  ariaLabel?: string
-}): JSX.Element {
-  return (
-    <div className="pe__swatchpick">
-      <input
-        type="color"
-        value={/^#[0-9a-f]{6}$/i.test(value ?? '') ? (value as string) : fallback}
-        onChange={(e) => onChange(e.target.value)}
-        aria-label={ariaLabel}
-      />
-      {used.length > 0 && (
-        <div className="pe__swatches">
-          {used.map((c) => (
-            <button
-              key={c}
-              type="button"
-              className="pe__swatch"
-              style={{ background: c }}
-              title={c}
-              aria-label={`Use ${c}`}
-              onClick={() => onChange(c)}
-            />
-          ))}
-        </div>
-      )}
-    </div>
   )
 }
 

--- a/src/renderer/src/components/RobotPropertiesDialog.tsx
+++ b/src/renderer/src/components/RobotPropertiesDialog.tsx
@@ -12,6 +12,7 @@ import {
   type JointMeta
 } from './robot-pose'
 import { SizeForm, JointForm } from './RobotBuildPanel'
+import { SwatchPicker } from './SwatchPicker'
 import './RobotPropertiesDialog.css'
 
 /**
@@ -50,6 +51,14 @@ export interface RobotPropertiesDialogProps {
   joint: JointDef | null
   jointNames: string[]
   onSetSize: (link: string, dims: number[]) => void
+  /** The edited link's colour (#rrggbb), or undefined for the default. */
+  linkColor?: string
+  /** Whether this link can be recoloured (a primitive, or an STL mesh — not DAE). */
+  colorable: boolean
+  /** Colours already used on the robot's links, for the quick-pick swatches. */
+  usedColors: string[]
+  /** Set a link's colour (#rrggbb) — recolours only that link, live + persisted. */
+  onSetColor: (link: string, hex: string) => void
   onSetJoint: (link: string, spec: JointSpec) => void
   /** Reposition the joint origin (offset, mm→m) and set its ABSOLUTE roll about its
    *  own normal axis (deg) — both applied live as the field changes. */
@@ -278,21 +287,47 @@ function LinkBody({
   parentOptions,
   currentParent,
   isBase,
-  onSetParent
+  onSetParent,
+  linkColor,
+  colorable,
+  usedColors,
+  onSetColor
 }: RobotPropertiesDialogProps & { context: PropsContext }): JSX.Element {
   // `link` = the block being edited, or the joint's child link (which carries it).
   const link = context.kind === 'joint' ? context.child : context.kind === 'link' ? context.link : ''
   return (
     <>
-      {context.kind === 'link' &&
-        (geom ? (
-          <section className="robotprops__section">
-            <div className="robotprops__label">Size (mm)</div>
-            <SizeForm geom={geom} onChange={(d) => onSetSize(link, d)} />
-          </section>
-        ) : (
-          <p className="robotprops__note">This is a mesh — grab a face in 3-D to move it.</p>
-        ))}
+      {context.kind === 'link' && (
+        <>
+          {geom && (
+            <section className="robotprops__section">
+              <div className="robotprops__label">Size (mm)</div>
+              <SizeForm geom={geom} onChange={(d) => onSetSize(link, d)} />
+            </section>
+          )}
+          {colorable ? (
+            // Primitives + STL meshes recolour via the inline URDF <material>. (DAE/
+            // Collada meshes carry their own materials, so they fall through to the note.)
+            <section className="robotprops__section">
+              <div className="robotprops__label">Colour</div>
+              <SwatchPicker
+                value={linkColor}
+                fallback="#9ea6b0"
+                used={usedColors}
+                onChange={(c) => onSetColor(link, c)}
+                ariaLabel={`Colour of ${link}`}
+              />
+              {!geom && (
+                <p className="robotprops__note">Recolours the mesh — grab a face in 3-D to move it.</p>
+              )}
+            </section>
+          ) : (
+            !geom && (
+              <p className="robotprops__note">This is a mesh — grab a face in 3-D to move it.</p>
+            )
+          )}
+        </>
+      )}
       {!isBase && parentOptions.length > 0 && (
         <section className="robotprops__section">
           <div className="robotprops__label" title="Which part this connects to in the chain">

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -38,6 +38,9 @@ import {
   orientJoint,
   subtreeOf,
   setPrimitiveSize,
+  setLinkColor,
+  readLinkColor,
+  collectLinkColors,
   setVisualOrigin,
   type JointDef,
   type JointSpec,
@@ -435,6 +438,24 @@ export function RobotView({
     [content, editLink]
   )
   const allJointNames = useMemo(() => jointNames(content), [content])
+  // The edited link's colour + the palette of colours already on the robot (#405).
+  const editLinkColor = useMemo(
+    () => (editLink ? readLinkColor(content, editLink) ?? undefined : undefined),
+    [content, editLink]
+  )
+  const usedLinkColors = useMemo(
+    () => collectLinkColors(content, editLink ?? undefined),
+    [content, editLink]
+  )
+  // A link is recolourable if it's a primitive (has editable geometry) OR an STL mesh
+  // (no baked material, so the inline <material> shows). DAE/Collada keep their own
+  // materials — no colour control for those (#405).
+  const editColorable = useMemo(() => {
+    if (!editLink) return false
+    if (readPrimitive(content, editLink)) return true
+    const it = parseAssembly(content).find((i) => i.link === editLink)
+    return it?.kind === 'mesh' && /\.stl$/i.test(it.mesh ?? '')
+  }, [content, editLink])
   // Valid parents for the part being edited: every link EXCEPT itself and its own
   // descendants (attaching onto its own branch would loop) — the "Attaches to" picker.
   const parentOptions = useMemo(() => {
@@ -570,6 +591,11 @@ export function RobotView({
   }
   const handleSetSize = (link: string, dims: number[]): void => {
     commitUrdf(setPrimitiveSize(content, link, dims))
+  }
+  // Colour a link (#405) — an inline URDF <material>, so it round-trips + undoes like
+  // any other build edit; urdf-loader renders it, recolouring only this link.
+  const handleSetColor = (link: string, hex: string): void => {
+    commitUrdf(setLinkColor(content, link, hex))
   }
   const handleSetJoint = (link: string, spec: JointSpec): void => {
     commitUrdf(setJoint(content, link, spec))
@@ -2136,7 +2162,17 @@ export function RobotView({
               const origMat = mesh.material
               const mk = (m: THREE.Material): THREE.Material => {
                 const c = m.clone() as THREE.MeshStandardMaterial
-                if ('color' in c && c.color) c.color = HL_BLUE.clone()
+                // A real TINT (lerp the block's own colour 60% toward blue), not a flat
+                // replace — so a link's custom colour still reads through the highlight.
+                // That's what lets a live colour edit be visible while the part is still
+                // selected (#405), and is truer to "keep the material's shading". A subtle
+                // emissive blue glow keeps the selection legible even when the custom
+                // colour is ALREADY near HL_BLUE (where the lerp alone barely moves it).
+                if ('color' in c && c.color) c.color.lerp(HL_BLUE, 0.6)
+                if ('emissive' in c && c.emissive) {
+                  c.emissive = HL_BLUE.clone()
+                  c.emissiveIntensity = 0.2
+                }
                 return c
               }
               const tint = Array.isArray(origMat) ? origMat.map(mk) : [mk(origMat)]
@@ -3243,6 +3279,10 @@ export function RobotView({
             joint={editJoint}
             jointNames={allJointNames}
             onSetSize={handleSetSize}
+            linkColor={editLinkColor}
+            colorable={editColorable}
+            usedColors={usedLinkColors}
+            onSetColor={handleSetColor}
             onSetJoint={handleSetJoint}
             onSetJointOrigin={handleSetJointOrigin}
             onRollJoint={setJointRoll}

--- a/src/renderer/src/components/SwatchPicker.css
+++ b/src/renderer/src/components/SwatchPicker.css
@@ -1,0 +1,26 @@
+/* Colour well + used-colour quick-pick swatches (shared: Part Editor + Robot View). */
+.swatchpick {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+.swatchpick__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.2rem;
+}
+.swatchpick__chip {
+  width: 1rem;
+  height: 1rem;
+  padding: 0;
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.2);
+}
+.swatchpick__chip:hover {
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.2),
+    0 0 0 2px var(--text-muted, #8b919b);
+}

--- a/src/renderer/src/components/SwatchPicker.tsx
+++ b/src/renderer/src/components/SwatchPicker.tsx
@@ -1,0 +1,43 @@
+import './SwatchPicker.css'
+
+/** A colour well (native `<input type="color">`) + quick-pick swatches of the colours
+ *  already in use. Shared by the Part Editor and the Robot View's link-colour control. */
+export function SwatchPicker({
+  value,
+  fallback,
+  used,
+  onChange,
+  ariaLabel
+}: {
+  value?: string
+  fallback: string
+  used: string[]
+  onChange: (c: string) => void
+  ariaLabel?: string
+}): JSX.Element {
+  return (
+    <div className="swatchpick">
+      <input
+        type="color"
+        value={/^#[0-9a-f]{6}$/i.test(value ?? '') ? (value as string) : fallback}
+        onChange={(e) => onChange(e.target.value)}
+        aria-label={ariaLabel}
+      />
+      {used.length > 0 && (
+        <div className="swatchpick__row">
+          {used.map((c) => (
+            <button
+              key={c}
+              type="button"
+              className="swatchpick__chip"
+              style={{ background: c }}
+              title={c}
+              aria-label={`Use ${c}`}
+              onClick={() => onChange(c)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/robot-assembly.ts
+++ b/src/renderer/src/components/robot-assembly.ts
@@ -300,6 +300,84 @@ export function setPrimitiveSize(urdf: string, link: string, dims: readonly numb
   return urdf.slice(0, span.bodyStart) + nextBody + urdf.slice(span.bodyEnd)
 }
 
+/** `#rrggbb` (or `#rgb`) → a URDF rgba float string `"r g b 1"` (0–1, ≤4 dp). */
+function hexToRgba(hex: string): string {
+  const h = hex.replace(/^#/, '')
+  const n = h.length === 3 ? h.split('').map((c) => c + c).join('') : h
+  const chan = (i: number): number => parseInt(n.slice(i, i + 2), 16) / 255
+  return `${fmtNum(chan(0))} ${fmtNum(chan(2))} ${fmtNum(chan(4))} 1`
+}
+/** A URDF rgba float string → `#rrggbb` (alpha ignored). null if unparseable. */
+function rgbaToHex(rgba: string): string | null {
+  const p = rgba.trim().split(/\s+/).map(Number)
+  if (p.length < 3 || p.slice(0, 3).some((x) => !Number.isFinite(x))) return null
+  const b = (x: number): string =>
+    Math.round(Math.min(1, Math.max(0, x)) * 255)
+      .toString(16)
+      .padStart(2, '0')
+  return `#${b(p[0])}${b(p[1])}${b(p[2])}`
+}
+
+/** Colour a link by giving its (first) visual its OWN inline material (#rrggbb).
+ *  Scoped to the link like setPrimitiveSize; urdf-loader renders inline `<material>`
+ *  colours, so it round-trips in the `.urdf` with no separate metadata layer (#405). */
+export function setLinkColor(urdf: string, link: string, hex: string): string {
+  const span = linkSpan(urdf, link)
+  if (!span) return urdf
+  const body = urdf.slice(span.bodyStart, span.bodyEnd)
+  const vs = visualSlice(body)
+  if (!vs) return urdf
+  const tag = `<material name="${link}__col"><color rgba="${hexToRgba(hex)}"/></material>`
+  const matRe = /<material\b[^>]*\/>|<material\b[^>]*>[\s\S]*?<\/material>/i
+  let visual = body.slice(vs.start, vs.end)
+  visual = matRe.test(visual)
+    ? visual.replace(matRe, tag)
+    : visual.replace(/<\/visual>/i, `  ${tag}\n    </visual>`)
+  const nextBody = body.slice(0, vs.start) + visual + body.slice(vs.end)
+  return urdf.slice(0, span.bodyStart) + nextBody + urdf.slice(span.bodyEnd)
+}
+
+/** A link's visual colour as `#rrggbb` — its inline `<color>`, or the robot-scope
+ *  `<material name>` it references — or null when it has no visual / no colour. */
+export function readLinkColor(urdf: string, link: string): string | null {
+  const span = linkSpan(urdf, link)
+  if (!span) return null
+  const body = urdf.slice(span.bodyStart, span.bodyEnd)
+  const vs = visualSlice(body)
+  if (!vs) return null
+  const visual = body.slice(vs.start, vs.end)
+  const block = /<material\b[^>]*>([\s\S]*?)<\/material>/i.exec(visual)
+  const inline = block && /<color\b[^>]*\brgba\s*=\s*"([^"]+)"/i.exec(block[1])?.[1]
+  if (inline) return rgbaToHex(inline)
+  const ref = /<material\b[^>]*\bname\s*=\s*"([^"]+)"/i.exec(visual)?.[1]
+  if (ref) {
+    // Resolve the robot-scope definition: it must be a real open+close `<material>`
+    // block (not self-closing, `(?<!/)>`) — an unresolved or self-closing reference has
+    // no colour of its own. Bound the colour search to that block's OWN `</material>`
+    // so a colourless definition yields null instead of grabbing a later link's colour.
+    const def = new RegExp(
+      `<material\\b[^>]*\\bname\\s*=\\s*"${escapeRe(ref)}"[^>]*(?<!/)>([\\s\\S]*?)</material>`,
+      'i'
+    ).exec(urdf)?.[1]
+    const rc = def ? /<color\b[^>]*\brgba\s*=\s*"([^"]+)"/i.exec(def)?.[1] : undefined
+    if (rc) return rgbaToHex(rc)
+  }
+  return null
+}
+
+/** Distinct link colours in the model, for the quick-pick swatches (#405).
+ *  `exclude` drops one link (the one being edited) so the picker offers the colours
+ *  of the OTHER links only. */
+export function collectLinkColors(urdf: string, exclude?: string): string[] {
+  const seen = new Set<string>()
+  for (const it of parseAssembly(urdf)) {
+    if (it.link === exclude) continue
+    const c = readLinkColor(urdf, it.link)
+    if (c) seen.add(c)
+  }
+  return [...seen]
+}
+
 /** Read a link's `<visual><origin>` (xyz + rpy), for ANY geometry (mesh included),
  *  or null when the link has no visual. */
 export function readVisualOrigin(

--- a/test/robotAssembly.test.ts
+++ b/test/robotAssembly.test.ts
@@ -11,6 +11,9 @@ import {
   connectJoint,
   orientJoint,
   buildChainTree,
+  setLinkColor,
+  readLinkColor,
+  collectLinkColors,
   subtreeOf,
   readAllJoints,
   removeJoint,
@@ -394,5 +397,67 @@ describe('buildChainTree — the explicit chain view (#354)', () => {
     const { a, j } = parse(urdf)
     const tree = buildChainTree(a, j, null)
     expect(tree.every((n) => n.loose)).toBe(true)
+  })
+})
+
+describe('link colour — setLinkColor / readLinkColor / collectLinkColors (#405)', () => {
+  const U = `<?xml version="1.0"?>
+<robot name="r">
+  <material name="steel"><color rgba="0.62 0.65 0.69 1"/></material>
+  <link name="a"><visual><geometry><box size="0.1 0.1 0.1"/></geometry><material name="steel"/></visual></link>
+  <link name="b"><visual><geometry><box size="0.1 0.1 0.1"/></geometry><material name="steel"/></visual></link>
+</robot>`
+  it('resolves a robot-scope <material name> reference to its hex', () => {
+    expect(readLinkColor(U, 'a')).toBe('#9ea6b0') // steel 0.62/0.65/0.69
+    expect(readLinkColor(U, 'nope')).toBeNull()
+  })
+  it('sets an inline colour that round-trips, touching ONLY that link', () => {
+    const out = setLinkColor(U, 'a', '#ff8800')
+    expect(readLinkColor(out, 'a')).toBe('#ff8800')
+    expect(readLinkColor(out, 'b')).toBe('#9ea6b0') // b untouched (still steel)
+    expect(out).toContain('<color rgba="1 0.5333 0 1"/>')
+  })
+  it('re-colouring REPLACES the material (no duplicate <material> in the visual)', () => {
+    let out = setLinkColor(U, 'a', '#ff8800')
+    out = setLinkColor(out, 'a', '#00ff00')
+    expect(readLinkColor(out, 'a')).toBe('#00ff00')
+    const aVisual = /<link name="a">[\s\S]*?<\/link>/.exec(out)![0]
+    expect((aVisual.match(/<material\b/g) || []).length).toBe(1)
+  })
+  it('collects the distinct colours in use (for the swatch palette)', () => {
+    const out = setLinkColor(U, 'a', '#ff8800')
+    expect(collectLinkColors(out).sort()).toEqual(['#9ea6b0', '#ff8800'])
+  })
+})
+
+describe('link colour — hardened edge cases (#405 review)', () => {
+  it('readLinkColor returns null for an unresolved / self-closing material ref (no colour of its own)', () => {
+    // link a references a material that is never defined; link b later carries red.
+    // The ref search must NOT jump forward and grab b's colour.
+    const u = `<?xml version="1.0"?>
+<robot name="r">
+  <link name="a"><visual><geometry><box size="0.1 0.1 0.1"/></geometry><material name="ghost"/></visual></link>
+  <link name="b"><visual><geometry><box size="0.1 0.1 0.1"/></geometry><material name="b__col"><color rgba="1 0 0 1"/></material></visual></link>
+</robot>`
+    expect(readLinkColor(u, 'a')).toBeNull()
+    expect(readLinkColor(u, 'b')).toBe('#ff0000')
+  })
+  it('readLinkColor returns null for a referenced-but-colourless material definition', () => {
+    const u = `<?xml version="1.0"?>
+<robot name="r">
+  <material name="plastic"></material>
+  <link name="a"><visual><geometry><box size="0.1 0.1 0.1"/></geometry><material name="plastic"/></visual></link>
+  <link name="b"><visual><geometry><box size="0.1 0.1 0.1"/></geometry><material name="b__col"><color rgba="1 0 0 1"/></material></visual></link>
+</robot>`
+    expect(readLinkColor(u, 'a')).toBeNull()
+  })
+  it('collectLinkColors(exclude) omits the given link, offering only the OTHER links’ colours', () => {
+    const u = `<?xml version="1.0"?>
+<robot name="r">
+  <link name="a"><visual><geometry><box size="0.1 0.1 0.1"/></geometry><material name="a__col"><color rgba="1 0 0 1"/></material></visual></link>
+  <link name="b"><visual><geometry><box size="0.1 0.1 0.1"/></geometry><material name="b__col"><color rgba="0 1 0 1"/></material></visual></link>
+</robot>`
+    expect(collectLinkColors(u).sort()).toEqual(['#00ff00', '#ff0000'])
+    expect(collectLinkColors(u, 'a')).toEqual(['#00ff00']) // a's own red excluded
   })
 })


### PR DESCRIPTION
Closes #405 (and extends it to STL meshes per follow-up request).

## What
The link **Properties** panel gains a **Colour** control — the same colour well + one-click "used colours" swatches as the Part Editor — beside **Size (mm)**. It works for **primitive** parts (box/cylinder/sphere) **and imported STL meshes**, so a multi-part robot is no longer a flat grey blob.

- Pick a colour → only that part recolours, **live**; every other part keeps its colour.
- Colour is stored in the model's URDF `<material>`, so it **round-trips** on reload and rides the normal `commitUrdf` **undo/redo + debounced-save** path.
- Quick-pick swatches offer the colours already used on the robot's **other** links (one-click reuse).
- **DAE/Collada** meshes carry their own baked materials, so they keep the "grab a face in 3-D" note (a colour override there wouldn't render) — no dead control.

## How
- `robot-assembly.ts` — `setLinkColor` / `readLinkColor` / `collectLinkColors` (+ hex↔rgba). Colour lives as an inline `<material name="${link}__col"><color rgba>` in the link's visual; urdf-loader renders it for both primitives and STL meshes (`loadMeshCb` receives the visual material).
- Shared `SwatchPicker` extracted from `PartEditor` (both call sites use it now).
- Selection highlight changed from a flat colour **replace** to a **tint** (`lerp` 0.6 toward blue) + a subtle emissive glow, so a link's custom colour reads through while selected **and** the highlight stays legible even when the custom colour is already near the highlight blue.

## Verification
- `typecheck`, `lint` (only the pre-existing DriverInstallBanner warning), **1563 tests**, `build` — all green.
- New unit tests: hex↔rgba round-trip, per-link scoping, replace-not-duplicate, palette, and the hardened `readLinkColor` edge cases (unresolved / self-closing / colourless material refs return `null` instead of a later link's colour) + `collectLinkColors(exclude)`.
- urdf-loader render path confirmed from its source (inline `<color rgba>` → primitive + STL mesh materials).
- Adversarial multi-agent review (ultracode) run against the ACs; its 4 findings (1 correctness LOW, 1 highlight LOW, 2 NIT) are all addressed in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)