### PR TITLE
feat: ease smoothly between poses everywhere, not just the docked viewer (#399)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Add Joint tool stays, now purely for geometry (where parts meet + orientation).
 
 ### Changed
+- **Robot View — poses ease smoothly everywhere (#399).** Selecting a saved pose now
+  **eases** the robot from its current position to the new one (≈0.4 s) instead of snapping —
+  not just in the docked mini viewer but also in the full pose tool's Poses list and the
+  pose dialog's **Recall**. Re-picking mid-transition re-targets smoothly.
 - **Robot View — clearer snap targets when joining parts (#399).** Adding a joint now draws
   each snap candidate with a **role-distinct glyph** (corner = square, edge = diamond, centre =
   dot, hole = ring) instead of identical dots, emphasises the one you're about to land on, and

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -270,24 +270,14 @@ export function RobotView({
     if (name) setDialogCtx({ kind: 'pose', name })
   }
 
-  const handleRecallPose = (pose: NamedPoseLike): void => {
-    const nv = { ...valuesRef.current }
-    for (const m of metaRef.current) {
-      if (!m.isMimic && typeof pose.values[m.name] === 'number') {
-        const lim = effectiveLimit(m, overridesRef.current[m.name])
-        nv[m.name] = clamp(toNative(m.type, pose.values[m.name]), lim.lower, lim.upper)
-      }
-    }
-    applyToRobot(nv)
-    setValues(nv)
-  }
-
-  // Smoothly EASE the docked model from its current joints to a saved pose (#409),
-  // rather than snapping. Self-contained rAF (the scene renders every frame anyway),
-  // used only by the compact preview dropdown; the full pose tool's Recall stays
-  // instant. Re-picking mid-tween re-targets smoothly from the live joint angles.
+  // Recall a pose by smoothly EASING the model from its current joints to the saved
+  // ones (#409/#409-follow-up), rather than snapping — used EVERYWHERE a pose is
+  // selected (the compact preview dropdown, the Poses list, and the pose dialog's
+  // Recall). Self-contained rAF (the scene renders every frame anyway); re-picking
+  // mid-tween re-targets smoothly from the live joint angles. `values` is settled at
+  // the end so the sidebar sliders land on the pose.
   const poseTweenRef = useRef<number | null>(null)
-  const smoothRecallPose = (pose: NamedPoseLike): void => {
+  const handleRecallPose = (pose: NamedPoseLike): void => {
     const r = robotRef.current
     if (!r) return
     const target = { ...valuesRef.current }
@@ -3417,7 +3407,7 @@ export function RobotView({
             value=""
             onChange={(e) => {
               const p = dockPoses.find((x) => x.name === e.target.value)
-              if (p) smoothRecallPose(p)
+              if (p) handleRecallPose(p)
             }}
             title="Preview a saved pose"
             aria-label="Preview a saved pose"


### PR DESCRIPTION
Follow-up to #409 (part of #399), in response to a request: *"when selecting different poses, can we make it smoothly change between them rather than just appear."*

## What
Selecting a saved pose now **eases** the robot from its current joints to the saved ones (~0.4 s, easeInOutCubic) in the **full pose tool** too — the Poses list and the pose dialog's **Recall** — not just the docked mini viewer where it already did (#409).

## How
Unified the two recall paths: the smooth tween **is** `handleRecallPose` now (the old instant version is removed), used by all three recall sites (mini dropdown, `handleOpenPose`, dialog `onRecallPose`). Re-picking mid-transition re-targets from the live joint angles; `values` settles at the end so the sidebar sliders land on the pose.

## Verification
- `typecheck`, `lint` (only the pre-existing DriverInstallBanner warning), **1583 tests**, `build` — all green.
- Reuses the already-adversarially-reviewed #409 tween; the change is a rename + repoint of three call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)