### PR TITLE
fix: fainter blueprint breadboard grid (#452)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   **Code · Robot** — the Board and Data Lab entries are hidden (the Board View is still reachable via
   its pop-out window and the Robot workspace; deeper cleanup tracked in #447). The blueprint
   breadboard's graph-paper grid lines are a touch softer so they read as a backdrop.
+- **Fainter blueprint grid (#452).** The blueprint breadboard's graph-paper lines are now ~50%
+  more transparent again, so they sit further back as a subtle backdrop behind the parts.
 - **Robot View — joints are first-class in the Build hierarchy.** Each connecting joint now has its
   own row directly above the link it drives, showing a **type glyph** (a lock for fixed, a rotation
   arrow for a hinge, a spoked wheel for continuous, a slider for prismatic), the **joint name** (so

--- a/src/renderer/src/components/WiringCanvas.css
+++ b/src/renderer/src/components/WiringCanvas.css
@@ -62,8 +62,9 @@
 }
 :root[data-breadboard-bg='blueprint'] .wc--lifelike .wc__grid {
   stroke: #d6e6ff;
-  /* A touch softer so the graph-paper grid reads as a backdrop, not foreground. */
-  stroke-opacity: 0.5;
+  /* A whisper so the graph-paper grid reads as a faint backdrop, not foreground
+     (#452 — ~50% softer again than the previous 0.5). */
+  stroke-opacity: 0.25;
 }
 /* Blueprint only: warp the grid with the paper fibre so the lines aren't
    machine-perfect — a subtle ink-on-paper wobble that scales with the grid. */


### PR DESCRIPTION
## Fainter blueprint grid (#452)

The blueprint breadboard's graph-paper grid lines were still reading a bit forward. This drops their `stroke-opacity` from **0.5 → 0.25** (~50% more transparent), so they sit back as a subtle backdrop behind the parts.

One-line CSS change on `.wc__grid` under the blueprint mat; build green.

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)