### PR TITLE
feat: Servo driver accepts a PWM (not just a pin)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Add Joint tool stays, now purely for geometry (where parts meet + orientation).
 
 ### Changed
+- **`Servo` accepts a PWM you made yourself.** The bundled SG90 driver's `Servo(...)` now takes a
+  GPIO number, a `Pin`, **or** an already-made `PWM` — so `base_pwm = PWM(Pin(0)); base = Servo(base_pwm)`
+  works and the code reads `pin → PWM → Servo → joint`, mirroring how a servo connects to the model.
+  A bare pin is still wrapped for you; a PWM is used (and shared) as-is.
 - **Exported motion is plain-MicroPython pin → variable setup.** The Robot View's exported motion
   code now sets each servo up as a pure `<joint>_servo = PWM(Pin(n))` followed by
   `<joint> = Servo(<joint>_servo, pin=n)` — servos are named by the joint they drive, so the code

--- a/examples/parts/snakie-standard/sg90/servo.py
+++ b/examples/parts/snakie-standard/sg90/servo.py
@@ -9,6 +9,13 @@ angle + pulse limits, blocking `sweep`, and eased motion (`ease`).
     s.sweep(0, 180)        # go end to end
     s.ease(0, 600)         # smooth glide to 0 over 600 ms
     s.detach()             # release (stop holding torque)
+
+You can also hand it a PWM you made yourself, so the wiring reads
+pin -> PWM -> Servo -> (joint in the model):
+
+    from machine import Pin, PWM
+    base_pwm = PWM(Pin(0))     # the GP0 signal
+    base = Servo(base_pwm)     # give the servo that PWM
 """
 
 from machine import Pin, PWM
@@ -21,7 +28,16 @@ def _clamp(n, lo, hi):
 
 class Servo:
     def __init__(self, pin, freq=50, min_us=500, max_us=2500, min_angle=0, max_angle=180):
-        self._pwm = PWM(Pin(pin))
+        # `pin` may be a GPIO number, a machine.Pin, OR an already-made machine.PWM
+        # — so `Servo(16)`, `Servo(Pin(16))` and `Servo(PWM(Pin(16)))` all work. This
+        # lets the code read pin -> PWM -> Servo -> joint: you make the PWM, then pass
+        # it in. A bare pin is wrapped for you; a PWM is used (and shared) as-is.
+        if isinstance(pin, PWM):
+            self._pwm = pin
+        elif isinstance(pin, Pin):
+            self._pwm = PWM(pin)
+        else:
+            self._pwm = PWM(Pin(pin))
         self._pwm.freq(freq)
         self._period_us = 1_000_000 // freq  # 20000 us @ 50 Hz
         self.min_us = min_us

--- a/python/tests/test_servo_driver.py
+++ b/python/tests/test_servo_driver.py
@@ -1,0 +1,97 @@
+"""Unit tests for the bundled SG90 driver ``examples/.../sg90/servo.py``.
+
+The driver is MicroPython (it ``from machine import Pin, PWM``), but it's pure
+Python logic, so we inject a tiny fake ``machine`` module and load it by file
+path (mirroring ``test_instruments.py``) to run it under CPython.
+
+The key behaviour under test: ``Servo`` accepts a GPIO number, a ``Pin`` OR an
+already-made ``PWM``, so ``base = Servo(PWM(Pin(0)))`` reads pin -> PWM -> Servo.
+
+Run from the repo root::
+
+    PYTHONPATH=python python3 -m unittest discover -s python/tests
+"""
+
+import importlib.util
+import os
+import sys
+import types
+import unittest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_DRIVER = os.path.join(
+    _REPO_ROOT, "examples", "parts", "snakie-standard", "sg90", "servo.py"
+)
+
+
+class _Pin:
+    def __init__(self, n):
+        self.n = n
+
+
+class _PWM:
+    def __init__(self, pin):
+        self.pin = pin
+        self.freq_hz = None
+        self.duty = None
+
+    def freq(self, f):
+        self.freq_hz = f
+
+    def duty_u16(self, d):
+        self.duty = d
+
+    def deinit(self):
+        pass
+
+
+def _load_servo():
+    """Load servo.py fresh with a fake ``machine`` module in place."""
+    machine = types.ModuleType("machine")
+    machine.Pin = _Pin
+    machine.PWM = _PWM
+    saved = sys.modules.get("machine")
+    sys.modules["machine"] = machine
+    try:
+        spec = importlib.util.spec_from_file_location("servo_under_test", _DRIVER)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        if saved is not None:
+            sys.modules["machine"] = saved
+        else:
+            del sys.modules["machine"]
+
+
+class ServoConstructionTests(unittest.TestCase):
+    def setUp(self):
+        self.servo = _load_servo()
+
+    def test_accepts_bare_pin_number(self):
+        s = self.servo.Servo(16)
+        self.assertIsInstance(s._pwm, _PWM)
+        self.assertEqual(s._pwm.pin.n, 16)
+        self.assertEqual(s._pwm.freq_hz, 50)  # 50 Hz servo timing set
+
+    def test_accepts_a_pin_object(self):
+        s = self.servo.Servo(_Pin(5))
+        self.assertIsInstance(s._pwm, _PWM)
+        self.assertEqual(s._pwm.pin.n, 5)
+
+    def test_accepts_an_existing_pwm_used_as_is(self):
+        my_pwm = _PWM(_Pin(0))
+        s = self.servo.Servo(my_pwm)
+        self.assertIs(s._pwm, my_pwm)  # the SAME PWM, not a fresh one
+        self.assertEqual(s._pwm.freq_hz, 50)
+
+    def test_drives_the_given_pwm(self):
+        my_pwm = _PWM(_Pin(0))
+        s = self.servo.Servo(my_pwm)
+        s.angle(90)
+        self.assertIsNotNone(my_pwm.duty)  # angle() wrote to the shared PWM
+        self.assertEqual(s.angle(), 90)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## `Servo` accepts a PWM you made yourself

The bundled SG90 driver (`servo.py`) built its own PWM: `self._pwm = PWM(Pin(pin))`. So a natural, conceptual usage —

```python
base_pwm = PWM(Pin(0))     # the GP0 signal
base = Servo(base_pwm)     # give the servo that PWM
```

— **crashed**, because `Pin()` can't take a `PWM`. (This is exactly what the `buddyjr` project's `buddy_jr.py` does.)

### Fix
`Servo.__init__` now accepts a **GPIO number, a `Pin`, or an already-made `PWM`**:
- a `PWM` → used (and shared) as-is,
- a `Pin` → wrapped in `PWM(pin)`,
- an `int` → wrapped in `PWM(Pin(pin))` (unchanged).

So the code reads `pin → PWM → Servo → joint`, mirroring how a servo actually connects to the model — which was the point of keeping the pin assignment explicit.

### Verification
- New `python/tests/test_servo_driver.py` loads the driver with a fake `machine` module and covers int / `Pin` / `PWM` construction (+ that the *given* PWM is the one driven). Full Python suite: **205 passing**.
- The two installed userData copies (dev `Electron` + packaged `Snakie`) were confirmed stock and synced with this fix, so the running app picks it up.

> Note: `servo.py` is MicroPython — it runs on the board **and** in Snakie's wasm simulator (both have `machine`); only the CPython unittest needs the mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)