### PR TITLE
feat: bindable-servos list in the URDF editor (bind from either view)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
-- **Board View — bind a servo to a 3-D joint.** Select a **servo** on the breadboard and its
-  inspector gains a **"drives joint"** picker: choose which URDF joint it moves. It reads the GPIO
-  the servo's **signal** pin is wired to and stores the pin↔joint binding in `robot.yml`, so a
-  running program's servo writes drive the matching joint in the 3-D Robot View live — no extra
-  setup. The picker guides you when the signal isn't wired to a GPIO yet, or when the model has no
-  joints. (Next: the same bindings listed in the URDF editor.)
+- **Bind a servo to a 3-D joint — from either view.** Wire a **servo** on the breadboard and choose
+  which URDF **joint** it moves; a running program's servo writes then drive the matching joint in
+  the 3-D Robot View live. Bind it two ways: from the **Board View** (a servo's inspector gains a
+  "drives joint" picker) or from the **URDF editor** (the Robot View's **Servos** list now shows
+  every breadboard servo — its label, the GPIO its signal is wired to, and a joint picker; unwired
+  servos are flagged). Both write the one pin↔joint map in `robot.yml`, so the two views stay in
+  step, and the existing telemetry pipe drives the model with no extra setup.
 - **Motion Studio — puppet controls (#403, #416).** A Controls panel in the Robot View lets you
   build a named **slider** from two or more saved poses. Dragging it smoothly blends between the
   ordered poses and drives the live 3-D model in real time — one slider can sweep the eyes, morph

--- a/src/renderer/src/components/RobotBuildPanel.css
+++ b/src/renderer/src/components/RobotBuildPanel.css
@@ -354,6 +354,55 @@
   border: 1px solid var(--border, #3a3d44);
   border-radius: 999px;
 }
+
+/* Breadboard-servo row (#): part name · GPIO · joint picker. */
+.robotbuild__servo {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.2rem 0.3rem;
+}
+.robotbuild__servo-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.66rem;
+  color: var(--text, #cdd2d9);
+  background: none;
+  border: none;
+  text-align: left;
+  padding: 0;
+}
+.robotbuild__servo-name--link {
+  cursor: pointer;
+}
+.robotbuild__servo-name--link:hover {
+  color: var(--accent-ink);
+  text-decoration: underline;
+}
+.robotbuild__servo-pin {
+  flex: 0 0 auto;
+  font-size: 0.58rem;
+  color: var(--text-muted, #8b919b);
+}
+.robotbuild__servo-pin--unwired {
+  color: #b4844a;
+  font-style: italic;
+}
+.robotbuild__servo-joint {
+  flex: 0 1 auto;
+  max-width: 7rem;
+  font-family: inherit;
+  font-size: 0.6rem;
+  color: var(--text, #cdd2d9);
+  background: var(--bg-sunken, rgba(0, 0, 0, 0.22));
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 4px;
+  padding: 0.05rem 0.2rem;
+  cursor: pointer;
+}
 .robotbuild__chain--loose .robotbuild__part-label {
   font-style: italic;
   opacity: 0.85;

--- a/src/renderer/src/components/RobotBuildPanel.tsx
+++ b/src/renderer/src/components/RobotBuildPanel.tsx
@@ -12,6 +12,7 @@ import { buildChainTree } from './robot-assembly'
 import type { Vec3 } from './robot-build'
 import { principalAxisName } from './robot-build'
 import { toDisplay, toNative, unitLabel, normPin, type MovableType } from './robot-pose'
+import { boundJoint, type BindableServo } from './servo-bind'
 import { shouldAutoHide } from './pin-overlay'
 import type { ServoJointBinding } from '../../../shared/robot'
 import type { NamedPoseLike } from './robot-pose'
@@ -94,6 +95,12 @@ export interface RobotBuildPanelProps {
   /** The model's joints, servo bindings and named poses — extra tree branches. */
   joints: JointFull[]
   servos: ServoJointBinding[]
+  /** Breadboard servos (placed servo parts) that can be bound to a joint (#). */
+  bindableServos: BindableServo[]
+  /** Joint names a servo can drive (the bind picker's options). */
+  jointOptions: string[]
+  /** Bind a servo's GPIO to a joint (`''` unbinds). */
+  onBindServo: (pin: string, joint: string) => void
   poses: NamedPoseLike[]
   selected: string | null
   onSelect: (link: string | null) => void
@@ -650,6 +657,9 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
     onRenameJoint,
     onOpenServo,
     onNewServo,
+    bindableServos,
+    jointOptions,
+    onBindServo,
     onOpenPose,
     onNewPose,
     rootLink,
@@ -732,6 +742,10 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
     active?.kind === 'link' ? active.link : active?.kind === 'joint' ? active.child : null
   const activeJoint = active?.kind === 'joint' ? active.joint : null
   const looseStart = tree.findIndex((n) => n.loose)
+  // Servo bindings NOT backed by a breadboard servo part (manual / legacy), so they
+  // aren't shown twice in the Servos section.
+  const bindablePins = new Set(bindableServos.filter((s) => s.pin).map((s) => normPin(s.pin as string)))
+  const orphanBindings = servos.filter((b) => !bindablePins.has(normPin(b.pin)))
 
   if (!open) {
     return (
@@ -824,35 +838,93 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
           </p>
         )}
 
-        {canEdit && joints.some((j) => j.type !== 'fixed') && (
-        <Section id="servos" label="Servos" count={servos.length} collapsed={collapsed} onToggle={toggle}>
-          <li className="robotbuild__part">
-            <button
-              type="button"
-              className="robotbuild__node robotbuild__newpose"
-              onClick={onNewServo}
-              title="Bind a servo pin to a joint"
-            >
-              ＋ Bind a servo
-            </button>
-          </li>
-          {servos.map((b) => {
-            const on = active?.kind === 'servo' && normPin(active.pin) === normPin(b.pin)
-            return (
-              <li className="robotbuild__part" key={b.pin}>
-                <button
-                  type="button"
-                  className={`robotbuild__node${on ? ' is-on' : ''}`}
-                  title={`Edit servo GP${normPin(b.pin)}`}
-                  onClick={() => onOpenServo(b.pin)}
-                >
-                  <span className="robotbuild__part-label">GP{normPin(b.pin)}</span>
-                  <span className="robotbuild__part-geo">→ {b.joint || '—'}</span>
-                </button>
-              </li>
-            )
-          })}
-        </Section>
+        {canEdit && (bindableServos.length > 0 || servos.length > 0 || joints.some((j) => j.type !== 'fixed')) && (
+          <Section
+            id="servos"
+            label="Servos"
+            count={bindableServos.length + orphanBindings.length}
+            collapsed={collapsed}
+            onToggle={toggle}
+          >
+            {/* Breadboard servos (#): the placed servo parts, each with a picker to
+                bind its signal GPIO to a URDF joint — mirrors the Board View. */}
+            {bindableServos.map((s) => {
+              const cur = s.pin ? boundJoint(servos, s.pin) : null
+              const on = active?.kind === 'servo' && !!s.pin && normPin(active.pin) === normPin(s.pin)
+              return (
+                <li className={`robotbuild__part${on ? ' is-sel' : ''}`} key={s.id}>
+                  <div className="robotbuild__servo">
+                    {s.pin && cur ? (
+                      <button
+                        type="button"
+                        className="robotbuild__servo-name robotbuild__servo-name--link"
+                        title={`${s.label} — click to calibrate GP${s.pin}`}
+                        onClick={() => onOpenServo(s.pin as string)}
+                      >
+                        {s.label}
+                      </button>
+                    ) : (
+                      <span className="robotbuild__servo-name" title={s.label}>
+                        {s.label}
+                      </span>
+                    )}
+                    {s.pin == null ? (
+                      <span
+                        className="robotbuild__servo-pin robotbuild__servo-pin--unwired"
+                        title="Wire this servo's signal pin to a GPIO in the Board View"
+                      >
+                        unwired
+                      </span>
+                    ) : (
+                      <>
+                        <span className="robotbuild__servo-pin">GP{s.pin}</span>
+                        <select
+                          className="robotbuild__servo-joint"
+                          value={cur ?? ''}
+                          aria-label={`Joint driven by GP${s.pin}`}
+                          onChange={(e) => onBindServo(s.pin as string, e.target.value)}
+                        >
+                          <option value="">→ (none)</option>
+                          {jointOptions.map((j) => (
+                            <option key={j} value={j}>
+                              {j}
+                            </option>
+                          ))}
+                        </select>
+                      </>
+                    )}
+                  </div>
+                </li>
+              )
+            })}
+            {/* Bindings NOT from a breadboard servo (manual / legacy) — open to calibrate. */}
+            {orphanBindings.map((b) => {
+              const on = active?.kind === 'servo' && normPin(active.pin) === normPin(b.pin)
+              return (
+                <li className="robotbuild__part" key={b.pin}>
+                  <button
+                    type="button"
+                    className={`robotbuild__node${on ? ' is-on' : ''}`}
+                    title={`Edit servo GP${normPin(b.pin)}`}
+                    onClick={() => onOpenServo(b.pin)}
+                  >
+                    <span className="robotbuild__part-label">GP{normPin(b.pin)}</span>
+                    <span className="robotbuild__part-geo">→ {b.joint || '—'}</span>
+                  </button>
+                </li>
+              )
+            })}
+            <li className="robotbuild__part">
+              <button
+                type="button"
+                className="robotbuild__node robotbuild__newpose"
+                onClick={onNewServo}
+                title="Bind a servo pin to a joint by hand"
+              >
+                ＋ Bind a servo by hand
+              </button>
+            </li>
+          </Section>
         )}
 
         {canEdit && (

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useReducer, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react'
 import * as THREE from 'three'
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
 import { STLLoader } from 'three/examples/jsm/loaders/STLLoader.js'
@@ -113,6 +113,8 @@ import {
 } from '../../../shared/managed-blocks'
 import { jointToServo } from '../../../shared/krf'
 import { buildServosPayload } from '../../../shared/control'
+import { bindableServos, bindServoJoint, type BindableServo } from './servo-bind'
+import type { PartLibraryWithParts } from '../../../preload/index.d'
 import { useTelemetryStream } from './instrument-telemetry-subscribe'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import type {
@@ -122,10 +124,13 @@ import type {
   MotionTimeline,
   PoseStep,
   PuppetControl,
+  RobotConnection,
   RobotDefinition,
   RobotModel,
+  RobotPart,
   ServoJointBinding
 } from '../../../shared/robot'
+import type { PartDefinition } from '../../../preload/index.d'
 import './RobotView.css'
 
 /** An empty motion clip (2 s, ease-in-out, looping). */
@@ -1254,6 +1259,27 @@ export function RobotView({
   const bindingsRef = useRef<ServoJointBinding[]>([])
   bindingsRef.current = bindings
 
+  // The breadboard servos + wiring (from robot.yml) and the installed libraries, for
+  // the "bindable servos" list (#) — servos placed on the board that this URDF editor
+  // can bind to a joint. Reloads when the Board window edits robot.yml.
+  const [placedParts, setPlacedParts] = useState<RobotPart[]>([])
+  const [placedConns, setPlacedConns] = useState<RobotConnection[]>([])
+  const [partLibs, setPartLibs] = useState<PartLibraryWithParts[]>([])
+  const [robotSyncNonce, setRobotSyncNonce] = useState(0)
+  useEffect(() => window.api.robot.onChanged(() => setRobotSyncNonce((n) => n + 1)), [])
+  useEffect(() => {
+    window.api.parts.listLibraries().then(setPartLibs).catch(() => setPartLibs([]))
+  }, [])
+  const resolvePartDef = useCallback(
+    (p: RobotPart): PartDefinition | undefined =>
+      partLibs.find((l) => l.id === p.lib)?.parts.find((d) => d.id === p.part),
+    [partLibs]
+  )
+  const servoList = useMemo<BindableServo[]>(
+    () => bindableServos(placedParts, placedConns, resolvePartDef),
+    [placedParts, placedConns, resolvePartDef]
+  )
+
   // Load the servo map whenever the project folder changes — for the docked mini
   // viewer too, so it animates on Run. (The full pose tool also refreshes it in
   // its model load below.)
@@ -1266,17 +1292,21 @@ export function RobotView({
         defRef.current = def // seed so persist() never clobbers an unloaded robot.yml
         setBindings(def.robot?.servoJointMap ?? [])
         setControls(def.robot?.controls ?? []) // puppet controls (#416)
+        setPlacedParts(def.parts ?? []) // breadboard parts (for the bindable-servos list)
+        setPlacedConns(def.connections ?? [])
       } catch {
         if (live) {
           setBindings([])
           setControls([])
+          setPlacedParts([])
+          setPlacedConns([])
         }
       }
     })()
     return () => {
       live = false
     }
-  }, [currentFolder])
+  }, [currentFolder, robotSyncNonce])
 
   // A running program's servo writes drive the mapped joints in real time. This
   // works headless: the simulator runs the Python and `inst.servo_on(pin).angle`
@@ -1429,6 +1459,16 @@ export function RobotView({
 
   const handleDeleteBinding = (pin: string): void => {
     const next = bindings.filter((b) => b.pin !== pin)
+    setBindings(next)
+    void persist((mm) => {
+      mm.servoJointMap = next
+    })
+  }
+
+  // Bind a breadboard servo's GPIO to a joint from the URDF editor (#) — the same
+  // servoJointMap the Board View writes; '' unbinds. Mirrors the board-side picker.
+  const handleBindServo = (pin: string, joint: string): void => {
+    const next = bindServoJoint(bindingsRef.current, pin, joint)
     setBindings(next)
     void persist((mm) => {
       mm.servoJointMap = next
@@ -4146,6 +4186,9 @@ export function RobotView({
             assembly={assembly}
             joints={joints}
             servos={bindings}
+            bindableServos={servoList}
+            jointOptions={movableNames}
+            onBindServo={handleBindServo}
             poses={poses}
             selected={selectedLink}
             onSelect={(link) => {

--- a/src/renderer/src/components/servo-bind.ts
+++ b/src/renderer/src/components/servo-bind.ts
@@ -7,7 +7,7 @@
  * Dependency-light (only `normPin`) so both views + tests can import it.
  */
 import type { PartDefinition } from '../../../shared/part'
-import type { RobotConnection, ServoJointBinding } from '../../../shared/robot'
+import type { RobotConnection, RobotPart, ServoJointBinding } from '../../../shared/robot'
 import { normPin } from './robot-pose'
 
 /** Whether a placed part is a servo (something that drives a joint). Matches the
@@ -72,4 +72,32 @@ export function bindServoJoint(
       ? prev
       : { pin: gpio, joint, servoMin: 0, servoMax: 180, jointMin: 0, jointMax: 180 }
   ]
+}
+
+/** A breadboard servo the URDF editor can bind — its instance id, label, and the
+ *  GPIO its signal is wired to (null when not yet wired). */
+export interface BindableServo {
+  id: string
+  label: string
+  pin: string | null
+}
+
+/**
+ * The servo parts placed on the breadboard, for the URDF editor's bindable-servos
+ * list (#). Filters `parts` to servos (via `resolveDef` → {@link isServoPart}) and
+ * resolves each one's signal GPIO from the wiring. Pure — `resolveDef` looks a
+ * placed part up in the installed libraries.
+ */
+export function bindableServos(
+  parts: RobotPart[],
+  connections: RobotConnection[],
+  resolveDef: (part: RobotPart) => PartDefinition | undefined | null
+): BindableServo[] {
+  return parts
+    .filter((p) => isServoPart(resolveDef(p)))
+    .map((p) => ({
+      id: p.id,
+      label: p.label || resolveDef(p)?.name || p.part,
+      pin: servoBoardGpio(p.id, connections)
+    }))
 }

--- a/test/servoBind.test.ts
+++ b/test/servoBind.test.ts
@@ -4,10 +4,11 @@ import {
   endpointParts,
   servoBoardGpio,
   boundJoint,
-  bindServoJoint
+  bindServoJoint,
+  bindableServos
 } from '../src/renderer/src/components/servo-bind'
 import type { PartDefinition } from '../src/shared/part'
-import type { RobotConnection, ServoJointBinding } from '../src/shared/robot'
+import type { RobotConnection, RobotPart, ServoJointBinding } from '../src/shared/robot'
 
 const def = (over: Partial<PartDefinition>): PartDefinition =>
   ({ id: 'x', name: 'X', headers: [], ...over }) as PartDefinition
@@ -72,5 +73,31 @@ describe('boundJoint + bindServoJoint (#)', () => {
   })
   it('unbinds on an empty joint', () => {
     expect(bindServoJoint(map, '16', '')).toEqual([])
+  })
+})
+
+describe('bindableServos (#)', () => {
+  const parts: RobotPart[] = [
+    { id: 'sg90', lib: 'std', part: 'sg90', label: 'Left arm' },
+    { id: 'sg902', lib: 'std', part: 'sg90' },
+    { id: 'led1', lib: 'std', part: 'led' }
+  ]
+  const conns: RobotConnection[] = [
+    { id: 'a', from: 'sg90.Signal#0', to: 'board.GP16#5', net: 'signal' }
+    // sg902 has no signal wire yet
+  ]
+  const defs: Record<string, PartDefinition> = {
+    sg90: { id: 'sg90', name: 'SG90 Micro Servo', tags: ['servo'], headers: [] } as PartDefinition,
+    led: { id: 'led', name: 'LED', family: 'Output', headers: [] } as PartDefinition
+  }
+  const resolve = (p: RobotPart): PartDefinition | undefined => defs[p.part]
+
+  it('lists only servos, with their label + signal GPIO (null when unwired)', () => {
+    const list = bindableServos(parts, conns, resolve)
+    expect(list).toEqual([
+      { id: 'sg90', label: 'Left arm', pin: '16' }, // label wins
+      { id: 'sg902', label: 'SG90 Micro Servo', pin: null } // def name, not wired
+    ])
+    expect(list.some((s) => s.id === 'led1')).toBe(false) // not a servo
   })
 })


### PR DESCRIPTION
The other half of the **Breadboard ↔ 3-D servo binding**. The Robot View's **Servos** list now shows the breadboard servos, so you can bind them to joints without switching to the Board View.

## What
- **`servo-bind.ts`**: `bindableServos(parts, connections, resolveDef)` — the placed servo parts + each one's signal GPIO (pure; `resolveDef` looks a part up in the installed libraries).
- **`RobotView`**: loads the installed libraries + the placed parts/connections (and reloads on `robot:didChange`, so it reflects edits from the Board window), computes the servo list, and handles `onBindServo` — which writes the **same `servoJointMap`** the Board View writes.
- **`RobotBuildPanel` Servos section**: each breadboard servo shows its **label**, the **GPIO** its signal is wired to, and a **joint `<select>`** (mirrors the board-side picker). Unwired servos are flagged; a **bound** servo's name opens the servo editor for calibration; bindings with no breadboard part (manual/legacy) still show; and **＋ Bind a servo by hand** is kept.

## Layout (verified headless)
```
▾ SERVOS                              3
  Left arm    GP16  [ shoulder ▾ ]
  Right arm   GP17  [ → (none) ▾ ]
  Head servo         unwired
  GP5                → pan            ← orphan (manual/legacy)
  ＋ Bind a servo by hand
```

## Verification
- **+1 unit test** for `bindableServos` (servo filter, label precedence, signal GPIO / unwired). **1671 vitest** + typecheck / lint / build green.

Both views write the one pin↔joint map, so they stay in step, and the existing `SNK SERVO` telemetry pipe drives the model with no extra setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)