### PR TITLE
feat: joints as first-class rows in the Build hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,13 +95,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Add Joint tool stays, now purely for geometry (where parts meet + orientation).
 
 ### Changed
-- **Robot View — clearer, self-sizing Build hierarchy.** Each row in the Chain tree now shows a
-  **type glyph** (a mesh triangle vs a primitive cube) between the tree connector and the pencil,
-  and the joint tag shows the **joint name** (e.g. `shoulder`) instead of just its type — so it
-  matches the joint names in the Servos list and the pose editor. The panel now **sizes to its
-  longest row** (name + indentation) and truncates anything past **a third of the screen**, and it
-  only grows down to the top of the bottom-left help hint — the **Open** / **+ STL / DAE** buttons
-  no longer sit over it; the list scrolls instead.
+- **Robot View — joints are first-class in the Build hierarchy.** Each connecting joint now has its
+  own row directly above the link it drives, showing a **type glyph** (a lock for fixed, a rotation
+  arrow for a hinge, a spoked wheel for continuous, a slider for prismatic), the **joint name** (so
+  it matches the Servos list and the pose editor), and its **type badge**. **Rename a joint** by
+  right-clicking its row or from the joint dialog's new **Name** field — the rename cascades through
+  the servo bindings, poses, timeline, mirror pairs and per-joint settings. Link rows also carry a
+  **mesh-vs-cube** glyph.
+- **Robot View — clearer, self-sizing Build hierarchy.** The panel now **sizes to its longest row**
+  (name + indentation) and truncates anything past **a third of the screen**, and it only grows down
+  to the top of the bottom-left help hint — the **Open** / **+ STL / DAE** buttons no longer sit
+  over it; the list scrolls instead.
 - **Robot View — Motion Studio tools share one collapsible dock (#403).** The keyframe timeline,
   pose sequencer and puppet controls no longer stack as three full-width bars crowding the bottom
   of the screen. They're now **tabs in a single dock** — pick **Keyframes / Sequence / Controls**,

--- a/src/renderer/src/components/RobotBuildPanel.css
+++ b/src/renderer/src/components/RobotBuildPanel.css
@@ -285,36 +285,74 @@
   font-size: 0.7rem;
   line-height: 1;
 }
