### PR TITLE
feat: collapse Motion Studio tools into one tabbed dock (#403)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Add Joint tool stays, now purely for geometry (where parts meet + orientation).
 
 ### Changed
+- **Robot View — Motion Studio tools share one collapsible dock (#403).** The keyframe timeline,
+  pose sequencer and puppet controls no longer stack as three full-width bars crowding the bottom
+  of the screen. They're now **tabs in a single dock** — pick **Keyframes / Sequence / Controls**,
+  and a chevron collapses the whole dock to just its tab strip so the 3-D stage goes full-height.
+  The dock remembers your last tab and open/closed state, and a tab shows a dot when that surface
+  already has content, so a populated-but-hidden tool advertises itself.
 - **In-app Help links to the full online docs (#418).** The Help panel now has a
   **"Full documentation at docs.snakie.org"** link in its contents view and after every
   article, so you can jump to the complete, searchable docs in your browser.

--- a/src/renderer/src/components/RobotMotionDock.css
+++ b/src/renderer/src/components/RobotMotionDock.css
@@ -1,0 +1,83 @@
+/* Motion dock (#403 follow-up) — the tabbed, collapsible bottom container for the
+   three Motion Studio surfaces. Theme-aware; unique `robotdock__` BEM prefix. */
+.robotdock {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--bg-elevated, #202227);
+  border-top: var(--border-w, 1px) solid var(--border, #2c2e33);
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+}
+
+.robotdock__tabs {
+  display: flex;
+  align-items: stretch;
+  gap: 0.1rem;
+  padding: 0 0.4rem;
+  border-bottom: 1px solid var(--border, #2c2e33);
+}
+.robotdock.is-collapsed .robotdock__tabs {
+  border-bottom: none;
+}
+
+.robotdock__tab {
+  position: relative;
+  font-family: inherit;
+  font-size: 0.64rem;
+  color: var(--muted, #8a8f96);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 0.32rem 0.6rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.robotdock__tab:hover {
+  color: var(--text, #cdd2d9);
+}
+.robotdock__tab.is-active {
+  color: var(--text, #cdd2d9);
+  border-bottom-color: var(--accent, #d6a23f);
+  font-weight: 600;
+}
+.robotdock__badge {
+  display: inline-block;
+  width: 0.32rem;
+  height: 0.32rem;
+  border-radius: 50%;
+  background: var(--accent, #d6a23f);
+  margin-left: 0.28rem;
+  vertical-align: middle;
+}
+
+.robotdock__spacer {
+  flex: 1 1 auto;
+}
+.robotdock__collapse {
+  font-family: inherit;
+  font-size: 0.8rem;
+  line-height: 1;
+  color: var(--muted, #8a8f96);
+  background: none;
+  border: none;
+  padding: 0.2rem 0.45rem;
+  cursor: pointer;
+}
+.robotdock__collapse:hover {
+  color: var(--text, #cdd2d9);
+}
+
+.robotdock__body {
+  min-height: 0;
+  max-height: 42vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+/* The nested panel (robottimeline / robotseq / robotctl) brings its own padding +
+   matching background; drop its top border so the dock's tab strip is the ONLY
+   divider (no double rule). */
+.robotdock__body > * {
+  border-top: none;
+}

--- a/src/renderer/src/components/RobotMotionDock.tsx
+++ b/src/renderer/src/components/RobotMotionDock.tsx
@@ -1,0 +1,101 @@
+import { useCallback, useState, type JSX, type ReactNode } from 'react'
+import './RobotMotionDock.css'
+
+/**
+ * MOTION DOCK (#403 follow-up) — one collapsible bottom dock that tabs between the
+ * three Motion Studio surfaces (Keyframes / Sequence / Controls) instead of
+ * stacking three full-width bars. Only the active tab's panel mounts; a chevron
+ * collapses the dock to just its tab strip (giving the full 3-D stage back). The
+ * active tab + collapsed state persist across sessions, and a tab shows a dot when
+ * that surface already has content, so a populated-but-hidden surface advertises
+ * itself. Own `robotdock__` BEM prefix (instrument CSS is global).
+ */
+
+export interface MotionTab {
+  id: string
+  label: string
+  /** Show a dot on the tab (this surface has authored content). */
+  badge?: boolean
+  content: ReactNode
+}
+
+export interface RobotMotionDockProps {
+  tabs: MotionTab[]
+}
+
+const STORE_KEY = 'snakie:motionDock'
+
+interface DockState {
+  active: string
+  collapsed: boolean
+}
+
+function loadState(fallback: string): DockState {
+  try {
+    const raw = localStorage.getItem(STORE_KEY)
+    if (raw) {
+      const s = JSON.parse(raw) as Partial<DockState>
+      return { active: typeof s.active === 'string' ? s.active : fallback, collapsed: s.collapsed === true }
+    }
+  } catch {
+    /* corrupt / unavailable storage — fall through to the default */
+  }
+  return { active: fallback, collapsed: false }
+}
+
+export function RobotMotionDock({ tabs }: RobotMotionDockProps): JSX.Element {
+  const first = tabs[0]?.id ?? ''
+  const [state, setState] = useState<DockState>(() => loadState(first))
+  // Guard against a persisted id that no longer exists (e.g. a renamed tab).
+  const active = tabs.some((t) => t.id === state.active) ? state.active : first
+  const { collapsed } = state
+
+  const persist = useCallback((next: DockState) => {
+    setState(next)
+    try {
+      localStorage.setItem(STORE_KEY, JSON.stringify(next))
+    } catch {
+      /* best-effort — a preference not persisting is non-fatal */
+    }
+  }, [])
+
+  // Clicking a tab always expands to it (so a hidden dock opens on the surface you
+  // asked for); the chevron just toggles visibility of the current tab.
+  const selectTab = (id: string): void => persist({ active: id, collapsed: false })
+  const toggleCollapsed = (): void => persist({ active, collapsed: !collapsed })
+
+  const activeTab = tabs.find((t) => t.id === active) ?? tabs[0]
+
+  return (
+    <div className={`robotdock${collapsed ? ' is-collapsed' : ''}`}>
+      <div className="robotdock__tabs" role="tablist" aria-label="Motion tools">
+        {tabs.map((t) => (
+          <button
+            key={t.id}
+            type="button"
+            role="tab"
+            aria-selected={!collapsed && t.id === active}
+            className={`robotdock__tab${!collapsed && t.id === active ? ' is-active' : ''}`}
+            onClick={() => selectTab(t.id)}
+          >
+            {t.label}
+            {t.badge && <span className="robotdock__badge" title="has content" aria-hidden="true" />}
+          </button>
+        ))}
+        <span className="robotdock__spacer" />
+        <button
+          type="button"
+          className="robotdock__collapse"
+          onClick={toggleCollapsed}
+          title={collapsed ? 'Show motion tools' : 'Hide motion tools (reclaim the 3-D view)'}
+          aria-label={collapsed ? 'Expand motion dock' : 'Collapse motion dock'}
+        >
+          {collapsed ? '⌃' : '⌄'}
+        </button>
+      </div>
+      {!collapsed && <div className="robotdock__body">{activeTab?.content}</div>}
+    </div>
+  )
+}
+
+export default RobotMotionDock

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -86,6 +86,7 @@ import { loadPin, savePin, PIN_KEYS } from './pin-overlay'
 import { RobotTimeline } from './RobotTimeline'
 import { RobotSequencer } from './RobotSequencer'
 import { RobotControls } from './RobotControls'
+import { RobotMotionDock } from './RobotMotionDock'
 import {
   autoMirrorPairs,
   deleteKey,
@@ -4223,74 +4224,97 @@ export function RobotView({
       </div>
       </div>
       {showTimeline && (
-        <RobotTimeline
-          timeline={timeline}
-          movableJoints={movableNames}
-          playhead={playhead}
-          playing={playing}
-          selected={selectedKey}
-          poses={poses}
-          canExport={bindings.length > 0}
-          canMirror={mirrorPairs.length > 0}
-          onPlayPause={handlePlayPause}
-          onStop={() => seek(0)}
-          onToggleLoop={() => commitTimeline({ ...timelineRef.current, loop: !timelineRef.current.loop })}
-          onScrub={seek}
-          onSetDuration={(d) =>
-            commitTimeline({ ...timelineRef.current, duration: Math.max(0.1, d) })
-          }
-          onSetEasing={(e: MotionEasing) => commitTimeline({ ...timelineRef.current, easing: e })}
-          onSetFps={(f) =>
-            commitTimeline({ ...timelineRef.current, fps: Math.max(1, Math.min(60, Math.round(f))) })
-          }
-          onCapture={handleCapture}
-          onImportPose={handleImportPose}
-          onMirror={handleMirror}
-          mirrorPairs={mirrorPairs}
-          onToggleInvert={handleToggleInvert}
-          onDuplicate={handleDuplicate}
-          onExport={handleExport}
-          onSelectKey={handleSelectKey}
-          onMoveKey={handleMoveKey}
-          onDeleteKey={handleDeleteKey}
-          onAddKey={handleAddKey}
-        />
-      )}
-      {showTimeline && (
-        <RobotSequencer
-          sequence={sequence}
-          poses={poses}
-          playing={seqPlaying}
-          playhead={seqPlayhead}
-          live={seqLive}
-          canLive={canSeqLive}
-          canExport={bindings.length > 0}
-          onPlayPause={handleSeqPlayPause}
-          onStop={() => seqSeek(0)}
-          onScrub={seqSeek}
-          onToggleLoop={() => commitSequence({ ...sequenceRef.current, loop: !sequenceRef.current.loop })}
-          onToggleLive={() => setSeqLive((v) => !v)}
-          onAddStep={handleAddStep}
-          onRemoveStep={handleRemoveStep}
-          onMoveStep={handleMoveStep}
-          onSetStepPose={(i, pose) => patchStep(i, { pose })}
-          onSetStepDuration={(i, seconds) => patchStep(i, { duration: Math.max(0, seconds) })}
-          onSetStepEasing={(i, easing) => patchStep(i, { easing })}
-          onExport={handleExport}
-        />
-      )}
-      {showTimeline && (
-        <RobotControls
-          controls={controls}
-          poses={poses}
-          values={controlVals}
-          live={controlsLive}
-          canLive={canSeqLive}
-          onToggleLive={() => setControlsLive((v) => !v)}
-          onChange={handleControlChange}
-          onCreate={handleCreateControl}
-          onRename={handleRenameControl}
-          onDelete={handleDeleteControl}
+        <RobotMotionDock
+          tabs={[
+            {
+              id: 'keyframes',
+              label: 'Keyframes',
+              badge: timeline.tracks.some((t) => t.keys.length > 0),
+              content: (
+                <RobotTimeline
+                  timeline={timeline}
+                  movableJoints={movableNames}
+                  playhead={playhead}
+                  playing={playing}
+                  selected={selectedKey}
+                  poses={poses}
+                  canExport={bindings.length > 0}
+                  canMirror={mirrorPairs.length > 0}
+                  onPlayPause={handlePlayPause}
+                  onStop={() => seek(0)}
+                  onToggleLoop={() =>
+                    commitTimeline({ ...timelineRef.current, loop: !timelineRef.current.loop })
+                  }
+                  onScrub={seek}
+                  onSetDuration={(d) =>
+                    commitTimeline({ ...timelineRef.current, duration: Math.max(0.1, d) })
+                  }
+                  onSetEasing={(e: MotionEasing) => commitTimeline({ ...timelineRef.current, easing: e })}
+                  onSetFps={(f) =>
+                    commitTimeline({ ...timelineRef.current, fps: Math.max(1, Math.min(60, Math.round(f))) })
+                  }
+                  onCapture={handleCapture}
+                  onImportPose={handleImportPose}
+                  onMirror={handleMirror}
+                  mirrorPairs={mirrorPairs}
+                  onToggleInvert={handleToggleInvert}
+                  onDuplicate={handleDuplicate}
+                  onExport={handleExport}
+                  onSelectKey={handleSelectKey}
+                  onMoveKey={handleMoveKey}
+                  onDeleteKey={handleDeleteKey}
+                  onAddKey={handleAddKey}
+                />
+              )
+            },
+            {
+              id: 'sequence',
+              label: 'Sequence',
+              badge: sequence.steps.length > 0,
+              content: (
+                <RobotSequencer
+                  sequence={sequence}
+                  poses={poses}
+                  playing={seqPlaying}
+                  playhead={seqPlayhead}
+                  live={seqLive}
+                  canLive={canSeqLive}
+                  canExport={bindings.length > 0}
+                  onPlayPause={handleSeqPlayPause}
+                  onStop={() => seqSeek(0)}
+                  onScrub={seqSeek}
+                  onToggleLoop={() => commitSequence({ ...sequenceRef.current, loop: !sequenceRef.current.loop })}
+                  onToggleLive={() => setSeqLive((v) => !v)}
+                  onAddStep={handleAddStep}
+                  onRemoveStep={handleRemoveStep}
+                  onMoveStep={handleMoveStep}
+                  onSetStepPose={(i, pose) => patchStep(i, { pose })}
+                  onSetStepDuration={(i, seconds) => patchStep(i, { duration: Math.max(0, seconds) })}
+                  onSetStepEasing={(i, easing) => patchStep(i, { easing })}
+                  onExport={handleExport}
+                />
+              )
+            },
+            {
+              id: 'controls',
+              label: 'Controls',
+              badge: controls.length > 0,
+              content: (
+                <RobotControls
+                  controls={controls}
+                  poses={poses}
+                  values={controlVals}
+                  live={controlsLive}
+                  canLive={canSeqLive}
+                  onToggleLive={() => setControlsLive((v) => !v)}
+                  onChange={handleControlChange}
+                  onCreate={handleCreateControl}
+                  onRename={handleRenameControl}
+                  onDelete={handleDeleteControl}
+                />
+              )
+            }
+          ]}
         />
       )}
     </div>


### PR DESCRIPTION
UI cleanup for the Motion Studio epic (#403). The keyframe timeline, pose sequencer and puppet controls were stacking as **three full-width bars** at the bottom of the Robot View, crowding the 3-D stage.

## What
A single **`RobotMotionDock`** replaces the three stacked panels:
- A **tab strip** — `Keyframes · Sequence · Controls` — over the active surface.
- A **chevron** collapses the dock to just the strip, so the 3-D stage goes full height (and back).
- **Only the active tab mounts** (playback rAF + persistence live in `RobotView`, so they're unaffected by which tab shows).
- **Remembers** your last tab + collapsed state across sessions (localStorage).
- A **dot badge** on a tab when that surface has content (keyframe tracks / sequence steps / controls), so a populated-but-hidden tool advertises itself.

```
┌───────────────────────────────┐
│          3-D  STAGE           │
├ [Keyframes] Sequence Controls ⌄│   ← always-visible strip; ⌄ collapses
│ ▶ ❚❚ ■  loop  ├─scrub─┤  2.0s  │   ← active tab body
└───────────────────────────────┘
```

Purely presentational — no change to the timeline / sequence / control logic; the three panel components are unchanged and just rendered as tab bodies. Own `robotdock__` BEM prefix; reads on dark + skeuomorph light.

## Verification
- 1657 vitest + typecheck / lint / build green. (No logic touched, so no new unit tests; it's a layout shell.)

Follow-up ideas if wanted: drag-to-resize the dock height, and moving Controls to a right-side drawer (Bottango-style) as a later option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)