### PR TITLE
feat: Robot View — offer to copy out-of-project meshes into the project (#407)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Robot View — keep a robot's meshes with the project (#399).** When a `.urdf` points at
+  STL/DAE meshes that live **outside** the project folder (an absolute path, or one that
+  escapes via `..`), Robot View now shows a **"Copy N mesh(es) into project"** offer. Accepting
+  copies each file into the project's `meshes/` folder (collision-safe — never overwrites) and
+  rewrites the URDF to the in-project path, in **one undo step**, so the robot is self-contained
+  and safe to move, zip, or commit. In-folder and `package://` refs are left alone. Fixes meshes
+  silently going missing when a project is shared or relocated.
 - **Robot View — colour an individual part (#399).** The link Properties panel gains a
   **Colour** control — the same colour well + one-click "used colours" swatches as the Part
   Editor — right beside **Size (mm)**. It works for **primitive** parts (box/cylinder/sphere)

--- a/src/main/robot/ipc.ts
+++ b/src/main/robot/ipc.ts
@@ -107,12 +107,15 @@ export function registerRobotIpc(): void {
 
   // Import an STL/DAE mesh into the robot's KRF folder (#309): a native picker,
   // then copy the chosen file into `<urdf-folder>/meshes/`. The renderer wires
-  // the returned relative path into the URDF. The copy is binary-safe.
+  // the returned relative path into the URDF. The copy is binary-safe. With an
+  // explicit `src` (#407) the picker is skipped — used to pull a URDF's own
+  // out-of-project meshes into the project so it's self-contained.
   ipcMain.handle(
     'robot:importMesh',
-    async (e, args: { urdfPath: string }): Promise<ImportMeshResult> => {
+    async (e, args: { urdfPath: string; src?: string }): Promise<ImportMeshResult> => {
       try {
         if (!args?.urdfPath) return { error: 'No robot file to import into.' }
+        if (args.src) return await copyIntoMeshes(args.urdfPath, args.src)
         const win = BrowserWindow.fromWebContents(e.sender) ?? undefined
         const opts = {
           title: 'Import mesh',

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -976,12 +976,16 @@ const robot = {
   /** Save the robot definition. Resolves to {ok,error} — never rejects. */
   save: (folder: string | undefined, def: RobotDefinition): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('robot:save', { folder, def }),
-  /** Import an STL/DAE mesh into the robot's `<urdf-folder>/meshes/` via a native
-   *  picker (#309). Resolves to the mesh path relative to the URDF, or cancelled. */
+  /** Import an STL/DAE mesh into the robot's `<urdf-folder>/meshes/` (#309).
+   *  Without `src`, a native picker chooses the file; with `src` (an absolute path)
+   *  that file is copied straight in — used to pull a URDF's own out-of-project
+   *  meshes into the project (#407). Resolves to the mesh path relative to the
+   *  URDF, or cancelled. */
   importMesh: (
-    urdfPath: string
+    urdfPath: string,
+    src?: string
   ): Promise<{ cancelled?: boolean; error?: string; rel?: string; name?: string }> =>
-    ipcRenderer.invoke('robot:importMesh', { urdfPath }),
+    ipcRenderer.invoke('robot:importMesh', { urdfPath, src }),
   /** Subscribe to robot.yml changes from ANOTHER window (e.g. the Board View
    *  adding/removing a part). Returns an unsubscribe. */
   onChanged: (cb: () => void): (() => void) => {

--- a/src/renderer/src/components/RobotView.css
+++ b/src/renderer/src/components/RobotView.css
@@ -269,11 +269,23 @@
 
 /* A non-blocking banner when one or more meshes couldn't load (#319). Sits left
    of the navigation cube (top-right). */
-.robotview__note {
+/* Stack the mesh notes (couldn't-load warning + copy-external offer) top-right so
+   they never overlap; the container owns the positioning. */
+.robotview__notes {
   position: absolute;
   right: 216px;
   top: 0.55rem;
   max-width: 70%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.4rem;
+  z-index: 5;
+  /* Click-through by default (#319) so an orbit/drag started over a note reaches the
+     canvas; only the interactive offer note re-enables pointer-events on itself. */
+  pointer-events: none;
+}
+.robotview__note {
   padding: 0.3rem 0.55rem;
   border-radius: 6px;
   background: rgba(80, 44, 40, 0.82);
@@ -282,6 +294,38 @@
   line-height: 1.35;
   color: #f2d7d3;
   pointer-events: none;
+}
+/* The "copy external meshes into the project" offer (#407) — informational (not an
+   error) and interactive, so it overrides the warning tone + pointer-events. Reads
+   in both skins (dark slate + accent border/button). */
+.robotview__note--offer {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(28, 32, 38, 0.88);
+  border-color: var(--accent, #c8a24a);
+  color: #e8ecf1;
+  pointer-events: auto;
+}
+.robotview__note-action {
+  flex: none;
+  padding: 0.22rem 0.5rem;
+  border-radius: 5px;
+  border: 1px solid var(--accent, #c8a24a);
+  background: var(--accent, #c8a24a);
+  color: #1a1d22;
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  font-size: 0.6rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.robotview__note-action:hover:not(:disabled) {
+  filter: brightness(1.08);
+}
+.robotview__note-action:disabled {
+  opacity: 0.6;
+  cursor: default;
 }
 
 /* Floating status pills (#312) — the save state + measure readout, formerly in the

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -23,6 +23,8 @@ import {
   addMeshLink,
   addPrimitive,
   connectJoint,
+  externalMeshes,
+  rewriteMeshFilename,
   jointNames,
   looseLinks,
   parseAssembly,
@@ -322,6 +324,13 @@ export function RobotView({
   // Import is only possible for a saved local `.urdf` (a file we can edit).
   const canImport = poseUI && activeFile?.source === 'local' && !!activeFile.path
   const [importing, setImporting] = useState(false)
+  // Meshes this URDF points at that live OUTSIDE the project folder (#407) — they
+  // load now but go missing if the project is moved/shared. Offer to copy them in.
+  const externalMeshRefs = useMemo(
+    () => (canImport ? externalMeshes(content, effectiveBase) : []),
+    [canImport, content, effectiveBase]
+  )
+  const [copyingMeshes, setCopyingMeshes] = useState(false)
   const pendingSaveRef = useRef<string | null>(null)
 
   // Persist a just-imported URDF once the buffer state has updated (so saveFile
@@ -1431,6 +1440,46 @@ export function RobotView({
       setSavingLabel(`import failed: ${e instanceof Error ? e.message : 'error'}`)
     } finally {
       setImporting(false)
+    }
+  }
+
+  // Copy the URDF's out-of-project meshes into `<urdf-folder>/meshes/` and rewrite
+  // each `<mesh filename>` to the copied path (#407), so the robot is self-contained.
+  // One commitUrdf (⇒ one undo step + one save); the banner clears as refs re-resolve.
+  const handleCopyExternalMeshes = async (): Promise<void> => {
+    if (!activeFile?.path || externalMeshRefs.length === 0 || copyingMeshes) return
+    setCopyingMeshes(true)
+    try {
+      const rewrites: { ref: string; rel: string }[] = []
+      let failed = 0
+      const total = externalMeshRefs.length
+      for (const { ref, abs } of externalMeshRefs) {
+        setSavingLabel(`copying meshes… ${rewrites.length + failed + 1}/${total}`)
+        const res = await window.api.robot.importMesh(activeFile.path, abs)
+        if (res.error || !res.rel) {
+          failed += 1
+          continue
+        }
+        rewrites.push({ ref, rel: res.rel })
+      }
+      if (rewrites.length) {
+        // Rebase onto the CURRENT buffer (not the click-time snapshot) so an edit that
+        // landed during the async copies survives; the rewrites are keyed on the mesh
+        // ref, so applying them to the latest text is a no-op for any ref that changed.
+        let next = contentRef.current
+        for (const { ref, rel } of rewrites) next = rewriteMeshFilename(next, ref, rel)
+        commitUrdf(next) // one undoable step; pendingSaveRef → saveFile persists it
+      }
+      const done = rewrites.length
+      setSavingLabel(
+        failed === 0
+          ? `copied ${done} mesh${done === 1 ? '' : 'es'} into the project ✓`
+          : `copied ${done}, ${failed} couldn't be copied`
+      )
+    } catch (e) {
+      setSavingLabel(`copy failed: ${e instanceof Error ? e.message : 'error'}`)
+    } finally {
+      setCopyingMeshes(false)
     }
   }
 
@@ -3105,9 +3154,31 @@ export function RobotView({
             </div>
           )
         )}
-        {!error && meshNote && (
-          <div className="robotview__note" role="status">
-            {meshNote}
+        {!error && (meshNote || externalMeshRefs.length > 0) && (
+          <div className="robotview__notes">
+            {meshNote && (
+              <div className="robotview__note" role="status">
+                {meshNote}
+              </div>
+            )}
+            {externalMeshRefs.length > 0 && (
+              <div className="robotview__note robotview__note--offer" role="status">
+                <span>
+                  {externalMeshRefs.length} mesh{externalMeshRefs.length === 1 ? '' : 'es'} live
+                  outside this project and will go missing if it&apos;s moved.
+                </span>
+                <button
+                  type="button"
+                  className="robotview__note-action"
+                  onClick={handleCopyExternalMeshes}
+                  disabled={copyingMeshes}
+                >
+                  {copyingMeshes
+                    ? 'Copying…'
+                    : `Copy ${externalMeshRefs.length} mesh${externalMeshRefs.length === 1 ? '' : 'es'} into project`}
+                </button>
+              </div>
+            )}
           </div>
         )}
         {!isEmpty && !error && compact && (

--- a/src/renderer/src/components/robot-assembly.ts
+++ b/src/renderer/src/components/robot-assembly.ts
@@ -5,6 +5,7 @@
  * (no DOM) so they're cheap to unit-test in a node env.
  */
 import type { PrimitiveKind, Vec3 } from './robot-build'
+import { isExternalMeshRef, resolveMeshPath } from './robot-mesh'
 
 /**
  * A minimal, VALID starter URDF: one `base_link` with a small box so the pose
@@ -77,6 +78,21 @@ export function meshFiles(urdf: string): string[] {
     }
   }
   return out
+}
+
+/** The mesh refs that live OUTSIDE the URDF's folder (#407), each paired with its
+ *  resolved absolute path so the caller can copy the file in. In first-seen order. */
+export function externalMeshes(urdf: string, baseDir: string): { ref: string; abs: string }[] {
+  return meshFiles(urdf)
+    .filter((ref) => isExternalMeshRef(ref, baseDir))
+    .map((ref) => ({ ref, abs: resolveMeshPath(baseDir, ref) }))
+}
+
+/** Rewrite every `<mesh filename="oldRef">` to `newRel` (mirrors addMeshLink's
+ *  attribute form). Used after copying an external mesh into the project (#407). */
+export function rewriteMeshFilename(urdf: string, oldRef: string, newRel: string): string {
+  const re = new RegExp(`(<mesh\\b[^>]*\\bfilename\\s*=\\s*")${escapeRe(oldRef)}(")`, 'gi')
+  return urdf.replace(re, `$1${newRel}$2`)
 }
 
 /** The root link — one that is never a joint `child` (falls back to the first

--- a/src/renderer/src/components/robot-mesh.ts
+++ b/src/renderer/src/components/robot-mesh.ts
@@ -26,3 +26,67 @@ export function meshKind(path: string): 'stl' | 'dae' | null {
   const m = /\.(stl|dae)(?:$|[?#])/i.exec(path)
   return m ? (m[1].toLowerCase() as 'stl' | 'dae') : null
 }
+
+/** Whether a path is absolute — POSIX `/`, a Windows drive `C:\`/`C:/`, or a UNC
+ *  `\\server` — as opposed to a project-relative reference. */
+export function isAbsolutePath(p: string): boolean {
+  return /^(\/|[A-Za-z]:[/\\]|[/\\]{2})/.test(p)
+}
+
+/** Split off a path's absolute root marker (POSIX `/`, Windows `C:/`, UNC `//`),
+ *  returning the root and the remainder. An empty root means a relative path. */
+function splitRoot(p: string): { root: string; rest: string } {
+  if (/^[A-Za-z]:[/\\]/.test(p)) return { root: `${p.slice(0, 2)}/`, rest: p.slice(3) }
+  if (/^[/\\]{2}/.test(p)) return { root: '//', rest: p.slice(2) }
+  if (/^\//.test(p)) return { root: '/', rest: p.slice(1) }
+  return { root: '', rest: p }
+}
+
+/**
+ * Resolve a mesh reference against the URDF's folder into a normalised path
+ * (POSIX separators, `.`/`..` segments collapsed). An absolute ref resolves to
+ * itself; a relative one is joined onto `baseDir`. Any `?query`/`#frag` suffix is
+ * dropped. Pure string logic (no node `path`), so it runs in the renderer bundle
+ * and in unit tests alike.
+ */
+export function resolveMeshPath(baseDir: string, ref: string): string {
+  const clean = ref.replace(/[?#].*$/, '')
+  const combined = isAbsolutePath(clean) ? clean : `${baseDir}/${clean}`
+  const { root, rest } = splitRoot(combined)
+  const out: string[] = []
+  for (const seg of rest.split(/[/\\]+/)) {
+    if (seg === '' || seg === '.') continue
+    if (seg === '..') {
+      if (out.length && out[out.length - 1] !== '..') out.pop()
+      else if (!root) out.push('..') // a relative path may keep leading `..`
+    } else out.push(seg)
+  }
+  return root + out.join('/')
+}
+
+/**
+ * Whether a mesh ref is "external" to the URDF's folder — its resolved path lands
+ * OUTSIDE that folder's subtree (an absolute path elsewhere, or a relative one that
+ * escapes via `..`). Such refs go missing when the project is moved/shared. In-folder
+ * relatives, `package://` refs, and kinds we can't render (`.obj`/`.glb`) are NOT
+ * external (left untouched). Needs a known `baseDir`; returns false without one.
+ */
+export function isExternalMeshRef(ref: string, baseDir: string): boolean {
+  if (/^package:\/\//i.test(ref)) return false
+  if (!meshKind(ref)) return false
+  if (!baseDir) return false
+  const base = resolveMeshPath(baseDir, '.')
+  const resolved = resolveMeshPath(baseDir, ref)
+  return !isInSubtree(resolved, base)
+}
+
+/** Whether `p` is `base` or lives under it. Accepts a case-insensitive match too,
+ *  since Windows + the default macOS filesystem are case-insensitive (so an absolute
+ *  in-folder ref written in a different case still counts as in-folder, not external).
+ *  This only ever widens "in-folder", so it can never trigger a spurious copy. */
+function isInSubtree(p: string, base: string): boolean {
+  if (p === base || p.startsWith(`${base}/`)) return true
+  const pl = p.toLowerCase()
+  const bl = base.toLowerCase()
+  return pl === bl || pl.startsWith(`${bl}/`)
+}

--- a/test/robotAssembly.test.ts
+++ b/test/robotAssembly.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest'
 import {
   parseAssembly,
   meshFiles,
+  externalMeshes,
+  rewriteMeshFilename,
   rootLink,
   uniqueLinkName,
   addMeshLink,
@@ -459,5 +461,45 @@ describe('link colour — hardened edge cases (#405 review)', () => {
 </robot>`
     expect(collectLinkColors(u).sort()).toEqual(['#00ff00', '#ff0000'])
     expect(collectLinkColors(u, 'a')).toEqual(['#00ff00']) // a's own red excluded
+  })
+})
+
+describe('external meshes — copy-into-project helpers (#407)', () => {
+  const BASE = '/home/kev/proj'
+  const U = `<?xml version="1.0"?>
+<robot name="r">
+  <link name="a"><visual><geometry><mesh filename="meshes/inside.stl"/></geometry></visual></link>
+  <link name="b"><visual><geometry><mesh filename="../shared/arm.stl"/></geometry></visual></link>
+  <link name="c"><visual><geometry><mesh filename="/opt/parts/servo.dae"/></geometry></visual></link>
+  <link name="d"><visual><geometry><mesh filename="package://r/meshes/x.stl"/></geometry></visual></link>
+  <link name="e"><visual><geometry><mesh filename="../weird/body.obj"/></geometry></visual></link>
+</robot>`
+  it('externalMeshes returns only the out-of-folder stl/dae refs, with resolved abs paths', () => {
+    expect(externalMeshes(U, BASE)).toEqual([
+      { ref: '../shared/arm.stl', abs: '/home/kev/shared/arm.stl' },
+      { ref: '/opt/parts/servo.dae', abs: '/opt/parts/servo.dae' }
+      // meshes/inside.stl (in-folder), package:// and .obj are all excluded
+    ])
+  })
+  it('externalMeshes is empty when every mesh is already in-folder', () => {
+    const inFolder = `<robot name="r"><link name="a"><visual><geometry><mesh filename="meshes/x.stl"/></geometry></visual></link></robot>`
+    expect(externalMeshes(inFolder, BASE)).toEqual([])
+  })
+  it('rewriteMeshFilename swaps every matching <mesh filename>, leaving others', () => {
+    const out = rewriteMeshFilename(U, '../shared/arm.stl', 'meshes/arm.stl')
+    expect(out).toContain('<mesh filename="meshes/arm.stl"/>')
+    expect(out).not.toContain('../shared/arm.stl')
+    // untouched refs stay put
+    expect(out).toContain('<mesh filename="meshes/inside.stl"/>')
+    expect(out).toContain('<mesh filename="/opt/parts/servo.dae"/>')
+  })
+  it('rewriteMeshFilename replaces ALL occurrences of a shared ref (collision-safe copy → one rel)', () => {
+    const dup = `<robot name="r">
+  <link name="a"><visual><geometry><mesh filename="../m/x.stl"/></geometry></visual></link>
+  <link name="b"><visual><geometry><mesh filename="../m/x.stl"/></geometry></visual></link>
+</robot>`
+    const out = rewriteMeshFilename(dup, '../m/x.stl', 'meshes/x.stl')
+    expect((out.match(/meshes\/x\.stl/g) || []).length).toBe(2)
+    expect(out).not.toContain('../m/x.stl')
   })
 })

--- a/test/robotExternalMesh.e2e.test.ts
+++ b/test/robotExternalMesh.e2e.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+import { promises as fsp } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { basename, extname, join, dirname as pdir } from 'node:path'
+import { externalMeshes, rewriteMeshFilename } from '../src/renderer/src/components/robot-assembly'
+
+/**
+ * End-to-end (#407): the "copy external meshes into the project" flow exercised
+ * against a REAL filesystem. Replicates the main-process collision-safe copy
+ * (`copyIntoMeshes`) and the RobotView handler's loop (copy each external ref,
+ * rewrite each `<mesh filename>`, once), then proves the URDF is self-contained.
+ */
+
+// Mirror of src/main/robot/ipc.ts `copyIntoMeshes` — the code the IPC `src` branch runs.
+async function copyIntoMeshes(urdfPath: string, src: string): Promise<{ rel: string; name: string }> {
+  const meshesDir = join(pdir(urdfPath), 'meshes')
+  await fsp.mkdir(meshesDir, { recursive: true })
+  const ext = extname(src)
+  const stem = basename(src, ext)
+  let name = `${stem}${ext}`
+  let n = 1
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      await fsp.access(join(meshesDir, name))
+      name = `${stem}-${n++}${ext}`
+    } catch {
+      break
+    }
+  }
+  await fsp.copyFile(src, join(meshesDir, name))
+  return { rel: `meshes/${name}`, name }
+}
+
+describe('copy external meshes into the project — real fs round-trip (#407)', () => {
+  it('copies each out-of-folder mesh in + rewrites the URDF so nothing stays external', async () => {
+    const root = await fsp.mkdtemp(join(tmpdir(), 'snakie-407-'))
+    const proj = join(root, 'proj')
+    const shared = join(root, 'shared')
+    const opt = join(root, 'opt')
+    await fsp.mkdir(proj, { recursive: true })
+    await fsp.mkdir(shared, { recursive: true })
+    await fsp.mkdir(opt, { recursive: true })
+    // Two external meshes: one reached via `../` and one via an absolute path. One
+    // in-folder mesh that must be left alone.
+    await fsp.writeFile(join(shared, 'arm.stl'), 'ARM-BYTES')
+    await fsp.writeFile(join(opt, 'servo.stl'), 'SERVO-BYTES')
+    await fsp.mkdir(join(proj, 'meshes'), { recursive: true })
+    await fsp.writeFile(join(proj, 'meshes', 'base.stl'), 'BASE-BYTES')
+
+    const urdfPath = join(proj, 'robot.urdf')
+    const urdf = `<?xml version="1.0"?>
+<robot name="r">
+  <link name="base"><visual><geometry><mesh filename="meshes/base.stl"/></geometry></visual></link>
+  <link name="arm"><visual><geometry><mesh filename="../shared/arm.stl"/></geometry></visual></link>
+  <link name="servo"><visual><geometry><mesh filename="${join(opt, 'servo.stl')}"/></geometry></visual></link>
+</robot>`
+
+    // The handler's loop: resolve externals, copy each in, accumulate rewrites, one commit.
+    const externals = externalMeshes(urdf, proj)
+    expect(externals.map((e) => e.ref)).toEqual(['../shared/arm.stl', join(opt, 'servo.stl')])
+
+    let next = urdf
+    for (const { ref, abs } of externals) {
+      const { rel } = await copyIntoMeshes(urdfPath, abs)
+      next = rewriteMeshFilename(next, ref, rel)
+    }
+
+    // Files landed in the project's meshes/ with their bytes intact.
+    expect(await fsp.readFile(join(proj, 'meshes', 'arm.stl'), 'utf-8')).toBe('ARM-BYTES')
+    expect(await fsp.readFile(join(proj, 'meshes', 'servo.stl'), 'utf-8')).toBe('SERVO-BYTES')
+    // The URDF now points at in-project paths, and the in-folder ref is untouched.
+    expect(next).toContain('<mesh filename="meshes/arm.stl"/>')
+    expect(next).toContain('<mesh filename="meshes/servo.stl"/>')
+    expect(next).toContain('<mesh filename="meshes/base.stl"/>')
+    // Nothing is external any more → the offer clears.
+    expect(externalMeshes(next, proj)).toEqual([])
+
+    await fsp.rm(root, { recursive: true, force: true })
+  })
+
+  it('collision-safe copy: an external mesh whose name already exists lands beside it (-1)', async () => {
+    const root = await fsp.mkdtemp(join(tmpdir(), 'snakie-407b-'))
+    const proj = join(root, 'proj')
+    const other = join(root, 'other')
+    await fsp.mkdir(join(proj, 'meshes'), { recursive: true })
+    await fsp.mkdir(other, { recursive: true })
+    // A DIFFERENT arm.stl already sits in the project; the external one must not clobber it.
+    await fsp.writeFile(join(proj, 'meshes', 'arm.stl'), 'ORIGINAL')
+    await fsp.writeFile(join(other, 'arm.stl'), 'IMPORTED')
+
+    const urdfPath = join(proj, 'robot.urdf')
+    const { rel } = await copyIntoMeshes(urdfPath, join(other, 'arm.stl'))
+    expect(rel).toBe('meshes/arm-1.stl')
+    expect(await fsp.readFile(join(proj, 'meshes', 'arm.stl'), 'utf-8')).toBe('ORIGINAL')
+    expect(await fsp.readFile(join(proj, 'meshes', 'arm-1.stl'), 'utf-8')).toBe('IMPORTED')
+
+    await fsp.rm(root, { recursive: true, force: true })
+  })
+})

--- a/test/robotMesh.test.ts
+++ b/test/robotMesh.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { dirname, baseName, meshKind } from '../src/renderer/src/components/robot-mesh'
+import {
+  dirname,
+  baseName,
+  meshKind,
+  isAbsolutePath,
+  resolveMeshPath,
+  isExternalMeshRef
+} from '../src/renderer/src/components/robot-mesh'
 
 describe('robot-mesh path helpers (#319)', () => {
   it('dirname returns the folder (POSIX + Windows), empty at root', () => {
@@ -28,5 +35,55 @@ describe('robot-mesh path helpers (#319)', () => {
   it('meshKind tolerates a trailing query/fragment', () => {
     expect(meshKind('link.stl?v=2')).toBe('stl')
     expect(meshKind('body.dae#scene')).toBe('dae')
+  })
+})
+
+describe('mesh path resolution + external classification (#407)', () => {
+  it('isAbsolutePath spots POSIX, Windows-drive and UNC paths', () => {
+    expect(isAbsolutePath('/home/x.stl')).toBe(true)
+    expect(isAbsolutePath('C:\\r\\x.stl')).toBe(true)
+    expect(isAbsolutePath('C:/r/x.stl')).toBe(true)
+    expect(isAbsolutePath('\\\\srv\\share\\x.stl')).toBe(true)
+    expect(isAbsolutePath('meshes/x.stl')).toBe(false)
+    expect(isAbsolutePath('../x.stl')).toBe(false)
+  })
+
+  it('resolveMeshPath joins + normalises against the base (POSIX)', () => {
+    expect(resolveMeshPath('/home/kev/proj', 'meshes/x.stl')).toBe('/home/kev/proj/meshes/x.stl')
+    expect(resolveMeshPath('/home/kev/proj', './meshes/./x.stl')).toBe('/home/kev/proj/meshes/x.stl')
+    expect(resolveMeshPath('/home/kev/proj', '../shared/x.stl')).toBe('/home/kev/shared/x.stl')
+    expect(resolveMeshPath('/home/kev/proj', '/other/x.stl')).toBe('/other/x.stl') // absolute wins
+    expect(resolveMeshPath('/home/kev/proj', 'meshes/x.stl?v=2')).toBe('/home/kev/proj/meshes/x.stl')
+  })
+
+  it('resolveMeshPath handles Windows separators + drive roots', () => {
+    expect(resolveMeshPath('C:\\robots\\arm', 'meshes\\x.stl')).toBe('C:/robots/arm/meshes/x.stl')
+    expect(resolveMeshPath('C:\\robots\\arm', '..\\shared\\x.stl')).toBe('C:/robots/shared/x.stl')
+  })
+
+  it('isExternalMeshRef: in-folder relatives + package:// + unrenderable kinds are NOT external', () => {
+    const base = '/home/kev/proj'
+    expect(isExternalMeshRef('meshes/x.stl', base)).toBe(false)
+    expect(isExternalMeshRef('./x.dae', base)).toBe(false)
+    expect(isExternalMeshRef('package://robot/meshes/x.stl', base)).toBe(false)
+    expect(isExternalMeshRef('/home/kev/proj/meshes/x.stl', base)).toBe(false) // absolute, but inside
+    expect(isExternalMeshRef('../other/x.obj', base)).toBe(false) // .obj can't render → left untouched
+    expect(isExternalMeshRef('meshes/x.stl', '')).toBe(false) // no known folder → can't classify
+  })
+
+  it('isExternalMeshRef: paths escaping the folder subtree ARE external', () => {
+    const base = '/home/kev/proj'
+    expect(isExternalMeshRef('../shared/x.stl', base)).toBe(true)
+    expect(isExternalMeshRef('/elsewhere/x.stl', base)).toBe(true)
+    expect(isExternalMeshRef('/home/kev/proj-2/x.stl', base)).toBe(true) // sibling, not a prefix match
+    expect(isExternalMeshRef('../shared/x.dae', base)).toBe(true)
+  })
+
+  it('isExternalMeshRef: an absolute in-folder ref counts as in-folder despite case (Win/macOS FS)', () => {
+    // Case-insensitive filesystems: a differently-cased but in-folder absolute ref must
+    // NOT be flagged external (which would spuriously offer to copy an in-project file).
+    expect(isExternalMeshRef('/Users/kev/Proj/meshes/x.stl', '/Users/kev/proj')).toBe(false)
+    // …but a genuine sibling is still external (the trailing-slash guard holds under fold).
+    expect(isExternalMeshRef('/Users/kev/proj-backup/x.stl', '/Users/kev/proj')).toBe(true)
   })
 })


### PR DESCRIPTION
Closes #407.

## What
A saved `.urdf` that references STL/DAE meshes living **outside** its folder (absolute paths, or relatives escaping via `..`) silently loses those meshes the moment the project is moved, zipped, or shared. Robot View now:

- **Detects** external mesh refs on load and shows a non-blocking **"Copy N mesh(es) into project"** offer in the top-right note area.
- On accept, **copies** each file into the project's `meshes/` folder (collision-safe — never overwrites, appends `-1`, `-2`…) and **rewrites** the URDF to the in-project path, in **one undoable step** (persisted via the normal save path). The offer clears as the meshes re-resolve in-project.
- Leaves in-folder relatives, `package://` refs, and unrenderable `.obj`/`.glb` untouched. Only offered for a saved local `.urdf` — never the compact docked viewer or the bundled demo arm.

## How
- **`robot-mesh.ts`** — `isAbsolutePath`, `resolveMeshPath` (pure, separator-/`..`-aware, drops `?query`/`#frag`), `isExternalMeshRef` (in-subtree test; case-insensitive-aware so an absolute in-folder ref on Windows/macOS isn't misflagged).
- **`robot-assembly.ts`** — `externalMeshes(urdf, baseDir) → {ref, abs}[]` and `rewriteMeshFilename`.
- **IPC/preload** — `robot:importMesh` takes an optional `src` to skip the picker and copy a known file straight through the existing `copyIntoMeshes`.
- **`RobotView`** — `externalMeshRefs` memo (gated on `canImport`), the offer banner + button, and `handleCopyExternalMeshes` (copies each ref, applies all rewrites to the **current** buffer so an interleaved edit survives, commits once, reports mixed results).

## Verification
- `typecheck`, `lint` (only the pre-existing DriverInstallBanner warning), **1575 tests**, `build` — all green.
- Unit tests for path classification / `externalMeshes` / `rewriteMeshFilename`, **plus a real-filesystem e2e** proving the full round-trip: files copied with bytes intact, URDF rewritten to `meshes/…`, the offer clears, and a name collision lands as `arm-1.stl` without clobbering.
- Adversarial multi-agent review (ultracode) run against the ACs; its 4 findings (case-insensitive FS misclassification, a `pointer-events` regression on the click-through note, a stale-base rebase, and partial-failure messaging) are all fixed in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)