### PR TITLE
feat: bind a breadboard servo to a 3-D joint (board inspector)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Board View — bind a servo to a 3-D joint.** Select a **servo** on the breadboard and its
+  inspector gains a **"drives joint"** picker: choose which URDF joint it moves. It reads the GPIO
+  the servo's **signal** pin is wired to and stores the pin↔joint binding in `robot.yml`, so a
+  running program's servo writes drive the matching joint in the 3-D Robot View live — no extra
+  setup. The picker guides you when the signal isn't wired to a GPIO yet, or when the model has no
+  joints. (Next: the same bindings listed in the URDF editor.)
 - **Motion Studio — puppet controls (#403, #416).** A Controls panel in the Robot View lets you
   build a named **slider** from two or more saved poses. Dragging it smoothly blends between the
   ordered poses and drives the live 3-D model in real time — one slider can sweep the eyes, morph

--- a/src/renderer/src/board-main.tsx
+++ b/src/renderer/src/board-main.tsx
@@ -32,6 +32,7 @@ import { PartEditor } from './components/PartEditor'
 import { blankRobot, type RobotDefinition } from '../../shared/robot'
 import { readRobotModel } from '../../shared/krf'
 import { attachPartMesh } from './components/robot-part-mesh'
+import { jointNames } from './components/robot-assembly'
 import type {
   BoardDefinition,
   BoardSourcePayload,
@@ -213,6 +214,29 @@ function BoardWindowApp(): JSX.Element {
     [folder]
   )
 
+  // The URDF's joint names — read the linked `.urdf` so a servo's inspector can
+  // offer a "drives joint" picker (#). Empty when there's no URDF / no folder yet.
+  const [joints, setJoints] = useState<string[]>([])
+  const urdfPath = robot.robot?.urdf
+  useEffect(() => {
+    if (!folder || !urdfPath) {
+      setJoints([])
+      return
+    }
+    let live = true
+    window.api.fs
+      .readFile(`${folder}/${urdfPath}`)
+      .then((content) => {
+        if (live) setJoints(jointNames(content))
+      })
+      .catch(() => {
+        if (live) setJoints([])
+      })
+    return () => {
+      live = false
+    }
+  }, [folder, urdfPath, robotNonce])
+
   // Append a library part to the project (robot.yml), with a unique instance id.
   const addToProject = useCallback(
     (libraryId: string, part: PartDefinition, pos?: { x: number; y: number }): void => {
@@ -297,6 +321,7 @@ function BoardWindowApp(): JSX.Element {
         asWindow
         robot={robot}
         onChangeRobot={saveRobot}
+        joints={joints}
         libraries={libraries}
         onAddToProject={addToProject}
       />

--- a/src/renderer/src/components/BoardGraph.tsx
+++ b/src/renderer/src/components/BoardGraph.tsx
@@ -112,6 +112,8 @@ export interface BoardGraphProps {
   robot?: RobotDefinition
   /** Persist a changed robot definition (writes robot.yml). */
   onChangeRobot?: (next: RobotDefinition) => void
+  /** The linked URDF's joint names — for a servo's "drives joint" picker (#). */
+  joints?: string[]
   /** Installed part libraries (to resolve placed parts' pins). */
   libraries?: PartLibraryWithParts[]
   /** Append a library part to the project. When set, the library dock shows. `pos`
@@ -316,6 +318,7 @@ export function BoardGraph({
   asWindow = false,
   robot,
   onChangeRobot,
+  joints,
   libraries,
   onAddToProject
 }: BoardGraphProps): JSX.Element {
@@ -879,6 +882,7 @@ export function BoardGraph({
               renderMode={effectiveView}
               robot={robot as RobotDefinition}
               onChange={onChangeRobot as (next: RobotDefinition) => void}
+              joints={joints ?? []}
               libraries={libraries ?? []}
               usedByCode={usedByCode}
               onDropPart={onAddToProject ? handleAddToProject : undefined}

--- a/src/renderer/src/components/WiringCanvas.css
+++ b/src/renderer/src/components/WiringCanvas.css
@@ -311,6 +311,43 @@
   border-color: #a5281b;
 }
 
+/* Servo → joint binding controls (#): a note (not wired / no joints yet) or the
+   joint picker. Matches the dark floating toolbar. */
+.wc__parttb-note {
+  display: inline-flex;
+  align-items: center;
+  height: 1.6rem;
+  padding: 0 0.4rem;
+  font-size: 0.6rem;
+  color: #b7bcc4;
+  background: #26282d;
+  border: 1px solid #3a3d44;
+  border-radius: 6px;
+  white-space: nowrap;
+}
+.wc__parttb-joint {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  height: 1.6rem;
+  padding: 0 0.2rem 0 0.35rem;
+  color: #d6dade;
+  background: #26282d;
+  border: 1px solid #3a3d44;
+  border-radius: 6px;
+}
+.wc__parttb-select {
+  max-width: 8rem;
+  font-family: var(--font-mono, monospace);
+  font-size: 0.62rem;
+  color: #d6dade;
+  background: #1c1e22;
+  border: 1px solid #3a3d44;
+  border-radius: 4px;
+  padding: 0.1rem 0.2rem;
+  cursor: pointer;
+}
+
 .wc__parttb-input {
   width: 9rem;
   font-family: var(--font-mono);

--- a/src/renderer/src/components/WiringCanvas.tsx
+++ b/src/renderer/src/components/WiringCanvas.tsx
@@ -20,6 +20,7 @@ import {
   type RobotNet,
   type RobotPart
 } from '../../../shared/robot'
+import { isServoPart, servoBoardGpio, boundJoint, bindServoJoint } from './servo-bind'
 import type { BoardDefinition } from '../../../shared/board'
 import type { PartDefinition, PartLibraryWithParts } from '../../../preload/index.d'
 import type { PartPinBuses, PartPinCapability, PartPinSignals } from '../../../shared/part'
@@ -527,6 +528,8 @@ function partSchematicPins(def: PartDefinition): { w: number; h: number; placed:
 export interface WiringCanvasProps {
   robot: RobotDefinition
   onChange: (next: RobotDefinition) => void
+  /** The linked URDF's joint names — lets a servo's inspector bind to a joint (#). */
+  joints?: string[]
   /** Installed libraries (to resolve a placed part's pins). */
   libraries: PartLibraryWithParts[]
   /** The microcontroller to show as the board (the board view's selection). */
@@ -576,7 +579,7 @@ interface Drag {
   cy?: number
 }
 
-export function WiringCanvas({ robot, onChange, libraries, boardDef, boardPart, renderMode, usedByCode, onDropPart, onShowHelp, focusedChrome = false }: WiringCanvasProps): JSX.Element {
+export function WiringCanvas({ robot, onChange, joints = [], libraries, boardDef, boardPart, renderMode, usedByCode, onDropPart, onShowHelp, focusedChrome = false }: WiringCanvasProps): JSX.Element {
   const svgRef = useRef<SVGSVGElement>(null)
   const dragRef = useRef<Drag | null>(null)
   const [view, setView] = useState({ tx: 0, ty: 0, scale: 1 })
@@ -1424,6 +1427,21 @@ export function WiringCanvas({ robot, onChange, libraries, boardDef, boardPart, 
   // parts in the breadboard view are selectable/rotatable.
   const selSubject = renderMode === 'lifelike' && selectedKey ? subjByKey.get(selectedKey) : undefined
   const selPart = selSubject?.kind === 'part' ? selSubject : undefined
+  // Servo → joint binding (#): if the selected part is a servo, which board GPIO its
+  // signal is wired to and the URDF joint it currently drives (via robot.yml's map).
+  const selIsServo = !!selPart && isServoPart(selPart.partDef)
+  const selServoGpio = selIsServo && selPart ? servoBoardGpio(selPart.key, robot.connections) : null
+  const selServoJoint = selServoGpio ? boundJoint(robot.robot?.servoJointMap, selServoGpio) : null
+  const setServoJoint = (joint: string): void => {
+    if (!selServoGpio) return
+    onChange({
+      ...robot,
+      robot: {
+        ...(robot.robot ?? {}),
+        servoJointMap: bindServoJoint(robot.robot?.servoJointMap, selServoGpio, joint)
+      }
+    })
+  }
   const selToolbar = (() => {
     const svg = svgRef.current
     if (!selPart || !svg) return null
@@ -1660,6 +1678,44 @@ export function WiringCanvas({ robot, onChange, libraries, boardDef, boardPart, 
                     </svg>
                   </button>
                 )}
+                {/* Servo → joint binding (#): pick the URDF joint this servo drives.
+                    The signal must be wired to a GPIO first; joints come from the
+                    3-D model. Writing the pin↔joint map lets live code move the model. */}
+                {selIsServo &&
+                  (selServoGpio == null ? (
+                    <span className="wc__parttb-note" title="Wire this servo's signal pin to a microcontroller GPIO to bind it to a joint">
+                      ⚡ wire signal
+                    </span>
+                  ) : joints.length === 0 ? (
+                    <span className="wc__parttb-note" title="No joints yet — add them in the 3-D Robot View">
+                      GP{selServoGpio} · no joints
+                    </span>
+                  ) : (
+                    <label className="wc__parttb-joint" title={`GP${selServoGpio} drives this URDF joint`}>
+                      <svg width="13" height="13" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+                        <path
+                          d="M6.5 9.5l3-3M5.5 10.5a2 2 0 0 1 0-2.8l1.4-1.4M10.5 5.5a2 2 0 0 1 0 2.8L9.1 9.7"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth={1.3}
+                          strokeLinecap="round"
+                        />
+                      </svg>
+                      <select
+                        className="wc__parttb-select"
+                        value={selServoJoint ?? ''}
+                        aria-label={`Joint driven by GP${selServoGpio}`}
+                        onChange={(e) => setServoJoint(e.target.value)}
+                      >
+                        <option value="">GP{selServoGpio} → (none)</option>
+                        {joints.map((j) => (
+                          <option key={j} value={j}>
+                            {j}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  ))}
                 <button type="button" className="wc__parttb-btn" title="Rotate 90°" aria-label="Rotate 90 degrees" onClick={() => rotatePart(selPart.key)}>
                   <svg width="15" height="15" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                     <path d="M12 5V2L8 6l4 4V7a5 5 0 1 1-5 5H5a7 7 0 1 0 7-7Z" fill="currentColor" />

--- a/src/renderer/src/components/servo-bind.ts
+++ b/src/renderer/src/components/servo-bind.ts
@@ -1,0 +1,75 @@
+/**
+ * SERVO ↔ JOINT BINDING (#) — pure helpers that connect a breadboard servo to a
+ * URDF joint. The bridge is `RobotModel.servoJointMap` (pin ↔ joint) in `robot.yml`,
+ * shared by the Board View (this is where a servo gets wired to a GPIO) and the
+ * Robot View (where the joint lives + the live `SNK SERVO` telemetry drives it).
+ *
+ * Dependency-light (only `normPin`) so both views + tests can import it.
+ */
+import type { PartDefinition } from '../../../shared/part'
+import type { RobotConnection, ServoJointBinding } from '../../../shared/robot'
+import { normPin } from './robot-pose'
+
+/** Whether a placed part is a servo (something that drives a joint). Matches the
+ *  word "servo" anywhere in the part's family / tags / id / name — covers the
+ *  standard `SG90` (family `Motor`, tags `[servo, pwm, …]`) and hand-authored parts. */
+export function isServoPart(def: PartDefinition | undefined | null): boolean {
+  if (!def) return false
+  const hay = `${def.family ?? ''} ${(def.tags ?? []).join(' ')} ${def.id ?? ''} ${def.name ?? ''}`.toLowerCase()
+  return /\bservo\b/.test(hay)
+}
+
+/** Split a wire endpoint (`"partId.PinName#12"` or `"board.GP16#3"`) into its
+ *  subject key + pin name; the trailing `#index` is dropped. */
+export function endpointParts(ep: string): { key: string; pin: string } {
+  const hash = ep.lastIndexOf('#')
+  const head = hash >= 0 ? ep.slice(0, hash) : ep
+  const dot = head.indexOf('.')
+  return dot >= 0 ? { key: head.slice(0, dot), pin: head.slice(dot + 1) } : { key: head, pin: '' }
+}
+
+/**
+ * The board GPIO (normalised, e.g. `"16"`) a placed servo's signal is wired to, or
+ * `null`. Finds a wire between the part and a NUMERIC board pin — a GPIO; power pins
+ * like `3V3` / `GND` / `VBUS` normalise to non-numeric and are skipped, so the one
+ * that matches is the servo's signal.
+ */
+export function servoBoardGpio(partId: string, connections: RobotConnection[]): string | null {
+  for (const c of connections) {
+    const a = endpointParts(c.from)
+    const b = endpointParts(c.to)
+    const board = a.key === partId ? b : b.key === partId ? a : null
+    if (!board || board.key !== 'board') continue
+    const gp = normPin(board.pin)
+    if (/^\d+$/.test(gp)) return gp
+  }
+  return null
+}
+
+/** The joint a GPIO currently drives in the servo map, or `null`. */
+export function boundJoint(map: ServoJointBinding[] | undefined, gpio: string): string | null {
+  const b = (map ?? []).find((x) => normPin(x.pin) === normPin(gpio))
+  return b ? b.joint : null
+}
+
+/**
+ * Return an updated servo map that binds `gpio` → `joint` (replacing any existing
+ * binding on that pin). An empty `joint` UNBINDS the pin. New bindings get a neutral
+ * 0…180 servo + joint range; the Robot View's servo editor tunes it against the
+ * joint's real limits.
+ */
+export function bindServoJoint(
+  map: ServoJointBinding[] | undefined,
+  gpio: string,
+  joint: string
+): ServoJointBinding[] {
+  const rest = (map ?? []).filter((x) => normPin(x.pin) !== normPin(gpio))
+  if (!joint) return rest
+  const prev = (map ?? []).find((x) => normPin(x.pin) === normPin(gpio))
+  return [
+    ...rest,
+    prev && prev.joint === joint
+      ? prev
+      : { pin: gpio, joint, servoMin: 0, servoMax: 180, jointMin: 0, jointMax: 180 }
+  ]
+}

--- a/test/servoBind.test.ts
+++ b/test/servoBind.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isServoPart,
+  endpointParts,
+  servoBoardGpio,
+  boundJoint,
+  bindServoJoint
+} from '../src/renderer/src/components/servo-bind'
+import type { PartDefinition } from '../src/shared/part'
+import type { RobotConnection, ServoJointBinding } from '../src/shared/robot'
+
+const def = (over: Partial<PartDefinition>): PartDefinition =>
+  ({ id: 'x', name: 'X', headers: [], ...over }) as PartDefinition
+
+describe('isServoPart (#)', () => {
+  it('detects a servo by family / tags / id / name', () => {
+    expect(isServoPart(def({ id: 'sg90', name: 'SG90 Micro Servo', family: 'Motor', tags: ['servo', 'pwm'] }))).toBe(true)
+    expect(isServoPart(def({ id: 'my-servo', name: 'Big', tags: [] }))).toBe(true) // id
+    expect(isServoPart(def({ id: 'led', name: 'Red LED', family: 'Output', tags: ['led'] }))).toBe(false)
+    expect(isServoPart(undefined)).toBe(false)
+  })
+})
+
+describe('endpointParts (#)', () => {
+  it('splits key + pin, dropping the #index', () => {
+    expect(endpointParts('dist1.Signal#12')).toEqual({ key: 'dist1', pin: 'Signal' })
+    expect(endpointParts('board.GP16#3')).toEqual({ key: 'board', pin: 'GP16' })
+    expect(endpointParts('board')).toEqual({ key: 'board', pin: '' })
+  })
+})
+
+describe('servoBoardGpio (#)', () => {
+  const conns: RobotConnection[] = [
+    { id: 'a', from: 'servo1.VCC#0', to: 'board.3V3#40', net: 'vcc' },
+    { id: 'b', from: 'servo1.GND#1', to: 'board.GND#41', net: 'gnd' },
+    { id: 'c', from: 'servo1.Signal#2', to: 'board.GP16#5', net: 'signal' }
+  ]
+  it('finds the GPIO the signal is wired to (skips power pins)', () => {
+    expect(servoBoardGpio('servo1', conns)).toBe('16')
+  })
+  it('works whichever end is the board', () => {
+    expect(servoBoardGpio('servo1', [{ id: 'c', from: 'board.GP5#9', to: 'servo1.Signal#2', net: 'signal' }])).toBe('5')
+  })
+  it('returns null when the servo has no GPIO wire', () => {
+    expect(servoBoardGpio('servo1', [conns[0], conns[1]])).toBeNull() // only power
+    expect(servoBoardGpio('other', conns)).toBeNull()
+  })
+})
+
+describe('boundJoint + bindServoJoint (#)', () => {
+  const map: ServoJointBinding[] = [{ pin: 'GP16', joint: 'shoulder', jointMin: 0, jointMax: 180 }]
+
+  it('reads the joint a GPIO drives (pin-normalised)', () => {
+    expect(boundJoint(map, '16')).toBe('shoulder')
+    expect(boundJoint(map, 'GP16')).toBe('shoulder')
+    expect(boundJoint(map, '17')).toBeNull()
+  })
+  it('binds a new pin without disturbing others', () => {
+    const next = bindServoJoint(map, '17', 'elbow')
+    expect(next).toHaveLength(2)
+    expect(boundJoint(next, '17')).toBe('elbow')
+    expect(boundJoint(next, '16')).toBe('shoulder')
+  })
+  it('re-binds a pin to a different joint (replaces, pin-normalised)', () => {
+    const next = bindServoJoint(map, '16', 'wrist')
+    expect(next).toHaveLength(1)
+    expect(boundJoint(next, '16')).toBe('wrist')
+  })
+  it('keeps the existing binding object when the joint is unchanged (no churn)', () => {
+    const next = bindServoJoint(map, 'GP16', 'shoulder')
+    expect(next[0]).toBe(map[0]) // same reference
+  })
+  it('unbinds on an empty joint', () => {
+    expect(bindServoJoint(map, '16', '')).toEqual([])
+  })
+})


### PR DESCRIPTION
First half of the **Breadboard ↔ 3-D servo binding** we designed. Select a **servo** on the breadboard and its inspector gains a **"drives joint"** picker.

## What
- **Pure, tested helpers** (`servo-bind.ts`): `isServoPart` (matches "servo" in a part's family / tags / id / name), `servoBoardGpio` (traces the servo's **signal** wire to the numeric board GPIO — power pins are skipped), `boundJoint` / `bindServoJoint` (read/write `robot.yml`'s `servoJointMap`, pin-normalised).
- **`board-main`** reads the linked `.urdf` and passes its **joint names** down (`BoardGraph` → `WiringCanvas`).
- **`WiringCanvas`**: the selected servo's mini-toolbar shows the joint picker. Picking a joint stores the pin↔joint binding — the **same `servoJointMap`** the Robot View and the live `SNK SERVO` telemetry pipe already use — so a running program's servo writes move the matching joint in the 3-D model, no extra setup. It guides you when the signal isn't wired to a GPIO, or the model has no joints yet.

The `servoJointMap` is the shared spine, so there's **no new plumbing on the 3-D side** — the existing telemetry pipe drives the joint once the pin is bound.

## Three inspector states (verified headless)
- **Bound:** `🔗 shoulder ▾` — pick the joint.
- **Not wired:** `⚡ wire signal` — wire the signal pin to a GPIO first.
- **No joints:** `GP5 · no joints` — add joints in the 3-D Robot View.

## Verification
- **+10 unit tests** for the helpers (servo detection, signal→GPIO tracing incl. power-pin skip, bind/rebind/unbind, pin normalisation). **1670 vitest** + typecheck / lint / build green.

**Next (agreed):** list these bindable servos in the URDF editor, so you can bind from either side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)