### PR TITLE
fix: rename motion dock prefix to end .robotdock class collision

### DIFF
--- a/src/renderer/src/components/RobotMotionDock.css
+++ b/src/renderer/src/components/RobotMotionDock.css
@@ -1,6 +1,6 @@
 /* Motion dock (#403 follow-up) — the tabbed, collapsible bottom container for the
-   three Motion Studio surfaces. Theme-aware; unique `robotdock__` BEM prefix. */
-.robotdock {
+   three Motion Studio surfaces. Theme-aware; unique `motiondock__` BEM prefix. */
+.motiondock {
   flex: 0 0 auto;
   display: flex;
   flex-direction: column;
@@ -15,7 +15,7 @@
   font-family: var(--font-mono, 'JetBrains Mono', monospace);
 }
 
-.robotdock__tabs {
+.motiondock__tabs {
   flex: 0 0 auto;
   display: flex;
   align-items: stretch;
@@ -23,11 +23,11 @@
   padding: 0 0.4rem;
   border-bottom: 1px solid var(--border, #2c2e33);
 }
-.robotdock.is-collapsed .robotdock__tabs {
+.motiondock.is-collapsed .motiondock__tabs {
   border-bottom: none;
 }
 
-.robotdock__tab {
+.motiondock__tab {
   position: relative;
   font-family: inherit;
   font-size: 0.64rem;
@@ -39,15 +39,15 @@
   cursor: pointer;
   white-space: nowrap;
 }
-.robotdock__tab:hover {
+.motiondock__tab:hover {
   color: var(--text, #cdd2d9);
 }
-.robotdock__tab.is-active {
+.motiondock__tab.is-active {
   color: var(--text, #cdd2d9);
   border-bottom-color: var(--accent, #d6a23f);
   font-weight: 600;
 }
-.robotdock__badge {
+.motiondock__badge {
   display: inline-block;
   width: 0.32rem;
   height: 0.32rem;
@@ -57,10 +57,10 @@
   vertical-align: middle;
 }
 
-.robotdock__spacer {
+.motiondock__spacer {
   flex: 1 1 auto;
 }
-.robotdock__collapse {
+.motiondock__collapse {
   font-family: inherit;
   font-size: 0.8rem;
   line-height: 1;
@@ -70,11 +70,11 @@
   padding: 0.2rem 0.45rem;
   cursor: pointer;
 }
-.robotdock__collapse:hover {
+.motiondock__collapse:hover {
   color: var(--text, #cdd2d9);
 }
 
-.robotdock__body {
+.motiondock__body {
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
@@ -82,6 +82,6 @@
 /* The nested panel (robottimeline / robotseq / robotctl) brings its own padding +
    matching background; drop its top border so the dock's tab strip is the ONLY
    divider (no double rule). */
-.robotdock__body > * {
+.motiondock__body > * {
   border-top: none;
 }

--- a/src/renderer/src/components/RobotMotionDock.tsx
+++ b/src/renderer/src/components/RobotMotionDock.tsx
@@ -8,7 +8,7 @@ import './RobotMotionDock.css'
  * collapses the dock to just its tab strip (giving the full 3-D stage back). The
  * active tab + collapsed state persist across sessions, and a tab shows a dot when
  * that surface already has content, so a populated-but-hidden surface advertises
- * itself. Own `robotdock__` BEM prefix (instrument CSS is global).
+ * itself. Own `motiondock__` BEM prefix (instrument CSS is global).
  */
 
 export interface MotionTab {
@@ -67,25 +67,25 @@ export function RobotMotionDock({ tabs }: RobotMotionDockProps): JSX.Element {
   const activeTab = tabs.find((t) => t.id === active) ?? tabs[0]
 
   return (
-    <div className={`robotdock${collapsed ? ' is-collapsed' : ''}`}>
-      <div className="robotdock__tabs" role="tablist" aria-label="Motion tools">
+    <div className={`motiondock${collapsed ? ' is-collapsed' : ''}`}>
+      <div className="motiondock__tabs" role="tablist" aria-label="Motion tools">
         {tabs.map((t) => (
           <button
             key={t.id}
             type="button"
             role="tab"
             aria-selected={!collapsed && t.id === active}
-            className={`robotdock__tab${!collapsed && t.id === active ? ' is-active' : ''}`}
+            className={`motiondock__tab${!collapsed && t.id === active ? ' is-active' : ''}`}
             onClick={() => selectTab(t.id)}
           >
             {t.label}
-            {t.badge && <span className="robotdock__badge" title="has content" aria-hidden="true" />}
+            {t.badge && <span className="motiondock__badge" title="has content" aria-hidden="true" />}
           </button>
         ))}
-        <span className="robotdock__spacer" />
+        <span className="motiondock__spacer" />
         <button
           type="button"
-          className="robotdock__collapse"
+          className="motiondock__collapse"
           onClick={toggleCollapsed}
           title={collapsed ? 'Show motion tools' : 'Hide motion tools (reclaim the 3-D view)'}
           aria-label={collapsed ? 'Expand motion dock' : 'Collapse motion dock'}
@@ -93,7 +93,7 @@ export function RobotMotionDock({ tabs }: RobotMotionDockProps): JSX.Element {
           {collapsed ? '⌃' : '⌄'}
         </button>
       </div>
-      {!collapsed && <div className="robotdock__body">{activeTab?.content}</div>}
+      {!collapsed && <div className="motiondock__body">{activeTab?.content}</div>}
     </div>
   )
 }


### PR DESCRIPTION
Fixes two layout bugs reported after #439/#440:
1. The **URDF editor's** bottom motion-tools tab covered the **whole screen**.
2. The **mini 3-D viewer** only used **50%** of its panel.

## Root cause — a global CSS class collision
The new tabbed motion dock (#439) was named **`.robotdock`** — the *same* global class the pre-existing **mini 3-D viewer** (`RobotDockPanel`) already uses. Panel CSS is global, so the two rule-sets merged and cross-contaminated:

- The mini viewer's `.robotdock { position: absolute; inset: 0 }` leaked onto the **motion dock**, taking it out of flow to fill the entire Robot View → **bug 1**.
- The motion dock's `.robotdock { max-height: 50% }` leaked onto the absolutely-positioned **mini viewer** → it rendered at **50%** → **bug 2**.

This — not `vh` overshoot — was also the real cause of the original "dock fills the screen" report; the isolated-CSS repro in #440 couldn't reproduce it because it didn't include the mini viewer's `position: absolute` rule. (Exactly the "instrument CSS is global; each panel needs a unique BEM prefix" trap.)

## Fix
Give the motion dock a **unique `motiondock__` prefix**, so it no longer shares a namespace with `.robotdock`. Both surfaces render correctly again. The `snakie:motionDock` storage key is unchanged.

## Verification
Built bundle now has **14 `.motiondock` rules** (the dock) vs **7 unchanged `.robotdock` rules** (the mini viewer), fully separated. typecheck / lint / build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)