### PR TITLE
feat: Motion Studio pose authoring — Capture, duplicate, partial poses (#414)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Motion Studio — Capture Pose, duplicate, and partial poses (#403, #414).** The Robot View
+  pose editor becomes a proper authoring surface. **Capture Pose** snapshots the current live
+  posture into a named pose — whether you posed it with the sliders **or** a running program's
+  servos are driving the model (`SNK SERVO` telemetry back-drives the joints, and a **Live ●**
+  hint shows when they are). **Duplicate** copies a pose under a unique "*name* copy" without
+  touching the original. And poses can now be **partial**: tick only the joints a pose should
+  capture (e.g. a face-only wave) and the rest are left exactly where they are when you recall
+  it. The pose library keeps its rename / delete / preview. `NamedPose[]` stays the single
+  source the managed-block round-trip (#413) reads.
 - **Motion Studio — an exported `.py` round-trips its poses & servo map (#403, #413).** The
   Robot View's exported motion file now carries Snakie's pose library, sequences and servo map
   in **guarded, versioned managed blocks** (`# --- snakie:poses v1 ---` … `:end`), written as

--- a/src/renderer/src/components/RobotPropertiesDialog.css
+++ b/src/renderer/src/components/RobotPropertiesDialog.css
@@ -253,6 +253,51 @@
   justify-content: space-between;
   gap: 0.4rem;
 }
+/* "Live ●" — a running program's servos are driving the joints (#414). Green
+   reads on both the dark and the parchment (light) theme. */
+.robotprops__live {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.28rem;
+  font-size: 0.58rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: #2f9e5b;
+}
+.robotprops__live-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: #34c46b;
+  box-shadow: 0 0 0 2px rgba(52, 196, 107, 0.28);
+  animation: robotprops-livepulse 1.1s ease-in-out infinite;
+}
+@keyframes robotprops-livepulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+/* Per-joint include checkbox in the capture list (#414). */
+.robotprops__poj-inc {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+}
+.robotprops__poj-inc input {
+  margin: 0;
+  accent-color: var(--accent, #d6a23f);
+  cursor: pointer;
+}
+/* An excluded joint is dimmed — it won't be written to the pose. */
+.robotprops__poj--excluded {
+  opacity: 0.45;
+}
 .robotprops__poses-joints {
   display: flex;
   flex-direction: column;

--- a/src/renderer/src/components/RobotPropertiesDialog.tsx
+++ b/src/renderer/src/components/RobotPropertiesDialog.tsx
@@ -88,13 +88,20 @@ export interface RobotPropertiesDialogProps {
   onRecallPose: (pose: NamedPoseLike) => void
   onRenamePose: (oldName: string, newName: string) => void
   onDeletePose: (name: string) => void
+  /** Duplicate a pose under a unique "<name> copy" name (#414). */
+  onDuplicatePose: (name: string) => void
+  /** True while a running program's servo telemetry is driving a mapped joint —
+   *  the pose editor shows a "Live ●" hint that a Capture reads that posture (#414). */
+  poseLive?: boolean
   /** The movable joints + live values, so the pose editor can pose the robot with
    *  sliders (the retired pose sidebar's controls moved here — #312). */
   jointMeta: JointMeta[]
   values: Record<string, number>
   overrides: Record<string, { min?: number; max?: number }>
   onJointChange: (name: string, native: number) => void
-  onSavePose: (name: string) => void
+  /** Capture the live posture as a pose. `include` (when given) writes only those
+   *  joints — a PARTIAL pose that leaves the rest untouched on recall (#414). */
+  onSavePose: (name: string, include?: string[]) => void
   onResetPose: () => void
   // addjoint (#354 — pick two points in 3-D)
   /** The Add Joint pick state (which block/point is Component 1 / 2), driven by
@@ -247,6 +254,14 @@ export function RobotPropertiesDialog(props: RobotPropertiesDialogProps): JSX.El
               onClick={() => props.pose && props.onRecallPose(props.pose)}
             >
               Recall
+            </button>
+            <button
+              type="button"
+              className="robotprops__btn"
+              onClick={() => props.onDuplicatePose(context.name)}
+              title="Copy this pose under a new name"
+            >
+              Duplicate
             </button>
             <button
               type="button"
@@ -516,7 +531,9 @@ function PoseNum({
  *  it first, so the sliders start on its saved values. */
 function PoseBody({
   name,
+  pose,
   poseNames,
+  poseLive,
   onRenamePose,
   jointMeta,
   values,
@@ -533,20 +550,36 @@ function PoseBody({
   const trimmed = draftName.trim()
   // A name that already belongs to a DIFFERENT pose would overwrite it.
   const clash = trimmed !== name && poseNames.includes(trimmed)
+  const movable = jointMeta.filter((j) => !j.isMimic)
+  const mimics = jointMeta.filter((j) => j.isMimic)
+
+  // Which joints this capture INCLUDES (#414). Default: all movable joints on;
+  // when editing an existing PARTIAL pose, start from the joints it actually
+  // stored so re-capturing keeps its shape.
+  const [included, setIncluded] = useState<Record<string, boolean>>(() => {
+    const init: Record<string, boolean> = {}
+    const saved = pose?.values
+    for (const j of movable) init[j.name] = saved ? Object.prototype.hasOwnProperty.call(saved, j.name) : true
+    return init
+  })
+  const includedNames = movable.filter((j) => included[j.name] !== false).map((j) => j.name)
+  const allIncluded = includedNames.length === movable.length
+  const partial = includedNames.length > 0 && !allIncluded
+
   // Save the current joint values as this pose. For an EXISTING pose the values are
   // saved under its ORIGINAL name (so a name-field edit never duplicates it); the
   // rename is a separate op via OK. For a NEW pose, Save creates it under the name.
+  // Only the INCLUDED joints are written (a partial pose); when all are on we pass
+  // no filter so the stored shape stays "full".
   const saveValues = (): void => {
-    if (name || trimmed) onSavePose(name || trimmed)
+    if (name || trimmed) onSavePose(name || trimmed, allIncluded ? undefined : includedNames)
   }
   // Footer OK: save a NEW pose (else it'd discard silently), or rename an EXISTING
   // pose whose name was changed. (Editing an existing pose's values is the Save button.)
   commitRef.current = () => {
-    if (!name && trimmed) onSavePose(trimmed)
+    if (!name && trimmed) onSavePose(trimmed, allIncluded ? undefined : includedNames)
     else if (name && trimmed && trimmed !== name && !clash) onRenamePose(name, trimmed)
   }
-  const movable = jointMeta.filter((j) => !j.isMimic)
-  const mimics = jointMeta.filter((j) => j.isMimic)
   return (
     <>
       <section className="robotprops__section">
@@ -569,6 +602,26 @@ function PoseBody({
       <section className="robotprops__section">
         <div className="robotprops__poserow">
           <span className="robotprops__label">Joints — drag to pose</span>
+          {poseLive && (
+            <span className="robotprops__live" title="A running program's servos are driving these joints — Capture reads the live posture">
+              <span className="robotprops__live-dot" aria-hidden="true" />
+              Live
+            </span>
+          )}
+          <span className="robotprops__foot-spacer" />
+          {movable.length > 1 && (
+            <button
+              type="button"
+              className="robotprops__chip"
+              onClick={() => {
+                const next = !allIncluded
+                setIncluded(Object.fromEntries(movable.map((j) => [j.name, next])))
+              }}
+              title={allIncluded ? 'Exclude all joints (then pick which to capture)' : 'Include every joint'}
+            >
+              {allIncluded ? 'None' : 'All'}
+            </button>
+          )}
           <button
             type="button"
             className="robotprops__chip"
@@ -578,6 +631,12 @@ function PoseBody({
             Reset
           </button>
         </div>
+        {partial && (
+          <p className="robotprops__note">
+            Partial pose — only the {includedNames.length} ticked joint
+            {includedNames.length > 1 ? 's' : ''} will be captured; the rest stay where they are on recall.
+          </p>
+        )}
         {movable.length === 0 ? (
           <p className="robotprops__note">This robot has no movable joints.</p>
         ) : (
@@ -588,9 +647,18 @@ function PoseBody({
               const dUpper = toDisplay(j.type, lim.upper)
               const dVal = toDisplay(j.type, values[j.name] ?? 0)
               const step = j.type === 'prismatic' ? 0.5 : 1
+              const inc = included[j.name] !== false
               return (
-                <div className="robotprops__poj" key={j.name}>
+                <div className={`robotprops__poj${inc ? '' : ' robotprops__poj--excluded'}`} key={j.name}>
                   <div className="robotprops__poj-head">
+                    <label className="robotprops__poj-inc" title={inc ? 'Included in this pose' : 'Excluded — left untouched on recall'}>
+                      <input
+                        type="checkbox"
+                        checked={inc}
+                        onChange={(e) => setIncluded((prev) => ({ ...prev, [j.name]: e.target.checked }))}
+                        aria-label={`Include ${j.name}`}
+                      />
+                    </label>
                     <span className="robotprops__poj-name" title={j.name}>
                       {j.name}
                     </span>
@@ -640,17 +708,19 @@ function PoseBody({
         <button
           type="button"
           className="robotprops__btn robotprops__btn--ok robotprops__savepose"
-          disabled={!(name || trimmed)}
+          disabled={!(name || trimmed) || includedNames.length === 0}
           onClick={saveValues}
           title={
-            name
-              ? `Save the current joint values to “${name}” (rename via OK)`
-              : trimmed
-                ? 'Save the current joint values as this pose'
-                : 'Name the pose first'
+            includedNames.length === 0
+              ? 'Tick at least one joint to capture'
+              : name
+                ? `Capture the current posture into “${name}” (rename via OK)`
+                : trimmed
+                  ? 'Capture the current posture as this pose'
+                  : 'Name the pose first'
           }
         >
-          {name ? 'Save pose' : 'Save new pose'}
+          {name ? 'Capture Pose' : 'Capture new pose'}
         </button>
       </section>
     </>

--- a/src/renderer/src/components/RobotPropertiesDialog.tsx
+++ b/src/renderer/src/components/RobotPropertiesDialog.tsx
@@ -576,8 +576,10 @@ function PoseBody({
   }
   // Footer OK: save a NEW pose (else it'd discard silently), or rename an EXISTING
   // pose whose name was changed. (Editing an existing pose's values is the Save button.)
+  // Mirror the Capture button's guard — never persist an empty (0-joint) pose.
   commitRef.current = () => {
-    if (!name && trimmed) onSavePose(trimmed, allIncluded ? undefined : includedNames)
+    if (!name && trimmed && includedNames.length > 0)
+      onSavePose(trimmed, allIncluded ? undefined : includedNames)
     else if (name && trimmed && trimmed !== name && !clash) onRenamePose(name, trimmed)
   }
   return (

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -286,6 +286,8 @@ export function RobotView({
   // leaves the legs out of `values`. Works whether the sliders OR a running
   // program's `SNK SERVO` telemetry are driving the joints (both update `values`).
   const handleSavePose = (name: string, include?: string[]): void => {
+    // A partial capture with nothing ticked would persist a dead, empty pose — refuse it.
+    if (include && include.length === 0) return
     const vals = capturePoseValues(metaRef.current, valuesRef.current, include)
     const next = [...poses.filter((p) => p.name !== name), { name, values: vals }]
     setPoses(next)

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -11,13 +11,16 @@ import { baseName, dirname, meshKind } from './robot-mesh'
 import {
   type JointMeta,
   type NamedPoseLike,
+  capturePoseValues,
   clamp,
   effectiveLimit,
   extractJoints,
   normPin,
+  poseTargetNative,
   servoToJointNative,
   toDisplay,
-  toNative
+  toNative,
+  uniquePoseName
 } from './robot-pose'
 import { solveCCD, type IkJoint } from './robot-ik'
 import {
@@ -202,6 +205,11 @@ export function RobotView({
   const [measureActive, setMeasureActive] = useState(false)
   const [measureDist, setMeasureDist] = useState<number | null>(null)
   const [savingLabel, setSavingLabel] = useState<string | null>(null)
+  // True while a running program's `SNK SERVO` telemetry is actively driving a
+  // mapped joint (#414) — so the pose editor can show a "Live ●" hint that a
+  // Capture reads the hardware/simulator posture. Clears ~1.2s after it stops.
+  const [poseLive, setPoseLive] = useState(false)
+  const poseLiveTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Refs kept fresh for imperative handlers + the three.js pointer callbacks.
   const robotRef = useRef<URDFRobot | null>(null)
@@ -273,11 +281,12 @@ export function RobotView({
   }
 
 
-  const handleSavePose = (name: string): void => {
-    const vals: Record<string, number> = {}
-    for (const m of metaRef.current) {
-      if (!m.isMimic) vals[m.name] = Number(toDisplay(m.type, valuesRef.current[m.name] ?? 0).toFixed(2))
-    }
+  // Capture the live posture as a named pose (#414). `include` (when given) makes
+  // it a PARTIAL pose — only those joints are stored, so a face-only capture
+  // leaves the legs out of `values`. Works whether the sliders OR a running
+  // program's `SNK SERVO` telemetry are driving the joints (both update `values`).
+  const handleSavePose = (name: string, include?: string[]): void => {
+    const vals = capturePoseValues(metaRef.current, valuesRef.current, include)
     const next = [...poses.filter((p) => p.name !== name), { name, values: vals }]
     setPoses(next)
     void persist((m) => {
@@ -286,6 +295,20 @@ export function RobotView({
     // Advance the editor to the just-saved pose so it flips from "new" to edit mode
     // (Recall/Delete appear, the name locks in), instead of a stale new-pose draft.
     if (name) setDialogCtx({ kind: 'pose', name })
+  }
+
+  // Duplicate a pose under a unique "<name> copy" name, keeping the original and
+  // never clobbering an existing entry (#414). Opens the copy for editing.
+  const handleDuplicatePose = (name: string): void => {
+    const src = poses.find((p) => p.name === name)
+    if (!src) return
+    const copyName = uniquePoseName(name, poses.map((p) => p.name))
+    const next = [...poses, { name: copyName, values: { ...src.values } }]
+    setPoses(next)
+    void persist((m) => {
+      m.poses = next
+    })
+    setDialogCtx({ kind: 'pose', name: copyName })
   }
 
   // Recall a pose by smoothly EASING the model from its current joints to the saved
@@ -298,13 +321,8 @@ export function RobotView({
   const handleRecallPose = (pose: NamedPoseLike): void => {
     const r = robotRef.current
     if (!r) return
-    const target = { ...valuesRef.current }
-    for (const m of metaRef.current) {
-      if (!m.isMimic && typeof pose.values[m.name] === 'number') {
-        const lim = effectiveLimit(m, overridesRef.current[m.name])
-        target[m.name] = clamp(toNative(m.type, pose.values[m.name]), lim.lower, lim.upper)
-      }
-    }
+    // Partial poses leave omitted joints where they are (#414) — see poseTargetNative.
+    const target = poseTargetNative(metaRef.current, valuesRef.current, pose.values, overridesRef.current)
     const start: Record<string, number> = {}
     for (const m of metaRef.current) {
       if (m.isMimic) continue
@@ -1195,7 +1213,12 @@ export function RobotView({
     if (!res || !robotRef.current) return
     robotRef.current.setJointValue(res.joint, res.native)
     setValues((v) => (v[res.joint] === res.native ? v : { ...v, [res.joint]: res.native }))
+    // Flag "live" so the pose editor knows a Capture reads the hardware posture.
+    setPoseLive(true)
+    if (poseLiveTimer.current) clearTimeout(poseLiveTimer.current)
+    poseLiveTimer.current = setTimeout(() => setPoseLive(false), 1200)
   })
+  useEffect(() => () => void (poseLiveTimer.current && clearTimeout(poseLiveTimer.current)), [])
 
   // Round-trip managed Motion Studio blocks (#413): when the user focuses a local
   // .py carrying Snakie-managed blocks in the full Robot View, read its pose
@@ -3855,6 +3878,8 @@ export function RobotView({
             onRecallPose={handleRecallPose}
             onRenamePose={handleRenamePose}
             onDeletePose={handleDeletePose}
+            onDuplicatePose={handleDuplicatePose}
+            poseLive={poseLive}
             jointMeta={jointMeta}
             values={values}
             overrides={overrides}

--- a/src/renderer/src/components/robot-pose.ts
+++ b/src/renderer/src/components/robot-pose.ts
@@ -150,6 +150,66 @@ export function servoToJointNative(
 }
 
 /**
+ * Capture the current live posture as a pose's stored values (#414): each
+ * movable, non-mimic joint's NATIVE value converted to DISPLAY units (deg/mm)
+ * and rounded to 2dp, matching KRF `NamedPose`. When `include` is given the pose
+ * is PARTIAL — only those joints are written, so a face-only pose leaves the legs
+ * out of `values` entirely (and recall then leaves them alone). Mimic joints are
+ * never captured (they follow their master).
+ */
+export function capturePoseValues(
+  meta: JointMeta[],
+  valuesNative: Record<string, number>,
+  include?: Iterable<string>
+): Record<string, number> {
+  const inc = include ? new Set(include) : null
+  const out: Record<string, number> = {}
+  for (const m of meta) {
+    if (m.isMimic) continue
+    if (inc && !inc.has(m.name)) continue
+    out[m.name] = Number(toDisplay(m.type, valuesNative[m.name] ?? 0).toFixed(2))
+  }
+  return out
+}
+
+/**
+ * The NATIVE target values for recalling a pose onto the model (#414): each
+ * movable joint the pose lists is clamped into its effective limits; a joint the
+ * pose OMITS (a partial pose) keeps its `current` value — so recalling a
+ * face-only pose never disturbs the legs. Mimic joints follow their master and
+ * are left out.
+ */
+export function poseTargetNative(
+  meta: JointMeta[],
+  current: Record<string, number>,
+  poseValues: Record<string, number>,
+  overrides: Record<string, { min?: number; max?: number }> = {}
+): Record<string, number> {
+  const target = { ...current }
+  for (const m of meta) {
+    if (m.isMimic) continue
+    if (typeof poseValues[m.name] !== 'number') continue // partial: leave this joint alone
+    const lim = effectiveLimit(m, overrides[m.name])
+    target[m.name] = clamp(toNative(m.type, poseValues[m.name]), lim.lower, lim.upper)
+  }
+  return target
+}
+
+/**
+ * A unique "<base> copy" name for duplicating a pose (#414) — `Wave` → `Wave
+ * copy`, then `Wave copy 2`, `Wave copy 3`… — never colliding with an existing
+ * pose so a duplicate can't clobber the original or another entry.
+ */
+export function uniquePoseName(base: string, existing: Iterable<string>): string {
+  const taken = new Set(existing)
+  const first = `${base} copy`
+  if (!taken.has(first)) return first
+  let n = 2
+  while (taken.has(`${base} copy ${n}`)) n++
+  return `${base} copy ${n}`
+}
+
+/**
  * The EFFECTIVE native limits for a joint: the URDF limits, overridden by any
  * in-app min/max (stored in KRF as display units — deg/mm).
  */

--- a/test/robotPose.test.ts
+++ b/test/robotPose.test.ts
@@ -177,6 +177,12 @@ describe('capturePoseValues — Capture Pose incl. partial (#414)', () => {
     expect(capturePoseValues(meta, native, ['finger', 'elbow'])).toEqual({ elbow: -45 })
   })
 
+  it('an empty include set captures nothing (callers must refuse a 0-joint pose)', () => {
+    // handleSavePose bails on an empty `include`; this locks in that [] ⇒ {} so a
+    // future caller can rely on it to detect "nothing ticked".
+    expect(capturePoseValues(meta, native, [])).toEqual({})
+  })
+
   it('rounds to 2 decimals', () => {
     const vals = capturePoseValues(
       [{ name: 'j', type: 'revolute', lower: -Math.PI, upper: Math.PI, isMimic: false }],

--- a/test/robotPose.test.ts
+++ b/test/robotPose.test.ts
@@ -9,6 +9,9 @@ import {
   effectiveLimit,
   normPin,
   servoToJointNative,
+  capturePoseValues,
+  poseTargetNative,
+  uniquePoseName,
   CONTINUOUS_RANGE,
   type JointMeta,
   type RobotLike
@@ -144,5 +147,77 @@ describe('servoToJointNative — the code-driven pipe (#313)', () => {
     ]
     expect(servoToJointNative(bindings, meta, '99', 90)).toBeNull()
     expect(servoToJointNative([{ pin: '16', joint: 'ghost', jointMin: 0, jointMax: 1 }], meta, '16', 90)).toBeNull()
+  })
+})
+
+describe('capturePoseValues — Capture Pose incl. partial (#414)', () => {
+  const meta: JointMeta[] = [
+    { name: 'shoulder', type: 'revolute', lower: -Math.PI, upper: Math.PI, isMimic: false },
+    { name: 'elbow', type: 'revolute', lower: -Math.PI, upper: Math.PI, isMimic: false },
+    { name: 'slide', type: 'prismatic', lower: 0, upper: 0.1, isMimic: false },
+    // a mimic — never captured
+    { name: 'finger', type: 'revolute', lower: -1, upper: 1, isMimic: true, master: 'shoulder' }
+  ]
+  const native = { shoulder: Math.PI / 2, elbow: -Math.PI / 4, slide: 0.025, finger: 0.3 }
+
+  it('captures every non-mimic joint in display units (deg/mm), 2dp', () => {
+    const vals = capturePoseValues(meta, native)
+    expect(vals).toEqual({ shoulder: 90, elbow: -45, slide: 25 })
+    expect(vals).not.toHaveProperty('finger') // mimics excluded
+  })
+
+  it('captures ONLY the included joints for a partial pose', () => {
+    const vals = capturePoseValues(meta, native, ['shoulder'])
+    expect(vals).toEqual({ shoulder: 90 })
+    expect(vals).not.toHaveProperty('elbow')
+    expect(vals).not.toHaveProperty('slide')
+  })
+
+  it('a mimic can never be forced in via include', () => {
+    expect(capturePoseValues(meta, native, ['finger', 'elbow'])).toEqual({ elbow: -45 })
+  })
+
+  it('rounds to 2 decimals', () => {
+    const vals = capturePoseValues(
+      [{ name: 'j', type: 'revolute', lower: -Math.PI, upper: Math.PI, isMimic: false }],
+      { j: 1 } // 1 rad = 57.2957…°
+    )
+    expect(vals.j).toBe(57.3)
+  })
+})
+
+describe('poseTargetNative — recall leaves partial-pose omissions alone (#414)', () => {
+  const meta: JointMeta[] = [
+    { name: 'shoulder', type: 'revolute', lower: -Math.PI, upper: Math.PI, isMimic: false },
+    { name: 'elbow', type: 'revolute', lower: -Math.PI, upper: Math.PI, isMimic: false }
+  ]
+  const current = { shoulder: 0.1, elbow: 0.2 }
+
+  it('applies listed joints (converting deg→rad) and clamps to limits', () => {
+    const t = poseTargetNative(meta, current, { shoulder: 90, elbow: -45 })
+    expect(t.shoulder).toBeCloseTo(Math.PI / 2)
+    expect(t.elbow).toBeCloseTo(-Math.PI / 4)
+  })
+
+  it('leaves a joint the partial pose omits at its CURRENT value', () => {
+    const t = poseTargetNative(meta, current, { shoulder: 90 }) // elbow omitted
+    expect(t.shoulder).toBeCloseTo(Math.PI / 2)
+    expect(t.elbow).toBe(0.2) // untouched
+  })
+
+  it('clamps an out-of-range stored value into the effective limit', () => {
+    const t = poseTargetNative(meta, current, { shoulder: 720 }, { shoulder: { min: -90, max: 90 } })
+    expect(t.shoulder).toBeCloseTo(Math.PI / 2) // clamped to +90°
+  })
+})
+
+describe('uniquePoseName — duplicate never clobbers (#414)', () => {
+  it('appends " copy" then numbers, skipping taken names', () => {
+    expect(uniquePoseName('Wave', ['Wave'])).toBe('Wave copy')
+    expect(uniquePoseName('Wave', ['Wave', 'Wave copy'])).toBe('Wave copy 2')
+    expect(uniquePoseName('Wave', ['Wave', 'Wave copy', 'Wave copy 2'])).toBe('Wave copy 3')
+  })
+  it('is stable for a name with no existing copy', () => {
+    expect(uniquePoseName('Rest', ['Wave', 'Sit'])).toBe('Rest copy')
   })
 })


### PR DESCRIPTION
Third piece of the **Motion Studio** epic (#403). Closes #414.

Turns the Robot View pose editor into Motion Studio's pose-authoring surface.

## What
- **Capture Pose** — the Save button becomes **Capture Pose**; it snapshots the *current* live posture, whether you posed it with the sliders **or** a running program's servos are driving the model. The servo telemetry (`SNK SERVO <pin> <deg>`) already back-drives the joints, so capture-from-hardware Just Works — and a **Live ●** hint appears in the editor while telemetry is actively driving a mapped joint.
- **Partial poses** — a per-joint **include checkbox** (+ an **All/None** toggle) writes only the ticked joints to `values`; recalling a partial pose leaves the omitted joints exactly where they are. A hint shows how many joints will be captured, and Capture/OK refuse a 0-joint pose.
- **Duplicate** — copies a pose under a unique `"<name> copy"` (then `copy 2`, `copy 3`…) without clobbering the original, and opens the copy for editing. New footer button beside Recall/Delete.
- `NamedPose[]` stays the **single source** the #413 managed-block round-trip reads — no divergent second store.

## Design
The core logic is three pure, unit-tested helpers in `robot-pose.ts` (`capturePoseValues`, `poseTargetNative`, `uniquePoseName`); `handleSavePose`/`handleRecallPose`/`handleDuplicatePose` reuse them. Recall keeps its smooth ease/tween. New CSS reads in both the dark and skeuomorph-light themes.

## Adversarial review
A skeptical review traced every flow and found **one** real defect — the footer **OK** path bypassed the Capture button's "tick at least one joint" guard and could persist a dead empty pose. Fixed at both seams (`commitRef` + `handleSavePose`) with a regression test; everything else (helper correctness, PoseBody remount-per-pose so include-state can't leak, `poseLive` timer cleanup, duplicate never clobbering, no Save/Rename/Recall/Delete regression) was verified sound.

## Verification
- **1631 vitest** (+11 robot-pose: capture full/partial/mimic/rounding/empty-set, partial-recall keeps omitted joints + clamps, duplicate naming). typecheck / lint / build green. JS-only — Python unaffected.

## Scope
Pose authoring only. Sequence editor (#415) and puppet controls (#416) are separate. Part of #403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)