### PR TITLE
feat: pose-preview dropdown in the docked mini Robot View, with smooth easing (#409)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Robot View — preview saved poses from the docked mini viewer (#399).** The compact Robot
+  View (above the instrument dock in Robot mode) gains a small **pose dropdown** (top-right,
+  beside the Home button) when the robot has saved poses. Pick one and the docked model
+  **eases smoothly** to that pose — a quick preview without opening the full pose tool. It's
+  view-only (never writes `robot.yml`), lists only poses that fit the displayed model, and
+  hides when there are none.
 - **Robot View — keep a robot's meshes with the project (#399).** When a `.urdf` points at
   STL/DAE meshes that live **outside** the project folder (an absolute path, or one that
   escapes via `..`), Robot View now shows a **"Copy N mesh(es) into project"** offer. Accepting

--- a/src/renderer/src/components/RobotView.css
+++ b/src/renderer/src/components/RobotView.css
@@ -166,6 +166,35 @@
   color: var(--accent-ink);
   border-color: var(--accent-ink);
 }
+/* Saved-pose preview dropdown in the compact/docked viewer (#409). Top-right, just
+   LEFT of the 24px Home button. Its width is capped so, growing leftward from the
+   right anchor, it can never reach the top-left New/Open/Pop-out action row on a
+   narrow dock. Mirrors the mini-home chrome: dark glass + skeuomorph parchment. */
+.robotview__minipose {
+  position: absolute;
+  top: 0.35rem;
+  right: calc(0.35rem + 24px + 0.3rem);
+  z-index: 2;
+  /* Reserve ~18rem at the left for the New/Open/Pop-out row (its emoji/symbol glyphs
+     render wide) + this control's right offset, so the dropdown's left edge stays
+     clear of the Pop-out button even on a narrow dock. */
+  max-width: min(9rem, calc(100% - 18rem));
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  font-size: 0.6rem;
+  color: var(--text, #cdd2d9);
+  background: rgba(20, 21, 24, 0.78);
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 5px;
+  padding: 0.18rem 0.3rem;
+  cursor: pointer;
+}
+:root[data-theme='skeuomorph'] .robotview__minipose {
+  background: rgba(231, 226, 211, 0.9);
+}
+.robotview__minipose:hover {
+  color: var(--accent-ink);
+  border-color: var(--accent-ink);
+}
 /* The ViewCube's own canvas is appended here (2× — was 96px). */
 .robotview__viewcube {
   width: 144px;

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -279,6 +279,56 @@ export function RobotView({
     setValues(nv)
   }
 
+  // Smoothly EASE the docked model from its current joints to a saved pose (#409),
+  // rather than snapping. Self-contained rAF (the scene renders every frame anyway),
+  // used only by the compact preview dropdown; the full pose tool's Recall stays
+  // instant. Re-picking mid-tween re-targets smoothly from the live joint angles.
+  const poseTweenRef = useRef<number | null>(null)
+  const smoothRecallPose = (pose: NamedPoseLike): void => {
+    const r = robotRef.current
+    if (!r) return
+    const target = { ...valuesRef.current }
+    for (const m of metaRef.current) {
+      if (!m.isMimic && typeof pose.values[m.name] === 'number') {
+        const lim = effectiveLimit(m, overridesRef.current[m.name])
+        target[m.name] = clamp(toNative(m.type, pose.values[m.name]), lim.lower, lim.upper)
+      }
+    }
+    const start: Record<string, number> = {}
+    for (const m of metaRef.current) {
+      if (m.isMimic) continue
+      const a = (r.joints?.[m.name] as { angle?: number } | undefined)?.angle
+      start[m.name] = typeof a === 'number' ? a : valuesRef.current[m.name] ?? 0
+    }
+    if (poseTweenRef.current !== null) cancelAnimationFrame(poseTweenRef.current)
+    const DURATION = 380
+    const t0 = performance.now()
+    // easeInOutCubic
+    const ease = (x: number): number => (x < 0.5 ? 4 * x * x * x : 1 - Math.pow(-2 * x + 2, 3) / 2)
+    const step = (): void => {
+      // Robot torn down / replaced (effect re-run or unmount) → abandon the tween.
+      if (robotRef.current !== r) {
+        poseTweenRef.current = null
+        return
+      }
+      const k = Math.min(1, (performance.now() - t0) / DURATION)
+      const e = ease(k)
+      for (const m of metaRef.current) {
+        if (m.isMimic) continue
+        const a = start[m.name] ?? 0
+        const b = target[m.name] ?? a
+        r.setJointValue(m.name, a + (b - a) * e)
+      }
+      if (k < 1) {
+        poseTweenRef.current = requestAnimationFrame(step)
+      } else {
+        poseTweenRef.current = null
+        setValues(target) // settle state so the next recall starts from the right base
+      }
+    }
+    poseTweenRef.current = requestAnimationFrame(step)
+  }
+
   const handleDeletePose = (name: string): void => {
     const next = poses.filter((p) => p.name !== name)
     setPoses(next)
@@ -1196,6 +1246,13 @@ export function RobotView({
   timelineRef.current = timeline
 
   const movableNames = jointMeta.filter((m) => !m.isMimic).map((m) => m.name)
+  // Poses that actually apply to the DISPLAYED robot — at least one of their joints
+  // exists here. Guards the compact dropdown against a robot.yml whose poses belong to
+  // a different model (e.g. RobotDockPanel's demo-arm fallback), where recall is a no-op
+  // and the list is confusing (#409). Empty ⇒ no dropdown.
+  const dockPoses = compact
+    ? poses.filter((p) => movableNames.some((n) => typeof p.values[n] === 'number'))
+    : []
 
   // Apply a sampled timeline frame to the robot IMPERATIVELY (mimics auto-follow).
   // `commitState` also pushes the sliders (only on scrub/stop — never per frame).
@@ -1996,6 +2053,36 @@ export function RobotView({
           links: Object.keys(robot.links).length
         })
         framePreservingCamera(robot) // frame a new robot; keep the camera on an edit
+
+        if (!poseUI) {
+          // DOCKED MINI VIEWER (#409): the pose-tool seeding below is gated to the full
+          // view, so seed the minimum the compact viewer needs to RECALL a saved pose —
+          // a live robot handle + movable-joint meta at a neutral rest — then load the
+          // saved poses for the dropdown. Preview-only: the compact view never writes
+          // robot.yml (create/rename/delete stay in the full pose tool).
+          const meta = extractJoints(robot)
+          robotRef.current = robot
+          const initial: Record<string, number> = {}
+          for (const m of meta) {
+            if (m.isMimic) continue
+            const v = clamp(0, m.lower, m.upper)
+            initial[m.name] = v
+            robot.setJointValue(m.name, v)
+          }
+          setJointMeta(meta)
+          setValues(initial)
+          setPoses([]) // clear synchronously so a model switch can't flash the old list
+          void (async () => {
+            try {
+              const def = await window.api.robot.load(currentFolder || undefined)
+              if (disposed || !robotRef.current) return
+              const ps = (def.robot ?? {}).poses
+              setPoses(Array.isArray(ps) ? ps : [])
+            } catch {
+              /* no robot.yml — nothing to recall */
+            }
+          })()
+        }
 
         if (poseUI) {
           // POSE TOOL (#312): expose the movable joints, seed a neutral pose, then
@@ -3200,6 +3287,29 @@ export function RobotView({
               />
             </svg>
           </button>
+        )}
+        {!isEmpty && !error && compact && dockPoses.length > 0 && (
+          // Saved-pose preview dropdown (#409). Controlled to "" so it resets to the
+          // placeholder after a pick — re-selecting the same pose re-applies it.
+          <select
+            className="robotview__minipose"
+            value=""
+            onChange={(e) => {
+              const p = dockPoses.find((x) => x.name === e.target.value)
+              if (p) smoothRecallPose(p)
+            }}
+            title="Preview a saved pose"
+            aria-label="Preview a saved pose"
+          >
+            <option value="" disabled>
+              Pose…
+            </option>
+            {dockPoses.map((p) => (
+              <option key={p.name} value={p.name}>
+                {p.name}
+              </option>
+            ))}
+          </select>
         )}
         {!isEmpty && !error && !compact && (
           <div className="robotview__navzone">


### PR DESCRIPTION
Closes #409.

## What
The full-screen pose tool can save named poses to `robot.yml`, but the compact/docked Robot View (above the instrument dock in Robot mode) couldn't recall them. This adds a small **pose dropdown** to the mini viewer:

- Appears **top-right, beside the Home button**, only when the robot has saved poses that fit the displayed model. Width-capped so it never overlaps the top-left New/Open/**Pop-out** actions.
- Picking a pose **eases the docked model smoothly** to it (easeInOutCubic, ~380 ms) instead of snapping; re-picking mid-transition re-targets smoothly.
- **Preview-only** — never writes `robot.yml` (create/rename/delete stay in the full pose tool).

## How
- **Compact seeding** — a small isolated `if (!poseUI)` block in the 3-D effect gives the docked viewer what recall needs: a live robot handle + movable-joint meta at a neutral rest, plus the `robot.yml` poses. The large editor-only `poseUI` block is left untouched. Poses reset synchronously on a model switch (no stale flash).
- **`smoothRecallPose`** — a self-contained `requestAnimationFrame` tween (the scene renders continuously) from the live joint angles to the clamped pose target; abandons if the robot is torn down. The full pose tool's Recall stays instant.
- **`dockPoses`** — filters to poses whose joints exist on the shown robot, so RobotDockPanel's demo-arm fallback (or any mismatch) doesn't list un-recallable poses.
- **`.robotview__minipose`** mirrors the mini-home chrome (dark + `skeuomorph`), `max-width: min(9rem, calc(100% - 18rem))`.

## Verification
- `typecheck`, `lint` (only the pre-existing DriverInstallBanner warning), **1575 tests**, `build` — all green.
- Adversarial multi-agent review (ultracode) against the ACs; its 3 findings (synchronous pose reset on model switch; demo-arm pose filtering) are fixed in this branch. Two follow-up UX refinements (top-right placement, smooth easing) folded in per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)