### PR TITLE
chore: hide Board + Data Lab from the switcher; soften the blueprint grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Add Joint tool stays, now purely for geometry (where parts meet + orientation).
 
 ### Changed
+- **Simpler workspace switcher + softer blueprint grid.** The workspace switcher now shows just
+  **Code · Robot** — the Board and Data Lab entries are hidden (the Board View is still reachable via
+  its pop-out window and the Robot workspace; deeper cleanup tracked in #447). The blueprint
+  breadboard's graph-paper grid lines are a touch softer so they read as a backdrop.
 - **Robot View — joints are first-class in the Build hierarchy.** Each connecting joint now has its
   own row directly above the link it drives, showing a **type glyph** (a lock for fixed, a rotation
   arrow for a hinge, a spoked wheel for continuous, a slider for prismatic), the **joint name** (so

--- a/src/renderer/src/components/WiringCanvas.css
+++ b/src/renderer/src/components/WiringCanvas.css
@@ -62,6 +62,8 @@
 }
 :root[data-breadboard-bg='blueprint'] .wc--lifelike .wc__grid {
   stroke: #d6e6ff;
+  /* A touch softer so the graph-paper grid reads as a backdrop, not foreground. */
+  stroke-opacity: 0.5;
 }
 /* Blueprint only: warp the grid with the paper fibre so the lines aren't
    machine-perfect — a subtle ink-on-paper wobble that scales with the grid. */

--- a/src/renderer/src/components/WorkspaceSwitcher.tsx
+++ b/src/renderer/src/components/WorkspaceSwitcher.tsx
@@ -4,22 +4,25 @@ import './WorkspaceSwitcher.css'
 /**
  * WORKSPACE SWITCHER (epic #259, Phase 1) — one-click named layouts.
  *
- * A compact segmented control in the toolbar: **Code · Board · Lab · Data**.
- * Each workspace remembers its own geometry (sidebar view, panel sizes,
- * collapse states, instrument dock); switching restyles the SAME mounted tree
- * so nothing (editor, console scrollback, instruments) is lost. The ↺ button
- * restores the active workspace to its factory preset — the always-available
- * "Reset layout" escape hatch.
+ * A compact segmented control in the toolbar: **Code · Robot**. Each workspace
+ * remembers its own geometry (sidebar view, panel sizes, collapse states,
+ * instrument dock); switching restyles the SAME mounted tree so nothing (editor,
+ * console scrollback, instruments) is lost. The ↺ button restores the active
+ * workspace to its factory preset — the always-available "Reset layout" escape hatch.
  *
- * Reads the layout store directly (no prop threading through Toolbar).
+ * The Board + Data Lab workspaces are hidden from the switcher (the Board View is
+ * still reachable via its pop-out window and the Robot workspace); a follow-up issue
+ * tracks removing the underlying views. Reads the layout store directly.
  */
+const VISIBLE_WORKSPACES = WORKSPACE_IDS.filter((id) => id === 'code' || id === 'robot')
+
 export function WorkspaceSwitcher(): JSX.Element {
   const layout = useWorkspaceLayout()
 
   return (
     <div className="ws-switcher" role="group" aria-label="Workspace layout">
       <div className="ws-switcher__seg">
-        {WORKSPACE_IDS.map((id) => (
+        {VISIBLE_WORKSPACES.map((id) => (
           <button
             key={id}
             type="button"


### PR DESCRIPTION
Two small UI tweaks from feedback.

## Workspace switcher → Code · Robot
The switcher now shows just **Code · Robot** — the **Board** and **Data Lab** entries are filtered out. The Board View is still reachable via its **pop-out window** and inside the **Robot** workspace, so nothing's lost. Display-only: the layout store still holds all four workspaces, so migration + `layoutStore` tests are unaffected. The deeper cleanup of the unused view/workspace machinery is tracked in **#447**.

## Softer blueprint grid
The blueprint breadboard's graph-paper grid lines get `stroke-opacity: 0.5`, so the near-white lines read as a backdrop rather than foreground.

typecheck / lint / build / **1671 vitest** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)