### PR TITLE
feat: Pose instrument drives the 3-D model live + eases pose changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 - **Poses instrument — a live servo test bench.** A new dock instrument reads your rig's
-  servo↔joint map and saved poses from `robot.yml` and gives two quick ways to drive the real
-  hardware while a program runs: **pose buttons** snap every bound servo into a saved pose (applying
-  each servo's calibration), and **per-servo sliders** nudge one servo by hand. Both send a single
-  `SNKCMD servos …` line, so a slider here also moves the on-screen 3-D model. It lights up
-  automatically once a servo is bound, reloads when you bind a servo or save a pose in either editor,
-  and guides you when nothing is bound yet.
+  servo↔joint map and saved poses from `robot.yml` and gives two quick ways to move the servos:
+  **pose buttons** glide every bound servo smoothly into a saved pose (eased, applying each servo's
+  calibration), and **per-servo sliders** nudge one servo by hand. Both drive the on-screen 3-D
+  model **live with no program running** (via an in-app servo-drive channel) *and* stream a
+  `SNKCMD servos …` line to the board, so a running program follows too. It lights up automatically
+  once a servo is bound, reloads when you bind a servo or save a pose in either editor, and guides
+  you when nothing is bound yet.
 - **Bind a servo to a 3-D joint — from either view.** Wire a **servo** on the breadboard and choose
   which URDF **joint** it moves; a running program's servo writes then drive the matching joint in
   the 3-D Robot View live. Bind it two ways: from the **Board View** (a servo's inspector gains a

--- a/src/renderer/src/components/PoseInstrument.tsx
+++ b/src/renderer/src/components/PoseInstrument.tsx
@@ -4,7 +4,9 @@ import { InstrumentWindow, type FloatProps } from './InstrumentWindow'
 import { type InstrumentDef } from './instruments-registry'
 import { useWorkspaceOptional } from '../store/workspace'
 import { buildServosPayload } from '../../../shared/control'
-import { poseServoAngles } from './servo-bind'
+import { ease } from '../../../shared/robot-timeline'
+import { poseServoAngles, tweenServoAngles } from './servo-bind'
+import { emitServoDrive } from './servo-drive-bus'
 import { normPin } from './robot-pose'
 import type { NamedPose, ServoJointBinding } from '../../../shared/robot'
 import './PoseInstrument.css'
@@ -42,6 +44,8 @@ export interface PoseInstrumentProps {
 const SERVOS_TARGET = 'servos'
 /** Neutral servo angle for a freshly-loaded slider. */
 const NEUTRAL_DEG = 90
+/** How long a pose-button press takes to glide every servo into place. */
+const POSE_TWEEN_MS = 450
 
 function clampDeg(n: number): number {
   return !Number.isFinite(n) ? NEUTRAL_DEG : n < 0 ? 0 : n > 180 ? 180 : Math.round(n)
@@ -63,7 +67,11 @@ export function PoseInstrument({
   const [poses, setPoses] = useState<NamedPose[]>([])
   // Commanded angle per NUMERIC pin (optimistic) — keys match buildServosPayload.
   const [angles, setAngles] = useState<Record<string, number>>({})
+  // A ref mirror so a pose tween reads the LATEST angles at click time.
+  const anglesRef = useRef(angles)
+  anglesRef.current = angles
   const lastSent = useRef(0)
+  const tweenRef = useRef<number | null>(null)
 
   // Load the rig's servo map + poses, and follow live edits from the other views.
   useEffect(() => {
@@ -96,9 +104,14 @@ export function PoseInstrument({
     }
   }, [folder])
 
-  /** Fire a servos payload; throttle rapid streams (slider drags) like the servo panel. */
-  const send = useCallback((byPin: Record<string, number>, throttle = false): void => {
-    if (throttle) {
+  // Drive a servo batch: move the 3-D model live (board-free) via the drive bus
+  // AND — throttled while streaming — write the hardware control channel so a
+  // running program follows too. The model move is what makes a slider/pose
+  // press visible without a board (the previous version only wrote control that
+  // nothing consumed, so it looked dead).
+  const drive = useCallback((byPin: Record<string, number>, throttleHw = false): void => {
+    emitServoDrive(byPin)
+    if (throttleHw) {
       const now = Date.now()
       if (now - lastSent.current < 40) return
       lastSent.current = now
@@ -107,26 +120,47 @@ export function PoseInstrument({
     if (payload) void window.api.device.sendControl(SERVOS_TARGET, payload).catch(reporter('poses send'))
   }, [])
 
-  /** Jump every bound servo to a saved pose. */
+  const cancelTween = useCallback((): void => {
+    if (tweenRef.current !== null) {
+      cancelAnimationFrame(tweenRef.current)
+      tweenRef.current = null
+    }
+  }, [])
+
+  /** Glide every bound servo from where it is now into a saved pose (eased). */
   const recall = useCallback(
     (pose: NamedPose): void => {
-      const byPin = poseServoAngles(bindings, pose.values)
-      if (Object.keys(byPin).length === 0) return
-      setAngles((a) => ({ ...a, ...byPin }))
-      send(byPin)
+      const target = poseServoAngles(bindings, pose.values)
+      if (Object.keys(target).length === 0) return
+      cancelTween()
+      const from = { ...anglesRef.current }
+      let start: number | null = null
+      const step = (ts: number): void => {
+        if (start === null) start = ts
+        const u = Math.min(1, (ts - start) / POSE_TWEEN_MS)
+        const frame = tweenServoAngles(from, target, ease('easeInOut', u))
+        setAngles((a) => ({ ...a, ...frame }))
+        drive(frame, u < 1) // throttle the hardware mid-glide; final frame lands un-throttled
+        tweenRef.current = u < 1 ? requestAnimationFrame(step) : null
+      }
+      tweenRef.current = requestAnimationFrame(step)
     },
-    [bindings, send]
+    [bindings, drive, cancelTween]
   )
 
-  /** Nudge one servo live. */
+  /** Nudge one servo live (a manual grab cancels any in-flight pose glide). */
   const setServo = useCallback(
     (pin: string, deg: number, throttle = false): void => {
+      cancelTween()
       const d = clampDeg(deg)
       setAngles((a) => ({ ...a, [pin]: d }))
-      send({ [pin]: d }, throttle)
+      drive({ [pin]: d }, throttle)
     },
-    [send]
+    [drive, cancelTween]
   )
+
+  // Stop any running glide when the panel unmounts.
+  useEffect(() => cancelTween, [cancelTween])
 
   const hasServos = bindings.length > 0
   const source = hasServos

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -114,6 +114,7 @@ import {
 import { jointToServo } from '../../../shared/krf'
 import { buildServosPayload } from '../../../shared/control'
 import { bindableServos, bindServoJoint, type BindableServo } from './servo-bind'
+import { onServoDrive } from './servo-drive-bus'
 import type { PartLibraryWithParts } from '../../../preload/index.d'
 import { useTelemetryStream } from './instrument-telemetry-subscribe'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
@@ -1323,6 +1324,26 @@ export function RobotView({
     poseLiveTimer.current = setTimeout(() => setPoseLive(false), 1200)
   })
   useEffect(() => () => void (poseLiveTimer.current && clearTimeout(poseLiveTimer.current)), [])
+
+  // A dock instrument (the Pose bench) can drive the model directly — no running
+  // program needed. It emits pin→angle batches on the in-renderer servo-drive bus;
+  // apply each the same way as `SNK SERVO` telemetry so sliders/pose presses move
+  // the 3-D model live (the instrument also streams to hardware separately).
+  useEffect(
+    () =>
+      onServoDrive((byPin) => {
+        if (!robotRef.current) return
+        const updates: Record<string, number> = {}
+        for (const [pin, angle] of Object.entries(byPin)) {
+          const res = servoToJointNative(bindingsRef.current, metaRef.current, pin, angle)
+          if (!res) continue
+          robotRef.current.setJointValue(res.joint, res.native)
+          updates[res.joint] = res.native
+        }
+        if (Object.keys(updates).length > 0) setValues((v) => ({ ...v, ...updates }))
+      }),
+    []
+  )
 
   // Round-trip managed Motion Studio blocks (#413): when the user focuses a local
   // .py carrying Snakie-managed blocks in the full Robot View, read its pose

--- a/src/renderer/src/components/help/inst-poses.md
+++ b/src/renderer/src/components/help/inst-poses.md
@@ -1,7 +1,7 @@
-A live **test bench** for your robot's servos — press a saved **pose** to snap every bound servo into place, or drag a **per-servo slider** to nudge one by hand, all while a program is running.
+A live **test bench** for your robot's servos — press a saved **pose** to glide every bound servo into place, or drag a **per-servo slider** to nudge one by hand. It works with or without a board.
 
 ## What it does
-It reads your project's `robot.yml` — the **servo ↔ joint map** and your **saved poses** — and drives the real hardware over the control channel. A pose button (or a slider) writes one `SNKCMD servos "<pin>:<deg> …"` line via `sendControl('servos', …)`, the multi-servo payload the on-device `servos_command` receiver understands. Because it uses the same servo-map spine as the 3-D view, moving a slider here also moves the on-screen model.
+It reads your project's `robot.yml` — the **servo ↔ joint map** and your **saved poses** — and drives both the **on-screen 3-D model** (instantly, no program required) and the **real hardware**. A pose button (or a slider) moves the model live *and* writes one `SNKCMD servos "<pin>:<deg> …"` line via `sendControl('servos', …)` — the multi-servo payload the on-device `servos_command` receiver understands — so a running program follows too. Pose presses **ease** smoothly from the current position to the target.
 
 ## How to use it
 1. In the **Board View**, wire a servo's signal to a GPIO; in the **Robot View**, bind that servo to a joint (and calibrate its range). The servo then appears here with a slider.

--- a/src/renderer/src/components/servo-bind.ts
+++ b/src/renderer/src/components/servo-bind.ts
@@ -122,3 +122,23 @@ export function poseServoAngles(
   }
   return byPin
 }
+
+/**
+ * One frame of a pin→angle tween at progress `t` (0..1, already eased): each pin
+ * in `to` is lerped from its `from` angle (or, if `from` doesn't have it, held at
+ * the target so it doesn't jump from 0) and rounded to a whole servo degree. Pins
+ * only in `from` are dropped — the tween moves exactly the target set. Pure, so
+ * the live Pose instrument can smoothly glide between poses (#).
+ */
+export function tweenServoAngles(
+  from: Record<string, number>,
+  to: Record<string, number>,
+  t: number
+): Record<string, number> {
+  const out: Record<string, number> = {}
+  for (const [pin, target] of Object.entries(to)) {
+    const start = typeof from[pin] === 'number' ? from[pin] : target
+    out[pin] = Math.round(start + (target - start) * t)
+  }
+  return out
+}

--- a/src/renderer/src/components/servo-drive-bus.ts
+++ b/src/renderer/src/components/servo-drive-bus.ts
@@ -1,0 +1,43 @@
+/**
+ * SERVO-DRIVE BUS (#) — a tiny in-renderer channel that lets a dock instrument
+ * drive the live 3-D model directly, without a running program.
+ * =============================================================================
+ *
+ * The Pose / Servo instruments WRITE hardware control (`SNKCMD servos …`), but
+ * that only moves anything once a program on the board polls the control channel.
+ * With no program running, moving a slider or clicking a pose does nothing
+ * visible. This bus closes that gap: an instrument also `emitServoDrive({pin: deg})`,
+ * and the Robot View subscribes (`onServoDrive`) and applies each pin→joint the
+ * same way it applies live `SNK SERVO` telemetry — so the model moves immediately,
+ * board-free, alongside the hardware send.
+ *
+ * It's a module-singleton listener set (no DOM events), so it's dependency-free
+ * and unit-testable. It only reaches within ONE renderer window: a docked
+ * instrument and the Robot View share it; a popped-out instrument window (a
+ * separate realm) falls back to the hardware send. Keys are NUMERIC pins (e.g.
+ * "16"), values whole servo degrees (0–180) — the shape `buildServosPayload` and
+ * `servoToJointNative` both take.
+ */
+
+/** A batch of servo commands: numeric-pin → servo angle (degrees). */
+export type ServoDriveMap = Record<string, number>
+
+type Listener = (byPin: ServoDriveMap) => void
+
+const listeners = new Set<Listener>()
+
+/** Push a servo-drive batch to every subscriber (Robot View). No-op when empty. */
+export function emitServoDrive(byPin: ServoDriveMap): void {
+  if (!byPin || Object.keys(byPin).length === 0) return
+  // Copy so a subscriber can't mutate the caller's object mid-iteration.
+  const snapshot = { ...byPin }
+  for (const l of [...listeners]) l(snapshot)
+}
+
+/** Subscribe to servo-drive batches. Returns an unsubscribe. */
+export function onServoDrive(cb: Listener): () => void {
+  listeners.add(cb)
+  return () => {
+    listeners.delete(cb)
+  }
+}

--- a/test/servoBind.test.ts
+++ b/test/servoBind.test.ts
@@ -6,7 +6,8 @@ import {
   boundJoint,
   bindServoJoint,
   bindableServos,
-  poseServoAngles
+  poseServoAngles,
+  tweenServoAngles
 } from '../src/renderer/src/components/servo-bind'
 import type { PartDefinition } from '../src/shared/part'
 import type { RobotConnection, RobotPart, ServoJointBinding } from '../src/shared/robot'
@@ -126,5 +127,25 @@ describe('poseServoAngles (#)', () => {
     expect(poseServoAngles([], { base: 90 })).toEqual({})
     expect(poseServoAngles(bindings, undefined)).toEqual({})
     expect(poseServoAngles(undefined, undefined)).toEqual({})
+  })
+})
+
+describe('tweenServoAngles (#)', () => {
+  it('lerps each target pin from its start angle, rounding to whole degrees', () => {
+    const from = { '16': 0, '17': 180 }
+    const to = { '16': 100, '17': 80 }
+    expect(tweenServoAngles(from, to, 0)).toEqual({ '16': 0, '17': 180 })
+    expect(tweenServoAngles(from, to, 1)).toEqual({ '16': 100, '17': 80 })
+    expect(tweenServoAngles(from, to, 0.5)).toEqual({ '16': 50, '17': 130 })
+  })
+
+  it('only moves the target set (pins only in `from` are dropped)', () => {
+    expect(tweenServoAngles({ '16': 0, '99': 10 }, { '16': 90 }, 1)).toEqual({ '16': 90 })
+  })
+
+  it('holds a pin at its target when `from` lacks it (no jump from 0)', () => {
+    // GP17 has no prior angle → it should sit at the target the whole tween, not sweep up from 0.
+    expect(tweenServoAngles({ '16': 0 }, { '16': 90, '17': 45 }, 0)).toEqual({ '16': 0, '17': 45 })
+    expect(tweenServoAngles({ '16': 0 }, { '16': 90, '17': 45 }, 0.5)).toEqual({ '16': 45, '17': 45 })
   })
 })

--- a/test/servoDriveBus.test.ts
+++ b/test/servoDriveBus.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest'
+import { emitServoDrive, onServoDrive } from '../src/renderer/src/components/servo-drive-bus'
+
+describe('servo-drive-bus (#)', () => {
+  it('delivers an emitted batch to every subscriber', () => {
+    const a = vi.fn()
+    const b = vi.fn()
+    const offA = onServoDrive(a)
+    const offB = onServoDrive(b)
+    emitServoDrive({ '16': 90, '17': 45 })
+    expect(a).toHaveBeenCalledWith({ '16': 90, '17': 45 })
+    expect(b).toHaveBeenCalledWith({ '16': 90, '17': 45 })
+    offA()
+    offB()
+  })
+
+  it('stops delivering after unsubscribe', () => {
+    const cb = vi.fn()
+    const off = onServoDrive(cb)
+    off()
+    emitServoDrive({ '0': 10 })
+    expect(cb).not.toHaveBeenCalled()
+  })
+
+  it('ignores an empty (or missing) batch', () => {
+    const cb = vi.fn()
+    const off = onServoDrive(cb)
+    emitServoDrive({})
+    expect(cb).not.toHaveBeenCalled()
+    off()
+  })
+
+  it('hands each subscriber a copy it cannot use to mutate the caller', () => {
+    const original = { '5': 120 }
+    let received: Record<string, number> | null = null
+    const off = onServoDrive((m) => {
+      received = m
+      m['5'] = 0 // mutating the delivered object must not touch the caller's
+    })
+    emitServoDrive(original)
+    expect(received).not.toBe(original)
+    expect(original['5']).toBe(120)
+    off()
+  })
+})


### PR DESCRIPTION
## Make the Pose bench actually move things

**Symptom:** moving the Pose instrument's sliders or clicking a pose button did nothing visible, and pose presses would have snapped instantly.

**Why:** the instrument only *wrote* hardware control (`SNKCMD servos …`). That value is inert until a program on the board polls the control channel — so with no program running (the common "I just want to test my poses" case), nothing happened. The instrument also had no handle on the 3-D model (that only moves from `SNK SERVO` telemetry).

### Fix
- **`servo-drive-bus.ts`** — a tiny in-renderer channel. An instrument `emitServoDrive({pin: deg})`; **RobotView** subscribes (`onServoDrive`) and applies each pin→joint exactly like live `SNK SERVO` telemetry. So the **3-D model moves live, board-free**.
- **`PoseInstrument`** now drives the model on every slider change / pose press **and** still streams `SNKCMD servos` to the board (throttled) for a running program.
- **Pose presses ease** (~450 ms `easeInOut`) from the current angles to the target via a `requestAnimationFrame` loop; grabbing a slider cancels an in-flight glide; the tween is cancelled on unmount.
- Pure **`tweenServoAngles`** helper (in `servo-bind.ts`) does the per-frame lerp.

> The bus is per-renderer-window: a **docked** instrument drives the model; a **popped-out** instrument window still drives hardware (separate realm).

### Verification
- `typecheck` · `lint` · `test` (**1681**, +7: tween + bus) · `build` all green.
- New tests: `tweenServoAngles` (endpoints, target-only set, no-jump when `from` lacks a pin) and `servo-drive-bus` (delivery, unsubscribe, empty no-op, copy-on-emit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)