### PR TITLE
feat: widen the Robot View Build (Chain) dock so long STL names read (#408)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Add Joint tool stays, now purely for geometry (where parts meet + orientation).
 
 ### Changed
+- **Robot View — the Build (Chain) dock is a little wider (#399).** Bumped from `15.5rem`
+  to `17.5rem` (capped `min(18rem, 42vw)`) so long STL-derived link names like
+  `left_shoulder_bracket_v3` read in full in the Chain tree instead of being cut off by the
+  ellipsis. It still floats over the 3-D stage and never claims more than a modest slice on
+  narrow windows.
 - **Robot View — the pose sidebar is retired; posing moves to a popup (#312).** The
   old right-hand pose panel duplicated the build panel (assembly, servos, poses). It's
   gone: **pose the robot in a popup** — the build panel's **Poses → ＋ New pose** (or

--- a/src/renderer/src/components/RobotBuildPanel.css
+++ b/src/renderer/src/components/RobotBuildPanel.css
@@ -34,7 +34,11 @@
      bottom-left; the parts list scrolls if the robot has more blocks than fit. */
   max-height: calc(100% - 1rem);
   z-index: 4;
-  width: 15.5rem;
+  /* A little wider so STL-derived link names (e.g. left_shoulder_bracket_v3, plus
+     _2/_3 suffixes) read without the ellipsis; capped viewport-relative so on narrow
+     windows the floating dock still only claims a modest slice of the 3-D stage (#408). */
+  width: 17.5rem;
+  max-width: min(18rem, 42vw);
   display: flex;
   flex-direction: column;
   gap: 0.35rem;


### PR DESCRIPTION
Closes #408.

## What
The floating Build dock (the kinematic **Chain** tree) was `15.5rem` wide, so STL-derived link names — sanitized filenames like `left_shoulder_bracket_v3` plus `_2`/`_3` uniqueness suffixes — got chopped by the ellipsis and were hard to tell apart.

- Widened `.robotbuild__dock` to **`17.5rem`** with a viewport-relative cap **`max-width: min(18rem, 42vw)`**, so typical names read in full while the overlay still only claims a modest slice of the 3-D stage on narrow windows.
- The dock stays `position: absolute` and transparent (Fusion-style, each row carries its own backing), so widening only changes the overlay footprint — it never reflows or resizes the three.js canvas.
- The `.robotbuild__part-label` ellipsis + the full-name `title` tooltip stay as the fallback for genuinely extreme names. `max-height: calc(100% - 1rem)` scroll behaviour (no overlap with the bottom-left Help hint) is untouched.

One CSS knob, per the issue — no `ChainRow`/`INDENT`/markup changes.

## Verification
- `typecheck`, `lint` (only the pre-existing DriverInstallBanner warning), `build` — all green. No JS/logic touched.
- Unaffected across both skins (dark glass + `data-theme='skeuomorph'` parchment) since only width/max-width changed, not theming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)