### PR TITLE
feat: grab-and-move IK drag in the Robot View (#410)

### DIFF
--- a/src/renderer/src/components/RobotToolbar.tsx
+++ b/src/renderer/src/components/RobotToolbar.tsx
@@ -11,6 +11,9 @@ export interface RobotToolbarProps {
   onSetTool: (t: BuildTool) => void
   /** Editing needs a saved project file — tools disable without one. */
   canEdit: boolean
+  /** Posing (the Grab/IK tool) only needs a loaded robot with movable joints —
+   *  NOT a saved file — so it gates separately from the editing tools. */
+  canPose: boolean
   /** Add a primitive at the workspace origin. */
   onAdd: (kind: PrimitiveKind) => void
   /** Point-to-point measure tool (toggle). */
@@ -65,13 +68,23 @@ const ICONS: Record<BuildTool, JSX.Element> = {
       <circle cx="12" cy="8" r="2.2" fill="currentColor" />
       <path d="M6 8h4" stroke="currentColor" strokeWidth="1.4" />
     </svg>
+  ),
+  // A little jointed arm with a grabbable end — grab it and the chain follows.
+  ik: (
+    <svg viewBox="0 0 16 16" width="15" height="15" aria-hidden="true">
+      <path d="M3 13L7 8l4-4" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+      <circle cx="3" cy="13" r="1.5" fill="currentColor" />
+      <circle cx="7" cy="8" r="1.3" fill="currentColor" />
+      <circle cx="11.5" cy="4" r="2" fill="none" stroke="currentColor" strokeWidth="1.3" />
+    </svg>
   )
 }
 
-const TOOLS: Array<{ id: BuildTool; label: string; soon?: boolean }> = [
+const TOOLS: Array<{ id: BuildTool; label: string; soon?: boolean; pose?: boolean }> = [
   { id: 'select', label: 'Pick a block' },
   { id: 'pushpull', label: 'Push & pull to resize' },
-  { id: 'move', label: 'Move a block' }
+  { id: 'move', label: 'Move a block' },
+  { id: 'ik', label: 'Grab & pose — drag a part and the chain follows', pose: true }
 ]
 
 const UNDO_ICON = (
@@ -89,6 +102,7 @@ export function RobotToolbar({
   tool,
   onSetTool,
   canEdit,
+  canPose,
   onAdd,
   measureActive,
   onToggleMeasure,
@@ -115,7 +129,13 @@ export function RobotToolbar({
       ))}
       <span className="robottool__sep" aria-hidden="true" />
       {TOOLS.map((t) => {
-        const disabled = t.soon || !canEdit
+        const gated = t.pose ? !canPose : !canEdit
+        const disabled = t.soon || gated
+        const title = gated && !t.soon
+          ? t.pose
+            ? 'Add movable joints to pose the robot'
+            : 'Save the robot to a folder first'
+          : t.label
         return (
           <button
             key={t.id}
@@ -123,7 +143,7 @@ export function RobotToolbar({
             className={`robottool__btn${tool === t.id ? ' is-active' : ''}`}
             aria-pressed={tool === t.id}
             disabled={disabled}
-            title={!canEdit && !t.soon ? 'Save the robot to a folder first' : t.label}
+            title={title}
             aria-label={t.label}
             onClick={() => onSetTool(t.id)}
           >

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -3639,7 +3639,9 @@ export function RobotView({
             tool={buildTool}
             onSetTool={onSetTool}
             canEdit={canEdit}
-            canPose={movableNames.length > 0}
+            canPose={jointMeta.some(
+              (m) => !m.isMimic && (m.type === 'revolute' || m.type === 'continuous')
+            )}
             onAdd={handleAddPrimitive}
             measureActive={measureActive}
             onToggleMeasure={() => setMeasureActive((a) => !a)}

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -19,6 +19,7 @@ import {
   toDisplay,
   toNative
 } from './robot-pose'
+import { solveCCD, type IkJoint } from './robot-ik'
 import {
   addMeshLink,
   addPrimitive,
@@ -2621,6 +2622,108 @@ export function RobotView({
             ;(e.target as HTMLElement).setPointerCapture?.(e.pointerId)
           }
 
+          // ── Grab / IK tool (#410): grab a link + drag; the movable-joint chain from
+          // the base to it re-poses (CCD) so the grabbed point follows the cursor. ──
+          type Grab = {
+            link: string // the grabbed (end-effector) link
+            localOffset: THREE.Vector3 // grabbed point in that link's LOCAL frame
+            plane: THREE.Plane // camera-facing drag plane
+            joints: string[] // participating movable joints, NEAREST-to-effector first
+          }
+          let grab: Grab | null = null
+          // The non-mimic revolute/continuous joints on the chain from `endLink` up to
+          // the root, nearest-to-effector first — the joints IK is allowed to turn.
+          const ikChainJoints = (endLink: string): string[] => {
+            const byChild = new Map(readAllJoints(contentRef.current).map((j) => [j.child, j]))
+            const out: string[] = []
+            const seen = new Set<string>()
+            let cur: string | undefined = endLink
+            while (cur && !seen.has(cur)) {
+              seen.add(cur)
+              const j = byChild.get(cur) // the joint whose child is `cur` (its parent joint)
+              if (!j) break // reached a root (no parent joint)
+              const m = metaRef.current.find((x) => x.name === j.name)
+              if (m && !m.isMimic && (m.type === 'revolute' || m.type === 'continuous')) out.push(j.name)
+              cur = j.parent
+            }
+            return out
+          }
+          const startGrab = (e: PointerEvent): void => {
+            const robot = robotRef.current
+            if (!robot) return
+            buildNdcFrom(e)
+            buildRay.setFromCamera(buildNdc, camera)
+            const hit = buildRay.intersectObject(robot, true).find((h) => h.face)
+            if (!hit || !hit.face) return
+            const link = ownerLinkName(hit.object)
+            if (!link || !robot.links[link]) return
+            const joints = ikChainJoints(link)
+            if (!joints.length) return // the base, or no movable ancestor joint → no-op
+            setSelectedLink(link)
+            robot.updateMatrixWorld(true)
+            camera.getWorldDirection(camDir)
+            grab = {
+              link,
+              localOffset: robot.links[link].worldToLocal(hit.point.clone()),
+              plane: new THREE.Plane().setFromNormalAndCoplanarPoint(camDir, hit.point),
+              joints
+            }
+            controls.enabled = false
+            ;(e.target as HTMLElement).setPointerCapture?.(e.pointerId)
+          }
+          // Solve one drag frame: move the grabbed point toward the cursor's plane target.
+          const dragGrab = (e: PointerEvent): void => {
+            const robot = robotRef.current
+            if (!grab || !robot) return
+            buildNdcFrom(e)
+            buildRay.setFromCamera(buildNdc, camera)
+            const target = new THREE.Vector3()
+            if (!buildRay.ray.intersectPlane(grab.plane, target)) return
+            robot.updateMatrixWorld(true)
+            const eff = robot.links[grab.link].localToWorld(grab.localOffset.clone())
+            const p = new THREE.Vector3()
+            const ax = new THREE.Vector3()
+            const ikJoints: IkJoint[] = grab.joints.map((name) => {
+              const j = robot.joints[name]
+              j.getWorldPosition(p)
+              ax.copy(j.axis).transformDirection(j.matrixWorld).normalize()
+              const m = metaRef.current.find((x) => x.name === name)
+              const lim = m
+                ? effectiveLimit(m, overridesRef.current[name])
+                : { lower: -Math.PI, upper: Math.PI }
+              return {
+                pivot: [p.x, p.y, p.z],
+                axis: [ax.x, ax.y, ax.z],
+                angle: j.angle,
+                lower: lim.lower,
+                upper: lim.upper
+              }
+            })
+            const solved = solveCCD(ikJoints, [eff.x, eff.y, eff.z], [target.x, target.y, target.z], {
+              iterations: 6
+            })
+            grab.joints.forEach((name, i) => robot.setJointValue(name, solved[i]))
+            robot.updateMatrixWorld(true)
+          }
+          // Push the grabbed chain's final joint angles into React `values` so the pose
+          // sliders reflect the new pose and it's savable via Save Pose. No URDF write.
+          const finishGrab = (): void => {
+            const robot = robotRef.current
+            if (!grab) return
+            const joints = grab.joints
+            grab = null
+            controls.enabled = true
+            if (!robot) return
+            setValues((v) => {
+              const next = { ...v }
+              for (const name of joints) {
+                const a = robot.joints[name]?.angle
+                if (typeof a === 'number') next[name] = a
+              }
+              return next
+            })
+          }
+
           // ── Join tool (#354): click a point on two blocks to connect them ──
           // Markers are a CIRCLE laid flat on the picked face + an X/Y/Z axis triad
           // (Z = the face normal) so the pick reads accurately in 3-D from any angle.
@@ -2966,12 +3069,23 @@ export function RobotView({
             bDownX = e.clientX
             bDownY = e.clientY
             if (jointPickRef.current.active) return // pick mode owns clicks (no move/resize)
-            if (!buildActive() || !canEditRef.current || !robotRef.current) return
+            if (!buildActive() || !robotRef.current) return
+            // The Grab/IK tool only POSES (live joint values), so it needs a loaded robot
+            // but NOT a saved project file — unlike the geometry-editing tools below.
+            if (buildToolRef.current === 'ik') {
+              startGrab(e)
+              return
+            }
+            if (!canEditRef.current) return
             if (buildToolRef.current === 'pushpull') startResize(e)
             else if (buildToolRef.current === 'move') startMove(e)
           }
 
           const onBuildMove = (e: PointerEvent): void => {
+            if (grab) {
+              dragGrab(e)
+              return
+            }
             if (drag) {
               buildNdcFrom(e)
               buildRay.setFromCamera(buildNdc, camera)
@@ -3057,6 +3171,10 @@ export function RobotView({
               }
               return
             }
+            if (grab) {
+              finishGrab() // write the posed joint angles into `values`; restore controls
+              return
+            }
             if (drag) {
               const d = drag
               drag = null
@@ -3096,7 +3214,7 @@ export function RobotView({
           // (circle + axis, cross-hair over holes), and holding SHIFT LOCKS the snaps
           // so you can slide onto a hole centre (empty space) and click it.
           const onBuildHover = (e: PointerEvent): void => {
-            if (drag || move) return
+            if (drag || move || grab) return
             const jointActive = jointPickRef.current.active
             const wantHandles = buildToolRef.current === 'move' || jointActive
             if (!buildActive() || !wantHandles || !robotRef.current) {
@@ -3197,6 +3315,7 @@ export function RobotView({
             controls.enabled = true
             setBuildDim(null)
             clearHandles()
+            if (grab) finishGrab() // keep the live pose; sync it into `values` + restore controls
             if (drag) {
               applyPreview(drag.kind, drag.mesh, drag.group, drag.dims0, drag.origin0)
               drag = null
@@ -3520,6 +3639,7 @@ export function RobotView({
             tool={buildTool}
             onSetTool={onSetTool}
             canEdit={canEdit}
+            canPose={movableNames.length > 0}
             onAdd={handleAddPrimitive}
             measureActive={measureActive}
             onToggleMeasure={() => setMeasureActive((a) => !a)}

--- a/src/renderer/src/components/robot-build.ts
+++ b/src/renderer/src/components/robot-build.ts
@@ -9,7 +9,7 @@ export type PrimitiveKind = 'box' | 'cylinder' | 'sphere'
 export type Vec3 = [number, number, number]
 
 /** The active builder tool (#335). */
-export type BuildTool = 'select' | 'pushpull' | 'move' | 'joint'
+export type BuildTool = 'select' | 'pushpull' | 'move' | 'joint' | 'ik'
 
 /** Which dimension a picked face resizes, and how. */
 export interface FaceEdit {

--- a/src/renderer/src/components/robot-ik.ts
+++ b/src/renderer/src/components/robot-ik.ts
@@ -1,0 +1,95 @@
+/**
+ * INVERSE KINEMATICS — Cyclic Coordinate Descent (#410). Pure three.js math (no
+ * scene/DOM) so it's cheap to unit-test. The Robot View's Grab tool snapshots the
+ * live world pivot + axis of each movable joint on the base→grabbed-link chain and
+ * calls `solveCCD` every pointer-move to re-pose the chain so the grabbed point
+ * follows the cursor. CCD is angle-native: it works directly with each joint's
+ * arbitrary 3-D axis and its `[lower, upper]` limits, which map 1:1 onto URDF
+ * revolute/continuous joints and their `effectiveLimit`.
+ */
+import * as THREE from 'three'
+import type { Vec3 } from './robot-build'
+
+/** One participating joint, in WORLD space at the moment of the solve. */
+export interface IkJoint {
+  /** World position of the joint's rotation centre. */
+  pivot: Vec3
+  /** World rotation axis (need not be pre-normalised). */
+  axis: Vec3
+  /** The joint's current angle (native radians). */
+  angle: number
+  /** Native lower/upper limit (radians). */
+  lower: number
+  upper: number
+}
+
+export interface CcdOptions {
+  /** Max full sweeps over the chain per call (a small fixed budget for live drag). */
+  iterations?: number
+  /** Stop early once the effector is within this many metres of the target. */
+  tolerance?: number
+}
+
+function rotatePointAbout(p: THREE.Vector3, pivot: THREE.Vector3, q: THREE.Quaternion): void {
+  p.sub(pivot).applyQuaternion(q).add(pivot)
+}
+
+/**
+ * Solve the chain so `effector` reaches `target`, returning each joint's new angle
+ * (native radians, same order as `joints`). `joints` are ordered NEAREST-to-effector
+ * first (CCD sweeps from the tip toward the base). Angles are clamped to each joint's
+ * `[lower, upper]`, so an unreachable target yields the best limited reach. The inputs
+ * are a world-space snapshot; the caller re-snapshots + re-solves each frame, so the
+ * fixed-pivot approximation within a call is corrected as the drag proceeds.
+ */
+export function solveCCD(
+  joints: IkJoint[],
+  effector: Vec3,
+  target: Vec3,
+  opts: CcdOptions = {}
+): number[] {
+  const iterations = opts.iterations ?? 10
+  const tol = opts.tolerance ?? 1e-4
+
+  const eff = new THREE.Vector3(effector[0], effector[1], effector[2])
+  const tgt = new THREE.Vector3(target[0], target[1], target[2])
+  const pivots = joints.map((j) => new THREE.Vector3(j.pivot[0], j.pivot[1], j.pivot[2]))
+  const axes = joints.map((j) => new THREE.Vector3(j.axis[0], j.axis[1], j.axis[2]).normalize())
+  const angles = joints.map((j) => j.angle)
+
+  const q = new THREE.Quaternion()
+  const toEff = new THREE.Vector3()
+  const toTgt = new THREE.Vector3()
+
+  for (let it = 0; it < iterations; it++) {
+    if (eff.distanceTo(tgt) <= tol) break
+    for (let i = 0; i < joints.length; i++) {
+      const pivot = pivots[i]
+      const axis = axes[i]
+      if (axis.lengthSq() < 1e-12) continue
+      // In-plane (⟂ axis) directions from the pivot to the effector and the target.
+      toEff.copy(eff).sub(pivot).projectOnPlane(axis)
+      toTgt.copy(tgt).sub(pivot).projectOnPlane(axis)
+      if (toEff.lengthSq() < 1e-12 || toTgt.lengthSq() < 1e-12) continue
+      toEff.normalize()
+      toTgt.normalize()
+      // Signed angle about `axis` that rotates the effector toward the target.
+      const cos = THREE.MathUtils.clamp(toEff.dot(toTgt), -1, 1)
+      const sign = Math.sign(toEff.clone().cross(toTgt).dot(axis)) || 1
+      const delta = Math.acos(cos) * sign
+      const next = Math.min(joints[i].upper, Math.max(joints[i].lower, angles[i] + delta))
+      const applied = next - angles[i]
+      angles[i] = next
+      if (Math.abs(applied) < 1e-9) continue
+      // Rotate the effector + every joint CLOSER to it (already-processed, downstream)
+      // rigidly about this joint — their world pivots AND axes move with the link.
+      q.setFromAxisAngle(axis, applied)
+      rotatePointAbout(eff, pivot, q)
+      for (let k = 0; k < i; k++) {
+        rotatePointAbout(pivots[k], pivot, q)
+        axes[k].applyQuaternion(q)
+      }
+    }
+  }
+  return angles
+}

--- a/src/renderer/src/components/robot-ik.ts
+++ b/src/renderer/src/components/robot-ik.ts
@@ -55,7 +55,10 @@ export function solveCCD(
   const tgt = new THREE.Vector3(target[0], target[1], target[2])
   const pivots = joints.map((j) => new THREE.Vector3(j.pivot[0], j.pivot[1], j.pivot[2]))
   const axes = joints.map((j) => new THREE.Vector3(j.axis[0], j.axis[1], j.axis[2]).normalize())
-  const angles = joints.map((j) => j.angle)
+  // Start each joint at its CLAMPED current angle. A continuous joint driven past its
+  // ±range elsewhere (e.g. by unclamped live telemetry) must not snap on the first
+  // solve — clamping here keeps every applied delta a genuine incremental move.
+  const angles = joints.map((j) => Math.min(j.upper, Math.max(j.lower, j.angle)))
 
   const q = new THREE.Quaternion()
   const toEff = new THREE.Vector3()

--- a/test/robotIk.test.ts
+++ b/test/robotIk.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { solveCCD, type IkJoint } from '../src/renderer/src/components/robot-ik'
+
+// A 2-link planar arm in the XY plane, both joints rotating about +Z.
+// base joint A at origin → link1 (len 1) → elbow joint B at [1,0,0] → link2 (len 1)
+// → effector at [2,0,0]. CCD order is NEAREST-to-effector first, so joints = [B, A].
+const chain = (limit = Math.PI): IkJoint[] => [
+  { pivot: [1, 0, 0], axis: [0, 0, 1], angle: 0, lower: -limit, upper: limit }, // elbow (near)
+  { pivot: [0, 0, 0], axis: [0, 0, 1], angle: 0, lower: -limit, upper: limit } //  base (far)
+]
+const EFFECTOR: [number, number, number] = [2, 0, 0]
+
+// Planar forward kinematics for THIS chain: angles = [thetaB (elbow), thetaA (base)].
+function effOf(angles: number[]): { x: number; y: number } {
+  const b = angles[0]
+  const a = angles[1]
+  return {
+    x: Math.cos(a) + Math.cos(a + b),
+    y: Math.sin(a) + Math.sin(a + b)
+  }
+}
+
+describe('solveCCD — inverse kinematics (#410)', () => {
+  it('reaches a reachable target (effector lands on the target)', () => {
+    const target: [number, number, number] = [1, 1, 0] // |t| = √2 < reach 2
+    const angles = solveCCD(chain(), EFFECTOR, target, { iterations: 30 })
+    const e = effOf(angles)
+    expect(e.x).toBeCloseTo(1, 2)
+    expect(e.y).toBeCloseTo(1, 2)
+  })
+
+  it('reaches a second reachable target', () => {
+    const target: [number, number, number] = [0.4, -1.3, 0]
+    const angles = solveCCD(chain(), EFFECTOR, target, { iterations: 40 })
+    const e = effOf(angles)
+    expect(e.x).toBeCloseTo(0.4, 1)
+    expect(e.y).toBeCloseTo(-1.3, 1)
+  })
+
+  it('leaves a target it can already touch (target == effector) essentially unchanged', () => {
+    const angles = solveCCD(chain(), EFFECTOR, EFFECTOR, { iterations: 10 })
+    expect(Math.abs(angles[0])).toBeLessThan(1e-3)
+    expect(Math.abs(angles[1])).toBeLessThan(1e-3)
+  })
+
+  it('respects joint limits on an UNREACHABLE target (clamps, best limited reach)', () => {
+    const lim = 0.2 // radians — a very restricted arm
+    const target: [number, number, number] = [0, 5, 0] // far out of reach, straight up
+    const angles = solveCCD(chain(lim), EFFECTOR, target, { iterations: 40 })
+    // Every returned angle stays within its limit.
+    for (const a of angles) {
+      expect(a).toBeGreaterThanOrEqual(-lim - 1e-9)
+      expect(a).toBeLessThanOrEqual(lim + 1e-9)
+    }
+    // And it does NOT teleport to the target — the effector stays within the arm's reach.
+    const e = effOf(angles)
+    expect(Math.hypot(e.x, e.y)).toBeLessThanOrEqual(2 + 1e-6)
+    expect(e.y).toBeLessThan(5) // nowhere near the unreachable target
+  })
+
+  it('honours an asymmetric limit on the base joint', () => {
+    // Base joint capped at +0.3 rad; a target that wants a big positive base turn.
+    const joints: IkJoint[] = [
+      { pivot: [1, 0, 0], axis: [0, 0, 1], angle: 0, lower: -Math.PI, upper: Math.PI },
+      { pivot: [0, 0, 0], axis: [0, 0, 1], angle: 0, lower: -0.3, upper: 0.3 }
+    ]
+    const angles = solveCCD(joints, EFFECTOR, [0, 2, 0], { iterations: 40 })
+    expect(angles[1]).toBeLessThanOrEqual(0.3 + 1e-9)
+    expect(angles[1]).toBeGreaterThanOrEqual(-0.3 - 1e-9)
+  })
+})

--- a/test/robotIk.test.ts
+++ b/test/robotIk.test.ts
@@ -64,8 +64,22 @@ describe('solveCCD — inverse kinematics (#410)', () => {
       { pivot: [1, 0, 0], axis: [0, 0, 1], angle: 0, lower: -Math.PI, upper: Math.PI },
       { pivot: [0, 0, 0], axis: [0, 0, 1], angle: 0, lower: -0.3, upper: 0.3 }
     ]
+    // The target [0,2,0] is at the arm's max reach straight up, which needs the base
+    // to turn well past +0.3 — so the base joint must be DRIVEN INTO its cap (not just
+    // left within it: a no-op solver would fail this).
     const angles = solveCCD(joints, EFFECTOR, [0, 2, 0], { iterations: 40 })
-    expect(angles[1]).toBeLessThanOrEqual(0.3 + 1e-9)
-    expect(angles[1]).toBeGreaterThanOrEqual(-0.3 - 1e-9)
+    expect(angles[1]).toBeCloseTo(0.3, 4) // pinned at the cap
+  })
+
+  it('clamps a joint whose CURRENT angle starts OUTSIDE its limits (no first-frame snap past the cap)', () => {
+    // A continuous joint driven to 4 rad (past its ±π range) elsewhere; the solver must
+    // treat it as starting at the clamped π, never return a value beyond the limit.
+    const joints: IkJoint[] = [
+      { pivot: [1, 0, 0], axis: [0, 0, 1], angle: 4, lower: -Math.PI, upper: Math.PI },
+      { pivot: [0, 0, 0], axis: [0, 0, 1], angle: 0, lower: -Math.PI, upper: Math.PI }
+    ]
+    const angles = solveCCD(joints, EFFECTOR, [1, 1, 0], { iterations: 20 })
+    expect(angles[0]).toBeLessThanOrEqual(Math.PI + 1e-9)
+    expect(angles[0]).toBeGreaterThanOrEqual(-Math.PI - 1e-9)
   })
 })


### PR DESCRIPTION
Closes #410 (the last item in epic #399).

## What
A new **Grab** tool: grab any link in 3-D and drag it, and the movable-joint chain from the base to that link **re-poses so the grabbed point follows the cursor** — "shake its hand" posing instead of per-slider fiddling. It's a live pose only; nothing is written to the URDF (savable via the existing **Save Pose**).

## How
- **`robot-ik.ts`** — a pure, unit-tested **Cyclic Coordinate Descent** solver over the chain's revolute/continuous joints, each clamped to its limit, dragging the grabbed point to a screen-plane target. Incremental (rotates the effector + downstream pivots/axes per joint); the caller re-snapshots world pivots/axes each frame. Starting angles are clamped into range so an out-of-range joint can't snap.
- **`RobotToolbar`** — a Grab button (`BuildTool 'ik'`), gated on the presence of a movable **revolute/continuous** joint (posing needs a loaded robot, not a saved file).
- **`RobotView`** — `startGrab` (raycast the end-effector + walk the base→link chain for non-mimic revolute/continuous joints), `dragGrab` (snapshot world pivot/axis + native-radian limits, `solveCCD`, `setJointValue`), `finishGrab` (write final angles into `values` so the sliders reflect the pose; restore OrbitControls on up **and** cancel). Dispatched before the `canEdit` gate; **no URDF mutation, no undo checkpoint**. Prismatic joints left untouched (v1 scope).

## Verification
- `typecheck`, `lint` (only the pre-existing warning), **1589 tests**, `build` — all green.
- 6 solver tests: a 2-link planar chain reaches reachable targets (verified via independent FK), the capped joint is **pinned at its limit** on an unreachable target, and an out-of-range start angle is clamped.
- Adversarial multi-agent review (ultracode) against the CCD maths, view glue and gating; its 4 findings (out-of-range start snap; prismatic-only inert tool ×2; a limit test that a no-op solver would pass) are all fixed in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)