### PR TITLE
feat: Motion Studio runtime library snakie_motion.py (Servo + Rig) (#412)

### DIFF
--- a/micropython/snakie_motion.py
+++ b/micropython/snakie_motion.py
@@ -1,0 +1,323 @@
+"""snakie_motion — Motion Studio runtime (#412).
+
+Turns the Motion Studio data model into live motion: a calibrated :class:`Servo`
+(pin/PWM, URDF joint binding, min/max, trim, invert, pulse calibration) and a
+:class:`Rig` that runs non-blocking group moves with easing, plays sequences of
+poses, and blends named puppet controls.
+
+It imports + runs headless under **CPython** (all hardware is isolated behind the
+``machine`` import inside ``instruments``), so the same code drives the 3-D preview
+with no board — and its joint maths mirrors the app's ``jointToServo`` /
+``servoToJoint`` (``src/shared/krf.ts``) and ``ease`` (``src/shared/robot-timeline.ts``)
+exactly, so what you see on screen is what the servos do.
+
+Poses are dicts of ``{urdf_joint: display_value}`` in the joint's own units (degrees
+for a revolute joint, like ``NamedPose.values``).
+"""
+
+__version__ = "1"
+
+import math
+
+RAD2DEG = 180.0 / math.pi
+DEG2RAD = math.pi / 180.0
+
+DEFAULT_SERVO_MIN = 0
+DEFAULT_SERVO_MAX = 180
+
+
+# ── Time (MicroPython ticks / CPython fallback), guarded like instruments._sleep_ms ──
+def _now_ms():
+    import time
+
+    if hasattr(time, "ticks_ms"):
+        return time.ticks_ms()
+    return int(time.time() * 1000)
+
+
+def _diff_ms(a, b):
+    import time
+
+    if hasattr(time, "ticks_diff"):
+        return time.ticks_diff(a, b)
+    return a - b
+
+
+def _sleep_ms(ms):
+    import time
+
+    if hasattr(time, "sleep_ms"):
+        time.sleep_ms(int(ms))
+    else:
+        time.sleep(ms / 1000.0)
+
+
+def _clamp(v, lo, hi):
+    return lo if v < lo else hi if v > hi else v
+
+
+def ease(easing, u):
+    """The Python twin of ``robot-timeline.ts`` ``ease`` — ``linear`` is the identity,
+    everything else is the ``x*x*(3-2*x)`` smoothstep — so preview == hardware."""
+    x = _clamp(u, 0.0, 1.0)
+    return x if easing == "linear" else x * x * (3.0 - 2.0 * x)
+
+
+def _lerp_pose(a, b, f):
+    """Blend two poses (dicts) at ``f`` in 0..1 over the UNION of their joints; a joint
+    present in only one side holds that value."""
+    out = {}
+    for k in a:
+        av = a[k]
+        bv = b.get(k, av)
+        out[k] = av + (bv - av) * f
+    for k in b:
+        if k not in out:
+            out[k] = b[k]  # only in b → hold (a-side missing = treat as b)
+    return out
+
+
+class Servo:
+    """A calibrated servo bound to a URDF joint.
+
+    ``write_joint(rad)`` maps a joint angle in **radians** to a whole servo degree
+    (the Python twin of ``jointToServo``: joint-rad → display-deg → lerp over the
+    servo range, ``invert``, ``trim``, clamp) and drives it. All hardware + the
+    ``SNK SERVO <pin> <deg>`` telemetry live in the composed ``instruments`` servo,
+    so the 3-D view mirrors it for free (#313).
+    """
+
+    def __init__(
+        self,
+        pin,
+        joint=None,
+        *,
+        freq=50,
+        min_us=500,
+        max_us=2500,
+        servo_min=DEFAULT_SERVO_MIN,
+        servo_max=DEFAULT_SERVO_MAX,
+        joint_min=0.0,
+        joint_max=180.0,
+        trim=0.0,
+        invert=False,
+        _servo=None,
+    ):
+        self.pin = pin
+        self.joint = joint
+        self.servo_min = servo_min
+        self.servo_max = servo_max
+        self.joint_min = joint_min
+        self.joint_max = joint_max
+        self.trim = trim
+        self.invert = invert
+        # Compose the telemetry/hardware servo from `instruments` (imported lazily so
+        # tests can inject a fake via `_servo`). Reuses the `machine` guard + the
+        # `SNK SERVO` emission — one place owns hardware.
+        if _servo is not None:
+            self._servo = _servo
+        else:
+            import instruments
+
+            # Construct instruments.Servo directly (not servo_on) so the pulse
+            # calibration min_us/max_us is honoured; it still emits SNK SERVO.
+            self._servo = instruments.Servo(pin=pin, freq=freq, min_us=min_us, max_us=max_us)
+        self._current_deg = 90
+
+    @property
+    def deg_per_joint_rad(self):
+        """Calibration slope: servo-degrees per joint-radian (signed; negative when
+        ``invert``). 0 for a zero-width joint range."""
+        jspan = self.joint_max - self.joint_min  # display units (deg for revolute)
+        sspan = self.servo_max - self.servo_min
+        slope = 0.0 if jspan == 0 else (sspan / jspan)
+        if self.invert:
+            slope = -slope
+        return slope * RAD2DEG
+
+    def _servo_deg_for(self, rad):
+        deg = rad * RAD2DEG  # joint radians → joint display degrees
+        span = self.joint_max - self.joint_min
+        t = 0.0 if span == 0 else (deg - self.joint_min) / span
+        t = _clamp(t, 0.0, 1.0)
+        if self.invert:
+            t = 1.0 - t
+        raw = self.servo_min + t * (self.servo_max - self.servo_min) + self.trim
+        raw = _clamp(raw, self.servo_min, self.servo_max)  # soft servo limits
+        return int(_clamp(round(raw), 0, 180))
+
+    def write_joint(self, rad):
+        """Drive the servo so its bound joint reaches ``rad`` radians. Returns the
+        whole servo degree written (and emits ``SNK SERVO <pin> <deg>``)."""
+        deg = self._servo_deg_for(rad)
+        self._servo.angle(deg)
+        self._current_deg = deg
+        return deg
+
+    @property
+    def current_deg(self):
+        """The last servo degree written."""
+        return self._current_deg
+
+    def joint_display(self):
+        """The current joint value in DISPLAY units (deg) — the ``servoToJoint`` twin
+        of the current servo degree."""
+        span = self.servo_max - self.servo_min
+        t = 0.0 if span == 0 else (self._current_deg - self.servo_min) / span
+        t = _clamp(t, 0.0, 1.0)
+        if self.invert:
+            t = 1.0 - t
+        return self.joint_min + t * (self.joint_max - self.joint_min)
+
+    def joint_radians(self):
+        """The current joint value in radians — ``servoToJoint`` + ``toNative``."""
+        return self.joint_display() * DEG2RAD
+
+
+class Rig:
+    """A named group of servos driven together: non-blocking group moves (``goto_pose``),
+    pose sequences (``play``) and blended puppet controls (``set_control``). Tick it with
+    ``update()`` in your loop, or hand off to the blocking ``run()`` driver."""
+
+    def __init__(self, servos, *, hz=50, controls=None):
+        # servos: name -> Servo (a joint may be driven by >1 pin via distinct names).
+        self._servos = dict(servos)
+        self.hz = hz
+        self._controls = dict(controls) if controls else {}
+        self._move = None  # {"start":{name:disp}, "target":{name:disp}, "t0", "dur_ms", "easing"}
+        self._seq = None
+        self._loop = False
+        self._step = 0
+
+    def servos(self):
+        return self._servos
+
+    def add_control(self, name, poses):
+        """Register a puppet control: a list of poses blended by a 0..1 slider."""
+        self._controls[name] = list(poses)
+
+    # ── Group move ────────────────────────────────────────────────────────────
+    def goto_pose(self, pose, duration=0.5, easing="easeInOut"):
+        """Begin a NON-BLOCKING move of every servo toward ``pose`` (a
+        ``{joint: display}`` dict) over ``duration`` seconds. Records intent only;
+        the interpolation happens inside ``update()``. A joint absent from ``pose``
+        holds its current value (partial poses)."""
+        start = {}
+        target = {}
+        for name, servo in self._servos.items():
+            cur = servo.joint_display()
+            start[name] = cur
+            j = servo.joint
+            target[name] = pose.get(j, cur) if j is not None else cur
+        self._move = {
+            "start": start,
+            "target": target,
+            "t0": _now_ms(),
+            "dur_ms": max(0.0, duration * 1000.0),
+            "easing": easing,
+        }
+        self._apply(0.0)
+
+    def _apply(self, e):
+        for name, servo in self._servos.items():
+            s = self._move["start"][name]
+            t = self._move["target"][name]
+            servo.write_joint((s + (t - s) * e) * DEG2RAD)
+
+    # ── Sequence ──────────────────────────────────────────────────────────────
+    def play(self, sequence, loop=False):
+        """Queue a list of ``(pose, duration_ms[, easing])`` steps; ``update()``
+        advances through them (``loop`` wraps). Replaces any active sequence/move."""
+        self._seq = list(sequence)
+        self._loop = loop
+        self._step = 0
+        self._move = None
+        if self._seq:
+            self._start_step(0, _now_ms())
+
+    def _start_step(self, i, now):
+        step = self._seq[i]
+        pose = step[0]
+        dur_ms = step[1] if len(step) > 1 else 500
+        easing = step[2] if len(step) > 2 else "easeInOut"
+        self.goto_pose(pose, duration=dur_ms / 1000.0, easing=easing)
+        self._move["t0"] = now  # continuous timing across steps
+
+    # ── Puppet control (blend) ────────────────────────────────────────────────
+    def set_control(self, name, t):
+        """Blend a registered control's poses at ``t`` in 0..1 and apply it AT ONCE — a
+        puppet slider is instantaneous. N poses span N-1 segments (e.g.
+        frown→neutral→smile). Overrides any in-flight move."""
+        poses = self._controls.get(name)
+        if not poses:
+            return
+        n = len(poses)
+        if n == 1:
+            blended = poses[0]
+        else:
+            tt = _clamp(t, 0.0, 1.0)
+            seg = tt * (n - 1)
+            i = int(seg)
+            if i >= n - 1:
+                i = n - 2
+            blended = _lerp_pose(poses[i], poses[i + 1], seg - i)
+        self._move = None  # a live slider overrides any active goto/sequence move
+        self._seq = None
+        for servo in self._servos.values():
+            j = servo.joint
+            if j is not None and j in blended:
+                servo.write_joint(blended[j] * DEG2RAD)
+
+    # ── Tick / run ────────────────────────────────────────────────────────────
+    def update(self, now=None):
+        """Advance the active move/sequence, writing every servo. Returns whether
+        motion is still in progress. Safe to call every loop."""
+        if self._move is None:
+            return False
+        now = _now_ms() if now is None else now
+        m = self._move
+        u = 1.0 if m["dur_ms"] <= 0 else _clamp(_diff_ms(now, m["t0"]) / m["dur_ms"], 0.0, 1.0)
+        self._apply(ease(m["easing"], u))
+        if u < 1.0:
+            return True
+        # This move finished — advance the sequence, if any.
+        self._move = None
+        if self._seq is not None:
+            self._step += 1
+            if self._step < len(self._seq):
+                self._start_step(self._step, now)
+                return True
+            if self._loop:
+                self._step = 0
+                self._start_step(0, now)
+                return True
+            self._seq = None
+        return False
+
+    def run(self, hz=None):
+        """Blocking convenience driver: tick ``update()`` forever at ``hz``. Use as
+        your ``while True:`` loop on-device."""
+        hz = hz or self.hz
+        dt = max(1, int(1000 / hz))
+        while True:
+            self.update()
+            _sleep_ms(dt)
+
+    # ── State (for Capture Pose + the 3-D mirror) ─────────────────────────────
+    def snapshot(self):
+        """Current pose as ``{joint: display_value}`` (rounded like ``NamedPose.values``),
+        for Capture Pose."""
+        pose = {}
+        for servo in self._servos.values():
+            if servo.joint is not None:
+                pose[servo.joint] = round(servo.joint_display(), 2)
+        return pose
+
+    def joint_state(self):
+        """Current ``{urdf_joint: radians}`` feed for the 3-D view to mirror the robot
+        (the ``servoToJoint`` + ``toNative`` inverse per bound servo)."""
+        state = {}
+        for servo in self._servos.values():
+            if servo.joint is not None:
+                state[servo.joint] = servo.joint_radians()
+        return state

--- a/micropython/snakie_motion.py
+++ b/micropython/snakie_motion.py
@@ -56,6 +56,15 @@ def _clamp(v, lo, hi):
     return lo if v < lo else hi if v > hi else v
 
 
+def _round_half_up(x):
+    """Round half AWAY from zero toward +∞ — matches JS ``Math.round`` (which
+    ``jointToServo`` uses), unlike Python's built-in round-half-to-even. Keeps the
+    servo degree identical to the app so preview == hardware."""
+    import math
+
+    return int(math.floor(x + 0.5))
+
+
 def ease(easing, u):
     """The Python twin of ``robot-timeline.ts`` ``ease`` — ``linear`` is the identity,
     everything else is the ``x*x*(3-2*x)`` smoothstep — so preview == hardware."""
@@ -123,6 +132,11 @@ class Servo:
             # calibration min_us/max_us is honoured; it still emits SNK SERVO.
             self._servo = instruments.Servo(pin=pin, freq=freq, min_us=min_us, max_us=max_us)
         self._current_deg = 90
+        # The last COMMANDED joint value (radians). goto_pose reads THIS as its move
+        # start (not a servo read-back), so a non-zero `trim` — which write_joint applies
+        # but the servo→joint inverse can't recover — never makes a move drift. Seeded
+        # from the neutral servo position.
+        self._cmd_rad = self.joint_radians()
 
     @property
     def deg_per_joint_rad(self):
@@ -143,12 +157,17 @@ class Servo:
         if self.invert:
             t = 1.0 - t
         raw = self.servo_min + t * (self.servo_max - self.servo_min) + self.trim
-        raw = _clamp(raw, self.servo_min, self.servo_max)  # soft servo limits
-        return int(_clamp(round(raw), 0, 180))
+        # Soft servo limits (order-agnostic — a binding may flip via servo_min>servo_max
+        # instead of `invert`, which jointToServo handles too).
+        lo = self.servo_min if self.servo_min <= self.servo_max else self.servo_max
+        hi = self.servo_max if self.servo_max >= self.servo_min else self.servo_min
+        raw = _clamp(raw, lo, hi)
+        return int(_clamp(_round_half_up(raw), 0, 180))
 
     def write_joint(self, rad):
         """Drive the servo so its bound joint reaches ``rad`` radians. Returns the
         whole servo degree written (and emits ``SNK SERVO <pin> <deg>``)."""
+        self._cmd_rad = rad
         deg = self._servo_deg_for(rad)
         self._servo.angle(deg)
         self._current_deg = deg
@@ -159,9 +178,14 @@ class Servo:
         """The last servo degree written."""
         return self._current_deg
 
+    def commanded_display(self):
+        """The last COMMANDED joint value in DISPLAY units (deg). Round-trips exactly
+        with ``write_joint`` (trim-safe) — what Capture Pose + move interpolation use."""
+        return self._cmd_rad * RAD2DEG
+
     def joint_display(self):
         """The current joint value in DISPLAY units (deg) — the ``servoToJoint`` twin
-        of the current servo degree."""
+        of the current servo degree (the app-mirror view; trim is folded into it)."""
         span = self.servo_max - self.servo_min
         t = 0.0 if span == 0 else (self._current_deg - self.servo_min) / span
         t = _clamp(t, 0.0, 1.0)
@@ -205,10 +229,12 @@ class Rig:
         start = {}
         target = {}
         for name, servo in self._servos.items():
-            cur = servo.joint_display()
+            cur = servo.commanded_display()  # last COMMANDED value → trim-safe, no drift
             start[name] = cur
             j = servo.joint
             target[name] = pose.get(j, cur) if j is not None else cur
+        # Records intent ONLY — the first servo write happens in update() (u=0), so
+        # goto_pose is truly non-blocking and doesn't burst redundant SNK SERVO lines.
         self._move = {
             "start": start,
             "target": target,
@@ -216,7 +242,6 @@ class Rig:
             "dur_ms": max(0.0, duration * 1000.0),
             "easing": easing,
         }
-        self._apply(0.0)
 
     def _apply(self, e):
         for name, servo in self._servos.items():
@@ -297,7 +322,9 @@ class Rig:
     def run(self, hz=None):
         """Blocking convenience driver: tick ``update()`` forever at ``hz``. Use as
         your ``while True:`` loop on-device."""
-        hz = hz or self.hz
+        hz = hz or self.hz or 50
+        if hz <= 0:
+            hz = 50
         dt = max(1, int(1000 / hz))
         while True:
             self.update()
@@ -310,7 +337,8 @@ class Rig:
         pose = {}
         for servo in self._servos.values():
             if servo.joint is not None:
-                pose[servo.joint] = round(servo.joint_display(), 2)
+                # The COMMANDED joint value (trim-safe), so a captured pose replays exactly.
+                pose[servo.joint] = round(servo.commanded_display(), 2)
         return pose
 
     def joint_state(self):

--- a/python/tests/test_motion.py
+++ b/python/tests/test_motion.py
@@ -1,0 +1,183 @@
+"""Unit tests for the device-side ``micropython/snakie_motion.py`` runtime (#412).
+
+They assert the joint↔servo calibration mirrors the app (``jointToServo`` /
+``servoToJoint`` in ``src/shared/krf.ts``), that ``goto_pose`` is non-blocking with
+the ``ease`` (smoothstep) curve, that sequences play and puppet controls blend, and
+that ``snapshot`` / ``joint_state`` report the right units — all under CPython, no
+``machine`` module. Run from the repo root::
+
+    PYTHONPATH=python python3 -m unittest discover -s python/tests
+"""
+
+import importlib.util
+import io
+import math
+import os
+import sys
+import unittest
+from contextlib import redirect_stdout
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# So snakie_motion's lazy `import instruments` resolves to the real device lib.
+sys.path.insert(0, os.path.join(_REPO_ROOT, "micropython"))
+
+_LIB_PATH = os.path.join(_REPO_ROOT, "micropython", "snakie_motion.py")
+_spec = importlib.util.spec_from_file_location("snakie_motion_under_test", _LIB_PATH)
+assert _spec and _spec.loader
+motion = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(motion)
+
+DEG2RAD = math.pi / 180.0
+
+
+class _FakeServo:
+    """A stand-in for ``instruments.Servo`` that records every ``angle(deg)`` call."""
+
+    def __init__(self):
+        self.degs = []
+
+    def angle(self, deg):
+        self.degs.append(deg)
+        return deg
+
+
+def _servo(joint="j", **kw):
+    fake = _FakeServo()
+    s = motion.Servo(0, joint, _servo=fake, **kw)
+    return s, fake
+
+
+class CalibrationTests(unittest.TestCase):
+    def test_write_joint_matches_jointToServo(self):
+        # jointMin/max in degrees; servo 0..180; centre maps to 90.
+        s, _ = _servo(joint_min=-90, joint_max=90, servo_min=0, servo_max=180)
+        self.assertEqual(s.write_joint(0.0), 90)
+        self.assertEqual(s.write_joint(90 * DEG2RAD), 180)
+        self.assertEqual(s.write_joint(-90 * DEG2RAD), 0)
+        # Out-of-range joint clamps at the servo endpoint.
+        self.assertEqual(s.write_joint(180 * DEG2RAD), 180)
+
+    def test_invert_flips_the_mapping(self):
+        s, _ = _servo(joint_min=-90, joint_max=90, invert=True)
+        self.assertEqual(s.write_joint(-90 * DEG2RAD), 180)
+        self.assertEqual(s.write_joint(90 * DEG2RAD), 0)
+
+    def test_servo_sub_range_and_trim(self):
+        s, _ = _servo(joint_min=-90, joint_max=90, servo_min=30, servo_max=150)
+        self.assertEqual(s.write_joint(0.0), 90)  # midpoint of 30..150
+        self.assertEqual(s.write_joint(90 * DEG2RAD), 150)
+        # Trim offsets the servo degree, clamped to the soft servo max.
+        s2, _ = _servo(joint_min=-90, joint_max=90, servo_min=0, servo_max=180, trim=10)
+        self.assertEqual(s2.write_joint(0.0), 100)  # 90 + 10
+        self.assertEqual(s2.write_joint(90 * DEG2RAD), 180)  # 180 + 10 clamped to 180
+
+    def test_deg_per_joint_rad_slope(self):
+        s, _ = _servo(joint_min=-90, joint_max=90, servo_min=0, servo_max=180)
+        # 180 servo-deg over 180 joint-deg = 1 deg/deg → RAD2DEG servo-deg per joint-rad.
+        self.assertAlmostEqual(s.deg_per_joint_rad, 180.0 / math.pi, places=4)
+        s2, _ = _servo(joint_min=-90, joint_max=90, invert=True)
+        self.assertAlmostEqual(s2.deg_per_joint_rad, -180.0 / math.pi, places=4)
+
+    def test_emits_snk_servo_line_headless(self):
+        # Uses the REAL instruments.Servo (no `machine`): write_joint prints SNK SERVO.
+        s = motion.Servo(5, "j", joint_min=-90, joint_max=90)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            s.write_joint(0.0)  # joint 0° → servo 90
+        self.assertIn("SNK SERVO 5 90", buf.getvalue().splitlines())
+
+
+class RigMoveTests(unittest.TestCase):
+    def _rig(self):
+        s, fake = _servo(joint_min=-90, joint_max=90, servo_min=0, servo_max=180)
+        return motion.Rig({"j": s}), s, fake
+
+    def test_goto_pose_is_non_blocking_and_eases(self):
+        rig, s, fake = self._rig()
+        # Servo starts at 90° → joint 0°.
+        rig.goto_pose({"j": 90}, duration=1.0, easing="easeInOut")
+        t0 = rig._move["t0"]
+        self.assertTrue(rig.update(t0))  # u=0, still moving
+        self.assertEqual(fake.degs[-1], 90)  # start = joint 0° → servo 90
+        # Halfway in time → ease(0.5)=0.5 → joint 45° → servo 135.
+        self.assertTrue(rig.update(t0 + 500))
+        self.assertEqual(fake.degs[-1], 135)
+        # End → joint 90° → servo 180, and no longer moving.
+        self.assertFalse(rig.update(t0 + 1000))
+        self.assertEqual(fake.degs[-1], 180)
+
+    def test_partial_pose_holds_unlisted_joints(self):
+        a, fa = _servo("a", joint_min=-90, joint_max=90)
+        b, fb = _servo("b", joint_min=-90, joint_max=90)
+        rig = motion.Rig({"a": a, "b": b})
+        rig.goto_pose({"a": 90}, duration=1.0)  # b not in the pose
+        t0 = rig._move["t0"]
+        rig.update(t0 + 1000)
+        self.assertEqual(fa.degs[-1], 180)  # a moved to 90°
+        self.assertEqual(fb.degs[-1], 90)  # b held at 0° → servo 90
+
+
+class RigSequenceTests(unittest.TestCase):
+    def test_play_advances_through_steps(self):
+        s, fake = _servo(joint_min=-90, joint_max=90, servo_min=0, servo_max=180)
+        rig = motion.Rig({"j": s})
+        rig.play([({"j": -90}, 100), ({"j": 90}, 100)])
+        t0 = rig._move["t0"]
+        # Step 1 completes → servo at -90° (0); advances to step 2 (still moving).
+        self.assertTrue(rig.update(t0 + 100))
+        self.assertEqual(fake.degs[-1], 0)
+        t1 = rig._move["t0"]
+        # Step 2 completes → servo at 90° (180); sequence done.
+        self.assertFalse(rig.update(t1 + 100))
+        self.assertEqual(fake.degs[-1], 180)
+
+    def test_play_loops(self):
+        s, fake = _servo(joint_min=-90, joint_max=90)
+        rig = motion.Rig({"j": s})
+        rig.play([({"j": -90}, 100), ({"j": 90}, 100)], loop=True)
+        t0 = rig._move["t0"]
+        self.assertTrue(rig.update(t0 + 100))  # step1 → step2
+        t1 = rig._move["t0"]
+        self.assertTrue(rig.update(t1 + 100))  # step2 done → WRAPS to step1 (loop)
+        self.assertIsNotNone(rig._move)  # still running
+
+
+class RigControlTests(unittest.TestCase):
+    def test_set_control_blends_immediately(self):
+        s, fake = _servo(joint_min=-90, joint_max=90, servo_min=0, servo_max=180)
+        rig = motion.Rig({"j": s})
+        rig.add_control("mouth", [{"j": -90}, {"j": 90}])
+        rig.set_control("mouth", 0.0)  # low pose → joint -90° → servo 0
+        self.assertEqual(fake.degs[-1], 0)
+        rig.set_control("mouth", 1.0)  # high pose → joint 90° → servo 180
+        self.assertEqual(fake.degs[-1], 180)
+        rig.set_control("mouth", 0.5)  # midpoint → joint 0° → servo 90
+        self.assertEqual(fake.degs[-1], 90)
+
+    def test_three_pose_control_uses_the_right_segment(self):
+        s, fake = _servo(joint_min=-90, joint_max=90, servo_min=0, servo_max=180)
+        rig = motion.Rig({"j": s})
+        rig.add_control("blend", [{"j": -90}, {"j": 0}, {"j": 90}])
+        rig.set_control("blend", 0.25)  # first half → between -90 and 0 → -45° → servo 45
+        self.assertEqual(fake.degs[-1], 45)
+        rig.set_control("blend", 0.75)  # second half → between 0 and 90 → 45° → servo 135
+        self.assertEqual(fake.degs[-1], 135)
+
+
+class RigStateTests(unittest.TestCase):
+    def test_snapshot_and_joint_state(self):
+        s, _ = _servo(joint_min=-90, joint_max=90, servo_min=0, servo_max=180)
+        rig = motion.Rig({"j": s})
+        s.write_joint(45 * DEG2RAD)  # → servo 135 → joint 45°
+        snap = rig.snapshot()
+        self.assertAlmostEqual(snap["j"], 45.0, places=1)  # DISPLAY degrees
+        state = rig.joint_state()
+        self.assertAlmostEqual(state["j"], 45 * DEG2RAD, places=3)  # RADIANS
+
+    def test_version_literal_present(self):
+        self.assertTrue(hasattr(motion, "__version__"))
+        self.assertIsInstance(motion.__version__, str)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_motion.py
+++ b/python/tests/test_motion.py
@@ -179,5 +179,62 @@ class RigStateTests(unittest.TestCase):
         self.assertIsInstance(motion.__version__, str)
 
 
+class RoundingAndEasingTests(unittest.TestCase):
+    def test_half_degree_rounds_half_up_like_math_round(self):
+        # Identity map (joint deg == servo deg). A servo raw landing on x.5 must round
+        # UP (JS Math.round, what jointToServo uses), not to-even (Python's round()).
+        s, _ = _servo(joint_min=0, joint_max=180, servo_min=0, servo_max=180)
+        self.assertEqual(s.write_joint(0.5 * DEG2RAD), 1)  # 0.5 → 1 (not 0)
+        self.assertEqual(s.write_joint(2.5 * DEG2RAD), 3)  # 2.5 → 3 (not 2)
+
+    def test_easing_is_smoothstep_not_linear(self):
+        # At u=0.25 the smoothstep (ease_in_out) is well behind a linear ramp, so the
+        # two produce DIFFERENT servo degrees — a linear-only impl would fail this.
+        se, fe = _servo(joint_min=-90, joint_max=90, servo_min=0, servo_max=180)
+        sl, fl = _servo(joint_min=-90, joint_max=90, servo_min=0, servo_max=180)
+        re = motion.Rig({"j": se})
+        rl = motion.Rig({"j": sl})
+        re.goto_pose({"j": 90}, duration=1.0, easing="easeInOut")
+        rl.goto_pose({"j": 90}, duration=1.0, easing="linear")
+        t0 = re._move["t0"]
+        re.update(t0 + 250)
+        rl._move["t0"] = t0
+        rl.update(t0 + 250)
+        self.assertNotEqual(fe.degs[-1], fl.degs[-1])
+        self.assertLess(fe.degs[-1], fl.degs[-1])  # smoothstep starts slower
+
+    def test_reversed_servo_range_matches_the_app(self):
+        # servo_min > servo_max (a flip via range, not the invert flag) still lerps
+        # correctly (order-agnostic clamp), like jointToServo.
+        s, _ = _servo(joint_min=-90, joint_max=90, servo_min=150, servo_max=30)
+        self.assertEqual(s.write_joint(-90 * DEG2RAD), 150)
+        self.assertEqual(s.write_joint(0.0), 90)
+        self.assertEqual(s.write_joint(90 * DEG2RAD), 30)
+
+
+class TrimTests(unittest.TestCase):
+    def test_snapshot_round_trips_the_commanded_pose_with_trim(self):
+        # trim shifts the SERVO degree but Capture Pose must report the COMMANDED joint
+        # so a captured pose replays exactly (no trim drift).
+        s, _ = _servo(joint_min=-90, joint_max=90, servo_min=0, servo_max=180, trim=8)
+        rig = motion.Rig({"j": s})
+        s.write_joint(30 * DEG2RAD)
+        self.assertAlmostEqual(rig.snapshot()["j"], 30.0, places=6)
+
+    def test_looping_fixed_pose_does_not_drift_with_trim(self):
+        s, fake = _servo(joint_min=-90, joint_max=90, servo_min=0, servo_max=180, trim=8)
+        rig = motion.Rig({"j": s})
+        rig.play([({"j": 30}, 100)], loop=True)
+        t = rig._move["t0"]
+        seen = set()
+        for _ in range(6):  # several loop cycles
+            rig.update(t + 100)
+            seen.add(fake.degs[-1])
+            t = rig._move["t0"]
+        # Every cycle lands on the SAME servo degree — the start is read from the
+        # commanded value, so trim never accumulates.
+        self.assertEqual(len(seen), 1)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
First piece of the **Motion Studio** epic (#403). Closes #412.

## What
A small, CPython-safe on-device runtime, `micropython/snakie_motion.py`, that turns the Motion Studio data model into live motion:
- **`Servo`** — pin/PWM (composes `instruments.Servo` for the `machine` guard + `SNK SERVO` telemetry), URDF joint binding, pulse calibration, servo/joint ranges, `trim`, `invert`. `write_joint(rad)` is the Python twin of `jointToServo` (`src/shared/krf.ts`) **to the whole degree**, so the 3-D preview mirrors the servos exactly.
- **`Rig`** — non-blocking `goto_pose` (records intent; interpolates in `update()` with the `ease()` smoothstep), `play(sequence, loop)` of `(pose, duration_ms)` steps, `set_control(name, t)` puppet blends, `update()`/`run()` driver, and `snapshot()` / `joint_state()` for Capture Pose + the 3-D mirror.
- Imports headless under CPython (no top-level `import machine`); timing guarded `ticks_ms`/`ticks_diff` vs `time.time`/`sleep`.

## Verification
- **183 Python tests green** (`PYTHONPATH=python python3 -m unittest discover -s python/tests`), 18 for this module: calibration parity (incl. half-degree rounding matching JS `Math.round`, reversed ranges, trim), non-blocking easing (smoothstep ≠ linear), partial poses, sequence play + loop (no trim drift), control blends, snapshot/joint_state units, and the real `SNK SERVO` emission headless.
- Adversarial multi-agent review (ultracode); its **8 findings** are all fixed in this branch: half-up rounding, trim-safe move/snapshot (the HIGH drift bug), order-agnostic clamp, records-intent-only `goto_pose`, and the `run()` hz guard.

## Scope
Library + CPython tests only — no exporter/installer/UI wiring (separate issues in the epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)