### PR TITLE
fix: motion dock no longer collapses the 3-D stage on a short pane (#403)

### DIFF
--- a/src/renderer/src/components/RobotMotionDock.css
+++ b/src/renderer/src/components/RobotMotionDock.css
@@ -5,12 +5,18 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
+  /* Never let the dock eat the 3-D stage: cap it at HALF the Robot View pane (a
+     definite height), not a window-relative `vh` — the latter overflows a short
+     pane and, because the stage canvas is absolutely positioned, collapses the
+     3-D view entirely. The body flex-fills + scrolls within this cap. */
+  max-height: 50%;
   background: var(--bg-elevated, #202227);
   border-top: var(--border-w, 1px) solid var(--border, #2c2e33);
   font-family: var(--font-mono, 'JetBrains Mono', monospace);
 }
 
 .robotdock__tabs {
+  flex: 0 0 auto;
   display: flex;
   align-items: stretch;
   gap: 0.1rem;
@@ -69,11 +75,9 @@
 }
 
 .robotdock__body {
+  flex: 1 1 auto;
   min-height: 0;
-  max-height: 42vh;
   overflow-y: auto;
-  display: flex;
-  flex-direction: column;
 }
 /* The nested panel (robottimeline / robotseq / robotctl) brings its own padding +
    matching background; drop its top border so the dock's tab strip is the ONLY


### PR DESCRIPTION
Follow-up to #439. Users reported the new tabbed motion dock **"takes up the whole screen rather than just being at the bottom."**

## Cause
The dock body was capped with a **window-relative** `max-height: 42vh`. When the Robot View pane is shorter than ~42vh (a short window, a split editor, or a robot with a tall keyframe timeline), that cap overshoots the pane — and because the 3-D stage's canvas is `position: absolute`, `robotview__main` shrinks to zero and the dock fills the entire view.

## Fix
Cap the dock at **50% of the Robot View pane** (a *definite* height, since `.robotview` is `height: 100%`), not a window-`vh`, and let the body `flex: 1 1 auto` + `overflow-y: auto` fill and scroll within it. The 3-D stage now always keeps ≥50% of the pane, and when the dock's content is short it's still only as tall as that content.

## Verification
Reproduced and fixed headless (Playwright/Chromium) with the real CSS in isolation:

| before | after |
|--------|-------|
| stage collapses to a sliver, dock ~80% | stage keeps ≥50%; short content → small dock; tall content → dock capped at 50% and its body scrolls |

CSS-only change; typecheck / lint / build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)