### PR TITLE
feat: link the in-app Help to docs.snakie.org (#418)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Add Joint tool stays, now purely for geometry (where parts meet + orientation).
 
 ### Changed
+- **In-app Help links to the full online docs (#418).** The Help panel now has a
+  **"Full documentation at docs.snakie.org"** link in its contents view and after every
+  article, so you can jump to the complete, searchable docs in your browser.
 - **Robot View — poses ease smoothly everywhere (#399).** Selecting a saved pose now
   **eases** the robot from its current position to the new one (≈0.4 s) instead of snapping —
   not just in the docked mini viewer but also in the full pose tool's Poses list and the

--- a/src/renderer/src/components/HelpPanel.css
+++ b/src/renderer/src/components/HelpPanel.css
@@ -318,3 +318,28 @@
 .help__example:hover {
   background: #f6efdb;
 }
+
+/* Link to the full online docs (docs.snakie.org): a footer in the contents view and
+   after each article. Green-tinted to match Snakie's brand + the parchment Help chrome. */
+.help__docs {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  margin: 0.55rem 0 0;
+  padding: 0.42rem 0.6rem;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-align: center;
+  color: #21493d;
+  background: linear-gradient(180deg, #d8ecdf, #b7d8c4);
+  border: 1px solid #7fae94;
+  border-radius: 7px;
+  cursor: pointer;
+}
+.help__docs:hover {
+  background: linear-gradient(180deg, #e4f3ea, #c6e3d1);
+}
+.help__docs--article {
+  margin-top: 1.2rem;
+}

--- a/src/renderer/src/components/HelpPanel.tsx
+++ b/src/renderer/src/components/HelpPanel.tsx
@@ -16,6 +16,12 @@ import { useWorkspace } from '../store/workspace'
 import type { PartLibraryWithParts } from '../../../preload/index.d'
 import './HelpPanel.css'
 
+/** The full online documentation, opened in the browser from the Help panel. */
+const DOCS_URL = 'https://docs.snakie.org'
+function openDocs(): void {
+  void window.api?.openExternal?.(DOCS_URL).catch(() => undefined)
+}
+
 /**
  * HELP LIBRARY — a TechNet/`.chm`-style document tree for the Help side view.
  *
@@ -272,6 +278,14 @@ export function HelpPanel({ target }: { target?: { id: string; nonce: number } }
             </div>
           )}
           {body ? <Markdown source={body} /> : <p className="help__empty">No help written for this page yet.</p>}
+          <button
+            type="button"
+            className="help__docs help__docs--article"
+            onClick={openDocs}
+            title={DOCS_URL}
+          >
+            📚 More in the full documentation ↗
+          </button>
         </div>
       </div>
     )
@@ -301,6 +315,9 @@ export function HelpPanel({ target }: { target?: { id: string; nonce: number } }
       <div className="help-tree" role="tree" aria-label="Help contents">
         {tree.map((n) => renderNode(n, 0))}
       </div>
+      <button type="button" className="help__docs" onClick={openDocs} title={DOCS_URL}>
+        📚 Full documentation at docs.snakie.org ↗
+      </button>
       <div className="help__legend" aria-hidden="true">
         <span className="help__legend-item" style={{ color: '#b8892b' }}>
           <ShelfIcon size={13} /> library


### PR DESCRIPTION
Part of #418. Response to: *"the in-app help can also now link out to docs.snakie.org where needed."*

## What
The in-app **Help** panel now points users to the full online documentation:
- a **"📚 Full documentation at docs.snakie.org ↗"** link in the contents view (below the tree), and
- a **"📚 More in the full documentation ↗"** link after every article.

Both open [docs.snakie.org](https://docs.snakie.org) in the browser via `app:openExternal`.

## Verification
`typecheck`, `lint` (only the pre-existing warning), **1589 tests**, `build` — all green. The Help panel is always-parchment (no dark variant, like the existing kevsrobots guide button), so the green-tinted link styling is consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)