### PR TITLE
fix: servo "drives joint" picker works in the in-window board pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -461,6 +461,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   or reopen any panel. Nothing about Robot mode is permanently changed.
 
 ### Fixed
+- **Servo "drives joint" picker works in the in-window board pane.** In the main window's
+  breadboard view, clicking a servo always showed "GPn · no joints" even when the linked rig had
+  joints — because that pane never loaded the URDF's joint names (only the pop-out Board *window*
+  did). It now reads the linked `.urdf`'s joints like the pop-out, so you can bind a servo to a
+  joint from either place. The picker also keeps showing a servo's current joint even if that
+  joint was renamed/removed from the URDF (an orphan binding), instead of silently blanking —
+  matching the URDF editor's servo list.
 - **Robot View — the 3-D view keeps its camera when you switch editor tabs (#399).**
   Flipping to another file tab and back used to reset the robot to the default framing,
   losing your orbit. Two causes: orbiting/panning wasn't recorded (only the zoom/home/fit

--- a/src/renderer/src/components/BoardPane.tsx
+++ b/src/renderer/src/components/BoardPane.tsx
@@ -4,6 +4,7 @@ import { PartEditor } from './PartEditor'
 import { OPEN_PART_EDITOR_EVENT, PARTS_CHANGED_EVENT, type OpenPartEditorDetail } from './PartsPanel'
 import { blankRobot, type RobotDefinition } from '../../../shared/robot'
 import { readRobotModel } from '../../../shared/krf'
+import { jointNames } from './robot-assembly'
 import { attachPartMesh } from './robot-part-mesh'
 import { useWorkspace } from '../store/workspace'
 import { useEditorSettings } from '../store/settings'
@@ -102,6 +103,32 @@ export function BoardPane(): JSX.Element {
       live = false
     }
   }, [folder, robotNonce])
+
+  // The linked URDF's joint names, so a placed servo's inspector can offer a
+  // "drives joint" picker (#) — mirrors the floating Board View window, which
+  // loads these too. Read the `.urdf` pointed at by robot.yml; empty when there's
+  // no URDF link / folder yet (then the picker shows "no joints"). Without this
+  // the in-window board pane ALWAYS showed "no joints", even with a linked rig.
+  const [joints, setJoints] = useState<string[]>([])
+  const urdfPath = robot.robot?.urdf
+  useEffect(() => {
+    if (!folder || !urdfPath) {
+      setJoints([])
+      return
+    }
+    let live = true
+    window.api.fs
+      .readFile(`${folder}/${urdfPath}`)
+      .then((content) => {
+        if (live) setJoints(jointNames(content))
+      })
+      .catch(() => {
+        if (live) setJoints([])
+      })
+    return () => {
+      live = false
+    }
+  }, [folder, urdfPath, robotNonce])
 
   const saveRobot = useCallback(
     (next: RobotDefinition): void => {
@@ -215,6 +242,7 @@ export function BoardPane(): JSX.Element {
         robot={robot}
         onChangeRobot={saveRobot}
         libraries={libraries}
+        joints={joints}
         onAddToProject={addToProject}
       />
       {editing && (

--- a/src/renderer/src/components/WiringCanvas.tsx
+++ b/src/renderer/src/components/WiringCanvas.tsx
@@ -1432,6 +1432,12 @@ export function WiringCanvas({ robot, onChange, joints = [], libraries, boardDef
   const selIsServo = !!selPart && isServoPart(selPart.partDef)
   const selServoGpio = selIsServo && selPart ? servoBoardGpio(selPart.key, robot.connections) : null
   const selServoJoint = selServoGpio ? boundJoint(robot.robot?.servoJointMap, selServoGpio) : null
+  // The joints the picker offers: the URDF's joints, plus the current binding if
+  // it's an ORPHAN (a saved joint the URDF no longer has), so a bound servo always
+  // shows its joint — matching the URDF editor's servo list (avoids the "editor
+  // shows base_joint, board shows nothing" disconnect).
+  const selServoJointChoices =
+    selServoJoint && !joints.includes(selServoJoint) ? [selServoJoint, ...joints] : joints
   const setServoJoint = (joint: string): void => {
     if (!selServoGpio) return
     onChange({
@@ -1686,7 +1692,7 @@ export function WiringCanvas({ robot, onChange, joints = [], libraries, boardDef
                     <span className="wc__parttb-note" title="Wire this servo's signal pin to a microcontroller GPIO to bind it to a joint">
                       ⚡ wire signal
                     </span>
-                  ) : joints.length === 0 ? (
+                  ) : selServoJointChoices.length === 0 ? (
                     <span className="wc__parttb-note" title="No joints yet — add them in the 3-D Robot View">
                       GP{selServoGpio} · no joints
                     </span>
@@ -1708,7 +1714,7 @@ export function WiringCanvas({ robot, onChange, joints = [], libraries, boardDef
                         onChange={(e) => setServoJoint(e.target.value)}
                       >
                         <option value="">GP{selServoGpio} → (none)</option>
-                        {joints.map((j) => (
+                        {selServoJointChoices.map((j) => (
                           <option key={j} value={j}>
                             {j}
                           </option>


### PR DESCRIPTION
## Servo "drives joint" picker works in the in-window board pane

**Symptom:** In the main window's breadboard view, clicking a servo showed `GP0 · no joints`, yet the URDF editor showed the same servo bound to a real joint (e.g. `base_joint`).

**Root cause:** `BoardGraph.joints` is optional and defaults to `[]`. The pop-out Board *window* (`board-main.tsx`) loads the linked URDF's joint names and passes them in — but the in-window **`BoardPane`** never did. So its picker's joint list was *always* empty → "no joints", regardless of the rig. (The GPIO shown, e.g. `GP0`, comes purely from the wiring via `servoBoardGpio` — the Python `PWM(Pin(0))` is not parsed for this.)

### Fix
- **`BoardPane`** now reads the `robot.yml`-linked `.urdf`'s joints (`jointNames`) and passes them to `BoardGraph`, reloading on `robot:onChanged` — mirroring the pop-out window. Bind a servo to a joint from either place now.
- **`WiringCanvas`** picker keeps showing a servo's *current* joint even if that joint is an **orphan** (renamed/removed from the URDF) instead of silently blanking — consistent with the URDF editor's servo list, so the two views no longer disagree.

### Verification
- `typecheck` · `lint` · `test` (1674) · `build` all green.
- Traced against a real project (`buddyjr`): `robot.yml` links `urdf: robot.urdf`, whose joints (`base_joint`, `shoulder_joint_2`, `arm_joint`, `camera_joint`) all match the `servoJointMap` — so the pane will now list them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
