### PR TITLE
feat: link an STL to a library part — dragging it drops the mesh into the Robot View (#406)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
-- **Robot View — preview saved poses from the docked mini viewer (#399).** The compact Robot
+- **Parts Library — a part can carry a 3-D mesh that drops into the Robot View (#399).** A
+  library part can now link an **STL** (a relative `mesh:` filename in its folder, with
+  `meshUnits: mm`/`m` or a `meshScale`) the way it already carries an image, driver and help
+  doc. When you drag a mesh-linked part onto a design, its part is added to `robot.yml` as
+  before **and** its STL is copied into the project's URDF `meshes/` folder and dropped into
+  the 3-D **Robot View** as a loose part — staggered beside the base, ready to place and join,
+  with no manual import. If the project has no URDF yet, a blank one is created and linked.
+  The bundled **SG90 servo** ships a `model.stl` as the first mesh-linked part. Parts without a
+  mesh drop exactly as before.
   View (above the instrument dock in Robot mode) gains a small **pose dropdown** (top-right,
   beside the Home button) when the robot has saved poses. Pick one and the docked model
   **eases smoothly** to that pose — a quick preview without opening the full pose tool. It's

--- a/examples/parts/snakie-standard/sg90/model.stl
+++ b/examples/parts/snakie-standard/sg90/model.stl
@@ -1,0 +1,9788 @@
+solid ASCII
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   9.228633e+00 0.000000e+00 1.133657e+01
+      vertex   7.585252e+00 0.000000e+00 8.048468e+00
+      vertex   8.700000e+00 0.000000e+00 1.161815e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.700000e+00 0.000000e+00 1.161815e+01
+      vertex   7.585252e+00 0.000000e+00 8.048468e+00
+      vertex   7.270414e+00 0.000000e+00 8.252355e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.700000e+00 0.000000e+00 1.161815e+01
+      vertex   7.270414e+00 0.000000e+00 8.252355e+00
+      vertex   6.928141e+00 0.000000e+00 8.405793e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   9.228633e+00 0.000000e+00 1.133657e+01
+      vertex   9.727103e+00 0.000000e+00 1.100450e+01
+      vertex   7.585252e+00 0.000000e+00 8.048468e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.585252e+00 0.000000e+00 8.048468e+00
+      vertex   9.727103e+00 0.000000e+00 1.100450e+01
+      vertex   7.865278e+00 0.000000e+00 7.798910e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.865278e+00 0.000000e+00 7.798910e+00
+      vertex   9.727103e+00 0.000000e+00 1.100450e+01
+      vertex   1.019060e+01 0.000000e+00 1.062515e+01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.865278e+00 0.000000e+00 7.798910e+00
+      vertex   1.019060e+01 0.000000e+00 1.062515e+01
+      vertex   8.103927e+00 0.000000e+00 7.509531e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.103927e+00 0.000000e+00 7.509531e+00
+      vertex   1.019060e+01 0.000000e+00 1.062515e+01
+      vertex   1.061467e+01 0.000000e+00 1.020217e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.103927e+00 0.000000e+00 7.509531e+00
+      vertex   1.061467e+01 0.000000e+00 1.020217e+01
+      vertex   1.099520e+01 0.000000e+00 9.739639e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.103927e+00 0.000000e+00 7.509531e+00
+      vertex   1.099520e+01 0.000000e+00 9.739639e+00
+      vertex   8.295606e+00 0.000000e+00 7.187114e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.295606e+00 0.000000e+00 7.187114e+00
+      vertex   1.099520e+01 0.000000e+00 9.739639e+00
+      vertex   1.132855e+01 0.000000e+00 9.242021e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.295606e+00 0.000000e+00 7.187114e+00
+      vertex   1.132855e+01 0.000000e+00 9.242021e+00
+      vertex   8.435821e+00 0.000000e+00 6.839215e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.435821e+00 0.000000e+00 6.839215e+00
+      vertex   1.132855e+01 0.000000e+00 9.242021e+00
+      vertex   1.161148e+01 0.000000e+00 8.714110e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.435821e+00 0.000000e+00 6.839215e+00
+      vertex   1.161148e+01 0.000000e+00 8.714110e+00
+      vertex   1.184128e+01 0.000000e+00 8.160997e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.435821e+00 0.000000e+00 6.839215e+00
+      vertex   1.184128e+01 0.000000e+00 8.160997e+00
+      vertex   8.521287e+00 0.000000e+00 6.473991e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.521287e+00 0.000000e+00 6.473991e+00
+      vertex   1.184128e+01 0.000000e+00 8.160997e+00
+      vertex   1.201573e+01 0.000000e+00 7.588013e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.521287e+00 0.000000e+00 6.473991e+00
+      vertex   1.201573e+01 0.000000e+00 7.588013e+00
+      vertex   1.213314e+01 0.000000e+00 7.000684e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.521287e+00 0.000000e+00 6.473991e+00
+      vertex   1.213314e+01 0.000000e+00 7.000684e+00
+      vertex   8.550000e+00 0.000000e+00 6.100000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.550000e+00 0.000000e+00 6.100000e+00
+      vertex   1.213314e+01 0.000000e+00 7.000684e+00
+      vertex   1.219239e+01 0.000000e+00 6.404671e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.550000e+00 0.000000e+00 6.100000e+00
+      vertex   1.219239e+01 0.000000e+00 6.404671e+00
+      vertex   1.219290e+01 0.000000e+00 5.805721e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.219290e+01 0.000000e+00 5.805721e+00
+      vertex   1.213467e+01 0.000000e+00 5.209608e+00
+      vertex   8.550000e+00 0.000000e+00 6.100000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.550000e+00 0.000000e+00 6.100000e+00
+      vertex   1.213467e+01 0.000000e+00 5.209608e+00
+      vertex   8.521287e+00 0.000000e+00 5.726009e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.521287e+00 0.000000e+00 5.726009e+00
+      vertex   1.213467e+01 0.000000e+00 5.209608e+00
+      vertex   1.201826e+01 0.000000e+00 4.622079e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.521287e+00 0.000000e+00 5.726009e+00
+      vertex   1.201826e+01 0.000000e+00 4.622079e+00
+      vertex   1.184479e+01 0.000000e+00 4.048799e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.521287e+00 0.000000e+00 5.726009e+00
+      vertex   1.184479e+01 0.000000e+00 4.048799e+00
+      vertex   8.435821e+00 0.000000e+00 5.360785e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.435821e+00 0.000000e+00 5.360785e+00
+      vertex   1.184479e+01 0.000000e+00 4.048799e+00
+      vertex   1.161593e+01 0.000000e+00 3.495295e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.435821e+00 0.000000e+00 5.360785e+00
+      vertex   1.161593e+01 0.000000e+00 3.495295e+00
+      vertex   1.133390e+01 0.000000e+00 2.966902e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.435821e+00 0.000000e+00 5.360785e+00
+      vertex   1.133390e+01 0.000000e+00 2.966902e+00
+      vertex   8.295606e+00 0.000000e+00 5.012886e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.295606e+00 0.000000e+00 5.012886e+00
+      vertex   1.133390e+01 0.000000e+00 2.966902e+00
+      vertex   1.100141e+01 0.000000e+00 2.468716e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.295606e+00 0.000000e+00 5.012886e+00
+      vertex   1.100141e+01 0.000000e+00 2.468716e+00
+      vertex   8.103927e+00 0.000000e+00 4.690469e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.103927e+00 0.000000e+00 4.690469e+00
+      vertex   1.100141e+01 0.000000e+00 2.468716e+00
+      vertex   1.062166e+01 0.000000e+00 2.005539e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.103927e+00 0.000000e+00 4.690469e+00
+      vertex   1.062166e+01 0.000000e+00 2.005539e+00
+      vertex   1.019832e+01 0.000000e+00 1.581836e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.103927e+00 0.000000e+00 4.690469e+00
+      vertex   1.019832e+01 0.000000e+00 1.581836e+00
+      vertex   7.865278e+00 0.000000e+00 4.401090e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.865278e+00 0.000000e+00 4.401090e+00
+      vertex   1.019832e+01 0.000000e+00 1.581836e+00
+      vertex   9.735463e+00 0.000000e+00 1.201693e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.865278e+00 0.000000e+00 4.401090e+00
+      vertex   9.735463e+00 0.000000e+00 1.201693e+00
+      vertex   7.585252e+00 0.000000e+00 4.151532e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.585252e+00 0.000000e+00 4.151532e+00
+      vertex   9.735463e+00 0.000000e+00 1.201693e+00
+      vertex   9.237561e+00 0.000000e+00 8.687751e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.585252e+00 0.000000e+00 4.151532e+00
+      vertex   9.237561e+00 0.000000e+00 8.687751e-01
+      vertex   8.709409e+00 0.000000e+00 5.862911e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.585252e+00 0.000000e+00 4.151532e+00
+      vertex   8.709409e+00 0.000000e+00 5.862911e-01
+      vertex   7.270414e+00 0.000000e+00 3.947645e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.270414e+00 0.000000e+00 3.947645e+00
+      vertex   8.709409e+00 0.000000e+00 5.862911e-01
+      vertex   8.156100e+00 0.000000e+00 3.569647e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.270414e+00 0.000000e+00 3.947645e+00
+      vertex   8.156100e+00 0.000000e+00 3.569647e-01
+      vertex   6.928141e+00 0.000000e+00 3.794207e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.928141e+00 0.000000e+00 3.794207e+00
+      vertex   8.156100e+00 0.000000e+00 3.569647e-01
+      vertex   7.582968e+00 0.000000e+00 1.830069e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.928141e+00 0.000000e+00 3.794207e+00
+      vertex   7.582968e+00 0.000000e+00 1.830069e-01
+      vertex   6.566458e+00 0.000000e+00 3.694815e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.566458e+00 0.000000e+00 3.694815e+00
+      vertex   7.582968e+00 0.000000e+00 1.830069e-01
+      vertex   6.995538e+00 0.000000e+00 6.609487e-02
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.566458e+00 0.000000e+00 3.694815e+00
+      vertex   6.995538e+00 0.000000e+00 6.609487e-02
+      vertex   6.399475e+00 0.000000e+00 7.355697e-03
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.566458e+00 0.000000e+00 3.694815e+00
+      vertex   6.399475e+00 0.000000e+00 7.355697e-03
+      vertex   6.193842e+00 0.000000e+00 3.651798e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.193842e+00 0.000000e+00 3.651798e+00
+      vertex   6.399475e+00 0.000000e+00 7.355697e-03
+      vertex   5.800525e+00 0.000000e+00 7.355697e-03
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.193842e+00 0.000000e+00 3.651798e+00
+      vertex   5.800525e+00 0.000000e+00 7.355697e-03
+      vertex   5.819026e+00 0.000000e+00 3.666165e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.819026e+00 0.000000e+00 3.666165e+00
+      vertex   5.800525e+00 0.000000e+00 7.355697e-03
+      vertex   5.204462e+00 0.000000e+00 6.609487e-02
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.819026e+00 0.000000e+00 3.666165e+00
+      vertex   5.204462e+00 0.000000e+00 6.609487e-02
+      vertex   5.450795e+00 0.000000e+00 3.737579e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.450795e+00 0.000000e+00 3.737579e+00
+      vertex   5.204462e+00 0.000000e+00 6.609487e-02
+      vertex   4.617032e+00 0.000000e+00 1.830069e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.450795e+00 0.000000e+00 3.737579e+00
+      vertex   4.617032e+00 0.000000e+00 1.830069e-01
+      vertex   5.097782e+00 0.000000e+00 3.864366e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.097782e+00 0.000000e+00 3.864366e+00
+      vertex   4.617032e+00 0.000000e+00 1.830069e-01
+      vertex   4.043900e+00 0.000000e+00 3.569647e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.097782e+00 0.000000e+00 3.864366e+00
+      vertex   4.043900e+00 0.000000e+00 3.569647e-01
+      vertex   3.490591e+00 0.000000e+00 5.862911e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.097782e+00 0.000000e+00 3.864366e+00
+      vertex   3.490591e+00 0.000000e+00 5.862911e-01
+      vertex   4.768260e+00 0.000000e+00 4.043555e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.768260e+00 0.000000e+00 4.043555e+00
+      vertex   3.490591e+00 0.000000e+00 5.862911e-01
+      vertex   2.962439e+00 0.000000e+00 8.687751e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.768260e+00 0.000000e+00 4.043555e+00
+      vertex   2.962439e+00 0.000000e+00 8.687751e-01
+      vertex   4.469952e+00 0.000000e+00 4.270945e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.469952e+00 0.000000e+00 4.270945e+00
+      vertex   2.962439e+00 0.000000e+00 8.687751e-01
+      vertex   2.464537e+00 0.000000e+00 1.201693e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.469952e+00 0.000000e+00 4.270945e+00
+      vertex   2.464537e+00 0.000000e+00 1.201693e+00
+      vertex   4.209852e+00 0.000000e+00 4.541206e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.209852e+00 0.000000e+00 4.541206e+00
+      vertex   2.464537e+00 0.000000e+00 1.201693e+00
+      vertex   2.001684e+00 0.000000e+00 1.581836e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.209852e+00 0.000000e+00 4.541206e+00
+      vertex   2.001684e+00 0.000000e+00 1.581836e+00
+      vertex   1.578343e+00 0.000000e+00 2.005539e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.209852e+00 0.000000e+00 4.541206e+00
+      vertex   1.578343e+00 0.000000e+00 2.005539e+00
+      vertex   3.994054e+00 0.000000e+00 4.848004e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.994054e+00 0.000000e+00 4.848004e+00
+      vertex   1.578343e+00 0.000000e+00 2.005539e+00
+      vertex   1.198595e+00 0.000000e+00 2.468716e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.994054e+00 0.000000e+00 4.848004e+00
+      vertex   1.198595e+00 0.000000e+00 2.468716e+00
+      vertex   3.827619e+00 0.000000e+00 5.184148e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.827619e+00 0.000000e+00 5.184148e+00
+      vertex   1.198595e+00 0.000000e+00 2.468716e+00
+      vertex   8.661011e-01 0.000000e+00 2.966902e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.827619e+00 0.000000e+00 5.184148e+00
+      vertex   8.661011e-01 0.000000e+00 2.966902e+00
+      vertex   5.840676e-01 0.000000e+00 3.495295e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.827619e+00 0.000000e+00 5.184148e+00
+      vertex   5.840676e-01 0.000000e+00 3.495295e+00
+      vertex   3.714446e+00 0.000000e+00 5.541759e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.714446e+00 0.000000e+00 5.541759e+00
+      vertex   5.840676e-01 0.000000e+00 3.495295e+00
+      vertex   3.552132e-01 0.000000e+00 4.048799e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.714446e+00 0.000000e+00 5.541759e+00
+      vertex   3.552132e-01 0.000000e+00 4.048799e+00
+      vertex   1.817443e-01 0.000000e+00 4.622079e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.714446e+00 0.000000e+00 5.541759e+00
+      vertex   1.817443e-01 0.000000e+00 4.622079e+00
+      vertex   3.657189e+00 0.000000e+00 5.912454e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.657189e+00 0.000000e+00 5.912454e+00
+      vertex   1.817443e-01 0.000000e+00 4.622079e+00
+      vertex   6.533329e-02 0.000000e+00 5.209608e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.657189e+00 0.000000e+00 5.912454e+00
+      vertex   6.533329e-02 0.000000e+00 5.209608e+00
+      vertex   7.102500e-03 0.000000e+00 5.805721e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   3.657189e+00 0.000000e+00 5.912454e+00
+      vertex   7.102500e-03 0.000000e+00 5.805721e+00
+      vertex   3.657189e+00 0.000000e+00 6.287546e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.657189e+00 0.000000e+00 6.287546e+00
+      vertex   7.102500e-03 0.000000e+00 5.805721e+00
+      vertex   7.613325e-03 0.000000e+00 6.404671e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.657189e+00 0.000000e+00 6.287546e+00
+      vertex   7.613325e-03 0.000000e+00 6.404671e+00
+      vertex   6.686084e-02 0.000000e+00 7.000684e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.686084e-02 0.000000e+00 7.000684e+00
+      vertex   1.842738e-01 0.000000e+00 7.588013e+00
+      vertex   3.657189e+00 0.000000e+00 6.287546e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   3.657189e+00 0.000000e+00 6.287546e+00
+      vertex   1.842738e-01 0.000000e+00 7.588013e+00
+      vertex   3.714446e+00 0.000000e+00 6.658241e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.714446e+00 0.000000e+00 6.658241e+00
+      vertex   1.842738e-01 0.000000e+00 7.588013e+00
+      vertex   3.587204e-01 0.000000e+00 8.160997e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.714446e+00 0.000000e+00 6.658241e+00
+      vertex   3.587204e-01 0.000000e+00 8.160997e+00
+      vertex   5.885186e-01 0.000000e+00 8.714110e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   3.714446e+00 0.000000e+00 6.658241e+00
+      vertex   5.885186e-01 0.000000e+00 8.714110e+00
+      vertex   3.827619e+00 0.000000e+00 7.015852e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.827619e+00 0.000000e+00 7.015852e+00
+      vertex   5.885186e-01 0.000000e+00 8.714110e+00
+      vertex   8.714529e-01 0.000000e+00 9.242021e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.827619e+00 0.000000e+00 7.015852e+00
+      vertex   8.714529e-01 0.000000e+00 9.242021e+00
+      vertex   1.204796e+00 0.000000e+00 9.739639e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   3.827619e+00 0.000000e+00 7.015852e+00
+      vertex   1.204796e+00 0.000000e+00 9.739639e+00
+      vertex   3.994054e+00 0.000000e+00 7.351996e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.994054e+00 0.000000e+00 7.351996e+00
+      vertex   1.204796e+00 0.000000e+00 9.739639e+00
+      vertex   1.585333e+00 0.000000e+00 1.020217e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   3.994054e+00 0.000000e+00 7.351996e+00
+      vertex   1.585333e+00 0.000000e+00 1.020217e+01
+      vertex   4.209852e+00 0.000000e+00 7.658794e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.209852e+00 0.000000e+00 7.658794e+00
+      vertex   1.585333e+00 0.000000e+00 1.020217e+01
+      vertex   2.009397e+00 0.000000e+00 1.062515e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.209852e+00 0.000000e+00 7.658794e+00
+      vertex   2.009397e+00 0.000000e+00 1.062515e+01
+      vertex   2.472897e+00 0.000000e+00 1.100450e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   4.209852e+00 0.000000e+00 7.658794e+00
+      vertex   2.472897e+00 0.000000e+00 1.100450e+01
+      vertex   4.469952e+00 0.000000e+00 7.929055e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.469952e+00 0.000000e+00 7.929055e+00
+      vertex   2.472897e+00 0.000000e+00 1.100450e+01
+      vertex   2.971367e+00 0.000000e+00 1.133657e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   4.469952e+00 0.000000e+00 7.929055e+00
+      vertex   2.971367e+00 0.000000e+00 1.133657e+01
+      vertex   4.768260e+00 0.000000e+00 8.156445e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.768260e+00 0.000000e+00 8.156445e+00
+      vertex   2.971367e+00 0.000000e+00 1.133657e+01
+      vertex   3.500000e+00 0.000000e+00 1.161815e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   4.768260e+00 0.000000e+00 8.156445e+00
+      vertex   3.500000e+00 0.000000e+00 1.161815e+01
+      vertex   5.097782e+00 0.000000e+00 8.335634e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   5.097782e+00 0.000000e+00 8.335634e+00
+      vertex   3.500000e+00 0.000000e+00 1.161815e+01
+      vertex   5.450795e+00 0.000000e+00 8.462421e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   5.450795e+00 0.000000e+00 8.462421e+00
+      vertex   3.500000e+00 0.000000e+00 1.161815e+01
+      vertex   5.819026e+00 0.000000e+00 8.533835e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   5.819026e+00 0.000000e+00 8.533835e+00
+      vertex   3.500000e+00 0.000000e+00 1.161815e+01
+      vertex   6.193842e+00 0.000000e+00 8.548202e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.193842e+00 0.000000e+00 8.548202e+00
+      vertex   3.500000e+00 0.000000e+00 1.161815e+01
+      vertex   5.521446e+00 0.000000e+00 1.443481e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.193842e+00 0.000000e+00 8.548202e+00
+      vertex   5.521446e+00 0.000000e+00 1.443481e+01
+      vertex   5.905702e+00 0.000000e+00 1.449273e+01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.500000e+00 0.000000e+00 1.190000e+01
+      vertex   4.478927e+00 0.000000e+00 1.393276e+01
+      vertex   3.500000e+00 0.000000e+00 1.161815e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.500000e+00 0.000000e+00 1.161815e+01
+      vertex   4.478927e+00 0.000000e+00 1.393276e+01
+      vertex   4.800000e+00 0.000000e+00 1.415167e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.500000e+00 0.000000e+00 1.161815e+01
+      vertex   4.800000e+00 0.000000e+00 1.415167e+01
+      vertex   5.150113e+00 0.000000e+00 1.432027e+01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.529040e+00 0.000000e+00 1.228751e+01
+      vertex   3.615511e+00 0.000000e+00 1.266636e+01
+      vertex   3.500000e+00 0.000000e+00 1.190000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.500000e+00 0.000000e+00 1.190000e+01
+      vertex   3.615511e+00 0.000000e+00 1.266636e+01
+      vertex   3.757481e+00 0.000000e+00 1.302810e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.500000e+00 0.000000e+00 1.190000e+01
+      vertex   3.757481e+00 0.000000e+00 1.302810e+01
+      vertex   3.951779e+00 0.000000e+00 1.336463e+01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.951779e+00 0.000000e+00 1.336463e+01
+      vertex   4.194065e+00 0.000000e+00 1.366845e+01
+      vertex   3.500000e+00 0.000000e+00 1.190000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.500000e+00 0.000000e+00 1.190000e+01
+      vertex   4.194065e+00 0.000000e+00 1.366845e+01
+      vertex   4.478927e+00 0.000000e+00 1.393276e+01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.150113e+00 0.000000e+00 1.432027e+01
+      vertex   5.521446e+00 0.000000e+00 1.443481e+01
+      vertex   3.500000e+00 0.000000e+00 1.161815e+01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.905702e+00 0.000000e+00 1.449273e+01
+      vertex   6.294298e+00 0.000000e+00 1.449273e+01
+      vertex   6.193842e+00 0.000000e+00 8.548202e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.193842e+00 0.000000e+00 8.548202e+00
+      vertex   6.294298e+00 0.000000e+00 1.449273e+01
+      vertex   6.678554e+00 0.000000e+00 1.443481e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.193842e+00 0.000000e+00 8.548202e+00
+      vertex   6.678554e+00 0.000000e+00 1.443481e+01
+      vertex   8.700000e+00 0.000000e+00 1.161815e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.700000e+00 0.000000e+00 1.161815e+01
+      vertex   6.678554e+00 0.000000e+00 1.443481e+01
+      vertex   7.049887e+00 0.000000e+00 1.432027e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.700000e+00 0.000000e+00 1.161815e+01
+      vertex   7.049887e+00 0.000000e+00 1.432027e+01
+      vertex   7.400000e+00 0.000000e+00 1.415167e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.400000e+00 0.000000e+00 1.415167e+01
+      vertex   7.721073e+00 0.000000e+00 1.393276e+01
+      vertex   8.700000e+00 0.000000e+00 1.161815e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   8.700000e+00 0.000000e+00 1.161815e+01
+      vertex   7.721073e+00 0.000000e+00 1.393276e+01
+      vertex   8.700000e+00 0.000000e+00 1.190000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.700000e+00 0.000000e+00 1.190000e+01
+      vertex   7.721073e+00 0.000000e+00 1.393276e+01
+      vertex   8.005935e+00 0.000000e+00 1.366845e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.700000e+00 0.000000e+00 1.190000e+01
+      vertex   8.005935e+00 0.000000e+00 1.366845e+01
+      vertex   8.248221e+00 0.000000e+00 1.336463e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.248221e+00 0.000000e+00 1.336463e+01
+      vertex   8.442519e+00 0.000000e+00 1.302810e+01
+      vertex   8.700000e+00 0.000000e+00 1.190000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.700000e+00 0.000000e+00 1.190000e+01
+      vertex   8.442519e+00 0.000000e+00 1.302810e+01
+      vertex   8.584489e+00 0.000000e+00 1.266636e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.700000e+00 0.000000e+00 1.190000e+01
+      vertex   8.584489e+00 0.000000e+00 1.266636e+01
+      vertex   8.670960e+00 0.000000e+00 1.228751e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   6.928141e+00 0.000000e+00 8.405793e+00
+      vertex   6.566458e+00 0.000000e+00 8.505185e+00
+      vertex   8.700000e+00 0.000000e+00 1.161815e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.700000e+00 0.000000e+00 1.161815e+01
+      vertex   6.566458e+00 0.000000e+00 8.505185e+00
+      vertex   6.193842e+00 0.000000e+00 8.548202e+00
+    endloop
+  endfacet
+  facet normal -9.914449e-01 -1.305262e-01 -0.000000e+00
+    outer loop
+      vertex   6.600000e+00 -2.430000e+01 1.000000e-01
+      vertex   6.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   6.617037e+00 -2.442941e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal -9.914449e-01 -1.305262e-01 -0.000000e+00
+    outer loop
+      vertex   6.617037e+00 -2.442941e+01 1.000000e-01
+      vertex   6.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   6.617037e+00 -2.442941e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal -9.238795e-01 -3.826834e-01 -0.000000e+00
+    outer loop
+      vertex   6.617037e+00 -2.442941e+01 1.000000e-01
+      vertex   6.617037e+00 -2.442941e+01 0.000000e+00
+      vertex   6.666987e+00 -2.455000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal -9.238795e-01 -3.826834e-01 -0.000000e+00
+    outer loop
+      vertex   6.666987e+00 -2.455000e+01 1.000000e-01
+      vertex   6.617037e+00 -2.442941e+01 0.000000e+00
+      vertex   6.666987e+00 -2.455000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal -7.933533e-01 -6.087614e-01 -0.000000e+00
+    outer loop
+      vertex   6.666987e+00 -2.455000e+01 1.000000e-01
+      vertex   6.666987e+00 -2.455000e+01 0.000000e+00
+      vertex   6.746447e+00 -2.465355e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal -7.933533e-01 -6.087614e-01 -0.000000e+00
+    outer loop
+      vertex   6.746447e+00 -2.465355e+01 1.000000e-01
+      vertex   6.666987e+00 -2.455000e+01 0.000000e+00
+      vertex   6.746447e+00 -2.465355e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal -6.087614e-01 -7.933533e-01 -0.000000e+00
+    outer loop
+      vertex   6.746447e+00 -2.465355e+01 1.000000e-01
+      vertex   6.746447e+00 -2.465355e+01 0.000000e+00
+      vertex   6.850000e+00 -2.473301e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal -6.087614e-01 -7.933533e-01 -0.000000e+00
+    outer loop
+      vertex   6.850000e+00 -2.473301e+01 1.000000e-01
+      vertex   6.746447e+00 -2.465355e+01 0.000000e+00
+      vertex   6.850000e+00 -2.473301e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal -3.826834e-01 -9.238795e-01 -0.000000e+00
+    outer loop
+      vertex   6.850000e+00 -2.473301e+01 1.000000e-01
+      vertex   6.850000e+00 -2.473301e+01 0.000000e+00
+      vertex   6.970590e+00 -2.478296e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal -3.826834e-01 -9.238795e-01 -0.000000e+00
+    outer loop
+      vertex   6.970590e+00 -2.478296e+01 1.000000e-01
+      vertex   6.850000e+00 -2.473301e+01 0.000000e+00
+      vertex   6.970590e+00 -2.478296e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal -1.305262e-01 -9.914449e-01 -0.000000e+00
+    outer loop
+      vertex   6.970590e+00 -2.478296e+01 1.000000e-01
+      vertex   6.970590e+00 -2.478296e+01 0.000000e+00
+      vertex   7.100000e+00 -2.480000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal -1.305262e-01 -9.914449e-01 -0.000000e+00
+    outer loop
+      vertex   7.100000e+00 -2.480000e+01 1.000000e-01
+      vertex   6.970590e+00 -2.478296e+01 0.000000e+00
+      vertex   7.100000e+00 -2.480000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 1.305262e-01 -9.914449e-01 0.000000e+00
+    outer loop
+      vertex   7.100000e+00 -2.480000e+01 1.000000e-01
+      vertex   7.100000e+00 -2.480000e+01 0.000000e+00
+      vertex   7.229410e+00 -2.478296e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 1.305262e-01 -9.914449e-01 0.000000e+00
+    outer loop
+      vertex   7.229410e+00 -2.478296e+01 1.000000e-01
+      vertex   7.100000e+00 -2.480000e+01 0.000000e+00
+      vertex   7.229410e+00 -2.478296e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 3.826834e-01 -9.238795e-01 0.000000e+00
+    outer loop
+      vertex   7.229410e+00 -2.478296e+01 1.000000e-01
+      vertex   7.229410e+00 -2.478296e+01 0.000000e+00
+      vertex   7.350000e+00 -2.473301e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 3.826834e-01 -9.238795e-01 0.000000e+00
+    outer loop
+      vertex   7.350000e+00 -2.473301e+01 1.000000e-01
+      vertex   7.229410e+00 -2.478296e+01 0.000000e+00
+      vertex   7.350000e+00 -2.473301e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 6.087614e-01 -7.933533e-01 0.000000e+00
+    outer loop
+      vertex   7.350000e+00 -2.473301e+01 1.000000e-01
+      vertex   7.350000e+00 -2.473301e+01 0.000000e+00
+      vertex   7.453553e+00 -2.465355e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 6.087614e-01 -7.933533e-01 0.000000e+00
+    outer loop
+      vertex   7.453553e+00 -2.465355e+01 1.000000e-01
+      vertex   7.350000e+00 -2.473301e+01 0.000000e+00
+      vertex   7.453553e+00 -2.465355e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 7.933533e-01 -6.087614e-01 0.000000e+00
+    outer loop
+      vertex   7.453553e+00 -2.465355e+01 1.000000e-01
+      vertex   7.453553e+00 -2.465355e+01 0.000000e+00
+      vertex   7.533013e+00 -2.455000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 7.933533e-01 -6.087614e-01 0.000000e+00
+    outer loop
+      vertex   7.533013e+00 -2.455000e+01 1.000000e-01
+      vertex   7.453553e+00 -2.465355e+01 0.000000e+00
+      vertex   7.533013e+00 -2.455000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 9.238795e-01 -3.826834e-01 0.000000e+00
+    outer loop
+      vertex   7.533013e+00 -2.455000e+01 1.000000e-01
+      vertex   7.533013e+00 -2.455000e+01 0.000000e+00
+      vertex   7.582963e+00 -2.442941e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 9.238795e-01 -3.826834e-01 0.000000e+00
+    outer loop
+      vertex   7.582963e+00 -2.442941e+01 1.000000e-01
+      vertex   7.533013e+00 -2.455000e+01 0.000000e+00
+      vertex   7.582963e+00 -2.442941e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 9.914449e-01 -1.305262e-01 0.000000e+00
+    outer loop
+      vertex   7.582963e+00 -2.442941e+01 1.000000e-01
+      vertex   7.582963e+00 -2.442941e+01 0.000000e+00
+      vertex   7.600000e+00 -2.430000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 9.914449e-01 -1.305262e-01 0.000000e+00
+    outer loop
+      vertex   7.600000e+00 -2.430000e+01 1.000000e-01
+      vertex   7.582963e+00 -2.442941e+01 0.000000e+00
+      vertex   7.600000e+00 -2.430000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal -1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   7.600000e+00 -2.830000e+01 0.000000e+00
+      vertex   7.600000e+00 -2.430000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal -1.000000e+00 -0.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.600000e+00 -2.430000e+01 1.000000e-01
+      vertex   7.600000e+00 -2.830000e+01 0.000000e+00
+      vertex   7.600000e+00 -2.830000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 1.000000e+00 4.440892e-16 -0.000000e+00
+    outer loop
+      vertex   4.600000e+00 -2.830000e+01 0.000000e+00
+      vertex   4.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   4.600000e+00 -2.830000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 1.000000e+00 4.440892e-16 0.000000e+00
+    outer loop
+      vertex   4.600000e+00 -2.830000e+01 1.000000e-01
+      vertex   4.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   4.600000e+00 -2.430000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal -9.914449e-01 -1.305262e-01 -0.000000e+00
+    outer loop
+      vertex   4.600000e+00 -2.430000e+01 1.000000e-01
+      vertex   4.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   4.617037e+00 -2.442941e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal -9.914449e-01 -1.305262e-01 -0.000000e+00
+    outer loop
+      vertex   4.617037e+00 -2.442941e+01 1.000000e-01
+      vertex   4.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   4.617037e+00 -2.442941e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal -9.238795e-01 -3.826834e-01 -0.000000e+00
+    outer loop
+      vertex   4.617037e+00 -2.442941e+01 1.000000e-01
+      vertex   4.617037e+00 -2.442941e+01 0.000000e+00
+      vertex   4.666987e+00 -2.455000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal -9.238795e-01 -3.826834e-01 -0.000000e+00
+    outer loop
+      vertex   4.666987e+00 -2.455000e+01 1.000000e-01
+      vertex   4.617037e+00 -2.442941e+01 0.000000e+00
+      vertex   4.666987e+00 -2.455000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal -7.933534e-01 -6.087614e-01 -0.000000e+00
+    outer loop
+      vertex   4.666987e+00 -2.455000e+01 1.000000e-01
+      vertex   4.666987e+00 -2.455000e+01 0.000000e+00
+      vertex   4.746447e+00 -2.465355e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal -7.933534e-01 -6.087614e-01 7.046393e-15
+    outer loop
+      vertex   4.746447e+00 -2.465355e+01 1.000000e-01
+      vertex   4.666987e+00 -2.455000e+01 0.000000e+00
+      vertex   4.746447e+00 -2.465355e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal -6.087614e-01 -7.933533e-01 5.406888e-15
+    outer loop
+      vertex   4.746447e+00 -2.465355e+01 1.000000e-01
+      vertex   4.746447e+00 -2.465355e+01 0.000000e+00
+      vertex   4.850000e+00 -2.473301e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal -6.087614e-01 -7.933533e-01 5.406888e-15
+    outer loop
+      vertex   4.850000e+00 -2.473301e+01 1.000000e-01
+      vertex   4.746447e+00 -2.465355e+01 0.000000e+00
+      vertex   4.850000e+00 -2.473301e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal -3.826834e-01 -9.238795e-01 3.398912e-15
+    outer loop
+      vertex   4.850000e+00 -2.473301e+01 1.000000e-01
+      vertex   4.850000e+00 -2.473301e+01 0.000000e+00
+      vertex   4.970590e+00 -2.478296e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal -3.826834e-01 -9.238795e-01 3.398912e-15
+    outer loop
+      vertex   4.970590e+00 -2.478296e+01 1.000000e-01
+      vertex   4.850000e+00 -2.473301e+01 0.000000e+00
+      vertex   4.970590e+00 -2.478296e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal -1.305262e-01 -9.914449e-01 1.159306e-15
+    outer loop
+      vertex   4.970590e+00 -2.478296e+01 1.000000e-01
+      vertex   4.970590e+00 -2.478296e+01 0.000000e+00
+      vertex   5.100000e+00 -2.480000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal -1.305262e-01 -9.914449e-01 1.159306e-15
+    outer loop
+      vertex   5.100000e+00 -2.480000e+01 1.000000e-01
+      vertex   4.970590e+00 -2.478296e+01 0.000000e+00
+      vertex   5.100000e+00 -2.480000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 1.305262e-01 -9.914449e-01 -1.159305e-15
+    outer loop
+      vertex   5.100000e+00 -2.480000e+01 1.000000e-01
+      vertex   5.100000e+00 -2.480000e+01 0.000000e+00
+      vertex   5.229410e+00 -2.478296e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 1.305262e-01 -9.914449e-01 -2.318611e-15
+    outer loop
+      vertex   5.229410e+00 -2.478296e+01 1.000000e-01
+      vertex   5.100000e+00 -2.480000e+01 0.000000e+00
+      vertex   5.229410e+00 -2.478296e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 3.826834e-01 -9.238795e-01 -6.797823e-15
+    outer loop
+      vertex   5.229410e+00 -2.478296e+01 1.000000e-01
+      vertex   5.229410e+00 -2.478296e+01 0.000000e+00
+      vertex   5.350000e+00 -2.473301e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 3.826834e-01 -9.238795e-01 -3.398912e-15
+    outer loop
+      vertex   5.350000e+00 -2.473301e+01 1.000000e-01
+      vertex   5.229410e+00 -2.478296e+01 0.000000e+00
+      vertex   5.350000e+00 -2.473301e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 6.087614e-01 -7.933533e-01 -5.406888e-15
+    outer loop
+      vertex   5.350000e+00 -2.473301e+01 1.000000e-01
+      vertex   5.350000e+00 -2.473301e+01 0.000000e+00
+      vertex   5.453553e+00 -2.465355e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 6.087614e-01 -7.933533e-01 -5.406888e-15
+    outer loop
+      vertex   5.453553e+00 -2.465355e+01 1.000000e-01
+      vertex   5.350000e+00 -2.473301e+01 0.000000e+00
+      vertex   5.453553e+00 -2.465355e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 7.933533e-01 -6.087614e-01 -7.046393e-15
+    outer loop
+      vertex   5.453553e+00 -2.465355e+01 1.000000e-01
+      vertex   5.453553e+00 -2.465355e+01 0.000000e+00
+      vertex   5.533013e+00 -2.455000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 7.933533e-01 -6.087614e-01 0.000000e+00
+    outer loop
+      vertex   5.533013e+00 -2.455000e+01 1.000000e-01
+      vertex   5.453553e+00 -2.465355e+01 0.000000e+00
+      vertex   5.533013e+00 -2.455000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 9.238795e-01 -3.826834e-01 0.000000e+00
+    outer loop
+      vertex   5.533013e+00 -2.455000e+01 1.000000e-01
+      vertex   5.533013e+00 -2.455000e+01 0.000000e+00
+      vertex   5.582963e+00 -2.442941e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 9.238795e-01 -3.826834e-01 0.000000e+00
+    outer loop
+      vertex   5.582963e+00 -2.442941e+01 1.000000e-01
+      vertex   5.533013e+00 -2.455000e+01 0.000000e+00
+      vertex   5.582963e+00 -2.442941e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 9.914449e-01 -1.305262e-01 0.000000e+00
+    outer loop
+      vertex   5.582963e+00 -2.442941e+01 1.000000e-01
+      vertex   5.582963e+00 -2.442941e+01 0.000000e+00
+      vertex   5.600000e+00 -2.430000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 9.914449e-01 -1.305262e-01 0.000000e+00
+    outer loop
+      vertex   5.600000e+00 -2.430000e+01 1.000000e-01
+      vertex   5.582963e+00 -2.442941e+01 0.000000e+00
+      vertex   5.600000e+00 -2.430000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal -9.914449e-01 -1.305262e-01 -0.000000e+00
+    outer loop
+      vertex   5.600000e+00 -2.430000e+01 1.000000e-01
+      vertex   5.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   5.617037e+00 -2.442941e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal -9.914449e-01 -1.305262e-01 -0.000000e+00
+    outer loop
+      vertex   5.617037e+00 -2.442941e+01 1.000000e-01
+      vertex   5.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   5.617037e+00 -2.442941e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal -9.238795e-01 -3.826834e-01 -0.000000e+00
+    outer loop
+      vertex   5.617037e+00 -2.442941e+01 1.000000e-01
+      vertex   5.617037e+00 -2.442941e+01 0.000000e+00
+      vertex   5.666987e+00 -2.455000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal -9.238795e-01 -3.826834e-01 -0.000000e+00
+    outer loop
+      vertex   5.666987e+00 -2.455000e+01 1.000000e-01
+      vertex   5.617037e+00 -2.442941e+01 0.000000e+00
+      vertex   5.666987e+00 -2.455000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal -7.933533e-01 -6.087614e-01 -0.000000e+00
+    outer loop
+      vertex   5.666987e+00 -2.455000e+01 1.000000e-01
+      vertex   5.666987e+00 -2.455000e+01 0.000000e+00
+      vertex   5.746447e+00 -2.465355e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal -7.933533e-01 -6.087614e-01 -0.000000e+00
+    outer loop
+      vertex   5.746447e+00 -2.465355e+01 1.000000e-01
+      vertex   5.666987e+00 -2.455000e+01 0.000000e+00
+      vertex   5.746447e+00 -2.465355e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal -6.087614e-01 -7.933533e-01 -0.000000e+00
+    outer loop
+      vertex   5.746447e+00 -2.465355e+01 1.000000e-01
+      vertex   5.746447e+00 -2.465355e+01 0.000000e+00
+      vertex   5.850000e+00 -2.473301e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal -6.087614e-01 -7.933533e-01 -0.000000e+00
+    outer loop
+      vertex   5.850000e+00 -2.473301e+01 1.000000e-01
+      vertex   5.746447e+00 -2.465355e+01 0.000000e+00
+      vertex   5.850000e+00 -2.473301e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal -3.826834e-01 -9.238795e-01 -0.000000e+00
+    outer loop
+      vertex   5.850000e+00 -2.473301e+01 1.000000e-01
+      vertex   5.850000e+00 -2.473301e+01 0.000000e+00
+      vertex   5.970590e+00 -2.478296e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal -3.826834e-01 -9.238795e-01 -0.000000e+00
+    outer loop
+      vertex   5.970590e+00 -2.478296e+01 1.000000e-01
+      vertex   5.850000e+00 -2.473301e+01 0.000000e+00
+      vertex   5.970590e+00 -2.478296e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal -1.305262e-01 -9.914449e-01 -0.000000e+00
+    outer loop
+      vertex   5.970590e+00 -2.478296e+01 1.000000e-01
+      vertex   5.970590e+00 -2.478296e+01 0.000000e+00
+      vertex   6.100000e+00 -2.480000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal -1.305262e-01 -9.914449e-01 -0.000000e+00
+    outer loop
+      vertex   6.100000e+00 -2.480000e+01 1.000000e-01
+      vertex   5.970590e+00 -2.478296e+01 0.000000e+00
+      vertex   6.100000e+00 -2.480000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 1.305262e-01 -9.914449e-01 0.000000e+00
+    outer loop
+      vertex   6.100000e+00 -2.480000e+01 1.000000e-01
+      vertex   6.100000e+00 -2.480000e+01 0.000000e+00
+      vertex   6.229410e+00 -2.478296e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 1.305262e-01 -9.914449e-01 0.000000e+00
+    outer loop
+      vertex   6.229410e+00 -2.478296e+01 1.000000e-01
+      vertex   6.100000e+00 -2.480000e+01 0.000000e+00
+      vertex   6.229410e+00 -2.478296e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 3.826834e-01 -9.238795e-01 0.000000e+00
+    outer loop
+      vertex   6.229410e+00 -2.478296e+01 1.000000e-01
+      vertex   6.229410e+00 -2.478296e+01 0.000000e+00
+      vertex   6.350000e+00 -2.473301e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 3.826834e-01 -9.238795e-01 0.000000e+00
+    outer loop
+      vertex   6.350000e+00 -2.473301e+01 1.000000e-01
+      vertex   6.229410e+00 -2.478296e+01 0.000000e+00
+      vertex   6.350000e+00 -2.473301e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 6.087614e-01 -7.933533e-01 0.000000e+00
+    outer loop
+      vertex   6.350000e+00 -2.473301e+01 1.000000e-01
+      vertex   6.350000e+00 -2.473301e+01 0.000000e+00
+      vertex   6.453553e+00 -2.465355e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 6.087614e-01 -7.933533e-01 0.000000e+00
+    outer loop
+      vertex   6.453553e+00 -2.465355e+01 1.000000e-01
+      vertex   6.350000e+00 -2.473301e+01 0.000000e+00
+      vertex   6.453553e+00 -2.465355e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 7.933533e-01 -6.087614e-01 0.000000e+00
+    outer loop
+      vertex   6.453553e+00 -2.465355e+01 1.000000e-01
+      vertex   6.453553e+00 -2.465355e+01 0.000000e+00
+      vertex   6.533013e+00 -2.455000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 7.933533e-01 -6.087614e-01 0.000000e+00
+    outer loop
+      vertex   6.533013e+00 -2.455000e+01 1.000000e-01
+      vertex   6.453553e+00 -2.465355e+01 0.000000e+00
+      vertex   6.533013e+00 -2.455000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 9.238795e-01 -3.826834e-01 0.000000e+00
+    outer loop
+      vertex   6.533013e+00 -2.455000e+01 1.000000e-01
+      vertex   6.533013e+00 -2.455000e+01 0.000000e+00
+      vertex   6.582963e+00 -2.442941e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 9.238795e-01 -3.826834e-01 0.000000e+00
+    outer loop
+      vertex   6.582963e+00 -2.442941e+01 1.000000e-01
+      vertex   6.533013e+00 -2.455000e+01 0.000000e+00
+      vertex   6.582963e+00 -2.442941e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 9.914449e-01 -1.305262e-01 0.000000e+00
+    outer loop
+      vertex   6.582963e+00 -2.442941e+01 1.000000e-01
+      vertex   6.582963e+00 -2.442941e+01 0.000000e+00
+      vertex   6.600000e+00 -2.430000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 9.914449e-01 -1.305262e-01 0.000000e+00
+    outer loop
+      vertex   6.600000e+00 -2.430000e+01 1.000000e-01
+      vertex   6.582963e+00 -2.442941e+01 0.000000e+00
+      vertex   6.600000e+00 -2.430000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   5.600000e+00 -2.430000e+01 1.000000e-01
+      vertex   5.617037e+00 -2.442941e+01 1.000000e-01
+      vertex   5.582963e+00 -2.442941e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   5.582963e+00 -2.442941e+01 1.000000e-01
+      vertex   5.617037e+00 -2.442941e+01 1.000000e-01
+      vertex   5.666987e+00 -2.455000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   5.582963e+00 -2.442941e+01 1.000000e-01
+      vertex   5.666987e+00 -2.455000e+01 1.000000e-01
+      vertex   5.533013e+00 -2.455000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   5.533013e+00 -2.455000e+01 1.000000e-01
+      vertex   5.666987e+00 -2.455000e+01 1.000000e-01
+      vertex   5.746447e+00 -2.465355e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   5.533013e+00 -2.455000e+01 1.000000e-01
+      vertex   5.746447e+00 -2.465355e+01 1.000000e-01
+      vertex   5.453553e+00 -2.465355e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   5.453553e+00 -2.465355e+01 1.000000e-01
+      vertex   5.746447e+00 -2.465355e+01 1.000000e-01
+      vertex   5.850000e+00 -2.473301e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   5.453553e+00 -2.465355e+01 1.000000e-01
+      vertex   5.850000e+00 -2.473301e+01 1.000000e-01
+      vertex   5.350000e+00 -2.473301e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   5.350000e+00 -2.473301e+01 1.000000e-01
+      vertex   5.850000e+00 -2.473301e+01 1.000000e-01
+      vertex   5.970590e+00 -2.478296e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   5.350000e+00 -2.473301e+01 1.000000e-01
+      vertex   5.970590e+00 -2.478296e+01 1.000000e-01
+      vertex   5.229410e+00 -2.478296e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   5.229410e+00 -2.478296e+01 1.000000e-01
+      vertex   5.970590e+00 -2.478296e+01 1.000000e-01
+      vertex   4.600000e+00 -2.830000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   5.229410e+00 -2.478296e+01 1.000000e-01
+      vertex   4.600000e+00 -2.830000e+01 1.000000e-01
+      vertex   5.100000e+00 -2.480000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   5.100000e+00 -2.480000e+01 1.000000e-01
+      vertex   4.600000e+00 -2.830000e+01 1.000000e-01
+      vertex   4.970590e+00 -2.478296e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   4.970590e+00 -2.478296e+01 1.000000e-01
+      vertex   4.600000e+00 -2.830000e+01 1.000000e-01
+      vertex   4.850000e+00 -2.473301e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   4.850000e+00 -2.473301e+01 1.000000e-01
+      vertex   4.600000e+00 -2.830000e+01 1.000000e-01
+      vertex   4.746447e+00 -2.465355e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   4.746447e+00 -2.465355e+01 1.000000e-01
+      vertex   4.600000e+00 -2.830000e+01 1.000000e-01
+      vertex   4.666987e+00 -2.455000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   4.666987e+00 -2.455000e+01 1.000000e-01
+      vertex   4.600000e+00 -2.830000e+01 1.000000e-01
+      vertex   4.617037e+00 -2.442941e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   4.617037e+00 -2.442941e+01 1.000000e-01
+      vertex   4.600000e+00 -2.830000e+01 1.000000e-01
+      vertex   4.600000e+00 -2.430000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   5.970590e+00 -2.478296e+01 1.000000e-01
+      vertex   6.100000e+00 -2.480000e+01 1.000000e-01
+      vertex   4.600000e+00 -2.830000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   4.600000e+00 -2.830000e+01 1.000000e-01
+      vertex   6.100000e+00 -2.480000e+01 1.000000e-01
+      vertex   7.600000e+00 -2.830000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   7.600000e+00 -2.830000e+01 1.000000e-01
+      vertex   6.100000e+00 -2.480000e+01 1.000000e-01
+      vertex   6.229410e+00 -2.478296e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   7.600000e+00 -2.830000e+01 1.000000e-01
+      vertex   6.229410e+00 -2.478296e+01 1.000000e-01
+      vertex   6.970590e+00 -2.478296e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   6.970590e+00 -2.478296e+01 1.000000e-01
+      vertex   6.229410e+00 -2.478296e+01 1.000000e-01
+      vertex   6.850000e+00 -2.473301e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   6.850000e+00 -2.473301e+01 1.000000e-01
+      vertex   6.229410e+00 -2.478296e+01 1.000000e-01
+      vertex   6.350000e+00 -2.473301e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   6.850000e+00 -2.473301e+01 1.000000e-01
+      vertex   6.350000e+00 -2.473301e+01 1.000000e-01
+      vertex   6.746447e+00 -2.465355e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   6.746447e+00 -2.465355e+01 1.000000e-01
+      vertex   6.350000e+00 -2.473301e+01 1.000000e-01
+      vertex   6.453553e+00 -2.465355e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   6.746447e+00 -2.465355e+01 1.000000e-01
+      vertex   6.453553e+00 -2.465355e+01 1.000000e-01
+      vertex   6.666987e+00 -2.455000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   6.666987e+00 -2.455000e+01 1.000000e-01
+      vertex   6.453553e+00 -2.465355e+01 1.000000e-01
+      vertex   6.533013e+00 -2.455000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   6.666987e+00 -2.455000e+01 1.000000e-01
+      vertex   6.533013e+00 -2.455000e+01 1.000000e-01
+      vertex   6.617037e+00 -2.442941e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   6.617037e+00 -2.442941e+01 1.000000e-01
+      vertex   6.533013e+00 -2.455000e+01 1.000000e-01
+      vertex   6.582963e+00 -2.442941e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   6.617037e+00 -2.442941e+01 1.000000e-01
+      vertex   6.582963e+00 -2.442941e+01 1.000000e-01
+      vertex   6.600000e+00 -2.430000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   6.970590e+00 -2.478296e+01 1.000000e-01
+      vertex   7.100000e+00 -2.480000e+01 1.000000e-01
+      vertex   7.600000e+00 -2.830000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   7.600000e+00 -2.830000e+01 1.000000e-01
+      vertex   7.100000e+00 -2.480000e+01 1.000000e-01
+      vertex   7.229410e+00 -2.478296e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   7.600000e+00 -2.830000e+01 1.000000e-01
+      vertex   7.229410e+00 -2.478296e+01 1.000000e-01
+      vertex   7.350000e+00 -2.473301e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   7.350000e+00 -2.473301e+01 1.000000e-01
+      vertex   7.453553e+00 -2.465355e+01 1.000000e-01
+      vertex   7.600000e+00 -2.830000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   7.600000e+00 -2.830000e+01 1.000000e-01
+      vertex   7.453553e+00 -2.465355e+01 1.000000e-01
+      vertex   7.533013e+00 -2.455000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   7.600000e+00 -2.830000e+01 1.000000e-01
+      vertex   7.533013e+00 -2.455000e+01 1.000000e-01
+      vertex   7.582963e+00 -2.442941e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   7.582963e+00 -2.442941e+01 1.000000e-01
+      vertex   7.600000e+00 -2.430000e+01 1.000000e-01
+      vertex   7.600000e+00 -2.830000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.600000e+00 -2.830000e+01 0.000000e+00
+      vertex   4.600000e+00 -2.830000e+01 1.000000e-01
+      vertex   1.000000e+00 -2.830000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.000000e+00 -2.830000e+01 0.000000e+00
+      vertex   4.600000e+00 -2.830000e+01 1.000000e-01
+      vertex   0.000000e+00 -2.830000e+01 1.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.000000e+00 -2.830000e+01 0.000000e+00
+      vertex   0.000000e+00 -2.830000e+01 1.000000e+00
+      vertex   7.774791e-01 -2.830000e+01 2.507209e-02
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.774791e-01 -2.830000e+01 2.507209e-02
+      vertex   0.000000e+00 -2.830000e+01 1.000000e+00
+      vertex   5.661163e-01 -2.830000e+01 9.903113e-02
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.661163e-01 -2.830000e+01 9.903113e-02
+      vertex   0.000000e+00 -2.830000e+01 1.000000e+00
+      vertex   3.765102e-01 -2.830000e+01 2.181685e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.765102e-01 -2.830000e+01 2.181685e-01
+      vertex   0.000000e+00 -2.830000e+01 1.000000e+00
+      vertex   2.181685e-01 -2.830000e+01 3.765102e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   2.181685e-01 -2.830000e+01 3.765102e-01
+      vertex   0.000000e+00 -2.830000e+01 1.000000e+00
+      vertex   9.903113e-02 -2.830000e+01 5.661163e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   9.903113e-02 -2.830000e+01 5.661163e-01
+      vertex   0.000000e+00 -2.830000e+01 1.000000e+00
+      vertex   2.507209e-02 -2.830000e+01 7.774791e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.600000e+00 -2.830000e+01 1.000000e-01
+      vertex   1.000000e+00 -2.830000e+01 2.300000e+01
+      vertex   4.600000e+00 -2.830000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.600000e+00 -2.830000e+01 1.000000e-01
+      vertex   1.000000e+00 -2.830000e+01 2.300000e+01
+      vertex   0.000000e+00 -2.830000e+01 2.200000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.600000e+00 -2.830000e+01 1.000000e-01
+      vertex   0.000000e+00 -2.830000e+01 2.200000e+01
+      vertex   0.000000e+00 -2.830000e+01 1.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.600000e+00 -2.830000e+01 0.000000e+00
+      vertex   1.120000e+01 -2.830000e+01 0.000000e+00
+      vertex   7.600000e+00 -2.830000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.600000e+00 -2.830000e+01 1.000000e-01
+      vertex   1.120000e+01 -2.830000e+01 0.000000e+00
+      vertex   1.220000e+01 -2.830000e+01 1.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.600000e+00 -2.830000e+01 1.000000e-01
+      vertex   1.220000e+01 -2.830000e+01 1.000000e+00
+      vertex   1.220000e+01 -2.830000e+01 2.200000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.120000e+01 -2.830000e+01 0.000000e+00
+      vertex   1.142252e+01 -2.830000e+01 2.507209e-02
+      vertex   1.220000e+01 -2.830000e+01 1.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -2.830000e+01 1.000000e+00
+      vertex   1.142252e+01 -2.830000e+01 2.507209e-02
+      vertex   1.163388e+01 -2.830000e+01 9.903113e-02
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -2.830000e+01 1.000000e+00
+      vertex   1.163388e+01 -2.830000e+01 9.903113e-02
+      vertex   1.182349e+01 -2.830000e+01 2.181685e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.182349e+01 -2.830000e+01 2.181685e-01
+      vertex   1.198183e+01 -2.830000e+01 3.765102e-01
+      vertex   1.220000e+01 -2.830000e+01 1.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -2.830000e+01 1.000000e+00
+      vertex   1.198183e+01 -2.830000e+01 3.765102e-01
+      vertex   1.210097e+01 -2.830000e+01 5.661163e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -2.830000e+01 1.000000e+00
+      vertex   1.210097e+01 -2.830000e+01 5.661163e-01
+      vertex   1.217493e+01 -2.830000e+01 7.774791e-01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 -1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   1.217493e+01 -2.830000e+01 2.222252e+01
+      vertex   1.210097e+01 -2.830000e+01 2.243388e+01
+      vertex   1.220000e+01 -2.830000e+01 2.200000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -2.830000e+01 2.200000e+01
+      vertex   1.210097e+01 -2.830000e+01 2.243388e+01
+      vertex   1.198183e+01 -2.830000e+01 2.262349e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -2.830000e+01 2.200000e+01
+      vertex   1.198183e+01 -2.830000e+01 2.262349e+01
+      vertex   1.182349e+01 -2.830000e+01 2.278183e+01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 -1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   1.182349e+01 -2.830000e+01 2.278183e+01
+      vertex   1.163388e+01 -2.830000e+01 2.290097e+01
+      vertex   1.220000e+01 -2.830000e+01 2.200000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -2.830000e+01 2.200000e+01
+      vertex   1.163388e+01 -2.830000e+01 2.290097e+01
+      vertex   1.142252e+01 -2.830000e+01 2.297493e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -2.830000e+01 2.200000e+01
+      vertex   1.142252e+01 -2.830000e+01 2.297493e+01
+      vertex   1.120000e+01 -2.830000e+01 2.300000e+01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -2.830000e+01 2.200000e+01
+      vertex   1.120000e+01 -2.830000e+01 2.300000e+01
+      vertex   7.600000e+00 -2.830000e+01 1.000000e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.600000e+00 -2.830000e+01 1.000000e-01
+      vertex   1.120000e+01 -2.830000e+01 2.300000e+01
+      vertex   1.000000e+00 -2.830000e+01 2.300000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.000000e+00 -2.830000e+01 2.300000e+01
+      vertex   7.774791e-01 -2.830000e+01 2.297493e+01
+      vertex   0.000000e+00 -2.830000e+01 2.200000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -2.830000e+01 2.200000e+01
+      vertex   7.774791e-01 -2.830000e+01 2.297493e+01
+      vertex   5.661163e-01 -2.830000e+01 2.290097e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -2.830000e+01 2.200000e+01
+      vertex   5.661163e-01 -2.830000e+01 2.290097e+01
+      vertex   3.765102e-01 -2.830000e+01 2.278183e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.765102e-01 -2.830000e+01 2.278183e+01
+      vertex   2.181685e-01 -2.830000e+01 2.262349e+01
+      vertex   0.000000e+00 -2.830000e+01 2.200000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -2.830000e+01 2.200000e+01
+      vertex   2.181685e-01 -2.830000e+01 2.262349e+01
+      vertex   9.903113e-02 -2.830000e+01 2.243388e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -2.830000e+01 2.200000e+01
+      vertex   9.903113e-02 -2.830000e+01 2.243388e+01
+      vertex   2.507209e-02 -2.830000e+01 2.222252e+01
+    endloop
+  endfacet
+  facet normal -1.119645e-01 0.000000e+00 -9.937122e-01
+    outer loop
+      vertex   7.774791e-01 -2.830000e+01 2.507209e-02
+      vertex   7.774791e-01 -2.390000e+01 2.507209e-02
+      vertex   1.000000e+00 -2.830000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal -1.119645e-01 4.240799e-19 -9.937122e-01
+    outer loop
+      vertex   1.000000e+00 -2.830000e+01 0.000000e+00
+      vertex   7.774791e-01 -2.390000e+01 2.507209e-02
+      vertex   7.774791e-01 -1.950000e+01 2.507209e-02
+    endloop
+  endfacet
+  facet normal -1.119645e-01 0.000000e+00 -9.937122e-01
+    outer loop
+      vertex   1.000000e+00 -2.830000e+01 0.000000e+00
+      vertex   7.774791e-01 -1.950000e+01 2.507209e-02
+      vertex   1.000000e+00 -1.070000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal -1.119645e-01 4.240799e-19 -9.937122e-01
+    outer loop
+      vertex   1.000000e+00 -1.070000e+01 0.000000e+00
+      vertex   7.774791e-01 -1.950000e+01 2.507209e-02
+      vertex   7.774791e-01 -1.510000e+01 2.507209e-02
+    endloop
+  endfacet
+  facet normal -1.119645e-01 4.240799e-19 -9.937122e-01
+    outer loop
+      vertex   1.000000e+00 -1.070000e+01 0.000000e+00
+      vertex   7.774791e-01 -1.510000e+01 2.507209e-02
+      vertex   7.774791e-01 -1.070000e+01 2.507209e-02
+    endloop
+  endfacet
+  facet normal -3.302791e-01 -0.000000e+00 -9.438833e-01
+    outer loop
+      vertex   7.774791e-01 -1.070000e+01 2.507209e-02
+      vertex   7.774791e-01 -1.510000e+01 2.507209e-02
+      vertex   5.661163e-01 -1.070000e+01 9.903113e-02
+    endloop
+  endfacet
+  facet normal -3.302791e-01 5.954097e-18 -9.438833e-01
+    outer loop
+      vertex   5.661163e-01 -1.070000e+01 9.903113e-02
+      vertex   7.774791e-01 -1.510000e+01 2.507209e-02
+      vertex   5.661163e-01 -1.510000e+01 9.903113e-02
+    endloop
+  endfacet
+  facet normal -5.320321e-01 5.341209e-18 -8.467242e-01
+    outer loop
+      vertex   5.661163e-01 -1.070000e+01 9.903113e-02
+      vertex   5.661163e-01 -1.510000e+01 9.903113e-02
+      vertex   3.765102e-01 -1.070000e+01 2.181685e-01
+    endloop
+  endfacet
+  facet normal -5.320321e-01 -8.083206e-18 -8.467242e-01
+    outer loop
+      vertex   3.765102e-01 -1.070000e+01 2.181685e-01
+      vertex   5.661163e-01 -1.510000e+01 9.903113e-02
+      vertex   3.765102e-01 -1.510000e+01 2.181685e-01
+    endloop
+  endfacet
+  facet normal -7.071068e-01 -1.338147e-17 -7.071068e-01
+    outer loop
+      vertex   3.765102e-01 -1.070000e+01 2.181685e-01
+      vertex   3.765102e-01 -1.510000e+01 2.181685e-01
+      vertex   2.181685e-01 -1.070000e+01 3.765102e-01
+    endloop
+  endfacet
+  facet normal -7.071068e-01 1.784196e-17 -7.071068e-01
+    outer loop
+      vertex   2.181685e-01 -1.070000e+01 3.765102e-01
+      vertex   3.765102e-01 -1.510000e+01 2.181685e-01
+      vertex   2.181685e-01 -1.510000e+01 3.765102e-01
+    endloop
+  endfacet
+  facet normal -8.467242e-01 1.342442e-17 -5.320321e-01
+    outer loop
+      vertex   2.181685e-01 -1.070000e+01 3.765102e-01
+      vertex   2.181685e-01 -1.510000e+01 3.765102e-01
+      vertex   9.903113e-02 -1.070000e+01 5.661163e-01
+    endloop
+  endfacet
+  facet normal -8.467242e-01 -2.150762e-17 -5.320321e-01
+    outer loop
+      vertex   9.903113e-02 -1.070000e+01 5.661163e-01
+      vertex   2.181685e-01 -1.510000e+01 3.765102e-01
+      vertex   9.903113e-02 -1.510000e+01 5.661163e-01
+    endloop
+  endfacet
+  facet normal -9.438833e-01 -1.071333e-17 -3.302791e-01
+    outer loop
+      vertex   9.903113e-02 -1.070000e+01 5.661163e-01
+      vertex   9.903113e-02 -1.510000e+01 5.661163e-01
+      vertex   2.507209e-02 -1.070000e+01 7.774791e-01
+    endloop
+  endfacet
+  facet normal -9.438833e-01 -2.977048e-17 -3.302791e-01
+    outer loop
+      vertex   2.507209e-02 -1.070000e+01 7.774791e-01
+      vertex   9.903113e-02 -1.510000e+01 5.661163e-01
+      vertex   2.507209e-02 -1.510000e+01 7.774791e-01
+    endloop
+  endfacet
+  facet normal -9.937122e-01 -3.134211e-17 -1.119645e-01
+    outer loop
+      vertex   2.507209e-02 -1.070000e+01 7.774791e-01
+      vertex   2.507209e-02 -1.510000e+01 7.774791e-01
+      vertex   0.000000e+00 -1.070000e+01 1.000000e+00
+    endloop
+  endfacet
+  facet normal -9.937122e-01 2.546371e-19 -1.119645e-01
+    outer loop
+      vertex   0.000000e+00 -1.070000e+01 1.000000e+00
+      vertex   2.507209e-02 -1.510000e+01 7.774791e-01
+      vertex   2.507209e-02 -1.950000e+01 7.774791e-01
+    endloop
+  endfacet
+  facet normal -9.937122e-01 -0.000000e+00 -1.119645e-01
+    outer loop
+      vertex   0.000000e+00 -1.070000e+01 1.000000e+00
+      vertex   2.507209e-02 -1.950000e+01 7.774791e-01
+      vertex   0.000000e+00 -2.830000e+01 1.000000e+00
+    endloop
+  endfacet
+  facet normal -9.937122e-01 2.546371e-19 -1.119645e-01
+    outer loop
+      vertex   0.000000e+00 -2.830000e+01 1.000000e+00
+      vertex   2.507209e-02 -1.950000e+01 7.774791e-01
+      vertex   2.507209e-02 -2.390000e+01 7.774791e-01
+    endloop
+  endfacet
+  facet normal -9.937122e-01 1.592569e-17 -1.119645e-01
+    outer loop
+      vertex   0.000000e+00 -2.830000e+01 1.000000e+00
+      vertex   2.507209e-02 -2.390000e+01 7.774791e-01
+      vertex   2.507209e-02 -2.830000e+01 7.774791e-01
+    endloop
+  endfacet
+  facet normal -9.438833e-01 1.488524e-17 -3.302791e-01
+    outer loop
+      vertex   2.507209e-02 -2.830000e+01 7.774791e-01
+      vertex   2.507209e-02 -2.390000e+01 7.774791e-01
+      vertex   9.903113e-02 -2.830000e+01 5.661163e-01
+    endloop
+  endfacet
+  facet normal -9.438833e-01 2.262152e-17 -3.302791e-01
+    outer loop
+      vertex   9.903113e-02 -2.830000e+01 5.661163e-01
+      vertex   2.507209e-02 -2.390000e+01 7.774791e-01
+      vertex   9.903113e-02 -2.390000e+01 5.661163e-01
+    endloop
+  endfacet
+  facet normal -8.467242e-01 3.219004e-17 -5.320321e-01
+    outer loop
+      vertex   9.903113e-02 -2.830000e+01 5.661163e-01
+      vertex   9.903113e-02 -2.390000e+01 5.661163e-01
+      vertex   2.181685e-01 -2.830000e+01 3.765102e-01
+    endloop
+  endfacet
+  facet normal -8.467242e-01 1.068242e-17 -5.320321e-01
+    outer loop
+      vertex   2.181685e-01 -2.830000e+01 3.765102e-01
+      vertex   9.903113e-02 -2.390000e+01 5.661163e-01
+      vertex   2.181685e-01 -2.390000e+01 3.765102e-01
+    endloop
+  endfacet
+  facet normal -7.071068e-01 8.920980e-18 -7.071068e-01
+    outer loop
+      vertex   2.181685e-01 -2.830000e+01 3.765102e-01
+      vertex   2.181685e-01 -2.390000e+01 3.765102e-01
+      vertex   3.765102e-01 -2.830000e+01 2.181685e-01
+    endloop
+  endfacet
+  facet normal -7.071068e-01 -8.920980e-18 -7.071068e-01
+    outer loop
+      vertex   3.765102e-01 -2.830000e+01 2.181685e-01
+      vertex   2.181685e-01 -2.390000e+01 3.765102e-01
+      vertex   3.765102e-01 -2.390000e+01 2.181685e-01
+    endloop
+  endfacet
+  facet normal -5.320321e-01 -1.068242e-17 -8.467242e-01
+    outer loop
+      vertex   3.765102e-01 -2.830000e+01 2.181685e-01
+      vertex   3.765102e-01 -2.390000e+01 2.181685e-01
+      vertex   5.661163e-01 -2.830000e+01 9.903113e-02
+    endloop
+  endfacet
+  facet normal -5.320321e-01 5.341209e-18 -8.467242e-01
+    outer loop
+      vertex   5.661163e-01 -2.830000e+01 9.903113e-02
+      vertex   3.765102e-01 -2.390000e+01 2.181685e-01
+      vertex   5.661163e-01 -2.390000e+01 9.903113e-02
+    endloop
+  endfacet
+  facet normal -3.302791e-01 5.954097e-18 -9.438833e-01
+    outer loop
+      vertex   5.661163e-01 -2.830000e+01 9.903113e-02
+      vertex   5.661163e-01 -2.390000e+01 9.903113e-02
+      vertex   7.774791e-01 -2.830000e+01 2.507209e-02
+    endloop
+  endfacet
+  facet normal -3.302791e-01 0.000000e+00 -9.438833e-01
+    outer loop
+      vertex   7.774791e-01 -2.830000e+01 2.507209e-02
+      vertex   5.661163e-01 -2.390000e+01 9.903113e-02
+      vertex   7.774791e-01 -2.390000e+01 2.507209e-02
+    endloop
+  endfacet
+  facet normal -3.302791e-01 3.039598e-20 -9.438833e-01
+    outer loop
+      vertex   5.661163e-01 -1.510000e+01 9.903113e-02
+      vertex   7.774791e-01 -1.510000e+01 2.507209e-02
+      vertex   7.774791e-01 -1.950000e+01 2.507209e-02
+    endloop
+  endfacet
+  facet normal -3.302791e-01 -0.000000e+00 -9.438833e-01
+    outer loop
+      vertex   7.774791e-01 -1.950000e+01 2.507209e-02
+      vertex   7.774791e-01 -2.390000e+01 2.507209e-02
+      vertex   5.661163e-01 -1.950000e+01 9.903113e-02
+    endloop
+  endfacet
+  facet normal -3.302791e-01 -0.000000e+00 -9.438833e-01
+    outer loop
+      vertex   5.661163e-01 -1.950000e+01 9.903113e-02
+      vertex   7.774791e-01 -2.390000e+01 2.507209e-02
+      vertex   5.661163e-01 -2.390000e+01 9.903113e-02
+    endloop
+  endfacet
+  facet normal -5.320321e-01 -0.000000e+00 -8.467242e-01
+    outer loop
+      vertex   5.661163e-01 -1.950000e+01 9.903113e-02
+      vertex   5.661163e-01 -2.390000e+01 9.903113e-02
+      vertex   3.765102e-01 -1.950000e+01 2.181685e-01
+    endloop
+  endfacet
+  facet normal -5.320321e-01 2.670604e-17 -8.467242e-01
+    outer loop
+      vertex   3.765102e-01 -1.950000e+01 2.181685e-01
+      vertex   5.661163e-01 -2.390000e+01 9.903113e-02
+      vertex   3.765102e-01 -2.390000e+01 2.181685e-01
+    endloop
+  endfacet
+  facet normal -7.071068e-01 2.230245e-17 -7.071068e-01
+    outer loop
+      vertex   3.765102e-01 -1.950000e+01 2.181685e-01
+      vertex   3.765102e-01 -2.390000e+01 2.181685e-01
+      vertex   2.181685e-01 -1.950000e+01 3.765102e-01
+    endloop
+  endfacet
+  facet normal -7.071068e-01 -0.000000e+00 -7.071068e-01
+    outer loop
+      vertex   2.181685e-01 -1.950000e+01 3.765102e-01
+      vertex   3.765102e-01 -2.390000e+01 2.181685e-01
+      vertex   2.181685e-01 -2.390000e+01 3.765102e-01
+    endloop
+  endfacet
+  facet normal -8.467242e-01 -0.000000e+00 -5.320321e-01
+    outer loop
+      vertex   2.181685e-01 -1.950000e+01 3.765102e-01
+      vertex   2.181685e-01 -2.390000e+01 3.765102e-01
+      vertex   9.903113e-02 -1.950000e+01 5.661163e-01
+    endloop
+  endfacet
+  facet normal -8.467242e-01 -2.670604e-17 -5.320321e-01
+    outer loop
+      vertex   9.903113e-02 -1.950000e+01 5.661163e-01
+      vertex   2.181685e-01 -2.390000e+01 3.765102e-01
+      vertex   9.903113e-02 -2.390000e+01 5.661163e-01
+    endloop
+  endfacet
+  facet normal -9.438833e-01 -2.977048e-17 -3.302791e-01
+    outer loop
+      vertex   9.903113e-02 -1.950000e+01 5.661163e-01
+      vertex   9.903113e-02 -2.390000e+01 5.661163e-01
+      vertex   2.507209e-02 -1.950000e+01 7.774791e-01
+    endloop
+  endfacet
+  facet normal -9.438833e-01 -0.000000e+00 -3.302791e-01
+    outer loop
+      vertex   2.507209e-02 -1.950000e+01 7.774791e-01
+      vertex   9.903113e-02 -2.390000e+01 5.661163e-01
+      vertex   2.507209e-02 -2.390000e+01 7.774791e-01
+    endloop
+  endfacet
+  facet normal -5.320321e-01 -6.634496e-17 -8.467242e-01
+    outer loop
+      vertex   3.765102e-01 -1.510000e+01 2.181685e-01
+      vertex   5.661163e-01 -1.510000e+01 9.903113e-02
+      vertex   5.661163e-01 -1.950000e+01 9.903113e-02
+    endloop
+  endfacet
+  facet normal -3.302791e-01 -5.477163e-17 -9.438833e-01
+    outer loop
+      vertex   5.661163e-01 -1.950000e+01 9.903113e-02
+      vertex   5.661163e-01 -1.510000e+01 9.903113e-02
+      vertex   7.774791e-01 -1.950000e+01 2.507209e-02
+    endloop
+  endfacet
+  facet normal -5.320321e-01 -0.000000e+00 -8.467242e-01
+    outer loop
+      vertex   3.765102e-01 -1.510000e+01 2.181685e-01
+      vertex   5.661163e-01 -1.950000e+01 9.903113e-02
+      vertex   3.765102e-01 -1.950000e+01 2.181685e-01
+    endloop
+  endfacet
+  facet normal -7.071068e-01 -1.386255e-18 -7.071068e-01
+    outer loop
+      vertex   2.181685e-01 -1.510000e+01 3.765102e-01
+      vertex   3.765102e-01 -1.510000e+01 2.181685e-01
+      vertex   3.765102e-01 -1.950000e+01 2.181685e-01
+    endloop
+  endfacet
+  facet normal -7.071068e-01 -2.230245e-17 -7.071068e-01
+    outer loop
+      vertex   2.181685e-01 -1.510000e+01 3.765102e-01
+      vertex   3.765102e-01 -1.950000e+01 2.181685e-01
+      vertex   2.181685e-01 -1.950000e+01 3.765102e-01
+    endloop
+  endfacet
+  facet normal -8.467242e-01 -2.834724e-17 -5.320321e-01
+    outer loop
+      vertex   9.903113e-02 -1.510000e+01 5.661163e-01
+      vertex   2.181685e-01 -1.510000e+01 3.765102e-01
+      vertex   2.181685e-01 -1.950000e+01 3.765102e-01
+    endloop
+  endfacet
+  facet normal -8.467242e-01 2.684883e-17 -5.320321e-01
+    outer loop
+      vertex   9.903113e-02 -1.510000e+01 5.661163e-01
+      vertex   2.181685e-01 -1.950000e+01 3.765102e-01
+      vertex   9.903113e-02 -1.950000e+01 5.661163e-01
+    endloop
+  endfacet
+  facet normal -9.438833e-01 1.512939e-17 -3.302791e-01
+    outer loop
+      vertex   2.507209e-02 -1.510000e+01 7.774791e-01
+      vertex   9.903113e-02 -1.510000e+01 5.661163e-01
+      vertex   9.903113e-02 -1.950000e+01 5.661163e-01
+    endloop
+  endfacet
+  facet normal -9.438833e-01 -0.000000e+00 -3.302791e-01
+    outer loop
+      vertex   2.507209e-02 -1.510000e+01 7.774791e-01
+      vertex   9.903113e-02 -1.950000e+01 5.661163e-01
+      vertex   2.507209e-02 -1.950000e+01 7.774791e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   4.600000e+00 -2.830000e+01 0.000000e+00
+      vertex   1.000000e+00 -2.830000e+01 0.000000e+00
+      vertex   4.600000e+00 -2.430000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   4.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   1.000000e+00 -2.830000e+01 0.000000e+00
+      vertex   1.000000e+00 -1.070000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   4.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   1.000000e+00 -1.070000e+01 0.000000e+00
+      vertex   5.600000e+00 -2.430000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   5.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   1.000000e+00 -1.070000e+01 0.000000e+00
+      vertex   6.600000e+00 -2.430000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   5.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   6.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   6.100000e+00 -2.480000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   6.100000e+00 -2.480000e+01 0.000000e+00
+      vertex   6.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   6.229410e+00 -2.478296e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   6.229410e+00 -2.478296e+01 0.000000e+00
+      vertex   6.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   6.350000e+00 -2.473301e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   6.350000e+00 -2.473301e+01 0.000000e+00
+      vertex   6.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   6.453553e+00 -2.465355e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   6.453553e+00 -2.465355e+01 0.000000e+00
+      vertex   6.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   6.533013e+00 -2.455000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   6.533013e+00 -2.455000e+01 0.000000e+00
+      vertex   6.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   6.582963e+00 -2.442941e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   1.000000e+00 -1.070000e+01 0.000000e+00
+      vertex   1.120000e+01 -1.070000e+01 0.000000e+00
+      vertex   6.600000e+00 -2.430000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   6.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   1.120000e+01 -1.070000e+01 0.000000e+00
+      vertex   7.600000e+00 -2.430000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   6.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   7.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   7.100000e+00 -2.480000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   7.100000e+00 -2.480000e+01 0.000000e+00
+      vertex   7.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   7.229410e+00 -2.478296e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   7.229410e+00 -2.478296e+01 0.000000e+00
+      vertex   7.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   7.350000e+00 -2.473301e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   7.350000e+00 -2.473301e+01 0.000000e+00
+      vertex   7.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   7.453553e+00 -2.465355e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   7.453553e+00 -2.465355e+01 0.000000e+00
+      vertex   7.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   7.533013e+00 -2.455000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   7.533013e+00 -2.455000e+01 0.000000e+00
+      vertex   7.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   7.582963e+00 -2.442941e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   1.120000e+01 -1.070000e+01 0.000000e+00
+      vertex   1.120000e+01 -2.830000e+01 0.000000e+00
+      vertex   7.600000e+00 -2.430000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   7.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   1.120000e+01 -2.830000e+01 0.000000e+00
+      vertex   7.600000e+00 -2.830000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   7.100000e+00 -2.480000e+01 0.000000e+00
+      vertex   6.970590e+00 -2.478296e+01 0.000000e+00
+      vertex   6.600000e+00 -2.430000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   6.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   6.970590e+00 -2.478296e+01 0.000000e+00
+      vertex   6.850000e+00 -2.473301e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   6.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   6.850000e+00 -2.473301e+01 0.000000e+00
+      vertex   6.746447e+00 -2.465355e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   6.746447e+00 -2.465355e+01 0.000000e+00
+      vertex   6.666987e+00 -2.455000e+01 0.000000e+00
+      vertex   6.600000e+00 -2.430000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   6.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   6.666987e+00 -2.455000e+01 0.000000e+00
+      vertex   6.617037e+00 -2.442941e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   6.100000e+00 -2.480000e+01 0.000000e+00
+      vertex   5.970590e+00 -2.478296e+01 0.000000e+00
+      vertex   5.600000e+00 -2.430000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   5.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   5.970590e+00 -2.478296e+01 0.000000e+00
+      vertex   5.850000e+00 -2.473301e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   5.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   5.850000e+00 -2.473301e+01 0.000000e+00
+      vertex   5.746447e+00 -2.465355e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   5.746447e+00 -2.465355e+01 0.000000e+00
+      vertex   5.666987e+00 -2.455000e+01 0.000000e+00
+      vertex   5.600000e+00 -2.430000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   5.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   5.666987e+00 -2.455000e+01 0.000000e+00
+      vertex   5.617037e+00 -2.442941e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   5.582963e+00 -2.442941e+01 0.000000e+00
+      vertex   5.533013e+00 -2.455000e+01 0.000000e+00
+      vertex   5.600000e+00 -2.430000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   5.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   5.533013e+00 -2.455000e+01 0.000000e+00
+      vertex   5.453553e+00 -2.465355e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   5.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   5.453553e+00 -2.465355e+01 0.000000e+00
+      vertex   5.350000e+00 -2.473301e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   5.350000e+00 -2.473301e+01 0.000000e+00
+      vertex   5.229410e+00 -2.478296e+01 0.000000e+00
+      vertex   5.600000e+00 -2.430000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   5.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   5.229410e+00 -2.478296e+01 0.000000e+00
+      vertex   5.100000e+00 -2.480000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   5.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   5.100000e+00 -2.480000e+01 0.000000e+00
+      vertex   4.600000e+00 -2.430000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   4.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   5.100000e+00 -2.480000e+01 0.000000e+00
+      vertex   4.970590e+00 -2.478296e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   4.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   4.970590e+00 -2.478296e+01 0.000000e+00
+      vertex   4.850000e+00 -2.473301e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   4.850000e+00 -2.473301e+01 0.000000e+00
+      vertex   4.746447e+00 -2.465355e+01 0.000000e+00
+      vertex   4.600000e+00 -2.430000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   4.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   4.746447e+00 -2.465355e+01 0.000000e+00
+      vertex   4.666987e+00 -2.455000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   4.600000e+00 -2.430000e+01 0.000000e+00
+      vertex   4.666987e+00 -2.455000e+01 0.000000e+00
+      vertex   4.617037e+00 -2.442941e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal -9.937122e-01 0.000000e+00 -1.119645e-01
+    outer loop
+      vertex   0.000000e+00 -8.300000e+00 1.000000e+00
+      vertex   0.000000e+00 -4.200000e+00 1.000000e+00
+      vertex   2.507209e-02 -8.300000e+00 7.774791e-01
+    endloop
+  endfacet
+  facet normal -9.937122e-01 -1.681772e-17 -1.119645e-01
+    outer loop
+      vertex   2.507209e-02 -8.300000e+00 7.774791e-01
+      vertex   0.000000e+00 -4.200000e+00 1.000000e+00
+      vertex   2.507209e-02 -4.200000e+00 7.774791e-01
+    endloop
+  endfacet
+  facet normal -9.438833e-01 -1.597441e-17 -3.302791e-01
+    outer loop
+      vertex   2.507209e-02 -8.300000e+00 7.774791e-01
+      vertex   2.507209e-02 -4.200000e+00 7.774791e-01
+      vertex   9.903113e-02 -8.300000e+00 5.661163e-01
+    endloop
+  endfacet
+  facet normal -9.438833e-01 -1.282291e-18 -3.302791e-01
+    outer loop
+      vertex   9.903113e-02 -8.300000e+00 5.661163e-01
+      vertex   2.507209e-02 -4.200000e+00 7.774791e-01
+      vertex   9.903113e-02 -4.200000e+00 5.661163e-01
+    endloop
+  endfacet
+  facet normal -8.467242e-01 1.161729e-17 -5.320321e-01
+    outer loop
+      vertex   9.903113e-02 -8.300000e+00 5.661163e-01
+      vertex   9.903113e-02 -4.200000e+00 5.661163e-01
+      vertex   2.181685e-01 -8.300000e+00 3.765102e-01
+    endloop
+  endfacet
+  facet normal -8.467242e-01 -2.789397e-18 -5.320321e-01
+    outer loop
+      vertex   2.181685e-01 -8.300000e+00 3.765102e-01
+      vertex   9.903113e-02 -4.200000e+00 5.661163e-01
+      vertex   2.181685e-01 -4.200000e+00 3.765102e-01
+    endloop
+  endfacet
+  facet normal -7.071068e-01 4.786867e-18 -7.071068e-01
+    outer loop
+      vertex   2.181685e-01 -8.300000e+00 3.765102e-01
+      vertex   2.181685e-01 -4.200000e+00 3.765102e-01
+      vertex   3.765102e-01 -8.300000e+00 2.181685e-01
+    endloop
+  endfacet
+  facet normal -7.071068e-01 -1.678172e-32 -7.071068e-01
+    outer loop
+      vertex   3.765102e-01 -8.300000e+00 2.181685e-01
+      vertex   2.181685e-01 -4.200000e+00 3.765102e-01
+      vertex   3.765102e-01 -4.200000e+00 2.181685e-01
+    endloop
+  endfacet
+  facet normal -5.320321e-01 8.521425e-18 -8.467242e-01
+    outer loop
+      vertex   3.765102e-01 -8.300000e+00 2.181685e-01
+      vertex   3.765102e-01 -4.200000e+00 2.181685e-01
+      vertex   5.661163e-01 -8.300000e+00 9.903113e-02
+    endloop
+  endfacet
+  facet normal -5.320321e-01 -6.041615e-17 -8.467242e-01
+    outer loop
+      vertex   5.661163e-01 -8.300000e+00 9.903113e-02
+      vertex   3.765102e-01 -4.200000e+00 2.181685e-01
+      vertex   5.661163e-01 -4.200000e+00 9.903113e-02
+    endloop
+  endfacet
+  facet normal -3.302791e-01 -4.599978e-17 -9.438833e-01
+    outer loop
+      vertex   5.661163e-01 -8.300000e+00 9.903113e-02
+      vertex   5.661163e-01 -4.200000e+00 9.903113e-02
+      vertex   7.774791e-01 -8.300000e+00 2.507209e-02
+    endloop
+  endfacet
+  facet normal -3.302791e-01 0.000000e+00 -9.438833e-01
+    outer loop
+      vertex   7.774791e-01 -8.300000e+00 2.507209e-02
+      vertex   5.661163e-01 -4.200000e+00 9.903113e-02
+      vertex   7.774791e-01 -4.200000e+00 2.507209e-02
+    endloop
+  endfacet
+  facet normal -1.119645e-01 0.000000e+00 -9.937122e-01
+    outer loop
+      vertex   7.774791e-01 -8.300000e+00 2.507209e-02
+      vertex   7.774791e-01 -4.200000e+00 2.507209e-02
+      vertex   1.000000e+00 -8.300000e+00 0.000000e+00
+    endloop
+  endfacet
+  facet normal -1.119645e-01 0.000000e+00 -9.937122e-01
+    outer loop
+      vertex   1.000000e+00 -8.300000e+00 0.000000e+00
+      vertex   7.774791e-01 -4.200000e+00 2.507209e-02
+      vertex   1.000000e+00 -4.200000e+00 0.000000e+00
+    endloop
+  endfacet
+  facet normal 1.088454e-16 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   1.000000e+00 -4.200000e+00 0.000000e+00
+      vertex   6.100000e+00 -4.200000e+00 5.551115e-16
+      vertex   1.000000e+00 -8.300000e+00 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.353931e-16 -1.000000e+00
+    outer loop
+      vertex   1.000000e+00 -8.300000e+00 0.000000e+00
+      vertex   6.100000e+00 -4.200000e+00 5.551115e-16
+      vertex   1.120000e+01 -8.300000e+00 0.000000e+00
+    endloop
+  endfacet
+  facet normal -1.088454e-16 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   1.120000e+01 -8.300000e+00 0.000000e+00
+      vertex   6.100000e+00 -4.200000e+00 5.551115e-16
+      vertex   1.120000e+01 -4.200000e+00 0.000000e+00
+    endloop
+  endfacet
+  facet normal 3.749420e-15 1.000000e+00 -2.147963e-15
+    outer loop
+      vertex   7.774791e-01 -4.200000e+00 2.507209e-02
+      vertex   1.786649e+00 -4.200000e+00 1.786649e+00
+      vertex   1.000000e+00 -4.200000e+00 0.000000e+00
+    endloop
+  endfacet
+  facet normal -3.220475e-16 1.000000e+00 -3.553246e-16
+    outer loop
+      vertex   1.000000e+00 -4.200000e+00 0.000000e+00
+      vertex   1.786649e+00 -4.200000e+00 1.786649e+00
+      vertex   2.230201e+00 -4.200000e+00 1.384636e+00
+    endloop
+  endfacet
+  facet normal -2.867713e-16 1.000000e+00 -3.866663e-16
+    outer loop
+      vertex   1.000000e+00 -4.200000e+00 0.000000e+00
+      vertex   2.230201e+00 -4.200000e+00 1.384636e+00
+      vertex   2.711022e+00 -4.200000e+00 1.028035e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   7.774791e-01 -4.200000e+00 2.507209e-02
+      vertex   5.661163e-01 -4.200000e+00 9.903113e-02
+      vertex   1.786649e+00 -4.200000e+00 1.786649e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.786649e+00 -4.200000e+00 1.786649e+00
+      vertex   5.661163e-01 -4.200000e+00 9.903113e-02
+      vertex   3.765102e-01 -4.200000e+00 2.181685e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.786649e+00 -4.200000e+00 1.786649e+00
+      vertex   3.765102e-01 -4.200000e+00 2.181685e-01
+      vertex   2.181685e-01 -4.200000e+00 3.765102e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   2.181685e-01 -4.200000e+00 3.765102e-01
+      vertex   9.903113e-02 -4.200000e+00 5.661163e-01
+      vertex   1.786649e+00 -4.200000e+00 1.786649e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.786649e+00 -4.200000e+00 1.786649e+00
+      vertex   9.903113e-02 -4.200000e+00 5.661163e-01
+      vertex   2.507209e-02 -4.200000e+00 7.774791e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.786649e+00 -4.200000e+00 1.786649e+00
+      vertex   2.507209e-02 -4.200000e+00 7.774791e-01
+      vertex   0.000000e+00 -4.200000e+00 1.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -4.200000e+00 6.100000e+00
+      vertex   2.937317e-02 -4.200000e+00 5.502095e+00
+      vertex   0.000000e+00 -4.200000e+00 1.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -4.200000e+00 1.000000e+00
+      vertex   2.937317e-02 -4.200000e+00 5.502095e+00
+      vertex   1.172098e-01 -4.200000e+00 4.909949e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -4.200000e+00 1.000000e+00
+      vertex   1.172098e-01 -4.200000e+00 4.909949e+00
+      vertex   2.626640e-01 -4.200000e+00 4.329263e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   2.626640e-01 -4.200000e+00 4.329263e+00
+      vertex   4.643349e-01 -4.200000e+00 3.765631e+00
+      vertex   0.000000e+00 -4.200000e+00 1.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -4.200000e+00 1.000000e+00
+      vertex   4.643349e-01 -4.200000e+00 3.765631e+00
+      vertex   7.202803e-01 -4.200000e+00 3.224480e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -4.200000e+00 1.000000e+00
+      vertex   7.202803e-01 -4.200000e+00 3.224480e+00
+      vertex   1.028035e+00 -4.200000e+00 2.711022e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.028035e+00 -4.200000e+00 2.711022e+00
+      vertex   1.384636e+00 -4.200000e+00 2.230201e+00
+      vertex   0.000000e+00 -4.200000e+00 1.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -4.200000e+00 1.000000e+00
+      vertex   1.384636e+00 -4.200000e+00 2.230201e+00
+      vertex   1.786649e+00 -4.200000e+00 1.786649e+00
+    endloop
+  endfacet
+  facet normal -2.592317e-16 1.000000e+00 -4.325020e-16
+    outer loop
+      vertex   2.711022e+00 -4.200000e+00 1.028035e+00
+      vertex   3.224480e+00 -4.200000e+00 7.202803e-01
+      vertex   1.000000e+00 -4.200000e+00 0.000000e+00
+    endloop
+  endfacet
+  facet normal -2.370129e-16 1.000000e+00 -5.011216e-16
+    outer loop
+      vertex   1.000000e+00 -4.200000e+00 0.000000e+00
+      vertex   3.224480e+00 -4.200000e+00 7.202803e-01
+      vertex   3.765631e+00 -4.200000e+00 4.643349e-01
+    endloop
+  endfacet
+  facet normal -2.185823e-16 1.000000e+00 -6.108965e-16
+    outer loop
+      vertex   1.000000e+00 -4.200000e+00 0.000000e+00
+      vertex   3.765631e+00 -4.200000e+00 4.643349e-01
+      vertex   4.329263e+00 -4.200000e+00 2.626640e-01
+    endloop
+  endfacet
+  facet normal -2.028788e-16 1.000000e+00 -8.099376e-16
+    outer loop
+      vertex   4.329263e+00 -4.200000e+00 2.626640e-01
+      vertex   4.909949e+00 -4.200000e+00 1.172098e-01
+      vertex   1.000000e+00 -4.200000e+00 0.000000e+00
+    endloop
+  endfacet
+  facet normal -1.889696e-16 1.000000e+00 -1.273929e-15
+    outer loop
+      vertex   1.000000e+00 -4.200000e+00 0.000000e+00
+      vertex   4.909949e+00 -4.200000e+00 1.172098e-01
+      vertex   5.502095e+00 -4.200000e+00 2.937317e-02
+    endloop
+  endfacet
+  facet normal -1.741526e-16 1.000000e+00 -3.544958e-15
+    outer loop
+      vertex   1.000000e+00 -4.200000e+00 0.000000e+00
+      vertex   5.502095e+00 -4.200000e+00 2.937317e-02
+      vertex   6.100000e+00 -4.200000e+00 5.551115e-16
+    endloop
+  endfacet
+  facet normal 1.119645e-01 0.000000e+00 -9.937122e-01
+    outer loop
+      vertex   1.120000e+01 -8.300000e+00 0.000000e+00
+      vertex   1.120000e+01 -4.200000e+00 0.000000e+00
+      vertex   1.142252e+01 -8.300000e+00 2.507209e-02
+    endloop
+  endfacet
+  facet normal 1.119645e-01 0.000000e+00 -9.937122e-01
+    outer loop
+      vertex   1.142252e+01 -8.300000e+00 2.507209e-02
+      vertex   1.120000e+01 -4.200000e+00 0.000000e+00
+      vertex   1.142252e+01 -4.200000e+00 2.507209e-02
+    endloop
+  endfacet
+  facet normal 3.302791e-01 0.000000e+00 -9.438833e-01
+    outer loop
+      vertex   1.142252e+01 -8.300000e+00 2.507209e-02
+      vertex   1.142252e+01 -4.200000e+00 2.507209e-02
+      vertex   1.163388e+01 -8.300000e+00 9.903113e-02
+    endloop
+  endfacet
+  facet normal 3.302791e-01 0.000000e+00 -9.438833e-01
+    outer loop
+      vertex   1.163388e+01 -8.300000e+00 9.903113e-02
+      vertex   1.142252e+01 -4.200000e+00 2.507209e-02
+      vertex   1.163388e+01 -4.200000e+00 9.903113e-02
+    endloop
+  endfacet
+  facet normal 5.320321e-01 0.000000e+00 -8.467242e-01
+    outer loop
+      vertex   1.163388e+01 -8.300000e+00 9.903113e-02
+      vertex   1.163388e+01 -4.200000e+00 9.903113e-02
+      vertex   1.182349e+01 -8.300000e+00 2.181685e-01
+    endloop
+  endfacet
+  facet normal 5.320321e-01 0.000000e+00 -8.467242e-01
+    outer loop
+      vertex   1.182349e+01 -8.300000e+00 2.181685e-01
+      vertex   1.163388e+01 -4.200000e+00 9.903113e-02
+      vertex   1.182349e+01 -4.200000e+00 2.181685e-01
+    endloop
+  endfacet
+  facet normal 7.071068e-01 0.000000e+00 -7.071068e-01
+    outer loop
+      vertex   1.182349e+01 -8.300000e+00 2.181685e-01
+      vertex   1.182349e+01 -4.200000e+00 2.181685e-01
+      vertex   1.198183e+01 -8.300000e+00 3.765102e-01
+    endloop
+  endfacet
+  facet normal 7.071068e-01 0.000000e+00 -7.071068e-01
+    outer loop
+      vertex   1.198183e+01 -8.300000e+00 3.765102e-01
+      vertex   1.182349e+01 -4.200000e+00 2.181685e-01
+      vertex   1.198183e+01 -4.200000e+00 3.765102e-01
+    endloop
+  endfacet
+  facet normal 8.467242e-01 0.000000e+00 -5.320321e-01
+    outer loop
+      vertex   1.198183e+01 -8.300000e+00 3.765102e-01
+      vertex   1.198183e+01 -4.200000e+00 3.765102e-01
+      vertex   1.210097e+01 -8.300000e+00 5.661163e-01
+    endloop
+  endfacet
+  facet normal 8.467242e-01 0.000000e+00 -5.320321e-01
+    outer loop
+      vertex   1.210097e+01 -8.300000e+00 5.661163e-01
+      vertex   1.198183e+01 -4.200000e+00 3.765102e-01
+      vertex   1.210097e+01 -4.200000e+00 5.661163e-01
+    endloop
+  endfacet
+  facet normal 9.438833e-01 0.000000e+00 -3.302791e-01
+    outer loop
+      vertex   1.210097e+01 -8.300000e+00 5.661163e-01
+      vertex   1.210097e+01 -4.200000e+00 5.661163e-01
+      vertex   1.217493e+01 -8.300000e+00 7.774791e-01
+    endloop
+  endfacet
+  facet normal 9.438833e-01 0.000000e+00 -3.302791e-01
+    outer loop
+      vertex   1.217493e+01 -8.300000e+00 7.774791e-01
+      vertex   1.210097e+01 -4.200000e+00 5.661163e-01
+      vertex   1.217493e+01 -4.200000e+00 7.774791e-01
+    endloop
+  endfacet
+  facet normal 9.937122e-01 0.000000e+00 -1.119645e-01
+    outer loop
+      vertex   1.217493e+01 -8.300000e+00 7.774791e-01
+      vertex   1.217493e+01 -4.200000e+00 7.774791e-01
+      vertex   1.220000e+01 -8.300000e+00 1.000000e+00
+    endloop
+  endfacet
+  facet normal 9.937122e-01 0.000000e+00 -1.119645e-01
+    outer loop
+      vertex   1.220000e+01 -8.300000e+00 1.000000e+00
+      vertex   1.217493e+01 -4.200000e+00 7.774791e-01
+      vertex   1.220000e+01 -4.200000e+00 1.000000e+00
+    endloop
+  endfacet
+  facet normal 1.000000e+00 0.000000e+00 -0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -8.300000e+00 -4.000000e+00
+      vertex   1.220000e+01 -8.300000e+00 1.000000e+00
+      vertex   1.220000e+01 -1.070000e+01 -4.000000e+00
+    endloop
+  endfacet
+  facet normal 1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -1.070000e+01 -4.000000e+00
+      vertex   1.220000e+01 -8.300000e+00 1.000000e+00
+      vertex   1.220000e+01 -1.070000e+01 1.000000e+00
+    endloop
+  endfacet
+  facet normal 1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -1.070000e+01 1.000000e+00
+      vertex   1.220000e+01 -8.300000e+00 1.000000e+00
+      vertex   1.220000e+01 -4.200000e+00 6.100000e+00
+    endloop
+  endfacet
+  facet normal 1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -1.070000e+01 1.000000e+00
+      vertex   1.220000e+01 -4.200000e+00 6.100000e+00
+      vertex   1.220000e+01 -1.070000e+01 2.200000e+01
+    endloop
+  endfacet
+  facet normal 1.000000e+00 -0.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -1.070000e+01 2.200000e+01
+      vertex   1.220000e+01 -4.200000e+00 6.100000e+00
+      vertex   1.220000e+01 -8.300000e+00 2.200000e+01
+    endloop
+  endfacet
+  facet normal 1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -1.070000e+01 2.200000e+01
+      vertex   1.220000e+01 -8.300000e+00 2.200000e+01
+      vertex   1.220000e+01 -8.300000e+00 2.700000e+01
+    endloop
+  endfacet
+  facet normal 1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -8.300000e+00 1.000000e+00
+      vertex   1.220000e+01 -4.200000e+00 1.000000e+00
+      vertex   1.220000e+01 -4.200000e+00 6.100000e+00
+    endloop
+  endfacet
+  facet normal 1.000000e+00 0.000000e+00 -0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -4.200000e+00 6.100000e+00
+      vertex   1.220000e+01 -4.200000e+00 2.200000e+01
+      vertex   1.220000e+01 -8.300000e+00 2.200000e+01
+    endloop
+  endfacet
+  facet normal 1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -8.300000e+00 2.700000e+01
+      vertex   1.220000e+01 -1.070000e+01 2.700000e+01
+      vertex   1.220000e+01 -1.070000e+01 2.200000e+01
+    endloop
+  endfacet
+  facet normal 1.000000e+00 -0.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -2.830000e+01 2.200000e+01
+      vertex   1.220000e+01 -2.830000e+01 1.000000e+00
+      vertex   1.220000e+01 -1.070000e+01 2.200000e+01
+    endloop
+  endfacet
+  facet normal 1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -1.070000e+01 2.200000e+01
+      vertex   1.220000e+01 -2.830000e+01 1.000000e+00
+      vertex   1.220000e+01 -1.070000e+01 1.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   1.217493e+01 -4.200000e+00 7.774791e-01
+      vertex   1.041335e+01 -4.200000e+00 1.786649e+00
+      vertex   1.220000e+01 -4.200000e+00 1.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -4.200000e+00 1.000000e+00
+      vertex   1.041335e+01 -4.200000e+00 1.786649e+00
+      vertex   1.081536e+01 -4.200000e+00 2.230201e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -4.200000e+00 1.000000e+00
+      vertex   1.081536e+01 -4.200000e+00 2.230201e+00
+      vertex   1.117196e+01 -4.200000e+00 2.711022e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.217493e+01 -4.200000e+00 7.774791e-01
+      vertex   1.210097e+01 -4.200000e+00 5.661163e-01
+      vertex   1.041335e+01 -4.200000e+00 1.786649e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.041335e+01 -4.200000e+00 1.786649e+00
+      vertex   1.210097e+01 -4.200000e+00 5.661163e-01
+      vertex   1.198183e+01 -4.200000e+00 3.765102e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.041335e+01 -4.200000e+00 1.786649e+00
+      vertex   1.198183e+01 -4.200000e+00 3.765102e-01
+      vertex   1.182349e+01 -4.200000e+00 2.181685e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.182349e+01 -4.200000e+00 2.181685e-01
+      vertex   1.163388e+01 -4.200000e+00 9.903113e-02
+      vertex   1.041335e+01 -4.200000e+00 1.786649e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.041335e+01 -4.200000e+00 1.786649e+00
+      vertex   1.163388e+01 -4.200000e+00 9.903113e-02
+      vertex   1.142252e+01 -4.200000e+00 2.507209e-02
+    endloop
+  endfacet
+  facet normal -3.749420e-15 1.000000e+00 -2.147963e-15
+    outer loop
+      vertex   1.041335e+01 -4.200000e+00 1.786649e+00
+      vertex   1.142252e+01 -4.200000e+00 2.507209e-02
+      vertex   1.120000e+01 -4.200000e+00 0.000000e+00
+    endloop
+  endfacet
+  facet normal 1.741526e-16 1.000000e+00 -3.544958e-15
+    outer loop
+      vertex   6.100000e+00 -4.200000e+00 5.551115e-16
+      vertex   6.697905e+00 -4.200000e+00 2.937317e-02
+      vertex   1.120000e+01 -4.200000e+00 0.000000e+00
+    endloop
+  endfacet
+  facet normal 1.889696e-16 1.000000e+00 -1.273929e-15
+    outer loop
+      vertex   1.120000e+01 -4.200000e+00 0.000000e+00
+      vertex   6.697905e+00 -4.200000e+00 2.937317e-02
+      vertex   7.290051e+00 -4.200000e+00 1.172098e-01
+    endloop
+  endfacet
+  facet normal 2.028788e-16 1.000000e+00 -8.099376e-16
+    outer loop
+      vertex   1.120000e+01 -4.200000e+00 0.000000e+00
+      vertex   7.290051e+00 -4.200000e+00 1.172098e-01
+      vertex   7.870737e+00 -4.200000e+00 2.626640e-01
+    endloop
+  endfacet
+  facet normal 2.185823e-16 1.000000e+00 -6.108965e-16
+    outer loop
+      vertex   7.870737e+00 -4.200000e+00 2.626640e-01
+      vertex   8.434369e+00 -4.200000e+00 4.643349e-01
+      vertex   1.120000e+01 -4.200000e+00 0.000000e+00
+    endloop
+  endfacet
+  facet normal 2.370129e-16 1.000000e+00 -5.011216e-16
+    outer loop
+      vertex   1.120000e+01 -4.200000e+00 0.000000e+00
+      vertex   8.434369e+00 -4.200000e+00 4.643349e-01
+      vertex   8.975520e+00 -4.200000e+00 7.202803e-01
+    endloop
+  endfacet
+  facet normal 2.592317e-16 1.000000e+00 -4.325020e-16
+    outer loop
+      vertex   1.120000e+01 -4.200000e+00 0.000000e+00
+      vertex   8.975520e+00 -4.200000e+00 7.202803e-01
+      vertex   9.488978e+00 -4.200000e+00 1.028035e+00
+    endloop
+  endfacet
+  facet normal 2.867713e-16 1.000000e+00 -3.866663e-16
+    outer loop
+      vertex   9.488978e+00 -4.200000e+00 1.028035e+00
+      vertex   9.969799e+00 -4.200000e+00 1.384636e+00
+      vertex   1.120000e+01 -4.200000e+00 0.000000e+00
+    endloop
+  endfacet
+  facet normal 3.220475e-16 1.000000e+00 -3.553246e-16
+    outer loop
+      vertex   1.120000e+01 -4.200000e+00 0.000000e+00
+      vertex   9.969799e+00 -4.200000e+00 1.384636e+00
+      vertex   1.041335e+01 -4.200000e+00 1.786649e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.117196e+01 -4.200000e+00 2.711022e+00
+      vertex   1.147972e+01 -4.200000e+00 3.224480e+00
+      vertex   1.220000e+01 -4.200000e+00 1.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -4.200000e+00 1.000000e+00
+      vertex   1.147972e+01 -4.200000e+00 3.224480e+00
+      vertex   1.173567e+01 -4.200000e+00 3.765631e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -4.200000e+00 1.000000e+00
+      vertex   1.173567e+01 -4.200000e+00 3.765631e+00
+      vertex   1.193734e+01 -4.200000e+00 4.329263e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.193734e+01 -4.200000e+00 4.329263e+00
+      vertex   1.208279e+01 -4.200000e+00 4.909949e+00
+      vertex   1.220000e+01 -4.200000e+00 1.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -4.200000e+00 1.000000e+00
+      vertex   1.208279e+01 -4.200000e+00 4.909949e+00
+      vertex   1.217063e+01 -4.200000e+00 5.502095e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -4.200000e+00 1.000000e+00
+      vertex   1.217063e+01 -4.200000e+00 5.502095e+00
+      vertex   1.220000e+01 -4.200000e+00 6.100000e+00
+    endloop
+  endfacet
+  facet normal 9.937122e-01 -5.650252e-18 -1.119645e-01
+    outer loop
+      vertex   1.217493e+01 -2.830000e+01 7.774791e-01
+      vertex   1.217493e+01 -2.390000e+01 7.774791e-01
+      vertex   1.220000e+01 -2.830000e+01 1.000000e+00
+    endloop
+  endfacet
+  facet normal 9.937122e-01 -3.101355e-18 -1.119645e-01
+    outer loop
+      vertex   1.220000e+01 -2.830000e+01 1.000000e+00
+      vertex   1.217493e+01 -2.390000e+01 7.774791e-01
+      vertex   1.217493e+01 -1.950000e+01 7.774791e-01
+    endloop
+  endfacet
+  facet normal 9.937122e-01 -7.062815e-18 -1.119645e-01
+    outer loop
+      vertex   1.220000e+01 -2.830000e+01 1.000000e+00
+      vertex   1.217493e+01 -1.950000e+01 7.774791e-01
+      vertex   1.220000e+01 -1.070000e+01 1.000000e+00
+    endloop
+  endfacet
+  facet normal 9.937122e-01 -8.280279e-18 -1.119645e-01
+    outer loop
+      vertex   1.220000e+01 -1.070000e+01 1.000000e+00
+      vertex   1.217493e+01 -1.950000e+01 7.774791e-01
+      vertex   1.217493e+01 -1.510000e+01 7.774791e-01
+    endloop
+  endfacet
+  facet normal 9.937122e-01 -8.608035e-18 -1.119645e-01
+    outer loop
+      vertex   1.220000e+01 -1.070000e+01 1.000000e+00
+      vertex   1.217493e+01 -1.510000e+01 7.774791e-01
+      vertex   1.217493e+01 -1.070000e+01 7.774791e-01
+    endloop
+  endfacet
+  facet normal 9.438833e-01 -2.500114e-17 -3.302791e-01
+    outer loop
+      vertex   1.217493e+01 -1.070000e+01 7.774791e-01
+      vertex   1.217493e+01 -1.510000e+01 7.774791e-01
+      vertex   1.210097e+01 -1.070000e+01 5.661163e-01
+    endloop
+  endfacet
+  facet normal 9.438833e-01 -8.037929e-16 -3.302791e-01
+    outer loop
+      vertex   1.210097e+01 -1.070000e+01 5.661163e-01
+      vertex   1.217493e+01 -1.510000e+01 7.774791e-01
+      vertex   1.210097e+01 -1.510000e+01 5.661163e-01
+    endloop
+  endfacet
+  facet normal 8.467242e-01 -7.507968e-16 -5.320321e-01
+    outer loop
+      vertex   1.210097e+01 -1.070000e+01 5.661163e-01
+      vertex   1.210097e+01 -1.510000e+01 5.661163e-01
+      vertex   1.198183e+01 -1.070000e+01 3.765102e-01
+    endloop
+  endfacet
+  facet normal 8.467242e-01 1.342442e-17 -5.320321e-01
+    outer loop
+      vertex   1.198183e+01 -1.070000e+01 3.765102e-01
+      vertex   1.210097e+01 -1.510000e+01 5.661163e-01
+      vertex   1.198183e+01 -1.510000e+01 3.765102e-01
+    endloop
+  endfacet
+  facet normal 7.071068e-01 1.784196e-17 -7.071068e-01
+    outer loop
+      vertex   1.198183e+01 -1.070000e+01 3.765102e-01
+      vertex   1.198183e+01 -1.510000e+01 3.765102e-01
+      vertex   1.182349e+01 -1.070000e+01 2.181685e-01
+    endloop
+  endfacet
+  facet normal 7.071068e-01 -4.460490e-17 -7.071068e-01
+    outer loop
+      vertex   1.182349e+01 -1.070000e+01 2.181685e-01
+      vertex   1.198183e+01 -1.510000e+01 3.765102e-01
+      vertex   1.182349e+01 -1.510000e+01 2.181685e-01
+    endloop
+  endfacet
+  facet normal 5.320321e-01 -5.341209e-17 -8.467242e-01
+    outer loop
+      vertex   1.182349e+01 -1.070000e+01 2.181685e-01
+      vertex   1.182349e+01 -1.510000e+01 2.181685e-01
+      vertex   1.163388e+01 -1.070000e+01 9.903113e-02
+    endloop
+  endfacet
+  facet normal 5.320321e-01 2.670604e-17 -8.467242e-01
+    outer loop
+      vertex   1.163388e+01 -1.070000e+01 9.903113e-02
+      vertex   1.182349e+01 -1.510000e+01 2.181685e-01
+      vertex   1.163388e+01 -1.510000e+01 9.903113e-02
+    endloop
+  endfacet
+  facet normal 3.302791e-01 2.977048e-17 -9.438833e-01
+    outer loop
+      vertex   1.163388e+01 -1.070000e+01 9.903113e-02
+      vertex   1.163388e+01 -1.510000e+01 9.903113e-02
+      vertex   1.142252e+01 -1.070000e+01 2.507209e-02
+    endloop
+  endfacet
+  facet normal 3.302791e-01 -7.442621e-17 -9.438833e-01
+    outer loop
+      vertex   1.142252e+01 -1.070000e+01 2.507209e-02
+      vertex   1.163388e+01 -1.510000e+01 9.903113e-02
+      vertex   1.142252e+01 -1.510000e+01 2.507209e-02
+    endloop
+  endfacet
+  facet normal 1.119645e-01 -7.835527e-17 -9.937122e-01
+    outer loop
+      vertex   1.142252e+01 -1.070000e+01 2.507209e-02
+      vertex   1.142252e+01 -1.510000e+01 2.507209e-02
+      vertex   1.120000e+01 -1.070000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 1.119645e-01 2.163827e-19 -9.937122e-01
+    outer loop
+      vertex   1.120000e+01 -1.070000e+01 0.000000e+00
+      vertex   1.142252e+01 -1.510000e+01 2.507209e-02
+      vertex   1.142252e+01 -1.950000e+01 2.507209e-02
+    endloop
+  endfacet
+  facet normal 1.119645e-01 0.000000e+00 -9.937122e-01
+    outer loop
+      vertex   1.120000e+01 -1.070000e+01 0.000000e+00
+      vertex   1.142252e+01 -1.950000e+01 2.507209e-02
+      vertex   1.120000e+01 -2.830000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 1.119645e-01 2.163827e-19 -9.937122e-01
+    outer loop
+      vertex   1.120000e+01 -2.830000e+01 0.000000e+00
+      vertex   1.142252e+01 -1.950000e+01 2.507209e-02
+      vertex   1.142252e+01 -2.390000e+01 2.507209e-02
+    endloop
+  endfacet
+  facet normal 1.119645e-01 6.271864e-17 -9.937122e-01
+    outer loop
+      vertex   1.120000e+01 -2.830000e+01 0.000000e+00
+      vertex   1.142252e+01 -2.390000e+01 2.507209e-02
+      vertex   1.142252e+01 -2.830000e+01 2.507209e-02
+    endloop
+  endfacet
+  facet normal 3.302791e-01 5.954097e-17 -9.438833e-01
+    outer loop
+      vertex   1.142252e+01 -2.830000e+01 2.507209e-02
+      vertex   1.142252e+01 -2.390000e+01 2.507209e-02
+      vertex   1.163388e+01 -2.830000e+01 9.903113e-02
+    endloop
+  endfacet
+  facet normal 3.302791e-01 -5.954097e-17 -9.438833e-01
+    outer loop
+      vertex   1.163388e+01 -2.830000e+01 9.903113e-02
+      vertex   1.142252e+01 -2.390000e+01 2.507209e-02
+      vertex   1.163388e+01 -2.390000e+01 9.903113e-02
+    endloop
+  endfacet
+  facet normal 5.320321e-01 -5.341209e-17 -8.467242e-01
+    outer loop
+      vertex   1.163388e+01 -2.830000e+01 9.903113e-02
+      vertex   1.163388e+01 -2.390000e+01 9.903113e-02
+      vertex   1.182349e+01 -2.830000e+01 2.181685e-01
+    endloop
+  endfacet
+  facet normal 5.320321e-01 2.670604e-17 -8.467242e-01
+    outer loop
+      vertex   1.182349e+01 -2.830000e+01 2.181685e-01
+      vertex   1.163388e+01 -2.390000e+01 9.903113e-02
+      vertex   1.182349e+01 -2.390000e+01 2.181685e-01
+    endloop
+  endfacet
+  facet normal 7.071068e-01 2.230245e-17 -7.071068e-01
+    outer loop
+      vertex   1.182349e+01 -2.830000e+01 2.181685e-01
+      vertex   1.182349e+01 -2.390000e+01 2.181685e-01
+      vertex   1.198183e+01 -2.830000e+01 3.765102e-01
+    endloop
+  endfacet
+  facet normal 7.071068e-01 -8.028882e-17 -7.071068e-01
+    outer loop
+      vertex   1.198183e+01 -2.830000e+01 3.765102e-01
+      vertex   1.182349e+01 -2.390000e+01 2.181685e-01
+      vertex   1.198183e+01 -2.390000e+01 3.765102e-01
+    endloop
+  endfacet
+  facet normal 8.467242e-01 -6.040987e-17 -5.320321e-01
+    outer loop
+      vertex   1.198183e+01 -2.830000e+01 3.765102e-01
+      vertex   1.198183e+01 -2.390000e+01 3.765102e-01
+      vertex   1.210097e+01 -2.830000e+01 5.661163e-01
+    endloop
+  endfacet
+  facet normal 8.467242e-01 -2.684883e-17 -5.320321e-01
+    outer loop
+      vertex   1.210097e+01 -2.830000e+01 5.661163e-01
+      vertex   1.198183e+01 -2.390000e+01 3.765102e-01
+      vertex   1.210097e+01 -2.390000e+01 5.661163e-01
+    endloop
+  endfacet
+  facet normal 9.438833e-01 -1.666743e-17 -3.302791e-01
+    outer loop
+      vertex   1.210097e+01 -2.830000e+01 5.661163e-01
+      vertex   1.210097e+01 -2.390000e+01 5.661163e-01
+      vertex   1.217493e+01 -2.830000e+01 7.774791e-01
+    endloop
+  endfacet
+  facet normal 9.438833e-01 -1.666743e-17 -3.302791e-01
+    outer loop
+      vertex   1.217493e+01 -2.830000e+01 7.774791e-01
+      vertex   1.210097e+01 -2.390000e+01 5.661163e-01
+      vertex   1.217493e+01 -2.390000e+01 7.774791e-01
+    endloop
+  endfacet
+  facet normal 9.438833e-01 -2.382815e-17 -3.302791e-01
+    outer loop
+      vertex   1.210097e+01 -1.510000e+01 5.661163e-01
+      vertex   1.217493e+01 -1.510000e+01 7.774791e-01
+      vertex   1.217493e+01 -1.950000e+01 7.774791e-01
+    endloop
+  endfacet
+  facet normal 9.438833e-01 -8.333714e-18 -3.302791e-01
+    outer loop
+      vertex   1.217493e+01 -1.950000e+01 7.774791e-01
+      vertex   1.217493e+01 -2.390000e+01 7.774791e-01
+      vertex   1.210097e+01 -1.950000e+01 5.661163e-01
+    endloop
+  endfacet
+  facet normal 9.438833e-01 0.000000e+00 -3.302791e-01
+    outer loop
+      vertex   1.210097e+01 -1.950000e+01 5.661163e-01
+      vertex   1.217493e+01 -2.390000e+01 7.774791e-01
+      vertex   1.210097e+01 -2.390000e+01 5.661163e-01
+    endloop
+  endfacet
+  facet normal 8.467242e-01 0.000000e+00 -5.320321e-01
+    outer loop
+      vertex   1.210097e+01 -1.950000e+01 5.661163e-01
+      vertex   1.210097e+01 -2.390000e+01 5.661163e-01
+      vertex   1.198183e+01 -1.950000e+01 3.765102e-01
+    endloop
+  endfacet
+  facet normal 8.467242e-01 -6.712208e-18 -5.320321e-01
+    outer loop
+      vertex   1.198183e+01 -1.950000e+01 3.765102e-01
+      vertex   1.210097e+01 -2.390000e+01 5.661163e-01
+      vertex   1.198183e+01 -2.390000e+01 3.765102e-01
+    endloop
+  endfacet
+  facet normal 7.071068e-01 -8.920980e-18 -7.071068e-01
+    outer loop
+      vertex   1.198183e+01 -1.950000e+01 3.765102e-01
+      vertex   1.198183e+01 -2.390000e+01 3.765102e-01
+      vertex   1.182349e+01 -1.950000e+01 2.181685e-01
+    endloop
+  endfacet
+  facet normal 7.071068e-01 0.000000e+00 -7.071068e-01
+    outer loop
+      vertex   1.182349e+01 -1.950000e+01 2.181685e-01
+      vertex   1.198183e+01 -2.390000e+01 3.765102e-01
+      vertex   1.182349e+01 -2.390000e+01 2.181685e-01
+    endloop
+  endfacet
+  facet normal 5.320321e-01 0.000000e+00 -8.467242e-01
+    outer loop
+      vertex   1.182349e+01 -1.950000e+01 2.181685e-01
+      vertex   1.182349e+01 -2.390000e+01 2.181685e-01
+      vertex   1.163388e+01 -1.950000e+01 9.903113e-02
+    endloop
+  endfacet
+  facet normal 5.320321e-01 0.000000e+00 -8.467242e-01
+    outer loop
+      vertex   1.163388e+01 -1.950000e+01 9.903113e-02
+      vertex   1.182349e+01 -2.390000e+01 2.181685e-01
+      vertex   1.163388e+01 -2.390000e+01 9.903113e-02
+    endloop
+  endfacet
+  facet normal 3.302791e-01 0.000000e+00 -9.438833e-01
+    outer loop
+      vertex   1.163388e+01 -1.950000e+01 9.903113e-02
+      vertex   1.163388e+01 -2.390000e+01 9.903113e-02
+      vertex   1.142252e+01 -1.950000e+01 2.507209e-02
+    endloop
+  endfacet
+  facet normal 3.302791e-01 0.000000e+00 -9.438833e-01
+    outer loop
+      vertex   1.142252e+01 -1.950000e+01 2.507209e-02
+      vertex   1.163388e+01 -2.390000e+01 9.903113e-02
+      vertex   1.142252e+01 -2.390000e+01 2.507209e-02
+    endloop
+  endfacet
+  facet normal 8.467242e-01 1.187158e-17 -5.320321e-01
+    outer loop
+      vertex   1.198183e+01 -1.510000e+01 3.765102e-01
+      vertex   1.210097e+01 -1.510000e+01 5.661163e-01
+      vertex   1.210097e+01 -1.950000e+01 5.661163e-01
+    endloop
+  endfacet
+  facet normal 9.438833e-01 8.333714e-18 -3.302791e-01
+    outer loop
+      vertex   1.210097e+01 -1.950000e+01 5.661163e-01
+      vertex   1.210097e+01 -1.510000e+01 5.661163e-01
+      vertex   1.217493e+01 -1.950000e+01 7.774791e-01
+    endloop
+  endfacet
+  facet normal 8.467242e-01 -6.712208e-18 -5.320321e-01
+    outer loop
+      vertex   1.198183e+01 -1.510000e+01 3.765102e-01
+      vertex   1.210097e+01 -1.950000e+01 5.661163e-01
+      vertex   1.198183e+01 -1.950000e+01 3.765102e-01
+    endloop
+  endfacet
+  facet normal 7.071068e-01 -9.895160e-18 -7.071068e-01
+    outer loop
+      vertex   1.182349e+01 -1.510000e+01 2.181685e-01
+      vertex   1.198183e+01 -1.510000e+01 3.765102e-01
+      vertex   1.198183e+01 -1.950000e+01 3.765102e-01
+    endloop
+  endfacet
+  facet normal 7.071068e-01 0.000000e+00 -7.071068e-01
+    outer loop
+      vertex   1.182349e+01 -1.510000e+01 2.181685e-01
+      vertex   1.198183e+01 -1.950000e+01 3.765102e-01
+      vertex   1.182349e+01 -1.950000e+01 2.181685e-01
+    endloop
+  endfacet
+  facet normal 5.320321e-01 -1.083700e-19 -8.467242e-01
+    outer loop
+      vertex   1.163388e+01 -1.510000e+01 9.903113e-02
+      vertex   1.182349e+01 -1.510000e+01 2.181685e-01
+      vertex   1.182349e+01 -1.950000e+01 2.181685e-01
+    endloop
+  endfacet
+  facet normal 5.320321e-01 0.000000e+00 -8.467242e-01
+    outer loop
+      vertex   1.163388e+01 -1.510000e+01 9.903113e-02
+      vertex   1.182349e+01 -1.950000e+01 2.181685e-01
+      vertex   1.163388e+01 -1.950000e+01 9.903113e-02
+    endloop
+  endfacet
+  facet normal 3.302791e-01 9.655886e-20 -9.438833e-01
+    outer loop
+      vertex   1.142252e+01 -1.510000e+01 2.507209e-02
+      vertex   1.163388e+01 -1.510000e+01 9.903113e-02
+      vertex   1.163388e+01 -1.950000e+01 9.903113e-02
+    endloop
+  endfacet
+  facet normal 3.302791e-01 0.000000e+00 -9.438833e-01
+    outer loop
+      vertex   1.142252e+01 -1.510000e+01 2.507209e-02
+      vertex   1.163388e+01 -1.950000e+01 9.903113e-02
+      vertex   1.142252e+01 -1.950000e+01 2.507209e-02
+    endloop
+  endfacet
+  facet normal 9.937122e-01 -0.000000e+00 1.119645e-01
+    outer loop
+      vertex   1.220000e+01 -8.300000e+00 2.200000e+01
+      vertex   1.220000e+01 -4.200000e+00 2.200000e+01
+      vertex   1.217493e+01 -8.300000e+00 2.222252e+01
+    endloop
+  endfacet
+  facet normal 9.937122e-01 -0.000000e+00 1.119645e-01
+    outer loop
+      vertex   1.217493e+01 -8.300000e+00 2.222252e+01
+      vertex   1.220000e+01 -4.200000e+00 2.200000e+01
+      vertex   1.217493e+01 -4.200000e+00 2.222252e+01
+    endloop
+  endfacet
+  facet normal 9.438833e-01 -0.000000e+00 3.302791e-01
+    outer loop
+      vertex   1.217493e+01 -8.300000e+00 2.222252e+01
+      vertex   1.217493e+01 -4.200000e+00 2.222252e+01
+      vertex   1.210097e+01 -8.300000e+00 2.243388e+01
+    endloop
+  endfacet
+  facet normal 9.438833e-01 -0.000000e+00 3.302791e-01
+    outer loop
+      vertex   1.210097e+01 -8.300000e+00 2.243388e+01
+      vertex   1.217493e+01 -4.200000e+00 2.222252e+01
+      vertex   1.210097e+01 -4.200000e+00 2.243388e+01
+    endloop
+  endfacet
+  facet normal 8.467242e-01 -0.000000e+00 5.320321e-01
+    outer loop
+      vertex   1.210097e+01 -8.300000e+00 2.243388e+01
+      vertex   1.210097e+01 -4.200000e+00 2.243388e+01
+      vertex   1.198183e+01 -8.300000e+00 2.262349e+01
+    endloop
+  endfacet
+  facet normal 8.467242e-01 -0.000000e+00 5.320321e-01
+    outer loop
+      vertex   1.198183e+01 -8.300000e+00 2.262349e+01
+      vertex   1.210097e+01 -4.200000e+00 2.243388e+01
+      vertex   1.198183e+01 -4.200000e+00 2.262349e+01
+    endloop
+  endfacet
+  facet normal 7.071068e-01 -0.000000e+00 7.071068e-01
+    outer loop
+      vertex   1.198183e+01 -8.300000e+00 2.262349e+01
+      vertex   1.198183e+01 -4.200000e+00 2.262349e+01
+      vertex   1.182349e+01 -8.300000e+00 2.278183e+01
+    endloop
+  endfacet
+  facet normal 7.071068e-01 -0.000000e+00 7.071068e-01
+    outer loop
+      vertex   1.182349e+01 -8.300000e+00 2.278183e+01
+      vertex   1.198183e+01 -4.200000e+00 2.262349e+01
+      vertex   1.182349e+01 -4.200000e+00 2.278183e+01
+    endloop
+  endfacet
+  facet normal 5.320321e-01 -0.000000e+00 8.467242e-01
+    outer loop
+      vertex   1.182349e+01 -8.300000e+00 2.278183e+01
+      vertex   1.182349e+01 -4.200000e+00 2.278183e+01
+      vertex   1.163388e+01 -8.300000e+00 2.290097e+01
+    endloop
+  endfacet
+  facet normal 5.320321e-01 -0.000000e+00 8.467242e-01
+    outer loop
+      vertex   1.163388e+01 -8.300000e+00 2.290097e+01
+      vertex   1.182349e+01 -4.200000e+00 2.278183e+01
+      vertex   1.163388e+01 -4.200000e+00 2.290097e+01
+    endloop
+  endfacet
+  facet normal 3.302791e-01 -0.000000e+00 9.438833e-01
+    outer loop
+      vertex   1.163388e+01 -8.300000e+00 2.290097e+01
+      vertex   1.163388e+01 -4.200000e+00 2.290097e+01
+      vertex   1.142252e+01 -8.300000e+00 2.297493e+01
+    endloop
+  endfacet
+  facet normal 3.302791e-01 -0.000000e+00 9.438833e-01
+    outer loop
+      vertex   1.142252e+01 -8.300000e+00 2.297493e+01
+      vertex   1.163388e+01 -4.200000e+00 2.290097e+01
+      vertex   1.142252e+01 -4.200000e+00 2.297493e+01
+    endloop
+  endfacet
+  facet normal 1.119645e-01 -0.000000e+00 9.937122e-01
+    outer loop
+      vertex   1.142252e+01 -8.300000e+00 2.297493e+01
+      vertex   1.142252e+01 -4.200000e+00 2.297493e+01
+      vertex   1.120000e+01 -8.300000e+00 2.300000e+01
+    endloop
+  endfacet
+  facet normal 1.119645e-01 -0.000000e+00 9.937122e-01
+    outer loop
+      vertex   1.120000e+01 -8.300000e+00 2.300000e+01
+      vertex   1.142252e+01 -4.200000e+00 2.297493e+01
+      vertex   1.120000e+01 -4.200000e+00 2.300000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -0.000000e+00 1.000000e+00
+    outer loop
+      vertex   1.120000e+01 -8.300000e+00 2.300000e+01
+      vertex   1.120000e+01 -4.200000e+00 2.300000e+01
+      vertex   1.000000e+00 -8.300000e+00 2.300000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 1.000000e+00
+    outer loop
+      vertex   1.000000e+00 -8.300000e+00 2.300000e+01
+      vertex   1.120000e+01 -4.200000e+00 2.300000e+01
+      vertex   1.000000e+00 -4.200000e+00 2.300000e+01
+    endloop
+  endfacet
+  facet normal -1.127810e-16 1.000000e+00 -1.000959e-15
+    outer loop
+      vertex   1.142252e+01 -4.200000e+00 2.297493e+01
+      vertex   1.220000e+01 -4.200000e+00 2.200000e+01
+      vertex   1.120000e+01 -4.200000e+00 2.300000e+01
+    endloop
+  endfacet
+  facet normal 5.711026e-16 1.000000e+00 -3.170759e-16
+    outer loop
+      vertex   1.120000e+01 -4.200000e+00 2.300000e+01
+      vertex   1.220000e+01 -4.200000e+00 2.200000e+01
+      vertex   7.721073e+00 -4.200000e+00 1.393276e+01
+    endloop
+  endfacet
+  facet normal -5.293670e-17 1.000000e+00 -7.764388e-17
+    outer loop
+      vertex   1.120000e+01 -4.200000e+00 2.300000e+01
+      vertex   7.721073e+00 -4.200000e+00 1.393276e+01
+      vertex   7.400000e+00 -4.200000e+00 1.415167e+01
+    endloop
+  endfacet
+  facet normal -4.421647e-16 1.000000e+00 -1.263634e-15
+    outer loop
+      vertex   1.142252e+01 -4.200000e+00 2.297493e+01
+      vertex   1.163388e+01 -4.200000e+00 2.290097e+01
+      vertex   1.220000e+01 -4.200000e+00 2.200000e+01
+    endloop
+  endfacet
+  facet normal -1.023521e-15 1.000000e+00 -1.628925e-15
+    outer loop
+      vertex   1.220000e+01 -4.200000e+00 2.200000e+01
+      vertex   1.163388e+01 -4.200000e+00 2.290097e+01
+      vertex   1.182349e+01 -4.200000e+00 2.278183e+01
+    endloop
+  endfacet
+  facet normal -2.191295e-15 1.000000e+00 -2.191295e-15
+    outer loop
+      vertex   1.220000e+01 -4.200000e+00 2.200000e+01
+      vertex   1.182349e+01 -4.200000e+00 2.278183e+01
+      vertex   1.198183e+01 -4.200000e+00 2.262349e+01
+    endloop
+  endfacet
+  facet normal -5.116350e-15 1.000000e+00 -3.214816e-15
+    outer loop
+      vertex   1.198183e+01 -4.200000e+00 2.262349e+01
+      vertex   1.210097e+01 -4.200000e+00 2.243388e+01
+      vertex   1.220000e+01 -4.200000e+00 2.200000e+01
+    endloop
+  endfacet
+  facet normal -1.682432e-14 1.000000e+00 -5.887083e-15
+    outer loop
+      vertex   1.220000e+01 -4.200000e+00 2.200000e+01
+      vertex   1.210097e+01 -4.200000e+00 2.243388e+01
+      vertex   1.217493e+01 -4.200000e+00 2.222252e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -4.200000e+00 6.100000e+00
+      vertex   1.217295e+01 -4.200000e+00 6.673809e+00
+      vertex   1.220000e+01 -4.200000e+00 2.200000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -4.200000e+00 2.200000e+01
+      vertex   1.217295e+01 -4.200000e+00 6.673809e+00
+      vertex   1.209205e+01 -4.200000e+00 7.242529e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -4.200000e+00 2.200000e+01
+      vertex   1.209205e+01 -4.200000e+00 7.242529e+00
+      vertex   1.195800e+01 -4.200000e+00 7.801117e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   1.195800e+01 -4.200000e+00 7.801117e+00
+      vertex   1.177201e+01 -4.200000e+00 8.344619e+00
+      vertex   1.220000e+01 -4.200000e+00 2.200000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -4.200000e+00 2.200000e+01
+      vertex   1.177201e+01 -4.200000e+00 8.344619e+00
+      vertex   1.153571e+01 -4.200000e+00 8.868215e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -4.200000e+00 2.200000e+01
+      vertex   1.153571e+01 -4.200000e+00 8.868215e+00
+      vertex   1.125121e+01 -4.200000e+00 9.367262e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   1.125121e+01 -4.200000e+00 9.367262e+00
+      vertex   1.092103e+01 -4.200000e+00 9.837334e+00
+      vertex   1.220000e+01 -4.200000e+00 2.200000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -4.200000e+00 2.200000e+01
+      vertex   1.092103e+01 -4.200000e+00 9.837334e+00
+      vertex   1.054809e+01 -4.200000e+00 1.027426e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -4.200000e+00 2.200000e+01
+      vertex   1.054809e+01 -4.200000e+00 1.027426e+01
+      vertex   1.013571e+01 -4.200000e+00 1.067417e+01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   9.687536e+00 -4.200000e+00 1.103352e+01
+      vertex   8.584489e+00 -4.200000e+00 1.266636e+01
+      vertex   1.013571e+01 -4.200000e+00 1.067417e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.013571e+01 -4.200000e+00 1.067417e+01
+      vertex   8.584489e+00 -4.200000e+00 1.266636e+01
+      vertex   8.442519e+00 -4.200000e+00 1.302810e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   1.013571e+01 -4.200000e+00 1.067417e+01
+      vertex   8.442519e+00 -4.200000e+00 1.302810e+01
+      vertex   1.220000e+01 -4.200000e+00 2.200000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -4.200000e+00 2.200000e+01
+      vertex   8.442519e+00 -4.200000e+00 1.302810e+01
+      vertex   8.248221e+00 -4.200000e+00 1.336463e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -4.200000e+00 2.200000e+01
+      vertex   8.248221e+00 -4.200000e+00 1.336463e+01
+      vertex   8.005935e+00 -4.200000e+00 1.366845e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.584489e+00 -4.200000e+00 1.266636e+01
+      vertex   9.687536e+00 -4.200000e+00 1.103352e+01
+      vertex   8.670960e+00 -4.200000e+00 1.228751e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.670960e+00 -4.200000e+00 1.228751e+01
+      vertex   9.687536e+00 -4.200000e+00 1.103352e+01
+      vertex   9.207547e+00 -4.200000e+00 1.134911e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.670960e+00 -4.200000e+00 1.228751e+01
+      vertex   9.207547e+00 -4.200000e+00 1.134911e+01
+      vertex   8.700000e+00 -4.200000e+00 1.190000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.700000e+00 -4.200000e+00 1.190000e+01
+      vertex   9.207547e+00 -4.200000e+00 1.134911e+01
+      vertex   8.700000e+00 -4.200000e+00 1.161815e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   8.005935e+00 -4.200000e+00 1.366845e+01
+      vertex   7.721073e+00 -4.200000e+00 1.393276e+01
+      vertex   1.220000e+01 -4.200000e+00 2.200000e+01
+    endloop
+  endfacet
+  facet normal -4.005539e-17 1.000000e+00 -8.317588e-17
+    outer loop
+      vertex   7.400000e+00 -4.200000e+00 1.415167e+01
+      vertex   7.049887e+00 -4.200000e+00 1.432027e+01
+      vertex   1.120000e+01 -4.200000e+00 2.300000e+01
+    endloop
+  endfacet
+  facet normal -2.750707e-17 1.000000e+00 -8.917572e-17
+    outer loop
+      vertex   1.120000e+01 -4.200000e+00 2.300000e+01
+      vertex   7.049887e+00 -4.200000e+00 1.432027e+01
+      vertex   6.678554e+00 -4.200000e+00 1.443481e+01
+    endloop
+  endfacet
+  facet normal -1.447777e-17 1.000000e+00 -9.605370e-17
+    outer loop
+      vertex   1.120000e+01 -4.200000e+00 2.300000e+01
+      vertex   6.678554e+00 -4.200000e+00 1.443481e+01
+      vertex   6.294298e+00 -4.200000e+00 1.449273e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -1.044023e-16
+    outer loop
+      vertex   1.120000e+01 -4.200000e+00 2.300000e+01
+      vertex   6.294298e+00 -4.200000e+00 1.449273e+01
+      vertex   1.000000e+00 -4.200000e+00 2.300000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -1.044023e-16
+    outer loop
+      vertex   1.000000e+00 -4.200000e+00 2.300000e+01
+      vertex   6.294298e+00 -4.200000e+00 1.449273e+01
+      vertex   5.905702e+00 -4.200000e+00 1.449273e+01
+    endloop
+  endfacet
+  facet normal 1.447777e-17 1.000000e+00 -9.605370e-17
+    outer loop
+      vertex   1.000000e+00 -4.200000e+00 2.300000e+01
+      vertex   5.905702e+00 -4.200000e+00 1.449273e+01
+      vertex   5.521446e+00 -4.200000e+00 1.443481e+01
+    endloop
+  endfacet
+  facet normal 2.750707e-17 1.000000e+00 -8.917572e-17
+    outer loop
+      vertex   5.521446e+00 -4.200000e+00 1.443481e+01
+      vertex   5.150113e+00 -4.200000e+00 1.432027e+01
+      vertex   1.000000e+00 -4.200000e+00 2.300000e+01
+    endloop
+  endfacet
+  facet normal 4.005539e-17 1.000000e+00 -8.317588e-17
+    outer loop
+      vertex   1.000000e+00 -4.200000e+00 2.300000e+01
+      vertex   5.150113e+00 -4.200000e+00 1.432027e+01
+      vertex   4.800000e+00 -4.200000e+00 1.415167e+01
+    endloop
+  endfacet
+  facet normal 5.293670e-17 1.000000e+00 -7.764388e-17
+    outer loop
+      vertex   1.000000e+00 -4.200000e+00 2.300000e+01
+      vertex   4.800000e+00 -4.200000e+00 1.415167e+01
+      vertex   4.478927e+00 -4.200000e+00 1.393276e+01
+    endloop
+  endfacet
+  facet normal -5.711026e-16 1.000000e+00 -3.170759e-16
+    outer loop
+      vertex   1.000000e+00 -4.200000e+00 2.300000e+01
+      vertex   4.478927e+00 -4.200000e+00 1.393276e+01
+      vertex   0.000000e+00 -4.200000e+00 2.200000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -4.200000e+00 2.200000e+01
+      vertex   4.478927e+00 -4.200000e+00 1.393276e+01
+      vertex   4.194065e+00 -4.200000e+00 1.366845e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -4.200000e+00 2.200000e+01
+      vertex   4.194065e+00 -4.200000e+00 1.366845e+01
+      vertex   3.951779e+00 -4.200000e+00 1.336463e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.951779e+00 -4.200000e+00 1.336463e+01
+      vertex   3.757481e+00 -4.200000e+00 1.302810e+01
+      vertex   0.000000e+00 -4.200000e+00 2.200000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -4.200000e+00 2.200000e+01
+      vertex   3.757481e+00 -4.200000e+00 1.302810e+01
+      vertex   2.064290e+00 -4.200000e+00 1.067417e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -4.200000e+00 2.200000e+01
+      vertex   2.064290e+00 -4.200000e+00 1.067417e+01
+      vertex   1.651906e+00 -4.200000e+00 1.027426e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.757481e+00 -4.200000e+00 1.302810e+01
+      vertex   3.615511e+00 -4.200000e+00 1.266636e+01
+      vertex   2.064290e+00 -4.200000e+00 1.067417e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   2.064290e+00 -4.200000e+00 1.067417e+01
+      vertex   3.615511e+00 -4.200000e+00 1.266636e+01
+      vertex   2.512464e+00 -4.200000e+00 1.103352e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   2.512464e+00 -4.200000e+00 1.103352e+01
+      vertex   3.615511e+00 -4.200000e+00 1.266636e+01
+      vertex   3.529040e+00 -4.200000e+00 1.228751e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   2.512464e+00 -4.200000e+00 1.103352e+01
+      vertex   3.529040e+00 -4.200000e+00 1.228751e+01
+      vertex   2.992453e+00 -4.200000e+00 1.134911e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   2.992453e+00 -4.200000e+00 1.134911e+01
+      vertex   3.529040e+00 -4.200000e+00 1.228751e+01
+      vertex   3.500000e+00 -4.200000e+00 1.190000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   2.992453e+00 -4.200000e+00 1.134911e+01
+      vertex   3.500000e+00 -4.200000e+00 1.190000e+01
+      vertex   3.500000e+00 -4.200000e+00 1.161815e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.651906e+00 -4.200000e+00 1.027426e+01
+      vertex   1.278969e+00 -4.200000e+00 9.837334e+00
+      vertex   0.000000e+00 -4.200000e+00 2.200000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -4.200000e+00 2.200000e+01
+      vertex   1.278969e+00 -4.200000e+00 9.837334e+00
+      vertex   9.487866e-01 -4.200000e+00 9.367262e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -4.200000e+00 2.200000e+01
+      vertex   9.487866e-01 -4.200000e+00 9.367262e+00
+      vertex   6.642861e-01 -4.200000e+00 8.868215e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.642861e-01 -4.200000e+00 8.868215e+00
+      vertex   4.279910e-01 -4.200000e+00 8.344619e+00
+      vertex   0.000000e+00 -4.200000e+00 2.200000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -4.200000e+00 2.200000e+01
+      vertex   4.279910e-01 -4.200000e+00 8.344619e+00
+      vertex   2.419968e-01 -4.200000e+00 7.801117e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -4.200000e+00 2.200000e+01
+      vertex   2.419968e-01 -4.200000e+00 7.801117e+00
+      vertex   1.079530e-01 -4.200000e+00 7.242529e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.079530e-01 -4.200000e+00 7.242529e+00
+      vertex   2.704822e-02 -4.200000e+00 6.673809e+00
+      vertex   0.000000e+00 -4.200000e+00 2.200000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -4.200000e+00 2.200000e+01
+      vertex   2.704822e-02 -4.200000e+00 6.673809e+00
+      vertex   0.000000e+00 -4.200000e+00 6.100000e+00
+    endloop
+  endfacet
+  facet normal 1.682432e-14 1.000000e+00 -5.887083e-15
+    outer loop
+      vertex   2.507209e-02 -4.200000e+00 2.222252e+01
+      vertex   9.903113e-02 -4.200000e+00 2.243388e+01
+      vertex   0.000000e+00 -4.200000e+00 2.200000e+01
+    endloop
+  endfacet
+  facet normal 5.116350e-15 1.000000e+00 -3.214816e-15
+    outer loop
+      vertex   0.000000e+00 -4.200000e+00 2.200000e+01
+      vertex   9.903113e-02 -4.200000e+00 2.243388e+01
+      vertex   2.181685e-01 -4.200000e+00 2.262349e+01
+    endloop
+  endfacet
+  facet normal 2.191295e-15 1.000000e+00 -2.191295e-15
+    outer loop
+      vertex   0.000000e+00 -4.200000e+00 2.200000e+01
+      vertex   2.181685e-01 -4.200000e+00 2.262349e+01
+      vertex   3.765102e-01 -4.200000e+00 2.278183e+01
+    endloop
+  endfacet
+  facet normal 1.023521e-15 1.000000e+00 -1.628925e-15
+    outer loop
+      vertex   3.765102e-01 -4.200000e+00 2.278183e+01
+      vertex   5.661163e-01 -4.200000e+00 2.290097e+01
+      vertex   0.000000e+00 -4.200000e+00 2.200000e+01
+    endloop
+  endfacet
+  facet normal 4.421647e-16 1.000000e+00 -1.263634e-15
+    outer loop
+      vertex   0.000000e+00 -4.200000e+00 2.200000e+01
+      vertex   5.661163e-01 -4.200000e+00 2.290097e+01
+      vertex   7.774791e-01 -4.200000e+00 2.297493e+01
+    endloop
+  endfacet
+  facet normal 1.127810e-16 1.000000e+00 -1.000959e-15
+    outer loop
+      vertex   0.000000e+00 -4.200000e+00 2.200000e+01
+      vertex   7.774791e-01 -4.200000e+00 2.297493e+01
+      vertex   1.000000e+00 -4.200000e+00 2.300000e+01
+    endloop
+  endfacet
+  facet normal 1.119645e-01 -0.000000e+00 9.937122e-01
+    outer loop
+      vertex   1.142252e+01 -2.830000e+01 2.297493e+01
+      vertex   1.142252e+01 -2.390000e+01 2.297493e+01
+      vertex   1.120000e+01 -2.830000e+01 2.300000e+01
+    endloop
+  endfacet
+  facet normal 1.119645e-01 2.547735e-19 9.937122e-01
+    outer loop
+      vertex   1.120000e+01 -2.830000e+01 2.300000e+01
+      vertex   1.142252e+01 -2.390000e+01 2.297493e+01
+      vertex   1.142252e+01 -1.950000e+01 2.297493e+01
+    endloop
+  endfacet
+  facet normal 1.119645e-01 -0.000000e+00 9.937122e-01
+    outer loop
+      vertex   1.120000e+01 -2.830000e+01 2.300000e+01
+      vertex   1.142252e+01 -1.950000e+01 2.297493e+01
+      vertex   1.120000e+01 -1.070000e+01 2.300000e+01
+    endloop
+  endfacet
+  facet normal 1.119645e-01 2.547735e-19 9.937122e-01
+    outer loop
+      vertex   1.120000e+01 -1.070000e+01 2.300000e+01
+      vertex   1.142252e+01 -1.950000e+01 2.297493e+01
+      vertex   1.142252e+01 -1.510000e+01 2.297493e+01
+    endloop
+  endfacet
+  facet normal 1.119645e-01 2.547735e-19 9.937122e-01
+    outer loop
+      vertex   1.120000e+01 -1.070000e+01 2.300000e+01
+      vertex   1.142252e+01 -1.510000e+01 2.297493e+01
+      vertex   1.142252e+01 -1.070000e+01 2.297493e+01
+    endloop
+  endfacet
+  facet normal 3.302791e-01 0.000000e+00 9.438833e-01
+    outer loop
+      vertex   1.142252e+01 -1.070000e+01 2.297493e+01
+      vertex   1.142252e+01 -1.510000e+01 2.297493e+01
+      vertex   1.163388e+01 -1.070000e+01 2.290097e+01
+    endloop
+  endfacet
+  facet normal 3.302791e-01 0.000000e+00 9.438833e-01
+    outer loop
+      vertex   1.163388e+01 -1.070000e+01 2.290097e+01
+      vertex   1.142252e+01 -1.510000e+01 2.297493e+01
+      vertex   1.163388e+01 -1.510000e+01 2.290097e+01
+    endloop
+  endfacet
+  facet normal 5.320321e-01 0.000000e+00 8.467242e-01
+    outer loop
+      vertex   1.163388e+01 -1.070000e+01 2.290097e+01
+      vertex   1.163388e+01 -1.510000e+01 2.290097e+01
+      vertex   1.182349e+01 -1.070000e+01 2.278183e+01
+    endloop
+  endfacet
+  facet normal 5.320321e-01 -8.984653e-16 8.467242e-01
+    outer loop
+      vertex   1.182349e+01 -1.070000e+01 2.278183e+01
+      vertex   1.163388e+01 -1.510000e+01 2.290097e+01
+      vertex   1.182349e+01 -1.510000e+01 2.278183e+01
+    endloop
+  endfacet
+  facet normal 7.071068e-01 -8.564141e-16 7.071068e-01
+    outer loop
+      vertex   1.182349e+01 -1.070000e+01 2.278183e+01
+      vertex   1.182349e+01 -1.510000e+01 2.278183e+01
+      vertex   1.198183e+01 -1.070000e+01 2.262349e+01
+    endloop
+  endfacet
+  facet normal 7.071068e-01 0.000000e+00 7.071068e-01
+    outer loop
+      vertex   1.198183e+01 -1.070000e+01 2.262349e+01
+      vertex   1.182349e+01 -1.510000e+01 2.278183e+01
+      vertex   1.198183e+01 -1.510000e+01 2.262349e+01
+    endloop
+  endfacet
+  facet normal 8.467242e-01 0.000000e+00 5.320321e-01
+    outer loop
+      vertex   1.198183e+01 -1.070000e+01 2.262349e+01
+      vertex   1.198183e+01 -1.510000e+01 2.262349e+01
+      vertex   1.210097e+01 -1.070000e+01 2.243388e+01
+    endloop
+  endfacet
+  facet normal 8.467242e-01 6.836747e-16 5.320321e-01
+    outer loop
+      vertex   1.210097e+01 -1.070000e+01 2.243388e+01
+      vertex   1.198183e+01 -1.510000e+01 2.262349e+01
+      vertex   1.210097e+01 -1.510000e+01 2.243388e+01
+    endloop
+  endfacet
+  facet normal 9.438833e-01 7.621244e-16 3.302791e-01
+    outer loop
+      vertex   1.210097e+01 -1.070000e+01 2.243388e+01
+      vertex   1.210097e+01 -1.510000e+01 2.243388e+01
+      vertex   1.217493e+01 -1.070000e+01 2.222252e+01
+    endloop
+  endfacet
+  facet normal 9.438833e-01 0.000000e+00 3.302791e-01
+    outer loop
+      vertex   1.217493e+01 -1.070000e+01 2.222252e+01
+      vertex   1.210097e+01 -1.510000e+01 2.243388e+01
+      vertex   1.217493e+01 -1.510000e+01 2.222252e+01
+    endloop
+  endfacet
+  facet normal 9.937122e-01 0.000000e+00 1.119645e-01
+    outer loop
+      vertex   1.217493e+01 -1.070000e+01 2.222252e+01
+      vertex   1.217493e+01 -1.510000e+01 2.222252e+01
+      vertex   1.220000e+01 -1.070000e+01 2.200000e+01
+    endloop
+  endfacet
+  facet normal 9.937122e-01 -5.125499e-20 1.119645e-01
+    outer loop
+      vertex   1.220000e+01 -1.070000e+01 2.200000e+01
+      vertex   1.217493e+01 -1.510000e+01 2.222252e+01
+      vertex   1.217493e+01 -1.950000e+01 2.222252e+01
+    endloop
+  endfacet
+  facet normal 9.937122e-01 0.000000e+00 1.119645e-01
+    outer loop
+      vertex   1.220000e+01 -1.070000e+01 2.200000e+01
+      vertex   1.217493e+01 -1.950000e+01 2.222252e+01
+      vertex   1.220000e+01 -2.830000e+01 2.200000e+01
+    endloop
+  endfacet
+  facet normal 9.937122e-01 -5.125499e-20 1.119645e-01
+    outer loop
+      vertex   1.220000e+01 -2.830000e+01 2.200000e+01
+      vertex   1.217493e+01 -1.950000e+01 2.222252e+01
+      vertex   1.217493e+01 -2.390000e+01 2.222252e+01
+    endloop
+  endfacet
+  facet normal 9.937122e-01 -5.125499e-20 1.119645e-01
+    outer loop
+      vertex   1.220000e+01 -2.830000e+01 2.200000e+01
+      vertex   1.217493e+01 -2.390000e+01 2.222252e+01
+      vertex   1.217493e+01 -2.830000e+01 2.222252e+01
+    endloop
+  endfacet
+  facet normal 9.438833e-01 -0.000000e+00 3.302791e-01
+    outer loop
+      vertex   1.217493e+01 -2.830000e+01 2.222252e+01
+      vertex   1.217493e+01 -2.390000e+01 2.222252e+01
+      vertex   1.210097e+01 -2.830000e+01 2.243388e+01
+    endloop
+  endfacet
+  facet normal 9.438833e-01 -7.621244e-16 3.302791e-01
+    outer loop
+      vertex   1.210097e+01 -2.830000e+01 2.243388e+01
+      vertex   1.217493e+01 -2.390000e+01 2.222252e+01
+      vertex   1.210097e+01 -2.390000e+01 2.243388e+01
+    endloop
+  endfacet
+  facet normal 8.467242e-01 -6.836747e-16 5.320321e-01
+    outer loop
+      vertex   1.210097e+01 -2.830000e+01 2.243388e+01
+      vertex   1.210097e+01 -2.390000e+01 2.243388e+01
+      vertex   1.198183e+01 -2.830000e+01 2.262349e+01
+    endloop
+  endfacet
+  facet normal 8.467242e-01 -0.000000e+00 5.320321e-01
+    outer loop
+      vertex   1.198183e+01 -2.830000e+01 2.262349e+01
+      vertex   1.210097e+01 -2.390000e+01 2.243388e+01
+      vertex   1.198183e+01 -2.390000e+01 2.262349e+01
+    endloop
+  endfacet
+  facet normal 7.071068e-01 -0.000000e+00 7.071068e-01
+    outer loop
+      vertex   1.198183e+01 -2.830000e+01 2.262349e+01
+      vertex   1.198183e+01 -2.390000e+01 2.262349e+01
+      vertex   1.182349e+01 -2.830000e+01 2.278183e+01
+    endloop
+  endfacet
+  facet normal 7.071068e-01 8.564141e-16 7.071068e-01
+    outer loop
+      vertex   1.182349e+01 -2.830000e+01 2.278183e+01
+      vertex   1.198183e+01 -2.390000e+01 2.262349e+01
+      vertex   1.182349e+01 -2.390000e+01 2.278183e+01
+    endloop
+  endfacet
+  facet normal 5.320321e-01 8.984653e-16 8.467242e-01
+    outer loop
+      vertex   1.182349e+01 -2.830000e+01 2.278183e+01
+      vertex   1.182349e+01 -2.390000e+01 2.278183e+01
+      vertex   1.163388e+01 -2.830000e+01 2.290097e+01
+    endloop
+  endfacet
+  facet normal 5.320321e-01 -0.000000e+00 8.467242e-01
+    outer loop
+      vertex   1.163388e+01 -2.830000e+01 2.290097e+01
+      vertex   1.182349e+01 -2.390000e+01 2.278183e+01
+      vertex   1.163388e+01 -2.390000e+01 2.290097e+01
+    endloop
+  endfacet
+  facet normal 3.302791e-01 -0.000000e+00 9.438833e-01
+    outer loop
+      vertex   1.163388e+01 -2.830000e+01 2.290097e+01
+      vertex   1.163388e+01 -2.390000e+01 2.290097e+01
+      vertex   1.142252e+01 -2.830000e+01 2.297493e+01
+    endloop
+  endfacet
+  facet normal 3.302791e-01 -0.000000e+00 9.438833e-01
+    outer loop
+      vertex   1.142252e+01 -2.830000e+01 2.297493e+01
+      vertex   1.163388e+01 -2.390000e+01 2.290097e+01
+      vertex   1.142252e+01 -2.390000e+01 2.297493e+01
+    endloop
+  endfacet
+  facet normal 3.302791e-01 -6.485604e-19 9.438833e-01
+    outer loop
+      vertex   1.163388e+01 -1.510000e+01 2.290097e+01
+      vertex   1.142252e+01 -1.510000e+01 2.297493e+01
+      vertex   1.142252e+01 -1.950000e+01 2.297493e+01
+    endloop
+  endfacet
+  facet normal 3.302791e-01 0.000000e+00 9.438833e-01
+    outer loop
+      vertex   1.142252e+01 -1.950000e+01 2.297493e+01
+      vertex   1.142252e+01 -2.390000e+01 2.297493e+01
+      vertex   1.163388e+01 -1.950000e+01 2.290097e+01
+    endloop
+  endfacet
+  facet normal 3.302791e-01 0.000000e+00 9.438833e-01
+    outer loop
+      vertex   1.163388e+01 -1.950000e+01 2.290097e+01
+      vertex   1.142252e+01 -2.390000e+01 2.297493e+01
+      vertex   1.163388e+01 -2.390000e+01 2.290097e+01
+    endloop
+  endfacet
+  facet normal 5.320321e-01 0.000000e+00 8.467242e-01
+    outer loop
+      vertex   1.163388e+01 -1.950000e+01 2.290097e+01
+      vertex   1.163388e+01 -2.390000e+01 2.290097e+01
+      vertex   1.182349e+01 -1.950000e+01 2.278183e+01
+    endloop
+  endfacet
+  facet normal 5.320321e-01 0.000000e+00 8.467242e-01
+    outer loop
+      vertex   1.182349e+01 -1.950000e+01 2.278183e+01
+      vertex   1.163388e+01 -2.390000e+01 2.290097e+01
+      vertex   1.182349e+01 -2.390000e+01 2.278183e+01
+    endloop
+  endfacet
+  facet normal 7.071068e-01 0.000000e+00 7.071068e-01
+    outer loop
+      vertex   1.182349e+01 -1.950000e+01 2.278183e+01
+      vertex   1.182349e+01 -2.390000e+01 2.278183e+01
+      vertex   1.198183e+01 -1.950000e+01 2.262349e+01
+    endloop
+  endfacet
+  facet normal 7.071068e-01 0.000000e+00 7.071068e-01
+    outer loop
+      vertex   1.198183e+01 -1.950000e+01 2.262349e+01
+      vertex   1.182349e+01 -2.390000e+01 2.278183e+01
+      vertex   1.198183e+01 -2.390000e+01 2.262349e+01
+    endloop
+  endfacet
+  facet normal 8.467242e-01 0.000000e+00 5.320321e-01
+    outer loop
+      vertex   1.198183e+01 -1.950000e+01 2.262349e+01
+      vertex   1.198183e+01 -2.390000e+01 2.262349e+01
+      vertex   1.210097e+01 -1.950000e+01 2.243388e+01
+    endloop
+  endfacet
+  facet normal 8.467242e-01 0.000000e+00 5.320321e-01
+    outer loop
+      vertex   1.210097e+01 -1.950000e+01 2.243388e+01
+      vertex   1.198183e+01 -2.390000e+01 2.262349e+01
+      vertex   1.210097e+01 -2.390000e+01 2.243388e+01
+    endloop
+  endfacet
+  facet normal 9.438833e-01 0.000000e+00 3.302791e-01
+    outer loop
+      vertex   1.210097e+01 -1.950000e+01 2.243388e+01
+      vertex   1.210097e+01 -2.390000e+01 2.243388e+01
+      vertex   1.217493e+01 -1.950000e+01 2.222252e+01
+    endloop
+  endfacet
+  facet normal 9.438833e-01 0.000000e+00 3.302791e-01
+    outer loop
+      vertex   1.217493e+01 -1.950000e+01 2.222252e+01
+      vertex   1.210097e+01 -2.390000e+01 2.243388e+01
+      vertex   1.217493e+01 -2.390000e+01 2.222252e+01
+    endloop
+  endfacet
+  facet normal 5.320321e-01 1.319961e-18 8.467242e-01
+    outer loop
+      vertex   1.182349e+01 -1.510000e+01 2.278183e+01
+      vertex   1.163388e+01 -1.510000e+01 2.290097e+01
+      vertex   1.163388e+01 -1.950000e+01 2.290097e+01
+    endloop
+  endfacet
+  facet normal 3.302791e-01 -0.000000e+00 9.438833e-01
+    outer loop
+      vertex   1.163388e+01 -1.950000e+01 2.290097e+01
+      vertex   1.163388e+01 -1.510000e+01 2.290097e+01
+      vertex   1.142252e+01 -1.950000e+01 2.297493e+01
+    endloop
+  endfacet
+  facet normal 5.320321e-01 0.000000e+00 8.467242e-01
+    outer loop
+      vertex   1.182349e+01 -1.510000e+01 2.278183e+01
+      vertex   1.163388e+01 -1.950000e+01 2.290097e+01
+      vertex   1.182349e+01 -1.950000e+01 2.278183e+01
+    endloop
+  endfacet
+  facet normal 7.071068e-01 -6.932914e-19 7.071068e-01
+    outer loop
+      vertex   1.198183e+01 -1.510000e+01 2.262349e+01
+      vertex   1.182349e+01 -1.510000e+01 2.278183e+01
+      vertex   1.182349e+01 -1.950000e+01 2.278183e+01
+    endloop
+  endfacet
+  facet normal 7.071068e-01 0.000000e+00 7.071068e-01
+    outer loop
+      vertex   1.198183e+01 -1.510000e+01 2.262349e+01
+      vertex   1.182349e+01 -1.950000e+01 2.278183e+01
+      vertex   1.198183e+01 -1.950000e+01 2.262349e+01
+    endloop
+  endfacet
+  facet normal 8.467242e-01 2.345681e-19 5.320321e-01
+    outer loop
+      vertex   1.210097e+01 -1.510000e+01 2.243388e+01
+      vertex   1.198183e+01 -1.510000e+01 2.262349e+01
+      vertex   1.198183e+01 -1.950000e+01 2.262349e+01
+    endloop
+  endfacet
+  facet normal 8.467242e-01 0.000000e+00 5.320321e-01
+    outer loop
+      vertex   1.210097e+01 -1.510000e+01 2.243388e+01
+      vertex   1.198183e+01 -1.950000e+01 2.262349e+01
+      vertex   1.210097e+01 -1.950000e+01 2.243388e+01
+    endloop
+  endfacet
+  facet normal 9.438833e-01 1.482102e-18 3.302791e-01
+    outer loop
+      vertex   1.217493e+01 -1.510000e+01 2.222252e+01
+      vertex   1.210097e+01 -1.510000e+01 2.243388e+01
+      vertex   1.210097e+01 -1.950000e+01 2.243388e+01
+    endloop
+  endfacet
+  facet normal 9.438833e-01 0.000000e+00 3.302791e-01
+    outer loop
+      vertex   1.217493e+01 -1.510000e+01 2.222252e+01
+      vertex   1.210097e+01 -1.950000e+01 2.243388e+01
+      vertex   1.217493e+01 -1.950000e+01 2.222252e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -0.000000e+00 1.000000e+00
+    outer loop
+      vertex   1.120000e+01 -2.830000e+01 2.300000e+01
+      vertex   1.120000e+01 -1.070000e+01 2.300000e+01
+      vertex   1.000000e+00 -2.830000e+01 2.300000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 1.000000e+00
+    outer loop
+      vertex   1.000000e+00 -2.830000e+01 2.300000e+01
+      vertex   1.120000e+01 -1.070000e+01 2.300000e+01
+      vertex   1.000000e+00 -1.070000e+01 2.300000e+01
+    endloop
+  endfacet
+  facet normal -1.119645e-01 0.000000e+00 9.937122e-01
+    outer loop
+      vertex   1.000000e+00 -8.300000e+00 2.300000e+01
+      vertex   1.000000e+00 -4.200000e+00 2.300000e+01
+      vertex   7.774791e-01 -8.300000e+00 2.297493e+01
+    endloop
+  endfacet
+  facet normal -1.119645e-01 0.000000e+00 9.937122e-01
+    outer loop
+      vertex   7.774791e-01 -8.300000e+00 2.297493e+01
+      vertex   1.000000e+00 -4.200000e+00 2.300000e+01
+      vertex   7.774791e-01 -4.200000e+00 2.297493e+01
+    endloop
+  endfacet
+  facet normal -3.302791e-01 0.000000e+00 9.438833e-01
+    outer loop
+      vertex   7.774791e-01 -8.300000e+00 2.297493e+01
+      vertex   7.774791e-01 -4.200000e+00 2.297493e+01
+      vertex   5.661163e-01 -8.300000e+00 2.290097e+01
+    endloop
+  endfacet
+  facet normal -3.302791e-01 0.000000e+00 9.438833e-01
+    outer loop
+      vertex   5.661163e-01 -8.300000e+00 2.290097e+01
+      vertex   7.774791e-01 -4.200000e+00 2.297493e+01
+      vertex   5.661163e-01 -4.200000e+00 2.290097e+01
+    endloop
+  endfacet
+  facet normal -5.320321e-01 0.000000e+00 8.467242e-01
+    outer loop
+      vertex   5.661163e-01 -8.300000e+00 2.290097e+01
+      vertex   5.661163e-01 -4.200000e+00 2.290097e+01
+      vertex   3.765102e-01 -8.300000e+00 2.278183e+01
+    endloop
+  endfacet
+  facet normal -5.320321e-01 0.000000e+00 8.467242e-01
+    outer loop
+      vertex   3.765102e-01 -8.300000e+00 2.278183e+01
+      vertex   5.661163e-01 -4.200000e+00 2.290097e+01
+      vertex   3.765102e-01 -4.200000e+00 2.278183e+01
+    endloop
+  endfacet
+  facet normal -7.071068e-01 0.000000e+00 7.071068e-01
+    outer loop
+      vertex   3.765102e-01 -8.300000e+00 2.278183e+01
+      vertex   3.765102e-01 -4.200000e+00 2.278183e+01
+      vertex   2.181685e-01 -8.300000e+00 2.262349e+01
+    endloop
+  endfacet
+  facet normal -7.071068e-01 0.000000e+00 7.071068e-01
+    outer loop
+      vertex   2.181685e-01 -8.300000e+00 2.262349e+01
+      vertex   3.765102e-01 -4.200000e+00 2.278183e+01
+      vertex   2.181685e-01 -4.200000e+00 2.262349e+01
+    endloop
+  endfacet
+  facet normal -8.467242e-01 0.000000e+00 5.320321e-01
+    outer loop
+      vertex   2.181685e-01 -8.300000e+00 2.262349e+01
+      vertex   2.181685e-01 -4.200000e+00 2.262349e+01
+      vertex   9.903113e-02 -8.300000e+00 2.243388e+01
+    endloop
+  endfacet
+  facet normal -8.467242e-01 0.000000e+00 5.320321e-01
+    outer loop
+      vertex   9.903113e-02 -8.300000e+00 2.243388e+01
+      vertex   2.181685e-01 -4.200000e+00 2.262349e+01
+      vertex   9.903113e-02 -4.200000e+00 2.243388e+01
+    endloop
+  endfacet
+  facet normal -9.438833e-01 0.000000e+00 3.302791e-01
+    outer loop
+      vertex   9.903113e-02 -8.300000e+00 2.243388e+01
+      vertex   9.903113e-02 -4.200000e+00 2.243388e+01
+      vertex   2.507209e-02 -8.300000e+00 2.222252e+01
+    endloop
+  endfacet
+  facet normal -9.438833e-01 0.000000e+00 3.302791e-01
+    outer loop
+      vertex   2.507209e-02 -8.300000e+00 2.222252e+01
+      vertex   9.903113e-02 -4.200000e+00 2.243388e+01
+      vertex   2.507209e-02 -4.200000e+00 2.222252e+01
+    endloop
+  endfacet
+  facet normal -9.937122e-01 0.000000e+00 1.119645e-01
+    outer loop
+      vertex   2.507209e-02 -8.300000e+00 2.222252e+01
+      vertex   2.507209e-02 -4.200000e+00 2.222252e+01
+      vertex   0.000000e+00 -8.300000e+00 2.200000e+01
+    endloop
+  endfacet
+  facet normal -9.937122e-01 0.000000e+00 1.119645e-01
+    outer loop
+      vertex   0.000000e+00 -8.300000e+00 2.200000e+01
+      vertex   2.507209e-02 -4.200000e+00 2.222252e+01
+      vertex   0.000000e+00 -4.200000e+00 2.200000e+01
+    endloop
+  endfacet
+  facet normal -9.937122e-01 6.268421e-17 1.119645e-01
+    outer loop
+      vertex   2.507209e-02 -2.830000e+01 2.222252e+01
+      vertex   2.507209e-02 -2.390000e+01 2.222252e+01
+      vertex   0.000000e+00 -2.830000e+01 2.200000e+01
+    endloop
+  endfacet
+  facet normal -9.937122e-01 3.551942e-19 1.119645e-01
+    outer loop
+      vertex   0.000000e+00 -2.830000e+01 2.200000e+01
+      vertex   2.507209e-02 -2.390000e+01 2.222252e+01
+      vertex   2.507209e-02 -1.950000e+01 2.222252e+01
+    endloop
+  endfacet
+  facet normal -9.937122e-01 0.000000e+00 1.119645e-01
+    outer loop
+      vertex   0.000000e+00 -2.830000e+01 2.200000e+01
+      vertex   2.507209e-02 -1.950000e+01 2.222252e+01
+      vertex   0.000000e+00 -1.070000e+01 2.200000e+01
+    endloop
+  endfacet
+  facet normal -9.937122e-01 3.551942e-19 1.119645e-01
+    outer loop
+      vertex   0.000000e+00 -1.070000e+01 2.200000e+01
+      vertex   2.507209e-02 -1.950000e+01 2.222252e+01
+      vertex   2.507209e-02 -1.510000e+01 2.222252e+01
+    endloop
+  endfacet
+  facet normal -9.937122e-01 -6.232902e-17 1.119645e-01
+    outer loop
+      vertex   0.000000e+00 -1.070000e+01 2.200000e+01
+      vertex   2.507209e-02 -1.510000e+01 2.222252e+01
+      vertex   2.507209e-02 -1.070000e+01 2.222252e+01
+    endloop
+  endfacet
+  facet normal -9.438833e-01 -5.954097e-17 3.302791e-01
+    outer loop
+      vertex   2.507209e-02 -1.070000e+01 2.222252e+01
+      vertex   2.507209e-02 -1.510000e+01 2.222252e+01
+      vertex   9.903113e-02 -1.070000e+01 2.243388e+01
+    endloop
+  endfacet
+  facet normal -9.438833e-01 2.530491e-16 3.302791e-01
+    outer loop
+      vertex   9.903113e-02 -1.070000e+01 2.243388e+01
+      vertex   2.507209e-02 -1.510000e+01 2.222252e+01
+      vertex   9.903113e-02 -1.510000e+01 2.243388e+01
+    endloop
+  endfacet
+  facet normal -8.467242e-01 2.270014e-16 5.320321e-01
+    outer loop
+      vertex   9.903113e-02 -1.070000e+01 2.243388e+01
+      vertex   9.903113e-02 -1.510000e+01 2.243388e+01
+      vertex   2.181685e-01 -1.070000e+01 2.262349e+01
+    endloop
+  endfacet
+  facet normal -8.467242e-01 -8.011813e-17 5.320321e-01
+    outer loop
+      vertex   2.181685e-01 -1.070000e+01 2.262349e+01
+      vertex   9.903113e-02 -1.510000e+01 2.243388e+01
+      vertex   2.181685e-01 -1.510000e+01 2.262349e+01
+    endloop
+  endfacet
+  facet normal -7.071068e-01 -6.690735e-17 7.071068e-01
+    outer loop
+      vertex   2.181685e-01 -1.070000e+01 2.262349e+01
+      vertex   2.181685e-01 -1.510000e+01 2.262349e+01
+      vertex   3.765102e-01 -1.070000e+01 2.278183e+01
+    endloop
+  endfacet
+  facet normal -7.071068e-01 1.784196e-17 7.071068e-01
+    outer loop
+      vertex   3.765102e-01 -1.070000e+01 2.278183e+01
+      vertex   2.181685e-01 -1.510000e+01 2.262349e+01
+      vertex   3.765102e-01 -1.510000e+01 2.278183e+01
+    endloop
+  endfacet
+  facet normal -5.320321e-01 1.342442e-17 8.467242e-01
+    outer loop
+      vertex   3.765102e-01 -1.070000e+01 2.278183e+01
+      vertex   3.765102e-01 -1.510000e+01 2.278183e+01
+      vertex   5.661163e-01 -1.070000e+01 2.290097e+01
+    endloop
+  endfacet
+  facet normal -5.320321e-01 8.179188e-16 8.467242e-01
+    outer loop
+      vertex   5.661163e-01 -1.070000e+01 2.290097e+01
+      vertex   3.765102e-01 -1.510000e+01 2.278183e+01
+      vertex   5.661163e-01 -1.510000e+01 2.290097e+01
+    endloop
+  endfacet
+  facet normal -3.302791e-01 8.454615e-16 9.438833e-01
+    outer loop
+      vertex   5.661163e-01 -1.070000e+01 2.290097e+01
+      vertex   5.661163e-01 -1.510000e+01 2.290097e+01
+      vertex   7.774791e-01 -1.070000e+01 2.297493e+01
+    endloop
+  endfacet
+  facet normal -3.302791e-01 8.287941e-16 9.438833e-01
+    outer loop
+      vertex   7.774791e-01 -1.070000e+01 2.297493e+01
+      vertex   5.661163e-01 -1.510000e+01 2.290097e+01
+      vertex   7.774791e-01 -1.510000e+01 2.297493e+01
+    endloop
+  endfacet
+  facet normal -1.119645e-01 8.249590e-16 9.937122e-01
+    outer loop
+      vertex   7.774791e-01 -1.070000e+01 2.297493e+01
+      vertex   7.774791e-01 -1.510000e+01 2.297493e+01
+      vertex   1.000000e+00 -1.070000e+01 2.300000e+01
+    endloop
+  endfacet
+  facet normal -1.119645e-01 3.236894e-20 9.937122e-01
+    outer loop
+      vertex   1.000000e+00 -1.070000e+01 2.300000e+01
+      vertex   7.774791e-01 -1.510000e+01 2.297493e+01
+      vertex   7.774791e-01 -1.950000e+01 2.297493e+01
+    endloop
+  endfacet
+  facet normal -1.119645e-01 0.000000e+00 9.937122e-01
+    outer loop
+      vertex   1.000000e+00 -1.070000e+01 2.300000e+01
+      vertex   7.774791e-01 -1.950000e+01 2.297493e+01
+      vertex   1.000000e+00 -2.830000e+01 2.300000e+01
+    endloop
+  endfacet
+  facet normal -1.119645e-01 3.236894e-20 9.937122e-01
+    outer loop
+      vertex   1.000000e+00 -2.830000e+01 2.300000e+01
+      vertex   7.774791e-01 -1.950000e+01 2.297493e+01
+      vertex   7.774791e-01 -2.390000e+01 2.297493e+01
+    endloop
+  endfacet
+  facet normal -1.119645e-01 -8.245342e-16 9.937122e-01
+    outer loop
+      vertex   1.000000e+00 -2.830000e+01 2.300000e+01
+      vertex   7.774791e-01 -2.390000e+01 2.297493e+01
+      vertex   7.774791e-01 -2.830000e+01 2.297493e+01
+    endloop
+  endfacet
+  facet normal -3.302791e-01 -8.287941e-16 9.438833e-01
+    outer loop
+      vertex   7.774791e-01 -2.830000e+01 2.297493e+01
+      vertex   7.774791e-01 -2.390000e+01 2.297493e+01
+      vertex   5.661163e-01 -2.830000e+01 2.290097e+01
+    endloop
+  endfacet
+  facet normal -3.302791e-01 -8.454615e-16 9.438833e-01
+    outer loop
+      vertex   5.661163e-01 -2.830000e+01 2.290097e+01
+      vertex   7.774791e-01 -2.390000e+01 2.297493e+01
+      vertex   5.661163e-01 -2.390000e+01 2.290097e+01
+    endloop
+  endfacet
+  facet normal -5.320321e-01 -8.179188e-16 8.467242e-01
+    outer loop
+      vertex   5.661163e-01 -2.830000e+01 2.290097e+01
+      vertex   5.661163e-01 -2.390000e+01 2.290097e+01
+      vertex   3.765102e-01 -2.830000e+01 2.278183e+01
+    endloop
+  endfacet
+  facet normal -5.320321e-01 -1.342442e-17 8.467242e-01
+    outer loop
+      vertex   3.765102e-01 -2.830000e+01 2.278183e+01
+      vertex   5.661163e-01 -2.390000e+01 2.290097e+01
+      vertex   3.765102e-01 -2.390000e+01 2.278183e+01
+    endloop
+  endfacet
+  facet normal -7.071068e-01 -1.784196e-17 7.071068e-01
+    outer loop
+      vertex   3.765102e-01 -2.830000e+01 2.278183e+01
+      vertex   3.765102e-01 -2.390000e+01 2.278183e+01
+      vertex   2.181685e-01 -2.830000e+01 2.262349e+01
+    endloop
+  endfacet
+  facet normal -7.071068e-01 6.690735e-17 7.071068e-01
+    outer loop
+      vertex   2.181685e-01 -2.830000e+01 2.262349e+01
+      vertex   3.765102e-01 -2.390000e+01 2.278183e+01
+      vertex   2.181685e-01 -2.390000e+01 2.262349e+01
+    endloop
+  endfacet
+  facet normal -8.467242e-01 8.011813e-17 5.320321e-01
+    outer loop
+      vertex   2.181685e-01 -2.830000e+01 2.262349e+01
+      vertex   2.181685e-01 -2.390000e+01 2.262349e+01
+      vertex   9.903113e-02 -2.830000e+01 2.243388e+01
+    endloop
+  endfacet
+  facet normal -8.467242e-01 -2.270014e-16 5.320321e-01
+    outer loop
+      vertex   9.903113e-02 -2.830000e+01 2.243388e+01
+      vertex   2.181685e-01 -2.390000e+01 2.262349e+01
+      vertex   9.903113e-02 -2.390000e+01 2.243388e+01
+    endloop
+  endfacet
+  facet normal -9.438833e-01 -2.530491e-16 3.302791e-01
+    outer loop
+      vertex   9.903113e-02 -2.830000e+01 2.243388e+01
+      vertex   9.903113e-02 -2.390000e+01 2.243388e+01
+      vertex   2.507209e-02 -2.830000e+01 2.222252e+01
+    endloop
+  endfacet
+  facet normal -9.438833e-01 5.954097e-17 3.302791e-01
+    outer loop
+      vertex   2.507209e-02 -2.830000e+01 2.222252e+01
+      vertex   9.903113e-02 -2.390000e+01 2.243388e+01
+      vertex   2.507209e-02 -2.390000e+01 2.222252e+01
+    endloop
+  endfacet
+  facet normal -9.438833e-01 -7.463082e-20 3.302791e-01
+    outer loop
+      vertex   9.903113e-02 -1.510000e+01 2.243388e+01
+      vertex   2.507209e-02 -1.510000e+01 2.222252e+01
+      vertex   2.507209e-02 -1.950000e+01 2.222252e+01
+    endloop
+  endfacet
+  facet normal -9.438833e-01 0.000000e+00 3.302791e-01
+    outer loop
+      vertex   2.507209e-02 -1.950000e+01 2.222252e+01
+      vertex   2.507209e-02 -2.390000e+01 2.222252e+01
+      vertex   9.903113e-02 -1.950000e+01 2.243388e+01
+    endloop
+  endfacet
+  facet normal -9.438833e-01 0.000000e+00 3.302791e-01
+    outer loop
+      vertex   9.903113e-02 -1.950000e+01 2.243388e+01
+      vertex   2.507209e-02 -2.390000e+01 2.222252e+01
+      vertex   9.903113e-02 -2.390000e+01 2.243388e+01
+    endloop
+  endfacet
+  facet normal -8.467242e-01 0.000000e+00 5.320321e-01
+    outer loop
+      vertex   9.903113e-02 -1.950000e+01 2.243388e+01
+      vertex   9.903113e-02 -2.390000e+01 2.243388e+01
+      vertex   2.181685e-01 -1.950000e+01 2.262349e+01
+    endloop
+  endfacet
+  facet normal -8.467242e-01 0.000000e+00 5.320321e-01
+    outer loop
+      vertex   2.181685e-01 -1.950000e+01 2.262349e+01
+      vertex   9.903113e-02 -2.390000e+01 2.243388e+01
+      vertex   2.181685e-01 -2.390000e+01 2.262349e+01
+    endloop
+  endfacet
+  facet normal -7.071068e-01 0.000000e+00 7.071068e-01
+    outer loop
+      vertex   2.181685e-01 -1.950000e+01 2.262349e+01
+      vertex   2.181685e-01 -2.390000e+01 2.262349e+01
+      vertex   3.765102e-01 -1.950000e+01 2.278183e+01
+    endloop
+  endfacet
+  facet normal -7.071068e-01 0.000000e+00 7.071068e-01
+    outer loop
+      vertex   3.765102e-01 -1.950000e+01 2.278183e+01
+      vertex   2.181685e-01 -2.390000e+01 2.262349e+01
+      vertex   3.765102e-01 -2.390000e+01 2.278183e+01
+    endloop
+  endfacet
+  facet normal -5.320321e-01 0.000000e+00 8.467242e-01
+    outer loop
+      vertex   3.765102e-01 -1.950000e+01 2.278183e+01
+      vertex   3.765102e-01 -2.390000e+01 2.278183e+01
+      vertex   5.661163e-01 -1.950000e+01 2.290097e+01
+    endloop
+  endfacet
+  facet normal -5.320321e-01 0.000000e+00 8.467242e-01
+    outer loop
+      vertex   5.661163e-01 -1.950000e+01 2.290097e+01
+      vertex   3.765102e-01 -2.390000e+01 2.278183e+01
+      vertex   5.661163e-01 -2.390000e+01 2.290097e+01
+    endloop
+  endfacet
+  facet normal -3.302791e-01 0.000000e+00 9.438833e-01
+    outer loop
+      vertex   5.661163e-01 -1.950000e+01 2.290097e+01
+      vertex   5.661163e-01 -2.390000e+01 2.290097e+01
+      vertex   7.774791e-01 -1.950000e+01 2.297493e+01
+    endloop
+  endfacet
+  facet normal -3.302791e-01 0.000000e+00 9.438833e-01
+    outer loop
+      vertex   7.774791e-01 -1.950000e+01 2.297493e+01
+      vertex   5.661163e-01 -2.390000e+01 2.290097e+01
+      vertex   7.774791e-01 -2.390000e+01 2.297493e+01
+    endloop
+  endfacet
+  facet normal -8.467242e-01 2.016374e-19 5.320321e-01
+    outer loop
+      vertex   2.181685e-01 -1.510000e+01 2.262349e+01
+      vertex   9.903113e-02 -1.510000e+01 2.243388e+01
+      vertex   9.903113e-02 -1.950000e+01 2.243388e+01
+    endloop
+  endfacet
+  facet normal -9.438833e-01 0.000000e+00 3.302791e-01
+    outer loop
+      vertex   9.903113e-02 -1.950000e+01 2.243388e+01
+      vertex   9.903113e-02 -1.510000e+01 2.243388e+01
+      vertex   2.507209e-02 -1.950000e+01 2.222252e+01
+    endloop
+  endfacet
+  facet normal -8.467242e-01 0.000000e+00 5.320321e-01
+    outer loop
+      vertex   2.181685e-01 -1.510000e+01 2.262349e+01
+      vertex   9.903113e-02 -1.950000e+01 2.243388e+01
+      vertex   2.181685e-01 -1.950000e+01 2.262349e+01
+    endloop
+  endfacet
+  facet normal -7.071068e-01 2.148555e-19 7.071068e-01
+    outer loop
+      vertex   3.765102e-01 -1.510000e+01 2.278183e+01
+      vertex   2.181685e-01 -1.510000e+01 2.262349e+01
+      vertex   2.181685e-01 -1.950000e+01 2.262349e+01
+    endloop
+  endfacet
+  facet normal -7.071068e-01 0.000000e+00 7.071068e-01
+    outer loop
+      vertex   3.765102e-01 -1.510000e+01 2.278183e+01
+      vertex   2.181685e-01 -1.950000e+01 2.262349e+01
+      vertex   3.765102e-01 -1.950000e+01 2.278183e+01
+    endloop
+  endfacet
+  facet normal -5.320321e-01 9.833622e-19 8.467242e-01
+    outer loop
+      vertex   5.661163e-01 -1.510000e+01 2.290097e+01
+      vertex   3.765102e-01 -1.510000e+01 2.278183e+01
+      vertex   3.765102e-01 -1.950000e+01 2.278183e+01
+    endloop
+  endfacet
+  facet normal -5.320321e-01 0.000000e+00 8.467242e-01
+    outer loop
+      vertex   5.661163e-01 -1.510000e+01 2.290097e+01
+      vertex   3.765102e-01 -1.950000e+01 2.278183e+01
+      vertex   5.661163e-01 -1.950000e+01 2.290097e+01
+    endloop
+  endfacet
+  facet normal -3.302791e-01 4.062169e-19 9.438833e-01
+    outer loop
+      vertex   7.774791e-01 -1.510000e+01 2.297493e+01
+      vertex   5.661163e-01 -1.510000e+01 2.290097e+01
+      vertex   5.661163e-01 -1.950000e+01 2.290097e+01
+    endloop
+  endfacet
+  facet normal -3.302791e-01 0.000000e+00 9.438833e-01
+    outer loop
+      vertex   7.774791e-01 -1.510000e+01 2.297493e+01
+      vertex   5.661163e-01 -1.950000e+01 2.290097e+01
+      vertex   7.774791e-01 -1.950000e+01 2.297493e+01
+    endloop
+  endfacet
+  facet normal -1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.600000e+00 -1.070000e+01 2.666421e+01
+      vertex   6.600000e+00 -1.070000e+01 2.750000e+01
+      vertex   6.600000e+00 -8.300000e+00 2.666421e+01
+    endloop
+  endfacet
+  facet normal -1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.600000e+00 -8.300000e+00 2.666421e+01
+      vertex   6.600000e+00 -1.070000e+01 2.750000e+01
+      vertex   6.600000e+00 -8.300000e+00 2.750000e+01
+    endloop
+  endfacet
+  facet normal 4.227242e-01 0.000000e+00 -9.062584e-01
+    outer loop
+      vertex   5.600000e+00 -8.300000e+00 2.666421e+01
+      vertex   5.600000e+00 -1.070000e+01 2.666421e+01
+      vertex   5.337741e+00 -8.300000e+00 2.654188e+01
+    endloop
+  endfacet
+  facet normal 4.227242e-01 -1.564394e-16 -9.062584e-01
+    outer loop
+      vertex   5.337741e+00 -8.300000e+00 2.654188e+01
+      vertex   5.600000e+00 -1.070000e+01 2.666421e+01
+      vertex   5.337741e+00 -1.070000e+01 2.654188e+01
+    endloop
+  endfacet
+  facet normal 5.888811e-01 -2.179298e-16 -8.082197e-01
+    outer loop
+      vertex   5.337741e+00 -8.300000e+00 2.654188e+01
+      vertex   5.337741e+00 -1.070000e+01 2.654188e+01
+      vertex   5.103854e+00 -8.300000e+00 2.637147e+01
+    endloop
+  endfacet
+  facet normal 5.888811e-01 -4.358596e-16 -8.082197e-01
+    outer loop
+      vertex   5.103854e+00 -8.300000e+00 2.637147e+01
+      vertex   5.337741e+00 -1.070000e+01 2.654188e+01
+      vertex   5.103854e+00 -1.070000e+01 2.637147e+01
+    endloop
+  endfacet
+  facet normal 7.331200e-01 -5.426178e-16 -6.800993e-01
+    outer loop
+      vertex   5.103854e+00 -8.300000e+00 2.637147e+01
+      vertex   5.103854e+00 -1.070000e+01 2.637147e+01
+      vertex   4.907043e+00 -8.300000e+00 2.615931e+01
+    endloop
+  endfacet
+  facet normal 7.331200e-01 0.000000e+00 -6.800993e-01
+    outer loop
+      vertex   4.907043e+00 -8.300000e+00 2.615931e+01
+      vertex   5.103854e+00 -1.070000e+01 2.637147e+01
+      vertex   4.907043e+00 -1.070000e+01 2.615931e+01
+    endloop
+  endfacet
+  facet normal 8.500724e-01 0.000000e+00 -5.266658e-01
+    outer loop
+      vertex   4.907043e+00 -8.300000e+00 2.615931e+01
+      vertex   4.907043e+00 -1.070000e+01 2.615931e+01
+      vertex   4.754633e+00 -8.300000e+00 2.591332e+01
+    endloop
+  endfacet
+  facet normal 8.500724e-01 0.000000e+00 -5.266658e-01
+    outer loop
+      vertex   4.754633e+00 -8.300000e+00 2.591332e+01
+      vertex   4.907043e+00 -1.070000e+01 2.615931e+01
+      vertex   4.754633e+00 -1.070000e+01 2.591332e+01
+    endloop
+  endfacet
+  facet normal 9.353854e-01 0.000000e+00 -3.536300e-01
+    outer loop
+      vertex   4.754633e+00 -8.300000e+00 2.591332e+01
+      vertex   4.754633e+00 -1.070000e+01 2.591332e+01
+      vertex   4.652297e+00 -8.300000e+00 2.564263e+01
+    endloop
+  endfacet
+  facet normal 9.353854e-01 0.000000e+00 -3.536300e-01
+    outer loop
+      vertex   4.652297e+00 -8.300000e+00 2.564263e+01
+      vertex   4.754633e+00 -1.070000e+01 2.591332e+01
+      vertex   4.652297e+00 -1.070000e+01 2.564263e+01
+    endloop
+  endfacet
+  facet normal 9.858836e-01 0.000000e+00 -1.674322e-01
+    outer loop
+      vertex   4.652297e+00 -8.300000e+00 2.564263e+01
+      vertex   4.652297e+00 -1.070000e+01 2.564263e+01
+      vertex   4.603845e+00 -8.300000e+00 2.535733e+01
+    endloop
+  endfacet
+  facet normal 9.858836e-01 3.648502e-16 -1.674322e-01
+    outer loop
+      vertex   4.603845e+00 -8.300000e+00 2.535733e+01
+      vertex   4.652297e+00 -1.070000e+01 2.564263e+01
+      vertex   4.603845e+00 -1.070000e+01 2.535733e+01
+    endloop
+  endfacet
+  facet normal 9.996875e-01 3.699587e-16 2.499745e-02
+    outer loop
+      vertex   4.603845e+00 -8.300000e+00 2.535733e+01
+      vertex   4.603845e+00 -1.070000e+01 2.535733e+01
+      vertex   4.611079e+00 -8.300000e+00 2.506803e+01
+    endloop
+  endfacet
+  facet normal 9.996875e-01 0.000000e+00 2.499745e-02
+    outer loop
+      vertex   4.611079e+00 -8.300000e+00 2.506803e+01
+      vertex   4.603845e+00 -1.070000e+01 2.535733e+01
+      vertex   4.611079e+00 -1.070000e+01 2.506803e+01
+    endloop
+  endfacet
+  facet normal 9.762834e-01 0.000000e+00 2.164967e-01
+    outer loop
+      vertex   4.611079e+00 -8.300000e+00 2.506803e+01
+      vertex   4.611079e+00 -1.070000e+01 2.506803e+01
+      vertex   4.673730e+00 -8.300000e+00 2.478551e+01
+    endloop
+  endfacet
+  facet normal 9.762834e-01 0.000000e+00 2.164967e-01
+    outer loop
+      vertex   4.673730e+00 -8.300000e+00 2.478551e+01
+      vertex   4.611079e+00 -1.070000e+01 2.506803e+01
+      vertex   4.673730e+00 -1.070000e+01 2.478551e+01
+    endloop
+  endfacet
+  facet normal 9.165422e-01 0.000000e+00 3.999379e-01
+    outer loop
+      vertex   4.673730e+00 -8.300000e+00 2.478551e+01
+      vertex   4.673730e+00 -1.070000e+01 2.478551e+01
+      vertex   4.789466e+00 -8.300000e+00 2.452027e+01
+    endloop
+  endfacet
+  facet normal 9.165422e-01 3.391888e-16 3.999379e-01
+    outer loop
+      vertex   4.789466e+00 -8.300000e+00 2.452027e+01
+      vertex   4.673730e+00 -1.070000e+01 2.478551e+01
+      vertex   4.789466e+00 -1.070000e+01 2.452027e+01
+    endloop
+  endfacet
+  facet normal 8.226877e-01 3.044556e-16 5.684936e-01
+    outer loop
+      vertex   4.789466e+00 -8.300000e+00 2.452027e+01
+      vertex   4.789466e+00 -1.070000e+01 2.452027e+01
+      vertex   4.953980e+00 -8.300000e+00 2.428220e+01
+    endloop
+  endfacet
+  facet normal 8.226877e-01 3.044556e-16 5.684936e-01
+    outer loop
+      vertex   4.953980e+00 -8.300000e+00 2.428220e+01
+      vertex   4.789466e+00 -1.070000e+01 2.452027e+01
+      vertex   4.953980e+00 -1.070000e+01 2.428220e+01
+    endloop
+  endfacet
+  facet normal 6.982129e-01 2.583907e-16 7.158902e-01
+    outer loop
+      vertex   4.953980e+00 -8.300000e+00 2.428220e+01
+      vertex   4.953980e+00 -1.070000e+01 2.428220e+01
+      vertex   5.161149e+00 -8.300000e+00 2.408015e+01
+    endloop
+  endfacet
+  facet normal 6.982129e-01 0.000000e+00 7.158902e-01
+    outer loop
+      vertex   5.161149e+00 -8.300000e+00 2.408015e+01
+      vertex   4.953980e+00 -1.070000e+01 2.428220e+01
+      vertex   5.161149e+00 -1.070000e+01 2.408015e+01
+    endloop
+  endfacet
+  facet normal 5.477509e-01 0.000000e+00 8.366415e-01
+    outer loop
+      vertex   5.161149e+00 -8.300000e+00 2.408015e+01
+      vertex   5.161149e+00 -1.070000e+01 2.408015e+01
+      vertex   5.403261e+00 -8.300000e+00 2.392163e+01
+    endloop
+  endfacet
+  facet normal 5.477509e-01 0.000000e+00 8.366415e-01
+    outer loop
+      vertex   5.403261e+00 -8.300000e+00 2.392163e+01
+      vertex   5.161149e+00 -1.070000e+01 2.408015e+01
+      vertex   5.403261e+00 -1.070000e+01 2.392163e+01
+    endloop
+  endfacet
+  facet normal 3.769017e-01 0.000000e+00 9.262532e-01
+    outer loop
+      vertex   5.403261e+00 -8.300000e+00 2.392163e+01
+      vertex   5.403261e+00 -1.070000e+01 2.392163e+01
+      vertex   5.671306e+00 -8.300000e+00 2.381256e+01
+    endloop
+  endfacet
+  facet normal 3.769017e-01 0.000000e+00 9.262532e-01
+    outer loop
+      vertex   5.671306e+00 -8.300000e+00 2.381256e+01
+      vertex   5.403261e+00 -1.070000e+01 2.392163e+01
+      vertex   5.671306e+00 -1.070000e+01 2.381256e+01
+    endloop
+  endfacet
+  facet normal 1.920244e-01 0.000000e+00 9.813901e-01
+    outer loop
+      vertex   5.671306e+00 -8.300000e+00 2.381256e+01
+      vertex   5.671306e+00 -1.070000e+01 2.381256e+01
+      vertex   5.955307e+00 -8.300000e+00 2.375700e+01
+    endloop
+  endfacet
+  facet normal 1.920244e-01 7.106331e-17 9.813901e-01
+    outer loop
+      vertex   5.955307e+00 -8.300000e+00 2.375700e+01
+      vertex   5.671306e+00 -1.070000e+01 2.381256e+01
+      vertex   5.955307e+00 -1.070000e+01 2.375700e+01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 0.000000e+00 1.000000e+00
+    outer loop
+      vertex   5.955307e+00 -8.300000e+00 2.375700e+01
+      vertex   5.955307e+00 -1.070000e+01 2.375700e+01
+      vertex   6.244693e+00 -8.300000e+00 2.375700e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 1.000000e+00
+    outer loop
+      vertex   6.244693e+00 -8.300000e+00 2.375700e+01
+      vertex   5.955307e+00 -1.070000e+01 2.375700e+01
+      vertex   6.244693e+00 -1.070000e+01 2.375700e+01
+    endloop
+  endfacet
+  facet normal -1.920244e-01 0.000000e+00 9.813901e-01
+    outer loop
+      vertex   6.244693e+00 -8.300000e+00 2.375700e+01
+      vertex   6.244693e+00 -1.070000e+01 2.375700e+01
+      vertex   6.528694e+00 -8.300000e+00 2.381256e+01
+    endloop
+  endfacet
+  facet normal -1.920244e-01 0.000000e+00 9.813901e-01
+    outer loop
+      vertex   6.528694e+00 -8.300000e+00 2.381256e+01
+      vertex   6.244693e+00 -1.070000e+01 2.375700e+01
+      vertex   6.528694e+00 -1.070000e+01 2.381256e+01
+    endloop
+  endfacet
+  facet normal -3.769017e-01 0.000000e+00 9.262532e-01
+    outer loop
+      vertex   6.528694e+00 -8.300000e+00 2.381256e+01
+      vertex   6.528694e+00 -1.070000e+01 2.381256e+01
+      vertex   6.796739e+00 -8.300000e+00 2.392163e+01
+    endloop
+  endfacet
+  facet normal -3.769017e-01 1.394817e-16 9.262532e-01
+    outer loop
+      vertex   6.796739e+00 -8.300000e+00 2.392163e+01
+      vertex   6.528694e+00 -1.070000e+01 2.381256e+01
+      vertex   6.796739e+00 -1.070000e+01 2.392163e+01
+    endloop
+  endfacet
+  facet normal -5.477509e-01 2.027085e-16 8.366415e-01
+    outer loop
+      vertex   6.796739e+00 -8.300000e+00 2.392163e+01
+      vertex   6.796739e+00 -1.070000e+01 2.392163e+01
+      vertex   7.038851e+00 -8.300000e+00 2.408015e+01
+    endloop
+  endfacet
+  facet normal -5.477509e-01 0.000000e+00 8.366415e-01
+    outer loop
+      vertex   7.038851e+00 -8.300000e+00 2.408015e+01
+      vertex   6.796739e+00 -1.070000e+01 2.392163e+01
+      vertex   7.038851e+00 -1.070000e+01 2.408015e+01
+    endloop
+  endfacet
+  facet normal -6.982129e-01 0.000000e+00 7.158902e-01
+    outer loop
+      vertex   7.038851e+00 -8.300000e+00 2.408015e+01
+      vertex   7.038851e+00 -1.070000e+01 2.408015e+01
+      vertex   7.246020e+00 -8.300000e+00 2.428220e+01
+    endloop
+  endfacet
+  facet normal -6.982129e-01 0.000000e+00 7.158902e-01
+    outer loop
+      vertex   7.246020e+00 -8.300000e+00 2.428220e+01
+      vertex   7.038851e+00 -1.070000e+01 2.408015e+01
+      vertex   7.246020e+00 -1.070000e+01 2.428220e+01
+    endloop
+  endfacet
+  facet normal -8.226877e-01 0.000000e+00 5.684936e-01
+    outer loop
+      vertex   7.246020e+00 -8.300000e+00 2.428220e+01
+      vertex   7.246020e+00 -1.070000e+01 2.428220e+01
+      vertex   7.410534e+00 -8.300000e+00 2.452027e+01
+    endloop
+  endfacet
+  facet normal -8.226877e-01 0.000000e+00 5.684936e-01
+    outer loop
+      vertex   7.410534e+00 -8.300000e+00 2.452027e+01
+      vertex   7.246020e+00 -1.070000e+01 2.428220e+01
+      vertex   7.410534e+00 -1.070000e+01 2.452027e+01
+    endloop
+  endfacet
+  facet normal -9.165422e-01 0.000000e+00 3.999379e-01
+    outer loop
+      vertex   7.410534e+00 -8.300000e+00 2.452027e+01
+      vertex   7.410534e+00 -1.070000e+01 2.452027e+01
+      vertex   7.526270e+00 -8.300000e+00 2.478551e+01
+    endloop
+  endfacet
+  facet normal -9.165422e-01 0.000000e+00 3.999379e-01
+    outer loop
+      vertex   7.526270e+00 -8.300000e+00 2.478551e+01
+      vertex   7.410534e+00 -1.070000e+01 2.452027e+01
+      vertex   7.526270e+00 -1.070000e+01 2.478551e+01
+    endloop
+  endfacet
+  facet normal -9.762834e-01 0.000000e+00 2.164967e-01
+    outer loop
+      vertex   7.526270e+00 -8.300000e+00 2.478551e+01
+      vertex   7.526270e+00 -1.070000e+01 2.478551e+01
+      vertex   7.588921e+00 -8.300000e+00 2.506803e+01
+    endloop
+  endfacet
+  facet normal -9.762834e-01 0.000000e+00 2.164967e-01
+    outer loop
+      vertex   7.588921e+00 -8.300000e+00 2.506803e+01
+      vertex   7.526270e+00 -1.070000e+01 2.478551e+01
+      vertex   7.588921e+00 -1.070000e+01 2.506803e+01
+    endloop
+  endfacet
+  facet normal -9.996875e-01 0.000000e+00 2.499745e-02
+    outer loop
+      vertex   7.588921e+00 -8.300000e+00 2.506803e+01
+      vertex   7.588921e+00 -1.070000e+01 2.506803e+01
+      vertex   7.596155e+00 -8.300000e+00 2.535733e+01
+    endloop
+  endfacet
+  facet normal -9.996875e-01 3.700366e-17 2.499745e-02
+    outer loop
+      vertex   7.596155e+00 -8.300000e+00 2.535733e+01
+      vertex   7.588921e+00 -1.070000e+01 2.506803e+01
+      vertex   7.596155e+00 -1.070000e+01 2.535733e+01
+    endloop
+  endfacet
+  facet normal -9.858836e-01 -2.478494e-16 -1.674322e-01
+    outer loop
+      vertex   7.596155e+00 -8.300000e+00 2.535733e+01
+      vertex   7.596155e+00 -1.070000e+01 2.535733e+01
+      vertex   7.547703e+00 -8.300000e+00 2.564263e+01
+    endloop
+  endfacet
+  facet normal -9.858836e-01 -0.000000e+00 -1.674322e-01
+    outer loop
+      vertex   7.547703e+00 -8.300000e+00 2.564263e+01
+      vertex   7.596155e+00 -1.070000e+01 2.535733e+01
+      vertex   7.547703e+00 -1.070000e+01 2.564263e+01
+    endloop
+  endfacet
+  facet normal -9.353854e-01 -0.000000e+00 -3.536300e-01
+    outer loop
+      vertex   7.547703e+00 -8.300000e+00 2.564263e+01
+      vertex   7.547703e+00 -1.070000e+01 2.564263e+01
+      vertex   7.445367e+00 -8.300000e+00 2.591332e+01
+    endloop
+  endfacet
+  facet normal -9.353854e-01 -0.000000e+00 -3.536300e-01
+    outer loop
+      vertex   7.445367e+00 -8.300000e+00 2.591332e+01
+      vertex   7.547703e+00 -1.070000e+01 2.564263e+01
+      vertex   7.445367e+00 -1.070000e+01 2.591332e+01
+    endloop
+  endfacet
+  facet normal -8.500724e-01 -0.000000e+00 -5.266658e-01
+    outer loop
+      vertex   7.445367e+00 -8.300000e+00 2.591332e+01
+      vertex   7.445367e+00 -1.070000e+01 2.591332e+01
+      vertex   7.292957e+00 -8.300000e+00 2.615931e+01
+    endloop
+  endfacet
+  facet normal -8.500724e-01 3.145900e-16 -5.266658e-01
+    outer loop
+      vertex   7.292957e+00 -8.300000e+00 2.615931e+01
+      vertex   7.445367e+00 -1.070000e+01 2.591332e+01
+      vertex   7.292957e+00 -1.070000e+01 2.615931e+01
+    endloop
+  endfacet
+  facet normal -7.331200e-01 2.713089e-16 -6.800993e-01
+    outer loop
+      vertex   7.292957e+00 -8.300000e+00 2.615931e+01
+      vertex   7.292957e+00 -1.070000e+01 2.615931e+01
+      vertex   7.096146e+00 -8.300000e+00 2.637147e+01
+    endloop
+  endfacet
+  facet normal -7.331200e-01 5.426178e-16 -6.800993e-01
+    outer loop
+      vertex   7.096146e+00 -8.300000e+00 2.637147e+01
+      vertex   7.292957e+00 -1.070000e+01 2.615931e+01
+      vertex   7.096146e+00 -1.070000e+01 2.637147e+01
+    endloop
+  endfacet
+  facet normal -5.888811e-01 4.358596e-16 -8.082197e-01
+    outer loop
+      vertex   7.096146e+00 -8.300000e+00 2.637147e+01
+      vertex   7.096146e+00 -1.070000e+01 2.637147e+01
+      vertex   6.862259e+00 -8.300000e+00 2.654188e+01
+    endloop
+  endfacet
+  facet normal -5.888811e-01 -9.784757e-16 -8.082197e-01
+    outer loop
+      vertex   6.862259e+00 -8.300000e+00 2.654188e+01
+      vertex   7.096146e+00 -1.070000e+01 2.637147e+01
+      vertex   6.862259e+00 -1.070000e+01 2.654188e+01
+    endloop
+  endfacet
+  facet normal -4.227242e-01 -1.185093e-15 -9.062584e-01
+    outer loop
+      vertex   6.862259e+00 -8.300000e+00 2.654188e+01
+      vertex   6.862259e+00 -1.070000e+01 2.654188e+01
+      vertex   6.600000e+00 -8.300000e+00 2.666421e+01
+    endloop
+  endfacet
+  facet normal -4.227242e-01 -0.000000e+00 -9.062584e-01
+    outer loop
+      vertex   6.600000e+00 -8.300000e+00 2.666421e+01
+      vertex   6.862259e+00 -1.070000e+01 2.654188e+01
+      vertex   6.600000e+00 -1.070000e+01 2.666421e+01
+    endloop
+  endfacet
+  facet normal 1.000000e+00 -0.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.600000e+00 -1.070000e+01 2.750000e+01
+      vertex   5.600000e+00 -1.070000e+01 2.666421e+01
+      vertex   5.600000e+00 -8.300000e+00 2.750000e+01
+    endloop
+  endfacet
+  facet normal 1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.600000e+00 -8.300000e+00 2.750000e+01
+      vertex   5.600000e+00 -1.070000e+01 2.666421e+01
+      vertex   5.600000e+00 -8.300000e+00 2.666421e+01
+    endloop
+  endfacet
+  facet normal -4.227242e-01 0.000000e+00 9.062584e-01
+    outer loop
+      vertex   6.600000e+00 -8.300000e+00 -3.664214e+00
+      vertex   6.600000e+00 -1.070000e+01 -3.664214e+00
+      vertex   6.862259e+00 -8.300000e+00 -3.541883e+00
+    endloop
+  endfacet
+  facet normal -4.227242e-01 0.000000e+00 9.062584e-01
+    outer loop
+      vertex   6.862259e+00 -8.300000e+00 -3.541883e+00
+      vertex   6.600000e+00 -1.070000e+01 -3.664214e+00
+      vertex   6.862259e+00 -1.070000e+01 -3.541883e+00
+    endloop
+  endfacet
+  facet normal -5.888811e-01 0.000000e+00 8.082197e-01
+    outer loop
+      vertex   6.862259e+00 -8.300000e+00 -3.541883e+00
+      vertex   6.862259e+00 -1.070000e+01 -3.541883e+00
+      vertex   7.096146e+00 -8.300000e+00 -3.371469e+00
+    endloop
+  endfacet
+  facet normal -5.888811e-01 -1.367582e-16 8.082197e-01
+    outer loop
+      vertex   7.096146e+00 -8.300000e+00 -3.371469e+00
+      vertex   6.862259e+00 -1.070000e+01 -3.541883e+00
+      vertex   7.096146e+00 -1.070000e+01 -3.371469e+00
+    endloop
+  endfacet
+  facet normal -7.331200e-01 -2.909305e-16 6.800993e-01
+    outer loop
+      vertex   7.096146e+00 -8.300000e+00 -3.371469e+00
+      vertex   7.096146e+00 -1.070000e+01 -3.371469e+00
+      vertex   7.292957e+00 -8.300000e+00 -3.159314e+00
+    endloop
+  endfacet
+  facet normal -7.331200e-01 1.258437e-16 6.800993e-01
+    outer loop
+      vertex   7.292957e+00 -8.300000e+00 -3.159314e+00
+      vertex   7.096146e+00 -1.070000e+01 -3.371469e+00
+      vertex   7.292957e+00 -1.070000e+01 -3.159314e+00
+    endloop
+  endfacet
+  facet normal -8.500724e-01 9.745275e-17 5.266658e-01
+    outer loop
+      vertex   7.292957e+00 -8.300000e+00 -3.159314e+00
+      vertex   7.292957e+00 -1.070000e+01 -3.159314e+00
+      vertex   7.445367e+00 -8.300000e+00 -2.913315e+00
+    endloop
+  endfacet
+  facet normal -8.500724e-01 -9.745275e-17 5.266658e-01
+    outer loop
+      vertex   7.445367e+00 -8.300000e+00 -2.913315e+00
+      vertex   7.292957e+00 -1.070000e+01 -3.159314e+00
+      vertex   7.445367e+00 -1.070000e+01 -2.913315e+00
+    endloop
+  endfacet
+  facet normal -9.353854e-01 -6.543469e-17 3.536300e-01
+    outer loop
+      vertex   7.445367e+00 -8.300000e+00 -2.913315e+00
+      vertex   7.445367e+00 -1.070000e+01 -2.913315e+00
+      vertex   7.547703e+00 -8.300000e+00 -2.642628e+00
+    endloop
+  endfacet
+  facet normal -9.353854e-01 1.963041e-16 3.536300e-01
+    outer loop
+      vertex   7.547703e+00 -8.300000e+00 -2.642628e+00
+      vertex   7.445367e+00 -1.070000e+01 -2.913315e+00
+      vertex   7.547703e+00 -1.070000e+01 -2.642628e+00
+    endloop
+  endfacet
+  facet normal -9.858836e-01 9.294352e-17 1.674322e-01
+    outer loop
+      vertex   7.547703e+00 -8.300000e+00 -2.642628e+00
+      vertex   7.547703e+00 -1.070000e+01 -2.642628e+00
+      vertex   7.596155e+00 -8.300000e+00 -2.357327e+00
+    endloop
+  endfacet
+  facet normal -9.858836e-01 3.098117e-17 1.674322e-01
+    outer loop
+      vertex   7.596155e+00 -8.300000e+00 -2.357327e+00
+      vertex   7.547703e+00 -1.070000e+01 -2.642628e+00
+      vertex   7.596155e+00 -1.070000e+01 -2.357327e+00
+    endloop
+  endfacet
+  facet normal -9.996875e-01 -4.625457e-18 -2.499745e-02
+    outer loop
+      vertex   7.596155e+00 -8.300000e+00 -2.357327e+00
+      vertex   7.596155e+00 -1.070000e+01 -2.357327e+00
+      vertex   7.588921e+00 -8.300000e+00 -2.068031e+00
+    endloop
+  endfacet
+  facet normal -9.996875e-01 4.625457e-18 -2.499745e-02
+    outer loop
+      vertex   7.588921e+00 -8.300000e+00 -2.068031e+00
+      vertex   7.596155e+00 -1.070000e+01 -2.357327e+00
+      vertex   7.588921e+00 -1.070000e+01 -2.068031e+00
+    endloop
+  endfacet
+  facet normal -9.762834e-01 4.005993e-17 -2.164967e-01
+    outer loop
+      vertex   7.588921e+00 -8.300000e+00 -2.068031e+00
+      vertex   7.588921e+00 -1.070000e+01 -2.068031e+00
+      vertex   7.526270e+00 -8.300000e+00 -1.785508e+00
+    endloop
+  endfacet
+  facet normal -9.762834e-01 -8.011986e-17 -2.164967e-01
+    outer loop
+      vertex   7.526270e+00 -8.300000e+00 -1.785508e+00
+      vertex   7.588921e+00 -1.070000e+01 -2.068031e+00
+      vertex   7.526270e+00 -1.070000e+01 -1.785508e+00
+    endloop
+  endfacet
+  facet normal -9.165422e-01 -1.480068e-16 -3.999379e-01
+    outer loop
+      vertex   7.526270e+00 -8.300000e+00 -1.785508e+00
+      vertex   7.526270e+00 -1.070000e+01 -1.785508e+00
+      vertex   7.410534e+00 -8.300000e+00 -1.520273e+00
+    endloop
+  endfacet
+  facet normal -9.165422e-01 -0.000000e+00 -3.999379e-01
+    outer loop
+      vertex   7.410534e+00 -8.300000e+00 -1.520273e+00
+      vertex   7.526270e+00 -1.070000e+01 -1.785508e+00
+      vertex   7.410534e+00 -1.070000e+01 -1.520273e+00
+    endloop
+  endfacet
+  facet normal -8.226877e-01 -0.000000e+00 -5.684936e-01
+    outer loop
+      vertex   7.410534e+00 -8.300000e+00 -1.520273e+00
+      vertex   7.410534e+00 -1.070000e+01 -1.520273e+00
+      vertex   7.246020e+00 -8.300000e+00 -1.282199e+00
+    endloop
+  endfacet
+  facet normal -8.226877e-01 -5.259623e-17 -5.684936e-01
+    outer loop
+      vertex   7.246020e+00 -8.300000e+00 -1.282199e+00
+      vertex   7.410534e+00 -1.070000e+01 -1.520273e+00
+      vertex   7.246020e+00 -1.070000e+01 -1.282199e+00
+    endloop
+  endfacet
+  facet normal -6.982129e-01 -6.623315e-17 -7.158902e-01
+    outer loop
+      vertex   7.246020e+00 -8.300000e+00 -1.282199e+00
+      vertex   7.246020e+00 -1.070000e+01 -1.282199e+00
+      vertex   7.038851e+00 -8.300000e+00 -1.080146e+00
+    endloop
+  endfacet
+  facet normal -6.982129e-01 6.623315e-17 -7.158902e-01
+    outer loop
+      vertex   7.038851e+00 -8.300000e+00 -1.080146e+00
+      vertex   7.246020e+00 -1.070000e+01 -1.282199e+00
+      vertex   7.038851e+00 -1.070000e+01 -1.080146e+00
+    endloop
+  endfacet
+  facet normal -5.477509e-01 7.740489e-17 -8.366415e-01
+    outer loop
+      vertex   7.038851e+00 -8.300000e+00 -1.080146e+00
+      vertex   7.038851e+00 -1.070000e+01 -1.080146e+00
+      vertex   6.796739e+00 -8.300000e+00 -9.216343e-01
+    endloop
+  endfacet
+  facet normal -5.477509e-01 -2.027085e-16 -8.366415e-01
+    outer loop
+      vertex   6.796739e+00 -8.300000e+00 -9.216343e-01
+      vertex   7.038851e+00 -1.070000e+01 -1.080146e+00
+      vertex   6.796739e+00 -1.070000e+01 -9.216343e-01
+    endloop
+  endfacet
+  facet normal -3.769017e-01 -1.394817e-16 -9.262532e-01
+    outer loop
+      vertex   6.796739e+00 -8.300000e+00 -9.216343e-01
+      vertex   6.796739e+00 -1.070000e+01 -9.216343e-01
+      vertex   6.528694e+00 -8.300000e+00 -8.125642e-01
+    endloop
+  endfacet
+  facet normal -3.769017e-01 -1.285435e-16 -9.262532e-01
+    outer loop
+      vertex   6.528694e+00 -8.300000e+00 -8.125642e-01
+      vertex   6.796739e+00 -1.070000e+01 -9.216343e-01
+      vertex   6.528694e+00 -1.070000e+01 -8.125642e-01
+    endloop
+  endfacet
+  facet normal -1.920244e-01 -1.361952e-16 -9.813901e-01
+    outer loop
+      vertex   6.528694e+00 -8.300000e+00 -8.125642e-01
+      vertex   6.528694e+00 -1.070000e+01 -8.125642e-01
+      vertex   6.244693e+00 -8.300000e+00 -7.569950e-01
+    endloop
+  endfacet
+  facet normal -1.920244e-01 7.106331e-17 -9.813901e-01
+    outer loop
+      vertex   6.244693e+00 -8.300000e+00 -7.569950e-01
+      vertex   6.528694e+00 -1.070000e+01 -8.125642e-01
+      vertex   6.244693e+00 -1.070000e+01 -7.569950e-01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   6.244693e+00 -8.300000e+00 -7.569950e-01
+      vertex   6.244693e+00 -1.070000e+01 -7.569950e-01
+      vertex   5.955307e+00 -8.300000e+00 -7.569950e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   5.955307e+00 -8.300000e+00 -7.569950e-01
+      vertex   6.244693e+00 -1.070000e+01 -7.569950e-01
+      vertex   5.955307e+00 -1.070000e+01 -7.569950e-01
+    endloop
+  endfacet
+  facet normal 1.920244e-01 -7.106331e-17 -9.813901e-01
+    outer loop
+      vertex   5.955307e+00 -8.300000e+00 -7.569950e-01
+      vertex   5.955307e+00 -1.070000e+01 -7.569950e-01
+      vertex   5.671306e+00 -8.300000e+00 -8.125642e-01
+    endloop
+  endfacet
+  facet normal 1.920244e-01 0.000000e+00 -9.813901e-01
+    outer loop
+      vertex   5.671306e+00 -8.300000e+00 -8.125642e-01
+      vertex   5.955307e+00 -1.070000e+01 -7.569950e-01
+      vertex   5.671306e+00 -1.070000e+01 -8.125642e-01
+    endloop
+  endfacet
+  facet normal 3.769017e-01 0.000000e+00 -9.262532e-01
+    outer loop
+      vertex   5.671306e+00 -8.300000e+00 -8.125642e-01
+      vertex   5.671306e+00 -1.070000e+01 -8.125642e-01
+      vertex   5.403261e+00 -8.300000e+00 -9.216343e-01
+    endloop
+  endfacet
+  facet normal 3.769017e-01 0.000000e+00 -9.262532e-01
+    outer loop
+      vertex   5.403261e+00 -8.300000e+00 -9.216343e-01
+      vertex   5.671306e+00 -1.070000e+01 -8.125642e-01
+      vertex   5.403261e+00 -1.070000e+01 -9.216343e-01
+    endloop
+  endfacet
+  facet normal 5.477509e-01 0.000000e+00 -8.366415e-01
+    outer loop
+      vertex   5.403261e+00 -8.300000e+00 -9.216343e-01
+      vertex   5.403261e+00 -1.070000e+01 -9.216343e-01
+      vertex   5.161149e+00 -8.300000e+00 -1.080146e+00
+    endloop
+  endfacet
+  facet normal 5.477509e-01 2.506073e-16 -8.366415e-01
+    outer loop
+      vertex   5.161149e+00 -8.300000e+00 -1.080146e+00
+      vertex   5.403261e+00 -1.070000e+01 -9.216343e-01
+      vertex   5.161149e+00 -1.070000e+01 -1.080146e+00
+    endloop
+  endfacet
+  facet normal 6.982129e-01 3.843151e-16 -7.158902e-01
+    outer loop
+      vertex   5.161149e+00 -8.300000e+00 -1.080146e+00
+      vertex   5.161149e+00 -1.070000e+01 -1.080146e+00
+      vertex   4.953980e+00 -8.300000e+00 -1.282199e+00
+    endloop
+  endfacet
+  facet normal 6.982129e-01 -1.259244e-16 -7.158902e-01
+    outer loop
+      vertex   4.953980e+00 -8.300000e+00 -1.282199e+00
+      vertex   5.161149e+00 -1.070000e+01 -1.080146e+00
+      vertex   4.953980e+00 -1.070000e+01 -1.282199e+00
+    endloop
+  endfacet
+  facet normal 8.226877e-01 -1.992631e-16 -5.684936e-01
+    outer loop
+      vertex   4.953980e+00 -8.300000e+00 -1.282199e+00
+      vertex   4.953980e+00 -1.070000e+01 -1.282199e+00
+      vertex   4.789466e+00 -8.300000e+00 -1.520273e+00
+    endloop
+  endfacet
+  facet normal 8.226877e-01 -9.407069e-17 -5.684936e-01
+    outer loop
+      vertex   4.789466e+00 -8.300000e+00 -1.520273e+00
+      vertex   4.953980e+00 -1.070000e+01 -1.282199e+00
+      vertex   4.789466e+00 -1.070000e+01 -1.520273e+00
+    endloop
+  endfacet
+  facet normal 9.165422e-01 -1.911820e-16 -3.999379e-01
+    outer loop
+      vertex   4.789466e+00 -8.300000e+00 -1.520273e+00
+      vertex   4.789466e+00 -1.070000e+01 -1.520273e+00
+      vertex   4.673730e+00 -8.300000e+00 -1.785508e+00
+    endloop
+  endfacet
+  facet normal 9.165422e-01 2.220101e-16 -3.999379e-01
+    outer loop
+      vertex   4.673730e+00 -8.300000e+00 -1.785508e+00
+      vertex   4.789466e+00 -1.070000e+01 -1.520273e+00
+      vertex   4.673730e+00 -1.070000e+01 -1.785508e+00
+    endloop
+  endfacet
+  facet normal 9.762834e-01 1.201798e-16 -2.164967e-01
+    outer loop
+      vertex   4.673730e+00 -8.300000e+00 -1.785508e+00
+      vertex   4.673730e+00 -1.070000e+01 -1.785508e+00
+      vertex   4.611079e+00 -8.300000e+00 -2.068031e+00
+    endloop
+  endfacet
+  facet normal 9.762834e-01 2.811776e-16 -2.164967e-01
+    outer loop
+      vertex   4.611079e+00 -8.300000e+00 -2.068031e+00
+      vertex   4.673730e+00 -1.070000e+01 -1.785508e+00
+      vertex   4.611079e+00 -1.070000e+01 -2.068031e+00
+    endloop
+  endfacet
+  facet normal 9.996875e-01 3.607078e-16 -2.499745e-02
+    outer loop
+      vertex   4.611079e+00 -8.300000e+00 -2.068031e+00
+      vertex   4.611079e+00 -1.070000e+01 -2.068031e+00
+      vertex   4.603845e+00 -8.300000e+00 -2.357327e+00
+    endloop
+  endfacet
+  facet normal 9.996875e-01 -3.745842e-16 -2.499745e-02
+    outer loop
+      vertex   4.603845e+00 -8.300000e+00 -2.357327e+00
+      vertex   4.611079e+00 -1.070000e+01 -2.068031e+00
+      vertex   4.603845e+00 -1.070000e+01 -2.357327e+00
+    endloop
+  endfacet
+  facet normal 9.858836e-01 -3.338691e-16 1.674322e-01
+    outer loop
+      vertex   4.603845e+00 -8.300000e+00 -2.357327e+00
+      vertex   4.603845e+00 -1.070000e+01 -2.357327e+00
+      vertex   4.652297e+00 -8.300000e+00 -2.642628e+00
+    endloop
+  endfacet
+  facet normal 9.858836e-01 0.000000e+00 1.674322e-01
+    outer loop
+      vertex   4.652297e+00 -8.300000e+00 -2.642628e+00
+      vertex   4.603845e+00 -1.070000e+01 -2.357327e+00
+      vertex   4.652297e+00 -1.070000e+01 -2.642628e+00
+    endloop
+  endfacet
+  facet normal 9.353854e-01 0.000000e+00 3.536300e-01
+    outer loop
+      vertex   4.652297e+00 -8.300000e+00 -2.642628e+00
+      vertex   4.652297e+00 -1.070000e+01 -2.642628e+00
+      vertex   4.754633e+00 -8.300000e+00 -2.913315e+00
+    endloop
+  endfacet
+  facet normal 9.353854e-01 0.000000e+00 3.536300e-01
+    outer loop
+      vertex   4.754633e+00 -8.300000e+00 -2.913315e+00
+      vertex   4.652297e+00 -1.070000e+01 -2.642628e+00
+      vertex   4.754633e+00 -1.070000e+01 -2.913315e+00
+    endloop
+  endfacet
+  facet normal 8.500724e-01 0.000000e+00 5.266658e-01
+    outer loop
+      vertex   4.754633e+00 -8.300000e+00 -2.913315e+00
+      vertex   4.754633e+00 -1.070000e+01 -2.913315e+00
+      vertex   4.907043e+00 -8.300000e+00 -3.159314e+00
+    endloop
+  endfacet
+  facet normal 8.500724e-01 2.171372e-16 5.266658e-01
+    outer loop
+      vertex   4.907043e+00 -8.300000e+00 -3.159314e+00
+      vertex   4.754633e+00 -1.070000e+01 -2.913315e+00
+      vertex   4.907043e+00 -1.070000e+01 -3.159314e+00
+    endloop
+  endfacet
+  facet normal 7.331200e-01 1.454653e-16 6.800993e-01
+    outer loop
+      vertex   4.907043e+00 -8.300000e+00 -3.159314e+00
+      vertex   4.907043e+00 -1.070000e+01 -3.159314e+00
+      vertex   5.103854e+00 -8.300000e+00 -3.371469e+00
+    endloop
+  endfacet
+  facet normal 7.331200e-01 -1.062221e-16 6.800993e-01
+    outer loop
+      vertex   5.103854e+00 -8.300000e+00 -3.371469e+00
+      vertex   4.907043e+00 -1.070000e+01 -3.159314e+00
+      vertex   5.103854e+00 -1.070000e+01 -3.371469e+00
+    endloop
+  endfacet
+  facet normal 5.888811e-01 -2.307223e-16 8.082197e-01
+    outer loop
+      vertex   5.103854e+00 -8.300000e+00 -3.371469e+00
+      vertex   5.103854e+00 -1.070000e+01 -3.371469e+00
+      vertex   5.337741e+00 -8.300000e+00 -3.541883e+00
+    endloop
+  endfacet
+  facet normal 5.888811e-01 0.000000e+00 8.082197e-01
+    outer loop
+      vertex   5.337741e+00 -8.300000e+00 -3.541883e+00
+      vertex   5.103854e+00 -1.070000e+01 -3.371469e+00
+      vertex   5.337741e+00 -1.070000e+01 -3.541883e+00
+    endloop
+  endfacet
+  facet normal 4.227242e-01 0.000000e+00 9.062584e-01
+    outer loop
+      vertex   5.337741e+00 -8.300000e+00 -3.541883e+00
+      vertex   5.337741e+00 -1.070000e+01 -3.541883e+00
+      vertex   5.600000e+00 -8.300000e+00 -3.664214e+00
+    endloop
+  endfacet
+  facet normal 4.227242e-01 0.000000e+00 9.062584e-01
+    outer loop
+      vertex   5.600000e+00 -8.300000e+00 -3.664214e+00
+      vertex   5.337741e+00 -1.070000e+01 -3.541883e+00
+      vertex   5.600000e+00 -1.070000e+01 -3.664214e+00
+    endloop
+  endfacet
+  facet normal -1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.600000e+00 -1.070000e+01 -4.500000e+00
+      vertex   6.600000e+00 -1.070000e+01 -3.664214e+00
+      vertex   6.600000e+00 -8.300000e+00 -4.500000e+00
+    endloop
+  endfacet
+  facet normal -1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.600000e+00 -8.300000e+00 -4.500000e+00
+      vertex   6.600000e+00 -1.070000e+01 -3.664214e+00
+      vertex   6.600000e+00 -8.300000e+00 -3.664214e+00
+    endloop
+  endfacet
+  facet normal 1.000000e+00 -0.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.600000e+00 -1.070000e+01 -3.664214e+00
+      vertex   5.600000e+00 -1.070000e+01 -4.500000e+00
+      vertex   5.600000e+00 -8.300000e+00 -3.664214e+00
+    endloop
+  endfacet
+  facet normal 1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.600000e+00 -8.300000e+00 -3.664214e+00
+      vertex   5.600000e+00 -1.070000e+01 -4.500000e+00
+      vertex   5.600000e+00 -8.300000e+00 -4.500000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   5.600000e+00 -8.300000e+00 2.666421e+01
+      vertex   5.337741e+00 -8.300000e+00 2.654188e+01
+      vertex   5.600000e+00 -8.300000e+00 2.750000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.600000e+00 -8.300000e+00 2.750000e+01
+      vertex   5.337741e+00 -8.300000e+00 2.654188e+01
+      vertex   5.000000e-01 -8.300000e+00 2.750000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.000000e-01 -8.300000e+00 2.750000e+01
+      vertex   5.337741e+00 -8.300000e+00 2.654188e+01
+      vertex   5.103854e+00 -8.300000e+00 2.637147e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.000000e-01 -8.300000e+00 2.750000e+01
+      vertex   5.103854e+00 -8.300000e+00 2.637147e+01
+      vertex   0.000000e+00 -8.300000e+00 2.700000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -8.300000e+00 2.700000e+01
+      vertex   5.103854e+00 -8.300000e+00 2.637147e+01
+      vertex   4.907043e+00 -8.300000e+00 2.615931e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -8.300000e+00 2.700000e+01
+      vertex   4.907043e+00 -8.300000e+00 2.615931e+01
+      vertex   4.754633e+00 -8.300000e+00 2.591332e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.754633e+00 -8.300000e+00 2.591332e+01
+      vertex   4.652297e+00 -8.300000e+00 2.564263e+01
+      vertex   0.000000e+00 -8.300000e+00 2.700000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -8.300000e+00 2.700000e+01
+      vertex   4.652297e+00 -8.300000e+00 2.564263e+01
+      vertex   4.603845e+00 -8.300000e+00 2.535733e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -8.300000e+00 2.700000e+01
+      vertex   4.603845e+00 -8.300000e+00 2.535733e+01
+      vertex   4.611079e+00 -8.300000e+00 2.506803e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -8.300000e+00 2.700000e+01
+      vertex   4.611079e+00 -8.300000e+00 2.506803e+01
+      vertex   1.000000e+00 -8.300000e+00 2.300000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.000000e+00 -8.300000e+00 2.300000e+01
+      vertex   4.611079e+00 -8.300000e+00 2.506803e+01
+      vertex   4.673730e+00 -8.300000e+00 2.478551e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.000000e+00 -8.300000e+00 2.300000e+01
+      vertex   4.673730e+00 -8.300000e+00 2.478551e+01
+      vertex   4.789466e+00 -8.300000e+00 2.452027e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.789466e+00 -8.300000e+00 2.452027e+01
+      vertex   4.953980e+00 -8.300000e+00 2.428220e+01
+      vertex   1.000000e+00 -8.300000e+00 2.300000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.000000e+00 -8.300000e+00 2.300000e+01
+      vertex   4.953980e+00 -8.300000e+00 2.428220e+01
+      vertex   5.161149e+00 -8.300000e+00 2.408015e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.000000e+00 -8.300000e+00 2.300000e+01
+      vertex   5.161149e+00 -8.300000e+00 2.408015e+01
+      vertex   5.403261e+00 -8.300000e+00 2.392163e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.403261e+00 -8.300000e+00 2.392163e+01
+      vertex   5.671306e+00 -8.300000e+00 2.381256e+01
+      vertex   1.000000e+00 -8.300000e+00 2.300000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.000000e+00 -8.300000e+00 2.300000e+01
+      vertex   5.671306e+00 -8.300000e+00 2.381256e+01
+      vertex   5.955307e+00 -8.300000e+00 2.375700e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.000000e+00 -8.300000e+00 2.300000e+01
+      vertex   5.955307e+00 -8.300000e+00 2.375700e+01
+      vertex   6.244693e+00 -8.300000e+00 2.375700e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.000000e+00 -8.300000e+00 2.300000e+01
+      vertex   6.244693e+00 -8.300000e+00 2.375700e+01
+      vertex   1.120000e+01 -8.300000e+00 2.300000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.120000e+01 -8.300000e+00 2.300000e+01
+      vertex   6.244693e+00 -8.300000e+00 2.375700e+01
+      vertex   6.528694e+00 -8.300000e+00 2.381256e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.120000e+01 -8.300000e+00 2.300000e+01
+      vertex   6.528694e+00 -8.300000e+00 2.381256e+01
+      vertex   6.796739e+00 -8.300000e+00 2.392163e+01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.796739e+00 -8.300000e+00 2.392163e+01
+      vertex   7.038851e+00 -8.300000e+00 2.408015e+01
+      vertex   1.120000e+01 -8.300000e+00 2.300000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.120000e+01 -8.300000e+00 2.300000e+01
+      vertex   7.038851e+00 -8.300000e+00 2.408015e+01
+      vertex   7.246020e+00 -8.300000e+00 2.428220e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.120000e+01 -8.300000e+00 2.300000e+01
+      vertex   7.246020e+00 -8.300000e+00 2.428220e+01
+      vertex   7.410534e+00 -8.300000e+00 2.452027e+01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.410534e+00 -8.300000e+00 2.452027e+01
+      vertex   7.526270e+00 -8.300000e+00 2.478551e+01
+      vertex   1.120000e+01 -8.300000e+00 2.300000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.120000e+01 -8.300000e+00 2.300000e+01
+      vertex   7.526270e+00 -8.300000e+00 2.478551e+01
+      vertex   7.588921e+00 -8.300000e+00 2.506803e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   1.120000e+01 -8.300000e+00 2.300000e+01
+      vertex   7.588921e+00 -8.300000e+00 2.506803e+01
+      vertex   1.220000e+01 -8.300000e+00 2.700000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -8.300000e+00 2.700000e+01
+      vertex   7.588921e+00 -8.300000e+00 2.506803e+01
+      vertex   7.596155e+00 -8.300000e+00 2.535733e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -8.300000e+00 2.700000e+01
+      vertex   7.596155e+00 -8.300000e+00 2.535733e+01
+      vertex   7.547703e+00 -8.300000e+00 2.564263e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   7.547703e+00 -8.300000e+00 2.564263e+01
+      vertex   7.445367e+00 -8.300000e+00 2.591332e+01
+      vertex   1.220000e+01 -8.300000e+00 2.700000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -8.300000e+00 2.700000e+01
+      vertex   7.445367e+00 -8.300000e+00 2.591332e+01
+      vertex   7.292957e+00 -8.300000e+00 2.615931e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -8.300000e+00 2.700000e+01
+      vertex   7.292957e+00 -8.300000e+00 2.615931e+01
+      vertex   7.096146e+00 -8.300000e+00 2.637147e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -8.300000e+00 2.700000e+01
+      vertex   7.096146e+00 -8.300000e+00 2.637147e+01
+      vertex   1.170000e+01 -8.300000e+00 2.750000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.170000e+01 -8.300000e+00 2.750000e+01
+      vertex   7.096146e+00 -8.300000e+00 2.637147e+01
+      vertex   6.862259e+00 -8.300000e+00 2.654188e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.170000e+01 -8.300000e+00 2.750000e+01
+      vertex   6.862259e+00 -8.300000e+00 2.654188e+01
+      vertex   6.600000e+00 -8.300000e+00 2.750000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.600000e+00 -8.300000e+00 2.750000e+01
+      vertex   6.862259e+00 -8.300000e+00 2.654188e+01
+      vertex   6.600000e+00 -8.300000e+00 2.666421e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.182941e+01 -8.300000e+00 2.748296e+01
+      vertex   1.195000e+01 -8.300000e+00 2.743301e+01
+      vertex   1.170000e+01 -8.300000e+00 2.750000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.170000e+01 -8.300000e+00 2.750000e+01
+      vertex   1.195000e+01 -8.300000e+00 2.743301e+01
+      vertex   1.205355e+01 -8.300000e+00 2.735355e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.170000e+01 -8.300000e+00 2.750000e+01
+      vertex   1.205355e+01 -8.300000e+00 2.735355e+01
+      vertex   1.213301e+01 -8.300000e+00 2.725000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.213301e+01 -8.300000e+00 2.725000e+01
+      vertex   1.218296e+01 -8.300000e+00 2.712941e+01
+      vertex   1.170000e+01 -8.300000e+00 2.750000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.170000e+01 -8.300000e+00 2.750000e+01
+      vertex   1.218296e+01 -8.300000e+00 2.712941e+01
+      vertex   1.220000e+01 -8.300000e+00 2.700000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -8.300000e+00 2.200000e+01
+      vertex   1.217493e+01 -8.300000e+00 2.222252e+01
+      vertex   1.220000e+01 -8.300000e+00 2.700000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -8.300000e+00 2.700000e+01
+      vertex   1.217493e+01 -8.300000e+00 2.222252e+01
+      vertex   1.210097e+01 -8.300000e+00 2.243388e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -8.300000e+00 2.700000e+01
+      vertex   1.210097e+01 -8.300000e+00 2.243388e+01
+      vertex   1.198183e+01 -8.300000e+00 2.262349e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   1.198183e+01 -8.300000e+00 2.262349e+01
+      vertex   1.182349e+01 -8.300000e+00 2.278183e+01
+      vertex   1.220000e+01 -8.300000e+00 2.700000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -8.300000e+00 2.700000e+01
+      vertex   1.182349e+01 -8.300000e+00 2.278183e+01
+      vertex   1.163388e+01 -8.300000e+00 2.290097e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -8.300000e+00 2.700000e+01
+      vertex   1.163388e+01 -8.300000e+00 2.290097e+01
+      vertex   1.142252e+01 -8.300000e+00 2.297493e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   1.142252e+01 -8.300000e+00 2.297493e+01
+      vertex   1.120000e+01 -8.300000e+00 2.300000e+01
+      vertex   1.220000e+01 -8.300000e+00 2.700000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.000000e+00 -8.300000e+00 2.300000e+01
+      vertex   7.774791e-01 -8.300000e+00 2.297493e+01
+      vertex   0.000000e+00 -8.300000e+00 2.700000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -8.300000e+00 2.700000e+01
+      vertex   7.774791e-01 -8.300000e+00 2.297493e+01
+      vertex   5.661163e-01 -8.300000e+00 2.290097e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -8.300000e+00 2.700000e+01
+      vertex   5.661163e-01 -8.300000e+00 2.290097e+01
+      vertex   3.765102e-01 -8.300000e+00 2.278183e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.765102e-01 -8.300000e+00 2.278183e+01
+      vertex   2.181685e-01 -8.300000e+00 2.262349e+01
+      vertex   0.000000e+00 -8.300000e+00 2.700000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -8.300000e+00 2.700000e+01
+      vertex   2.181685e-01 -8.300000e+00 2.262349e+01
+      vertex   9.903113e-02 -8.300000e+00 2.243388e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -8.300000e+00 2.700000e+01
+      vertex   9.903113e-02 -8.300000e+00 2.243388e+01
+      vertex   2.507209e-02 -8.300000e+00 2.222252e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   2.507209e-02 -8.300000e+00 2.222252e+01
+      vertex   0.000000e+00 -8.300000e+00 2.200000e+01
+      vertex   0.000000e+00 -8.300000e+00 2.700000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -8.300000e+00 2.700000e+01
+      vertex   1.703709e-02 -8.300000e+00 2.712941e+01
+      vertex   5.000000e-01 -8.300000e+00 2.750000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.000000e-01 -8.300000e+00 2.750000e+01
+      vertex   1.703709e-02 -8.300000e+00 2.712941e+01
+      vertex   6.698730e-02 -8.300000e+00 2.725000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.000000e-01 -8.300000e+00 2.750000e+01
+      vertex   6.698730e-02 -8.300000e+00 2.725000e+01
+      vertex   1.464466e-01 -8.300000e+00 2.735355e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.464466e-01 -8.300000e+00 2.735355e+01
+      vertex   2.500000e-01 -8.300000e+00 2.743301e+01
+      vertex   5.000000e-01 -8.300000e+00 2.750000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.000000e-01 -8.300000e+00 2.750000e+01
+      vertex   2.500000e-01 -8.300000e+00 2.743301e+01
+      vertex   3.705905e-01 -8.300000e+00 2.748296e+01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 0.000000e+00 1.000000e+00
+    outer loop
+      vertex   6.600000e+00 -8.300000e+00 2.750000e+01
+      vertex   6.600000e+00 -1.070000e+01 2.750000e+01
+      vertex   1.170000e+01 -8.300000e+00 2.750000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 1.000000e+00
+    outer loop
+      vertex   1.170000e+01 -8.300000e+00 2.750000e+01
+      vertex   6.600000e+00 -1.070000e+01 2.750000e+01
+      vertex   1.170000e+01 -1.070000e+01 2.750000e+01
+    endloop
+  endfacet
+  facet normal 1.354660e-14 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.600000e+00 -8.300000e+00 -3.664214e+00
+      vertex   6.862259e+00 -8.300000e+00 -3.541883e+00
+      vertex   6.600000e+00 -8.300000e+00 -4.500000e+00
+    endloop
+  endfacet
+  facet normal 3.483053e-16 1.000000e+00 3.612678e-15
+    outer loop
+      vertex   6.600000e+00 -8.300000e+00 -4.500000e+00
+      vertex   6.862259e+00 -8.300000e+00 -3.541883e+00
+      vertex   1.170000e+01 -8.300000e+00 -4.500000e+00
+    endloop
+  endfacet
+  facet normal -1.911925e-15 1.000000e+00 -7.799718e-15
+    outer loop
+      vertex   1.170000e+01 -8.300000e+00 -4.500000e+00
+      vertex   6.862259e+00 -8.300000e+00 -3.541883e+00
+      vertex   7.096146e+00 -8.300000e+00 -3.371469e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   1.170000e+01 -8.300000e+00 -4.500000e+00
+      vertex   7.096146e+00 -8.300000e+00 -3.371469e+00
+      vertex   1.220000e+01 -8.300000e+00 -4.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -8.300000e+00 -4.000000e+00
+      vertex   7.096146e+00 -8.300000e+00 -3.371469e+00
+      vertex   7.292957e+00 -8.300000e+00 -3.159314e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -8.300000e+00 -4.000000e+00
+      vertex   7.292957e+00 -8.300000e+00 -3.159314e+00
+      vertex   7.445367e+00 -8.300000e+00 -2.913315e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.445367e+00 -8.300000e+00 -2.913315e+00
+      vertex   7.547703e+00 -8.300000e+00 -2.642628e+00
+      vertex   1.220000e+01 -8.300000e+00 -4.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -8.300000e+00 -4.000000e+00
+      vertex   7.547703e+00 -8.300000e+00 -2.642628e+00
+      vertex   7.596155e+00 -8.300000e+00 -2.357327e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -8.300000e+00 -4.000000e+00
+      vertex   7.596155e+00 -8.300000e+00 -2.357327e+00
+      vertex   7.588921e+00 -8.300000e+00 -2.068031e+00
+    endloop
+  endfacet
+  facet normal -2.078364e-16 1.000000e+00 -4.960483e-16
+    outer loop
+      vertex   1.220000e+01 -8.300000e+00 -4.000000e+00
+      vertex   7.588921e+00 -8.300000e+00 -2.068031e+00
+      vertex   1.120000e+01 -8.300000e+00 0.000000e+00
+    endloop
+  endfacet
+  facet normal -4.364860e-16 1.000000e+00 -9.679337e-17
+    outer loop
+      vertex   1.120000e+01 -8.300000e+00 0.000000e+00
+      vertex   7.588921e+00 -8.300000e+00 -2.068031e+00
+      vertex   7.526270e+00 -8.300000e+00 -1.785508e+00
+    endloop
+  endfacet
+  facet normal -3.989262e-16 1.000000e+00 -1.740735e-16
+    outer loop
+      vertex   1.120000e+01 -8.300000e+00 0.000000e+00
+      vertex   7.526270e+00 -8.300000e+00 -1.785508e+00
+      vertex   7.410534e+00 -8.300000e+00 -1.520273e+00
+    endloop
+  endfacet
+  facet normal -3.670155e-16 1.000000e+00 -2.536150e-16
+    outer loop
+      vertex   7.410534e+00 -8.300000e+00 -1.520273e+00
+      vertex   7.246020e+00 -8.300000e+00 -1.282199e+00
+      vertex   1.120000e+01 -8.300000e+00 0.000000e+00
+    endloop
+  endfacet
+  facet normal 1.802388e-15 1.000000e+00 -6.943512e-15
+    outer loop
+      vertex   1.120000e+01 -8.300000e+00 0.000000e+00
+      vertex   7.246020e+00 -8.300000e+00 -1.282199e+00
+      vertex   7.038851e+00 -8.300000e+00 -1.080146e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.120000e+01 -8.300000e+00 0.000000e+00
+      vertex   7.038851e+00 -8.300000e+00 -1.080146e+00
+      vertex   6.796739e+00 -8.300000e+00 -9.216343e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   6.796739e+00 -8.300000e+00 -9.216343e-01
+      vertex   6.528694e+00 -8.300000e+00 -8.125642e-01
+      vertex   1.120000e+01 -8.300000e+00 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.120000e+01 -8.300000e+00 0.000000e+00
+      vertex   6.528694e+00 -8.300000e+00 -8.125642e-01
+      vertex   6.244693e+00 -8.300000e+00 -7.569950e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.120000e+01 -8.300000e+00 0.000000e+00
+      vertex   6.244693e+00 -8.300000e+00 -7.569950e-01
+      vertex   1.000000e+00 -8.300000e+00 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.000000e+00 -8.300000e+00 0.000000e+00
+      vertex   6.244693e+00 -8.300000e+00 -7.569950e-01
+      vertex   5.955307e+00 -8.300000e+00 -7.569950e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.000000e+00 -8.300000e+00 0.000000e+00
+      vertex   5.955307e+00 -8.300000e+00 -7.569950e-01
+      vertex   5.671306e+00 -8.300000e+00 -8.125642e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.671306e+00 -8.300000e+00 -8.125642e-01
+      vertex   5.403261e+00 -8.300000e+00 -9.216343e-01
+      vertex   1.000000e+00 -8.300000e+00 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.000000e+00 -8.300000e+00 0.000000e+00
+      vertex   5.403261e+00 -8.300000e+00 -9.216343e-01
+      vertex   5.161149e+00 -8.300000e+00 -1.080146e+00
+    endloop
+  endfacet
+  facet normal -1.802388e-15 1.000000e+00 -6.943512e-15
+    outer loop
+      vertex   1.000000e+00 -8.300000e+00 0.000000e+00
+      vertex   5.161149e+00 -8.300000e+00 -1.080146e+00
+      vertex   4.953980e+00 -8.300000e+00 -1.282199e+00
+    endloop
+  endfacet
+  facet normal 3.670155e-16 1.000000e+00 -2.536150e-16
+    outer loop
+      vertex   4.953980e+00 -8.300000e+00 -1.282199e+00
+      vertex   4.789466e+00 -8.300000e+00 -1.520273e+00
+      vertex   1.000000e+00 -8.300000e+00 0.000000e+00
+    endloop
+  endfacet
+  facet normal 3.989262e-16 1.000000e+00 -1.740735e-16
+    outer loop
+      vertex   1.000000e+00 -8.300000e+00 0.000000e+00
+      vertex   4.789466e+00 -8.300000e+00 -1.520273e+00
+      vertex   4.673730e+00 -8.300000e+00 -1.785508e+00
+    endloop
+  endfacet
+  facet normal 4.364860e-16 1.000000e+00 -9.679337e-17
+    outer loop
+      vertex   1.000000e+00 -8.300000e+00 0.000000e+00
+      vertex   4.673730e+00 -8.300000e+00 -1.785508e+00
+      vertex   4.611079e+00 -8.300000e+00 -2.068031e+00
+    endloop
+  endfacet
+  facet normal 2.078364e-16 1.000000e+00 -4.960483e-16
+    outer loop
+      vertex   1.000000e+00 -8.300000e+00 0.000000e+00
+      vertex   4.611079e+00 -8.300000e+00 -2.068031e+00
+      vertex   0.000000e+00 -8.300000e+00 -4.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -8.300000e+00 -4.000000e+00
+      vertex   4.611079e+00 -8.300000e+00 -2.068031e+00
+      vertex   4.603845e+00 -8.300000e+00 -2.357327e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -8.300000e+00 -4.000000e+00
+      vertex   4.603845e+00 -8.300000e+00 -2.357327e+00
+      vertex   4.652297e+00 -8.300000e+00 -2.642628e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.652297e+00 -8.300000e+00 -2.642628e+00
+      vertex   4.754633e+00 -8.300000e+00 -2.913315e+00
+      vertex   0.000000e+00 -8.300000e+00 -4.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -8.300000e+00 -4.000000e+00
+      vertex   4.754633e+00 -8.300000e+00 -2.913315e+00
+      vertex   4.907043e+00 -8.300000e+00 -3.159314e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -8.300000e+00 -4.000000e+00
+      vertex   4.907043e+00 -8.300000e+00 -3.159314e+00
+      vertex   5.103854e+00 -8.300000e+00 -3.371469e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -8.300000e+00 -4.000000e+00
+      vertex   5.103854e+00 -8.300000e+00 -3.371469e+00
+      vertex   5.000000e-01 -8.300000e+00 -4.500000e+00
+    endloop
+  endfacet
+  facet normal 1.911925e-15 1.000000e+00 -7.799718e-15
+    outer loop
+      vertex   5.000000e-01 -8.300000e+00 -4.500000e+00
+      vertex   5.103854e+00 -8.300000e+00 -3.371469e+00
+      vertex   5.337741e+00 -8.300000e+00 -3.541883e+00
+    endloop
+  endfacet
+  facet normal -3.483053e-16 1.000000e+00 3.612678e-15
+    outer loop
+      vertex   5.000000e-01 -8.300000e+00 -4.500000e+00
+      vertex   5.337741e+00 -8.300000e+00 -3.541883e+00
+      vertex   5.600000e+00 -8.300000e+00 -4.500000e+00
+    endloop
+  endfacet
+  facet normal -1.354660e-14 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.600000e+00 -8.300000e+00 -4.500000e+00
+      vertex   5.337741e+00 -8.300000e+00 -3.541883e+00
+      vertex   5.600000e+00 -8.300000e+00 -3.664214e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   3.705905e-01 -8.300000e+00 -4.482963e+00
+      vertex   2.500000e-01 -8.300000e+00 -4.433013e+00
+      vertex   5.000000e-01 -8.300000e+00 -4.500000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.000000e-01 -8.300000e+00 -4.500000e+00
+      vertex   2.500000e-01 -8.300000e+00 -4.433013e+00
+      vertex   1.464466e-01 -8.300000e+00 -4.353553e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.000000e-01 -8.300000e+00 -4.500000e+00
+      vertex   1.464466e-01 -8.300000e+00 -4.353553e+00
+      vertex   6.698730e-02 -8.300000e+00 -4.250000e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   6.698730e-02 -8.300000e+00 -4.250000e+00
+      vertex   1.703709e-02 -8.300000e+00 -4.129410e+00
+      vertex   5.000000e-01 -8.300000e+00 -4.500000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.000000e-01 -8.300000e+00 -4.500000e+00
+      vertex   1.703709e-02 -8.300000e+00 -4.129410e+00
+      vertex   0.000000e+00 -8.300000e+00 -4.000000e+00
+    endloop
+  endfacet
+  facet normal 6.769686e-14 1.000000e+00 -3.552714e-16
+    outer loop
+      vertex   0.000000e+00 -8.300000e+00 1.000000e+00
+      vertex   2.507209e-02 -8.300000e+00 7.774791e-01
+      vertex   0.000000e+00 -8.300000e+00 -4.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -8.300000e+00 -4.000000e+00
+      vertex   2.507209e-02 -8.300000e+00 7.774791e-01
+      vertex   9.903113e-02 -8.300000e+00 5.661163e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -8.300000e+00 -4.000000e+00
+      vertex   9.903113e-02 -8.300000e+00 5.661163e-01
+      vertex   2.181685e-01 -8.300000e+00 3.765102e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   2.181685e-01 -8.300000e+00 3.765102e-01
+      vertex   3.765102e-01 -8.300000e+00 2.181685e-01
+      vertex   0.000000e+00 -8.300000e+00 -4.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -8.300000e+00 -4.000000e+00
+      vertex   3.765102e-01 -8.300000e+00 2.181685e-01
+      vertex   5.661163e-01 -8.300000e+00 9.903113e-02
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -8.300000e+00 -4.000000e+00
+      vertex   5.661163e-01 -8.300000e+00 9.903113e-02
+      vertex   7.774791e-01 -8.300000e+00 2.507209e-02
+    endloop
+  endfacet
+  facet normal -7.812838e-15 1.000000e+00 1.509120e-15
+    outer loop
+      vertex   7.774791e-01 -8.300000e+00 2.507209e-02
+      vertex   1.000000e+00 -8.300000e+00 0.000000e+00
+      vertex   0.000000e+00 -8.300000e+00 -4.000000e+00
+    endloop
+  endfacet
+  facet normal 7.812838e-15 1.000000e+00 1.509120e-15
+    outer loop
+      vertex   1.120000e+01 -8.300000e+00 0.000000e+00
+      vertex   1.142252e+01 -8.300000e+00 2.507209e-02
+      vertex   1.220000e+01 -8.300000e+00 -4.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -8.300000e+00 -4.000000e+00
+      vertex   1.142252e+01 -8.300000e+00 2.507209e-02
+      vertex   1.163388e+01 -8.300000e+00 9.903113e-02
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -8.300000e+00 -4.000000e+00
+      vertex   1.163388e+01 -8.300000e+00 9.903113e-02
+      vertex   1.182349e+01 -8.300000e+00 2.181685e-01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.182349e+01 -8.300000e+00 2.181685e-01
+      vertex   1.198183e+01 -8.300000e+00 3.765102e-01
+      vertex   1.220000e+01 -8.300000e+00 -4.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -8.300000e+00 -4.000000e+00
+      vertex   1.198183e+01 -8.300000e+00 3.765102e-01
+      vertex   1.210097e+01 -8.300000e+00 5.661163e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -8.300000e+00 -4.000000e+00
+      vertex   1.210097e+01 -8.300000e+00 5.661163e-01
+      vertex   1.217493e+01 -8.300000e+00 7.774791e-01
+    endloop
+  endfacet
+  facet normal -6.769686e-14 1.000000e+00 -3.552714e-16
+    outer loop
+      vertex   1.217493e+01 -8.300000e+00 7.774791e-01
+      vertex   1.220000e+01 -8.300000e+00 1.000000e+00
+      vertex   1.220000e+01 -8.300000e+00 -4.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -8.300000e+00 -4.000000e+00
+      vertex   1.218296e+01 -8.300000e+00 -4.129410e+00
+      vertex   1.170000e+01 -8.300000e+00 -4.500000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.170000e+01 -8.300000e+00 -4.500000e+00
+      vertex   1.218296e+01 -8.300000e+00 -4.129410e+00
+      vertex   1.213301e+01 -8.300000e+00 -4.250000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.170000e+01 -8.300000e+00 -4.500000e+00
+      vertex   1.213301e+01 -8.300000e+00 -4.250000e+00
+      vertex   1.205355e+01 -8.300000e+00 -4.353553e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.205355e+01 -8.300000e+00 -4.353553e+00
+      vertex   1.195000e+01 -8.300000e+00 -4.433013e+00
+      vertex   1.170000e+01 -8.300000e+00 -4.500000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.170000e+01 -8.300000e+00 -4.500000e+00
+      vertex   1.195000e+01 -8.300000e+00 -4.433013e+00
+      vertex   1.182941e+01 -8.300000e+00 -4.482963e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   5.600000e+00 -8.300000e+00 -4.500000e+00
+      vertex   5.600000e+00 -1.070000e+01 -4.500000e+00
+      vertex   5.000000e-01 -8.300000e+00 -4.500000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   5.000000e-01 -8.300000e+00 -4.500000e+00
+      vertex   5.600000e+00 -1.070000e+01 -4.500000e+00
+      vertex   5.000000e-01 -1.070000e+01 -4.500000e+00
+    endloop
+  endfacet
+  facet normal 1.305262e-01 0.000000e+00 -9.914449e-01
+    outer loop
+      vertex   1.170000e+01 -1.070000e+01 -4.500000e+00
+      vertex   1.170000e+01 -8.300000e+00 -4.500000e+00
+      vertex   1.182941e+01 -1.070000e+01 -4.482963e+00
+    endloop
+  endfacet
+  facet normal 1.305262e-01 3.669083e-16 -9.914449e-01
+    outer loop
+      vertex   1.182941e+01 -1.070000e+01 -4.482963e+00
+      vertex   1.170000e+01 -8.300000e+00 -4.500000e+00
+      vertex   1.182941e+01 -8.300000e+00 -4.482963e+00
+    endloop
+  endfacet
+  facet normal 3.826834e-01 3.419041e-16 -9.238795e-01
+    outer loop
+      vertex   1.182941e+01 -1.070000e+01 -4.482963e+00
+      vertex   1.182941e+01 -8.300000e+00 -4.482963e+00
+      vertex   1.195000e+01 -1.070000e+01 -4.433013e+00
+    endloop
+  endfacet
+  facet normal 3.826834e-01 0.000000e+00 -9.238795e-01
+    outer loop
+      vertex   1.195000e+01 -1.070000e+01 -4.433013e+00
+      vertex   1.182941e+01 -8.300000e+00 -4.482963e+00
+      vertex   1.195000e+01 -8.300000e+00 -4.433013e+00
+    endloop
+  endfacet
+  facet normal 6.087614e-01 0.000000e+00 -7.933533e-01
+    outer loop
+      vertex   1.195000e+01 -1.070000e+01 -4.433013e+00
+      vertex   1.195000e+01 -8.300000e+00 -4.433013e+00
+      vertex   1.205355e+01 -1.070000e+01 -4.353553e+00
+    endloop
+  endfacet
+  facet normal 6.087614e-01 0.000000e+00 -7.933533e-01
+    outer loop
+      vertex   1.205355e+01 -1.070000e+01 -4.353553e+00
+      vertex   1.195000e+01 -8.300000e+00 -4.433013e+00
+      vertex   1.205355e+01 -8.300000e+00 -4.353553e+00
+    endloop
+  endfacet
+  facet normal 7.933533e-01 0.000000e+00 -6.087614e-01
+    outer loop
+      vertex   1.205355e+01 -1.070000e+01 -4.353553e+00
+      vertex   1.205355e+01 -8.300000e+00 -4.353553e+00
+      vertex   1.213301e+01 -1.070000e+01 -4.250000e+00
+    endloop
+  endfacet
+  facet normal 7.933533e-01 0.000000e+00 -6.087614e-01
+    outer loop
+      vertex   1.213301e+01 -1.070000e+01 -4.250000e+00
+      vertex   1.205355e+01 -8.300000e+00 -4.353553e+00
+      vertex   1.213301e+01 -8.300000e+00 -4.250000e+00
+    endloop
+  endfacet
+  facet normal 9.238795e-01 0.000000e+00 -3.826834e-01
+    outer loop
+      vertex   1.213301e+01 -1.070000e+01 -4.250000e+00
+      vertex   1.213301e+01 -8.300000e+00 -4.250000e+00
+      vertex   1.218296e+01 -1.070000e+01 -4.129410e+00
+    endloop
+  endfacet
+  facet normal 9.238795e-01 0.000000e+00 -3.826834e-01
+    outer loop
+      vertex   1.218296e+01 -1.070000e+01 -4.129410e+00
+      vertex   1.213301e+01 -8.300000e+00 -4.250000e+00
+      vertex   1.218296e+01 -8.300000e+00 -4.129410e+00
+    endloop
+  endfacet
+  facet normal 9.914449e-01 0.000000e+00 -1.305262e-01
+    outer loop
+      vertex   1.218296e+01 -1.070000e+01 -4.129410e+00
+      vertex   1.218296e+01 -8.300000e+00 -4.129410e+00
+      vertex   1.220000e+01 -1.070000e+01 -4.000000e+00
+    endloop
+  endfacet
+  facet normal 9.914449e-01 0.000000e+00 -1.305262e-01
+    outer loop
+      vertex   1.220000e+01 -1.070000e+01 -4.000000e+00
+      vertex   1.218296e+01 -8.300000e+00 -4.129410e+00
+      vertex   1.220000e+01 -8.300000e+00 -4.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   6.600000e+00 -1.070000e+01 -4.500000e+00
+      vertex   6.600000e+00 -8.300000e+00 -4.500000e+00
+      vertex   1.170000e+01 -1.070000e+01 -4.500000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 -1.000000e+00
+    outer loop
+      vertex   1.170000e+01 -1.070000e+01 -4.500000e+00
+      vertex   6.600000e+00 -8.300000e+00 -4.500000e+00
+      vertex   1.170000e+01 -8.300000e+00 -4.500000e+00
+    endloop
+  endfacet
+  facet normal -9.914449e-01 0.000000e+00 -1.305262e-01
+    outer loop
+      vertex   0.000000e+00 -1.070000e+01 -4.000000e+00
+      vertex   0.000000e+00 -8.300000e+00 -4.000000e+00
+      vertex   1.703709e-02 -1.070000e+01 -4.129410e+00
+    endloop
+  endfacet
+  facet normal -9.914449e-01 0.000000e+00 -1.305262e-01
+    outer loop
+      vertex   1.703709e-02 -1.070000e+01 -4.129410e+00
+      vertex   0.000000e+00 -8.300000e+00 -4.000000e+00
+      vertex   1.703709e-02 -8.300000e+00 -4.129410e+00
+    endloop
+  endfacet
+  facet normal -9.238795e-01 0.000000e+00 -3.826834e-01
+    outer loop
+      vertex   1.703709e-02 -1.070000e+01 -4.129410e+00
+      vertex   1.703709e-02 -8.300000e+00 -4.129410e+00
+      vertex   6.698730e-02 -1.070000e+01 -4.250000e+00
+    endloop
+  endfacet
+  facet normal -9.238795e-01 -1.068450e-17 -3.826834e-01
+    outer loop
+      vertex   6.698730e-02 -1.070000e+01 -4.250000e+00
+      vertex   1.703709e-02 -8.300000e+00 -4.129410e+00
+      vertex   6.698730e-02 -8.300000e+00 -4.250000e+00
+    endloop
+  endfacet
+  facet normal -7.933533e-01 -9.174991e-18 -6.087614e-01
+    outer loop
+      vertex   6.698730e-02 -1.070000e+01 -4.250000e+00
+      vertex   6.698730e-02 -8.300000e+00 -4.250000e+00
+      vertex   1.464466e-01 -1.070000e+01 -4.353553e+00
+    endloop
+  endfacet
+  facet normal -7.933533e-01 0.000000e+00 -6.087614e-01
+    outer loop
+      vertex   1.464466e-01 -1.070000e+01 -4.353553e+00
+      vertex   6.698730e-02 -8.300000e+00 -4.250000e+00
+      vertex   1.464466e-01 -8.300000e+00 -4.353553e+00
+    endloop
+  endfacet
+  facet normal -6.087614e-01 0.000000e+00 -7.933533e-01
+    outer loop
+      vertex   1.464466e-01 -1.070000e+01 -4.353553e+00
+      vertex   1.464466e-01 -8.300000e+00 -4.353553e+00
+      vertex   2.500000e-01 -1.070000e+01 -4.433013e+00
+    endloop
+  endfacet
+  facet normal -6.087614e-01 0.000000e+00 -7.933533e-01
+    outer loop
+      vertex   2.500000e-01 -1.070000e+01 -4.433013e+00
+      vertex   1.464466e-01 -8.300000e+00 -4.353553e+00
+      vertex   2.500000e-01 -8.300000e+00 -4.433013e+00
+    endloop
+  endfacet
+  facet normal -3.826834e-01 0.000000e+00 -9.238795e-01
+    outer loop
+      vertex   2.500000e-01 -1.070000e+01 -4.433013e+00
+      vertex   2.500000e-01 -8.300000e+00 -4.433013e+00
+      vertex   3.705905e-01 -1.070000e+01 -4.482963e+00
+    endloop
+  endfacet
+  facet normal -3.826834e-01 -8.851332e-18 -9.238795e-01
+    outer loop
+      vertex   3.705905e-01 -1.070000e+01 -4.482963e+00
+      vertex   2.500000e-01 -8.300000e+00 -4.433013e+00
+      vertex   3.705905e-01 -8.300000e+00 -4.482963e+00
+    endloop
+  endfacet
+  facet normal -1.305262e-01 -3.019025e-18 -9.914449e-01
+    outer loop
+      vertex   3.705905e-01 -1.070000e+01 -4.482963e+00
+      vertex   3.705905e-01 -8.300000e+00 -4.482963e+00
+      vertex   5.000000e-01 -1.070000e+01 -4.500000e+00
+    endloop
+  endfacet
+  facet normal -1.305262e-01 0.000000e+00 -9.914449e-01
+    outer loop
+      vertex   5.000000e-01 -1.070000e+01 -4.500000e+00
+      vertex   3.705905e-01 -8.300000e+00 -4.482963e+00
+      vertex   5.000000e-01 -8.300000e+00 -4.500000e+00
+    endloop
+  endfacet
+  facet normal 1.305262e-01 0.000000e+00 9.914449e-01
+    outer loop
+      vertex   1.170000e+01 -8.300000e+00 2.750000e+01
+      vertex   1.170000e+01 -1.070000e+01 2.750000e+01
+      vertex   1.182941e+01 -8.300000e+00 2.748296e+01
+    endloop
+  endfacet
+  facet normal 1.305262e-01 0.000000e+00 9.914449e-01
+    outer loop
+      vertex   1.182941e+01 -8.300000e+00 2.748296e+01
+      vertex   1.170000e+01 -1.070000e+01 2.750000e+01
+      vertex   1.182941e+01 -1.070000e+01 2.748296e+01
+    endloop
+  endfacet
+  facet normal 3.826834e-01 0.000000e+00 9.238795e-01
+    outer loop
+      vertex   1.182941e+01 -8.300000e+00 2.748296e+01
+      vertex   1.182941e+01 -1.070000e+01 2.748296e+01
+      vertex   1.195000e+01 -8.300000e+00 2.743301e+01
+    endloop
+  endfacet
+  facet normal 3.826834e-01 0.000000e+00 9.238795e-01
+    outer loop
+      vertex   1.195000e+01 -8.300000e+00 2.743301e+01
+      vertex   1.182941e+01 -1.070000e+01 2.748296e+01
+      vertex   1.195000e+01 -1.070000e+01 2.743301e+01
+    endloop
+  endfacet
+  facet normal 6.087614e-01 0.000000e+00 7.933533e-01
+    outer loop
+      vertex   1.195000e+01 -8.300000e+00 2.743301e+01
+      vertex   1.195000e+01 -1.070000e+01 2.743301e+01
+      vertex   1.205355e+01 -8.300000e+00 2.735355e+01
+    endloop
+  endfacet
+  facet normal 6.087614e-01 0.000000e+00 7.933533e-01
+    outer loop
+      vertex   1.205355e+01 -8.300000e+00 2.735355e+01
+      vertex   1.195000e+01 -1.070000e+01 2.743301e+01
+      vertex   1.205355e+01 -1.070000e+01 2.735355e+01
+    endloop
+  endfacet
+  facet normal 7.933533e-01 0.000000e+00 6.087614e-01
+    outer loop
+      vertex   1.205355e+01 -8.300000e+00 2.735355e+01
+      vertex   1.205355e+01 -1.070000e+01 2.735355e+01
+      vertex   1.213301e+01 -8.300000e+00 2.725000e+01
+    endloop
+  endfacet
+  facet normal 7.933533e-01 0.000000e+00 6.087614e-01
+    outer loop
+      vertex   1.213301e+01 -8.300000e+00 2.725000e+01
+      vertex   1.205355e+01 -1.070000e+01 2.735355e+01
+      vertex   1.213301e+01 -1.070000e+01 2.725000e+01
+    endloop
+  endfacet
+  facet normal 9.238795e-01 0.000000e+00 3.826834e-01
+    outer loop
+      vertex   1.213301e+01 -8.300000e+00 2.725000e+01
+      vertex   1.213301e+01 -1.070000e+01 2.725000e+01
+      vertex   1.218296e+01 -8.300000e+00 2.712941e+01
+    endloop
+  endfacet
+  facet normal 9.238795e-01 0.000000e+00 3.826834e-01
+    outer loop
+      vertex   1.218296e+01 -8.300000e+00 2.712941e+01
+      vertex   1.213301e+01 -1.070000e+01 2.725000e+01
+      vertex   1.218296e+01 -1.070000e+01 2.712941e+01
+    endloop
+  endfacet
+  facet normal 9.914449e-01 0.000000e+00 1.305262e-01
+    outer loop
+      vertex   1.218296e+01 -8.300000e+00 2.712941e+01
+      vertex   1.218296e+01 -1.070000e+01 2.712941e+01
+      vertex   1.220000e+01 -8.300000e+00 2.700000e+01
+    endloop
+  endfacet
+  facet normal 9.914449e-01 0.000000e+00 1.305262e-01
+    outer loop
+      vertex   1.220000e+01 -8.300000e+00 2.700000e+01
+      vertex   1.218296e+01 -1.070000e+01 2.712941e+01
+      vertex   1.220000e+01 -1.070000e+01 2.700000e+01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.600000e+00 -1.070000e+01 2.666421e+01
+      vertex   5.600000e+00 -1.070000e+01 2.750000e+01
+      vertex   5.337741e+00 -1.070000e+01 2.654188e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.337741e+00 -1.070000e+01 2.654188e+01
+      vertex   5.600000e+00 -1.070000e+01 2.750000e+01
+      vertex   5.000000e-01 -1.070000e+01 2.750000e+01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.337741e+00 -1.070000e+01 2.654188e+01
+      vertex   5.000000e-01 -1.070000e+01 2.750000e+01
+      vertex   5.103854e+00 -1.070000e+01 2.637147e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.103854e+00 -1.070000e+01 2.637147e+01
+      vertex   5.000000e-01 -1.070000e+01 2.750000e+01
+      vertex   0.000000e+00 -1.070000e+01 2.700000e+01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.103854e+00 -1.070000e+01 2.637147e+01
+      vertex   0.000000e+00 -1.070000e+01 2.700000e+01
+      vertex   4.907043e+00 -1.070000e+01 2.615931e+01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.907043e+00 -1.070000e+01 2.615931e+01
+      vertex   0.000000e+00 -1.070000e+01 2.700000e+01
+      vertex   4.754633e+00 -1.070000e+01 2.591332e+01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.754633e+00 -1.070000e+01 2.591332e+01
+      vertex   0.000000e+00 -1.070000e+01 2.700000e+01
+      vertex   4.652297e+00 -1.070000e+01 2.564263e+01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.652297e+00 -1.070000e+01 2.564263e+01
+      vertex   0.000000e+00 -1.070000e+01 2.700000e+01
+      vertex   4.603845e+00 -1.070000e+01 2.535733e+01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 -1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   4.603845e+00 -1.070000e+01 2.535733e+01
+      vertex   0.000000e+00 -1.070000e+01 2.700000e+01
+      vertex   4.611079e+00 -1.070000e+01 2.506803e+01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.611079e+00 -1.070000e+01 2.506803e+01
+      vertex   0.000000e+00 -1.070000e+01 2.700000e+01
+      vertex   1.000000e+00 -1.070000e+01 2.300000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   4.611079e+00 -1.070000e+01 2.506803e+01
+      vertex   1.000000e+00 -1.070000e+01 2.300000e+01
+      vertex   4.673730e+00 -1.070000e+01 2.478551e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   4.673730e+00 -1.070000e+01 2.478551e+01
+      vertex   1.000000e+00 -1.070000e+01 2.300000e+01
+      vertex   4.789466e+00 -1.070000e+01 2.452027e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   4.789466e+00 -1.070000e+01 2.452027e+01
+      vertex   1.000000e+00 -1.070000e+01 2.300000e+01
+      vertex   4.953980e+00 -1.070000e+01 2.428220e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   4.953980e+00 -1.070000e+01 2.428220e+01
+      vertex   1.000000e+00 -1.070000e+01 2.300000e+01
+      vertex   5.161149e+00 -1.070000e+01 2.408015e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   5.161149e+00 -1.070000e+01 2.408015e+01
+      vertex   1.000000e+00 -1.070000e+01 2.300000e+01
+      vertex   5.403261e+00 -1.070000e+01 2.392163e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   5.403261e+00 -1.070000e+01 2.392163e+01
+      vertex   1.000000e+00 -1.070000e+01 2.300000e+01
+      vertex   5.671306e+00 -1.070000e+01 2.381256e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   5.671306e+00 -1.070000e+01 2.381256e+01
+      vertex   1.000000e+00 -1.070000e+01 2.300000e+01
+      vertex   5.955307e+00 -1.070000e+01 2.375700e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   5.955307e+00 -1.070000e+01 2.375700e+01
+      vertex   1.000000e+00 -1.070000e+01 2.300000e+01
+      vertex   6.244693e+00 -1.070000e+01 2.375700e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   6.244693e+00 -1.070000e+01 2.375700e+01
+      vertex   1.000000e+00 -1.070000e+01 2.300000e+01
+      vertex   1.120000e+01 -1.070000e+01 2.300000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.244693e+00 -1.070000e+01 2.375700e+01
+      vertex   1.120000e+01 -1.070000e+01 2.300000e+01
+      vertex   6.528694e+00 -1.070000e+01 2.381256e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.528694e+00 -1.070000e+01 2.381256e+01
+      vertex   1.120000e+01 -1.070000e+01 2.300000e+01
+      vertex   6.796739e+00 -1.070000e+01 2.392163e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.796739e+00 -1.070000e+01 2.392163e+01
+      vertex   1.120000e+01 -1.070000e+01 2.300000e+01
+      vertex   7.038851e+00 -1.070000e+01 2.408015e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.038851e+00 -1.070000e+01 2.408015e+01
+      vertex   1.120000e+01 -1.070000e+01 2.300000e+01
+      vertex   7.246020e+00 -1.070000e+01 2.428220e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.246020e+00 -1.070000e+01 2.428220e+01
+      vertex   1.120000e+01 -1.070000e+01 2.300000e+01
+      vertex   7.410534e+00 -1.070000e+01 2.452027e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.410534e+00 -1.070000e+01 2.452027e+01
+      vertex   1.120000e+01 -1.070000e+01 2.300000e+01
+      vertex   7.526270e+00 -1.070000e+01 2.478551e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.526270e+00 -1.070000e+01 2.478551e+01
+      vertex   1.120000e+01 -1.070000e+01 2.300000e+01
+      vertex   7.588921e+00 -1.070000e+01 2.506803e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.588921e+00 -1.070000e+01 2.506803e+01
+      vertex   1.120000e+01 -1.070000e+01 2.300000e+01
+      vertex   1.220000e+01 -1.070000e+01 2.700000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.588921e+00 -1.070000e+01 2.506803e+01
+      vertex   1.220000e+01 -1.070000e+01 2.700000e+01
+      vertex   7.596155e+00 -1.070000e+01 2.535733e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.596155e+00 -1.070000e+01 2.535733e+01
+      vertex   1.220000e+01 -1.070000e+01 2.700000e+01
+      vertex   7.547703e+00 -1.070000e+01 2.564263e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.547703e+00 -1.070000e+01 2.564263e+01
+      vertex   1.220000e+01 -1.070000e+01 2.700000e+01
+      vertex   7.445367e+00 -1.070000e+01 2.591332e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.445367e+00 -1.070000e+01 2.591332e+01
+      vertex   1.220000e+01 -1.070000e+01 2.700000e+01
+      vertex   7.292957e+00 -1.070000e+01 2.615931e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.292957e+00 -1.070000e+01 2.615931e+01
+      vertex   1.220000e+01 -1.070000e+01 2.700000e+01
+      vertex   7.096146e+00 -1.070000e+01 2.637147e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.096146e+00 -1.070000e+01 2.637147e+01
+      vertex   1.220000e+01 -1.070000e+01 2.700000e+01
+      vertex   1.170000e+01 -1.070000e+01 2.750000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.096146e+00 -1.070000e+01 2.637147e+01
+      vertex   1.170000e+01 -1.070000e+01 2.750000e+01
+      vertex   6.862259e+00 -1.070000e+01 2.654188e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.862259e+00 -1.070000e+01 2.654188e+01
+      vertex   1.170000e+01 -1.070000e+01 2.750000e+01
+      vertex   6.600000e+00 -1.070000e+01 2.750000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.862259e+00 -1.070000e+01 2.654188e+01
+      vertex   6.600000e+00 -1.070000e+01 2.750000e+01
+      vertex   6.600000e+00 -1.070000e+01 2.666421e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   3.705905e-01 -1.070000e+01 2.748296e+01
+      vertex   2.500000e-01 -1.070000e+01 2.743301e+01
+      vertex   5.000000e-01 -1.070000e+01 2.750000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.000000e-01 -1.070000e+01 2.750000e+01
+      vertex   2.500000e-01 -1.070000e+01 2.743301e+01
+      vertex   1.464466e-01 -1.070000e+01 2.735355e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.000000e-01 -1.070000e+01 2.750000e+01
+      vertex   1.464466e-01 -1.070000e+01 2.735355e+01
+      vertex   6.698730e-02 -1.070000e+01 2.725000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   6.698730e-02 -1.070000e+01 2.725000e+01
+      vertex   1.703709e-02 -1.070000e+01 2.712941e+01
+      vertex   5.000000e-01 -1.070000e+01 2.750000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.000000e-01 -1.070000e+01 2.750000e+01
+      vertex   1.703709e-02 -1.070000e+01 2.712941e+01
+      vertex   0.000000e+00 -1.070000e+01 2.700000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -1.070000e+01 2.200000e+01
+      vertex   2.507209e-02 -1.070000e+01 2.222252e+01
+      vertex   0.000000e+00 -1.070000e+01 2.700000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -1.070000e+01 2.700000e+01
+      vertex   2.507209e-02 -1.070000e+01 2.222252e+01
+      vertex   9.903113e-02 -1.070000e+01 2.243388e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -1.070000e+01 2.700000e+01
+      vertex   9.903113e-02 -1.070000e+01 2.243388e+01
+      vertex   2.181685e-01 -1.070000e+01 2.262349e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   2.181685e-01 -1.070000e+01 2.262349e+01
+      vertex   3.765102e-01 -1.070000e+01 2.278183e+01
+      vertex   0.000000e+00 -1.070000e+01 2.700000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -1.070000e+01 2.700000e+01
+      vertex   3.765102e-01 -1.070000e+01 2.278183e+01
+      vertex   5.661163e-01 -1.070000e+01 2.290097e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -1.070000e+01 2.700000e+01
+      vertex   5.661163e-01 -1.070000e+01 2.290097e+01
+      vertex   7.774791e-01 -1.070000e+01 2.297493e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.774791e-01 -1.070000e+01 2.297493e+01
+      vertex   1.000000e+00 -1.070000e+01 2.300000e+01
+      vertex   0.000000e+00 -1.070000e+01 2.700000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.120000e+01 -1.070000e+01 2.300000e+01
+      vertex   1.142252e+01 -1.070000e+01 2.297493e+01
+      vertex   1.220000e+01 -1.070000e+01 2.700000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -1.070000e+01 2.700000e+01
+      vertex   1.142252e+01 -1.070000e+01 2.297493e+01
+      vertex   1.163388e+01 -1.070000e+01 2.290097e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -1.070000e+01 2.700000e+01
+      vertex   1.163388e+01 -1.070000e+01 2.290097e+01
+      vertex   1.182349e+01 -1.070000e+01 2.278183e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.182349e+01 -1.070000e+01 2.278183e+01
+      vertex   1.198183e+01 -1.070000e+01 2.262349e+01
+      vertex   1.220000e+01 -1.070000e+01 2.700000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -1.070000e+01 2.700000e+01
+      vertex   1.198183e+01 -1.070000e+01 2.262349e+01
+      vertex   1.210097e+01 -1.070000e+01 2.243388e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -1.070000e+01 2.700000e+01
+      vertex   1.210097e+01 -1.070000e+01 2.243388e+01
+      vertex   1.217493e+01 -1.070000e+01 2.222252e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.217493e+01 -1.070000e+01 2.222252e+01
+      vertex   1.220000e+01 -1.070000e+01 2.200000e+01
+      vertex   1.220000e+01 -1.070000e+01 2.700000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -1.070000e+01 2.700000e+01
+      vertex   1.218296e+01 -1.070000e+01 2.712941e+01
+      vertex   1.170000e+01 -1.070000e+01 2.750000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.170000e+01 -1.070000e+01 2.750000e+01
+      vertex   1.218296e+01 -1.070000e+01 2.712941e+01
+      vertex   1.213301e+01 -1.070000e+01 2.725000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.170000e+01 -1.070000e+01 2.750000e+01
+      vertex   1.213301e+01 -1.070000e+01 2.725000e+01
+      vertex   1.205355e+01 -1.070000e+01 2.735355e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.205355e+01 -1.070000e+01 2.735355e+01
+      vertex   1.195000e+01 -1.070000e+01 2.743301e+01
+      vertex   1.170000e+01 -1.070000e+01 2.750000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.170000e+01 -1.070000e+01 2.750000e+01
+      vertex   1.195000e+01 -1.070000e+01 2.743301e+01
+      vertex   1.182941e+01 -1.070000e+01 2.748296e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -0.000000e+00 1.000000e+00
+    outer loop
+      vertex   5.600000e+00 -1.070000e+01 2.750000e+01
+      vertex   5.600000e+00 -8.300000e+00 2.750000e+01
+      vertex   5.000000e-01 -1.070000e+01 2.750000e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 1.000000e+00
+    outer loop
+      vertex   5.000000e-01 -1.070000e+01 2.750000e+01
+      vertex   5.600000e+00 -8.300000e+00 2.750000e+01
+      vertex   5.000000e-01 -8.300000e+00 2.750000e+01
+    endloop
+  endfacet
+  facet normal -9.914449e-01 0.000000e+00 1.305262e-01
+    outer loop
+      vertex   0.000000e+00 -8.300000e+00 2.700000e+01
+      vertex   0.000000e+00 -1.070000e+01 2.700000e+01
+      vertex   1.703709e-02 -8.300000e+00 2.712941e+01
+    endloop
+  endfacet
+  facet normal -9.914449e-01 0.000000e+00 1.305262e-01
+    outer loop
+      vertex   1.703709e-02 -8.300000e+00 2.712941e+01
+      vertex   0.000000e+00 -1.070000e+01 2.700000e+01
+      vertex   1.703709e-02 -1.070000e+01 2.712941e+01
+    endloop
+  endfacet
+  facet normal -9.238795e-01 0.000000e+00 3.826834e-01
+    outer loop
+      vertex   1.703709e-02 -8.300000e+00 2.712941e+01
+      vertex   1.703709e-02 -1.070000e+01 2.712941e+01
+      vertex   6.698730e-02 -8.300000e+00 2.725000e+01
+    endloop
+  endfacet
+  facet normal -9.238795e-01 2.136901e-17 3.826834e-01
+    outer loop
+      vertex   6.698730e-02 -8.300000e+00 2.725000e+01
+      vertex   1.703709e-02 -1.070000e+01 2.712941e+01
+      vertex   6.698730e-02 -1.070000e+01 2.725000e+01
+    endloop
+  endfacet
+  facet normal -7.933533e-01 1.834998e-17 6.087614e-01
+    outer loop
+      vertex   6.698730e-02 -8.300000e+00 2.725000e+01
+      vertex   6.698730e-02 -1.070000e+01 2.725000e+01
+      vertex   1.464466e-01 -8.300000e+00 2.735355e+01
+    endloop
+  endfacet
+  facet normal -7.933533e-01 0.000000e+00 6.087614e-01
+    outer loop
+      vertex   1.464466e-01 -8.300000e+00 2.735355e+01
+      vertex   6.698730e-02 -1.070000e+01 2.725000e+01
+      vertex   1.464466e-01 -1.070000e+01 2.735355e+01
+    endloop
+  endfacet
+  facet normal -6.087614e-01 0.000000e+00 7.933533e-01
+    outer loop
+      vertex   1.464466e-01 -8.300000e+00 2.735355e+01
+      vertex   1.464466e-01 -1.070000e+01 2.735355e+01
+      vertex   2.500000e-01 -8.300000e+00 2.743301e+01
+    endloop
+  endfacet
+  facet normal -6.087614e-01 7.040218e-18 7.933533e-01
+    outer loop
+      vertex   2.500000e-01 -8.300000e+00 2.743301e+01
+      vertex   1.464466e-01 -1.070000e+01 2.735355e+01
+      vertex   2.500000e-01 -1.070000e+01 2.743301e+01
+    endloop
+  endfacet
+  facet normal -3.826834e-01 4.425666e-18 9.238795e-01
+    outer loop
+      vertex   2.500000e-01 -8.300000e+00 2.743301e+01
+      vertex   2.500000e-01 -1.070000e+01 2.743301e+01
+      vertex   3.705905e-01 -8.300000e+00 2.748296e+01
+    endloop
+  endfacet
+  facet normal -3.826834e-01 0.000000e+00 9.238795e-01
+    outer loop
+      vertex   3.705905e-01 -8.300000e+00 2.748296e+01
+      vertex   2.500000e-01 -1.070000e+01 2.743301e+01
+      vertex   3.705905e-01 -1.070000e+01 2.748296e+01
+    endloop
+  endfacet
+  facet normal -1.305262e-01 0.000000e+00 9.914449e-01
+    outer loop
+      vertex   3.705905e-01 -8.300000e+00 2.748296e+01
+      vertex   3.705905e-01 -1.070000e+01 2.748296e+01
+      vertex   5.000000e-01 -8.300000e+00 2.750000e+01
+    endloop
+  endfacet
+  facet normal -1.305262e-01 0.000000e+00 9.914449e-01
+    outer loop
+      vertex   5.000000e-01 -8.300000e+00 2.750000e+01
+      vertex   3.705905e-01 -1.070000e+01 2.748296e+01
+      vertex   5.000000e-01 -1.070000e+01 2.750000e+01
+    endloop
+  endfacet
+  facet normal -4.683512e-01 0.000000e+00 8.835424e-01
+    outer loop
+      vertex   3.500000e+00 -4.200000e+00 1.161815e+01
+      vertex   3.500000e+00 0.000000e+00 1.161815e+01
+      vertex   2.992453e+00 -4.200000e+00 1.134911e+01
+    endloop
+  endfacet
+  facet normal -4.701270e-01 2.750339e-04 8.825988e-01
+    outer loop
+      vertex   2.992453e+00 -4.200000e+00 1.134911e+01
+      vertex   3.500000e+00 0.000000e+00 1.161815e+01
+      vertex   2.971367e+00 0.000000e+00 1.133657e+01
+    endloop
+  endfacet
+  facet normal -5.493867e-01 -2.633006e-04 8.355682e-01
+    outer loop
+      vertex   2.992453e+00 -4.200000e+00 1.134911e+01
+      vertex   2.971367e+00 0.000000e+00 1.133657e+01
+      vertex   2.512464e+00 -4.200000e+00 1.103352e+01
+    endloop
+  endfacet
+  facet normal -5.544173e-01 5.266000e-04 8.322387e-01
+    outer loop
+      vertex   2.512464e+00 -4.200000e+00 1.103352e+01
+      vertex   2.971367e+00 0.000000e+00 1.133657e+01
+      vertex   2.472897e+00 0.000000e+00 1.100450e+01
+    endloop
+  endfacet
+  facet normal -6.255500e-01 -5.031312e-04 7.801839e-01
+    outer loop
+      vertex   2.512464e+00 -4.200000e+00 1.103352e+01
+      vertex   2.472897e+00 0.000000e+00 1.100450e+01
+      vertex   2.064290e+00 -4.200000e+00 1.067417e+01
+    endloop
+  endfacet
+  facet normal -6.333624e-01 7.546942e-04 7.738549e-01
+    outer loop
+      vertex   2.064290e+00 -4.200000e+00 1.067417e+01
+      vertex   2.472897e+00 0.000000e+00 1.100450e+01
+      vertex   2.009397e+00 0.000000e+00 1.062515e+01
+    endloop
+  endfacet
+  facet normal -6.961657e-01 -7.194881e-04 7.178808e-01
+    outer loop
+      vertex   2.064290e+00 -4.200000e+00 1.067417e+01
+      vertex   2.009397e+00 0.000000e+00 1.062515e+01
+      vertex   1.651906e+00 -4.200000e+00 1.027426e+01
+    endloop
+  endfacet
+  facet normal -7.062013e-01 9.593128e-04 7.080105e-01
+    outer loop
+      vertex   1.651906e+00 -4.200000e+00 1.027426e+01
+      vertex   2.009397e+00 0.000000e+00 1.062515e+01
+      vertex   1.585333e+00 0.000000e+00 1.020217e+01
+    endloop
+  endfacet
+  facet normal -7.606076e-01 -9.123678e-04 6.492112e-01
+    outer loop
+      vertex   1.651906e+00 -4.200000e+00 1.027426e+01
+      vertex   1.585333e+00 0.000000e+00 1.020217e+01
+      vertex   1.278969e+00 -4.200000e+00 9.837334e+00
+    endloop
+  endfacet
+  facet normal -7.722316e-01 1.140453e-03 6.353401e-01
+    outer loop
+      vertex   1.278969e+00 -4.200000e+00 9.837334e+00
+      vertex   1.585333e+00 0.000000e+00 1.020217e+01
+      vertex   1.204796e+00 0.000000e+00 9.739639e+00
+    endloop
+  endfacet
+  facet normal -8.183042e-01 -1.081767e-03 5.747844e-01
+    outer loop
+      vertex   1.278969e+00 -4.200000e+00 9.837334e+00
+      vertex   1.204796e+00 0.000000e+00 9.739639e+00
+      vertex   9.487866e-01 -4.200000e+00 9.367262e+00
+    endloop
+  endfacet
+  facet normal -8.308168e-01 1.298110e-03 5.565444e-01
+    outer loop
+      vertex   9.487866e-01 -4.200000e+00 9.367262e+00
+      vertex   1.204796e+00 0.000000e+00 9.739639e+00
+      vertex   8.714529e-01 0.000000e+00 9.242021e+00
+    endloop
+  endfacet
+  facet normal -8.687438e-01 -1.227683e-03 4.952602e-01
+    outer loop
+      vertex   9.487866e-01 -4.200000e+00 9.367262e+00
+      vertex   8.714529e-01 0.000000e+00 9.242021e+00
+      vertex   6.642861e-01 -4.200000e+00 8.868215e+00
+    endloop
+  endfacet
+  facet normal -8.813921e-01 1.432284e-03 4.723832e-01
+    outer loop
+      vertex   6.642861e-01 -4.200000e+00 8.868215e+00
+      vertex   8.714529e-01 0.000000e+00 9.242021e+00
+      vertex   5.885186e-01 0.000000e+00 8.714110e+00
+    endloop
+  endfacet
+  facet normal -9.114792e-01 -1.350114e-03 4.113439e-01
+    outer loop
+      vertex   6.642861e-01 -4.200000e+00 8.868215e+00
+      vertex   5.885186e-01 0.000000e+00 8.714110e+00
+      vertex   4.279910e-01 -4.200000e+00 8.344619e+00
+    endloop
+  endfacet
+  facet normal -9.234699e-01 1.542971e-03 3.836677e-01
+    outer loop
+      vertex   4.279910e-01 -4.200000e+00 8.344619e+00
+      vertex   5.885186e-01 0.000000e+00 8.714110e+00
+      vertex   3.587204e-01 0.000000e+00 8.160997e+00
+    endloop
+  endfacet
+  facet normal -9.461314e-01 -1.449057e-03 3.237798e-01
+    outer loop
+      vertex   4.279910e-01 -4.200000e+00 8.344619e+00
+      vertex   3.587204e-01 0.000000e+00 8.160997e+00
+      vertex   2.419968e-01 -4.200000e+00 7.801117e+00
+    endloop
+  endfacet
+  facet normal -9.566446e-01 1.630170e-03 2.912533e-01
+    outer loop
+      vertex   2.419968e-01 -4.200000e+00 7.801117e+00
+      vertex   3.587204e-01 0.000000e+00 8.160997e+00
+      vertex   1.842738e-01 0.000000e+00 7.588013e+00
+    endloop
+  endfacet
+  facet normal -9.723930e-01 -1.524511e-03 2.333443e-01
+    outer loop
+      vertex   2.419968e-01 -4.200000e+00 7.801117e+00
+      vertex   1.842738e-01 0.000000e+00 7.588013e+00
+      vertex   1.079530e-01 -4.200000e+00 7.242529e+00
+    endloop
+  endfacet
+  facet normal -9.805962e-01 1.693879e-03 1.960310e-01
+    outer loop
+      vertex   1.079530e-01 -4.200000e+00 7.242529e+00
+      vertex   1.842738e-01 0.000000e+00 7.588013e+00
+      vertex   6.686084e-02 0.000000e+00 7.000684e+00
+    endloop
+  endfacet
+  facet normal -9.900312e-01 -1.576475e-03 1.408395e-01
+    outer loop
+      vertex   1.079530e-01 -4.200000e+00 7.242529e+00
+      vertex   6.686084e-02 0.000000e+00 7.000684e+00
+      vertex   2.704822e-02 -4.200000e+00 6.673809e+00
+    endloop
+  endfacet
+  facet normal -9.950940e-01 1.734098e-03 9.891876e-02
+    outer loop
+      vertex   2.704822e-02 -4.200000e+00 6.673809e+00
+      vertex   6.686084e-02 0.000000e+00 7.000684e+00
+      vertex   7.613325e-03 0.000000e+00 6.404671e+00
+    endloop
+  endfacet
+  facet normal -9.988896e-01 -1.604949e-03 4.708568e-02
+    outer loop
+      vertex   2.704822e-02 -4.200000e+00 6.673809e+00
+      vertex   7.613325e-03 0.000000e+00 6.404671e+00
+      vertex   0.000000e+00 -4.200000e+00 6.100000e+00
+    endloop
+  endfacet
+  facet normal -9.999981e-01 1.750825e-03 8.528656e-04
+    outer loop
+      vertex   0.000000e+00 -4.200000e+00 6.100000e+00
+      vertex   7.613325e-03 0.000000e+00 6.404671e+00
+      vertex   7.102500e-03 0.000000e+00 5.805721e+00
+    endloop
+  endfacet
+  facet normal -9.987939e-01 -1.748958e-03 -4.906760e-02
+    outer loop
+      vertex   0.000000e+00 -4.200000e+00 6.100000e+00
+      vertex   7.102500e-03 0.000000e+00 5.805721e+00
+      vertex   2.937317e-02 -4.200000e+00 5.502095e+00
+    endloop
+  endfacet
+  facet normal -9.952613e-01 1.750889e-03 -9.722125e-02
+    outer loop
+      vertex   2.937317e-02 -4.200000e+00 5.502095e+00
+      vertex   7.102500e-03 0.000000e+00 5.805721e+00
+      vertex   6.533329e-02 0.000000e+00 5.209608e+00
+    endloop
+  endfacet
+  facet normal -9.891750e-01 -1.749020e-03 -1.467303e-01
+    outer loop
+      vertex   2.937317e-02 -4.200000e+00 5.502095e+00
+      vertex   6.533329e-02 0.000000e+00 5.209608e+00
+      vertex   1.172098e-01 -4.200000e+00 4.909949e+00
+    endloop
+  endfacet
+  facet normal -9.809291e-01 1.750949e-03 -1.943581e-01
+    outer loop
+      vertex   1.172098e-01 -4.200000e+00 4.909949e+00
+      vertex   6.533329e-02 0.000000e+00 5.209608e+00
+      vertex   1.817443e-01 0.000000e+00 4.622079e+00
+    endloop
+  endfacet
+  facet normal -9.700298e-01 -1.749078e-03 -2.429798e-01
+    outer loop
+      vertex   1.172098e-01 -4.200000e+00 4.909949e+00
+      vertex   1.817443e-01 0.000000e+00 4.622079e+00
+      vertex   2.626640e-01 -4.200000e+00 4.329263e+00
+    endloop
+  endfacet
+  facet normal -9.571398e-01 1.751005e-03 -2.896210e-01
+    outer loop
+      vertex   2.626640e-01 -4.200000e+00 4.329263e+00
+      vertex   1.817443e-01 0.000000e+00 4.622079e+00
+      vertex   3.552132e-01 0.000000e+00 4.048799e+00
+    endloop
+  endfacet
+  facet normal -9.415426e-01 -1.749131e-03 -3.368893e-01
+    outer loop
+      vertex   2.626640e-01 -4.200000e+00 4.329263e+00
+      vertex   3.552132e-01 0.000000e+00 4.048799e+00
+      vertex   4.643349e-01 -4.200000e+00 3.765631e+00
+    endloop
+  endfacet
+  facet normal -9.241227e-01 1.751057e-03 -3.820918e-01
+    outer loop
+      vertex   4.643349e-01 -4.200000e+00 3.765631e+00
+      vertex   3.552132e-01 0.000000e+00 4.048799e+00
+      vertex   5.840676e-01 0.000000e+00 3.495295e+00
+    endloop
+  endfacet
+  facet normal -9.039879e-01 -1.749181e-03 -4.275544e-01
+    outer loop
+      vertex   4.643349e-01 -4.200000e+00 3.765631e+00
+      vertex   5.840676e-01 0.000000e+00 3.495295e+00
+      vertex   7.202803e-01 -4.200000e+00 3.224480e+00
+    endloop
+  endfacet
+  facet normal -8.821962e-01 1.751104e-03 -4.708788e-01
+    outer loop
+      vertex   7.202803e-01 -4.200000e+00 3.224480e+00
+      vertex   5.840676e-01 0.000000e+00 3.495295e+00
+      vertex   8.661011e-01 0.000000e+00 2.966902e+00
+    endloop
+  endfacet
+  facet normal -8.577273e-01 -1.749226e-03 -5.141020e-01
+    outer loop
+      vertex   7.202803e-01 -4.200000e+00 3.224480e+00
+      vertex   8.661011e-01 0.000000e+00 2.966902e+00
+      vertex   1.028035e+00 -4.200000e+00 2.711022e+00
+    endloop
+  endfacet
+  facet normal -8.317644e-01 1.751147e-03 -5.551261e-01
+    outer loop
+      vertex   1.028035e+00 -4.200000e+00 2.711022e+00
+      vertex   8.661011e-01 0.000000e+00 2.966902e+00
+      vertex   1.198595e+00 0.000000e+00 2.468716e+00
+    endloop
+  endfacet
+  facet normal -8.032063e-01 -1.749268e-03 -5.956984e-01
+    outer loop
+      vertex   1.028035e+00 -4.200000e+00 2.711022e+00
+      vertex   1.198595e+00 0.000000e+00 2.468716e+00
+      vertex   1.384636e+00 -4.200000e+00 2.230201e+00
+    endloop
+  endfacet
+  facet normal -7.733135e-01 1.751187e-03 -6.340214e-01
+    outer loop
+      vertex   1.384636e+00 -4.200000e+00 2.230201e+00
+      vertex   1.198595e+00 0.000000e+00 2.468716e+00
+      vertex   1.578343e+00 0.000000e+00 2.005539e+00
+    endloop
+  endfacet
+  facet normal -7.409500e-01 -1.749305e-03 -6.715579e-01
+    outer loop
+      vertex   1.384636e+00 -4.200000e+00 2.230201e+00
+      vertex   1.578343e+00 0.000000e+00 2.005539e+00
+      vertex   1.786649e+00 -4.200000e+00 1.786649e+00
+    endloop
+  endfacet
+  facet normal -7.074072e-01 1.751222e-03 -7.068041e-01
+    outer loop
+      vertex   1.786649e+00 -4.200000e+00 1.786649e+00
+      vertex   1.578343e+00 0.000000e+00 2.005539e+00
+      vertex   2.001684e+00 0.000000e+00 1.581836e+00
+    endloop
+  endfacet
+  facet normal -6.715579e-01 -1.749338e-03 -7.409500e-01
+    outer loop
+      vertex   1.786649e+00 -4.200000e+00 1.786649e+00
+      vertex   2.001684e+00 0.000000e+00 1.581836e+00
+      vertex   2.230201e+00 -4.200000e+00 1.384636e+00
+    endloop
+  endfacet
+  facet normal -6.346807e-01 1.751253e-03 -7.727725e-01
+    outer loop
+      vertex   2.230201e+00 -4.200000e+00 1.384636e+00
+      vertex   2.001684e+00 0.000000e+00 1.581836e+00
+      vertex   2.464537e+00 0.000000e+00 1.201693e+00
+    endloop
+  endfacet
+  facet normal -5.956984e-01 -1.749367e-03 -8.032063e-01
+    outer loop
+      vertex   2.230201e+00 -4.200000e+00 1.384636e+00
+      vertex   2.464537e+00 0.000000e+00 1.201693e+00
+      vertex   2.711022e+00 -4.200000e+00 1.028035e+00
+    endloop
+  endfacet
+  facet normal -5.558353e-01 1.751279e-03 -8.312906e-01
+    outer loop
+      vertex   2.711022e+00 -4.200000e+00 1.028035e+00
+      vertex   2.464537e+00 0.000000e+00 1.201693e+00
+      vertex   2.962439e+00 0.000000e+00 8.687751e-01
+    endloop
+  endfacet
+  facet normal -5.141020e-01 -1.749391e-03 -8.577273e-01
+    outer loop
+      vertex   2.711022e+00 -4.200000e+00 1.028035e+00
+      vertex   2.962439e+00 0.000000e+00 8.687751e-01
+      vertex   3.224480e+00 -4.200000e+00 7.202803e-01
+    endloop
+  endfacet
+  facet normal -4.716310e-01 1.751302e-03 -8.817942e-01
+    outer loop
+      vertex   3.224480e+00 -4.200000e+00 7.202803e-01
+      vertex   2.962439e+00 0.000000e+00 8.687751e-01
+      vertex   3.490591e+00 0.000000e+00 5.862911e-01
+    endloop
+  endfacet
+  facet normal -4.275544e-01 -1.749412e-03 -9.039879e-01
+    outer loop
+      vertex   3.224480e+00 -4.200000e+00 7.202803e-01
+      vertex   3.490591e+00 0.000000e+00 5.862911e-01
+      vertex   3.765631e+00 -4.200000e+00 4.643349e-01
+    endloop
+  endfacet
+  facet normal -3.828798e-01 1.751321e-03 -9.237965e-01
+    outer loop
+      vertex   3.765631e+00 -4.200000e+00 4.643349e-01
+      vertex   3.490591e+00 0.000000e+00 5.862911e-01
+      vertex   4.043900e+00 0.000000e+00 3.569647e-01
+    endloop
+  endfacet
+  facet normal -3.368893e-01 -1.749429e-03 -9.415426e-01
+    outer loop
+      vertex   3.765631e+00 -4.200000e+00 4.643349e-01
+      vertex   4.043900e+00 0.000000e+00 3.569647e-01
+      vertex   4.329263e+00 -4.200000e+00 2.626640e-01
+    endloop
+  endfacet
+  facet normal -2.904373e-01 1.751335e-03 -9.568924e-01
+    outer loop
+      vertex   4.329263e+00 -4.200000e+00 2.626640e-01
+      vertex   4.043900e+00 0.000000e+00 3.569647e-01
+      vertex   4.617032e+00 0.000000e+00 1.830069e-01
+    endloop
+  endfacet
+  facet normal -2.429798e-01 -1.749441e-03 -9.700298e-01
+    outer loop
+      vertex   4.329263e+00 -4.200000e+00 2.626640e-01
+      vertex   4.617032e+00 0.000000e+00 1.830069e-01
+      vertex   4.909949e+00 -4.200000e+00 1.172098e-01
+    endloop
+  endfacet
+  facet normal -1.951946e-01 1.751345e-03 -9.807630e-01
+    outer loop
+      vertex   4.909949e+00 -4.200000e+00 1.172098e-01
+      vertex   4.617032e+00 0.000000e+00 1.830069e-01
+      vertex   5.204462e+00 0.000000e+00 6.609487e-02
+    endloop
+  endfacet
+  facet normal -1.467302e-01 -1.749449e-03 -9.891750e-01
+    outer loop
+      vertex   4.909949e+00 -4.200000e+00 1.172098e-01
+      vertex   5.204462e+00 0.000000e+00 6.609487e-02
+      vertex   5.502095e+00 -4.200000e+00 2.937317e-02
+    endloop
+  endfacet
+  facet normal -9.807004e-02 1.751352e-03 -9.951780e-01
+    outer loop
+      vertex   5.502095e+00 -4.200000e+00 2.937317e-02
+      vertex   5.204462e+00 0.000000e+00 6.609487e-02
+      vertex   5.800525e+00 0.000000e+00 7.355697e-03
+    endloop
+  endfacet
+  facet normal -4.906760e-02 -1.749453e-03 -9.987939e-01
+    outer loop
+      vertex   5.502095e+00 -4.200000e+00 2.937317e-02
+      vertex   5.800525e+00 0.000000e+00 7.355697e-03
+      vertex   6.100000e+00 -4.200000e+00 5.551115e-16
+    endloop
+  endfacet
+  facet normal -6.945849e-16 1.751354e-03 -9.999985e-01
+    outer loop
+      vertex   6.100000e+00 -4.200000e+00 5.551115e-16
+      vertex   5.800525e+00 0.000000e+00 7.355697e-03
+      vertex   6.399475e+00 0.000000e+00 7.355697e-03
+    endloop
+  endfacet
+  facet normal 4.906760e-02 -1.749453e-03 -9.987939e-01
+    outer loop
+      vertex   6.100000e+00 -4.200000e+00 5.551115e-16
+      vertex   6.399475e+00 0.000000e+00 7.355697e-03
+      vertex   6.697905e+00 -4.200000e+00 2.937317e-02
+    endloop
+  endfacet
+  facet normal 9.807004e-02 1.751352e-03 -9.951780e-01
+    outer loop
+      vertex   6.697905e+00 -4.200000e+00 2.937317e-02
+      vertex   6.399475e+00 0.000000e+00 7.355697e-03
+      vertex   6.995538e+00 0.000000e+00 6.609487e-02
+    endloop
+  endfacet
+  facet normal 1.467302e-01 -1.749449e-03 -9.891750e-01
+    outer loop
+      vertex   6.697905e+00 -4.200000e+00 2.937317e-02
+      vertex   6.995538e+00 0.000000e+00 6.609487e-02
+      vertex   7.290051e+00 -4.200000e+00 1.172098e-01
+    endloop
+  endfacet
+  facet normal 1.951946e-01 1.751345e-03 -9.807630e-01
+    outer loop
+      vertex   7.290051e+00 -4.200000e+00 1.172098e-01
+      vertex   6.995538e+00 0.000000e+00 6.609487e-02
+      vertex   7.582968e+00 0.000000e+00 1.830069e-01
+    endloop
+  endfacet
+  facet normal 2.429798e-01 -1.749441e-03 -9.700298e-01
+    outer loop
+      vertex   7.290051e+00 -4.200000e+00 1.172098e-01
+      vertex   7.582968e+00 0.000000e+00 1.830069e-01
+      vertex   7.870737e+00 -4.200000e+00 2.626640e-01
+    endloop
+  endfacet
+  facet normal 2.904373e-01 1.751335e-03 -9.568924e-01
+    outer loop
+      vertex   7.870737e+00 -4.200000e+00 2.626640e-01
+      vertex   7.582968e+00 0.000000e+00 1.830069e-01
+      vertex   8.156100e+00 0.000000e+00 3.569647e-01
+    endloop
+  endfacet
+  facet normal 3.368893e-01 -1.749429e-03 -9.415426e-01
+    outer loop
+      vertex   7.870737e+00 -4.200000e+00 2.626640e-01
+      vertex   8.156100e+00 0.000000e+00 3.569647e-01
+      vertex   8.434369e+00 -4.200000e+00 4.643349e-01
+    endloop
+  endfacet
+  facet normal 3.828798e-01 1.751321e-03 -9.237965e-01
+    outer loop
+      vertex   8.434369e+00 -4.200000e+00 4.643349e-01
+      vertex   8.156100e+00 0.000000e+00 3.569647e-01
+      vertex   8.709409e+00 0.000000e+00 5.862911e-01
+    endloop
+  endfacet
+  facet normal 4.275544e-01 -1.749412e-03 -9.039879e-01
+    outer loop
+      vertex   8.434369e+00 -4.200000e+00 4.643349e-01
+      vertex   8.709409e+00 0.000000e+00 5.862911e-01
+      vertex   8.975520e+00 -4.200000e+00 7.202803e-01
+    endloop
+  endfacet
+  facet normal 4.716310e-01 1.751302e-03 -8.817942e-01
+    outer loop
+      vertex   8.975520e+00 -4.200000e+00 7.202803e-01
+      vertex   8.709409e+00 0.000000e+00 5.862911e-01
+      vertex   9.237561e+00 0.000000e+00 8.687751e-01
+    endloop
+  endfacet
+  facet normal 5.141020e-01 -1.749391e-03 -8.577273e-01
+    outer loop
+      vertex   8.975520e+00 -4.200000e+00 7.202803e-01
+      vertex   9.237561e+00 0.000000e+00 8.687751e-01
+      vertex   9.488978e+00 -4.200000e+00 1.028035e+00
+    endloop
+  endfacet
+  facet normal 5.558353e-01 1.751279e-03 -8.312906e-01
+    outer loop
+      vertex   9.488978e+00 -4.200000e+00 1.028035e+00
+      vertex   9.237561e+00 0.000000e+00 8.687751e-01
+      vertex   9.735463e+00 0.000000e+00 1.201693e+00
+    endloop
+  endfacet
+  facet normal 5.956984e-01 -1.749367e-03 -8.032063e-01
+    outer loop
+      vertex   9.488978e+00 -4.200000e+00 1.028035e+00
+      vertex   9.735463e+00 0.000000e+00 1.201693e+00
+      vertex   9.969799e+00 -4.200000e+00 1.384636e+00
+    endloop
+  endfacet
+  facet normal 6.346807e-01 1.751253e-03 -7.727725e-01
+    outer loop
+      vertex   9.969799e+00 -4.200000e+00 1.384636e+00
+      vertex   9.735463e+00 0.000000e+00 1.201693e+00
+      vertex   1.019832e+01 0.000000e+00 1.581836e+00
+    endloop
+  endfacet
+  facet normal 6.715579e-01 -1.749338e-03 -7.409500e-01
+    outer loop
+      vertex   9.969799e+00 -4.200000e+00 1.384636e+00
+      vertex   1.019832e+01 0.000000e+00 1.581836e+00
+      vertex   1.041335e+01 -4.200000e+00 1.786649e+00
+    endloop
+  endfacet
+  facet normal 7.074072e-01 1.751222e-03 -7.068041e-01
+    outer loop
+      vertex   1.041335e+01 -4.200000e+00 1.786649e+00
+      vertex   1.019832e+01 0.000000e+00 1.581836e+00
+      vertex   1.062166e+01 0.000000e+00 2.005539e+00
+    endloop
+  endfacet
+  facet normal 7.409500e-01 -1.749305e-03 -6.715579e-01
+    outer loop
+      vertex   1.041335e+01 -4.200000e+00 1.786649e+00
+      vertex   1.062166e+01 0.000000e+00 2.005539e+00
+      vertex   1.081536e+01 -4.200000e+00 2.230201e+00
+    endloop
+  endfacet
+  facet normal 7.733135e-01 1.751187e-03 -6.340214e-01
+    outer loop
+      vertex   1.081536e+01 -4.200000e+00 2.230201e+00
+      vertex   1.062166e+01 0.000000e+00 2.005539e+00
+      vertex   1.100141e+01 0.000000e+00 2.468716e+00
+    endloop
+  endfacet
+  facet normal 8.032063e-01 -1.749268e-03 -5.956984e-01
+    outer loop
+      vertex   1.081536e+01 -4.200000e+00 2.230201e+00
+      vertex   1.100141e+01 0.000000e+00 2.468716e+00
+      vertex   1.117196e+01 -4.200000e+00 2.711022e+00
+    endloop
+  endfacet
+  facet normal 8.317644e-01 1.751147e-03 -5.551261e-01
+    outer loop
+      vertex   1.117196e+01 -4.200000e+00 2.711022e+00
+      vertex   1.100141e+01 0.000000e+00 2.468716e+00
+      vertex   1.133390e+01 0.000000e+00 2.966902e+00
+    endloop
+  endfacet
+  facet normal 8.577273e-01 -1.749226e-03 -5.141020e-01
+    outer loop
+      vertex   1.117196e+01 -4.200000e+00 2.711022e+00
+      vertex   1.133390e+01 0.000000e+00 2.966902e+00
+      vertex   1.147972e+01 -4.200000e+00 3.224480e+00
+    endloop
+  endfacet
+  facet normal 8.821962e-01 1.751104e-03 -4.708788e-01
+    outer loop
+      vertex   1.147972e+01 -4.200000e+00 3.224480e+00
+      vertex   1.133390e+01 0.000000e+00 2.966902e+00
+      vertex   1.161593e+01 0.000000e+00 3.495295e+00
+    endloop
+  endfacet
+  facet normal 9.039879e-01 -1.749181e-03 -4.275544e-01
+    outer loop
+      vertex   1.147972e+01 -4.200000e+00 3.224480e+00
+      vertex   1.161593e+01 0.000000e+00 3.495295e+00
+      vertex   1.173567e+01 -4.200000e+00 3.765631e+00
+    endloop
+  endfacet
+  facet normal 9.241227e-01 1.751057e-03 -3.820918e-01
+    outer loop
+      vertex   1.173567e+01 -4.200000e+00 3.765631e+00
+      vertex   1.161593e+01 0.000000e+00 3.495295e+00
+      vertex   1.184479e+01 0.000000e+00 4.048799e+00
+    endloop
+  endfacet
+  facet normal 9.415426e-01 -1.749131e-03 -3.368893e-01
+    outer loop
+      vertex   1.173567e+01 -4.200000e+00 3.765631e+00
+      vertex   1.184479e+01 0.000000e+00 4.048799e+00
+      vertex   1.193734e+01 -4.200000e+00 4.329263e+00
+    endloop
+  endfacet
+  facet normal 9.571398e-01 1.751005e-03 -2.896210e-01
+    outer loop
+      vertex   1.193734e+01 -4.200000e+00 4.329263e+00
+      vertex   1.184479e+01 0.000000e+00 4.048799e+00
+      vertex   1.201826e+01 0.000000e+00 4.622079e+00
+    endloop
+  endfacet
+  facet normal 9.700298e-01 -1.749078e-03 -2.429798e-01
+    outer loop
+      vertex   1.193734e+01 -4.200000e+00 4.329263e+00
+      vertex   1.201826e+01 0.000000e+00 4.622079e+00
+      vertex   1.208279e+01 -4.200000e+00 4.909949e+00
+    endloop
+  endfacet
+  facet normal 9.809291e-01 1.750949e-03 -1.943581e-01
+    outer loop
+      vertex   1.208279e+01 -4.200000e+00 4.909949e+00
+      vertex   1.201826e+01 0.000000e+00 4.622079e+00
+      vertex   1.213467e+01 0.000000e+00 5.209608e+00
+    endloop
+  endfacet
+  facet normal 9.891750e-01 -1.749020e-03 -1.467303e-01
+    outer loop
+      vertex   1.208279e+01 -4.200000e+00 4.909949e+00
+      vertex   1.213467e+01 0.000000e+00 5.209608e+00
+      vertex   1.217063e+01 -4.200000e+00 5.502095e+00
+    endloop
+  endfacet
+  facet normal 9.952613e-01 1.750889e-03 -9.722125e-02
+    outer loop
+      vertex   1.217063e+01 -4.200000e+00 5.502095e+00
+      vertex   1.213467e+01 0.000000e+00 5.209608e+00
+      vertex   1.219290e+01 0.000000e+00 5.805721e+00
+    endloop
+  endfacet
+  facet normal 9.987939e-01 -1.748958e-03 -4.906760e-02
+    outer loop
+      vertex   1.217063e+01 -4.200000e+00 5.502095e+00
+      vertex   1.219290e+01 0.000000e+00 5.805721e+00
+      vertex   1.220000e+01 -4.200000e+00 6.100000e+00
+    endloop
+  endfacet
+  facet normal 9.999981e-01 1.750825e-03 8.528656e-04
+    outer loop
+      vertex   1.220000e+01 -4.200000e+00 6.100000e+00
+      vertex   1.219290e+01 0.000000e+00 5.805721e+00
+      vertex   1.219239e+01 0.000000e+00 6.404671e+00
+    endloop
+  endfacet
+  facet normal 9.988896e-01 -1.604949e-03 4.708568e-02
+    outer loop
+      vertex   1.220000e+01 -4.200000e+00 6.100000e+00
+      vertex   1.219239e+01 0.000000e+00 6.404671e+00
+      vertex   1.217295e+01 -4.200000e+00 6.673809e+00
+    endloop
+  endfacet
+  facet normal 9.950940e-01 1.734098e-03 9.891876e-02
+    outer loop
+      vertex   1.217295e+01 -4.200000e+00 6.673809e+00
+      vertex   1.219239e+01 0.000000e+00 6.404671e+00
+      vertex   1.213314e+01 0.000000e+00 7.000684e+00
+    endloop
+  endfacet
+  facet normal 9.900312e-01 -1.576475e-03 1.408395e-01
+    outer loop
+      vertex   1.217295e+01 -4.200000e+00 6.673809e+00
+      vertex   1.213314e+01 0.000000e+00 7.000684e+00
+      vertex   1.209205e+01 -4.200000e+00 7.242529e+00
+    endloop
+  endfacet
+  facet normal 9.805962e-01 1.693879e-03 1.960310e-01
+    outer loop
+      vertex   1.209205e+01 -4.200000e+00 7.242529e+00
+      vertex   1.213314e+01 0.000000e+00 7.000684e+00
+      vertex   1.201573e+01 0.000000e+00 7.588013e+00
+    endloop
+  endfacet
+  facet normal 9.723930e-01 -1.524511e-03 2.333443e-01
+    outer loop
+      vertex   1.209205e+01 -4.200000e+00 7.242529e+00
+      vertex   1.201573e+01 0.000000e+00 7.588013e+00
+      vertex   1.195800e+01 -4.200000e+00 7.801117e+00
+    endloop
+  endfacet
+  facet normal 9.566446e-01 1.630170e-03 2.912533e-01
+    outer loop
+      vertex   1.195800e+01 -4.200000e+00 7.801117e+00
+      vertex   1.201573e+01 0.000000e+00 7.588013e+00
+      vertex   1.184128e+01 0.000000e+00 8.160997e+00
+    endloop
+  endfacet
+  facet normal 9.461314e-01 -1.449057e-03 3.237798e-01
+    outer loop
+      vertex   1.195800e+01 -4.200000e+00 7.801117e+00
+      vertex   1.184128e+01 0.000000e+00 8.160997e+00
+      vertex   1.177201e+01 -4.200000e+00 8.344619e+00
+    endloop
+  endfacet
+  facet normal 9.234699e-01 1.542971e-03 3.836677e-01
+    outer loop
+      vertex   1.177201e+01 -4.200000e+00 8.344619e+00
+      vertex   1.184128e+01 0.000000e+00 8.160997e+00
+      vertex   1.161148e+01 0.000000e+00 8.714110e+00
+    endloop
+  endfacet
+  facet normal 9.114792e-01 -1.350114e-03 4.113439e-01
+    outer loop
+      vertex   1.177201e+01 -4.200000e+00 8.344619e+00
+      vertex   1.161148e+01 0.000000e+00 8.714110e+00
+      vertex   1.153571e+01 -4.200000e+00 8.868215e+00
+    endloop
+  endfacet
+  facet normal 8.813921e-01 1.432284e-03 4.723832e-01
+    outer loop
+      vertex   1.153571e+01 -4.200000e+00 8.868215e+00
+      vertex   1.161148e+01 0.000000e+00 8.714110e+00
+      vertex   1.132855e+01 0.000000e+00 9.242021e+00
+    endloop
+  endfacet
+  facet normal 8.687438e-01 -1.227683e-03 4.952602e-01
+    outer loop
+      vertex   1.153571e+01 -4.200000e+00 8.868215e+00
+      vertex   1.132855e+01 0.000000e+00 9.242021e+00
+      vertex   1.125121e+01 -4.200000e+00 9.367262e+00
+    endloop
+  endfacet
+  facet normal 8.308168e-01 1.298110e-03 5.565444e-01
+    outer loop
+      vertex   1.125121e+01 -4.200000e+00 9.367262e+00
+      vertex   1.132855e+01 0.000000e+00 9.242021e+00
+      vertex   1.099520e+01 0.000000e+00 9.739639e+00
+    endloop
+  endfacet
+  facet normal 8.183042e-01 -1.081767e-03 5.747844e-01
+    outer loop
+      vertex   1.125121e+01 -4.200000e+00 9.367262e+00
+      vertex   1.099520e+01 0.000000e+00 9.739639e+00
+      vertex   1.092103e+01 -4.200000e+00 9.837334e+00
+    endloop
+  endfacet
+  facet normal 7.722316e-01 1.140453e-03 6.353401e-01
+    outer loop
+      vertex   1.092103e+01 -4.200000e+00 9.837334e+00
+      vertex   1.099520e+01 0.000000e+00 9.739639e+00
+      vertex   1.061467e+01 0.000000e+00 1.020217e+01
+    endloop
+  endfacet
+  facet normal 7.606076e-01 -9.123678e-04 6.492112e-01
+    outer loop
+      vertex   1.092103e+01 -4.200000e+00 9.837334e+00
+      vertex   1.061467e+01 0.000000e+00 1.020217e+01
+      vertex   1.054809e+01 -4.200000e+00 1.027426e+01
+    endloop
+  endfacet
+  facet normal 7.062013e-01 9.593128e-04 7.080105e-01
+    outer loop
+      vertex   1.054809e+01 -4.200000e+00 1.027426e+01
+      vertex   1.061467e+01 0.000000e+00 1.020217e+01
+      vertex   1.019060e+01 0.000000e+00 1.062515e+01
+    endloop
+  endfacet
+  facet normal 6.961657e-01 -7.194881e-04 7.178808e-01
+    outer loop
+      vertex   1.054809e+01 -4.200000e+00 1.027426e+01
+      vertex   1.019060e+01 0.000000e+00 1.062515e+01
+      vertex   1.013571e+01 -4.200000e+00 1.067417e+01
+    endloop
+  endfacet
+  facet normal 6.333624e-01 7.546942e-04 7.738549e-01
+    outer loop
+      vertex   1.013571e+01 -4.200000e+00 1.067417e+01
+      vertex   1.019060e+01 0.000000e+00 1.062515e+01
+      vertex   9.727103e+00 0.000000e+00 1.100450e+01
+    endloop
+  endfacet
+  facet normal 6.255500e-01 -5.031312e-04 7.801839e-01
+    outer loop
+      vertex   1.013571e+01 -4.200000e+00 1.067417e+01
+      vertex   9.727103e+00 0.000000e+00 1.100450e+01
+      vertex   9.687536e+00 -4.200000e+00 1.103352e+01
+    endloop
+  endfacet
+  facet normal 5.544173e-01 5.266000e-04 8.322387e-01
+    outer loop
+      vertex   9.687536e+00 -4.200000e+00 1.103352e+01
+      vertex   9.727103e+00 0.000000e+00 1.100450e+01
+      vertex   9.228633e+00 0.000000e+00 1.133657e+01
+    endloop
+  endfacet
+  facet normal 5.493867e-01 -2.633006e-04 8.355682e-01
+    outer loop
+      vertex   9.687536e+00 -4.200000e+00 1.103352e+01
+      vertex   9.228633e+00 0.000000e+00 1.133657e+01
+      vertex   9.207547e+00 -4.200000e+00 1.134911e+01
+    endloop
+  endfacet
+  facet normal 4.701270e-01 2.750339e-04 8.825988e-01
+    outer loop
+      vertex   9.207547e+00 -4.200000e+00 1.134911e+01
+      vertex   9.228633e+00 0.000000e+00 1.133657e+01
+      vertex   8.700000e+00 0.000000e+00 1.161815e+01
+    endloop
+  endfacet
+  facet normal 4.683512e-01 -5.168532e-18 8.835424e-01
+    outer loop
+      vertex   9.207547e+00 -4.200000e+00 1.134911e+01
+      vertex   8.700000e+00 0.000000e+00 1.161815e+01
+      vertex   8.700000e+00 -4.200000e+00 1.161815e+01
+    endloop
+  endfacet
+  facet normal 1.000000e+00 0.000000e+00 -6.302532e-15
+    outer loop
+      vertex   8.700000e+00 0.000000e+00 1.161815e+01
+      vertex   8.700000e+00 0.000000e+00 1.190000e+01
+      vertex   8.700000e+00 -4.200000e+00 1.161815e+01
+    endloop
+  endfacet
+  facet normal 1.000000e+00 0.000000e+00 -6.302532e-15
+    outer loop
+      vertex   8.700000e+00 -4.200000e+00 1.161815e+01
+      vertex   8.700000e+00 0.000000e+00 1.190000e+01
+      vertex   8.700000e+00 -4.200000e+00 1.190000e+01
+    endloop
+  endfacet
+  facet normal 9.972038e-01 -0.000000e+00 7.473009e-02
+    outer loop
+      vertex   8.700000e+00 -4.200000e+00 1.190000e+01
+      vertex   8.700000e+00 0.000000e+00 1.190000e+01
+      vertex   8.670960e+00 -4.200000e+00 1.228751e+01
+    endloop
+  endfacet
+  facet normal 9.972038e-01 -0.000000e+00 7.473009e-02
+    outer loop
+      vertex   8.670960e+00 -4.200000e+00 1.228751e+01
+      vertex   8.700000e+00 0.000000e+00 1.190000e+01
+      vertex   8.670960e+00 0.000000e+00 1.228751e+01
+    endloop
+  endfacet
+  facet normal 9.749279e-01 -0.000000e+00 2.225209e-01
+    outer loop
+      vertex   8.670960e+00 -4.200000e+00 1.228751e+01
+      vertex   8.670960e+00 0.000000e+00 1.228751e+01
+      vertex   8.584489e+00 -4.200000e+00 1.266636e+01
+    endloop
+  endfacet
+  facet normal 9.749279e-01 -0.000000e+00 2.225209e-01
+    outer loop
+      vertex   8.584489e+00 -4.200000e+00 1.266636e+01
+      vertex   8.670960e+00 0.000000e+00 1.228751e+01
+      vertex   8.584489e+00 0.000000e+00 1.266636e+01
+    endloop
+  endfacet
+  facet normal 9.308737e-01 -0.000000e+00 3.653410e-01
+    outer loop
+      vertex   8.584489e+00 -4.200000e+00 1.266636e+01
+      vertex   8.584489e+00 0.000000e+00 1.266636e+01
+      vertex   8.442519e+00 -4.200000e+00 1.302810e+01
+    endloop
+  endfacet
+  facet normal 9.308737e-01 -0.000000e+00 3.653410e-01
+    outer loop
+      vertex   8.442519e+00 -4.200000e+00 1.302810e+01
+      vertex   8.584489e+00 0.000000e+00 1.266636e+01
+      vertex   8.442519e+00 0.000000e+00 1.302810e+01
+    endloop
+  endfacet
+  facet normal 8.660254e-01 -0.000000e+00 5.000000e-01
+    outer loop
+      vertex   8.442519e+00 -4.200000e+00 1.302810e+01
+      vertex   8.442519e+00 0.000000e+00 1.302810e+01
+      vertex   8.248221e+00 -4.200000e+00 1.336463e+01
+    endloop
+  endfacet
+  facet normal 8.660254e-01 -0.000000e+00 5.000000e-01
+    outer loop
+      vertex   8.248221e+00 -4.200000e+00 1.336463e+01
+      vertex   8.442519e+00 0.000000e+00 1.302810e+01
+      vertex   8.248221e+00 0.000000e+00 1.336463e+01
+    endloop
+  endfacet
+  facet normal 7.818315e-01 -0.000000e+00 6.234898e-01
+    outer loop
+      vertex   8.248221e+00 -4.200000e+00 1.336463e+01
+      vertex   8.248221e+00 0.000000e+00 1.336463e+01
+      vertex   8.005935e+00 -4.200000e+00 1.366845e+01
+    endloop
+  endfacet
+  facet normal 7.818315e-01 -0.000000e+00 6.234898e-01
+    outer loop
+      vertex   8.005935e+00 -4.200000e+00 1.366845e+01
+      vertex   8.248221e+00 0.000000e+00 1.336463e+01
+      vertex   8.005935e+00 0.000000e+00 1.366845e+01
+    endloop
+  endfacet
+  facet normal 6.801727e-01 -0.000000e+00 7.330519e-01
+    outer loop
+      vertex   8.005935e+00 -4.200000e+00 1.366845e+01
+      vertex   8.005935e+00 0.000000e+00 1.366845e+01
+      vertex   7.721073e+00 -4.200000e+00 1.393276e+01
+    endloop
+  endfacet
+  facet normal 6.801727e-01 -0.000000e+00 7.330519e-01
+    outer loop
+      vertex   7.721073e+00 -4.200000e+00 1.393276e+01
+      vertex   8.005935e+00 0.000000e+00 1.366845e+01
+      vertex   7.721073e+00 0.000000e+00 1.393276e+01
+    endloop
+  endfacet
+  facet normal 5.633201e-01 -0.000000e+00 8.262388e-01
+    outer loop
+      vertex   7.721073e+00 -4.200000e+00 1.393276e+01
+      vertex   7.721073e+00 0.000000e+00 1.393276e+01
+      vertex   7.400000e+00 -4.200000e+00 1.415167e+01
+    endloop
+  endfacet
+  facet normal 5.633201e-01 -0.000000e+00 8.262388e-01
+    outer loop
+      vertex   7.400000e+00 -4.200000e+00 1.415167e+01
+      vertex   7.721073e+00 0.000000e+00 1.393276e+01
+      vertex   7.400000e+00 0.000000e+00 1.415167e+01
+    endloop
+  endfacet
+  facet normal 4.338837e-01 -0.000000e+00 9.009689e-01
+    outer loop
+      vertex   7.400000e+00 -4.200000e+00 1.415167e+01
+      vertex   7.400000e+00 0.000000e+00 1.415167e+01
+      vertex   7.049887e+00 -4.200000e+00 1.432027e+01
+    endloop
+  endfacet
+  facet normal 4.338837e-01 -0.000000e+00 9.009689e-01
+    outer loop
+      vertex   7.049887e+00 -4.200000e+00 1.432027e+01
+      vertex   7.400000e+00 0.000000e+00 1.415167e+01
+      vertex   7.049887e+00 0.000000e+00 1.432027e+01
+    endloop
+  endfacet
+  facet normal 2.947552e-01 -0.000000e+00 9.555728e-01
+    outer loop
+      vertex   7.049887e+00 -4.200000e+00 1.432027e+01
+      vertex   7.049887e+00 0.000000e+00 1.432027e+01
+      vertex   6.678554e+00 -4.200000e+00 1.443481e+01
+    endloop
+  endfacet
+  facet normal 2.947552e-01 -0.000000e+00 9.555728e-01
+    outer loop
+      vertex   6.678554e+00 -4.200000e+00 1.443481e+01
+      vertex   7.049887e+00 0.000000e+00 1.432027e+01
+      vertex   6.678554e+00 0.000000e+00 1.443481e+01
+    endloop
+  endfacet
+  facet normal 1.490423e-01 -0.000000e+00 9.888308e-01
+    outer loop
+      vertex   6.678554e+00 -4.200000e+00 1.443481e+01
+      vertex   6.678554e+00 0.000000e+00 1.443481e+01
+      vertex   6.294298e+00 -4.200000e+00 1.449273e+01
+    endloop
+  endfacet
+  facet normal 1.490423e-01 -0.000000e+00 9.888308e-01
+    outer loop
+      vertex   6.294298e+00 -4.200000e+00 1.449273e+01
+      vertex   6.678554e+00 0.000000e+00 1.443481e+01
+      vertex   6.294298e+00 0.000000e+00 1.449273e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -0.000000e+00 1.000000e+00
+    outer loop
+      vertex   6.294298e+00 -4.200000e+00 1.449273e+01
+      vertex   6.294298e+00 0.000000e+00 1.449273e+01
+      vertex   5.905702e+00 -4.200000e+00 1.449273e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 0.000000e+00 1.000000e+00
+    outer loop
+      vertex   5.905702e+00 -4.200000e+00 1.449273e+01
+      vertex   6.294298e+00 0.000000e+00 1.449273e+01
+      vertex   5.905702e+00 0.000000e+00 1.449273e+01
+    endloop
+  endfacet
+  facet normal -1.490423e-01 0.000000e+00 9.888308e-01
+    outer loop
+      vertex   5.905702e+00 -4.200000e+00 1.449273e+01
+      vertex   5.905702e+00 0.000000e+00 1.449273e+01
+      vertex   5.521446e+00 -4.200000e+00 1.443481e+01
+    endloop
+  endfacet
+  facet normal -1.490423e-01 0.000000e+00 9.888308e-01
+    outer loop
+      vertex   5.521446e+00 -4.200000e+00 1.443481e+01
+      vertex   5.905702e+00 0.000000e+00 1.449273e+01
+      vertex   5.521446e+00 0.000000e+00 1.443481e+01
+    endloop
+  endfacet
+  facet normal -2.947552e-01 0.000000e+00 9.555728e-01
+    outer loop
+      vertex   5.521446e+00 -4.200000e+00 1.443481e+01
+      vertex   5.521446e+00 0.000000e+00 1.443481e+01
+      vertex   5.150113e+00 -4.200000e+00 1.432027e+01
+    endloop
+  endfacet
+  facet normal -2.947552e-01 0.000000e+00 9.555728e-01
+    outer loop
+      vertex   5.150113e+00 -4.200000e+00 1.432027e+01
+      vertex   5.521446e+00 0.000000e+00 1.443481e+01
+      vertex   5.150113e+00 0.000000e+00 1.432027e+01
+    endloop
+  endfacet
+  facet normal -4.338837e-01 0.000000e+00 9.009689e-01
+    outer loop
+      vertex   5.150113e+00 -4.200000e+00 1.432027e+01
+      vertex   5.150113e+00 0.000000e+00 1.432027e+01
+      vertex   4.800000e+00 -4.200000e+00 1.415167e+01
+    endloop
+  endfacet
+  facet normal -4.338837e-01 0.000000e+00 9.009689e-01
+    outer loop
+      vertex   4.800000e+00 -4.200000e+00 1.415167e+01
+      vertex   5.150113e+00 0.000000e+00 1.432027e+01
+      vertex   4.800000e+00 0.000000e+00 1.415167e+01
+    endloop
+  endfacet
+  facet normal -5.633201e-01 0.000000e+00 8.262388e-01
+    outer loop
+      vertex   4.800000e+00 -4.200000e+00 1.415167e+01
+      vertex   4.800000e+00 0.000000e+00 1.415167e+01
+      vertex   4.478927e+00 -4.200000e+00 1.393276e+01
+    endloop
+  endfacet
+  facet normal -5.633201e-01 0.000000e+00 8.262388e-01
+    outer loop
+      vertex   4.478927e+00 -4.200000e+00 1.393276e+01
+      vertex   4.800000e+00 0.000000e+00 1.415167e+01
+      vertex   4.478927e+00 0.000000e+00 1.393276e+01
+    endloop
+  endfacet
+  facet normal -6.801727e-01 0.000000e+00 7.330519e-01
+    outer loop
+      vertex   4.478927e+00 -4.200000e+00 1.393276e+01
+      vertex   4.478927e+00 0.000000e+00 1.393276e+01
+      vertex   4.194065e+00 -4.200000e+00 1.366845e+01
+    endloop
+  endfacet
+  facet normal -6.801727e-01 0.000000e+00 7.330519e-01
+    outer loop
+      vertex   4.194065e+00 -4.200000e+00 1.366845e+01
+      vertex   4.478927e+00 0.000000e+00 1.393276e+01
+      vertex   4.194065e+00 0.000000e+00 1.366845e+01
+    endloop
+  endfacet
+  facet normal -7.818315e-01 0.000000e+00 6.234898e-01
+    outer loop
+      vertex   4.194065e+00 -4.200000e+00 1.366845e+01
+      vertex   4.194065e+00 0.000000e+00 1.366845e+01
+      vertex   3.951779e+00 -4.200000e+00 1.336463e+01
+    endloop
+  endfacet
+  facet normal -7.818315e-01 0.000000e+00 6.234898e-01
+    outer loop
+      vertex   3.951779e+00 -4.200000e+00 1.336463e+01
+      vertex   4.194065e+00 0.000000e+00 1.366845e+01
+      vertex   3.951779e+00 0.000000e+00 1.336463e+01
+    endloop
+  endfacet
+  facet normal -8.660254e-01 0.000000e+00 5.000000e-01
+    outer loop
+      vertex   3.951779e+00 -4.200000e+00 1.336463e+01
+      vertex   3.951779e+00 0.000000e+00 1.336463e+01
+      vertex   3.757481e+00 -4.200000e+00 1.302810e+01
+    endloop
+  endfacet
+  facet normal -8.660254e-01 0.000000e+00 5.000000e-01
+    outer loop
+      vertex   3.757481e+00 -4.200000e+00 1.302810e+01
+      vertex   3.951779e+00 0.000000e+00 1.336463e+01
+      vertex   3.757481e+00 0.000000e+00 1.302810e+01
+    endloop
+  endfacet
+  facet normal -9.308737e-01 0.000000e+00 3.653410e-01
+    outer loop
+      vertex   3.757481e+00 -4.200000e+00 1.302810e+01
+      vertex   3.757481e+00 0.000000e+00 1.302810e+01
+      vertex   3.615511e+00 -4.200000e+00 1.266636e+01
+    endloop
+  endfacet
+  facet normal -9.308737e-01 0.000000e+00 3.653410e-01
+    outer loop
+      vertex   3.615511e+00 -4.200000e+00 1.266636e+01
+      vertex   3.757481e+00 0.000000e+00 1.302810e+01
+      vertex   3.615511e+00 0.000000e+00 1.266636e+01
+    endloop
+  endfacet
+  facet normal -9.749279e-01 0.000000e+00 2.225209e-01
+    outer loop
+      vertex   3.615511e+00 -4.200000e+00 1.266636e+01
+      vertex   3.615511e+00 0.000000e+00 1.266636e+01
+      vertex   3.529040e+00 -4.200000e+00 1.228751e+01
+    endloop
+  endfacet
+  facet normal -9.749279e-01 0.000000e+00 2.225209e-01
+    outer loop
+      vertex   3.529040e+00 -4.200000e+00 1.228751e+01
+      vertex   3.615511e+00 0.000000e+00 1.266636e+01
+      vertex   3.529040e+00 0.000000e+00 1.228751e+01
+    endloop
+  endfacet
+  facet normal -9.972038e-01 0.000000e+00 7.473009e-02
+    outer loop
+      vertex   3.529040e+00 -4.200000e+00 1.228751e+01
+      vertex   3.529040e+00 0.000000e+00 1.228751e+01
+      vertex   3.500000e+00 -4.200000e+00 1.190000e+01
+    endloop
+  endfacet
+  facet normal -9.972038e-01 0.000000e+00 7.473009e-02
+    outer loop
+      vertex   3.500000e+00 -4.200000e+00 1.190000e+01
+      vertex   3.529040e+00 0.000000e+00 1.228751e+01
+      vertex   3.500000e+00 0.000000e+00 1.190000e+01
+    endloop
+  endfacet
+  facet normal -1.000000e+00 -0.000000e+00 -1.890760e-14
+    outer loop
+      vertex   3.500000e+00 0.000000e+00 1.190000e+01
+      vertex   3.500000e+00 0.000000e+00 1.161815e+01
+      vertex   3.500000e+00 -4.200000e+00 1.190000e+01
+    endloop
+  endfacet
+  facet normal -1.000000e+00 0.000000e+00 -1.890760e-14
+    outer loop
+      vertex   3.500000e+00 -4.200000e+00 1.190000e+01
+      vertex   3.500000e+00 0.000000e+00 1.161815e+01
+      vertex   3.500000e+00 -4.200000e+00 1.161815e+01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.600000e+00 -1.070000e+01 -3.664214e+00
+      vertex   6.600000e+00 -1.070000e+01 -4.500000e+00
+      vertex   6.862259e+00 -1.070000e+01 -3.541883e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   6.862259e+00 -1.070000e+01 -3.541883e+00
+      vertex   6.600000e+00 -1.070000e+01 -4.500000e+00
+      vertex   1.170000e+01 -1.070000e+01 -4.500000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.862259e+00 -1.070000e+01 -3.541883e+00
+      vertex   1.170000e+01 -1.070000e+01 -4.500000e+00
+      vertex   7.096146e+00 -1.070000e+01 -3.371469e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.096146e+00 -1.070000e+01 -3.371469e+00
+      vertex   1.170000e+01 -1.070000e+01 -4.500000e+00
+      vertex   1.220000e+01 -1.070000e+01 -4.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.096146e+00 -1.070000e+01 -3.371469e+00
+      vertex   1.220000e+01 -1.070000e+01 -4.000000e+00
+      vertex   7.292957e+00 -1.070000e+01 -3.159314e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.292957e+00 -1.070000e+01 -3.159314e+00
+      vertex   1.220000e+01 -1.070000e+01 -4.000000e+00
+      vertex   7.445367e+00 -1.070000e+01 -2.913315e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.445367e+00 -1.070000e+01 -2.913315e+00
+      vertex   1.220000e+01 -1.070000e+01 -4.000000e+00
+      vertex   7.547703e+00 -1.070000e+01 -2.642628e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.547703e+00 -1.070000e+01 -2.642628e+00
+      vertex   1.220000e+01 -1.070000e+01 -4.000000e+00
+      vertex   7.596155e+00 -1.070000e+01 -2.357327e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.596155e+00 -1.070000e+01 -2.357327e+00
+      vertex   1.220000e+01 -1.070000e+01 -4.000000e+00
+      vertex   7.588921e+00 -1.070000e+01 -2.068031e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.588921e+00 -1.070000e+01 -2.068031e+00
+      vertex   1.220000e+01 -1.070000e+01 -4.000000e+00
+      vertex   1.120000e+01 -1.070000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.588921e+00 -1.070000e+01 -2.068031e+00
+      vertex   1.120000e+01 -1.070000e+01 0.000000e+00
+      vertex   7.526270e+00 -1.070000e+01 -1.785508e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.526270e+00 -1.070000e+01 -1.785508e+00
+      vertex   1.120000e+01 -1.070000e+01 0.000000e+00
+      vertex   7.410534e+00 -1.070000e+01 -1.520273e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.410534e+00 -1.070000e+01 -1.520273e+00
+      vertex   1.120000e+01 -1.070000e+01 0.000000e+00
+      vertex   7.246020e+00 -1.070000e+01 -1.282199e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.246020e+00 -1.070000e+01 -1.282199e+00
+      vertex   1.120000e+01 -1.070000e+01 0.000000e+00
+      vertex   7.038851e+00 -1.070000e+01 -1.080146e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.038851e+00 -1.070000e+01 -1.080146e+00
+      vertex   1.120000e+01 -1.070000e+01 0.000000e+00
+      vertex   6.796739e+00 -1.070000e+01 -9.216343e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.796739e+00 -1.070000e+01 -9.216343e-01
+      vertex   1.120000e+01 -1.070000e+01 0.000000e+00
+      vertex   6.528694e+00 -1.070000e+01 -8.125642e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.528694e+00 -1.070000e+01 -8.125642e-01
+      vertex   1.120000e+01 -1.070000e+01 0.000000e+00
+      vertex   6.244693e+00 -1.070000e+01 -7.569950e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.244693e+00 -1.070000e+01 -7.569950e-01
+      vertex   1.120000e+01 -1.070000e+01 0.000000e+00
+      vertex   1.000000e+00 -1.070000e+01 0.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.244693e+00 -1.070000e+01 -7.569950e-01
+      vertex   1.000000e+00 -1.070000e+01 0.000000e+00
+      vertex   5.955307e+00 -1.070000e+01 -7.569950e-01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.955307e+00 -1.070000e+01 -7.569950e-01
+      vertex   1.000000e+00 -1.070000e+01 0.000000e+00
+      vertex   5.671306e+00 -1.070000e+01 -8.125642e-01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.671306e+00 -1.070000e+01 -8.125642e-01
+      vertex   1.000000e+00 -1.070000e+01 0.000000e+00
+      vertex   5.403261e+00 -1.070000e+01 -9.216343e-01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.403261e+00 -1.070000e+01 -9.216343e-01
+      vertex   1.000000e+00 -1.070000e+01 0.000000e+00
+      vertex   5.161149e+00 -1.070000e+01 -1.080146e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.161149e+00 -1.070000e+01 -1.080146e+00
+      vertex   1.000000e+00 -1.070000e+01 0.000000e+00
+      vertex   4.953980e+00 -1.070000e+01 -1.282199e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.953980e+00 -1.070000e+01 -1.282199e+00
+      vertex   1.000000e+00 -1.070000e+01 0.000000e+00
+      vertex   4.789466e+00 -1.070000e+01 -1.520273e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.789466e+00 -1.070000e+01 -1.520273e+00
+      vertex   1.000000e+00 -1.070000e+01 0.000000e+00
+      vertex   4.673730e+00 -1.070000e+01 -1.785508e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.673730e+00 -1.070000e+01 -1.785508e+00
+      vertex   1.000000e+00 -1.070000e+01 0.000000e+00
+      vertex   4.611079e+00 -1.070000e+01 -2.068031e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.611079e+00 -1.070000e+01 -2.068031e+00
+      vertex   1.000000e+00 -1.070000e+01 0.000000e+00
+      vertex   0.000000e+00 -1.070000e+01 -4.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.611079e+00 -1.070000e+01 -2.068031e+00
+      vertex   0.000000e+00 -1.070000e+01 -4.000000e+00
+      vertex   4.603845e+00 -1.070000e+01 -2.357327e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   4.603845e+00 -1.070000e+01 -2.357327e+00
+      vertex   0.000000e+00 -1.070000e+01 -4.000000e+00
+      vertex   4.652297e+00 -1.070000e+01 -2.642628e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   4.652297e+00 -1.070000e+01 -2.642628e+00
+      vertex   0.000000e+00 -1.070000e+01 -4.000000e+00
+      vertex   4.754633e+00 -1.070000e+01 -2.913315e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   4.754633e+00 -1.070000e+01 -2.913315e+00
+      vertex   0.000000e+00 -1.070000e+01 -4.000000e+00
+      vertex   4.907043e+00 -1.070000e+01 -3.159314e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   4.907043e+00 -1.070000e+01 -3.159314e+00
+      vertex   0.000000e+00 -1.070000e+01 -4.000000e+00
+      vertex   5.103854e+00 -1.070000e+01 -3.371469e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.103854e+00 -1.070000e+01 -3.371469e+00
+      vertex   0.000000e+00 -1.070000e+01 -4.000000e+00
+      vertex   5.000000e-01 -1.070000e+01 -4.500000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   5.103854e+00 -1.070000e+01 -3.371469e+00
+      vertex   5.000000e-01 -1.070000e+01 -4.500000e+00
+      vertex   5.337741e+00 -1.070000e+01 -3.541883e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   5.337741e+00 -1.070000e+01 -3.541883e+00
+      vertex   5.000000e-01 -1.070000e+01 -4.500000e+00
+      vertex   5.600000e+00 -1.070000e+01 -4.500000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.337741e+00 -1.070000e+01 -3.541883e+00
+      vertex   5.600000e+00 -1.070000e+01 -4.500000e+00
+      vertex   5.600000e+00 -1.070000e+01 -3.664214e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.182941e+01 -1.070000e+01 -4.482963e+00
+      vertex   1.195000e+01 -1.070000e+01 -4.433013e+00
+      vertex   1.170000e+01 -1.070000e+01 -4.500000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.170000e+01 -1.070000e+01 -4.500000e+00
+      vertex   1.195000e+01 -1.070000e+01 -4.433013e+00
+      vertex   1.205355e+01 -1.070000e+01 -4.353553e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.170000e+01 -1.070000e+01 -4.500000e+00
+      vertex   1.205355e+01 -1.070000e+01 -4.353553e+00
+      vertex   1.213301e+01 -1.070000e+01 -4.250000e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.213301e+01 -1.070000e+01 -4.250000e+00
+      vertex   1.218296e+01 -1.070000e+01 -4.129410e+00
+      vertex   1.170000e+01 -1.070000e+01 -4.500000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.170000e+01 -1.070000e+01 -4.500000e+00
+      vertex   1.218296e+01 -1.070000e+01 -4.129410e+00
+      vertex   1.220000e+01 -1.070000e+01 -4.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -1.070000e+01 1.000000e+00
+      vertex   1.217493e+01 -1.070000e+01 7.774791e-01
+      vertex   1.220000e+01 -1.070000e+01 -4.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -1.070000e+01 -4.000000e+00
+      vertex   1.217493e+01 -1.070000e+01 7.774791e-01
+      vertex   1.210097e+01 -1.070000e+01 5.661163e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -1.070000e+01 -4.000000e+00
+      vertex   1.210097e+01 -1.070000e+01 5.661163e-01
+      vertex   1.198183e+01 -1.070000e+01 3.765102e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   1.198183e+01 -1.070000e+01 3.765102e-01
+      vertex   1.182349e+01 -1.070000e+01 2.181685e-01
+      vertex   1.220000e+01 -1.070000e+01 -4.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -1.070000e+01 -4.000000e+00
+      vertex   1.182349e+01 -1.070000e+01 2.181685e-01
+      vertex   1.163388e+01 -1.070000e+01 9.903113e-02
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.220000e+01 -1.070000e+01 -4.000000e+00
+      vertex   1.163388e+01 -1.070000e+01 9.903113e-02
+      vertex   1.142252e+01 -1.070000e+01 2.507209e-02
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 -0.000000e+00
+    outer loop
+      vertex   1.142252e+01 -1.070000e+01 2.507209e-02
+      vertex   1.120000e+01 -1.070000e+01 0.000000e+00
+      vertex   1.220000e+01 -1.070000e+01 -4.000000e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.000000e+00 -1.070000e+01 0.000000e+00
+      vertex   7.774791e-01 -1.070000e+01 2.507209e-02
+      vertex   0.000000e+00 -1.070000e+01 -4.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -1.070000e+01 -4.000000e+00
+      vertex   7.774791e-01 -1.070000e+01 2.507209e-02
+      vertex   5.661163e-01 -1.070000e+01 9.903113e-02
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -1.070000e+01 -4.000000e+00
+      vertex   5.661163e-01 -1.070000e+01 9.903113e-02
+      vertex   3.765102e-01 -1.070000e+01 2.181685e-01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.765102e-01 -1.070000e+01 2.181685e-01
+      vertex   2.181685e-01 -1.070000e+01 3.765102e-01
+      vertex   0.000000e+00 -1.070000e+01 -4.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -1.070000e+01 -4.000000e+00
+      vertex   2.181685e-01 -1.070000e+01 3.765102e-01
+      vertex   9.903113e-02 -1.070000e+01 5.661163e-01
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -1.070000e+01 -4.000000e+00
+      vertex   9.903113e-02 -1.070000e+01 5.661163e-01
+      vertex   2.507209e-02 -1.070000e+01 7.774791e-01
+    endloop
+  endfacet
+  facet normal -0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   2.507209e-02 -1.070000e+01 7.774791e-01
+      vertex   0.000000e+00 -1.070000e+01 1.000000e+00
+      vertex   0.000000e+00 -1.070000e+01 -4.000000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -1.070000e+01 -4.000000e+00
+      vertex   1.703709e-02 -1.070000e+01 -4.129410e+00
+      vertex   5.000000e-01 -1.070000e+01 -4.500000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.000000e-01 -1.070000e+01 -4.500000e+00
+      vertex   1.703709e-02 -1.070000e+01 -4.129410e+00
+      vertex   6.698730e-02 -1.070000e+01 -4.250000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.000000e-01 -1.070000e+01 -4.500000e+00
+      vertex   6.698730e-02 -1.070000e+01 -4.250000e+00
+      vertex   1.464466e-01 -1.070000e+01 -4.353553e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   1.464466e-01 -1.070000e+01 -4.353553e+00
+      vertex   2.500000e-01 -1.070000e+01 -4.433013e+00
+      vertex   5.000000e-01 -1.070000e+01 -4.500000e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 -1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.000000e-01 -1.070000e+01 -4.500000e+00
+      vertex   2.500000e-01 -1.070000e+01 -4.433013e+00
+      vertex   3.705905e-01 -1.070000e+01 -4.482963e+00
+    endloop
+  endfacet
+  facet normal -1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -2.830000e+01 1.000000e+00
+      vertex   0.000000e+00 -1.070000e+01 2.200000e+01
+      vertex   0.000000e+00 -1.070000e+01 1.000000e+00
+    endloop
+  endfacet
+  facet normal -1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -1.070000e+01 1.000000e+00
+      vertex   0.000000e+00 -1.070000e+01 2.200000e+01
+      vertex   0.000000e+00 -4.200000e+00 6.100000e+00
+    endloop
+  endfacet
+  facet normal -1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -1.070000e+01 1.000000e+00
+      vertex   0.000000e+00 -4.200000e+00 6.100000e+00
+      vertex   0.000000e+00 -8.300000e+00 1.000000e+00
+    endloop
+  endfacet
+  facet normal -1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -8.300000e+00 1.000000e+00
+      vertex   0.000000e+00 -4.200000e+00 6.100000e+00
+      vertex   0.000000e+00 -4.200000e+00 1.000000e+00
+    endloop
+  endfacet
+  facet normal -1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -2.830000e+01 1.000000e+00
+      vertex   0.000000e+00 -2.830000e+01 2.200000e+01
+      vertex   0.000000e+00 -1.070000e+01 2.200000e+01
+    endloop
+  endfacet
+  facet normal -1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -1.070000e+01 2.700000e+01
+      vertex   0.000000e+00 -8.300000e+00 2.700000e+01
+      vertex   0.000000e+00 -1.070000e+01 2.200000e+01
+    endloop
+  endfacet
+  facet normal -1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -1.070000e+01 2.200000e+01
+      vertex   0.000000e+00 -8.300000e+00 2.700000e+01
+      vertex   0.000000e+00 -8.300000e+00 2.200000e+01
+    endloop
+  endfacet
+  facet normal -1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -1.070000e+01 2.200000e+01
+      vertex   0.000000e+00 -8.300000e+00 2.200000e+01
+      vertex   0.000000e+00 -4.200000e+00 6.100000e+00
+    endloop
+  endfacet
+  facet normal -1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -4.200000e+00 6.100000e+00
+      vertex   0.000000e+00 -8.300000e+00 2.200000e+01
+      vertex   0.000000e+00 -4.200000e+00 2.200000e+01
+    endloop
+  endfacet
+  facet normal -1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -8.300000e+00 -4.000000e+00
+      vertex   0.000000e+00 -1.070000e+01 -4.000000e+00
+      vertex   0.000000e+00 -8.300000e+00 1.000000e+00
+    endloop
+  endfacet
+  facet normal -1.000000e+00 -0.000000e+00 0.000000e+00
+    outer loop
+      vertex   0.000000e+00 -8.300000e+00 1.000000e+00
+      vertex   0.000000e+00 -1.070000e+01 -4.000000e+00
+      vertex   0.000000e+00 -1.070000e+01 1.000000e+00
+    endloop
+  endfacet
+  facet normal 9.970658e-01 0.000000e+00 7.654925e-02
+    outer loop
+      vertex   8.521287e+00 3.500000e+00 6.473991e+00
+      vertex   8.521287e+00 0.000000e+00 6.473991e+00
+      vertex   8.550000e+00 3.500000e+00 6.100000e+00
+    endloop
+  endfacet
+  facet normal 9.970658e-01 0.000000e+00 7.654925e-02
+    outer loop
+      vertex   8.550000e+00 3.500000e+00 6.100000e+00
+      vertex   8.521287e+00 0.000000e+00 6.473991e+00
+      vertex   8.550000e+00 0.000000e+00 6.100000e+00
+    endloop
+  endfacet
+  facet normal 9.970658e-01 0.000000e+00 -7.654925e-02
+    outer loop
+      vertex   8.550000e+00 3.500000e+00 6.100000e+00
+      vertex   8.550000e+00 0.000000e+00 6.100000e+00
+      vertex   8.521287e+00 3.500000e+00 5.726009e+00
+    endloop
+  endfacet
+  facet normal 9.970658e-01 0.000000e+00 -7.654925e-02
+    outer loop
+      vertex   8.521287e+00 3.500000e+00 5.726009e+00
+      vertex   8.550000e+00 0.000000e+00 6.100000e+00
+      vertex   8.521287e+00 0.000000e+00 5.726009e+00
+    endloop
+  endfacet
+  facet normal 9.736954e-01 0.000000e+00 -2.278535e-01
+    outer loop
+      vertex   8.521287e+00 3.500000e+00 5.726009e+00
+      vertex   8.521287e+00 0.000000e+00 5.726009e+00
+      vertex   8.435821e+00 3.500000e+00 5.360785e+00
+    endloop
+  endfacet
+  facet normal 9.736954e-01 0.000000e+00 -2.278535e-01
+    outer loop
+      vertex   8.435821e+00 3.500000e+00 5.360785e+00
+      vertex   8.521287e+00 0.000000e+00 5.726009e+00
+      vertex   8.435821e+00 0.000000e+00 5.360785e+00
+    endloop
+  endfacet
+  facet normal 9.275025e-01 0.000000e+00 -3.738171e-01
+    outer loop
+      vertex   8.435821e+00 3.500000e+00 5.360785e+00
+      vertex   8.435821e+00 0.000000e+00 5.360785e+00
+      vertex   8.295606e+00 3.500000e+00 5.012886e+00
+    endloop
+  endfacet
+  facet normal 9.275025e-01 0.000000e+00 -3.738171e-01
+    outer loop
+      vertex   8.295606e+00 3.500000e+00 5.012886e+00
+      vertex   8.435821e+00 0.000000e+00 5.360785e+00
+      vertex   8.295606e+00 0.000000e+00 5.012886e+00
+    endloop
+  endfacet
+  facet normal 8.595696e-01 0.000000e+00 -5.110187e-01
+    outer loop
+      vertex   8.295606e+00 3.500000e+00 5.012886e+00
+      vertex   8.295606e+00 0.000000e+00 5.012886e+00
+      vertex   8.103927e+00 3.500000e+00 4.690469e+00
+    endloop
+  endfacet
+  facet normal 8.595696e-01 0.000000e+00 -5.110187e-01
+    outer loop
+      vertex   8.103927e+00 3.500000e+00 4.690469e+00
+      vertex   8.295606e+00 0.000000e+00 5.012886e+00
+      vertex   8.103927e+00 0.000000e+00 4.690469e+00
+    endloop
+  endfacet
+  facet normal 7.714892e-01 0.000000e+00 -6.362424e-01
+    outer loop
+      vertex   8.103927e+00 3.500000e+00 4.690469e+00
+      vertex   8.103927e+00 0.000000e+00 4.690469e+00
+      vertex   7.865278e+00 3.500000e+00 4.401090e+00
+    endloop
+  endfacet
+  facet normal 7.714892e-01 0.000000e+00 -6.362424e-01
+    outer loop
+      vertex   7.865278e+00 3.500000e+00 4.401090e+00
+      vertex   8.103927e+00 0.000000e+00 4.690469e+00
+      vertex   7.865278e+00 0.000000e+00 4.401090e+00
+    endloop
+  endfacet
+  facet normal 6.653257e-01 0.000000e+00 -7.465532e-01
+    outer loop
+      vertex   7.865278e+00 3.500000e+00 4.401090e+00
+      vertex   7.865278e+00 0.000000e+00 4.401090e+00
+      vertex   7.585252e+00 3.500000e+00 4.151532e+00
+    endloop
+  endfacet
+  facet normal 6.653257e-01 0.000000e+00 -7.465532e-01
+    outer loop
+      vertex   7.585252e+00 3.500000e+00 4.151532e+00
+      vertex   7.865278e+00 0.000000e+00 4.401090e+00
+      vertex   7.585252e+00 0.000000e+00 4.151532e+00
+    endloop
+  endfacet
+  facet normal 5.435676e-01 0.000000e+00 -8.393654e-01
+    outer loop
+      vertex   7.585252e+00 3.500000e+00 4.151532e+00
+      vertex   7.585252e+00 0.000000e+00 4.151532e+00
+      vertex   7.270414e+00 3.500000e+00 3.947645e+00
+    endloop
+  endfacet
+  facet normal 5.435676e-01 0.000000e+00 -8.393654e-01
+    outer loop
+      vertex   7.270414e+00 3.500000e+00 3.947645e+00
+      vertex   7.585252e+00 0.000000e+00 4.151532e+00
+      vertex   7.270414e+00 0.000000e+00 3.947645e+00
+    endloop
+  endfacet
+  facet normal 4.090686e-01 0.000000e+00 -9.125036e-01
+    outer loop
+      vertex   7.270414e+00 3.500000e+00 3.947645e+00
+      vertex   7.270414e+00 0.000000e+00 3.947645e+00
+      vertex   6.928141e+00 3.500000e+00 3.794207e+00
+    endloop
+  endfacet
+  facet normal 4.090686e-01 0.000000e+00 -9.125036e-01
+    outer loop
+      vertex   6.928141e+00 3.500000e+00 3.794207e+00
+      vertex   7.270414e+00 0.000000e+00 3.947645e+00
+      vertex   6.928141e+00 0.000000e+00 3.794207e+00
+    endloop
+  endfacet
+  facet normal 2.649815e-01 0.000000e+00 -9.642535e-01
+    outer loop
+      vertex   6.928141e+00 3.500000e+00 3.794207e+00
+      vertex   6.928141e+00 0.000000e+00 3.794207e+00
+      vertex   6.566458e+00 3.500000e+00 3.694815e+00
+    endloop
+  endfacet
+  facet normal 2.649815e-01 0.000000e+00 -9.642535e-01
+    outer loop
+      vertex   6.566458e+00 3.500000e+00 3.694815e+00
+      vertex   6.928141e+00 0.000000e+00 3.794207e+00
+      vertex   6.566458e+00 0.000000e+00 3.694815e+00
+    endloop
+  endfacet
+  facet normal 1.146834e-01 0.000000e+00 -9.934021e-01
+    outer loop
+      vertex   6.566458e+00 3.500000e+00 3.694815e+00
+      vertex   6.566458e+00 0.000000e+00 3.694815e+00
+      vertex   6.193842e+00 3.500000e+00 3.651798e+00
+    endloop
+  endfacet
+  facet normal 1.146834e-01 0.000000e+00 -9.934021e-01
+    outer loop
+      vertex   6.193842e+00 3.500000e+00 3.651798e+00
+      vertex   6.566458e+00 0.000000e+00 3.694815e+00
+      vertex   6.193842e+00 0.000000e+00 3.651798e+00
+    endloop
+  endfacet
+  facet normal -3.830273e-02 -0.000000e+00 -9.992662e-01
+    outer loop
+      vertex   6.193842e+00 3.500000e+00 3.651798e+00
+      vertex   6.193842e+00 0.000000e+00 3.651798e+00
+      vertex   5.819026e+00 3.500000e+00 3.666165e+00
+    endloop
+  endfacet
+  facet normal -3.830273e-02 -0.000000e+00 -9.992662e-01
+    outer loop
+      vertex   5.819026e+00 3.500000e+00 3.666165e+00
+      vertex   6.193842e+00 0.000000e+00 3.651798e+00
+      vertex   5.819026e+00 0.000000e+00 3.666165e+00
+    endloop
+  endfacet
+  facet normal -1.903911e-01 -0.000000e+00 -9.817083e-01
+    outer loop
+      vertex   5.819026e+00 3.500000e+00 3.666165e+00
+      vertex   5.819026e+00 0.000000e+00 3.666165e+00
+      vertex   5.450795e+00 3.500000e+00 3.737579e+00
+    endloop
+  endfacet
+  facet normal -1.903911e-01 -0.000000e+00 -9.817083e-01
+    outer loop
+      vertex   5.450795e+00 3.500000e+00 3.737579e+00
+      vertex   5.819026e+00 0.000000e+00 3.666165e+00
+      vertex   5.450795e+00 0.000000e+00 3.737579e+00
+    endloop
+  endfacet
+  facet normal -3.380169e-01 -0.000000e+00 -9.411400e-01
+    outer loop
+      vertex   5.450795e+00 3.500000e+00 3.737579e+00
+      vertex   5.450795e+00 0.000000e+00 3.737579e+00
+      vertex   5.097782e+00 3.500000e+00 3.864366e+00
+    endloop
+  endfacet
+  facet normal -3.380169e-01 -0.000000e+00 -9.411400e-01
+    outer loop
+      vertex   5.097782e+00 3.500000e+00 3.864366e+00
+      vertex   5.450795e+00 0.000000e+00 3.737579e+00
+      vertex   5.097782e+00 0.000000e+00 3.864366e+00
+    endloop
+  endfacet
+  facet normal -4.777198e-01 -0.000000e+00 -8.785123e-01
+    outer loop
+      vertex   5.097782e+00 3.500000e+00 3.864366e+00
+      vertex   5.097782e+00 0.000000e+00 3.864366e+00
+      vertex   4.768260e+00 3.500000e+00 4.043555e+00
+    endloop
+  endfacet
+  facet normal -4.777198e-01 -0.000000e+00 -8.785123e-01
+    outer loop
+      vertex   4.768260e+00 3.500000e+00 4.043555e+00
+      vertex   5.097782e+00 0.000000e+00 3.864366e+00
+      vertex   4.768260e+00 0.000000e+00 4.043555e+00
+    endloop
+  endfacet
+  facet normal -6.062254e-01 -0.000000e+00 -7.952929e-01
+    outer loop
+      vertex   4.768260e+00 3.500000e+00 4.043555e+00
+      vertex   4.768260e+00 0.000000e+00 4.043555e+00
+      vertex   4.469952e+00 3.500000e+00 4.270945e+00
+    endloop
+  endfacet
+  facet normal -6.062254e-01 -0.000000e+00 -7.952929e-01
+    outer loop
+      vertex   4.469952e+00 3.500000e+00 4.270945e+00
+      vertex   4.768260e+00 0.000000e+00 4.043555e+00
+      vertex   4.469952e+00 0.000000e+00 4.270945e+00
+    endloop
+  endfacet
+  facet normal -7.205216e-01 -0.000000e+00 -6.934325e-01
+    outer loop
+      vertex   4.469952e+00 3.500000e+00 4.270945e+00
+      vertex   4.469952e+00 0.000000e+00 4.270945e+00
+      vertex   4.209852e+00 3.500000e+00 4.541206e+00
+    endloop
+  endfacet
+  facet normal -7.205216e-01 -0.000000e+00 -6.934325e-01
+    outer loop
+      vertex   4.209852e+00 3.500000e+00 4.541206e+00
+      vertex   4.469952e+00 0.000000e+00 4.270945e+00
+      vertex   4.209852e+00 0.000000e+00 4.541206e+00
+    endloop
+  endfacet
+  facet normal -8.179294e-01 -0.000000e+00 -5.753187e-01
+    outer loop
+      vertex   4.209852e+00 3.500000e+00 4.541206e+00
+      vertex   4.209852e+00 0.000000e+00 4.541206e+00
+      vertex   3.994054e+00 3.500000e+00 4.848004e+00
+    endloop
+  endfacet
+  facet normal -8.179294e-01 -0.000000e+00 -5.753187e-01
+    outer loop
+      vertex   3.994054e+00 3.500000e+00 4.848004e+00
+      vertex   4.209852e+00 0.000000e+00 4.541206e+00
+      vertex   3.994054e+00 0.000000e+00 4.848004e+00
+    endloop
+  endfacet
+  facet normal -8.961656e-01 -0.000000e+00 -4.437198e-01
+    outer loop
+      vertex   3.994054e+00 3.500000e+00 4.848004e+00
+      vertex   3.994054e+00 0.000000e+00 4.848004e+00
+      vertex   3.827619e+00 3.500000e+00 5.184148e+00
+    endloop
+  endfacet
+  facet normal -8.961656e-01 -0.000000e+00 -4.437198e-01
+    outer loop
+      vertex   3.827619e+00 3.500000e+00 5.184148e+00
+      vertex   3.994054e+00 0.000000e+00 4.848004e+00
+      vertex   3.827619e+00 0.000000e+00 5.184148e+00
+    endloop
+  endfacet
+  facet normal -9.533964e-01 -0.000000e+00 -3.017206e-01
+    outer loop
+      vertex   3.827619e+00 3.500000e+00 5.184148e+00
+      vertex   3.827619e+00 0.000000e+00 5.184148e+00
+      vertex   3.714446e+00 3.500000e+00 5.541759e+00
+    endloop
+  endfacet
+  facet normal -9.533964e-01 -0.000000e+00 -3.017206e-01
+    outer loop
+      vertex   3.714446e+00 3.500000e+00 5.541759e+00
+      vertex   3.827619e+00 0.000000e+00 5.184148e+00
+      vertex   3.714446e+00 0.000000e+00 5.541759e+00
+    endloop
+  endfacet
+  facet normal -9.882804e-01 -0.000000e+00 -1.526493e-01
+    outer loop
+      vertex   3.714446e+00 3.500000e+00 5.541759e+00
+      vertex   3.714446e+00 0.000000e+00 5.541759e+00
+      vertex   3.657189e+00 3.500000e+00 5.912454e+00
+    endloop
+  endfacet
+  facet normal -9.882804e-01 -0.000000e+00 -1.526493e-01
+    outer loop
+      vertex   3.657189e+00 3.500000e+00 5.912454e+00
+      vertex   3.714446e+00 0.000000e+00 5.541759e+00
+      vertex   3.657189e+00 0.000000e+00 5.912454e+00
+    endloop
+  endfacet
+  facet normal -1.000000e+00 0.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.657189e+00 3.500000e+00 5.912454e+00
+      vertex   3.657189e+00 0.000000e+00 5.912454e+00
+      vertex   3.657189e+00 3.500000e+00 6.287546e+00
+    endloop
+  endfacet
+  facet normal -1.000000e+00 -0.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.657189e+00 3.500000e+00 6.287546e+00
+      vertex   3.657189e+00 0.000000e+00 5.912454e+00
+      vertex   3.657189e+00 0.000000e+00 6.287546e+00
+    endloop
+  endfacet
+  facet normal -9.882804e-01 0.000000e+00 1.526493e-01
+    outer loop
+      vertex   3.657189e+00 3.500000e+00 6.287546e+00
+      vertex   3.657189e+00 0.000000e+00 6.287546e+00
+      vertex   3.714446e+00 3.500000e+00 6.658241e+00
+    endloop
+  endfacet
+  facet normal -9.882804e-01 0.000000e+00 1.526493e-01
+    outer loop
+      vertex   3.714446e+00 3.500000e+00 6.658241e+00
+      vertex   3.657189e+00 0.000000e+00 6.287546e+00
+      vertex   3.714446e+00 0.000000e+00 6.658241e+00
+    endloop
+  endfacet
+  facet normal -9.533964e-01 0.000000e+00 3.017206e-01
+    outer loop
+      vertex   3.714446e+00 3.500000e+00 6.658241e+00
+      vertex   3.714446e+00 0.000000e+00 6.658241e+00
+      vertex   3.827619e+00 3.500000e+00 7.015852e+00
+    endloop
+  endfacet
+  facet normal -9.533964e-01 0.000000e+00 3.017206e-01
+    outer loop
+      vertex   3.827619e+00 3.500000e+00 7.015852e+00
+      vertex   3.714446e+00 0.000000e+00 6.658241e+00
+      vertex   3.827619e+00 0.000000e+00 7.015852e+00
+    endloop
+  endfacet
+  facet normal -8.961656e-01 0.000000e+00 4.437198e-01
+    outer loop
+      vertex   3.827619e+00 3.500000e+00 7.015852e+00
+      vertex   3.827619e+00 0.000000e+00 7.015852e+00
+      vertex   3.994054e+00 3.500000e+00 7.351996e+00
+    endloop
+  endfacet
+  facet normal -8.961656e-01 0.000000e+00 4.437198e-01
+    outer loop
+      vertex   3.994054e+00 3.500000e+00 7.351996e+00
+      vertex   3.827619e+00 0.000000e+00 7.015852e+00
+      vertex   3.994054e+00 0.000000e+00 7.351996e+00
+    endloop
+  endfacet
+  facet normal -8.179294e-01 0.000000e+00 5.753187e-01
+    outer loop
+      vertex   3.994054e+00 3.500000e+00 7.351996e+00
+      vertex   3.994054e+00 0.000000e+00 7.351996e+00
+      vertex   4.209852e+00 3.500000e+00 7.658794e+00
+    endloop
+  endfacet
+  facet normal -8.179294e-01 0.000000e+00 5.753187e-01
+    outer loop
+      vertex   4.209852e+00 3.500000e+00 7.658794e+00
+      vertex   3.994054e+00 0.000000e+00 7.351996e+00
+      vertex   4.209852e+00 0.000000e+00 7.658794e+00
+    endloop
+  endfacet
+  facet normal -7.205216e-01 0.000000e+00 6.934325e-01
+    outer loop
+      vertex   4.209852e+00 3.500000e+00 7.658794e+00
+      vertex   4.209852e+00 0.000000e+00 7.658794e+00
+      vertex   4.469952e+00 3.500000e+00 7.929055e+00
+    endloop
+  endfacet
+  facet normal -7.205216e-01 0.000000e+00 6.934325e-01
+    outer loop
+      vertex   4.469952e+00 3.500000e+00 7.929055e+00
+      vertex   4.209852e+00 0.000000e+00 7.658794e+00
+      vertex   4.469952e+00 0.000000e+00 7.929055e+00
+    endloop
+  endfacet
+  facet normal -6.062254e-01 0.000000e+00 7.952929e-01
+    outer loop
+      vertex   4.469952e+00 3.500000e+00 7.929055e+00
+      vertex   4.469952e+00 0.000000e+00 7.929055e+00
+      vertex   4.768260e+00 3.500000e+00 8.156445e+00
+    endloop
+  endfacet
+  facet normal -6.062254e-01 0.000000e+00 7.952929e-01
+    outer loop
+      vertex   4.768260e+00 3.500000e+00 8.156445e+00
+      vertex   4.469952e+00 0.000000e+00 7.929055e+00
+      vertex   4.768260e+00 0.000000e+00 8.156445e+00
+    endloop
+  endfacet
+  facet normal -4.777198e-01 0.000000e+00 8.785123e-01
+    outer loop
+      vertex   4.768260e+00 3.500000e+00 8.156445e+00
+      vertex   4.768260e+00 0.000000e+00 8.156445e+00
+      vertex   5.097782e+00 3.500000e+00 8.335634e+00
+    endloop
+  endfacet
+  facet normal -4.777198e-01 0.000000e+00 8.785123e-01
+    outer loop
+      vertex   5.097782e+00 3.500000e+00 8.335634e+00
+      vertex   4.768260e+00 0.000000e+00 8.156445e+00
+      vertex   5.097782e+00 0.000000e+00 8.335634e+00
+    endloop
+  endfacet
+  facet normal -3.380169e-01 0.000000e+00 9.411400e-01
+    outer loop
+      vertex   5.097782e+00 3.500000e+00 8.335634e+00
+      vertex   5.097782e+00 0.000000e+00 8.335634e+00
+      vertex   5.450795e+00 3.500000e+00 8.462421e+00
+    endloop
+  endfacet
+  facet normal -3.380169e-01 0.000000e+00 9.411400e-01
+    outer loop
+      vertex   5.450795e+00 3.500000e+00 8.462421e+00
+      vertex   5.097782e+00 0.000000e+00 8.335634e+00
+      vertex   5.450795e+00 0.000000e+00 8.462421e+00
+    endloop
+  endfacet
+  facet normal -1.903911e-01 0.000000e+00 9.817083e-01
+    outer loop
+      vertex   5.450795e+00 3.500000e+00 8.462421e+00
+      vertex   5.450795e+00 0.000000e+00 8.462421e+00
+      vertex   5.819026e+00 3.500000e+00 8.533835e+00
+    endloop
+  endfacet
+  facet normal -1.903911e-01 0.000000e+00 9.817083e-01
+    outer loop
+      vertex   5.819026e+00 3.500000e+00 8.533835e+00
+      vertex   5.450795e+00 0.000000e+00 8.462421e+00
+      vertex   5.819026e+00 0.000000e+00 8.533835e+00
+    endloop
+  endfacet
+  facet normal -3.830273e-02 0.000000e+00 9.992662e-01
+    outer loop
+      vertex   5.819026e+00 3.500000e+00 8.533835e+00
+      vertex   5.819026e+00 0.000000e+00 8.533835e+00
+      vertex   6.193842e+00 3.500000e+00 8.548202e+00
+    endloop
+  endfacet
+  facet normal -3.830273e-02 0.000000e+00 9.992662e-01
+    outer loop
+      vertex   6.193842e+00 3.500000e+00 8.548202e+00
+      vertex   5.819026e+00 0.000000e+00 8.533835e+00
+      vertex   6.193842e+00 0.000000e+00 8.548202e+00
+    endloop
+  endfacet
+  facet normal 1.146834e-01 0.000000e+00 9.934021e-01
+    outer loop
+      vertex   6.193842e+00 3.500000e+00 8.548202e+00
+      vertex   6.193842e+00 0.000000e+00 8.548202e+00
+      vertex   6.566458e+00 3.500000e+00 8.505185e+00
+    endloop
+  endfacet
+  facet normal 1.146834e-01 0.000000e+00 9.934021e-01
+    outer loop
+      vertex   6.566458e+00 3.500000e+00 8.505185e+00
+      vertex   6.193842e+00 0.000000e+00 8.548202e+00
+      vertex   6.566458e+00 0.000000e+00 8.505185e+00
+    endloop
+  endfacet
+  facet normal 2.649815e-01 0.000000e+00 9.642535e-01
+    outer loop
+      vertex   6.566458e+00 3.500000e+00 8.505185e+00
+      vertex   6.566458e+00 0.000000e+00 8.505185e+00
+      vertex   6.928141e+00 3.500000e+00 8.405793e+00
+    endloop
+  endfacet
+  facet normal 2.649815e-01 0.000000e+00 9.642535e-01
+    outer loop
+      vertex   6.928141e+00 3.500000e+00 8.405793e+00
+      vertex   6.566458e+00 0.000000e+00 8.505185e+00
+      vertex   6.928141e+00 0.000000e+00 8.405793e+00
+    endloop
+  endfacet
+  facet normal 4.090686e-01 0.000000e+00 9.125036e-01
+    outer loop
+      vertex   6.928141e+00 3.500000e+00 8.405793e+00
+      vertex   6.928141e+00 0.000000e+00 8.405793e+00
+      vertex   7.270414e+00 3.500000e+00 8.252355e+00
+    endloop
+  endfacet
+  facet normal 4.090686e-01 0.000000e+00 9.125036e-01
+    outer loop
+      vertex   7.270414e+00 3.500000e+00 8.252355e+00
+      vertex   6.928141e+00 0.000000e+00 8.405793e+00
+      vertex   7.270414e+00 0.000000e+00 8.252355e+00
+    endloop
+  endfacet
+  facet normal 5.435676e-01 0.000000e+00 8.393654e-01
+    outer loop
+      vertex   7.270414e+00 3.500000e+00 8.252355e+00
+      vertex   7.270414e+00 0.000000e+00 8.252355e+00
+      vertex   7.585252e+00 3.500000e+00 8.048468e+00
+    endloop
+  endfacet
+  facet normal 5.435676e-01 0.000000e+00 8.393654e-01
+    outer loop
+      vertex   7.585252e+00 3.500000e+00 8.048468e+00
+      vertex   7.270414e+00 0.000000e+00 8.252355e+00
+      vertex   7.585252e+00 0.000000e+00 8.048468e+00
+    endloop
+  endfacet
+  facet normal 6.653257e-01 0.000000e+00 7.465532e-01
+    outer loop
+      vertex   7.585252e+00 3.500000e+00 8.048468e+00
+      vertex   7.585252e+00 0.000000e+00 8.048468e+00
+      vertex   7.865278e+00 3.500000e+00 7.798910e+00
+    endloop
+  endfacet
+  facet normal 6.653257e-01 0.000000e+00 7.465532e-01
+    outer loop
+      vertex   7.865278e+00 3.500000e+00 7.798910e+00
+      vertex   7.585252e+00 0.000000e+00 8.048468e+00
+      vertex   7.865278e+00 0.000000e+00 7.798910e+00
+    endloop
+  endfacet
+  facet normal 7.714892e-01 0.000000e+00 6.362424e-01
+    outer loop
+      vertex   7.865278e+00 3.500000e+00 7.798910e+00
+      vertex   7.865278e+00 0.000000e+00 7.798910e+00
+      vertex   8.103927e+00 3.500000e+00 7.509531e+00
+    endloop
+  endfacet
+  facet normal 7.714892e-01 0.000000e+00 6.362424e-01
+    outer loop
+      vertex   8.103927e+00 3.500000e+00 7.509531e+00
+      vertex   7.865278e+00 0.000000e+00 7.798910e+00
+      vertex   8.103927e+00 0.000000e+00 7.509531e+00
+    endloop
+  endfacet
+  facet normal 8.595696e-01 0.000000e+00 5.110187e-01
+    outer loop
+      vertex   8.103927e+00 3.500000e+00 7.509531e+00
+      vertex   8.103927e+00 0.000000e+00 7.509531e+00
+      vertex   8.295606e+00 3.500000e+00 7.187114e+00
+    endloop
+  endfacet
+  facet normal 8.595696e-01 0.000000e+00 5.110187e-01
+    outer loop
+      vertex   8.295606e+00 3.500000e+00 7.187114e+00
+      vertex   8.103927e+00 0.000000e+00 7.509531e+00
+      vertex   8.295606e+00 0.000000e+00 7.187114e+00
+    endloop
+  endfacet
+  facet normal 9.275025e-01 0.000000e+00 3.738171e-01
+    outer loop
+      vertex   8.295606e+00 3.500000e+00 7.187114e+00
+      vertex   8.295606e+00 0.000000e+00 7.187114e+00
+      vertex   8.435821e+00 3.500000e+00 6.839215e+00
+    endloop
+  endfacet
+  facet normal 9.275025e-01 0.000000e+00 3.738171e-01
+    outer loop
+      vertex   8.435821e+00 3.500000e+00 6.839215e+00
+      vertex   8.295606e+00 0.000000e+00 7.187114e+00
+      vertex   8.435821e+00 0.000000e+00 6.839215e+00
+    endloop
+  endfacet
+  facet normal 9.736954e-01 0.000000e+00 2.278535e-01
+    outer loop
+      vertex   8.435821e+00 3.500000e+00 6.839215e+00
+      vertex   8.435821e+00 0.000000e+00 6.839215e+00
+      vertex   8.521287e+00 3.500000e+00 6.473991e+00
+    endloop
+  endfacet
+  facet normal 9.736954e-01 0.000000e+00 2.278535e-01
+    outer loop
+      vertex   8.521287e+00 3.500000e+00 6.473991e+00
+      vertex   8.435821e+00 0.000000e+00 6.839215e+00
+      vertex   8.521287e+00 0.000000e+00 6.473991e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.521287e+00 3.500000e+00 6.473991e+00
+      vertex   8.550000e+00 3.500000e+00 6.100000e+00
+      vertex   3.994054e+00 3.500000e+00 4.848004e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.994054e+00 3.500000e+00 4.848004e+00
+      vertex   8.550000e+00 3.500000e+00 6.100000e+00
+      vertex   8.521287e+00 3.500000e+00 5.726009e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.994054e+00 3.500000e+00 4.848004e+00
+      vertex   8.521287e+00 3.500000e+00 5.726009e+00
+      vertex   8.435821e+00 3.500000e+00 5.360785e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.435821e+00 3.500000e+00 5.360785e+00
+      vertex   8.295606e+00 3.500000e+00 5.012886e+00
+      vertex   3.994054e+00 3.500000e+00 4.848004e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.994054e+00 3.500000e+00 4.848004e+00
+      vertex   8.295606e+00 3.500000e+00 5.012886e+00
+      vertex   8.103927e+00 3.500000e+00 4.690469e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.994054e+00 3.500000e+00 4.848004e+00
+      vertex   8.103927e+00 3.500000e+00 4.690469e+00
+      vertex   4.209852e+00 3.500000e+00 4.541206e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.209852e+00 3.500000e+00 4.541206e+00
+      vertex   8.103927e+00 3.500000e+00 4.690469e+00
+      vertex   7.865278e+00 3.500000e+00 4.401090e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.209852e+00 3.500000e+00 4.541206e+00
+      vertex   7.865278e+00 3.500000e+00 4.401090e+00
+      vertex   4.469952e+00 3.500000e+00 4.270945e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.469952e+00 3.500000e+00 4.270945e+00
+      vertex   7.865278e+00 3.500000e+00 4.401090e+00
+      vertex   7.585252e+00 3.500000e+00 4.151532e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.469952e+00 3.500000e+00 4.270945e+00
+      vertex   7.585252e+00 3.500000e+00 4.151532e+00
+      vertex   4.768260e+00 3.500000e+00 4.043555e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.768260e+00 3.500000e+00 4.043555e+00
+      vertex   7.585252e+00 3.500000e+00 4.151532e+00
+      vertex   7.270414e+00 3.500000e+00 3.947645e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.768260e+00 3.500000e+00 4.043555e+00
+      vertex   7.270414e+00 3.500000e+00 3.947645e+00
+      vertex   5.097782e+00 3.500000e+00 3.864366e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.097782e+00 3.500000e+00 3.864366e+00
+      vertex   7.270414e+00 3.500000e+00 3.947645e+00
+      vertex   6.928141e+00 3.500000e+00 3.794207e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.097782e+00 3.500000e+00 3.864366e+00
+      vertex   6.928141e+00 3.500000e+00 3.794207e+00
+      vertex   5.450795e+00 3.500000e+00 3.737579e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.450795e+00 3.500000e+00 3.737579e+00
+      vertex   6.928141e+00 3.500000e+00 3.794207e+00
+      vertex   6.566458e+00 3.500000e+00 3.694815e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.450795e+00 3.500000e+00 3.737579e+00
+      vertex   6.566458e+00 3.500000e+00 3.694815e+00
+      vertex   5.819026e+00 3.500000e+00 3.666165e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.819026e+00 3.500000e+00 3.666165e+00
+      vertex   6.566458e+00 3.500000e+00 3.694815e+00
+      vertex   6.193842e+00 3.500000e+00 3.651798e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.827619e+00 3.500000e+00 5.184148e+00
+      vertex   5.819026e+00 3.500000e+00 8.533835e+00
+      vertex   3.994054e+00 3.500000e+00 4.848004e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.994054e+00 3.500000e+00 4.848004e+00
+      vertex   5.819026e+00 3.500000e+00 8.533835e+00
+      vertex   6.193842e+00 3.500000e+00 8.548202e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.994054e+00 3.500000e+00 4.848004e+00
+      vertex   6.193842e+00 3.500000e+00 8.548202e+00
+      vertex   6.566458e+00 3.500000e+00 8.505185e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.714446e+00 3.500000e+00 5.541759e+00
+      vertex   3.827619e+00 3.500000e+00 7.015852e+00
+      vertex   3.827619e+00 3.500000e+00 5.184148e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.827619e+00 3.500000e+00 5.184148e+00
+      vertex   3.827619e+00 3.500000e+00 7.015852e+00
+      vertex   3.994054e+00 3.500000e+00 7.351996e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.827619e+00 3.500000e+00 5.184148e+00
+      vertex   3.994054e+00 3.500000e+00 7.351996e+00
+      vertex   4.209852e+00 3.500000e+00 7.658794e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.827619e+00 3.500000e+00 7.015852e+00
+      vertex   3.714446e+00 3.500000e+00 5.541759e+00
+      vertex   3.714446e+00 3.500000e+00 6.658241e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.714446e+00 3.500000e+00 6.658241e+00
+      vertex   3.714446e+00 3.500000e+00 5.541759e+00
+      vertex   3.657189e+00 3.500000e+00 5.912454e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.714446e+00 3.500000e+00 6.658241e+00
+      vertex   3.657189e+00 3.500000e+00 5.912454e+00
+      vertex   3.657189e+00 3.500000e+00 6.287546e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   4.209852e+00 3.500000e+00 7.658794e+00
+      vertex   4.469952e+00 3.500000e+00 7.929055e+00
+      vertex   3.827619e+00 3.500000e+00 5.184148e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.827619e+00 3.500000e+00 5.184148e+00
+      vertex   4.469952e+00 3.500000e+00 7.929055e+00
+      vertex   4.768260e+00 3.500000e+00 8.156445e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.827619e+00 3.500000e+00 5.184148e+00
+      vertex   4.768260e+00 3.500000e+00 8.156445e+00
+      vertex   5.097782e+00 3.500000e+00 8.335634e+00
+    endloop
+  endfacet
+  facet normal -0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   5.097782e+00 3.500000e+00 8.335634e+00
+      vertex   5.450795e+00 3.500000e+00 8.462421e+00
+      vertex   3.827619e+00 3.500000e+00 5.184148e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.827619e+00 3.500000e+00 5.184148e+00
+      vertex   5.450795e+00 3.500000e+00 8.462421e+00
+      vertex   5.819026e+00 3.500000e+00 8.533835e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   6.566458e+00 3.500000e+00 8.505185e+00
+      vertex   6.928141e+00 3.500000e+00 8.405793e+00
+      vertex   3.994054e+00 3.500000e+00 4.848004e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.994054e+00 3.500000e+00 4.848004e+00
+      vertex   6.928141e+00 3.500000e+00 8.405793e+00
+      vertex   7.270414e+00 3.500000e+00 8.252355e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.994054e+00 3.500000e+00 4.848004e+00
+      vertex   7.270414e+00 3.500000e+00 8.252355e+00
+      vertex   7.585252e+00 3.500000e+00 8.048468e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   7.585252e+00 3.500000e+00 8.048468e+00
+      vertex   7.865278e+00 3.500000e+00 7.798910e+00
+      vertex   3.994054e+00 3.500000e+00 4.848004e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.994054e+00 3.500000e+00 4.848004e+00
+      vertex   7.865278e+00 3.500000e+00 7.798910e+00
+      vertex   8.103927e+00 3.500000e+00 7.509531e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.994054e+00 3.500000e+00 4.848004e+00
+      vertex   8.103927e+00 3.500000e+00 7.509531e+00
+      vertex   8.295606e+00 3.500000e+00 7.187114e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   8.295606e+00 3.500000e+00 7.187114e+00
+      vertex   8.435821e+00 3.500000e+00 6.839215e+00
+      vertex   3.994054e+00 3.500000e+00 4.848004e+00
+    endloop
+  endfacet
+  facet normal 0.000000e+00 1.000000e+00 0.000000e+00
+    outer loop
+      vertex   3.994054e+00 3.500000e+00 4.848004e+00
+      vertex   8.435821e+00 3.500000e+00 6.839215e+00
+      vertex   8.521287e+00 3.500000e+00 6.473991e+00
+    endloop
+  endfacet
+endsolid

--- a/examples/parts/snakie-standard/sg90/parts.yml
+++ b/examples/parts/snakie-standard/sg90/parts.yml
@@ -133,6 +133,10 @@ drivers:
     target: lib/servo.py
     label: Servo driver
 help: help.md
+# A 3-D mesh for the Robot View (#406): dropping this part onto a design also drops
+# this STL into the project URDF as a loose link. Authored in millimetres.
+mesh: model.stl
+meshUnits: mm
 layerVisibility:
   pcb: false
   image: false

--- a/src/main/parts/library.ts
+++ b/src/main/parts/library.ts
@@ -435,6 +435,22 @@ export async function readDriverSource(
 }
 
 /**
+ * Resolve the absolute path to a bundled file inside a part folder
+ * (`<parts>/<lib>/<part>/<filename>`), path-traversal guarded like the driver/image
+ * readers. Returns null for an unsafe or unknown ref. Used to copy a part's linked
+ * mesh into a project URDF's `meshes/` folder (#406).
+ */
+export function resolvePartAsset(libraryId: string, partId: string, filename: string): string | null {
+  const libId = sanitiseId(libraryId)
+  const pId = sanitiseId(partId)
+  const file = String(filename ?? '').trim()
+  if (!libId || !pId || !file) return null
+  const partDir = join(partsDir(), libId, pId)
+  if (!isContainedFile(partDir, file)) return null
+  return join(partDir, file)
+}
+
+/**
  * DEV workflow (#52/issue-3, #192): promote ANY part into the Standard library so
  * it becomes a shipped default — not just microcontrollers, so the standard
  * library can also hold sensors, ICs, power parts, displays, etc. Writes it into

--- a/src/main/robot/ipc.ts
+++ b/src/main/robot/ipc.ts
@@ -13,6 +13,7 @@ import { basename, dirname, extname, join } from 'path'
 import { promises as fsp } from 'fs'
 import { robotFromYaml, robotToYaml } from '../../shared/robot-yaml'
 import { blankRobot, type RobotDefinition } from '../../shared/robot'
+import { resolvePartAsset } from '../parts/library'
 
 /** Result of importing a mesh: the path relative to the URDF's folder, or a
  *  cancellation. */
@@ -23,6 +24,52 @@ export interface ImportMeshResult {
   rel?: string
   /** The copied file's base name, e.g. `wheel.stl`. */
   name?: string
+  /** For a copied STL: its largest bounding-box dimension in the file's own units,
+   *  so the renderer can guess a mm→m scale (#406). Undefined if not measurable. */
+  maxDim?: number
+}
+
+/** The largest bounding-box span of an STL (binary OR ASCII), in the file's own units
+ *  — a cheap DOM/three-free parse so the mm→m import heuristic works without the
+ *  renderer. Returns undefined for a malformed buffer (caller falls back to declared
+ *  units). Mirrors the reach of `handleImportStl`'s three.js STLLoader measure. */
+function stlMaxDim(buf: Buffer): number | undefined {
+  let minX = Infinity, minY = Infinity, minZ = Infinity
+  let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity
+  const grow = (x: number, y: number, z: number): void => {
+    if (x < minX) minX = x
+    if (x > maxX) maxX = x
+    if (y < minY) minY = y
+    if (y > maxY) maxY = y
+    if (z < minZ) minZ = z
+    if (z > maxZ) maxZ = z
+  }
+  const tris = buf.length >= 84 ? buf.readUInt32LE(80) : 0
+  if (tris > 0 && buf.length === 84 + tris * 50) {
+    // BINARY STL: exactly 84 + 50·tris bytes. Each triangle: normal(12) + 3 verts(36) + attr(2).
+    for (let t = 0; t < tris; t++) {
+      const base = 84 + t * 50 + 12 // skip the facet normal
+      for (let v = 0; v < 3; v++) {
+        const o = base + v * 12
+        grow(buf.readFloatLE(o), buf.readFloatLE(o + 4), buf.readFloatLE(o + 8))
+      }
+    }
+  } else {
+    // ASCII STL: `vertex <x> <y> <z>` lines.
+    const text = buf.toString('utf-8')
+    if (!/^\s*solid\b/i.test(text)) return undefined
+    // The `-` inside the class is what lets a negative EXPONENT (e.g. 1.5e-3) match.
+    const re = /\bvertex\s+([-\d.eE+]+)\s+([-\d.eE+]+)\s+([-\d.eE+]+)/g
+    let m: RegExpExecArray | null
+    let found = false
+    while ((m = re.exec(text))) {
+      found = true
+      grow(Number(m[1]), Number(m[2]), Number(m[3]))
+    }
+    if (!found) return undefined
+  }
+  const span = Math.max(maxX - minX, maxY - minY, maxZ - minZ)
+  return Number.isFinite(span) ? span : undefined
 }
 
 /** Copy `src` into `<urdfDir>/meshes/`, never overwriting (appends -1, -2 …). */
@@ -130,6 +177,41 @@ export function registerRobotIpc(): void {
           : await dialog.showOpenDialog(opts)
         if (result.canceled || result.filePaths.length === 0) return { cancelled: true }
         return await copyIntoMeshes(args.urdfPath, result.filePaths[0])
+      } catch (err) {
+        return { error: (err as Error).message }
+      }
+    }
+  )
+
+  // Copy a Parts Library part's BUNDLED mesh into a project URDF's meshes/ folder
+  // (#406) — the drop bridge calls this when a mesh-linked part is added to a design.
+  // The part's mesh path is resolved + path-traversal guarded in the parts layer.
+  ipcMain.handle(
+    'robot:importPartMesh',
+    async (
+      _e,
+      args: { urdfPath: string; libraryId: string; partId: string; mesh: string }
+    ): Promise<ImportMeshResult> => {
+      try {
+        if (!args?.urdfPath || !args?.mesh) return { error: 'No robot file or mesh to import.' }
+        const src = resolvePartAsset(args.libraryId, args.partId, args.mesh)
+        if (!src) return { error: `Unsafe or unknown part mesh: ${args.mesh}` }
+        // Refuse a SYMLINKED mesh: copyFile dereferences it, so a community part could
+        // ship `model.stl -> ~/.ssh/id_rsa` and exfiltrate its bytes into the project.
+        // The lexical isContainedFile guard can't see a symlink's target (#406 review).
+        if ((await fsp.lstat(src)).isSymbolicLink()) {
+          return { error: `Refusing symlinked part mesh: ${args.mesh}` }
+        }
+        const { rel, name } = await copyIntoMeshes(args.urdfPath, src)
+        let maxDim: number | undefined
+        if (/\.stl$/i.test(name)) {
+          try {
+            maxDim = stlMaxDim(await fsp.readFile(join(dirname(args.urdfPath), 'meshes', name)))
+          } catch {
+            // Unmeasurable → the renderer falls back to declared units.
+          }
+        }
+        return { rel, name, maxDim }
       } catch (err) {
         return { error: (err as Error).message }
       }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -986,6 +986,16 @@ const robot = {
     src?: string
   ): Promise<{ cancelled?: boolean; error?: string; rel?: string; name?: string }> =>
     ipcRenderer.invoke('robot:importMesh', { urdfPath, src }),
+  /** Copy a Parts Library part's BUNDLED mesh into `<urdf-folder>/meshes/` (#406) —
+   *  used by the drop bridge when a mesh-linked part is added to a design. Resolves to
+   *  the mesh path relative to the URDF + (for an STL) its largest bbox dimension. */
+  importPartMesh: (
+    urdfPath: string,
+    libraryId: string,
+    partId: string,
+    mesh: string
+  ): Promise<{ error?: string; rel?: string; name?: string; maxDim?: number }> =>
+    ipcRenderer.invoke('robot:importPartMesh', { urdfPath, libraryId, partId, mesh }),
   /** Subscribe to robot.yml changes from ANOTHER window (e.g. the Board View
    *  adding/removing a part). Returns an unsubscribe. */
   onChanged: (cb: () => void): (() => void) => {

--- a/src/renderer/src/board-main.tsx
+++ b/src/renderer/src/board-main.tsx
@@ -30,6 +30,8 @@ import { BoardGraph } from './components/BoardGraph'
 import { OPEN_PART_EDITOR_EVENT, PARTS_CHANGED_EVENT, type OpenPartEditorDetail } from './components/PartsPanel'
 import { PartEditor } from './components/PartEditor'
 import { blankRobot, type RobotDefinition } from '../../shared/robot'
+import { readRobotModel } from '../../shared/krf'
+import { attachPartMesh } from './components/robot-part-mesh'
 import type {
   BoardDefinition,
   BoardSourcePayload,
@@ -223,10 +225,27 @@ function BoardWindowApp(): JSX.Element {
       // A drag-drop carries a canvas position (#159); a click-add leaves x/y unset
       // so the canvas auto-lays the part out.
       const placed = pos ? { x: Math.round(pos.x), y: Math.round(pos.y) } : {}
-      saveRobot({
+      const withPart: RobotDefinition = {
         ...robot,
         parts: [...robot.parts, { id, lib: libraryId, part: part.id, label: part.name, ...placed }]
-      })
+      }
+      if (part.mesh && folder) {
+        // #406: a mesh-linked part ALSO drops its STL into the project URDF (creating +
+        // linking one if absent). Save the part + link SYNCHRONOUSLY (so a rapid second
+        // drop / cross-window reload can't clobber it), THEN write the mesh into the
+        // .urdf. It shows in the Robot View the next time that URDF is loaded (e.g. on
+        // switching to Robot mode); an already-open Robot View won't refresh live.
+        const existingUrdf = readRobotModel(robot)?.urdf
+        const urdfName = existingUrdf || 'robot.urdf'
+        saveRobot(
+          existingUrdf
+            ? withPart
+            : { ...withPart, robot: { ...(withPart.robot ?? {}), version: 1, urdf: urdfName } }
+        )
+        void attachPartMesh(folder, urdfName, libraryId, part).catch(() => undefined)
+      } else {
+        saveRobot(withPart)
+      }
       // #166: offer to install the part's linked MicroPython library via mip —
       // but ONLY when the part ships NO bundled driver files. When it declares
       // `drivers` (the Driver Install banner copies those to the board OFFLINE), a
@@ -249,7 +268,7 @@ function BoardWindowApp(): JSX.Element {
         }
       }
     },
-    [robot, saveRobot]
+    [robot, saveRobot, folder]
   )
 
   // Esc backs out one level at a time (so a stray Esc / a focused input's Esc

--- a/src/renderer/src/components/BoardPane.tsx
+++ b/src/renderer/src/components/BoardPane.tsx
@@ -3,6 +3,8 @@ import { BoardGraph } from './BoardGraph'
 import { PartEditor } from './PartEditor'
 import { OPEN_PART_EDITOR_EVENT, PARTS_CHANGED_EVENT, type OpenPartEditorDetail } from './PartsPanel'
 import { blankRobot, type RobotDefinition } from '../../../shared/robot'
+import { readRobotModel } from '../../../shared/krf'
+import { attachPartMesh } from './robot-part-mesh'
 import { useWorkspace } from '../store/workspace'
 import { useEditorSettings } from '../store/settings'
 import type {
@@ -120,10 +122,27 @@ export function BoardPane(): JSX.Element {
       let n = 2
       while (ids.has(id)) id = `${part.id}${n++}`
       const placed = pos ? { x: Math.round(pos.x), y: Math.round(pos.y) } : {}
-      saveRobot({
+      const withPart: RobotDefinition = {
         ...robot,
         parts: [...robot.parts, { id, lib: libraryId, part: part.id, label: part.name, ...placed }]
-      })
+      }
+      if (part.mesh && folder) {
+        // #406: a mesh-linked part ALSO drops its STL into the project URDF (creating +
+        // linking one if absent). Save the part + link SYNCHRONOUSLY (so a rapid second
+        // drop / cross-window reload can't clobber it), THEN write the mesh into the
+        // .urdf. It shows in the Robot View the next time that URDF is loaded (e.g. on
+        // switching to Robot mode); an already-open Robot View won't refresh live.
+        const existingUrdf = readRobotModel(robot)?.urdf
+        const urdfName = existingUrdf || 'robot.urdf'
+        saveRobot(
+          existingUrdf
+            ? withPart
+            : { ...withPart, robot: { ...(withPart.robot ?? {}), version: 1, urdf: urdfName } }
+        )
+        void attachPartMesh(folder, urdfName, libraryId, part).catch(() => undefined)
+      } else {
+        saveRobot(withPart)
+      }
       const lib = part.library
       if (lib?.url && !(part.drivers && part.drivers.length > 0)) {
         const mod = lib.module || part.name
@@ -145,7 +164,7 @@ export function BoardPane(): JSX.Element {
         }
       }
     },
-    [robot, saveRobot]
+    [robot, saveRobot, folder]
   )
 
   // The Part Editor overlay (opened from the pane's library dock, exactly like

--- a/src/renderer/src/components/part-editor.util.ts
+++ b/src/renderer/src/components/part-editor.util.ts
@@ -900,6 +900,10 @@ export function normalisePart(part: PartDefinition): PartDefinition {
   // `help` is the relative filename; keep it. `helpText` (the inlined markdown) is
   // runtime-only, like `imageData`, so it's NOT part of the round-trip shape.
   set('help', text(part.help))
+  // The 3-D mesh link (#406): a relative filename + its declared units/scale.
+  set('mesh', text(part.mesh))
+  if (part.meshUnits === 'mm' || part.meshUnits === 'm') out.meshUnits = part.meshUnits
+  if (typeof part.meshScale === 'number' && part.meshScale > 0) out.meshScale = part.meshScale
   if (
     part.imageLayer &&
     [part.imageLayer.x, part.imageLayer.y, part.imageLayer.w, part.imageLayer.h].every(

--- a/src/renderer/src/components/robot-assembly.ts
+++ b/src/renderer/src/components/robot-assembly.ts
@@ -127,6 +127,23 @@ export function uniqueLinkName(urdf: string, base: string): string {
  * first link of an empty URDF becomes the root (no joint). `meshRel` is relative
  * to the URDF folder. Returns the new URDF text + the created link name.
  */
+/**
+ * The import scale for a mesh (#406): an explicit `meshScale` wins, then declared
+ * `meshUnits` (`mm` → 0.001, `m` → 1), then a bounding-box heuristic (a part more
+ * than ~3 URDF-metres across was surely authored in millimetres → 0.001), else 1.
+ * Mirrors `handleImportStl`'s mm→m guess so a library-dropped mesh loads sane.
+ */
+export function meshImportScale(
+  opts: { meshScale?: number; meshUnits?: 'mm' | 'm' },
+  maxDim?: number
+): number {
+  if (typeof opts.meshScale === 'number' && opts.meshScale > 0) return opts.meshScale
+  if (opts.meshUnits === 'mm') return 0.001
+  if (opts.meshUnits === 'm') return 1
+  if (typeof maxDim === 'number' && maxDim > 3) return 0.001
+  return 1
+}
+
 export function addMeshLink(
   urdf: string,
   opts: { meshRel: string; linkBase: string; scale?: number; parent?: string }

--- a/src/renderer/src/components/robot-part-mesh.ts
+++ b/src/renderer/src/components/robot-part-mesh.ts
@@ -1,0 +1,73 @@
+/**
+ * DROP BRIDGE for mesh-linked Parts Library parts (#406). When a part that declares a
+ * `mesh` is added to a design, its bundled STL is copied into the project URDF's
+ * `meshes/` folder and appended as a loose, unconnected link — so it shows up in the
+ * 3-D Robot View (the next time that URDF is loaded) ready to place + join, like a
+ * manual STL import. Pure glue over existing pieces (`robot:importPartMesh`,
+ * `addMeshLink`, `blankUrdf`).
+ */
+import type { PartDefinition } from '../../../shared/part'
+import { addMeshLink, blankUrdf, meshImportScale, rootLink } from './robot-assembly'
+import { isAbsolutePath } from './robot-mesh'
+
+/**
+ * Serialise ALL part-mesh drops. Each does a read-modify-write of a `.urdf` through the
+ * fs bridge (NOT the main-process per-path write queue `robot:save` uses), so two drops
+ * in quick succession could both read the same base text and the second write would
+ * clobber the first's link. Chaining makes each read-modify-write atomic vs. the others.
+ */
+let chain: Promise<void> = Promise.resolve()
+
+/**
+ * Whether a URDF filename from `robot.yml` is safe to write to: a bare in-project
+ * relative path — not absolute, and not escaping the project via `..`. A crafted
+ * `robot: { urdf: '../../evil.urdf' }` must not redirect a drop's file write out of
+ * the project folder (#406 review).
+ */
+export function safeUrdfName(name: string): boolean {
+  if (!name || isAbsolutePath(name)) return false
+  return !/(^|[/\\])\.\.([/\\]|$)/.test(name)
+}
+
+/**
+ * Copy `part`'s bundled STL into `<folder>/meshes/` and append it as a loose link to
+ * the project URDF `urdfName`. Creates a blank URDF at that name if the project had
+ * none. Only touches the `.urdf` file (+ its `meshes/`) — the CALLER links `urdfName`
+ * in `robot.yml`. Best-effort: on a copy failure it still leaves a valid URDF so the
+ * robot.yml link is never dangling. No-op for a part without a `mesh` or an unsafe name.
+ */
+export async function attachPartMesh(
+  folder: string,
+  urdfName: string,
+  libraryId: string,
+  part: PartDefinition
+): Promise<void> {
+  const mesh = part.mesh
+  if (!mesh || !folder || !safeUrdfName(urdfName)) return
+  const run = chain.then(async () => {
+    const dir = folder.replace(/[/\\]$/, '')
+    const urdfPath = `${dir}/${urdfName}`
+    // Copy the part's bundled STL into <dir>/meshes/ (collision-safe, in main).
+    const res = await window.api.robot.importPartMesh(urdfPath, libraryId, part.id, mesh)
+    // Read the project URDF, or start a blank one if the project had none.
+    let urdf: string
+    try {
+      urdf = await window.api.fs.readFile(urdfPath)
+    } catch {
+      urdf = blankUrdf('my_robot')
+    }
+    if (res?.rel) {
+      const scale = meshImportScale(part, res.maxDim)
+      urdf = addMeshLink(urdf, {
+        meshRel: res.rel,
+        linkBase: part.name || part.id,
+        scale,
+        parent: rootLink(urdf)
+      }).urdf
+    }
+    await window.api.fs.writeFile(urdfPath, urdf)
+  })
+  // Keep the chain alive even if this drop throws, so a later drop still runs.
+  chain = run.catch(() => undefined)
+  return run
+}

--- a/src/shared/part-yaml.ts
+++ b/src/shared/part-yaml.ts
@@ -313,6 +313,10 @@ export function partToYaml(part: PartDefinition): string {
     imageLayer: part.imageLayer,
     // NB: `help` (the filename) is kept; `helpText` (the inlined markdown) is NOT.
     help: part.help,
+    // The linked mesh is a relative filename (never a blob), like `image`/`help`.
+    mesh: part.mesh,
+    meshUnits: part.meshUnits,
+    meshScale: part.meshScale,
     schematic: part.schematic,
     i2cAddresses: part.i2cAddresses,
     library: part.library,
@@ -522,6 +526,10 @@ export function partFromYaml(text: string): PartDefinition {
   assign('ledLabel', str(raw.ledLabel))
   assign('image', str(raw.image))
   assign('help', str(raw.help))
+  assign('mesh', str(raw.mesh))
+  const meshUnits = str(raw.meshUnits)
+  if (meshUnits === 'mm' || meshUnits === 'm') assign('meshUnits', meshUnits)
+  assign('meshScale', num(raw.meshScale))
   if (raw.imageLayer && typeof raw.imageLayer === 'object') {
     const il = raw.imageLayer as Record<string, unknown>
     const x = num(il.x)

--- a/src/shared/part.ts
+++ b/src/shared/part.ts
@@ -480,6 +480,27 @@ export interface PartDefinition {
    */
   drivers?: DriverFile[]
 
+  // --- 3-D mesh (Robot View, #406) -----------------------------------------
+  /**
+   * A 3-D mesh (STL) linked to this part. On disk this is a **relative filename**
+   * within the part folder (e.g. `"model.stl"`). Unlike `image`/`help` it is NOT
+   * inlined into the renderer; when the part is dropped onto a design the main
+   * process copies the file into the project URDF's `meshes/` folder and it's
+   * added as a loose link in the 3-D Robot View. Absent ⇒ no mesh.
+   */
+  mesh?: string
+  /**
+   * The units the linked {@link mesh} is authored in, so it loads at a sane size in
+   * the URDF world (which is metres; STLs are commonly millimetres). `'mm'` ⇒ a
+   * 0.001 scale. Absent ⇒ fall back to a bounding-box heuristic on import.
+   */
+  meshUnits?: 'mm' | 'm'
+  /**
+   * An explicit uniform scale for the linked {@link mesh}, overriding
+   * {@link meshUnits}. Absent ⇒ use `meshUnits` (or the bbox heuristic).
+   */
+  meshScale?: number
+
   // --- Editor display state (persisted) ------------------------------------
   /**
    * Which layers are shown when the part is drawn (Part Editor, Parts Library

--- a/test/partYaml.test.ts
+++ b/test/partYaml.test.ts
@@ -64,6 +64,8 @@ const RICH: PartDefinition = normalisePart({
   ledLabel: 'LED',
   image: 'image.png',
   imageLayer: { x: 0.1, y: 0.1, w: 0.8, h: 0.8, opacity: 0.9 },
+  mesh: 'model.stl',
+  meshUnits: 'mm',
   schematic: { aspect: 1, pins: [{ pin: 'SDA', side: 'left', order: 0 }] }
 })
 
@@ -86,6 +88,21 @@ describe('partToYaml / partFromYaml round-trip', () => {
     expect(yaml).not.toContain('base64')
     // The relative filename IS kept.
     expect(yaml).toContain('image: image.png')
+  })
+
+  it('round-trips the linked mesh filename + declared units/scale (#406)', () => {
+    // meshUnits (in RICH) round-trips as part of the rich part above; check meshScale
+    // + a bare mesh here.
+    const withScale = normalisePart({ id: 'm', name: 'M', headers: [], mesh: 'model.stl', meshScale: 0.01 })
+    const yaml = partToYaml(withScale)
+    expect(yaml).toContain('mesh: model.stl')
+    expect(yaml).toContain('meshScale: 0.01')
+    const back = normalisePart(partFromYaml(yaml))
+    expect(back.mesh).toBe('model.stl')
+    expect(back.meshScale).toBe(0.01)
+    expect(back.meshUnits).toBeUndefined()
+    // An unknown meshUnits value is dropped (tolerant parse).
+    expect(normalisePart(partFromYaml('id: m\nname: M\nmesh: x.stl\nmeshUnits: furlongs\n')).meshUnits).toBeUndefined()
   })
 
   it('never serialises the inlined helpText; keeps the help filename', () => {

--- a/test/robotAssembly.test.ts
+++ b/test/robotAssembly.test.ts
@@ -13,6 +13,7 @@ import {
   connectJoint,
   orientJoint,
   buildChainTree,
+  meshImportScale,
   setLinkColor,
   readLinkColor,
   collectLinkColors,
@@ -501,5 +502,21 @@ describe('external meshes — copy-into-project helpers (#407)', () => {
     const out = rewriteMeshFilename(dup, '../m/x.stl', 'meshes/x.stl')
     expect((out.match(/meshes\/x\.stl/g) || []).length).toBe(2)
     expect(out).not.toContain('../m/x.stl')
+  })
+})
+
+describe('meshImportScale — declared units vs bbox heuristic (#406)', () => {
+  it('an explicit meshScale wins over everything', () => {
+    expect(meshImportScale({ meshScale: 0.05, meshUnits: 'mm' }, 100)).toBe(0.05)
+    expect(meshImportScale({ meshScale: 0 }, 100)).toBe(0.001) // 0 is ignored → bbox
+  })
+  it('declared units map mm→0.001, m→1', () => {
+    expect(meshImportScale({ meshUnits: 'mm' })).toBe(0.001)
+    expect(meshImportScale({ meshUnits: 'm' }, 100)).toBe(1) // declared m beats the bbox
+  })
+  it('falls back to the bbox heuristic (>3 URDF-metres ⇒ authored in mm)', () => {
+    expect(meshImportScale({}, 40)).toBe(0.001)
+    expect(meshImportScale({}, 0.5)).toBe(1)
+    expect(meshImportScale({})).toBe(1) // nothing known ⇒ leave at 1
   })
 })

--- a/test/robotPartMesh.test.ts
+++ b/test/robotPartMesh.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { safeUrdfName } from '../src/renderer/src/components/robot-part-mesh'
+
+describe('safeUrdfName — the part-drop URDF write guard (#406)', () => {
+  it('accepts a bare in-project relative URDF name', () => {
+    expect(safeUrdfName('robot.urdf')).toBe(true)
+    expect(safeUrdfName('robot-2.urdf')).toBe(true)
+    expect(safeUrdfName('robots/arm.urdf')).toBe(true) // a subfolder is still in-project
+  })
+  it('rejects an escaping / absolute robot.yml urdf: so a drop can’t write outside the project', () => {
+    expect(safeUrdfName('../../evil.urdf')).toBe(false)
+    expect(safeUrdfName('a/../../evil.urdf')).toBe(false)
+    expect(safeUrdfName('/etc/evil.urdf')).toBe(false)
+    expect(safeUrdfName('C:\\evil.urdf')).toBe(false)
+    expect(safeUrdfName('..')).toBe(false)
+    expect(safeUrdfName('')).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #406.

## What
A Parts Library part can now carry a **3-D mesh (STL)** — a relative `mesh:` filename in its folder, with `meshUnits: mm`/`m` or a `meshScale` — the way it already carries an image, driver and help doc. When you drag a mesh-linked part onto a design:

- its part is appended to `robot.yml` **exactly as before**, **and**
- its STL is copied into the project URDF's `meshes/` folder and dropped into the 3-D **Robot View** as a **loose link**, staggered beside the base, ready to place + join — no manual STL import.
- If the project has no URDF yet, a blank one is created and linked (`robot.urdf`), preserving any existing URDF + wiring.
- A part **without** a mesh drops exactly as before (no URDF touched).

The bundled **SG90 servo** ships a `model.stl` (`meshUnits: mm`) as the first mesh-linked part.

## How
- **Schema/YAML** — `PartDefinition.mesh`/`meshUnits`/`meshScale`, round-tripping through `part-yaml` (filename only, never a blob) and surviving `normalisePart`'s field-by-field rebuild.
- **Main** — `resolvePartAsset` (path-traversal guarded) + `robot:importPartMesh` (copies via the existing collision-safe `copyIntoMeshes`, returns an STL bbox `maxDim` for the mm→m fallback; `stlMaxDim` parses **binary + ASCII** STL).
- **Drop bridge** — shared `attachPartMesh` + both `addToProject` impls (`board-main.tsx`, `BoardPane.tsx`). Scale = `meshImportScale` (explicit `meshScale` > `meshUnits` > bbox heuristic).

## Verification
- `typecheck`, `lint` (only the pre-existing DriverInstallBanner warning), **1581 tests**, `build` — all green.
- New unit tests: `part-yaml` mesh round-trip, `meshImportScale`, and the `safeUrdfName` write-guard. `stlMaxDim` verified against the real `servo.stl` (→ 32 mm).
- **Adversarial multi-agent review** (ultracode) against ACs + security + races; **all 6 findings fixed** in this branch:
  - **MEDIUM** symlink-exfiltration → the `importPartMesh` handler now `lstat`-rejects a symlinked mesh (`copyFile` would dereference it).
  - **MEDIUM** stale-closure race → the part+link now saves **synchronously**, then the mesh is written (no lost part on rapid/cross-window drops).
  - **MEDIUM** refresh semantics → the misleading "re-resolves live" comment is corrected; the mesh appears when the URDF is next loaded (e.g. switching to Robot mode).
  - **LOW** unsanitised `robot.yml` `urdf:` → `safeUrdfName` refuses an absolute/`..`-escaping name.
  - **LOW** unsynchronised `.urdf` read-modify-write → serialised so rapid drops can't clobber a link.
  - **LOW** ASCII-STL regex dropped negative exponents → fixed.

### Known limitation
A Robot View already open on the target `.urdf` won't refresh live (no workspace file-watcher) — it reads the mesh on next open/resolve. Live cross-window buffer sync is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)