### PR TITLE
feat: Poses instrument — a live servo test bench

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Poses instrument — a live servo test bench.** A new dock instrument reads your rig's
+  servo↔joint map and saved poses from `robot.yml` and gives two quick ways to drive the real
+  hardware while a program runs: **pose buttons** snap every bound servo into a saved pose (applying
+  each servo's calibration), and **per-servo sliders** nudge one servo by hand. Both send a single
+  `SNKCMD servos …` line, so a slider here also moves the on-screen 3-D model. It lights up
+  automatically once a servo is bound, reloads when you bind a servo or save a pose in either editor,
+  and guides you when nothing is bound yet.
 - **Bind a servo to a 3-D joint — from either view.** Wire a **servo** on the breadboard and choose
   which URDF **joint** it moves; a running program's servo writes then drive the matching joint in
   the 3-D Robot View live. Bind it two ways: from the **Board View** (a servo's inspector gains a

--- a/src/renderer/src/components/InstrumentHost.tsx
+++ b/src/renderer/src/components/InstrumentHost.tsx
@@ -27,6 +27,7 @@ import { EnvInstrument } from './EnvInstrument'
 import { DataLoggerInstrument } from './DataLoggerInstrument'
 import { LedInstrument } from './LedInstrument'
 import { ServoInstrument } from './ServoInstrument'
+import { PoseInstrument } from './PoseInstrument'
 import { PotentiometerInstrument } from './PotentiometerInstrument'
 import { ButtonInstrument } from './ButtonInstrument'
 import { BuzzerInstrument } from './BuzzerInstrument'
@@ -979,6 +980,8 @@ export function renderSingleton(
       return <LedInstrument {...p} />
     case 'servo':
       return <ServoInstrument {...p} />
+    case 'poses':
+      return <PoseInstrument {...p} />
     case 'pot':
       return <PotentiometerInstrument {...p} />
     case 'button':

--- a/src/renderer/src/components/PoseInstrument.css
+++ b/src/renderer/src/components/PoseInstrument.css
@@ -1,0 +1,111 @@
+/* POSE instrument (pose bench) — global CSS, so every selector uses the UNIQUE
+   `posebench__` prefix (never reuse another panel's prefix). Themed via the shared
+   tokens (--text/--border/--bg-sunken) + --accent/--accent-border, so it reads in
+   BOTH the dark and light (skeuomorph) skins. */
+.posebench {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  padding: 0.55rem 0.6rem 0.65rem;
+}
+
+.posebench__empty {
+  margin: 0;
+  padding: 0.9rem 0.7rem;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  line-height: 1.5;
+  color: var(--text-muted, #9aa0a8);
+  text-align: center;
+}
+
+.posebench__label {
+  font-family: var(--font-mono);
+  font-size: 0.56rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted, #9aa0a8);
+}
+
+/* --- Pose quick-jump buttons --- */
+.posebench__poses {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+.posebench__pose-btns {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+.posebench__pose {
+  padding: 0.32rem 0.6rem;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  color: var(--text, #d6dade);
+  background: var(--bg-sunken, #17181c);
+  border: 1px solid var(--border, #2c2e33);
+  border-radius: 6px;
+  cursor: pointer;
+}
+.posebench__pose:hover {
+  /* The accent is a fixed instrument colour (def.accent), so on-accent text is a
+     fixed dark ink — like ServoInstrument's is-on state — not the theme --accent-ink. */
+  color: #12241a;
+  background: var(--accent, #7fe0a8);
+  border-color: var(--accent, #7fe0a8);
+}
+.posebench__pose:active {
+  transform: translateY(1px);
+}
+
+/* --- Per-servo sliders --- */
+.posebench__servos {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+.posebench__servo {
+  display: grid;
+  grid-template-columns: minmax(6.5rem, 8.5rem) 1fr auto;
+  align-items: center;
+  gap: 0.5rem;
+}
+.posebench__servo-name {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+}
+.posebench__servo-pin {
+  flex: 0 0 auto;
+  font-weight: 700;
+  color: var(--accent, #7fe0a8);
+}
+.posebench__servo-joint {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-muted, #9aa0a8);
+}
+.posebench__slider {
+  min-width: 0;
+  width: 100%;
+  accent-color: var(--accent, #7fe0a8);
+}
+.posebench__servo-val {
+  flex: 0 0 auto;
+  min-width: 2.6rem;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  color: var(--text, #d6dade);
+}

--- a/src/renderer/src/components/PoseInstrument.tsx
+++ b/src/renderer/src/components/PoseInstrument.tsx
@@ -1,0 +1,211 @@
+import { useCallback, useEffect, useRef, useState, type CSSProperties } from 'react'
+import { reporter } from '../lib/report-error'
+import { InstrumentWindow, type FloatProps } from './InstrumentWindow'
+import { type InstrumentDef } from './instruments-registry'
+import { useWorkspaceOptional } from '../store/workspace'
+import { buildServosPayload } from '../../../shared/control'
+import { poseServoAngles } from './servo-bind'
+import { normPin } from './robot-pose'
+import type { NamedPose, ServoJointBinding } from '../../../shared/robot'
+import './PoseInstrument.css'
+
+/**
+ * POSE INSTRUMENT (#) — a live test bench for a rig's servos.
+ * =============================================================================
+ *
+ * Reads the project's `robot.yml` (its servo↔joint map + saved poses) and gives
+ * two quick ways to drive the real hardware while a program runs:
+ *
+ *  • **Pose buttons** — one per saved pose; a press snaps every bound servo to
+ *    the angle that reaches that pose (via each binding's calibration,
+ *    {@link poseServoAngles}).
+ *  • **Per-servo sliders** — one per bound GPIO; drag to nudge that servo live.
+ *
+ * Both WRITE a single `SNKCMD servos "<pin>:<deg> …"` control line via
+ * `window.api.device.sendControl('servos', …)` — the multi-servo payload built by
+ * {@link buildServosPayload}, matching the on-device `servos_command` receiver.
+ * The instrument reloads its map/poses on `robot:onChanged`, so binding a servo
+ * or saving a pose in either editor shows up here without reopening. It reads the
+ * same shared spine (`servoJointMap`) the 3-D view uses, so a slider here also
+ * moves the on-screen model (the board echoes `SNK SERVO`).
+ */
+
+export interface PoseInstrumentProps {
+  def: InstrumentDef
+  onClose?: () => void
+  docked?: boolean
+  onToggleDock?: () => void
+  float?: FloatProps
+}
+
+/** The multi-servo control target (`SNKCMD servos …`). */
+const SERVOS_TARGET = 'servos'
+/** Neutral servo angle for a freshly-loaded slider. */
+const NEUTRAL_DEG = 90
+
+function clampDeg(n: number): number {
+  return !Number.isFinite(n) ? NEUTRAL_DEG : n < 0 ? 0 : n > 180 ? 180 : Math.round(n)
+}
+
+export function PoseInstrument({
+  def,
+  onClose,
+  docked = true,
+  onToggleDock,
+  float
+}: PoseInstrumentProps): JSX.Element {
+  // The workspace is absent in a detached OS window (no provider); read it safely
+  // and fall back to the default project folder.
+  const ws = useWorkspaceOptional()
+  const folder = ws?.currentFolder ?? undefined
+
+  const [bindings, setBindings] = useState<ServoJointBinding[]>([])
+  const [poses, setPoses] = useState<NamedPose[]>([])
+  // Commanded angle per NUMERIC pin (optimistic) — keys match buildServosPayload.
+  const [angles, setAngles] = useState<Record<string, number>>({})
+  const lastSent = useRef(0)
+
+  // Load the rig's servo map + poses, and follow live edits from the other views.
+  useEffect(() => {
+    let live = true
+    const load = (): void => {
+      window.api.robot
+        .load(folder)
+        .then((d) => {
+          if (!live) return
+          const bs = d.robot?.servoJointMap ?? []
+          setBindings(bs)
+          setPoses(d.robot?.poses ?? [])
+          // Seed a neutral angle for any newly-bound pin; keep known ones.
+          setAngles((prev) => {
+            const next: Record<string, number> = {}
+            for (const b of bs) {
+              const pin = normPin(b.pin)
+              next[pin] = prev[pin] ?? NEUTRAL_DEG
+            }
+            return next
+          })
+        })
+        .catch(reporter('poses load'))
+    }
+    load()
+    const off = window.api.robot.onChanged(load)
+    return () => {
+      live = false
+      off()
+    }
+  }, [folder])
+
+  /** Fire a servos payload; throttle rapid streams (slider drags) like the servo panel. */
+  const send = useCallback((byPin: Record<string, number>, throttle = false): void => {
+    if (throttle) {
+      const now = Date.now()
+      if (now - lastSent.current < 40) return
+      lastSent.current = now
+    }
+    const payload = buildServosPayload(byPin)
+    if (payload) void window.api.device.sendControl(SERVOS_TARGET, payload).catch(reporter('poses send'))
+  }, [])
+
+  /** Jump every bound servo to a saved pose. */
+  const recall = useCallback(
+    (pose: NamedPose): void => {
+      const byPin = poseServoAngles(bindings, pose.values)
+      if (Object.keys(byPin).length === 0) return
+      setAngles((a) => ({ ...a, ...byPin }))
+      send(byPin)
+    },
+    [bindings, send]
+  )
+
+  /** Nudge one servo live. */
+  const setServo = useCallback(
+    (pin: string, deg: number, throttle = false): void => {
+      const d = clampDeg(deg)
+      setAngles((a) => ({ ...a, [pin]: d }))
+      send({ [pin]: d }, throttle)
+    },
+    [send]
+  )
+
+  const hasServos = bindings.length > 0
+  const source = hasServos
+    ? `${bindings.length} servo${bindings.length === 1 ? '' : 's'}`
+    : 'no servos'
+
+  return (
+    <InstrumentWindow
+      name={def.name.toUpperCase()}
+      helpId={`inst-${def.id}`}
+      source={source}
+      docked={docked}
+      onClose={onClose}
+      onToggleDock={onToggleDock}
+      {...float}
+    >
+      <div
+        className="posebench"
+        style={{ '--accent': def.accent, '--accent-border': def.border } as CSSProperties}
+      >
+        {!hasServos ? (
+          <p className="posebench__empty">
+            No servos bound yet. Bind a servo to a joint in the Board or Robot View — then its
+            slider (and your saved poses) appear here to test live.
+          </p>
+        ) : (
+          <>
+            {poses.length > 0 && (
+              <div className="posebench__poses">
+                <span className="posebench__label">Poses</span>
+                <div className="posebench__pose-btns">
+                  {poses.map((p) => (
+                    <button
+                      key={p.name}
+                      type="button"
+                      className="posebench__pose"
+                      onClick={() => recall(p)}
+                      title={`Send every servo to “${p.name}”`}
+                    >
+                      {p.name}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div className="posebench__servos">
+              <span className="posebench__label">Servos</span>
+              {bindings.map((b) => {
+                const pin = normPin(b.pin)
+                const val = angles[pin] ?? NEUTRAL_DEG
+                return (
+                  <div className="posebench__servo" key={pin}>
+                    <span className="posebench__servo-name" title={`GP${pin} · ${b.joint}`}>
+                      <span className="posebench__servo-pin">GP{pin}</span>
+                      <span className="posebench__servo-joint">{b.joint}</span>
+                    </span>
+                    <input
+                      className="posebench__slider"
+                      type="range"
+                      min={0}
+                      max={180}
+                      step={1}
+                      value={val}
+                      aria-label={`GP${pin} (${b.joint}) angle`}
+                      onChange={(e) => setServo(pin, Number(e.currentTarget.value), true)}
+                      // A final un-throttled send so the last position always lands.
+                      onPointerUp={() => setServo(pin, val)}
+                    />
+                    <span className="posebench__servo-val">{val}°</span>
+                  </div>
+                )
+              })}
+            </div>
+          </>
+        )}
+      </div>
+    </InstrumentWindow>
+  )
+}
+
+export default PoseInstrument

--- a/src/renderer/src/components/help/inst-poses.md
+++ b/src/renderer/src/components/help/inst-poses.md
@@ -1,0 +1,21 @@
+A live **test bench** for your robot's servos — press a saved **pose** to snap every bound servo into place, or drag a **per-servo slider** to nudge one by hand, all while a program is running.
+
+## What it does
+It reads your project's `robot.yml` — the **servo ↔ joint map** and your **saved poses** — and drives the real hardware over the control channel. A pose button (or a slider) writes one `SNKCMD servos "<pin>:<deg> …"` line via `sendControl('servos', …)`, the multi-servo payload the on-device `servos_command` receiver understands. Because it uses the same servo-map spine as the 3-D view, moving a slider here also moves the on-screen model.
+
+## How to use it
+1. In the **Board View**, wire a servo's signal to a GPIO; in the **Robot View**, bind that servo to a joint (and calibrate its range). The servo then appears here with a slider.
+2. Save some **poses** in the Robot View — each becomes a quick-press button here.
+3. Run a program that services the control channel, then test live:
+
+```python
+import instruments as inst, time
+
+inst.start()               # opens the control channel
+while True:
+    inst.control.poll()    # slider / pose → servos.command(pin:deg …)
+    time.sleep(0.02)
+```
+
+- Sliders send whole servo degrees (0–180); pose buttons apply each binding's calibration.
+- Nothing bound yet? The panel tells you where to bind a servo.

--- a/src/renderer/src/components/instruments-registry.ts
+++ b/src/renderer/src/components/instruments-registry.ts
@@ -219,6 +219,19 @@ export const INSTRUMENTS: InstrumentDef[] = [
     hints: ['servo', 'sg90', 'mg90', 'mg996', 'pca9685']
   },
   {
+    id: 'poses',
+    name: 'Poses',
+    accent: '#7fe0a8',
+    border: 'rgba(127,224,168,.5)',
+    // three slider tracks with knobs — a pose bench
+    icon: 'M4 6 h16 M4 12 h16 M4 18 h16 M9 6 m-2 0 a2 2 0 1 0 4 0 a2 2 0 1 0 -4 0 M15 12 m-2 0 a2 2 0 1 0 4 0 a2 2 0 1 0 -4 0 M8 18 m-2 0 a2 2 0 1 0 4 0 a2 2 0 1 0 -4 0',
+    group: 'output',
+    kind: 'singleton',
+    description: "Test a robot's saved poses live — jump to a pose or nudge each bound servo.",
+    // Lights up alongside the Servo panel — a rig with bound servos is what makes it useful.
+    hints: ['servo', 'pose', 'rig', 'sg90', 'mg90', 'mg996']
+  },
+  {
     id: 'button',
     name: 'Button',
     accent: '#6fb4ee',
@@ -412,7 +425,7 @@ export function moduleCoveredByInstrument(module: string, inUse: Set<string>): b
  */
 export const BOUND_KIND_INSTRUMENTS: Record<string, string[]> = {
   pwm: ['scope', 'servo'],
-  servo: ['servo'],
+  servo: ['servo', 'poses'],
   adc: ['meter', 'scope', 'pot'],
   i2c: ['i2c-detect'],
   pin: ['led', 'button'],

--- a/src/renderer/src/components/servo-bind.ts
+++ b/src/renderer/src/components/servo-bind.ts
@@ -8,6 +8,7 @@
  */
 import type { PartDefinition } from '../../../shared/part'
 import type { RobotConnection, RobotPart, ServoJointBinding } from '../../../shared/robot'
+import { jointToServo } from '../../../shared/krf'
 import { normPin } from './robot-pose'
 
 /** Whether a placed part is a servo (something that drives a joint). Matches the
@@ -100,4 +101,24 @@ export function bindableServos(
       label: p.label || resolveDef(p)?.name || p.part,
       pin: servoBoardGpio(p.id, connections)
     }))
+}
+
+/**
+ * The servo angle (whole degree, 0..180) each bound GPIO should hold to reach a
+ * pose — `{ "16": 90, … }`, keyed by the NUMERIC pin ({@link normPin}) so it drops
+ * straight into `buildServosPayload` and the on-device `servos_command` (which
+ * parses `pin:deg` with an integer pin). Applies each binding's calibration via
+ * {@link jointToServo}; joints the pose doesn't set are skipped. Pure — the live
+ * Pose instrument (#) uses it to snap every servo to a saved pose.
+ */
+export function poseServoAngles(
+  bindings: ServoJointBinding[] | undefined,
+  poseValues: Record<string, number> | undefined
+): Record<string, number> {
+  const byPin: Record<string, number> = {}
+  for (const b of bindings ?? []) {
+    const v = (poseValues ?? {})[b.joint]
+    if (typeof v === 'number' && Number.isFinite(v)) byPin[normPin(b.pin)] = jointToServo(b, v)
+  }
+  return byPin
 }

--- a/test/servoBind.test.ts
+++ b/test/servoBind.test.ts
@@ -5,7 +5,8 @@ import {
   servoBoardGpio,
   boundJoint,
   bindServoJoint,
-  bindableServos
+  bindableServos,
+  poseServoAngles
 } from '../src/renderer/src/components/servo-bind'
 import type { PartDefinition } from '../src/shared/part'
 import type { RobotConnection, RobotPart, ServoJointBinding } from '../src/shared/robot'
@@ -99,5 +100,31 @@ describe('bindableServos (#)', () => {
       { id: 'sg902', label: 'SG90 Micro Servo', pin: null } // def name, not wired
     ])
     expect(list.some((s) => s.id === 'led1')).toBe(false) // not a servo
+  })
+})
+
+describe('poseServoAngles (#)', () => {
+  const bindings: ServoJointBinding[] = [
+    // GP-prefixed pin, straight 0..180 → 0..180 map
+    { pin: 'GP16', joint: 'base', servoMin: 0, servoMax: 180, jointMin: 0, jointMax: 180 },
+    // bare pin, inverted, joint range 0..90 → servo 0..180
+    { pin: '17', joint: 'elbow', servoMin: 0, servoMax: 180, jointMin: 0, jointMax: 90, invert: true }
+  ]
+
+  it('maps a pose to per-pin servo degrees, keyed by NUMERIC pin, applying calibration', () => {
+    const byPin = poseServoAngles(bindings, { base: 90, elbow: 90 })
+    // base: 90/180 → 90°; elbow: 90/90=1, inverted → 0°
+    expect(byPin).toEqual({ '16': 90, '17': 0 })
+  })
+
+  it('skips joints the pose does not set and non-finite values', () => {
+    expect(poseServoAngles(bindings, { base: 45 })).toEqual({ '16': 45 })
+    expect(poseServoAngles(bindings, { base: Number.NaN, elbow: 45 })).toEqual({ '17': 90 })
+  })
+
+  it('is empty for no bindings or no values', () => {
+    expect(poseServoAngles([], { base: 90 })).toEqual({})
+    expect(poseServoAngles(bindings, undefined)).toEqual({})
+    expect(poseServoAngles(undefined, undefined)).toEqual({})
   })
 })


### PR DESCRIPTION
## Poses instrument — a live servo test bench

The last piece of the rig-editor vision: a dock instrument to **test your robot's poses live**.

It reads the project's `robot.yml` — the **servo↔joint map** and your **saved poses** — and drives the real hardware over the control channel while a program runs:

- **Pose buttons** — one per saved pose; a press snaps every bound servo into that pose, applying each binding's calibration.
- **Per-servo sliders** — one per bound GPIO; drag to nudge a single servo (raw 0–180 servo degrees).

Both write a single `SNKCMD servos "<pin>:<deg> …"` line via the shared `buildServosPayload`, matching the on-device `servos_command` receiver. Because it rides the same servo-map spine as the 3-D view, moving a slider here also moves the on-screen model.

### Behaviour
- Registered as a `poses` **singleton** instrument; lights up automatically once a servo is bound (`BOUND_KIND_INSTRUMENTS` `servo → [servo, poses]`).
- Reloads its map + poses on `robot:onChanged`, so binding a servo or saving a pose in **either** editor shows up without reopening.
- Empty-state guidance when nothing is bound yet.

### Implementation
- New pure helper `poseServoAngles(bindings, poseValues)` in `servo-bind.ts` — pin→servo-degree for a pose, keyed by the **numeric** pin so it drops straight into `buildServosPayload`.
- `PoseInstrument.tsx` + `.css` (unique `posebench__` BEM prefix), dispatched from `InstrumentHost`.
- `help/inst-poses.md` (auto-listed from `INSTRUMENTS`).

### Verification
- `typecheck` · `lint` · `test` (1674, +3 new for `poseServoAngles`) · `build` all green.
- Headless render checked in **dark + light** skins — pins in accent, long joint names truncate, sliders/values aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
