### PR TITLE
feat: Motion Studio puppet controls — blend poses with a live slider (#416)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Motion Studio — puppet controls (#403, #416).** A Controls panel in the Robot View lets you
+  build a named **slider** from two or more saved poses. Dragging it smoothly blends between the
+  ordered poses and drives the live 3-D model in real time — one slider can sweep the eyes, morph
+  a smile→frown, or play a stride. Arm **Live** (board connected + a servo bound) and the same drag
+  streams to the physical servos too. Create a control by naming it and picking its poses in order;
+  rename or delete controls, and pose renames/deletes cascade through them safely. Completes the
+  Motion Studio epic (runtime · round-trip · pose authoring · sequences · controls).
 - **Motion Studio — pose-step sequencer / walk cycles (#403, #415).** A new sequencer at the
   bottom of the Robot View authors motion as an ordered list of **saved poses** — stand → lift
   → step → plant — each with its own **duration** and **easing**, plus a **loop** toggle, instead

--- a/micropython/instruments.py
+++ b/micropython/instruments.py
@@ -598,7 +598,7 @@ control = Control()
 
 # What the board can do, announced to the IDE as ``SNK READY <caps...>`` so a
 # panel knows a Snakie program is live (and which triggers it services).
-READY_CAPS = ("scan:wifi", "scan:bt", "teleop", "led", "buzzer", "range", "screen", "servo", "watch")
+READY_CAPS = ("scan:wifi", "scan:bt", "teleop", "led", "buzzer", "range", "screen", "servo", "servos", "watch")
 
 _service_running = False
 
@@ -687,6 +687,8 @@ def start(i2c=None, buzzer_pin=None, range_trig=None, range_echo=None,
     if servo_pin is not None:
         servo.set_pin(servo_pin)
     control.on("servo", lambda payload: servo_command(payload, servo))
+    # A Robot-View puppet slider drives many servos at once via `servos` (#416).
+    control.on("servos", lambda payload: servos_command(payload))
     # `watch` drives whatever objects the user registered with inst.watch(...).
     control.on("watch", lambda payload: watch_command(payload, _watched))
     control.on("ping", lambda payload: ready(extra))
@@ -1568,6 +1570,43 @@ def servo_command(payload, servo=None):
     except (ValueError, IndexError, TypeError):
         return None
     return verb
+
+
+def servos_command(payload, factory=None):
+    """Drive SEVERAL servos from one ``servos`` control payload (#416).
+
+    The payload is space-separated ``<pin>:<deg>`` (or ``<pin>=<deg>``) pairs, so a
+    Robot-View puppet slider can move a whole limb at once::
+
+        SNKCMD servos 0:90 1:45 15:120
+
+    Each pin is attached/reused via :func:`servo_on` (override with ``factory`` for
+    tests) and set to its angle. Never raises on a malformed token — the bad pair
+    is skipped. Returns the number of servos driven, so it is easy to unit-test.
+    """
+    if not payload:
+        return 0
+    make = factory if factory is not None else globals().get("servo_on")
+    if make is None:
+        return 0
+    driven = 0
+    for tok in payload.split():
+        sep = tok.find(":")
+        if sep == -1:
+            sep = tok.find("=")
+        if sep <= 0:
+            continue
+        try:
+            pin = int(tok[:sep])
+            deg = int(float(tok[sep + 1:]))
+        except (ValueError, IndexError):
+            continue
+        try:
+            make(pin).angle(deg)
+            driven += 1
+        except Exception:  # a bad pin / no PWM — skip, keep driving the rest
+            continue
+    return driven
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/test_instruments.py
+++ b/python/tests/test_instruments.py
@@ -472,6 +472,32 @@ class BuzzerDevice(unittest.TestCase):
         self.assertIsNone(inst.servo_command("wat", srv))
         self.assertIsNone(inst.servo_command("", srv))
 
+    def test_servos_command_drives_several_pins(self):
+        # #416 puppet slider: one `servos` payload moves many servos at once.
+        calls = []
+
+        class _Fake:
+            def __init__(self, pin):
+                self.pin = pin
+
+            def angle(self, deg):
+                calls.append((self.pin, deg))
+
+        n = inst.servos_command("0:90 1:45 15:120", factory=_Fake)
+        self.assertEqual(n, 3)
+        self.assertEqual(calls, [(0, 90), (1, 45), (15, 120)])
+
+    def test_servos_command_accepts_equals_and_skips_bad_tokens(self):
+        calls = []
+        make = lambda pin: type("S", (), {"angle": lambda self, d: calls.append((pin, d))})()
+        # `2=30` (equals form) ok; `bad`, `:5`, `9:` skipped; float deg truncates.
+        n = inst.servos_command("2=30 bad :5 9: 3:44.9", factory=make)
+        self.assertEqual(n, 2)
+        self.assertEqual(sorted(calls), [(2, 30), (3, 44)])
+
+    def test_servos_command_empty_is_zero(self):
+        self.assertEqual(inst.servos_command("", factory=lambda p: None), 0)
+
     def test_servo_on_emits_pin_keyed_telemetry(self):
         # servo_on(pin).angle() prints both the legacy channel line AND a
         # pin-keyed SERVO line for Robot View (#313) — no `machine` needed.
@@ -633,7 +659,7 @@ class BackgroundService(unittest.TestCase):
     def test_ready_announces_default_caps(self):
         self.assertEqual(
             _emit(inst.ready),
-            "SNK READY scan:wifi scan:bt teleop led buzzer range screen servo watch",
+            "SNK READY scan:wifi scan:bt teleop led buzzer range screen servo servos watch",
         )
 
     def test_ready_includes_extra_caps(self):

--- a/src/renderer/src/components/RobotControls.css
+++ b/src/renderer/src/components/RobotControls.css
@@ -1,0 +1,234 @@
+/* Puppet controls panel (#416) — sits under the sequencer at the bottom of the
+   pose tool. Theme-aware; unique `robotctl__` BEM prefix (global instrument CSS). */
+.robotctl {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 0.35rem 0.5rem 0.5rem;
+  background: var(--bg-elevated, #202227);
+  border-top: var(--border-w, 1px) solid var(--border, #2c2e33);
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  color: var(--text, #cdd2d9);
+  font-size: 0.66rem;
+  max-height: 15rem;
+  overflow-y: auto;
+}
+
+.robotctl__bar {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.robotctl__title {
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+.robotctl__spacer {
+  flex: 1 1 auto;
+}
+.robotctl__live {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.58rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: #2f9e5b;
+}
+.robotctl__live-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: #34c46b;
+  box-shadow: 0 0 0 2px rgba(52, 196, 107, 0.28);
+  animation: robotctl-livepulse 1.1s ease-in-out infinite;
+}
+@keyframes robotctl-livepulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
+.robotctl__btn {
+  font-family: inherit;
+  font-size: 0.64rem;
+  color: var(--text, #cdd2d9);
+  background: var(--bg-sunken, #2a2d33);
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 5px;
+  padding: 0.15rem 0.5rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.robotctl__btn:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+.robotctl__btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+.robotctl__btn--ok {
+  color: var(--accent-contrast, #191a1d);
+  background: var(--accent);
+  border-color: var(--accent);
+  align-self: flex-start;
+}
+
+.robotctl__create {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 0.35rem;
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 6px;
+  background: var(--bg-sunken, #2a2d33);
+}
+.robotctl__name {
+  font-family: inherit;
+  font-size: 0.66rem;
+  color: var(--text, #cdd2d9);
+  background: var(--bg-elevated, #202227);
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 4px;
+  padding: 0.2rem 0.35rem;
+}
+.robotctl__pick,
+.robotctl__pool {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem;
+}
+.robotctl__pick-label,
+.robotctl__pick-hint {
+  opacity: 0.7;
+}
+.robotctl__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  font-size: 0.62rem;
+  color: var(--accent-contrast, #191a1d);
+  background: var(--accent, #d6a23f);
+  border-radius: 10px;
+  padding: 0.05rem 0.4rem;
+}
+.robotctl__chip-x {
+  border: none;
+  background: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 0;
+  font-size: 0.6rem;
+  line-height: 1;
+}
+.robotctl__pool-pose {
+  font-family: inherit;
+  font-size: 0.62rem;
+  color: var(--text, #cdd2d9);
+  background: var(--bg-elevated, #202227);
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 5px;
+  padding: 0.1rem 0.4rem;
+  cursor: pointer;
+}
+.robotctl__pool-pose:hover {
+  border-color: var(--accent);
+}
+
+.robotctl__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+.robotctl__empty {
+  margin: 0.3rem 0;
+  opacity: 0.7;
+}
+.robotctl__ctl {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+.robotctl__ctl.is-disabled {
+  opacity: 0.5;
+}
+.robotctl__ctl-head {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+.robotctl__ctl-name {
+  flex: 0 0 auto;
+  width: 7rem;
+  font-family: inherit;
+  font-size: 0.64rem;
+  font-weight: 600;
+  color: var(--text, #cdd2d9);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  padding: 0.1rem 0.25rem;
+}
+.robotctl__ctl-name:hover,
+.robotctl__ctl-name:focus {
+  border-color: var(--border, #3a3d44);
+  background: var(--bg-sunken, #2a2d33);
+}
+.robotctl__ctl-poses {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  opacity: 0.6;
+}
+.robotctl__ctl-del {
+  flex: 0 0 auto;
+  font-family: inherit;
+  font-size: 0.62rem;
+  line-height: 1;
+  color: var(--text, #cdd2d9);
+  background: var(--bg-sunken, #2a2d33);
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 4px;
+  padding: 0.1rem 0.3rem;
+  cursor: pointer;
+}
+.robotctl__ctl-del:hover {
+  border-color: #b4544e;
+  color: #b4544e;
+}
+
+.robotctl__slider-wrap {
+  position: relative;
+  padding-bottom: 0.5rem;
+}
+.robotctl__slider {
+  width: 100%;
+  accent-color: var(--accent, #d6a23f);
+}
+.robotctl__ticks {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 0.4rem;
+}
+.robotctl__tick {
+  position: absolute;
+  width: 1px;
+  height: 0.4rem;
+  background: var(--text, #cdd2d9);
+  opacity: 0.35;
+  transform: translateX(-0.5px);
+}
+.robotctl__ctl-warn {
+  font-size: 0.58rem;
+  color: #b4544e;
+}

--- a/src/renderer/src/components/RobotControls.css
+++ b/src/renderer/src/components/RobotControls.css
@@ -34,12 +34,23 @@
   font-size: 0.58rem;
   font-weight: 600;
   text-transform: uppercase;
+  color: var(--muted, #8a8f96);
+  cursor: pointer;
+}
+.robotctl__live input {
+  accent-color: var(--accent, #d6a23f);
+  cursor: pointer;
+}
+.robotctl__live.is-on {
   color: #2f9e5b;
 }
 .robotctl__live-dot {
   width: 0.5rem;
   height: 0.5rem;
   border-radius: 50%;
+  background: var(--border, #3a3d44);
+}
+.robotctl__live.is-on .robotctl__live-dot {
   background: #34c46b;
   box-shadow: 0 0 0 2px rgba(52, 196, 107, 0.28);
   animation: robotctl-livepulse 1.1s ease-in-out infinite;

--- a/src/renderer/src/components/RobotControls.tsx
+++ b/src/renderer/src/components/RobotControls.tsx
@@ -17,8 +17,11 @@ export interface RobotControlsProps {
   poses: NamedPose[]
   /** Current slider position per control id (0..1). */
   values: Record<string, number>
-  /** Whether a board is streaming (shows a Live hint on the panel). */
+  /** Board streaming is ARMED (dragging a slider also moves the physical servos). */
   live: boolean
+  /** A board is connected + a servo is bound (else Live can't be armed). */
+  canLive: boolean
+  onToggleLive: () => void
   onChange: (id: string, t: number) => void
   onCreate: (name: string, poses: string[]) => void
   onRename: (id: string, name: string) => void
@@ -30,6 +33,8 @@ export function RobotControls({
   poses,
   values,
   live,
+  canLive,
+  onToggleLive,
   onChange,
   onCreate,
   onRename,
@@ -56,12 +61,18 @@ export function RobotControls({
     <div className="robotctl" aria-label="Puppet controls">
       <div className="robotctl__bar">
         <span className="robotctl__title">Controls</span>
-        {live && (
-          <span className="robotctl__live" title="Streaming to the connected board">
-            <span className="robotctl__live-dot" aria-hidden="true" />
-            Live
-          </span>
-        )}
+        <label
+          className={`robotctl__live${live ? ' is-on' : ''}`}
+          title={
+            canLive
+              ? 'Stream slider drags to the connected board (SNKCMD servos)'
+              : 'Connect a board and bind a servo to drive it live'
+          }
+        >
+          <input type="checkbox" checked={live} onChange={onToggleLive} disabled={!canLive} />
+          <span className="robotctl__live-dot" aria-hidden="true" />
+          Live
+        </label>
         <span className="robotctl__spacer" />
         <button
           type="button"
@@ -141,8 +152,15 @@ export function RobotControls({
               <div className="robotctl__ctl-head">
                 <input
                   className="robotctl__ctl-name"
-                  value={c.name}
-                  onChange={(e) => onRename(c.id, e.target.value)}
+                  // Uncontrolled + commit on blur/Enter (keyed by id so it never
+                  // remounts on rename) so we don't serialize robot.yml per keystroke.
+                  key={c.id}
+                  defaultValue={c.name}
+                  onBlur={(e) => {
+                    const v = e.target.value.trim()
+                    if (v && v !== c.name) onRename(c.id, v)
+                  }}
+                  onKeyDown={(e) => e.key === 'Enter' && (e.currentTarget as HTMLInputElement).blur()}
                   aria-label={`Rename ${c.name}`}
                 />
                 <span className="robotctl__ctl-poses" title={c.poses.join(' → ')}>

--- a/src/renderer/src/components/RobotControls.tsx
+++ b/src/renderer/src/components/RobotControls.tsx
@@ -1,0 +1,192 @@
+import { useState, type JSX } from 'react'
+import type { NamedPose, PuppetControl } from '../../../shared/robot'
+import './RobotControls.css'
+
+/**
+ * PUPPET CONTROLS (#416, epic #403) — a Controls panel of named sliders, each
+ * blending 2+ saved poses (Bottango-style). Dragging a slider interpolates
+ * between the ordered poses and drives the live model + a connected board in real
+ * time (the drive lives in {@link RobotView}). A **+ Control** creator names a
+ * control and picks its ordered poses; controls can be renamed / deleted. Own
+ * `robotctl__` BEM prefix; reads on dark + skeuomorph light.
+ */
+
+export interface RobotControlsProps {
+  controls: PuppetControl[]
+  /** Saved poses to build a control from. */
+  poses: NamedPose[]
+  /** Current slider position per control id (0..1). */
+  values: Record<string, number>
+  /** Whether a board is streaming (shows a Live hint on the panel). */
+  live: boolean
+  onChange: (id: string, t: number) => void
+  onCreate: (name: string, poses: string[]) => void
+  onRename: (id: string, name: string) => void
+  onDelete: (id: string) => void
+}
+
+export function RobotControls({
+  controls,
+  poses,
+  values,
+  live,
+  onChange,
+  onCreate,
+  onRename,
+  onDelete
+}: RobotControlsProps): JSX.Element {
+  const [creating, setCreating] = useState(false)
+  const [draftName, setDraftName] = useState('')
+  const [draftPoses, setDraftPoses] = useState<string[]>([])
+  const poseNames = poses.map((p) => p.name)
+
+  const reset = (): void => {
+    setCreating(false)
+    setDraftName('')
+    setDraftPoses([])
+  }
+  const create = (): void => {
+    const name = draftName.trim()
+    if (!name || draftPoses.length < 2) return
+    onCreate(name, draftPoses)
+    reset()
+  }
+
+  return (
+    <div className="robotctl" aria-label="Puppet controls">
+      <div className="robotctl__bar">
+        <span className="robotctl__title">Controls</span>
+        {live && (
+          <span className="robotctl__live" title="Streaming to the connected board">
+            <span className="robotctl__live-dot" aria-hidden="true" />
+            Live
+          </span>
+        )}
+        <span className="robotctl__spacer" />
+        <button
+          type="button"
+          className="robotctl__btn"
+          onClick={() => (creating ? reset() : setCreating(true))}
+          disabled={poseNames.length < 2}
+          title={poseNames.length < 2 ? 'Save at least two poses first' : 'Create a control from your poses'}
+        >
+          {creating ? 'Cancel' : '+ Control'}
+        </button>
+      </div>
+
+      {creating && (
+        <div className="robotctl__create">
+          <input
+            className="robotctl__name"
+            placeholder="control name (e.g. look, walk)"
+            value={draftName}
+            onChange={(e) => setDraftName(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && create()}
+            autoFocus
+          />
+          <div className="robotctl__pick">
+            <span className="robotctl__pick-label">Poses in order:</span>
+            {draftPoses.length === 0 ? (
+              <span className="robotctl__pick-hint">click poses below (≥2)</span>
+            ) : (
+              draftPoses.map((p, i) => (
+                <span className="robotctl__chip" key={`${p}-${i}`}>
+                  {i + 1}. {p}
+                  <button
+                    type="button"
+                    className="robotctl__chip-x"
+                    onClick={() => setDraftPoses((d) => d.filter((_, j) => j !== i))}
+                    title="Remove"
+                  >
+                    ✕
+                  </button>
+                </span>
+              ))
+            )}
+          </div>
+          <div className="robotctl__pool">
+            {poseNames.map((n) => (
+              <button
+                key={n}
+                type="button"
+                className="robotctl__pool-pose"
+                onClick={() => setDraftPoses((d) => [...d, n])}
+                title={`Append “${n}”`}
+              >
+                + {n}
+              </button>
+            ))}
+          </div>
+          <button
+            type="button"
+            className="robotctl__btn robotctl__btn--ok"
+            onClick={create}
+            disabled={!draftName.trim() || draftPoses.length < 2}
+          >
+            Create control
+          </button>
+        </div>
+      )}
+
+      <div className="robotctl__list">
+        {controls.length === 0 && !creating && (
+          <p className="robotctl__empty">No controls yet — blend 2+ poses into a live slider.</p>
+        )}
+        {controls.map((c) => {
+          const valid = c.poses.filter((p) => poseNames.includes(p))
+          const usable = valid.length >= 2
+          const t = values[c.id] ?? 0
+          return (
+            <div className={`robotctl__ctl${usable ? '' : ' is-disabled'}`} key={c.id}>
+              <div className="robotctl__ctl-head">
+                <input
+                  className="robotctl__ctl-name"
+                  value={c.name}
+                  onChange={(e) => onRename(c.id, e.target.value)}
+                  aria-label={`Rename ${c.name}`}
+                />
+                <span className="robotctl__ctl-poses" title={c.poses.join(' → ')}>
+                  {c.poses.join(' → ')}
+                </span>
+                <button
+                  type="button"
+                  className="robotctl__ctl-del"
+                  onClick={() => onDelete(c.id)}
+                  title="Delete control"
+                >
+                  ✕
+                </button>
+              </div>
+              <div className="robotctl__slider-wrap">
+                <input
+                  className="robotctl__slider"
+                  type="range"
+                  min={0}
+                  max={1}
+                  step={0.01}
+                  value={t}
+                  disabled={!usable}
+                  onChange={(e) => onChange(c.id, Number(e.target.value))}
+                  aria-label={c.name}
+                />
+                <div className="robotctl__ticks" aria-hidden="true">
+                  {c.poses.map((p, i) => (
+                    <span
+                      className="robotctl__tick"
+                      key={i}
+                      style={{ left: `${c.poses.length > 1 ? (i / (c.poses.length - 1)) * 100 : 0}%` }}
+                      title={p}
+                    />
+                  ))}
+                </div>
+              </div>
+              {!usable && <span className="robotctl__ctl-warn">needs ≥2 saved poses</span>}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export default RobotControls

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -379,10 +379,14 @@ export function RobotView({
     const next = poses.filter((p) => p.name !== name)
     setPoses(next)
     // Degrade any puppet control that referenced this pose: drop the ref (#416). A
-    // control that falls below 2 poses stays but is disabled in the UI, never throws.
+    // control left with <2 poses can't blend and (unlike the sanitiser's silent
+    // drop on reload) has no UI to recover, so remove it outright — in-memory and
+    // persisted state stay in step. Never throws.
     const cur = controlsRef.current
-    const pruned = cur.map((c) => ({ ...c, poses: c.poses.filter((p) => p !== name) }))
-    const controlsChanged = pruned.some((c, i) => c.poses.length !== cur[i].poses.length)
+    const pruned = cur
+      .map((c) => ({ ...c, poses: c.poses.filter((p) => p !== name) }))
+      .filter((c) => c.poses.length >= 2)
+    const controlsChanged = pruned.length !== cur.length || pruned.some((c, i) => c.poses.length !== cur[i].poses.length)
     if (controlsChanged) setControls(pruned)
     void persist((m) => {
       m.poses = next
@@ -1574,6 +1578,15 @@ export function RobotView({
   controlsRef.current = controls
   const [controlVals, setControlVals] = useState<Record<string, number>>({}) // id → t (0..1)
   const controlIdSeq = useRef(0) // in-session counter for collision-free control ids
+  // Board streaming for puppet controls is EXPLICITLY armed (like the sequencer's
+  // Live), so dragging a slider previews on the model without surprising the
+  // hardware until the user opts in.
+  const [controlsLive, setControlsLive] = useState(false)
+  const controlsLiveRef = useRef(false)
+  controlsLiveRef.current = controlsLive
+  // Trailing-edge flush for streamServos so the final drag position always lands.
+  const pendingServoSend = useRef<string | null>(null)
+  const servoFlushTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const deviceStatus = useDeviceStatus()
   const canSeqLive = deviceStatus.state === 'connected' && bindings.length > 0
@@ -1581,7 +1594,10 @@ export function RobotView({
   // is on, drop back to preview-only rather than streaming into the void.
   useEffect(() => {
     if (!canSeqLive && seqLive) setSeqLive(false)
-  }, [canSeqLive, seqLive])
+    if (!canSeqLive && controlsLive) setControlsLive(false)
+  }, [canSeqLive, seqLive, controlsLive])
+  // Stop the trailing-flush timer firing after unmount.
+  useEffect(() => () => void (servoFlushTimer.current && clearTimeout(servoFlushTimer.current)), [])
 
   // Stream a DISPLAY-unit pose's servo angles to a connected board over the reverse
   // SNKCMD control channel (#415/#416): one "SNKCMD servos <pin>:<deg> …" line — a
@@ -1590,16 +1606,38 @@ export function RobotView({
   // is swallowed so preview never breaks. Shared by the sequence Live preview and
   // the puppet-control drag.
   const streamServos = (display: Record<string, number>): void => {
-    const now = performance.now()
-    if (now - lastLiveSend.current < 40) return // ~25 Hz cap on serial writes
-    lastLiveSend.current = now
     const byPin: Record<string, number> = {}
     for (const b of bindingsRef.current) {
       const disp = display[b.joint]
       if (typeof disp === 'number') byPin[b.pin] = jointToServo(b, disp)
     }
     const payload = buildServosPayload(byPin)
-    if (payload) void window.api.device.sendControl('servos', payload).catch(() => undefined)
+    if (!payload) return
+    const send = (p: string): void => void window.api.device.sendControl('servos', p).catch(() => undefined)
+    const now = performance.now()
+    if (now - lastLiveSend.current >= 40) {
+      // Leading edge — send now, cancel any queued trailing flush (it's superseded).
+      lastLiveSend.current = now
+      if (servoFlushTimer.current) {
+        clearTimeout(servoFlushTimer.current)
+        servoFlushTimer.current = null
+      }
+      send(payload)
+    } else {
+      // Throttled — remember the LATEST and schedule a trailing flush so the final
+      // slider position (on drag-release) always lands on the board, never one stale.
+      pendingServoSend.current = payload
+      if (!servoFlushTimer.current) {
+        servoFlushTimer.current = setTimeout(() => {
+          servoFlushTimer.current = null
+          if (pendingServoSend.current) {
+            lastLiveSend.current = performance.now()
+            send(pendingServoSend.current)
+            pendingServoSend.current = null
+          }
+        }, 40)
+      }
+    }
   }
 
   // Apply a sampled sequence frame (mirrors auto-follow); `commitState` syncs the
@@ -1607,7 +1645,7 @@ export function RobotView({
   const applySequenceAt = (t: number, commitState = false): void => {
     const sampled = samplePoseSequence(sequenceRef.current, posesByNameRef.current, t)
     applyDisplayPose(sampled, commitState)
-    if (seqLiveRef.current) streamServos(sampled)
+    if (seqLiveRef.current && robotRef.current) streamServos(sampled)
   }
 
   // rAF playback loop (mirrors the timeline's at :1410) — drives setJointValue each
@@ -1710,7 +1748,7 @@ export function RobotView({
     setSeqPlaying(false)
     const display = sampleControl(c, posesByNameRef.current, t)
     applyDisplayPose(display, true)
-    if (canSeqLive) streamServos(display)
+    if (controlsLiveRef.current) streamServos(display) // only when board streaming is armed
   }
   const handleCreateControl = (name: string, posesSel: string[]): void => {
     if (!name.trim() || posesSel.length < 2) return
@@ -4246,7 +4284,9 @@ export function RobotView({
           controls={controls}
           poses={poses}
           values={controlVals}
-          live={canSeqLive}
+          live={controlsLive}
+          canLive={canSeqLive}
+          onToggleLive={() => setControlsLive((v) => !v)}
           onChange={handleControlChange}
           onCreate={handleCreateControl}
           onRename={handleRenameControl}

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -85,6 +85,7 @@ import { RobotToolbar } from './RobotToolbar'
 import { loadPin, savePin, PIN_KEYS } from './pin-overlay'
 import { RobotTimeline } from './RobotTimeline'
 import { RobotSequencer } from './RobotSequencer'
+import { RobotControls } from './RobotControls'
 import {
   autoMirrorPairs,
   deleteKey,
@@ -96,6 +97,7 @@ import {
   moveKey,
   poseSequenceToManagedSteps,
   samplePoseSequence,
+  sampleControl,
   sampleTimeline,
   sequenceDuration,
   upsertKey
@@ -108,6 +110,7 @@ import {
   type ManagedSequenceStep
 } from '../../../shared/managed-blocks'
 import { jointToServo } from '../../../shared/krf'
+import { buildServosPayload } from '../../../shared/control'
 import { useTelemetryStream } from './instrument-telemetry-subscribe'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import type {
@@ -116,6 +119,7 @@ import type {
   MotionSequence,
   MotionTimeline,
   PoseStep,
+  PuppetControl,
   RobotDefinition,
   RobotModel,
   ServoJointBinding
@@ -374,8 +378,15 @@ export function RobotView({
   const handleDeletePose = (name: string): void => {
     const next = poses.filter((p) => p.name !== name)
     setPoses(next)
+    // Degrade any puppet control that referenced this pose: drop the ref (#416). A
+    // control that falls below 2 poses stays but is disabled in the UI, never throws.
+    const cur = controlsRef.current
+    const pruned = cur.map((c) => ({ ...c, poses: c.poses.filter((p) => p !== name) }))
+    const controlsChanged = pruned.some((c, i) => c.poses.length !== cur[i].poses.length)
+    if (controlsChanged) setControls(pruned)
     void persist((m) => {
       m.poses = next
+      if (controlsChanged) m.controls = pruned
     })
   }
 
@@ -392,8 +403,16 @@ export function RobotView({
     }
     const next = [...poses.filter((p) => p.name !== oldName), { name: target, values: pose.values }]
     setPoses(next)
+    // Cascade the rename into any puppet control that references the pose (#416).
+    const cur = controlsRef.current
+    const renamed = cur.map((c) =>
+      c.poses.includes(oldName) ? { ...c, poses: c.poses.map((p) => (p === oldName ? target : p)) } : c
+    )
+    const controlsChanged = renamed.some((c, i) => c !== cur[i])
+    if (controlsChanged) setControls(renamed)
     void persist((m) => {
       m.poses = next
+      if (controlsChanged) m.controls = renamed
     })
   }
 
@@ -1208,8 +1227,12 @@ export function RobotView({
         if (!live) return
         defRef.current = def // seed so persist() never clobbers an unloaded robot.yml
         setBindings(def.robot?.servoJointMap ?? [])
+        setControls(def.robot?.controls ?? []) // puppet controls (#416)
       } catch {
-        if (live) setBindings([])
+        if (live) {
+          setBindings([])
+          setControls([])
+        }
       }
     })()
     return () => {
@@ -1397,16 +1420,17 @@ export function RobotView({
     ? poses.filter((p) => movableNames.some((n) => typeof p.values[n] === 'number'))
     : []
 
-  // Apply a sampled timeline frame to the robot IMPERATIVELY (mimics auto-follow).
-  // `commitState` also pushes the sliders (only on scrub/stop — never per frame).
-  const applyTimelineAt = (t: number, commitState = false): void => {
+  // Drive the robot from a DISPLAY-unit pose IMPERATIVELY (mimics auto-follow), the
+  // shared inner loop of every motion source — timeline, sequence, and puppet
+  // control (#416). `commitState` also pushes the sliders (scrub/stop/drag; never
+  // per playback frame). Each joint is clamped to its effective limit.
+  const applyDisplayPose = (display: Record<string, number>, commitState = false): void => {
     const r = robotRef.current
     if (!r) return
-    const sampled = sampleTimeline(timelineRef.current, t)
     const patch: Record<string, number> = {}
     for (const m of metaRef.current) {
       if (m.isMimic) continue
-      const disp = sampled[m.name]
+      const disp = display[m.name]
       if (typeof disp !== 'number') continue
       const lim = effectiveLimit(m, overridesRef.current[m.name])
       const native = clamp(toNative(m.type, disp), lim.lower, lim.upper)
@@ -1414,6 +1438,11 @@ export function RobotView({
       patch[m.name] = native
     }
     if (commitState) setValues((v) => ({ ...v, ...patch }))
+  }
+
+  // Apply a sampled timeline frame (`commitState` on scrub/stop only).
+  const applyTimelineAt = (t: number, commitState = false): void => {
+    applyDisplayPose(sampleTimeline(timelineRef.current, t), commitState)
   }
 
   // Playback: a rAF loop drives setJointValue every frame; the scrubber/playhead
@@ -1539,6 +1568,13 @@ export function RobotView({
   const posesByNameRef = useRef<Record<string, Record<string, number>>>({})
   posesByNameRef.current = Object.fromEntries(poses.map((p) => [p.name, p.values]))
 
+  // ── Puppet controls (#416) ────────────────────────────────────────────────
+  const [controls, setControls] = useState<PuppetControl[]>([])
+  const controlsRef = useRef<PuppetControl[]>([])
+  controlsRef.current = controls
+  const [controlVals, setControlVals] = useState<Record<string, number>>({}) // id → t (0..1)
+  const controlIdSeq = useRef(0) // in-session counter for collision-free control ids
+
   const deviceStatus = useDeviceStatus()
   const canSeqLive = deviceStatus.state === 'connected' && bindings.length > 0
   // Degrade gracefully: if the board disconnects (or its bindings vanish) while Live
@@ -1547,41 +1583,31 @@ export function RobotView({
     if (!canSeqLive && seqLive) setSeqLive(false)
   }, [canSeqLive, seqLive])
 
-  // Stream the current frame's servo angles to a connected board (#415). Uses the
-  // reverse SNKCMD control channel: one line per frame, "SNKCMD servos <pin>=<deg> …"
-  // (a program running `inst.control` mirrors it onto the physical servos). Throttled;
-  // best-effort — a disconnect / write error is swallowed so preview never breaks.
-  const pushLiveFrame = (sampledDisplay: Record<string, number>): void => {
+  // Stream a DISPLAY-unit pose's servo angles to a connected board over the reverse
+  // SNKCMD control channel (#415/#416): one "SNKCMD servos <pin>:<deg> …" line — a
+  // program running `inst.control` (its `servos` handler) mirrors it onto the
+  // physical servos. Throttled (~25 Hz) + best-effort — a disconnect / write error
+  // is swallowed so preview never breaks. Shared by the sequence Live preview and
+  // the puppet-control drag.
+  const streamServos = (display: Record<string, number>): void => {
     const now = performance.now()
-    if (now - lastLiveSend.current < 55) return // ~18 Hz cap on serial writes
+    if (now - lastLiveSend.current < 40) return // ~25 Hz cap on serial writes
     lastLiveSend.current = now
-    const parts: string[] = []
+    const byPin: Record<string, number> = {}
     for (const b of bindingsRef.current) {
-      const disp = sampledDisplay[b.joint]
-      if (typeof disp !== 'number') continue
-      parts.push(`${b.pin}=${Math.round(jointToServo(b, disp))}`)
+      const disp = display[b.joint]
+      if (typeof disp === 'number') byPin[b.pin] = jointToServo(b, disp)
     }
-    if (parts.length) void window.api.device.sendControl('servos', parts.join(' ')).catch(() => undefined)
+    const payload = buildServosPayload(byPin)
+    if (payload) void window.api.device.sendControl('servos', payload).catch(() => undefined)
   }
 
-  // Apply a sampled sequence frame to the robot imperatively (mirrors auto-follow);
-  // `commitState` syncs the sliders (scrub/pause only). Streams to the board when Live.
+  // Apply a sampled sequence frame (mirrors auto-follow); `commitState` syncs the
+  // sliders (scrub/pause only). Streams to the board when Live.
   const applySequenceAt = (t: number, commitState = false): void => {
-    const r = robotRef.current
-    if (!r) return
     const sampled = samplePoseSequence(sequenceRef.current, posesByNameRef.current, t)
-    const patch: Record<string, number> = {}
-    for (const m of metaRef.current) {
-      if (m.isMimic) continue
-      const disp = sampled[m.name]
-      if (typeof disp !== 'number') continue
-      const lim = effectiveLimit(m, overridesRef.current[m.name])
-      const native = clamp(toNative(m.type, disp), lim.lower, lim.upper)
-      r.setJointValue(m.name, native)
-      patch[m.name] = native
-    }
-    if (commitState) setValues((v) => ({ ...v, ...patch }))
-    if (seqLiveRef.current) pushLiveFrame(sampled)
+    applyDisplayPose(sampled, commitState)
+    if (seqLiveRef.current) streamServos(sampled)
   }
 
   // rAF playback loop (mirrors the timeline's at :1410) — drives setJointValue each
@@ -1671,6 +1697,42 @@ export function RobotView({
     commitSequence({
       ...sequenceRef.current,
       steps: sequenceRef.current.steps.map((s, i) => (i === index ? { ...s, ...patch } : s))
+    })
+  }
+
+  // Drive a puppet control at slider position `t` (#416): blend its poses, drive
+  // the live model, and stream the servos to a connected board — all in real time.
+  const handleControlChange = (id: string, t: number): void => {
+    setControlVals((v) => ({ ...v, [id]: t }))
+    const c = controlsRef.current.find((x) => x.id === id)
+    if (!c) return
+    setPlaying(false) // a manual drag is exclusive with timeline / sequence playback
+    setSeqPlaying(false)
+    const display = sampleControl(c, posesByNameRef.current, t)
+    applyDisplayPose(display, true)
+    if (canSeqLive) streamServos(display)
+  }
+  const handleCreateControl = (name: string, posesSel: string[]): void => {
+    if (!name.trim() || posesSel.length < 2) return
+    const id = `ctl-${Date.now().toString(36)}-${controlIdSeq.current++}` // unique across reloads
+    const next = [...controlsRef.current, { id, name: name.trim(), poses: posesSel }]
+    setControls(next)
+    void persist((mm) => {
+      mm.controls = next
+    })
+  }
+  const handleRenameControl = (id: string, name: string): void => {
+    const next = controlsRef.current.map((c) => (c.id === id ? { ...c, name } : c))
+    setControls(next)
+    void persist((mm) => {
+      mm.controls = next
+    })
+  }
+  const handleDeleteControl = (id: string): void => {
+    const next = controlsRef.current.filter((c) => c.id !== id)
+    setControls(next)
+    void persist((mm) => {
+      mm.controls = next
     })
   }
 
@@ -4177,6 +4239,18 @@ export function RobotView({
           onSetStepDuration={(i, seconds) => patchStep(i, { duration: Math.max(0, seconds) })}
           onSetStepEasing={(i, easing) => patchStep(i, { easing })}
           onExport={handleExport}
+        />
+      )}
+      {showTimeline && (
+        <RobotControls
+          controls={controls}
+          poses={poses}
+          values={controlVals}
+          live={canSeqLive}
+          onChange={handleControlChange}
+          onCreate={handleCreateControl}
+          onRename={handleRenameControl}
+          onDelete={handleDeleteControl}
         />
       )}
     </div>

--- a/src/shared/control.ts
+++ b/src/shared/control.ts
@@ -86,3 +86,17 @@ export function buildTeleopPayload(
   }
   return toks.join(' ')
 }
+
+/**
+ * Build a multi-servo control payload (#416): `"<pin>:<deg> <pin>:<deg> …"`, so
+ * one slider can drive several servos in a single `SNKCMD servos …` line (the
+ * single-servo `servo` target can't). Degrees are rounded to whole numbers;
+ * non-finite angles are skipped. The device-side `servos_command` parses it.
+ */
+export function buildServosPayload(byPin: Record<string, number>): string {
+  const toks: string[] = []
+  for (const [pin, deg] of Object.entries(byPin)) {
+    if (Number.isFinite(deg)) toks.push(`${pin}:${Math.round(deg)}`)
+  }
+  return toks.join(' ')
+}

--- a/src/shared/krf.ts
+++ b/src/shared/krf.ts
@@ -28,6 +28,7 @@ import {
   type MotionTrack,
   type NamedPose,
   type PoseStep,
+  type PuppetControl,
   type RobotDefinition,
   type RobotModel,
   type ServoJointBinding
@@ -141,6 +142,23 @@ function sanitiseSequences(raw: unknown): MotionSequence[] | undefined {
   return out.length ? out : undefined
 }
 
+/** Validate the puppet controls (#416); `undefined` when none are usable. A
+ *  control needs an id/name and ≥2 pose names (fewer can't blend). */
+function sanitiseControls(raw: unknown): PuppetControl[] | undefined {
+  if (!Array.isArray(raw)) return undefined
+  const out: PuppetControl[] = []
+  for (const c of raw) {
+    const r = (c ?? {}) as Record<string, unknown>
+    if (!isStr(r.id) || !r.id.trim()) continue
+    const poses = Array.isArray(r.poses)
+      ? r.poses.filter((p): p is string => isStr(p) && !!p.trim()).map((p) => p.trim())
+      : []
+    if (poses.length < 2) continue
+    out.push({ id: r.id.trim(), name: isStr(r.name) && r.name.trim() ? r.name.trim() : r.id.trim(), poses })
+  }
+  return out.length ? out : undefined
+}
+
 /** Validate the mirror pairs; `undefined` when none are usable. */
 function sanitiseMirror(raw: unknown): MirrorPair[] | undefined {
   if (!Array.isArray(raw)) return undefined
@@ -246,6 +264,9 @@ export function sanitiseRobotModel(raw: unknown): RobotModel | undefined {
 
   const sequences = sanitiseSequences(r.sequences)
   if (sequences) model.sequences = sequences
+
+  const controls = sanitiseControls(r.controls)
+  if (controls) model.controls = controls
 
   const mirror = sanitiseMirror(r.mirror)
   if (mirror) model.mirror = mirror

--- a/src/shared/robot-timeline.ts
+++ b/src/shared/robot-timeline.ts
@@ -160,6 +160,29 @@ export function samplePoseSequence(
 }
 
 /**
+ * Blend a puppet control's poses at slider position `t` (#416): the N poses sit at
+ * even stops `i/(N-1)`, `t` is clamped to 0..1, and the bracketing pair is
+ * linearly interpolated joint-wise (a joint present in only one neighbour holds —
+ * see {@link lerpPoses}). Returns the joint→display map to drive the model/board.
+ * `posesByName` resolves each pose name to its stored values (`NamedPose.values`).
+ */
+export function sampleControl(
+  control: { poses: string[] },
+  posesByName: Record<string, Record<string, number>>,
+  t: number
+): Record<string, number> {
+  const names = control.poses
+  const n = names.length
+  if (n === 0) return {}
+  const poseOf = (i: number): Record<string, number> => posesByName[names[i]] ?? {}
+  if (n === 1) return { ...poseOf(0) }
+  const u = t < 0 ? 0 : t > 1 ? 1 : t
+  const pos = u * (n - 1)
+  const i = Math.min(n - 2, Math.floor(pos)) // bracket lower index (clamped so i+1 exists)
+  return lerpPoses(poseOf(i), poseOf(i + 1), pos - i)
+}
+
+/**
  * Convert a sequence's steps to the managed-block / runtime form (#413/#415):
  * `[[poseName, durationMs, easing], …]`. The editor stores each step's duration as
  * the OUTGOING segment (time to the next pose), but `snakie_motion.Rig.play`

--- a/src/shared/robot.ts
+++ b/src/shared/robot.ts
@@ -79,6 +79,8 @@ export interface RobotModel {
   timeline?: MotionTimeline
   /** Pose-to-pose sequences / walk cycles (#415) — sit beside `timeline`. */
   sequences?: MotionSequence[]
+  /** Puppet controls — sliders that blend 2+ poses live (#416). */
+  controls?: PuppetControl[]
   /** Left↔right joint mirror pairs, for symmetric gaits (Phase 4). */
   mirror?: MirrorPair[]
 }
@@ -171,6 +173,20 @@ export interface MotionSequence {
   fps?: number
   /** The ordered pose steps. */
   steps: PoseStep[]
+}
+
+/**
+ * A puppet control (#416): a named slider that blends 2+ saved poses. The poses
+ * sit at even parameter stops `i/(N-1)`; dragging the slider (0..1) linearly
+ * interpolates between the bracketing pair and drives the model + board live.
+ */
+export interface PuppetControl {
+  /** Stable id within the project. */
+  id: string
+  /** Display name (the slider label). */
+  name: string
+  /** The ordered saved-pose names to blend (≥2 to be usable). */
+  poses: string[]
 }
 
 /** A left↔right mirror pairing (`a` copies onto `b`), for symmetric gaits. */

--- a/test/krf.test.ts
+++ b/test/krf.test.ts
@@ -131,6 +131,23 @@ describe('sanitiseRobotModel — corruption-safe (#310)', () => {
     expect(m!.sequences![0].steps[0].pose).toBe('a')
   })
 
+  it('sanitises puppet controls (#416): keeps id/name + ≥2 poses, drops the rest', () => {
+    const m = sanitiseRobotModel({
+      controls: [
+        { id: ' look ', name: '  Look  ', poses: [' left ', 'right', '', 5] },
+        { id: 'c2', poses: ['only-one'] }, // <2 poses → dropped
+        { name: 'no-id', poses: ['a', 'b'] }, // no id → dropped
+        'junk'
+      ]
+    })
+    expect(m!.controls).toEqual([{ id: 'look', name: 'Look', poses: ['left', 'right'] }])
+  })
+
+  it('a controls-only model round-trips (regression: never silently dropped)', () => {
+    const m = sanitiseRobotModel({ controls: [{ id: 'c', poses: ['a', 'b'] }] })
+    expect(m!.controls![0]).toEqual({ id: 'c', name: 'c', poses: ['a', 'b'] }) // name defaults to id
+  })
+
   it('sanitises mirror pairs (#314)', () => {
     const m = sanitiseRobotModel({
       urdf: 'a.urdf',

--- a/test/robotControls.test.ts
+++ b/test/robotControls.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { sampleControl } from '../src/shared/robot-timeline'
+import { buildServosPayload } from '../src/shared/control'
+import type { PuppetControl } from '../src/shared/robot'
+
+const poses = {
+  left: { yaw: -90, tilt: 0 },
+  center: { yaw: 0, tilt: 0 },
+  right: { yaw: 90, tilt: 20 }
+}
+const ctl = (names: string[]): PuppetControl => ({ id: 'c1', name: 'look', poses: names })
+
+describe('sampleControl — puppet pose blend (#416)', () => {
+  it('lerps between two poses across the slider', () => {
+    const c = ctl(['left', 'center'])
+    expect(sampleControl(c, poses, 0)).toEqual({ yaw: -90, tilt: 0 })
+    expect(sampleControl(c, poses, 1)).toEqual({ yaw: 0, tilt: 0 })
+    expect(sampleControl(c, poses, 0.5).yaw).toBeCloseTo(-45)
+  })
+
+  it('clamps t to 0..1', () => {
+    const c = ctl(['left', 'center'])
+    expect(sampleControl(c, poses, -3)).toEqual({ yaw: -90, tilt: 0 })
+    expect(sampleControl(c, poses, 9)).toEqual({ yaw: 0, tilt: 0 })
+  })
+
+  it('brackets the right pair for 3 poses (stops at 0, 0.5, 1)', () => {
+    const c = ctl(['left', 'center', 'right'])
+    expect(sampleControl(c, poses, 0)).toEqual({ yaw: -90, tilt: 0 }) // left
+    expect(sampleControl(c, poses, 0.5)).toEqual({ yaw: 0, tilt: 0 }) // exactly center
+    expect(sampleControl(c, poses, 1)).toEqual({ yaw: 90, tilt: 20 }) // right (endpoint)
+    // quarter → halfway left↔center
+    expect(sampleControl(c, poses, 0.25).yaw).toBeCloseTo(-45)
+    // three-quarters → halfway center↔right
+    const tq = sampleControl(c, poses, 0.75)
+    expect(tq.yaw).toBeCloseTo(45)
+    expect(tq.tilt).toBeCloseTo(10)
+  })
+
+  it('holds a joint present in only one neighbour', () => {
+    const p = { a: { j: 0 }, b: { j: 10, k: 5 } }
+    // k is only in b → it holds b's value across the blend
+    expect(sampleControl(ctl(['a', 'b']), p, 0.5)).toEqual({ j: 5, k: 5 })
+  })
+
+  it('a single pose (or unknown names) never throws', () => {
+    expect(sampleControl(ctl(['center']), poses, 0.7)).toEqual({ yaw: 0, tilt: 0 })
+    // an unknown pose resolves to {}, so the blend holds the known neighbour's joints
+    expect(sampleControl(ctl(['ghost', 'center']), poses, 0)).toEqual({ yaw: 0, tilt: 0 })
+    expect(sampleControl({ id: 'x', name: 'x', poses: [] }, poses, 0.5)).toEqual({})
+  })
+})
+
+describe('buildServosPayload — multi-servo control line (#416)', () => {
+  it('emits rounded pin:deg pairs', () => {
+    expect(buildServosPayload({ '0': 90, '15': 44.6 })).toBe('0:90 15:45')
+  })
+  it('skips non-finite angles, empty map → empty string', () => {
+    expect(buildServosPayload({ '0': Number.NaN, '1': 30 })).toBe('1:30')
+    expect(buildServosPayload({})).toBe('')
+  })
+})


### PR DESCRIPTION
The **final** piece of the Motion Studio epic (#403). Closes #416.

A named **control** blends 2+ saved poses and exposes them as a slider. Dragging it interpolates between the ordered poses and drives the live 3-D model **and** (when armed) a running board's servos in real time — Bottango-style. One slider can sweep the eyes, morph a smile→frown, or play a stride without the timeline.

## What
- **Data model** — `PuppetControl { id, name, poses[] }` + `RobotModel.controls`, sanitised in `krf.ts` (`sanitiseControls`, needs id + ≥2 poses) so it round-trips `robot.yml`. Added **upfront** — the #415 review caught the exact "new field silently dropped by the sanitiser" class.
- **Pure blend** — `sampleControl(control, posesByName, t)`: N poses at even stops `i/(N-1)`, `t` clamped 0..1, bracketing pair linearly interpolated (reuses `lerpPoses`; a joint in only one neighbour holds). **Unit-tested** (2-pose lerp, 3-pose bracketing, both endpoints, missing-joint hold, unknown/empty).
- **Model drive** — extracted `applyDisplayPose` (the shared inner loop of timeline / sequence / control: `toNative` + `effectiveLimit` clamp + `setJointValue`, mimics auto-follow). The slider drives it on every input; dragging is exclusive with playback.
- **Board drive** — `buildServosPayload({pin:deg})` + a shared, throttled `streamServos` over the `SNKCMD servos` channel (with a **trailing flush** so the final drag position always lands); on-device `servos_command` parses `pin:deg …` and drives `servo_on(pin).angle` each, registered via `control.on("servos")` and announced in `READY_CAPS`. Behind an explicit **Live** arm (like the sequencer).
- **UI** — `RobotControls`: a panel of labelled sliders with pose-stop ticks, a **+ Control** creator (name + pick ≥2 ordered poses), rename (on blur) + delete. Own `robotctl__` BEM prefix; dark + light.
- Pose **rename cascades** into controls; **deleting** a pose drops the ref (and removes a control left with <2 poses) — the blend never throws.

## Adversarial review
A skeptical review verified the core clean (blend math, persistence round-trip, the `applyDisplayPose` extraction, the device parser) and found **no HIGH/MEDIUM** — only LOWs, all fixed: explicit Live arm, trailing-edge flush, blur-rename (no per-keystroke writes), and pruning below-2 controls.

## Verification
- **1657 vitest** (+control blend / payload, +krf controls round-trip) + **199 Python** (+`servos_command` parse/drive) + typecheck / lint / build green.

Part of #403 — this completes the epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)