-.robotbuild__jtype {
-  /* Shows the JOINT NAME (so it matches the servo/pose joint refs); can shrink +
-     ellipsis so a long joint name doesn't crowd out the link label. */
-  flex: 0 1 auto;
-  max-width: 8rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  margin-left: 0.25rem;
-  padding: 0.05rem 0.32rem;
-  font-family: inherit;
-  font-size: 0.56rem;
-  color: var(--text-muted, #8b919b);
-  background: var(--bg-sunken, rgba(0, 0, 0, 0.22));
-  border: 1px solid var(--border, #3a3d44);
-  border-radius: 999px;
-  cursor: pointer;
-}
-.robotbuild__jtype:hover,
-.robotbuild__jtype.is-on {
-  color: var(--accent-contrast, #15161a);
-  background: var(--accent, #d6a23f);
-  border-color: var(--accent, #d6a23f);
-}
 .robotbuild__loose-tag {
   flex: 0 0 auto;
   white-space: nowrap;
   margin-left: 0.25rem;
   font-size: 0.56rem;
   color: var(--accent);
+}
+
+/* JOINT rows (#): the connector between a parent and its child link. Lighter than
+   the boxed part rows (no slab) so they read as the "edge" between parts — a type
+   icon, the editable joint name, and its type badge. */
+.robotbuild__joint-row {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+  padding: 0.02rem 0.2rem;
+  color: var(--text-muted, #8b919b);
+}
+.robotbuild__joint-elbow {
+  flex: 0 0 auto;
+  opacity: 0.5;
+  font-size: 0.7rem;
+  line-height: 1;
+}
+.robotbuild__joint-icon {
+  flex: 0 0 auto;
+  width: 0.95rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted, #8b919b);
+}
+.robotbuild__joint-icon svg {
+  display: block;
+}
+.robotbuild__joint-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: left;
+  font-family: inherit;
+  font-size: 0.62rem;
+  color: var(--text, #cdd2d9);
+  background: none;
+  border: none;
+  padding: 0.05rem 0.2rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.robotbuild__joint-name:hover {
+  background: rgba(128, 128, 128, 0.14);
+}
+.robotbuild__joint-name.is-on {
+  color: var(--accent-ink);
+  background: rgba(200, 162, 74, 0.16);
+}
+.robotbuild__joint-badge {
+  flex: 0 0 auto;
+  white-space: nowrap;
+  padding: 0.02rem 0.32rem;
+  font-size: 0.52rem;
+  color: var(--text-muted, #8b919b);
+  background: var(--bg-sunken, rgba(0, 0, 0, 0.22));
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 999px;
 }
 .robotbuild__chain--loose .robotbuild__part-label {
   font-style: italic;

--- a/src/renderer/src/components/RobotBuildPanel.tsx
+++ b/src/renderer/src/components/RobotBuildPanel.tsx
@@ -101,6 +101,8 @@ export interface RobotBuildPanelProps {
   active: PropsContext | null
   onEdit: (link: string | null) => void
   onOpenJoint: (child: string, joint: string) => void
+  /** Rename a joint (right-click a joint row) — cascades servo map + poses. */
+  onRenameJoint: (oldName: string, newName: string) => void
   onOpenServo: (pin: string) => void
   /** Bind a servo to the next free pin + open its editor. */
   onNewServo: () => void
@@ -489,25 +491,89 @@ function Section({
 
 const INDENT = 14 // px of indent per depth level in the chain tree
 
+// A distinct glyph per joint type (#): a lock (fixed), a rotation arrow (hinge /
+// revolute), a spoked wheel (continuous) and a slider track (prismatic).
+const JOINT_ICONS: Record<JointType, JSX.Element> = {
+  fixed: (
+    <svg viewBox="0 0 16 16" width="11" height="11" aria-hidden="true">
+      <path d="M5 7V5.2a3 3 0 0 1 6 0V7" fill="none" stroke="currentColor" strokeWidth="1.2" />
+      <rect x="3.6" y="7" width="8.8" height="6" rx="1.1" fill="none" stroke="currentColor" strokeWidth="1.2" />
+    </svg>
+  ),
+  revolute: (
+    <svg viewBox="0 0 16 16" width="11" height="11" aria-hidden="true">
+      <path d="M12.6 8a4.6 4.6 0 1 1-1.5-3.4" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+      <path d="M12.7 3.2v2.4h-2.4" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" strokeLinecap="round" />
+    </svg>
+  ),
+  continuous: (
+    <svg viewBox="0 0 16 16" width="11" height="11" aria-hidden="true">
+      <circle cx="8" cy="8" r="5.2" fill="none" stroke="currentColor" strokeWidth="1.2" />
+      <circle cx="8" cy="8" r="1.5" fill="none" stroke="currentColor" strokeWidth="1.2" />
+      <path d="M8 2.8v2M8 11.2v2M2.8 8h2M11.2 8h2" stroke="currentColor" strokeWidth="1.1" strokeLinecap="round" />
+    </svg>
+  ),
+  prismatic: (
+    <svg viewBox="0 0 16 16" width="11" height="11" aria-hidden="true">
+      <path d="M3 8h10M4.6 5.8v4.4M11.4 5.8v4.4" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+      <rect x="6.5" y="5.9" width="3" height="4.2" rx="0.9" fill="none" stroke="currentColor" strokeWidth="1.2" />
+    </svg>
+  )
+}
+
+/** One JOINT row of the Chain tree (#): the connecting joint sits directly above its
+ *  child link at the same indent — a type icon, the (editable) joint NAME, and its
+ *  type badge. Click opens the joint dialog; right-click renames. */
+function JointRow({
+  node,
+  isActive,
+  onOpen,
+  onContextMenu
+}: {
+  node: ChainNode
+  isActive: boolean
+  onOpen: (child: string, joint: string) => void
+  onContextMenu: (e: React.MouseEvent, joint: string) => void
+}): JSX.Element | null {
+  if (!node.joint) return null
+  const j = node.joint
+  return (
+    <li className="robotbuild__joint-row" style={{ paddingLeft: node.depth * INDENT }}>
+      <span className="robotbuild__joint-elbow" aria-hidden="true">
+        ├
+      </span>
+      <span className="robotbuild__joint-icon" aria-hidden="true">
+        {JOINT_ICONS[j.type] ?? JOINT_ICONS.fixed}
+      </span>
+      <button
+        type="button"
+        className={`robotbuild__joint-name${isActive ? ' is-on' : ''}`}
+        title={`Joint “${j.name}” · ${jointTypeLabel(j.type)} · ${j.parent} → ${node.link} — click to edit, right-click to rename`}
+        onClick={() => onOpen(node.link, j.name)}
+        onContextMenu={(e) => onContextMenu(e, j.name)}
+      >
+        {j.name}
+      </button>
+      <span className="robotbuild__joint-badge">{jointTypeLabel(j.type)}</span>
+    </li>
+  )
+}
+
 /** One row of the kinematic Chain tree (#354): the part name (indented by depth), the
  *  joint type that connects it to its parent, and a "loose" flag for unconnected parts. */
 function ChainRow({
   node,
   isSel,
   isEdit,
-  activeJoint,
   onSelect,
   onEdit,
-  onOpenJoint,
   onContextMenu
 }: {
   node: ChainNode
   isSel: boolean
   isEdit: boolean
-  activeJoint: string | null
   onSelect: (link: string) => void
   onEdit: (link: string | null) => void
-  onOpenJoint: (child: string, joint: string) => void
   onContextMenu: (e: React.MouseEvent, link: string) => void
 }): JSX.Element {
   const geo = node.kind === 'mesh' ? node.mesh?.match(/\.(\w+)$/)?.[1]?.toLowerCase() ?? 'mesh' : node.kind
@@ -556,16 +622,7 @@ function ChainRow({
           <span className="robotbuild__part-label">{node.link}</span>
           <span className={`robotbuild__part-geo${node.kind === 'mesh' ? ' is-mesh' : ''}`}>{geo}</span>
         </button>
-        {node.joint ? (
-          <button
-            type="button"
-            className={`robotbuild__jtype${activeJoint === node.joint.name ? ' is-on' : ''}`}
-            title={`Joint “${node.joint.name}” · ${jointTypeLabel(node.joint.type)} · parent ${node.joint.parent} — click to edit`}
-            onClick={() => onOpenJoint(node.link, node.joint!.name)}
-          >
-            {node.joint.name}
-          </button>
-        ) : node.loose ? (
+        {node.loose ? (
           <span className="robotbuild__loose-tag" title="Not connected to the base — open it and pick a parent">
             ⚠ loose
           </span>
@@ -590,6 +647,7 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
     active,
     onEdit,
     onOpenJoint,
+    onRenameJoint,
     onOpenServo,
     onNewServo,
     onOpenPose,
@@ -617,6 +675,26 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
     e.stopPropagation()
     setMenu({ pos: { x: e.clientX, y: e.clientY }, link })
   }
+  // Right-click a joint row → rename the joint.
+  const [jmenu, setJmenu] = useState<{ pos: ContextMenuPosition; joint: string } | null>(null)
+  const openJointMenu = (e: React.MouseEvent, joint: string): void => {
+    if (!canEdit) return
+    e.preventDefault()
+    e.stopPropagation()
+    setJmenu({ pos: { x: e.clientX, y: e.clientY }, joint })
+  }
+  const jointMenuItems = (joint: string): ContextMenuItem[] => [
+    {
+      key: 'rename',
+      label: 'Rename joint…',
+      onSelect: () => {
+        void (async () => {
+          const to = await prompt('Rename joint', joint)
+          if (to && to.trim() && to.trim() !== joint) onRenameJoint(joint, to.trim())
+        })()
+      }
+    }
+  ]
   const menuItems = (link: string): ContextMenuItem[] => {
     const isBase = link === rootLink
     return [
@@ -721,14 +799,19 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
                     Not connected
                   </li>
                 )}
+                {/* The connecting joint sits directly above its child link (#). */}
+                <JointRow
+                  node={node}
+                  isActive={!!node.joint && activeJoint === node.joint.name}
+                  onOpen={onOpenJoint}
+                  onContextMenu={openJointMenu}
+                />
                 <ChainRow
                   node={node}
                   isSel={node.link === selected}
                   isEdit={node.link === activeLink}
-                  activeJoint={activeJoint}
                   onSelect={onSelect}
                   onEdit={onEdit}
-                  onOpenJoint={onOpenJoint}
                   onContextMenu={openMenu}
                 />
               </Fragment>
@@ -827,6 +910,9 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
       </div>
       {menu && (
         <ContextMenu position={menu.pos} items={menuItems(menu.link)} onClose={() => setMenu(null)} />
+      )}
+      {jmenu && (
+        <ContextMenu position={jmenu.pos} items={jointMenuItems(jmenu.joint)} onClose={() => setJmenu(null)} />
       )}
     </aside>
   )

--- a/src/renderer/src/components/RobotPropertiesDialog.css
+++ b/src/renderer/src/components/RobotPropertiesDialog.css
@@ -116,6 +116,10 @@
   border-radius: 5px;
   padding: 0.2rem 0.3rem;
 }
+/* The joint-name field sits above the Joint form; a little gap below it. */
+.robotprops__jname {
+  margin-bottom: 0.35rem;
+}
 .robotprops__check {
   display: flex;
   align-items: center;

--- a/src/renderer/src/components/RobotPropertiesDialog.tsx
+++ b/src/renderer/src/components/RobotPropertiesDialog.tsx
@@ -60,6 +60,8 @@ export interface RobotPropertiesDialogProps {
   /** Set a link's colour (#rrggbb) — recolours only that link, live + persisted. */
   onSetColor: (link: string, hex: string) => void
   onSetJoint: (link: string, spec: JointSpec) => void
+  /** Rename the open joint — cascades the servo map + poses (#). */
+  onRenameJoint: (oldName: string, newName: string) => void
   /** Reposition the joint origin (offset, mm→m) and set its ABSOLUTE roll about its
    *  own normal axis (deg) — both applied live as the field changes. */
   onSetJointOrigin: (child: string, xyz: [number, number, number]) => void
@@ -296,6 +298,7 @@ function LinkBody({
   jointNames,
   onSetSize,
   onSetJoint,
+  onRenameJoint,
   onSetJointOrigin,
   onRollJoint,
   jointRoll,
@@ -374,6 +377,19 @@ function LinkBody({
       {joint ? (
         <section className="robotprops__section">
           <div className="robotprops__label">Joint</div>
+          <input
+            key={joint.name}
+            className="robotprops__text robotprops__jname"
+            defaultValue={joint.name}
+            placeholder="joint name"
+            aria-label="Joint name"
+            title="The joint name — matches the Servos list and the pose editor"
+            onBlur={(e) => {
+              const v = e.target.value.trim()
+              if (v && v !== joint.name) onRenameJoint(joint.name, v)
+            }}
+            onKeyDown={(e) => e.key === 'Enter' && (e.currentTarget as HTMLInputElement).blur()}
+          />
           <JointForm
             joint={joint}
             names={jointNames}

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -39,6 +39,7 @@ import {
   removeJoint,
   removeLink,
   renameLink,
+  renameJoint,
   setJoint,
   setJointOrigin,
   orientJoint,
@@ -888,6 +889,38 @@ export function RobotView({
       return c
     })
   }
+  // Rename a JOINT (#): rewrite the URDF, then cascade every store that keys by joint
+  // NAME (servo map, poses, timeline tracks, mirror pairs, per-joint config/roll/
+  // normal, defaultPose) so the servo keeps driving it and its poses still apply.
+  const handleRenameJoint = (oldName: string, to: string): void => {
+    const { urdf, name } = renameJoint(content, oldName, to)
+    if (name === oldName) return
+    commitUrdf(urdf)
+    const rekey = <T,>(rec: Record<string, T> | undefined): Record<string, T> | undefined => {
+      if (!rec || !(oldName in rec)) return rec
+      const { [oldName]: v, ...rest } = rec
+      return { ...rest, [name]: v }
+    }
+    setBindings((bs) => bs.map((b) => (b.joint === oldName ? { ...b, joint: name } : b)))
+    setPoses((ps) => ps.map((p) => (oldName in p.values ? { ...p, values: rekey(p.values)! } : p)))
+    setTimeline((tl) => ({ ...tl, tracks: tl.tracks.map((t) => (t.joint === oldName ? { ...t, joint: name } : t)) }))
+    setMirrorPairs((ms) =>
+      ms.map((mp) => ({ ...mp, a: mp.a === oldName ? name : mp.a, b: mp.b === oldName ? name : mp.b }))
+    )
+    void persist((m) => {
+      if (m.servoJointMap) m.servoJointMap = m.servoJointMap.map((b) => (b.joint === oldName ? { ...b, joint: name } : b))
+      if (m.poses) m.poses = m.poses.map((p) => (oldName in p.values ? { ...p, values: rekey(p.values)! } : p))
+      m.defaultPose = rekey(m.defaultPose)
+      m.joints = rekey(m.joints)
+      m.jointRoll = rekey(m.jointRoll)
+      m.jointNormal = rekey(m.jointNormal)
+      if (m.timeline) m.timeline = { ...m.timeline, tracks: m.timeline.tracks.map((t) => (t.joint === oldName ? { ...t, joint: name } : t)) }
+      if (m.mirror) m.mirror = m.mirror.map((mp) => ({ ...mp, a: mp.a === oldName ? name : mp.a, b: mp.b === oldName ? name : mp.b }))
+    })
+    // Follow an open joint dialog to the new name.
+    setDialogCtx((c) => (c?.kind === 'joint' && c.joint === oldName ? { ...c, joint: name } : c))
+  }
+
   // Properties dialog (#352 / #353): clicking a node opens its context here. For a
   // block/mesh/joint we snapshot the URDF so Cancel can revert the live edits; OK
   // keeps them. Servo/pose contexts hold their own drafts (committed on OK).
@@ -4122,6 +4155,7 @@ export function RobotView({
             active={dialogCtx}
             onEdit={handleOpenProps}
             onOpenJoint={handleOpenJoint}
+            onRenameJoint={handleRenameJoint}
             onOpenServo={handleOpenServo}
             onNewServo={handleNewServo}
             onOpenPose={handleOpenPose}
@@ -4160,6 +4194,7 @@ export function RobotView({
             usedColors={usedLinkColors}
             onSetColor={handleSetColor}
             onSetJoint={handleSetJoint}
+            onRenameJoint={handleRenameJoint}
             onSetJointOrigin={handleSetJointOrigin}
             onRollJoint={setJointRoll}
             jointRoll={editJoint ? jointRollRef.current[editJoint.name] ?? 0 : 0}

--- a/src/renderer/src/components/robot-assembly.ts
+++ b/src/renderer/src/components/robot-assembly.ts
@@ -594,6 +594,28 @@ export function buildChainTree(
   return out
 }
 
+/**
+ * Rename a `<joint>` (#): rewrite its `name="…"` attribute and every `<mimic
+ * joint="…">` that follows it (mimic references a master joint by name). Sanitises
+ * to a URDF-safe token and de-duplicates against the other joint names. Returns the
+ * new URDF + the actual name used. Parent/child are LINK refs and are untouched.
+ * The caller cascades the non-URDF stores (servo map / poses / mirror / limits).
+ */
+export function renameJoint(urdf: string, from: string, to: string): { urdf: string; name: string } {
+  const safe = to.replace(/[^A-Za-z0-9_]+/g, '_').replace(/^_+|_+$/g, '') || 'joint'
+  if (safe === from) return { urdf, name: from }
+  const taken = new Set(jointNames(urdf))
+  taken.delete(from)
+  let name = safe
+  let n = 2
+  while (taken.has(name)) name = `${safe}_${n++}`
+  const e = escapeRe(from)
+  const out = urdf
+    .replace(new RegExp(`(<joint\\b[^>]*\\bname\\s*=\\s*")${e}(")`, 'g'), `$1${name}$2`)
+    .replace(new RegExp(`(<mimic\\b[^>]*\\bjoint\\s*=\\s*")${e}(")`, 'g'), `$1${name}$2`)
+  return { urdf: out, name }
+}
+
 /** Names of every `<joint>` in the model (for the mimic master picker). */
 export function jointNames(urdf: string): string[] {
   const re = /<joint\b([^>]*)>/gi

--- a/test/robotAssembly.test.ts
+++ b/test/robotAssembly.test.ts
@@ -9,6 +9,7 @@ import {
   addMeshLink,
   looseLinks,
   renameLink,
+  renameJoint,
   blankUrdf,
   connectJoint,
   orientJoint,
@@ -126,6 +127,37 @@ describe('renameLink (#354)', () => {
     expect(renameLink(URDF, 'tip', 'my tip!').name).toBe('my_tip') // XML-safe
     expect(renameLink(URDF, 'tip', 'base_link').name).toBe('base_link_2') // collision bump
     expect(renameLink(URDF, 'tip', 'tip')).toEqual({ urdf: URDF, name: 'tip' }) // no-op
+  })
+})
+
+describe('renameJoint (#)', () => {
+  const MIMIC = `<?xml version="1.0"?>
+<robot name="m">
+  <joint name="shoulder" type="revolute"><parent link="a"/><child link="b"/></joint>
+  <joint name="finger" type="revolute"><parent link="b"/><child link="c"/>
+    <mimic joint="shoulder" multiplier="0.5"/>
+  </joint>
+</robot>`
+
+  it('renames the joint name attribute only (link refs untouched)', () => {
+    const { urdf, name } = renameJoint(URDF, 'j1', 'shoulder')
+    expect(name).toBe('shoulder')
+    expect(urdf).toContain('<joint name="shoulder" type="revolute">')
+    expect(urdf).not.toContain('name="j1"')
+    expect(urdf).toContain('<child link="upper"/>') // link refs preserved
+  })
+
+  it('follows a <mimic joint="…"> reference to the renamed master', () => {
+    const { urdf } = renameJoint(MIMIC, 'shoulder', 'sh')
+    expect(urdf).toContain('<joint name="sh" type="revolute">')
+    expect(urdf).toContain('<mimic joint="sh" multiplier="0.5"/>')
+    expect(urdf).not.toContain('joint="shoulder"')
+  })
+
+  it('sanitises + de-collides; same-name is a no-op', () => {
+    expect(renameJoint(URDF, 'j1', 'my joint!').name).toBe('my_joint')
+    expect(renameJoint(URDF, 'j1', 'j2').name).toBe('j2_2') // collides with the other joint
+    expect(renameJoint(URDF, 'j1', 'j1')).toEqual({ urdf: URDF, name: 'j1' })
   })
 })
 


### PR DESCRIPTION
Phase A of the rig-editor direction we discussed. Makes joints first-class in the Robot View's Chain tree.

## What
- **Joints get their own rows.** Each connecting joint now renders directly **above the link it drives**, at the same indent (the compact layout you picked) — so the joint is a visible, selectable, renameable entity instead of a tag crammed onto the child row.
- **Four distinct type glyphs:** a **lock** (fixed), a **rotation arrow** (hinge / revolute), a **spoked wheel** (continuous), a **slider track** (prismatic).
- **Name + badge:** the row shows the **joint name** (so it matches the Servos list `GP0 → shoulder` and the pose editor) **and** its type badge is back.
- **Rename a joint:** right-click its row → *Rename joint…*, or the joint dialog's new **Name** field. `renameJoint` rewrites the URDF `name=` attribute + any `<mimic joint="…">` reference, and `handleRenameJoint` **cascades** every store that keys by joint name — servo bindings, poses, timeline tracks, mirror pairs, defaultPose, and per-joint config/roll/normal — so the servo keeps driving it and its poses still apply.
- Link rows keep the **mesh-vs-cube** glyph.

```
⚓ base                    box
  ↻ shoulder    [Hinge]        ← joint row
  △ upper_arm         stl      ← child link
    ↻ elbow      [Hinge]
    △ forearm         stl
      ⇔ wrist_lift [Slider]
      ⊟ wrist           box
        🔒 gripper  [Fixed]
```

## Verification
- **+3 unit tests** for `renameJoint` (name-only rewrite, `<mimic>`-ref follow, sanitise / de-collide / no-op). **1660 vitest** + typecheck / lint / build green.
- Interleaved layout + all four icons verified headless.

Yes, it makes the tree longer — but as agreed, it's much clearer what connects what, and it's where the servo binding will live next.

**Next (agreed):** the Breadboard ↔ 3-D servo binding — I'll sketch the shared data model before building.

🤖 Generated with [Claude Code](https://claude.com/claude-code)