### PR TITLE
feat: clearer snap-target UX when joining parts in the Robot View (#411)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Add Joint tool stays, now purely for geometry (where parts meet + orientation).
 
 ### Changed
+- **Robot View — clearer snap targets when joining parts (#399).** Adding a joint now draws
+  each snap candidate with a **role-distinct glyph** (corner = square, edge = diamond, centre =
+  dot, hole = ring) instead of identical dots, emphasises the one you're about to land on, and
+  shows a live **"snap ✓ hole centre / corner / edge …"** tooltip at the cursor *before* you
+  click. The hit tolerance is now a single set of tuned constants shared by hover and click, so
+  what lights up under the cursor is exactly what a click lands on — and holes still magnetise
+  within a generous radius so they're easy to hit.
 - **Robot View — the Build (Chain) dock is a little wider (#399).** Bumped from `15.5rem`
   to `17.5rem` (capped `min(18rem, 42vw)`) so long STL-derived link names like
   `left_shoulder_bracket_v3` read in full in the Chain tree instead of being cut off by the

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -65,6 +65,9 @@ import {
   faceSnapPoints,
   movedJointOrigin,
   resizeFromDrag,
+  SNAP_PX,
+  catchPx,
+  snapRoleLabel,
   type BuildTool,
   type FaceEdit,
   type PrimitiveKind,
@@ -2369,6 +2372,18 @@ export function RobotView({
           const snapGroup = new THREE.Group()
           scene.add(snapGroup)
           const discGeo = new THREE.CircleGeometry(1, 28) // unit disc in XY, +Z normal
+          // Role-distinct glyph geometries (#411), all unit-sized in the XY plane so
+          // they orient to the face normal + scale by `r` like the disc: a square for a
+          // corner, a diamond (square baked at 45°) for an edge, a ring for a hole.
+          const squareGeo = new THREE.PlaneGeometry(1.6, 1.6)
+          const diamondGeo = new THREE.PlaneGeometry(1.6, 1.6)
+          diamondGeo.rotateZ(Math.PI / 4)
+          const ringPts: THREE.Vector3[] = []
+          for (let a = 0; a < 32; a++) {
+            const t = (a / 32) * Math.PI * 2
+            ringPts.push(new THREE.Vector3(Math.cos(t), Math.sin(t), 0))
+          }
+          const ringGeo = new THREE.BufferGeometry().setFromPoints(ringPts)
           const handleMat = new THREE.MeshBasicMaterial({
             color: 0xbfe0ff,
             transparent: true,
@@ -2385,24 +2400,62 @@ export function RobotView({
             depthTest: false,
             depthWrite: false
           })
+          const ringMat = new THREE.LineBasicMaterial({
+            color: 0xbfe0ff,
+            transparent: true,
+            opacity: 0.6,
+            depthTest: false,
+            depthWrite: false
+          })
+          const ringMatOn = new THREE.LineBasicMaterial({
+            color: 0xffffff,
+            transparent: true,
+            opacity: 0.95,
+            depthTest: false,
+            depthWrite: false
+          })
+          // Build the glyph for a snap role (#411). Meshes for filled glyphs, a line
+          // loop for the hole ring; the caller positions/orients/scales it.
+          const glyphFor = (role: string, active: boolean): THREE.Object3D => {
+            const fill = active ? handleMatOn : handleMat
+            switch (role) {
+              case 'hole':
+                return new THREE.LineLoop(ringGeo, active ? ringMatOn : ringMat)
+              case 'corner':
+                return new THREE.Mesh(squareGeo, fill)
+              case 'edge':
+                return new THREE.Mesh(diamondGeo, fill)
+              default: // 'centre' → small dot, 'outline'/fallback → disc
+                return new THREE.Mesh(discGeo, fill)
+            }
+          }
           const clearHandles = (): void => {
             snapGroup.clear()
           }
-          const showHandles = (pts: THREE.Vector3[], activeIdx: number, normal?: THREE.Vector3): void => {
+          const showHandles = (
+            pts: THREE.Vector3[],
+            roles: string[],
+            activeIdx: number,
+            normal?: THREE.Vector3
+          ): void => {
             snapGroup.clear()
             const r = halfView * 0.025
             const q = normal
               ? new THREE.Quaternion().setFromUnitVectors(zAxis, normal.clone().normalize())
               : null
             pts.forEach((p, i) => {
-              const s = new THREE.Mesh(discGeo, i === activeIdx ? handleMatOn : handleMat)
-              s.position.copy(p)
-              if (q) s.quaternion.copy(q) // lie flat on the face
-              else s.quaternion.copy(camera.quaternion) // billboard fallback
-              s.scale.setScalar(i === activeIdx ? r * 1.8 : r)
-              s.renderOrder = 998
-              s.raycast = () => {}
-              snapGroup.add(s)
+              const role = roles[i] ?? 'point'
+              const active = i === activeIdx
+              const g = glyphFor(role, active)
+              g.position.copy(p)
+              if (q) g.quaternion.copy(q) // lie flat on the face
+              else g.quaternion.copy(camera.quaternion) // billboard fallback
+              // A centre 'dot' is smaller so it doesn't read like the 'outline' disc.
+              const base = role === 'centre' ? r * 0.6 : r
+              g.scale.setScalar(active ? base * 1.8 : base)
+              g.renderOrder = 998
+              g.raycast = () => {}
+              snapGroup.add(g)
             })
           }
           const mmv = (m: number): number => Math.round(m * 1000)
@@ -2455,7 +2508,6 @@ export function RobotView({
           // the hole as you move to click it. Only role 'hole' is magnetised (NOT the
           // 'outline' = face centroid every mesh face has, which would swallow edge picks
           // on small faces). Falls back to the plain nearest.
-          const HOLE_CATCH_PX = 48
           const nearestSnap = (
             pts: THREE.Vector3[],
             roles: string[],
@@ -2476,7 +2528,7 @@ export function RobotView({
               if (d < best.distPx) best = { index: i, distPx: d }
               if (roles[i] === 'hole' && d < hole.distPx) hole = { index: i, distPx: d }
             })
-            return hole.index >= 0 && hole.distPx <= HOLE_CATCH_PX ? hole : best
+            return hole.index >= 0 && hole.distPx <= SNAP_PX.hole ? hole : best
           }
 
           // ── Resize (push/pull tool) ──
@@ -2872,8 +2924,7 @@ export function RobotView({
               const geom = readPrimitive(contentRef.current, link)
               const th = geom ? hitToHandles(hit, link, geom) : meshSnapCentres(hit)
               const near = nearestSnap(th.pts, th.roles, e)
-              const isHole = near.index >= 0 && th.roles[near.index] === 'hole'
-              if (near.index >= 0 && near.distPx < (isHole ? HOLE_CATCH_PX : geom ? 24 : 28)) {
+              if (near.index >= 0 && near.distPx < catchPx(th.roles[near.index], !geom)) {
                 world = th.pts[near.index].clone()
                 role = th.roles[near.index]
               }
@@ -2889,6 +2940,7 @@ export function RobotView({
             const linkNormal = worldNormal.clone().applyQuaternion(lq.invert()) // face normal, link-local
             setJointMarker(world, worldNormal, jr.step === 'child')
             clearHoverMarker()
+            setBuildDim(null) // the pick consumed the armed target — drop its "snap ✓" label (#411)
             // Drop the consumed snaps so the NEXT pick (e.g. the child after the
             // parent) can't reuse this surface's stale snap without a fresh hover —
             // absent a new hover it falls through to the raycast under the cursor.
@@ -2937,6 +2989,7 @@ export function RobotView({
             let snapWorld: THREE.Vector3 | null = null
             let snapRole: string | null = null
             let handles: THREE.Vector3[] = []
+            let handleRoles: string[] = []
             let handleNormal: THREE.Vector3 | undefined
             let activeIdx = -1
             const tHit = buildRay
@@ -2953,12 +3006,13 @@ export function RobotView({
               if (tGeom) {
                 const th = hitToHandles(tHit, tLink, tGeom)
                 handles = th.pts
+                handleRoles = th.roles
                 const near = nearestScreen(handles, e)
                 const gp = movedGrab.clone().project(camera)
                 const hp = near.index >= 0 ? handles[near.index].clone().project(camera) : gp
                 const rect = renderer.domElement.getBoundingClientRect()
                 const dpx = Math.hypot(((hp.x - gp.x) * rect.width) / 2, ((hp.y - gp.y) * rect.height) / 2)
-                if (near.index >= 0 && dpx < 16) {
+                if (near.index >= 0 && dpx < SNAP_PX.move) {
                   snapWorld = handles[near.index]
                   snapRole = th.roles[near.index]
                   activeIdx = near.index
@@ -2974,12 +3028,14 @@ export function RobotView({
             )
             move.newXyz.set(nx[0], nx[1], nx[2])
             move.jointObj.position.copy(move.newXyz)
-            showHandles(handles, activeIdx, handleNormal)
+            showHandles(handles, handleRoles, activeIdx, handleNormal)
             const rect = mount.getBoundingClientRect()
             setBuildDim({
               x: e.clientX - rect.left + 14,
               y: e.clientY - rect.top + 14,
-              text: snapRole ? `snap ✓ ${snapRole}` : `${mmv(nx[0])} · ${mmv(nx[1])} · ${mmv(nx[2])} mm`
+              text: snapRole
+                ? `snap ✓ ${snapRoleLabel(snapRole)}`
+                : `${mmv(nx[0])} · ${mmv(nx[1])} · ${mmv(nx[2])} mm`
             })
           }
 
@@ -3038,6 +3094,7 @@ export function RobotView({
               clearHandles()
               clearHoverMarker()
               hoverSnaps = null
+              setBuildDim(null)
               return
             }
             buildNdcFrom(e)
@@ -3054,23 +3111,37 @@ export function RobotView({
                 // stays put — and stays clickable — as you move onto it. SHIFT
                 // force-locks them regardless of distance (large holes).
                 const near = nearestScreen(hoverSnaps.pts, e)
-                if (!e.shiftKey && (near.index < 0 || near.distPx > 90)) hoverSnaps = null
+                if (!e.shiftKey && (near.index < 0 || near.distPx > SNAP_PX.keepAlive)) hoverSnaps = null
               } else {
                 hoverSnaps = null
               }
               if (!hoverSnaps || !hoverSnaps.pts.length) {
                 clearHandles()
                 clearHoverMarker()
+                setBuildDim(null)
                 return
               }
               const near = nearestSnap(hoverSnaps.pts, hoverSnaps.roles, e)
-              showHandles(hoverSnaps.pts, near.index, hoverSnaps.worldNormal)
+              showHandles(hoverSnaps.pts, hoverSnaps.roles, near.index, hoverSnaps.worldNormal)
               if (near.index >= 0) {
-                setHoverMarker(hoverSnaps.pts[near.index], hoverSnaps.worldNormal, hoverSnaps.roles[near.index])
-              } else clearHoverMarker()
+                const role = hoverSnaps.roles[near.index]
+                setHoverMarker(hoverSnaps.pts[near.index], hoverSnaps.worldNormal, role)
+                // Name the armed target BEFORE the click (WYSIWYG) — same cursor
+                // tooltip the Move tool uses for its snap (#411).
+                const rect = mount.getBoundingClientRect()
+                setBuildDim({
+                  x: e.clientX - rect.left + 14,
+                  y: e.clientY - rect.top + 14,
+                  text: `snap ✓ ${snapRoleLabel(role)}`
+                })
+              } else {
+                clearHoverMarker()
+                setBuildDim(null)
+              }
               return
             }
 
+            setBuildDim(null) // move-tool hover shows no snap-role label
             // Move tool: primitive face handles only.
             const hit = buildRay.intersectObject(robotRef.current, true).find((h) => h.face)
             const link = hit ? ownerLinkName(hit.object) : null
@@ -3085,7 +3156,7 @@ export function RobotView({
               .clone()
               .transformDirection((hit.object as THREE.Mesh).matrixWorld)
               .normalize()
-            showHandles(th.pts, near.distPx < 16 ? near.index : -1, nW)
+            showHandles(th.pts, th.roles, near.distPx < SNAP_PX.move ? near.index : -1, nW)
           }
 
           // A cancelled/interrupted drag must never strand OrbitControls disabled
@@ -3110,6 +3181,7 @@ export function RobotView({
           const onHoverLeave = (): void => {
             clearHandles()
             clearHoverMarker()
+            setBuildDim(null) // don't strand an armed "snap ✓ …" label off-canvas (#411)
           }
           renderer.domElement.addEventListener('pointermove', onBuildHover)
           renderer.domElement.addEventListener('pointerup', onBuildUp)
@@ -3133,8 +3205,13 @@ export function RobotView({
             clearJointMarkers() // disposes the pick + hover markers
             scene.remove(snapGroup)
             discGeo.dispose()
+            squareGeo.dispose()
+            diamondGeo.dispose()
+            ringGeo.dispose()
             handleMat.dispose()
             handleMatOn.dispose()
+            ringMat.dispose()
+            ringMatOn.dispose()
             markerMat.dispose()
             lineMat.dispose()
             jointMatParent.dispose()

--- a/src/renderer/src/components/robot-build.ts
+++ b/src/renderer/src/components/robot-build.ts
@@ -85,6 +85,41 @@ export interface SnapPoint {
 }
 
 /**
+ * Snap hit tolerances in screen px, in ONE place (#411) so hover-highlight and
+ * click agree (WYSIWYG). `hole` is the generous magnetise radius; `primitive`/`mesh`
+ * gate the click fallback by geometry kind; `keepAlive` holds the last surface's snaps
+ * while a candidate is still near the cursor (e.g. moving onto a hole); `move` is the
+ * Move-tool snap-to-neighbour radius.
+ */
+export const SNAP_PX = { hole: 48, primitive: 24, mesh: 28, keepAlive: 90, move: 16 } as const
+
+/** The catch radius (px) for a snap candidate: a hole always uses the generous
+ *  `SNAP_PX.hole`; otherwise it depends on whether the surface is a mesh or a
+ *  primitive face. Keeps hover + click thresholds identical (#411). */
+export function catchPx(role: string, isMesh: boolean): number {
+  if (role === 'hole') return SNAP_PX.hole
+  return isMesh ? SNAP_PX.mesh : SNAP_PX.primitive
+}
+
+/** A short human label for a snap role, for the live "snap ✓ …" cursor tooltip (#411). */
+export function snapRoleLabel(role: string): string {
+  switch (role) {
+    case 'hole':
+      return 'hole centre'
+    case 'outline':
+      return 'face centre'
+    case 'centre':
+      return 'centre'
+    case 'corner':
+      return 'corner'
+    case 'edge':
+      return 'edge'
+    default:
+      return 'point'
+  }
+}
+
+/**
  * The snap handles of a picked face, in the LINK frame (metres): a box face gives
  * 4 corners + 4 edge-mids + centre; a cylinder cap gives a rim circle + centre;
  * anything else gives just the primitive centre. Reaches world via

--- a/test/robotSnap.test.ts
+++ b/test/robotSnap.test.ts
@@ -6,6 +6,9 @@ import {
   worldDeltaToParent,
   movedJointOrigin,
   jointOriginForCoincident,
+  SNAP_PX,
+  catchPx,
+  snapRoleLabel,
   type Vec3
 } from '../src/renderer/src/components/robot-build'
 import { addPrimitive, readJoint, blankUrdf } from '../src/renderer/src/components/robot-assembly'
@@ -80,5 +83,23 @@ describe('readJoint (#335)', () => {
     expect(j.xyz).toEqual([0.06, 0, 0])
     expect(readJoint(u, 'base_link')).toBeNull() // root has no parent joint → move refused
     expect(readJoint(u, 'ghost')).toBeNull()
+  })
+})
+
+describe('snap tolerance + role labels (#411)', () => {
+  it('catchPx magnetises a hole regardless of surface, else keys off mesh vs primitive', () => {
+    expect(catchPx('hole', true)).toBe(SNAP_PX.hole)
+    expect(catchPx('hole', false)).toBe(SNAP_PX.hole)
+    expect(catchPx('edge', true)).toBe(SNAP_PX.mesh) // mesh face
+    expect(catchPx('corner', false)).toBe(SNAP_PX.primitive) // primitive face
+    expect(catchPx('outline', true)).toBe(SNAP_PX.mesh)
+  })
+  it('snapRoleLabel names every role for the live tooltip; unknown → point', () => {
+    expect(snapRoleLabel('hole')).toBe('hole centre')
+    expect(snapRoleLabel('outline')).toBe('face centre')
+    expect(snapRoleLabel('corner')).toBe('corner')
+    expect(snapRoleLabel('edge')).toBe('edge')
+    expect(snapRoleLabel('centre')).toBe('centre')
+    expect(snapRoleLabel('weird')).toBe('point')
   })
 })


### PR DESCRIPTION
Closes #411.

## What
Picking parent/child points for a joint used to draw every snap candidate as the same faint disc, gate the hit with scattered magic numbers, and only reveal the target's role (corner/edge/hole) in the dialog *after* the click. Now the Join tool's snapping is legible and predictable:

- **Role-distinct glyphs** — corner = square, edge = diamond, centre = dot, hole = ring — instead of identical discs; the armed (nearest) candidate is emphasised (1.8× + brighter).
- **Live role tooltip** — a **`snap ✓ hole centre / corner / edge …`** label at the cursor *before* you click (the same `setBuildDim` treatment the Move tool uses; both now share `snapRoleLabel`).
- **One tolerance source of truth** — `SNAP_PX { hole, primitive, mesh, keepAlive, move }` + `catchPx(role, isMesh)` in `robot-build.ts`, replacing the scattered `48/24/28/90/16`, so **what highlights on hover is exactly what a click lands on** (WYSIWYG).
- The **hole magnetise bias** + SHIFT-lock onto an empty hole centre are preserved.

## How
- `robot-build.ts` (pure, unit-tested): `SNAP_PX`, `catchPx`, `snapRoleLabel`.
- `RobotView.tsx`: `glyphFor(role, active)` (Mesh fills / LineLoop ring) + a `showHandles(pts, roles, activeIdx, normal)` that scales the centre dot smaller; `nearestSnap`/`pickJointPoint`/keep-alive/Move all routed through the constants; the Join hover branch sets/clears the `snap ✓` tooltip; new geos/materials disposed at teardown.

## Verification
- `typecheck`, `lint` (only the pre-existing DriverInstallBanner warning), **1583 tests**, `build` — all green; `robotSnap.test.ts` still passes with 2 new cases (`catchPx`, `snapRoleLabel`).
- Headless three.js smoke confirmed each role builds a valid glyph (diamond genuinely rotated vs square; hole = LineLoop).
- Adversarial multi-agent review (ultracode) against ACs + regressions; **both findings fixed** — the `snap ✓` label is now cleared on `pointerleave` and after a pick (it was only cleared by a subsequent canvas `pointermove`).

Both dark + skeuomorph themes reuse the pre-existing handle palette (no new dark-only colours).

🤖 Generated with [Claude Code](https://claude.com/claude-code)