### PR TITLE
feat: clearer, self-sizing Build hierarchy (joint names, type icons, width, height)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Add Joint tool stays, now purely for geometry (where parts meet + orientation).
 
 ### Changed
+- **Robot View — clearer, self-sizing Build hierarchy.** Each row in the Chain tree now shows a
+  **type glyph** (a mesh triangle vs a primitive cube) between the tree connector and the pencil,
+  and the joint tag shows the **joint name** (e.g. `shoulder`) instead of just its type — so it
+  matches the joint names in the Servos list and the pose editor. The panel now **sizes to its
+  longest row** (name + indentation) and truncates anything past **a third of the screen**, and it
+  only grows down to the top of the bottom-left help hint — the **Open** / **+ STL / DAE** buttons
+  no longer sit over it; the list scrolls instead.
 - **Robot View — Motion Studio tools share one collapsible dock (#403).** The keyframe timeline,
   pose sequencer and puppet controls no longer stack as three full-width bars crowding the bottom
   of the screen. They're now **tabs in a single dock** — pick **Keyframes / Sequence / Controls**,

--- a/src/renderer/src/components/RobotBuildPanel.css
+++ b/src/renderer/src/components/RobotBuildPanel.css
@@ -30,15 +30,17 @@
   position: absolute;
   top: 0.5rem;
   left: 0.5rem;
-  /* Size to fit its contents (capped), so it never overlaps the Help hint in the
-     bottom-left; the parts list scrolls if the robot has more blocks than fit. */
-  max-height: calc(100% - 1rem);
+  /* Grow only to the top of the bottom-left Help hint (`.robotview__hud`, ~2.7rem
+     tall) + the foot buttons: leave that much clearance so the buttons never sit
+     over the hint; the parts list scrolls past that. */
+  max-height: calc(100% - 3.25rem);
   z-index: 4;
-  /* A little wider so STL-derived link names (e.g. left_shoulder_bracket_v3, plus
-     _2/_3 suffixes) read without the ellipsis; capped viewport-relative so on narrow
-     windows the floating dock still only claims a modest slice of the 3-D stage (#408). */
-  width: 17.5rem;
-  max-width: min(18rem, 42vw);
+  /* Fit the widest row (a long STL-derived link name + its indentation), capped at
+     a THIRD of the screen — beyond that, row labels truncate (ellipsis) rather than
+     let the floating dock swallow the 3-D stage. */
+  width: max-content;
+  min-width: 13rem;
+  max-width: 33vw;
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
@@ -114,8 +116,25 @@
 .robotbuild__rowbase.is-base {
   color: var(--accent-ink);
 }
+/* Type glyph between the elbow and the pencil: a mesh triangle vs a primitive cube,
+   so meshes and blocks read apart at a glance. */
+.robotbuild__typeicon {
+  flex: 0 0 auto;
+  width: 0.95rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted, #8b919b);
+  opacity: 0.8;
+}
+.robotbuild__typeicon svg {
+  display: block;
+}
 .robotbuild__hint {
   margin: 0;
+  /* Cap + wrap so a full-sentence hint doesn't drag the max-content dock out to its
+     full 1/3-screen width; the tree rows decide the width instead. */
+  max-width: 15rem;
   font-size: 0.56rem;
   color: var(--text-muted, #8b919b);
 }
@@ -267,7 +286,12 @@
   line-height: 1;
 }
 .robotbuild__jtype {
-  flex: 0 0 auto;
+  /* Shows the JOINT NAME (so it matches the servo/pose joint refs); can shrink +
+     ellipsis so a long joint name doesn't crowd out the link label. */
+  flex: 0 1 auto;
+  max-width: 8rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
   margin-left: 0.25rem;
   padding: 0.05rem 0.32rem;

--- a/src/renderer/src/components/RobotBuildPanel.tsx
+++ b/src/renderer/src/components/RobotBuildPanel.tsx
@@ -60,6 +60,30 @@ const ANCHOR = (
     />
   </svg>
 )
+// Row type glyphs (#): tell a MESH-backed link apart from a primitive/block at a
+// glance — a little triangle-mesh vs a cube, sat between the elbow and the pencil.
+const MESH_ICON = (
+  <svg viewBox="0 0 16 16" width="11" height="11" aria-hidden="true">
+    <path
+      d="M8 2.2l5.6 9.6H2.4z M8 2.2v9.6 M4.9 8.6h6.2"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      strokeLinejoin="round"
+    />
+  </svg>
+)
+const CUBE_ICON = (
+  <svg viewBox="0 0 16 16" width="11" height="11" aria-hidden="true">
+    <path
+      d="M8 2.3l5.4 3.1v5.2L8 13.7 2.6 10.6V5.4z M2.6 5.4L8 8.5l5.4-3.1 M8 8.5v5.2"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      strokeLinejoin="round"
+    />
+  </svg>
+)
 
 export interface RobotBuildPanelProps {
   open: boolean
@@ -506,6 +530,13 @@ function ChainRow({
         >
           {node.isBase ? ANCHOR : null}
         </span>
+        <span
+          className="robotbuild__typeicon"
+          title={node.kind === 'mesh' ? 'Mesh part' : 'Primitive block'}
+          aria-hidden="true"
+        >
+          {node.kind === 'mesh' ? MESH_ICON : CUBE_ICON}
+        </span>
         <button
           type="button"
           className={`robotbuild__edit${isEdit ? ' is-on' : ''}`}
@@ -529,10 +560,10 @@ function ChainRow({
           <button
             type="button"
             className={`robotbuild__jtype${activeJoint === node.joint.name ? ' is-on' : ''}`}
-            title={`${node.joint.name} — click to edit (parent: ${node.joint.parent})`}
+            title={`Joint “${node.joint.name}” · ${jointTypeLabel(node.joint.type)} · parent ${node.joint.parent} — click to edit`}
             onClick={() => onOpenJoint(node.link, node.joint!.name)}
           >
-            {jointTypeLabel(node.joint.type)}
+            {node.joint.name}
           </button>
         ) : node.loose ? (
           <span className="robotbuild__loose-tag" title="Not connected to the base — open it and pick a parent">


### PR DESCRIPTION
Four Robot-View Build-panel fixes from feedback:

1. **Joint names match everywhere.** The Chain tree's joint tag now shows the **joint name** (e.g. `shoulder`) instead of just the kid-friendly type label — so it matches the joint names in the Servos list (`GP0 → shoulder`) and the pose editor. Type + parent move to the tooltip; a long name truncates so it can't crowd out the link label.
2. **Mesh vs block at a glance.** A small **type glyph** (a mesh triangle vs a primitive cube) sits between the tree elbow and the pencil.
3. **Self-sizing width.** The dock sizes to its **widest row** (name + indentation) and truncates any row past **a third of the screen** (`max-width: 33vw`). Full-sentence hints are capped so they wrap instead of dragging the dock out to full width.
4. **No more overlap with the help hint.** The dock only grows down to the top of the bottom-left help hint + its buttons (`max-height: calc(100% - 3.25rem)`); the list scrolls past that, so **Open** / **+ STL / DAE** no longer sit over the hint.

## Verification
Reproduced headless (real CSS in isolation) across short names, a long name (truncates at 1/3), many rows (list scrolls, foot clears the hint), and a wrapping hint (doesn't blow up the width):

| short names | long name + many rows |
|---|---|
| narrow dock, joint names + type icons, foot well above the hint | dock capped at 1/3, `left_shoul…` truncated, foot clears the hint |

typecheck / lint / build / **1657 vitest** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)