### PR TITLE
feat: Motion Studio pose-step sequencer / walk cycles (#415)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Motion Studio — pose-step sequencer / walk cycles (#403, #415).** A new sequencer at the
+  bottom of the Robot View authors motion as an ordered list of **saved poses** — stand → lift
+  → step → plant — each with its own **duration** and **easing**, plus a **loop** toggle, instead
+  of a grid of per-joint keyframes (the keyframe timeline stays, unchanged). Play/pause, stop and
+  scrub against the 3-D model; add/reorder/remove steps inline. With a board connected and a servo
+  bound, a **Live** toggle streams each frame to the hardware so the physical robot mirrors the
+  preview (disconnect drops back to preview-only). Export writes the sequence into the managed
+  `SNAKIE_SEQUENCES` block (#413) — timed to match the `snakie_motion` runtime so hardware plays
+  exactly what you previewed.
 - **Motion Studio — Capture Pose, duplicate, and partial poses (#403, #414).** The Robot View
   pose editor becomes a proper authoring surface. **Capture Pose** snapshots the current live
   posture into a named pose — whether you posed it with the sliders **or** a running program's

--- a/python/snakie/host.py
+++ b/python/snakie/host.py
@@ -397,10 +397,15 @@ def _validate_sequences(raw: Any, warnings: List[str]) -> Dict[str, List[List[An
             continue
         good: List[List[Any]] = []
         for step in steps:
-            if isinstance(step, (list, tuple)) and len(step) == 2 and isinstance(step[0], str):
+            if isinstance(step, (list, tuple)) and len(step) in (2, 3) and isinstance(step[0], str):
                 dur = _as_finite_number(step[1])
-                if dur is not None:
-                    good.append([step[0], dur])
+                if dur is None:
+                    continue
+                item: List[Any] = [step[0], dur]
+                # An optional 3rd element is the easing (#415); keep it if it's a string.
+                if len(step) == 3 and isinstance(step[2], str):
+                    item.append(step[2])
+                good.append(item)
         out[name] = good
     return out
 

--- a/python/tests/test_motion_read.py
+++ b/python/tests/test_motion_read.py
@@ -154,6 +154,20 @@ class MotionReadRobustnessTests(unittest.TestCase):
         self.assertTrue(res["ok"])
         self.assertEqual(res["poses"]["p"], {"good": 45.0})  # only the finite value
 
+    def test_sequence_step_keeps_an_optional_easing_third_element(self) -> None:
+        # #415 exports [pose, ms, easing]; the reader must carry the easing (and
+        # still accept the legacy 2-tuple form).
+        res = read(
+            "# --- snakie:sequences v1 ---\n"
+            'SNAKIE_SEQUENCES = { "walk": [ ["a", 0, "linear"], ["b", 500, "easeInOut"], ["c", 200] ] }\n'
+            "# --- snakie:sequences:end ---\n"
+        )
+        self.assertTrue(res["ok"])
+        self.assertEqual(
+            res["sequences"]["walk"],
+            [["a", 0.0, "linear"], ["b", 500.0, "easeInOut"], ["c", 200.0]],
+        )
+
     def test_boolean_values_are_rejected_not_coerced(self) -> None:
         # bool subclasses int; True must NOT become 1.0 in a numeric slot.
         res = read(

--- a/src/main/plugins/types.ts
+++ b/src/main/plugins/types.ts
@@ -147,8 +147,8 @@ export interface MotionReadResult {
   schema?: number
   /** pose name → { joint → value } (display units). */
   poses?: Record<string, Record<string, number>>
-  /** sequence name → [poseName, durationMs] steps. */
-  sequences?: Record<string, Array<[string, number]>>
+  /** sequence name → [poseName, durationMs, easing?] steps. */
+  sequences?: Record<string, Array<[string, number] | [string, number, string]>>
   /** Servo bindings (pin/joint required; camelCase like `ServoJointBinding`). */
   servos?: Array<{
     pin: string

--- a/src/renderer/src/components/RobotSequencer.css
+++ b/src/renderer/src/components/RobotSequencer.css
@@ -1,0 +1,223 @@
+/* Pose-step sequencer (#415) — sits beside the keyframe timeline at the bottom of
+   the pose tool. Theme-aware tokens (reads on dark + skeuomorph light). Unique
+   `robotseq__` BEM prefix so its global styles never collide with the timeline. */
+.robotseq {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 0.35rem 0.5rem 0.5rem;
+  background: var(--bg-elevated, #202227);
+  border-top: var(--border-w, 1px) solid var(--border, #2c2e33);
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  color: var(--text, #cdd2d9);
+  font-size: 0.66rem;
+  max-height: 16rem;
+}
+
+.robotseq__bar {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.robotseq__btn {
+  font-family: inherit;
+  font-size: 0.66rem;
+  color: var(--text, #cdd2d9);
+  background: var(--bg-sunken, #2a2d33);
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 5px;
+  padding: 0.15rem 0.5rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.robotseq__btn:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+.robotseq__btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+.robotseq__btn.is-on {
+  color: var(--accent-contrast, #191a1d);
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.robotseq__loop,
+.robotseq__live {
+  display: flex;
+  align-items: center;
+  gap: 0.22rem;
+  white-space: nowrap;
+  cursor: pointer;
+}
+.robotseq__loop input,
+.robotseq__live input {
+  accent-color: var(--accent, #d6a23f);
+  cursor: pointer;
+}
+.robotseq__live-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: var(--border, #3a3d44);
+}
+.robotseq__live.is-on .robotseq__live-dot {
+  background: #34c46b;
+  box-shadow: 0 0 0 2px rgba(52, 196, 107, 0.28);
+  animation: robotseq-livepulse 1.1s ease-in-out infinite;
+}
+@keyframes robotseq-livepulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
+.robotseq__scrub {
+  flex: 1 1 auto;
+  min-width: 4rem;
+  accent-color: var(--accent, #d6a23f);
+}
+.robotseq__time {
+  flex: 0 0 auto;
+  opacity: 0.8;
+  font-variant-numeric: tabular-nums;
+}
+.robotseq__spacer {
+  flex: 1 1 auto;
+}
+
+.robotseq__steps {
+  overflow-y: auto;
+  min-height: 1.5rem;
+}
+.robotseq__empty {
+  margin: 0.3rem 0;
+  opacity: 0.7;
+}
+.robotseq__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+.robotseq__step {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+.robotseq__num {
+  flex: 0 0 auto;
+  width: 1.1rem;
+  text-align: right;
+  opacity: 0.6;
+  font-variant-numeric: tabular-nums;
+}
+.robotseq__pose {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-family: inherit;
+  font-size: 0.64rem;
+  color: var(--text, #cdd2d9);
+  background: var(--bg-sunken, #2a2d33);
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 4px;
+  padding: 0.12rem 0.25rem;
+}
+.robotseq__pose.is-missing {
+  border-color: #b4544e;
+  color: #b4544e;
+}
+.robotseq__dur {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 0.1rem;
+  opacity: 0.9;
+}
+.robotseq__dur input {
+  width: 3rem;
+  font-family: inherit;
+  font-size: 0.64rem;
+  color: var(--text, #cdd2d9);
+  background: var(--bg-sunken, #2a2d33);
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 4px;
+  padding: 0.12rem 0.2rem;
+}
+.robotseq__easing {
+  flex: 0 0 auto;
+  font-family: inherit;
+  font-size: 0.62rem;
+  color: var(--text, #cdd2d9);
+  background: var(--bg-sunken, #2a2d33);
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 4px;
+  padding: 0.12rem 0.2rem;
+}
+.robotseq__at {
+  flex: 0 0 auto;
+  width: 3rem;
+  text-align: right;
+  opacity: 0.55;
+  font-variant-numeric: tabular-nums;
+}
+.robotseq__ops {
+  flex: 0 0 auto;
+  display: flex;
+  gap: 0.15rem;
+}
+.robotseq__op {
+  font-family: inherit;
+  font-size: 0.62rem;
+  line-height: 1;
+  color: var(--text, #cdd2d9);
+  background: var(--bg-sunken, #2a2d33);
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 4px;
+  padding: 0.1rem 0.3rem;
+  cursor: pointer;
+}
+.robotseq__op:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+.robotseq__op:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.robotseq__op--del:hover:not(:disabled) {
+  border-color: #b4544e;
+  color: #b4544e;
+}
+
+.robotseq__add {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem;
+  padding-top: 0.15rem;
+  border-top: 1px solid var(--border, #2c2e33);
+}
+.robotseq__add-label {
+  opacity: 0.7;
+}
+.robotseq__add-pose {
+  font-family: inherit;
+  font-size: 0.62rem;
+  color: var(--text, #cdd2d9);
+  background: var(--bg-sunken, #2a2d33);
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 5px;
+  padding: 0.1rem 0.4rem;
+  cursor: pointer;
+}
+.robotseq__add-pose:hover {
+  border-color: var(--accent);
+}

--- a/src/renderer/src/components/RobotSequencer.tsx
+++ b/src/renderer/src/components/RobotSequencer.tsx
@@ -1,0 +1,238 @@
+import type { JSX } from 'react'
+import type { MotionEasing, MotionSequence, NamedPose } from '../../../shared/robot'
+import { sequenceDuration, sequenceSegments } from '../../../shared/robot-timeline'
+import './RobotSequencer.css'
+
+/**
+ * POSE-STEP SEQUENCER (#415, epic #403) — authors a walk cycle as an ordered list
+ * of saved poses, each with its own duration + easing, instead of a grid of
+ * per-joint keyframes. A transport bar (play/pause, stop, scrubber over the total
+ * duration, loop, Live, export) mirrors {@link RobotTimeline}; the body is the
+ * reorderable step list. Playback + persistence + the managed `SNAKIE_SEQUENCES`
+ * export live in {@link RobotView}; this is the presentational surface.
+ */
+
+export interface RobotSequencerProps {
+  sequence: MotionSequence
+  /** Saved poses to pick steps from (only those that apply to this robot). */
+  poses: NamedPose[]
+  playing: boolean
+  /** Current play time (seconds). */
+  playhead: number
+  /** Streaming to a connected board. */
+  live: boolean
+  /** A board is connected AND at least one servo is bound (else Live is disabled). */
+  canLive: boolean
+  /** A servo is bound (else Export has nothing to drive). */
+  canExport: boolean
+  onPlayPause: () => void
+  onStop: () => void
+  onScrub: (t: number) => void
+  onToggleLoop: () => void
+  onToggleLive: () => void
+  onAddStep: (pose: string) => void
+  onRemoveStep: (index: number) => void
+  onMoveStep: (index: number, dir: -1 | 1) => void
+  onSetStepPose: (index: number, pose: string) => void
+  onSetStepDuration: (index: number, seconds: number) => void
+  onSetStepEasing: (index: number, easing: MotionEasing) => void
+  onExport: () => void
+}
+
+const fmt = (s: number): string => `${s.toFixed(2)}s`
+
+export function RobotSequencer({
+  sequence,
+  poses,
+  playing,
+  playhead,
+  live,
+  canLive,
+  canExport,
+  onPlayPause,
+  onStop,
+  onScrub,
+  onToggleLoop,
+  onToggleLive,
+  onAddStep,
+  onRemoveStep,
+  onMoveStep,
+  onSetStepPose,
+  onSetStepDuration,
+  onSetStepEasing,
+  onExport
+}: RobotSequencerProps): JSX.Element {
+  const steps = sequence.steps
+  const total = sequenceDuration(sequence)
+  const segs = sequenceSegments(sequence)
+  const poseNames = poses.map((p) => p.name)
+  const hasPoses = poseNames.length > 0
+
+  // Cumulative end-time of each segment, so a step row can show when it lands.
+  let acc = 0
+  const segEnd = segs.map((d) => (acc += d))
+
+  return (
+    <div className="robotseq" aria-label="Pose sequence">
+      <div className="robotseq__bar">
+        <button
+          type="button"
+          className={`robotseq__btn${playing ? ' is-on' : ''}`}
+          onClick={onPlayPause}
+          disabled={steps.length < 1}
+          title={playing ? 'Pause' : 'Play the sequence'}
+        >
+          {playing ? '❚❚' : '▶'}
+        </button>
+        <button type="button" className="robotseq__btn" onClick={onStop} title="Stop / rewind">
+          ■
+        </button>
+        <label className="robotseq__loop" title="Loop the sequence (last step eases back to the first)">
+          <input type="checkbox" checked={sequence.loop} onChange={onToggleLoop} />
+          Loop
+        </label>
+        <input
+          className="robotseq__scrub"
+          type="range"
+          min={0}
+          max={Math.max(0.001, total)}
+          step={0.01}
+          value={Math.min(playhead, total)}
+          onChange={(e) => onScrub(Number(e.target.value))}
+          disabled={total <= 0}
+          aria-label="Scrub the sequence"
+        />
+        <span className="robotseq__time">
+          {fmt(Math.min(playhead, total))} / {fmt(total)}
+        </span>
+        <label
+          className={`robotseq__live${live ? ' is-on' : ''}`}
+          title={
+            canLive
+              ? 'Stream each frame to the connected board (SNKCMD servo)'
+              : 'Connect a board and bind a servo to stream live'
+          }
+        >
+          <input type="checkbox" checked={live} onChange={onToggleLive} disabled={!canLive} />
+          <span className="robotseq__live-dot" aria-hidden="true" />
+          Live
+        </label>
+        <span className="robotseq__spacer" />
+        <button
+          type="button"
+          className="robotseq__btn"
+          onClick={onExport}
+          disabled={!canExport}
+          title={canExport ? 'Export motion.py (with the sequence)' : 'Bind a servo first'}
+        >
+          Export
+        </button>
+      </div>
+
+      <div className="robotseq__steps">
+        {!hasPoses ? (
+          <p className="robotseq__empty">Save a pose first — steps reference your saved poses.</p>
+        ) : steps.length === 0 ? (
+          <p className="robotseq__empty">No steps yet. Add a pose below to start the sequence.</p>
+        ) : (
+          <ol className="robotseq__list">
+            {steps.map((step, i) => {
+              const known = poseNames.includes(step.pose)
+              return (
+                <li className="robotseq__step" key={i}>
+                  <span className="robotseq__num">{i + 1}</span>
+                  <select
+                    className={`robotseq__pose${known ? '' : ' is-missing'}`}
+                    value={known ? step.pose : ''}
+                    onChange={(e) => onSetStepPose(i, e.target.value)}
+                    title={known ? step.pose : `“${step.pose}” — no such pose`}
+                  >
+                    {!known && (
+                      <option value="" disabled>
+                        {step.pose} (missing)
+                      </option>
+                    )}
+                    {poseNames.map((n) => (
+                      <option key={n} value={n}>
+                        {n}
+                      </option>
+                    ))}
+                  </select>
+                  <label className="robotseq__dur" title="Seconds to the next pose">
+                    <input
+                      type="number"
+                      min={0}
+                      step={0.1}
+                      value={step.duration}
+                      onChange={(e) => onSetStepDuration(i, Number(e.target.value))}
+                    />
+                    s
+                  </label>
+                  <select
+                    className="robotseq__easing"
+                    value={step.easing ?? 'easeInOut'}
+                    onChange={(e) => onSetStepEasing(i, e.target.value as MotionEasing)}
+                    title="Interpolation into the next pose"
+                  >
+                    <option value="easeInOut">smooth</option>
+                    <option value="linear">linear</option>
+                  </select>
+                  <span className="robotseq__at" title="Reaches the next pose at">
+                    {fmt(segEnd[i] ?? total)}
+                  </span>
+                  <span className="robotseq__ops">
+                    <button
+                      type="button"
+                      className="robotseq__op"
+                      onClick={() => onMoveStep(i, -1)}
+                      disabled={i === 0}
+                      title="Move up"
+                    >
+                      ↑
+                    </button>
+                    <button
+                      type="button"
+                      className="robotseq__op"
+                      onClick={() => onMoveStep(i, 1)}
+                      disabled={i === steps.length - 1}
+                      title="Move down"
+                    >
+                      ↓
+                    </button>
+                    <button
+                      type="button"
+                      className="robotseq__op robotseq__op--del"
+                      onClick={() => onRemoveStep(i)}
+                      title="Remove step"
+                    >
+                      ✕
+                    </button>
+                  </span>
+                </li>
+              )
+            })}
+          </ol>
+        )}
+      </div>
+
+      {hasPoses && (
+        <div className="robotseq__add">
+          <span className="robotseq__add-label">Add step:</span>
+          {poses.map((p) => (
+            <button
+              key={p.name}
+              type="button"
+              className="robotseq__add-pose"
+              onClick={() => onAddStep(p.name)}
+              title={`Append “${p.name}” as a step`}
+            >
+              + {p.name}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default RobotSequencer

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -84,6 +84,7 @@ import { RobotPropertiesDialog, type PropsContext } from './RobotPropertiesDialo
 import { RobotToolbar } from './RobotToolbar'
 import { loadPin, savePin, PIN_KEYS } from './pin-overlay'
 import { RobotTimeline } from './RobotTimeline'
+import { RobotSequencer } from './RobotSequencer'
 import {
   autoMirrorPairs,
   deleteKey,
@@ -93,7 +94,10 @@ import {
   generateMicroPython,
   mirrorTracks,
   moveKey,
+  poseSequenceToManagedSteps,
+  samplePoseSequence,
   sampleTimeline,
+  sequenceDuration,
   upsertKey
 } from '../../../shared/robot-timeline'
 import {
@@ -103,11 +107,15 @@ import {
   type ManagedServo,
   type ManagedSequenceStep
 } from '../../../shared/managed-blocks'
+import { jointToServo } from '../../../shared/krf'
 import { useTelemetryStream } from './instrument-telemetry-subscribe'
+import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import type {
   MirrorPair,
   MotionEasing,
+  MotionSequence,
   MotionTimeline,
+  PoseStep,
   RobotDefinition,
   RobotModel,
   ServoJointBinding
@@ -116,6 +124,9 @@ import './RobotView.css'
 
 /** An empty motion clip (2 s, ease-in-out, looping). */
 const EMPTY_TIMELINE: MotionTimeline = { duration: 2, easing: 'easeInOut', loop: true, fps: 20, tracks: [] }
+
+/** An empty pose sequence (#415) — looping, no steps yet. */
+const EMPTY_SEQUENCE: MotionSequence = { name: 'sequence', loop: true, fps: 20, steps: [] }
 
 // Camera view per robot, kept at MODULE scope so it survives the RobotView unmounting
 // when you switch to a non-URDF editor tab — otherwise the orbit is lost and the view
@@ -1489,6 +1500,7 @@ export function RobotView({
         applyTimelineAt(playheadRef.current, true) // pausing → sync the sliders to the pose
         return false
       }
+      setSeqPlaying(false) // keyframe + sequence playback are mutually exclusive
       // Starting: rewind a FINISHED one-shot clip so it replays from the top.
       const tl = timelineRef.current
       if (!tl.loop && playheadRef.current >= tl.duration) {
@@ -1496,6 +1508,177 @@ export function RobotView({
         setPlayhead(0)
       }
       return true
+    })
+  }
+
+  // ── Pose-step sequences (#415) ─────────────────────────────────────────────
+  const [sequence, setSequence] = useState<MotionSequence>(EMPTY_SEQUENCE)
+  const [seqPlaying, setSeqPlaying] = useState(false)
+  const [seqPlayhead, setSeqPlayhead] = useState(0)
+  const [seqLive, setSeqLive] = useState(false)
+  const sequenceRef = useRef<MotionSequence>(EMPTY_SEQUENCE)
+  const seqPlayheadRef = useRef(0)
+  const lastSeqPush = useRef(0)
+  const lastLiveSend = useRef(0)
+  const seqSaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const pendingSeqSave = useRef<(() => Promise<void>) | null>(null)
+  const seqLoadedFolder = useRef<string | null>(null)
+  const seqLiveRef = useRef(false)
+  sequenceRef.current = sequence
+  seqLiveRef.current = seqLive
+  // Pose name → its saved DISPLAY values, for the sampler (kept fresh for rAF).
+  const posesByNameRef = useRef<Record<string, Record<string, number>>>({})
+  posesByNameRef.current = Object.fromEntries(poses.map((p) => [p.name, p.values]))
+
+  const deviceStatus = useDeviceStatus()
+  const canSeqLive = deviceStatus.state === 'connected' && bindings.length > 0
+  // Degrade gracefully: if the board disconnects (or its bindings vanish) while Live
+  // is on, drop back to preview-only rather than streaming into the void.
+  useEffect(() => {
+    if (!canSeqLive && seqLive) setSeqLive(false)
+  }, [canSeqLive, seqLive])
+
+  // Stream the current frame's servo angles to a connected board (#415). Uses the
+  // reverse SNKCMD control channel: one line per frame, "SNKCMD servos <pin>=<deg> …"
+  // (a program running `inst.control` mirrors it onto the physical servos). Throttled;
+  // best-effort — a disconnect / write error is swallowed so preview never breaks.
+  const pushLiveFrame = (sampledDisplay: Record<string, number>): void => {
+    const now = performance.now()
+    if (now - lastLiveSend.current < 55) return // ~18 Hz cap on serial writes
+    lastLiveSend.current = now
+    const parts: string[] = []
+    for (const b of bindingsRef.current) {
+      const disp = sampledDisplay[b.joint]
+      if (typeof disp !== 'number') continue
+      parts.push(`${b.pin}=${Math.round(jointToServo(b, disp))}`)
+    }
+    if (parts.length) void window.api.device.sendControl('servos', parts.join(' ')).catch(() => undefined)
+  }
+
+  // Apply a sampled sequence frame to the robot imperatively (mirrors auto-follow);
+  // `commitState` syncs the sliders (scrub/pause only). Streams to the board when Live.
+  const applySequenceAt = (t: number, commitState = false): void => {
+    const r = robotRef.current
+    if (!r) return
+    const sampled = samplePoseSequence(sequenceRef.current, posesByNameRef.current, t)
+    const patch: Record<string, number> = {}
+    for (const m of metaRef.current) {
+      if (m.isMimic) continue
+      const disp = sampled[m.name]
+      if (typeof disp !== 'number') continue
+      const lim = effectiveLimit(m, overridesRef.current[m.name])
+      const native = clamp(toNative(m.type, disp), lim.lower, lim.upper)
+      r.setJointValue(m.name, native)
+      patch[m.name] = native
+    }
+    if (commitState) setValues((v) => ({ ...v, ...patch }))
+    if (seqLiveRef.current) pushLiveFrame(sampled)
+  }
+
+  // rAF playback loop (mirrors the timeline's at :1410) — drives setJointValue each
+  // frame; the scrubber state is throttled to ~20 Hz so it never re-renders per frame.
+  useEffect(() => {
+    if (!seqPlaying) return
+    let raf = 0
+    const start = performance.now() - seqPlayheadRef.current * 1000
+    const tick = (): void => {
+      const seq = sequenceRef.current
+      const total = sequenceDuration(seq)
+      const elapsed = (performance.now() - start) / 1000
+      let t: number
+      if (seq.loop) {
+        t = total > 0 ? elapsed % total : 0
+      } else {
+        t = Math.min(elapsed, total)
+        if (elapsed >= total) {
+          applySequenceAt(t, true)
+          seqPlayheadRef.current = t
+          setSeqPlayhead(t)
+          setSeqPlaying(false)
+          return
+        }
+      }
+      applySequenceAt(t)
+      seqPlayheadRef.current = t
+      const now = performance.now()
+      if (now - lastSeqPush.current > 50) {
+        lastSeqPush.current = now
+        setSeqPlayhead(t)
+      }
+      raf = requestAnimationFrame(tick)
+    }
+    raf = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(raf)
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- refs carry the rest
+  }, [seqPlaying])
+
+  // Update the sequence + debounced persist (folder-snapshotting like commitTimeline,
+  // so a fast folder switch can't write it into another project's robot.yml).
+  const commitSequence = (next: MotionSequence): void => {
+    sequenceRef.current = next
+    setSequence(next)
+    const folder = currentFolder || undefined
+    pendingSeqSave.current = async (): Promise<void> => {
+      pendingSeqSave.current = null
+      try {
+        const def = await window.api.robot.load(folder)
+        def.robot = { ...(def.robot ?? {}), sequences: [next] }
+        await window.api.robot.save(folder, def)
+      } catch {
+        // best-effort — a sequence save failing is non-fatal
+      }
+    }
+    if (seqSaveTimer.current) clearTimeout(seqSaveTimer.current)
+    seqSaveTimer.current = setTimeout(() => void pendingSeqSave.current?.(), 400)
+  }
+  // Flush a pending sequence save on unmount (and stop the timer firing after).
+  useEffect(
+    () => () => {
+      if (seqSaveTimer.current) clearTimeout(seqSaveTimer.current)
+      void pendingSeqSave.current?.()
+    },
+    []
+  )
+
+  const seqSeek = (t: number): void => {
+    setSeqPlaying(false)
+    const cl = Math.max(0, Math.min(sequenceDuration(sequenceRef.current), t))
+    seqPlayheadRef.current = cl
+    setSeqPlayhead(cl)
+    applySequenceAt(cl, true)
+  }
+  const handleSeqPlayPause = (): void => {
+    setSeqPlaying((p) => {
+      if (p) {
+        applySequenceAt(seqPlayheadRef.current, true)
+        return false
+      }
+      setPlaying(false) // sequence + keyframe playback are mutually exclusive (both drive setJointValue)
+      const seq = sequenceRef.current
+      if (!seq.loop && seqPlayheadRef.current >= sequenceDuration(seq)) {
+        seqPlayheadRef.current = 0
+        setSeqPlayhead(0)
+      }
+      return true
+    })
+  }
+  const handleAddStep = (pose: string): void => {
+    commitSequence({ ...sequenceRef.current, steps: [...sequenceRef.current.steps, { pose, duration: 0.5, easing: 'easeInOut' }] })
+  }
+  const handleRemoveStep = (index: number): void => {
+    commitSequence({ ...sequenceRef.current, steps: sequenceRef.current.steps.filter((_, i) => i !== index) })
+  }
+  const handleMoveStep = (index: number, dir: -1 | 1): void => {
+    const steps = [...sequenceRef.current.steps]
+    const j = index + dir
+    if (j < 0 || j >= steps.length) return
+    ;[steps[index], steps[j]] = [steps[j], steps[index]]
+    commitSequence({ ...sequenceRef.current, steps })
+  }
+  const patchStep = (index: number, patch: Partial<PoseStep>): void => {
+    commitSequence({
+      ...sequenceRef.current,
+      steps: sequenceRef.current.steps.map((s, i) => (i === index ? { ...s, ...patch } : s))
     })
   }
 
@@ -1527,21 +1710,31 @@ export function RobotView({
     })
   }
 
-  // The current pose library + servo map as managed-block data (#413), so an
-  // export carries a round-trippable source of truth the app can read back. Note:
-  // `sequences` is deliberately OMITTED (undefined) — there is no sequence editor
-  // yet (#415), so any hand-authored SNAKIE_SEQUENCES block is left untouched
-  // rather than wiped, instead of being rewritten to `{}`.
-  const buildManagedMotion = (): ManagedMotion => ({
-    poses: Object.fromEntries(posesRef.current.map((p) => [p.name, p.values])),
-    servos: bindingsRef.current.map((b) => {
-      const s: ManagedServo = { pin: b.pin, joint: b.joint, jointMin: b.jointMin, jointMax: b.jointMax }
-      if (typeof b.servoMin === 'number') s.servoMin = b.servoMin
-      if (typeof b.servoMax === 'number') s.servoMax = b.servoMax
-      if (b.invert) s.invert = true
-      return s
-    })
-  })
+  // The current pose library + servo map + sequence as managed-block data (#413/
+  // #415), so an export carries a round-trippable source of truth the app reads
+  // back. `sequences` is included when the editor has steps (or a hand-authored
+  // block was parsed on open); when there's nothing to write we OMIT the field so
+  // writeManagedBlocks leaves any existing SNAKIE_SEQUENCES block untouched.
+  const buildManagedMotion = (): ManagedMotion => {
+    const m: ManagedMotion = {
+      poses: Object.fromEntries(posesRef.current.map((p) => [p.name, p.values])),
+      servos: bindingsRef.current.map((b) => {
+        const s: ManagedServo = { pin: b.pin, joint: b.joint, jointMin: b.jointMin, jointMax: b.jointMax }
+        if (typeof b.servoMin === 'number') s.servoMin = b.servoMin
+        if (typeof b.servoMax === 'number') s.servoMax = b.servoMax
+        if (b.invert) s.invert = true
+        return s
+      })
+    }
+    const seq = sequenceRef.current
+    const carried = managedSequencesRef.current
+    if (seq.steps.length || Object.keys(carried).length) {
+      // Preserve any other hand-authored sequences; the editor's sequence wins on its name.
+      m.sequences = { ...carried }
+      if (seq.steps.length) m.sequences[seq.name || 'sequence'] = poseSequenceToManagedSteps(seq)
+    }
+    return m
+  }
 
   const handleExport = (): void => {
     const ex = generateMicroPython(timelineRef.current, bindingsRef.current, {
@@ -2306,6 +2499,17 @@ export function RobotView({
                     ? model.mirror
                     : autoMirrorPairs(movable)
                 )
+              }
+              // Pose sequence (#415) — seed once per folder alongside the timeline.
+              if (seqLoadedFolder.current !== folderKey) {
+                seqLoadedFolder.current = folderKey
+                const seq = Array.isArray(model.sequences) ? model.sequences[0] : undefined
+                const loadedSeq = seq && Array.isArray(seq.steps) ? (seq as MotionSequence) : EMPTY_SEQUENCE
+                sequenceRef.current = loadedSeq
+                setSequence(loadedSeq)
+                seqPlayheadRef.current = 0
+                setSeqPlayhead(0)
+                setSeqPlaying(false)
               }
             } catch {
               // No robot.yml (or unreadable) — keep the neutral pose.
@@ -3958,6 +4162,29 @@ export function RobotView({
           onMoveKey={handleMoveKey}
           onDeleteKey={handleDeleteKey}
           onAddKey={handleAddKey}
+        />
+      )}
+      {showTimeline && (
+        <RobotSequencer
+          sequence={sequence}
+          poses={poses}
+          playing={seqPlaying}
+          playhead={seqPlayhead}
+          live={seqLive}
+          canLive={canSeqLive}
+          canExport={bindings.length > 0}
+          onPlayPause={handleSeqPlayPause}
+          onStop={() => seqSeek(0)}
+          onScrub={seqSeek}
+          onToggleLoop={() => commitSequence({ ...sequenceRef.current, loop: !sequenceRef.current.loop })}
+          onToggleLive={() => setSeqLive((v) => !v)}
+          onAddStep={handleAddStep}
+          onRemoveStep={handleRemoveStep}
+          onMoveStep={handleMoveStep}
+          onSetStepPose={(i, pose) => patchStep(i, { pose })}
+          onSetStepDuration={(i, seconds) => patchStep(i, { duration: Math.max(0, seconds) })}
+          onSetStepEasing={(i, easing) => patchStep(i, { easing })}
+          onExport={handleExport}
         />
       )}
     </div>

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -1452,31 +1452,42 @@ export function RobotView({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- refs carry the rest
   }, [playing])
 
-  // Update the timeline + schedule a debounced persist (drags/edits coalesce).
-  // The deferred save SNAPSHOTS the target folder and loads a FRESH def for it,
-  // writing only the timeline — so a folder switch within the 400 ms window can
-  // never write this timeline into a different project's robot.yml (data loss).
-  const commitTimeline = (next: MotionTimeline): void => {
-    timelineRef.current = next
-    setTimeline(next)
+  // Persist the motion state (keyframe timeline + pose sequence, #314/#415) with a
+  // SINGLE debounced, folder-snapshotting save. Both editors sit together at the
+  // bottom of the pose tool, so routing them through one saver (reading the latest
+  // refs) means a sequence edit can never clobber a concurrent timeline edit, or
+  // vice-versa. A field is written only once its own load-seed has run for this
+  // folder, so an early edit can't wipe a not-yet-loaded disk value; loading a
+  // FRESH def keeps a fast folder switch from writing into another project. defRef
+  // is kept in sync so a later persist() (poses/servos) never reverts motion.
+  const scheduleMotionSave = (): void => {
     const folder = currentFolder || undefined
+    const folderKey = currentFolder || ''
     pendingTimelineSave.current = async (): Promise<void> => {
       pendingTimelineSave.current = null
       try {
         const def = await window.api.robot.load(folder)
-        def.robot = { ...(def.robot ?? {}), timeline: next }
+        def.robot = { ...(def.robot ?? {}) }
+        if (timelineLoadedFolder.current === folderKey) def.robot.timeline = timelineRef.current
+        if (seqLoadedFolder.current === folderKey)
+          def.robot.sequences = sequenceRef.current.steps.length ? [sequenceRef.current] : []
         await window.api.robot.save(folder, def)
       } catch {
-        // best-effort — a keyframe save failing is non-fatal
+        // best-effort — a motion save failing is non-fatal
       }
     }
     if (timelineSaveTimer.current) clearTimeout(timelineSaveTimer.current)
-    timelineSaveTimer.current = setTimeout(() => {
-      void pendingTimelineSave.current?.()
-    }, 400)
+    timelineSaveTimer.current = setTimeout(() => void pendingTimelineSave.current?.(), 400)
   }
 
-  // Flush a pending timeline save on unmount so the last edit isn't lost (and the
+  const commitTimeline = (next: MotionTimeline): void => {
+    timelineRef.current = next
+    setTimeline(next)
+    if (defRef.current) defRef.current.robot = { ...(defRef.current.robot ?? {}), timeline: next }
+    scheduleMotionSave()
+  }
+
+  // Flush a pending motion save on unmount so the last edit isn't lost (and the
   // timer can't fire after unmount). Runs once.
   useEffect(
     () => () => {
@@ -1520,8 +1531,6 @@ export function RobotView({
   const seqPlayheadRef = useRef(0)
   const lastSeqPush = useRef(0)
   const lastLiveSend = useRef(0)
-  const seqSaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const pendingSeqSave = useRef<(() => Promise<void>) | null>(null)
   const seqLoadedFolder = useRef<string | null>(null)
   const seqLiveRef = useRef(false)
   sequenceRef.current = sequence
@@ -1612,33 +1621,16 @@ export function RobotView({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- refs carry the rest
   }, [seqPlaying])
 
-  // Update the sequence + debounced persist (folder-snapshotting like commitTimeline,
-  // so a fast folder switch can't write it into another project's robot.yml).
+  // Update the sequence + persist via the shared motion saver (which also carries
+  // the timeline, so the two can't clobber each other). defRef is kept in sync so a
+  // later persist() (poses/servos) never reverts the sequence.
   const commitSequence = (next: MotionSequence): void => {
     sequenceRef.current = next
     setSequence(next)
-    const folder = currentFolder || undefined
-    pendingSeqSave.current = async (): Promise<void> => {
-      pendingSeqSave.current = null
-      try {
-        const def = await window.api.robot.load(folder)
-        def.robot = { ...(def.robot ?? {}), sequences: [next] }
-        await window.api.robot.save(folder, def)
-      } catch {
-        // best-effort — a sequence save failing is non-fatal
-      }
-    }
-    if (seqSaveTimer.current) clearTimeout(seqSaveTimer.current)
-    seqSaveTimer.current = setTimeout(() => void pendingSeqSave.current?.(), 400)
+    if (defRef.current)
+      defRef.current.robot = { ...(defRef.current.robot ?? {}), sequences: next.steps.length ? [next] : [] }
+    scheduleMotionSave()
   }
-  // Flush a pending sequence save on unmount (and stop the timer firing after).
-  useEffect(
-    () => () => {
-      if (seqSaveTimer.current) clearTimeout(seqSaveTimer.current)
-      void pendingSeqSave.current?.()
-    },
-    []
-  )
 
   const seqSeek = (t: number): void => {
     setSeqPlaying(false)

--- a/src/shared/krf.ts
+++ b/src/shared/krf.ts
@@ -23,9 +23,11 @@ import {
   type MirrorPair,
   type MotionEasing,
   type MotionKey,
+  type MotionSequence,
   type MotionTimeline,
   type MotionTrack,
   type NamedPose,
+  type PoseStep,
   type RobotDefinition,
   type RobotModel,
   type ServoJointBinding
@@ -109,6 +111,34 @@ function sanitiseTimeline(raw: unknown): MotionTimeline | undefined {
   }
   if (isFiniteNum(r.fps)) tl.fps = Math.max(1, Math.min(60, Math.round(r.fps)))
   return tl
+}
+
+/** Validate the pose-step sequences (#415); `undefined` when none are usable. A
+ *  step needs a pose name + a finite non-negative duration; a bad easing falls to
+ *  easeInOut; a step-less sequence is dropped. */
+function sanitiseSequences(raw: unknown): MotionSequence[] | undefined {
+  if (!Array.isArray(raw)) return undefined
+  const out: MotionSequence[] = []
+  for (const s of raw) {
+    const r = (s ?? {}) as Record<string, unknown>
+    const steps: PoseStep[] = []
+    if (Array.isArray(r.steps)) {
+      for (const st of r.steps) {
+        const sr = (st ?? {}) as Record<string, unknown>
+        if (!isStr(sr.pose) || !sr.pose.trim()) continue
+        const duration = isFiniteNum(sr.duration) && sr.duration >= 0 ? sr.duration : 0
+        const step: PoseStep = { pose: sr.pose, duration }
+        step.easing = sr.easing === 'linear' ? 'linear' : 'easeInOut'
+        steps.push(step)
+      }
+    }
+    if (!steps.length) continue
+    const seq: MotionSequence = { loop: r.loop !== false, steps }
+    if (isStr(r.name) && r.name.trim()) seq.name = r.name.trim()
+    if (isFiniteNum(r.fps)) seq.fps = Math.max(1, Math.min(60, Math.round(r.fps)))
+    out.push(seq)
+  }
+  return out.length ? out : undefined
 }
 
 /** Validate the mirror pairs; `undefined` when none are usable. */
@@ -213,6 +243,9 @@ export function sanitiseRobotModel(raw: unknown): RobotModel | undefined {
 
   const tl = sanitiseTimeline(r.timeline)
   if (tl) model.timeline = tl
+
+  const sequences = sanitiseSequences(r.sequences)
+  if (sequences) model.sequences = sequences
 
   const mirror = sanitiseMirror(r.mirror)
   if (mirror) model.mirror = mirror

--- a/src/shared/managed-blocks.ts
+++ b/src/shared/managed-blocks.ts
@@ -34,8 +34,9 @@ export const MANAGED_SCHEMA_VERSION = 1
 /** A saved pose in managed form: joint name → value (deg / mm), DISPLAY units. */
 export type ManagedPose = Record<string, number>
 
-/** A sequence step: a pose name held for a duration in milliseconds. */
-export type ManagedSequenceStep = [pose: string, durationMs: number]
+/** A sequence step in the exported form: a pose REACHED over `durationMs` from the
+ *  previous pose, with an optional easing (matching `snakie_motion.Rig.play`). */
+export type ManagedSequenceStep = [pose: string, durationMs: number, easing?: string]
 
 /**
  * The managed datasets. Every field is OPTIONAL: an absent field means "I don't

--- a/src/shared/robot-timeline.ts
+++ b/src/shared/robot-timeline.ts
@@ -21,6 +21,7 @@ import type {
   MotionTrack,
   ServoJointBinding
 } from './robot'
+import type { ManagedSequenceStep } from './managed-blocks'
 import { jointToServo } from './krf'
 
 /** Default preview / export sample rate. */
@@ -159,12 +160,31 @@ export function samplePoseSequence(
 }
 
 /**
- * Convert a sequence's steps to the managed-block form (#413):
- * `[[poseName, durationMs], …]` — seconds rounded to whole milliseconds, matching
- * the `snakie_motion.Rig.play` runtime and the `SNAKIE_SEQUENCES` literal.
+ * Convert a sequence's steps to the managed-block / runtime form (#413/#415):
+ * `[[poseName, durationMs, easing], …]`. The editor stores each step's duration as
+ * the OUTGOING segment (time to the next pose), but `snakie_motion.Rig.play`
+ * transitions INTO each step's pose over that step's duration. So each exported
+ * step's duration/easing is the PREVIOUS segment's — the one that reaches this
+ * pose — keeping hardware timing identical to the preview:
+ *  - one-shot: pose[0] is reached at 0 ms (start there); pose[k>0] over step[k-1].
+ *  - loop: pose[k] over step[k-1] (pose[0]'s incoming is the seam = the last step).
  */
-export function poseSequenceToManagedSteps(seq: MotionSequence): Array<[string, number]> {
-  return seq.steps.map((s) => [s.pose, Math.max(0, Math.round((s.duration || 0) * 1000))])
+export function poseSequenceToManagedSteps(seq: MotionSequence): ManagedSequenceStep[] {
+  const steps = seq.steps
+  const n = steps.length
+  if (n === 0) return []
+  const durMs = (s: number): number => Math.max(0, Math.round((s || 0) * 1000))
+  const easeOf = (i: number): MotionEasing => steps[i].easing ?? 'easeInOut'
+  if (n === 1) return [[steps[0].pose, 0, 'linear']]
+  if (seq.loop) {
+    return steps.map((s, i): ManagedSequenceStep => {
+      const prev = (i - 1 + n) % n
+      return [s.pose, durMs(steps[prev].duration), easeOf(prev)]
+    })
+  }
+  const out: ManagedSequenceStep[] = [[steps[0].pose, 0, 'linear']]
+  for (let i = 1; i < n; i++) out.push([steps[i].pose, durMs(steps[i - 1].duration), easeOf(i - 1)])
+  return out
 }
 
 // ── Editing ────────────────────────────────────────────────────────────────

--- a/src/shared/robot-timeline.ts
+++ b/src/shared/robot-timeline.ts
@@ -16,6 +16,7 @@ import type {
   MirrorPair,
   MotionEasing,
   MotionKey,
+  MotionSequence,
   MotionTimeline,
   MotionTrack,
   ServoJointBinding
@@ -67,6 +68,103 @@ export function sampleTimeline(tl: MotionTimeline, t: number): Record<string, nu
 export function frameCount(tl: MotionTimeline, fps = tl.fps ?? DEFAULT_FPS): number {
   const n = Math.max(1, Math.round(tl.duration * fps))
   return tl.loop ? n : n + 1 // one-shot includes the final frame; a loop omits the seam
+}
+
+// ── Pose-to-pose sequences (#415) ────────────────────────────────────────────
+
+/**
+ * The per-SEGMENT durations of a pose sequence (seconds). Segment `i` transitions
+ * from `steps[i].pose` to the next pose using `steps[i].duration`/`easing`. A loop
+ * has one segment per step (the last wraps back to the first); a one-shot has
+ * `steps.length - 1` (the last step's duration is a no-op end hold). Negative /
+ * NaN durations are clamped to 0.
+ */
+export function sequenceSegments(seq: MotionSequence): number[] {
+  const n = seq.steps.length
+  const count = seq.loop ? n : Math.max(0, n - 1)
+  const out: number[] = []
+  for (let i = 0; i < count; i++) out.push(Math.max(0, seq.steps[i].duration || 0))
+  return out
+}
+
+/** Total play time of a sequence (seconds) — the scrubber's span. */
+export function sequenceDuration(seq: MotionSequence): number {
+  return sequenceSegments(seq).reduce((a, b) => a + b, 0)
+}
+
+/**
+ * Interpolate two poses joint-wise at eased progress `e` (0..1). A joint present
+ * in BOTH is lerped; a joint in only one pose takes that pose's value (a partial
+ * pose holds its specified joints and leaves the rest to the caller's model).
+ */
+export function lerpPoses(
+  a: Record<string, number>,
+  b: Record<string, number>,
+  e: number
+): Record<string, number> {
+  const out: Record<string, number> = {}
+  for (const j of new Set([...Object.keys(a), ...Object.keys(b)])) {
+    const av = a[j]
+    const bv = b[j]
+    if (typeof av === 'number' && typeof bv === 'number') out[j] = av + (bv - av) * e
+    else out[j] = typeof av === 'number' ? av : bv
+  }
+  return out
+}
+
+/**
+ * Sample a pose sequence at time `t` (seconds): the joint→display-value map of the
+ * posture between the bracketing steps' poses, eased by the from-step's easing.
+ * `posesByName` resolves a step's pose name to its stored joint values
+ * (`NamedPose.values`). A looping sequence wraps `t` over its total duration; a
+ * one-shot holds the first pose before `0` and the last pose after the end.
+ * Returns `{}` for an empty sequence.
+ */
+export function samplePoseSequence(
+  seq: MotionSequence,
+  posesByName: Record<string, Record<string, number>>,
+  t: number
+): Record<string, number> {
+  const steps = seq.steps
+  const n = steps.length
+  if (n === 0) return {}
+  const poseOf = (i: number): Record<string, number> => posesByName[steps[i].pose] ?? {}
+  if (n === 1) return { ...poseOf(0) }
+
+  const segs = sequenceSegments(seq)
+  const total = segs.reduce((a, b) => a + b, 0)
+  if (total <= 0) return { ...poseOf(0) }
+
+  let time: number
+  if (seq.loop) {
+    time = ((t % total) + total) % total // wrap into [0, total)
+  } else {
+    if (t <= 0) return { ...poseOf(0) }
+    if (t >= total) return { ...poseOf(n - 1) }
+    time = t
+  }
+
+  // Locate the segment containing `time`.
+  let i = 0
+  let acc = 0
+  while (i < segs.length - 1 && acc + segs[i] <= time) {
+    acc += segs[i]
+    i++
+  }
+  const segDur = segs[i]
+  const u = segDur <= 0 ? 1 : (time - acc) / segDur
+  const from = poseOf(i)
+  const to = poseOf(seq.loop ? (i + 1) % n : i + 1)
+  return lerpPoses(from, to, ease(steps[i].easing ?? 'easeInOut', u))
+}
+
+/**
+ * Convert a sequence's steps to the managed-block form (#413):
+ * `[[poseName, durationMs], …]` — seconds rounded to whole milliseconds, matching
+ * the `snakie_motion.Rig.play` runtime and the `SNAKIE_SEQUENCES` literal.
+ */
+export function poseSequenceToManagedSteps(seq: MotionSequence): Array<[string, number]> {
+  return seq.steps.map((s) => [s.pose, Math.max(0, Math.round((s.duration || 0) * 1000))])
 }
 
 // ── Editing ────────────────────────────────────────────────────────────────

--- a/src/shared/robot.ts
+++ b/src/shared/robot.ts
@@ -77,6 +77,8 @@ export interface RobotModel {
   poses?: NamedPose[]
   /** The choreographed motion timeline (Phase 4, #314). */
   timeline?: MotionTimeline
+  /** Pose-to-pose sequences / walk cycles (#415) — sit beside `timeline`. */
+  sequences?: MotionSequence[]
   /** Left↔right joint mirror pairs, for symmetric gaits (Phase 4). */
   mirror?: MirrorPair[]
 }
@@ -138,6 +140,37 @@ export interface MotionTimeline {
   fps?: number
   /** One track per animated joint. */
   tracks: MotionTrack[]
+}
+
+/**
+ * One step of a pose-to-pose sequence (#415): the model eases FROM this step's
+ * pose TO the next step's pose (wrapping to the first step on a loop) over
+ * `duration` seconds, using `easing`. `pose` names a {@link NamedPose} in
+ * `RobotModel.poses`.
+ */
+export interface PoseStep {
+  /** The saved pose this step starts on (a `NamedPose.name`). */
+  pose: string
+  /** Seconds to transition to the NEXT step's pose (the loop seam uses the last). */
+  duration: number
+  /** Interpolation into the next pose (default easeInOut). */
+  easing?: MotionEasing
+}
+
+/**
+ * A pose-to-pose motion clip (#415) — how makers author a walk cycle: an ordered
+ * list of saved poses, each held for a duration. Sits BESIDE the per-joint
+ * keyframe {@link MotionTimeline}; a robot may have either, both, or neither.
+ */
+export interface MotionSequence {
+  /** Display name (also the key of its exported `SNAKIE_SEQUENCES` entry). */
+  name?: string
+  /** Loop the sequence (the last step eases back to the first). */
+  loop: boolean
+  /** Preview / export sample rate (default 20). */
+  fps?: number
+  /** The ordered pose steps. */
+  steps: PoseStep[]
 }
 
 /** A left↔right mirror pairing (`a` copies onto `b`), for symmetric gaits. */

--- a/test/krf.test.ts
+++ b/test/krf.test.ts
@@ -94,6 +94,43 @@ describe('sanitiseRobotModel — corruption-safe (#310)', () => {
     expect(m!.timeline!.tracks[0].keys.map((k) => k.t)).toEqual([0, 2]) // sorted, bad dropped
   })
 
+  it('sanitises pose sequences (#415): keeps valid steps, drops empties, defaults easing/loop', () => {
+    const m = sanitiseRobotModel({
+      sequences: [
+        {
+          name: '  walk  ',
+          loop: false,
+          fps: 999, // clamped to 60
+          steps: [
+            { pose: 'stand', duration: 1, easing: 'linear' },
+            { pose: 'lift', duration: -3 }, // negative → 0, easing defaults
+            { pose: '', duration: 1 }, // no pose → dropped
+            { duration: 2 } // no pose → dropped
+          ]
+        },
+        { steps: [] }, // no steps → whole sequence dropped
+        'junk'
+      ]
+    })
+    expect(m!.sequences).toHaveLength(1)
+    const seq = m!.sequences![0]
+    expect(seq.name).toBe('walk') // trimmed
+    expect(seq.loop).toBe(false)
+    expect(seq.fps).toBe(60)
+    expect(seq.steps).toEqual([
+      { pose: 'stand', duration: 1, easing: 'linear' },
+      { pose: 'lift', duration: 0, easing: 'easeInOut' }
+    ])
+  })
+
+  it('a sequences-only model round-trips (regression for the drop-on-save bug)', () => {
+    // Before the fix sanitiseRobotModel silently omitted `sequences`, so a robot with
+    // only a sequence saved+loaded as empty. It must survive.
+    const m = sanitiseRobotModel({ sequences: [{ loop: true, steps: [{ pose: 'a', duration: 0.5 }] }] })
+    expect(m).toBeDefined()
+    expect(m!.sequences![0].steps[0].pose).toBe('a')
+  })
+
   it('sanitises mirror pairs (#314)', () => {
     const m = sanitiseRobotModel({
       urdf: 'a.urdf',

--- a/test/robotSequence.test.ts
+++ b/test/robotSequence.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest'
+import {
+  samplePoseSequence,
+  sequenceSegments,
+  sequenceDuration,
+  lerpPoses,
+  poseSequenceToManagedSteps
+} from '../src/shared/robot-timeline'
+import type { MotionSequence } from '../src/shared/robot'
+
+// Two poses on a single joint `j`, so interpolation is easy to reason about.
+const poses = {
+  a: { j: 0 },
+  b: { j: 100 },
+  c: { j: 40 }
+}
+
+const seq = (over: Partial<MotionSequence> = {}): MotionSequence => ({
+  loop: false,
+  steps: [
+    { pose: 'a', duration: 1, easing: 'linear' },
+    { pose: 'b', duration: 1, easing: 'linear' }
+  ],
+  ...over
+})
+
+describe('sequenceSegments / sequenceDuration (#415)', () => {
+  it('a one-shot has steps-1 segments (last duration is an end hold)', () => {
+    const s = seq({ steps: [
+      { pose: 'a', duration: 1 },
+      { pose: 'b', duration: 2 },
+      { pose: 'c', duration: 5 }
+    ] })
+    expect(sequenceSegments(s)).toEqual([1, 2]) // c's duration ignored (no wrap)
+    expect(sequenceDuration(s)).toBe(3)
+  })
+
+  it('a loop has one segment per step (the last wraps back to the first)', () => {
+    const s = seq({ loop: true, steps: [
+      { pose: 'a', duration: 1 },
+      { pose: 'b', duration: 2 },
+      { pose: 'c', duration: 3 }
+    ] })
+    expect(sequenceSegments(s)).toEqual([1, 2, 3])
+    expect(sequenceDuration(s)).toBe(6)
+  })
+
+  it('clamps negative / NaN durations to 0', () => {
+    const s = seq({ steps: [
+      { pose: 'a', duration: -5 },
+      { pose: 'b', duration: Number.NaN as unknown as number }
+    ] })
+    expect(sequenceSegments(s)).toEqual([0])
+  })
+})
+
+describe('lerpPoses (#415)', () => {
+  it('lerps joints present in both, holds joints present in only one', () => {
+    expect(lerpPoses({ x: 0, y: 10 }, { x: 100, z: 5 }, 0.5)).toEqual({ x: 50, y: 10, z: 5 })
+  })
+})
+
+describe('samplePoseSequence (#415)', () => {
+  it('holds the first pose before the start and the last pose after the end (one-shot)', () => {
+    const s = seq()
+    expect(samplePoseSequence(s, poses, -1)).toEqual({ j: 0 })
+    expect(samplePoseSequence(s, poses, 0)).toEqual({ j: 0 })
+    expect(samplePoseSequence(s, poses, 5)).toEqual({ j: 100 }) // past the end → last pose
+  })
+
+  it('linearly interpolates across a segment', () => {
+    const s = seq()
+    expect(samplePoseSequence(s, poses, 0.5).j).toBeCloseTo(50)
+    expect(samplePoseSequence(s, poses, 0.25).j).toBeCloseTo(25)
+  })
+
+  it('applies the from-step easing (smoothstep ≠ linear at u=0.25)', () => {
+    const smooth = seq({ steps: [
+      { pose: 'a', duration: 1, easing: 'easeInOut' },
+      { pose: 'b', duration: 1 }
+    ] })
+    // smoothstep(0.25) = 0.15625 → 15.625; linear would be 25.
+    expect(samplePoseSequence(smooth, poses, 0.25).j).toBeCloseTo(15.625)
+  })
+
+  it('wraps a looping sequence over its total duration', () => {
+    // a→b (1s) then b→a (1s, the loop seam). Total 2s.
+    const s = seq({ loop: true })
+    expect(samplePoseSequence(s, poses, 0).j).toBeCloseTo(0)
+    expect(samplePoseSequence(s, poses, 0.5).j).toBeCloseTo(50) // a→b mid
+    expect(samplePoseSequence(s, poses, 1.5).j).toBeCloseTo(50) // b→a mid (seam)
+    expect(samplePoseSequence(s, poses, 2).j).toBeCloseTo(0) // wrapped back to t=0
+    expect(samplePoseSequence(s, poses, 2.5).j).toBeCloseTo(50) // == t=0.5
+  })
+
+  it('a single-step sequence is just that pose', () => {
+    const s = seq({ steps: [{ pose: 'b', duration: 1 }] })
+    expect(samplePoseSequence(s, poses, 0)).toEqual({ j: 100 })
+    expect(samplePoseSequence(s, poses, 99)).toEqual({ j: 100 })
+  })
+
+  it('an empty sequence samples to nothing', () => {
+    expect(samplePoseSequence(seq({ steps: [] }), poses, 0)).toEqual({})
+  })
+
+  it('an unknown pose name resolves to an empty pose (no throw)', () => {
+    const s = seq({ steps: [{ pose: 'ghost', duration: 1 }, { pose: 'b', duration: 1 }] })
+    expect(samplePoseSequence(s, poses, 0.5)).toEqual({ j: 100 }) // only b's joint is known
+  })
+
+  it('multi-segment: picks the right segment and interpolates within it', () => {
+    const s = seq({ steps: [
+      { pose: 'a', duration: 1, easing: 'linear' }, // a→b over [0,1)
+      { pose: 'b', duration: 1, easing: 'linear' }, // b→c over [1,2)
+      { pose: 'c', duration: 1 }
+    ] })
+    expect(samplePoseSequence(s, poses, 0.5).j).toBeCloseTo(50) // a(0)→b(100)
+    expect(samplePoseSequence(s, poses, 1.5).j).toBeCloseTo(70) // b(100)→c(40) mid = 70
+  })
+})
+
+describe('poseSequenceToManagedSteps (#415 → #413 block)', () => {
+  it('emits [pose, durationMs] with whole-ms rounding', () => {
+    const s = seq({ steps: [
+      { pose: 'a', duration: 0.5 },
+      { pose: 'b', duration: 1.2345 }
+    ] })
+    expect(poseSequenceToManagedSteps(s)).toEqual([['a', 500], ['b', 1235]])
+  })
+})

--- a/test/robotSequence.test.ts
+++ b/test/robotSequence.test.ts
@@ -119,12 +119,35 @@ describe('samplePoseSequence (#415)', () => {
   })
 })
 
-describe('poseSequenceToManagedSteps (#415 → #413 block)', () => {
-  it('emits [pose, durationMs] with whole-ms rounding', () => {
+describe('poseSequenceToManagedSteps (#415 → #413 block, runtime INCOMING convention)', () => {
+  it('one-shot: pose[0] at 0ms, then each pose reached over the PRIOR step duration + easing', () => {
+    // Editor durations are OUTGOING (time to the next pose); the runtime moves INTO
+    // each pose over that step's duration, so a→b(0.5s) exports as b reached over 500ms.
     const s = seq({ steps: [
-      { pose: 'a', duration: 0.5 },
-      { pose: 'b', duration: 1.2345 }
+      { pose: 'a', duration: 0.5, easing: 'linear' },
+      { pose: 'b', duration: 1.2345, easing: 'easeInOut' }
     ] })
-    expect(poseSequenceToManagedSteps(s)).toEqual([['a', 500], ['b', 1235]])
+    expect(poseSequenceToManagedSteps(s)).toEqual([
+      ['a', 0, 'linear'],
+      ['b', 500, 'linear'] // reached over a's 0.5s with a's easing
+    ])
+  })
+
+  it('loop: each pose reached over the PREVIOUS segment (pose[0] over the seam = last step)', () => {
+    const s = seq({ loop: true, steps: [
+      { pose: 'a', duration: 1, easing: 'linear' },
+      { pose: 'b', duration: 2, easing: 'easeInOut' },
+      { pose: 'c', duration: 3, easing: 'linear' }
+    ] })
+    // a's incoming = c's segment (3000ms, linear); b's = a's (1000, linear); c's = b's (2000, smooth)
+    expect(poseSequenceToManagedSteps(s)).toEqual([
+      ['a', 3000, 'linear'],
+      ['b', 1000, 'linear'],
+      ['c', 2000, 'easeInOut']
+    ])
+  })
+
+  it('a single-step sequence exports as an instant hold', () => {
+    expect(poseSequenceToManagedSteps(seq({ steps: [{ pose: 'b', duration: 1 }] }))).toEqual([['b', 0, 'linear']])
   })
 })


### PR DESCRIPTION
Fourth piece of the **Motion Studio** epic (#403). Closes #415.

Reframes motion authoring from per-joint keyframes to **pose-to-pose steps** — how makers actually build a walk cycle (stand → lift → step → plant). Ships **beside** the keyframe timeline (no migration, no data loss).

## What
- **Data model** — `PoseStep { pose, duration, easing? }` + `MotionSequence { name?, loop, fps?, steps }` on `RobotModel.sequences` (`src/shared/robot.ts`), alongside the legacy `timeline`.
- **Pure engine** (`robot-timeline.ts`) — `samplePoseSequence` interpolates joint→display values between consecutive steps' poses over each step's duration + easing, wrapping at the loop seam; plus `sequenceSegments` / `sequenceDuration` / `lerpPoses` / `poseSequenceToManagedSteps`. **16 unit tests.**
- **UI** (`RobotSequencer`) — a transport bar (play/pause, stop, scrubber over total duration, loop, **Live**, Export) + a reorderable step list (pose picker, per-step duration + easing, up/down/delete) and an add-step row. Own `robotseq__` BEM prefix; reads on dark + skeuomorph light.
- **Playback** — a rAF loop mirroring the timeline's (`applySequenceAt` drives `setJointValue` per frame; sliders sync on scrub/pause only). Keyframe + sequence playback are mutually exclusive.
- **Persist** — one debounced, folder-snapshotting saver shared with the timeline (so the two can't clobber each other), seeded once per folder from `robot.yml`.
- **Live board preview** — with a board connected + a servo bound, a Live toggle streams each frame's servo angles over the `SNKCMD` control channel (`jointToServo`, ~18 Hz, best-effort); disconnect drops back to preview-only, no throw.
- **Export** — the sequence is written into the #413 `SNAKIE_SEQUENCES` managed block (preserving any other hand-authored sequences), **timed to the `snakie_motion` runtime** so hardware plays exactly what you previewed.

## Adversarial review — all 6 findings fixed
A skeptical multi-agent review caught **two HIGH bugs** and more, all fixed with regression tests:
- **HIGH** sequences never persisted — `sanitiseRobotModel` had no `sequences` field, so every save stripped it → added `sanitiseSequences`.
- **HIGH** exported timing was off-by-one — the editor's *outgoing* durations were mapped onto the runtime's *incoming* convention → remapped so hardware matches the preview.
- **MEDIUM** per-step easing dropped on export → carried as a 3rd tuple element (reader accepts it too); the two whole-def savers could clobber each other → unified saver + `defRef` sync.
- **LOW/NIT** folder-switch window (unchanged, matches the established pattern) and one-shot last-step duration (now correctly ignored on export).

## Verification
- **1648 vitest** + **196 Python** + typecheck / lint / build green.

## Scope
Sequence editor only; puppet controls are #416. Part of #403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)