### PR TITLE
feat: export pure PWM(Pin) → Servo(pwm) pin assignments, named by joint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Add Joint tool stays, now purely for geometry (where parts meet + orientation).
 
 ### Changed
+- **Exported motion is plain-MicroPython pin → variable setup.** The Robot View's exported motion
+  code now sets each servo up as a pure `<joint>_servo = PWM(Pin(n))` followed by
+  `<joint> = Servo(<joint>_servo, pin=n)` — servos are named by the joint they drive, so the code
+  reads like the rig. It runs on hardware *and* in the Snakie simulator (a `try/except` import falls
+  back to CPython-safe stubs), and the `pin=` keeps each servo emitting `SNK SERVO`, so running the
+  exported code still moves the 3-D model. `instruments.Servo(pwm)` now sets the 50 Hz servo
+  frequency on a hand-built PWM.
 - **Simpler workspace switcher + softer blueprint grid.** The workspace switcher now shows just
   **Code · Robot** — the Board and Data Lab entries are hidden (the Board View is still reachable via
   its pop-out window and the Robot workspace; deeper cleanup tracked in #447). The blueprint

--- a/micropython/instruments.py
+++ b/micropython/instruments.py
@@ -77,11 +77,43 @@ target. ``control`` stores the LATEST payload per target; poll it in your loop::
 
 import sys
 
+# Real machine.Pin / machine.PWM on a board; tiny no-op stubs under CPython (the
+# Snakie simulator runs exported device code headless). Re-exported so generated
+# code can fall back to `from instruments import Pin, PWM` and still run in the
+# simulator, where the Servo emits SNK telemetry to drive the 3-D model anyway.
+try:
+    from machine import Pin, PWM  # noqa: F401 - re-exported for generated code
+except ImportError:  # pragma: no cover - CPython simulator has no `machine`
+
+    class Pin:  # noqa: N801 - mirror machine.Pin's name
+        OUT = 1
+        IN = 0
+
+        def __init__(self, n, *args, **kwargs):
+            self.id = n
+
+        def value(self, *args):
+            return 0
+
+    class PWM:  # noqa: N801 - mirror machine.PWM's name
+        def __init__(self, pin, *args, **kwargs):
+            self.pin = pin
+
+        def freq(self, *args):
+            return 50
+
+        def duty_u16(self, *args):
+            return 0
+
+        def deinit(self):
+            pass
+
+
 # Library version. Bump this on ANY change to this file — the IDE compares it
 # against the copy installed on the board and offers a one-click UPDATE when they
 # differ (a legacy copy with no __version__ reads as out-of-date). Keep the
 # `__version__ = "X.Y.Z"` literal form so the IDE can parse it without importing.
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 
 # The sentinel that prefixes every telemetry line. Kept short + ASCII so it is
 # cheap to print and easy for the IDE to detect / strip.
@@ -1503,8 +1535,18 @@ class Servo:
         # Robot View can drive the mapped URDF joint (#313). Set here works even
         # with no ``machine`` (the simulator), so headless robots still animate.
         self.pin = None
-        if pin is not None:
-            self.set_pin(pin)
+        if pwm is not None:
+            # A hand-built ``PWM(Pin(n))`` may not be at the servo frequency — set
+            # it so ``Servo(PWM(Pin(n)))`` from generated code works electrically.
+            try:
+                pwm.freq(freq)
+            except Exception:  # noqa: BLE001 - a fake/odd PWM without freq() is fine
+                pass
+            # ``Servo(pwm, pin=n)`` remembers the GPIO for SNK SERVO telemetry.
+            if pin is not None:
+                self.pin = int(pin)
+        elif pin is not None:
+            self.set_pin(pin)  # build the PWM from the pin
 
     def set_pin(self, n):
         """(Re)target the PWM pin: build ``PWM(Pin(n))`` at 50 Hz (no-op w/o hw)."""

--- a/python/tests/test_instruments.py
+++ b/python/tests/test_instruments.py
@@ -472,6 +472,22 @@ class BuzzerDevice(unittest.TestCase):
         self.assertIsNone(inst.servo_command("wat", srv))
         self.assertIsNone(inst.servo_command("", srv))
 
+    def test_servo_from_pwm_sets_servo_freq(self):
+        # Exported `Servo(PWM(Pin(n)))` — the Servo sets the PWM to 50 Hz so a
+        # hand-built PWM works electrically.
+        pwm = _RecordingPWM()
+        inst.Servo(pwm)
+        self.assertIn(50, pwm.freqs)
+
+    def test_servo_from_pwm_with_pin_emits_servo_telemetry(self):
+        # `Servo(pwm, pin=n)` remembers the GPIO, so angle() emits SNK SERVO — the
+        # pin-keyed reading Robot View maps to a joint (code moves the 3-D model).
+        out = _emit(lambda: inst.Servo(_RecordingPWM(), pin=3).angle(90))
+        self.assertIn("SNK SERVO 3 90", out)
+        # Without a pin there's no SERVO telemetry (nothing to key the joint on).
+        out2 = _emit(lambda: inst.Servo(_RecordingPWM()).angle(90))
+        self.assertNotIn("SNK SERVO", out2)
+
     def test_servos_command_drives_several_pins(self):
         # #416 puppet slider: one `servos` payload moves many servos at once.
         calls = []

--- a/src/shared/robot-timeline.ts
+++ b/src/shared/robot-timeline.ts
@@ -433,6 +433,13 @@ export function pinNumber(pin: string): number {
   return /^-?\d+$/.test(rest) ? Number(rest) : NaN
 }
 
+/** A safe Python identifier from a joint name, for naming the exported servo
+ *  variables (`base` → `base`, `l-arm` → `l_arm`, `2wheel` → `_2wheel`). */
+export function pyIdent(name: string): string {
+  const s = String(name).replace(/[^A-Za-z0-9_]/g, '_')
+  return !s || /^[0-9]/.test(s) ? `_${s}` : s
+}
+
 export interface MotionExport {
   code: string
   /** Non-fatal problems (unbound joints, non-numeric pins) for the UI. */
@@ -447,8 +454,9 @@ export interface MotionExport {
  * Generate runnable MicroPython that reproduces the timeline on hardware (#314).
  * Bakes the SAME eased samples the preview uses into a flat FRAMES table, maps
  * each joint value to a whole servo degree via {@link jointToServo}, and drives
- * `inst.servo_on(pin).angle()`. Iterates the BINDINGS (a joint on two pins drives
- * both). `DT = 1/FPS` is symbolic to avoid sleep drift; the loop seam is dropped.
+ * pure `PWM(Pin(n))` → `Servo(pwm, pin=n)` variables named by joint. Iterates the
+ * BINDINGS (a joint on two pins drives both). `DT = 1/FPS` is symbolic to avoid
+ * sleep drift; the loop seam is dropped.
  */
 export function generateMicroPython(
   tl: MotionTimeline,
@@ -488,7 +496,11 @@ export function generateMicroPython(
     `# ${name} — motion exported from Snakie Robot View (#314).`,
     `# ${servos.length} servo(s), ${tl.duration}s @ ${fps}fps, ${tl.easing}${tl.loop ? ', looping' : ''}.`,
     ...warnings.map((w) => `# ! ${w}`),
-    'import instruments as inst',
+    'try:',
+    '    from machine import Pin, PWM',
+    'except ImportError:  # Snakie simulator (CPython) — headless stubs',
+    '    from instruments import Pin, PWM',
+    'from instruments import Servo',
     'import time',
     '',
     `FPS = ${fps}`,
@@ -524,15 +536,29 @@ export function generateMicroPython(
     )
   }
 
-  const servoDecls = servos.map(
-    (s, i) => `s${i} = inst.servo_on(${s.pin})  # ${s.b.joint}`
-  )
+  // Pure pin → typed-variable setup: `<joint>_servo = PWM(Pin(n))` then
+  // `<joint> = Servo(<joint>_servo, pin=n)`. `pin=` lets each Servo emit SNK SERVO
+  // telemetry so running this code also drives the 3-D model. Names are the joint
+  // (a safe identifier), de-collided when a joint drives two pins.
+  const usedVars = new Set<string>()
+  const servoVars = servos.map((s) => {
+    const base = pyIdent(s.b.joint) || `servo_${s.pin}`
+    let v = base
+    let n = 2
+    while (usedVars.has(v)) v = `${base}_${n++}`
+    usedVars.add(v)
+    return v
+  })
+  const servoDecls = servos.flatMap((s, i) => [
+    `${servoVars[i]}_servo = PWM(Pin(${s.pin}))`,
+    `${servoVars[i]} = Servo(${servoVars[i]}_servo, pin=${s.pin})`
+  ])
   // A 1-element Python tuple needs a trailing comma, else `(90)` is just an int.
   const framesLit = rows.map((r) => `    (${r.join(', ')}${r.length === 1 ? ',' : ''}),`)
 
   const body = [
     ...servoDecls,
-    `SERVOS = (${servos.map((_, i) => `s${i}`).join(', ')}${servos.length === 1 ? ',' : ''})`,
+    `SERVOS = (${servoVars.join(', ')}${servos.length === 1 ? ',' : ''})`,
     '',
     '# Baked servo angles (degrees) — one row per frame, easing already applied.',
     'FRAMES = (',

--- a/test/robotTimeline.test.ts
+++ b/test/robotTimeline.test.ts
@@ -215,8 +215,11 @@ describe('generateMicroPython — runnable export (#314)', () => {
   ]
   it('emits importable, servo-driving code with baked int frames', () => {
     const ex = generateMicroPython(tl(), bindings, { robotName: 'bot', fps: 4 })
-    expect(ex.code).toContain('import instruments as inst')
-    expect(ex.code).toContain('s0 = inst.servo_on(0)') // GP0 → 0 (not int("GP0")!)
+    expect(ex.code).toContain('from machine import Pin, PWM')
+    expect(ex.code).toContain('from instruments import Servo')
+    // Pure pin → typed variable, named by joint 'a': GP0 → 0 (not int("GP0")!).
+    expect(ex.code).toContain('a_servo = PWM(Pin(0))')
+    expect(ex.code).toContain('a = Servo(a_servo, pin=0)')
     expect(ex.code).toContain('DT = 1 / FPS')
     expect(ex.code).toMatch(/def play\(\):/)
     expect(ex.code).toContain('while True:')
@@ -232,7 +235,7 @@ describe('generateMicroPython — runnable export (#314)', () => {
   })
   it('warns + skips a non-numeric pin instead of emitting a crash', () => {
     const ex = generateMicroPython(tl(), [{ pin: 'SDA', joint: 'a', jointMin: 0, jointMax: 100 }])
-    expect(ex.code).not.toContain('servo_on(SDA)')
+    expect(ex.code).not.toContain('Pin(SDA') // the non-numeric pin is skipped, not emitted as code
     expect(ex.warnings.join(' ')).toMatch(/not a number/)
   })
   it('reports an animated joint with no binding as skipped', () => {
@@ -249,13 +252,16 @@ describe('generateMicroPython — runnable export (#314)', () => {
       { pin: '1', joint: 'a', jointMin: 0, jointMax: 100, invert: true }
     ]
     const ex = generateMicroPython(tl(), two)
-    expect(ex.code).toContain('s0 = inst.servo_on(0)')
-    expect(ex.code).toContain('s1 = inst.servo_on(1)')
-    expect(ex.code).toContain('SERVOS = (s0, s1)')
+    // Same joint 'a' on two pins → the second variable de-collides to a_2.
+    expect(ex.code).toContain('a_servo = PWM(Pin(0))')
+    expect(ex.code).toContain('a = Servo(a_servo, pin=0)')
+    expect(ex.code).toContain('a_2_servo = PWM(Pin(1))')
+    expect(ex.code).toContain('a_2 = Servo(a_2_servo, pin=1)')
+    expect(ex.code).toContain('SERVOS = (a, a_2)')
   })
   it('with no bindings emits valid, explanatory Python (no servos)', () => {
     const ex = generateMicroPython(tl(), [])
-    expect(ex.code).toContain('import instruments as inst')
+    expect(ex.code).toContain('from instruments import Servo')
     expect(ex.code).not.toContain('servo_on')
     expect(ex.code).toMatch(/bind pins to joints/i)
   })


### PR DESCRIPTION
The Robot View's exported motion code now sets each servo up the way you asked — plain-MicroPython pins bound to typed variables, named by the joint they drive.

## The generated setup
```python
try:
    from machine import Pin, PWM
except ImportError:        # Snakie simulator (CPython) — headless stubs
    from instruments import Pin, PWM
from instruments import Servo
import time

base_servo = PWM(Pin(0))
base = Servo(base_servo, pin=0)
shoulder_servo = PWM(Pin(1))
shoulder = Servo(shoulder_servo, pin=1)
SERVOS = (base, shoulder)
```

- **`generateMicroPython`**: emits `<joint>_servo = PWM(Pin(n))` + `<joint> = Servo(<joint>_servo, pin=n)` (was `s0 = inst.servo_on(n)`). Variables are named by the **joint** (`pyIdent`, de-collided when a joint drives two pins); `SERVOS`/`FRAMES`/`play` unchanged.
- **`instruments.py`**: module-level `Pin`/`PWM` (real on a board, CPython stubs for the simulator, re-exported for the fallback import); `Servo(pwm)` now sets the **50 Hz** servo frequency on a hand-built PWM; `Servo(pwm, pin=n)` remembers the GPIO so `angle()` still emits `SNK SERVO`. `__version__` 0.9.0 → 0.9.1.

## Runs on hardware *and* in the simulator
The `try/except` import means it runs on a Pico (`from machine import …`) and in Snakie's CPython simulator (the stubs), which is what drives the 3-D preview. And because each `Servo` keeps its `pin=`, **running the exported code moves the 3-D model** — the whole servo↔joint binding, end to end.

> **One small note:** `pin=n` is a tiny addition to the bare `Servo(base_servo)` you wrote. It's what keeps "code moves the model" working (the Servo needs its pin to emit `SNK SERVO`). Happy to drop it if you'd rather have the barest form and only drive real hardware.

## Verification
- Updated the export-code assertions; **+2 Python** tests (`Servo(pwm)` sets freq; `pin=` emits `SNK SERVO`, no pin ⇒ none). **1671 vitest + 201 Python** + typecheck/lint/build green. The **on-interpreter e2e** export test runs the new code and sees the `SNK SERVO` frames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)