### PR TITLE
feat: snakie — a friendly hardware module (from snakie import Servo)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **`snakie` — a friendly hardware module.** Board code can now `from snakie import Servo, Buzzer,
+  Led, Pin, PWM` — the *hardware* classes, under a clear, collision-proof name (a vendor `servo`
+  module, e.g. Pimoroni's frozen one, can't shadow it). It's a thin re-export of the on-device
+  runtime, so `snakie.Servo` *is* `instruments.Servo`; the measurement tools (scope/meter/plotter)
+  stay in `instruments`. Snakie installs `/lib/snakie.py` alongside `instruments.py` when you install
+  or update the board library, so `from snakie import …` just works.
 - **Poses instrument — a live servo test bench.** A new dock instrument reads your rig's
   servo↔joint map and saved poses from `robot.yml` and gives two quick ways to move the servos:
   **pose buttons** glide every bound servo smoothly into a saved pose (eased, applying each servo's

--- a/examples/buddyjr/pose_demo.py
+++ b/examples/buddyjr/pose_demo.py
@@ -1,0 +1,75 @@
+# Buddy Jr — pose player + a beep
+# =============================================================================
+# A quick demo that plays your saved poses and lets you play with the on-board
+# instruments. Everything hardware comes from Snakie's `snakie` module, so the
+# code reads pin -> PWM -> Servo, and there's no clash with a vendor `servo`
+# module (Pimoroni's frozen one, etc.).
+#
+# Because each Servo is made with `pin=`, it reports its angle to Snakie — so as
+# this runs you'll see the 3-D model move AND the Pose bench / Oscilloscope
+# instruments follow along live. The buzzer lights up the Buzzer panel.
+#
+# Run it, then open the instrument dock and watch.
+
+from snakie import Servo, Buzzer, Pin, PWM
+import time
+
+# --- Servos: signal wires on GP0..GP3 ---------------------------------------
+# Make each PWM yourself, then hand it to a Servo. `pin=n` tells Snakie which
+# GPIO it is, so the 3-D model + Pose bench mirror every move.
+servos = {
+    "base":     Servo(PWM(Pin(0)), pin=0),
+    "shoulder": Servo(PWM(Pin(1)), pin=1),
+    "arm":      Servo(PWM(Pin(2)), pin=2),
+    "camera":   Servo(PWM(Pin(3)), pin=3),
+}
+
+# --- Poses: servo angles (0..180) -------------------------------------------
+# Your Snakie poses, expressed as servo angles (centre = 90). Tweak to taste —
+# these are what actually gets sent to the servos.
+POSES = {
+    "start":        {"base": 90, "shoulder": 90,  "arm": 90, "camera": 90},
+    "duck":         {"base": 0,  "shoulder": 153, "arm": 32, "camera": 5},
+    "look_forward": {"base": 92, "shoulder": 121, "arm": 81, "camera": 24},
+    "look_down":    {"base": 75, "shoulder": 94,  "arm": 64, "camera": 152},
+}
+
+
+def glide(pose, ms=700, steps=35):
+    """Smoothly ease every servo to `pose` (a {name: angle} dict)."""
+    start = {name: s.angle_deg for name, s in servos.items()}
+    for k in range(steps + 1):
+        t = k / steps
+        e = t * t * (3 - 2 * t)  # smoothstep (ease in/out)
+        for name, s in servos.items():
+            target = pose.get(name, start[name])
+            s.angle(start[name] + (target - start[name]) * e)
+        time.sleep_ms(ms // steps)
+
+
+# --- A buzzer to play with (optional: piezo on GP5) --------------------------
+beeper = Buzzer(PWM(Pin(5)))
+
+
+def chirp(freq=880):
+    try:
+        beeper.tone(freq, 90)  # 90 ms blip
+    except Exception:
+        pass  # no buzzer wired? no problem
+
+
+# --- Run: tour the poses, chirp as each one lands ----------------------------
+tour = ["start", "duck", "look_forward", "look_down"]
+print("Buddy Jr pose demo — open the instrument dock and watch it follow along.")
+while True:
+    for name in tour:
+        print("pose:", name)
+        chirp()
+        glide(POSES[name])
+        time.sleep(1)
+
+# --- Tip -----------------------------------------------------------------------
+# The Pose bench instrument's sliders and pose buttons already drive the 3-D model
+# live on their own — you don't need a program running for that. This demo is the
+# other direction: your *code* driving the servos (and the model + panels follow).
+# Change the POSES angles, the tour order, or the glide time and re-run.

--- a/micropython/instruments.py
+++ b/micropython/instruments.py
@@ -113,7 +113,7 @@ except ImportError:  # pragma: no cover - CPython simulator has no `machine`
 # against the copy installed on the board and offers a one-click UPDATE when they
 # differ (a legacy copy with no __version__ reads as out-of-date). Keep the
 # `__version__ = "X.Y.Z"` literal form so the IDE can parse it without importing.
-__version__ = "0.9.1"
+__version__ = "0.9.2"
 
 # The sentinel that prefixes every telemetry line. Kept short + ASCII so it is
 # cheap to print and easy for the IDE to detect / strip.

--- a/micropython/snakie.py
+++ b/micropython/snakie.py
@@ -1,0 +1,23 @@
+"""snakie — the friendly hardware layer for Snakie sketches.
+
+Import the things you *drive* from here, so your code reads
+``pin -> PWM -> Servo -> joint`` and never clashes with a vendor ``servo``
+module (Pimoroni's frozen ``servo``, etc.)::
+
+    from snakie import Servo, Buzzer, Led, Pin, PWM
+
+    base = Servo(PWM(Pin(0)), pin=0)   # a servo on GP0; pin= drives the 3-D model
+    base.angle(90)
+
+These are re-exported from Snakie's on-device runtime (``instruments``), which
+keeps the *measurement* tools (scope / meter / plotter). Same classes, friendlier
+name — ``snakie.Servo`` *is* ``instruments.Servo``. Uploaded to ``/lib/snakie.py``
+alongside ``instruments.py`` by the Board View's library installer.
+"""
+
+# Re-export ONLY the hardware/actuator classes + raw IO — the "connect pins to
+# things" layer. Scopes/meters/plotters stay in `instruments` (they're not things
+# you wire up, they're how you observe the ones you do).
+from instruments import Servo, Buzzer, Led, Pin, PWM  # noqa: F401 - re-exported API
+
+__all__ = ["Servo", "Buzzer", "Led", "Pin", "PWM"]

--- a/python/tests/test_snakie_umbrella.py
+++ b/python/tests/test_snakie_umbrella.py
@@ -1,0 +1,67 @@
+"""Unit tests for the on-device ``snakie`` hardware umbrella.
+
+``micropython/snakie.py`` re-exports the *hardware* classes from ``instruments``
+so board code can ``from snakie import Servo, Buzzer, Led, Pin, PWM`` — a friendly,
+collision-proof name (a vendor ``servo`` module can't shadow it).
+
+NOTE: we load it by FILE PATH, not ``import snakie`` — under ``PYTHONPATH=python``
+a bare ``import snakie`` resolves to the HOST-side ``python/snakie`` package (the
+IDE SDK), which is a different thing in a different runtime. Both modules import
+cleanly under CPython (``instruments`` guards its ``machine`` import).
+
+Run from the repo root::
+
+    PYTHONPATH=python python3 -m unittest discover -s python/tests
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_MPY = os.path.join(_REPO_ROOT, "micropython")
+_HARDWARE = ("Servo", "Buzzer", "Led", "Pin", "PWM")
+
+
+def _load_by_path(modname, filename):
+    spec = importlib.util.spec_from_file_location(modname, os.path.join(_MPY, filename))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[modname] = mod  # so `from instruments import …` inside snakie.py resolves
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class SnakieUmbrellaTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Register the DEVICE instruments under the name snakie.py imports, then
+        # load the umbrella by path (avoids the host `python/snakie` collision).
+        cls.instruments = _load_by_path("instruments", "instruments.py")
+        cls.snakie = _load_by_path("snakie_umbrella_under_test", "snakie.py")
+
+    def test_reexports_hardware_as_the_same_objects(self):
+        for name in _HARDWARE:
+            self.assertIs(
+                getattr(self.snakie, name),
+                getattr(self.instruments, name),
+                "snakie.%s should be the same object as instruments.%s" % (name, name),
+            )
+
+    def test_all_lists_exactly_the_hardware_classes(self):
+        self.assertEqual(set(self.snakie.__all__), set(_HARDWARE))
+
+    def test_measurement_tools_stay_in_instruments(self):
+        # Scopes/meters/plotters are NOT re-exported — they're how you observe the
+        # hardware, not hardware you wire up.
+        self.assertFalse(hasattr(self.snakie, "scope"))
+        self.assertFalse(hasattr(self.snakie, "meter"))
+
+    def test_servo_still_accepts_a_pwm_through_the_umbrella(self):
+        pwm = self.snakie.PWM(self.snakie.Pin(0))
+        s = self.snakie.Servo(pwm, pin=0)
+        self.assertIs(s._pwm, pwm)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -60,6 +60,26 @@ function readInstrumentsLibrarySource(): string {
   }
 }
 
+/**
+ * The bundled `snakie.py` hardware umbrella — the friendly re-export of the
+ * instrument runtime's hardware classes (`from snakie import Servo, …`). Resolved
+ * like {@link readInstrumentsLibrarySource}; installed to `/lib/snakie.py`
+ * alongside `instruments.py` so a vendor `servo` module can't shadow ours.
+ */
+function readSnakieUmbrellaSource(): string {
+  const packaged = join(process.resourcesPath, 'micropython', 'snakie.py')
+  const path =
+    app.isPackaged && existsSync(packaged)
+      ? packaged
+      : join(__dirname, '..', '..', 'micropython', 'snakie.py')
+  try {
+    return readFileSync(path, 'utf-8')
+  } catch (err) {
+    console.error('[snakie] could not read the bundled umbrella at', path, err)
+    return ''
+  }
+}
+
 function createWindow(): void {
   // Create the browser window with secure defaults.
   const window = new BrowserWindow({
@@ -143,6 +163,7 @@ app.whenReady().then(() => {
   // (issue #107). Reads from resources when packaged, the repo in dev; never
   // throws (returns '' on failure — the renderer treats that as "unavailable").
   ipcMain.handle('instruments:librarySource', () => readInstrumentsLibrarySource())
+  ipcMain.handle('instruments:umbrellaSource', () => readSnakieUmbrellaSource())
 
   // Open an external URL in the user's default browser (used by clickable
   // plugin status-bar links). Only http(s) URLs are honoured.

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -799,6 +799,9 @@ const instruments = {
    * treats as "unavailable".
    */
   librarySource: (): Promise<string> => ipcRenderer.invoke('instruments:librarySource'),
+  /** The bundled `snakie.py` hardware-umbrella source, installed to `/lib/snakie.py`
+   *  alongside `instruments.py` so `from snakie import Servo, …` works on the board. */
+  umbrellaSource: (): Promise<string> => ipcRenderer.invoke('instruments:umbrellaSource'),
 
   // --- Detached instrument OS windows (#205) ---
   /** Open (or focus) a true OS window rendering one undocked instrument. */

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -60,6 +60,8 @@ import {
   INSTRUMENTS_LIB_PATH,
   INSTRUMENTS_ROOT_PATH,
   INSTRUMENTS_LIB_DIR,
+  SNAKIE_LIB_PATH,
+  SNAKIE_ROOT_PATH,
   classifyPresentCopy,
   parseLibVersion,
   shouldShowBanner,
@@ -647,6 +649,14 @@ export function AppShell(): JSX.Element {
           .catch(() => false)
         if (rootShadow) {
           await window.api.device.writeFile(INSTRUMENTS_ROOT_PATH, source)
+        }
+        // Install the `snakie.py` hardware umbrella beside it (best-effort — an
+        // older bundle without it just skips this), so `from snakie import Servo`
+        // works and a vendor `servo` module can't shadow ours.
+        const umbrella = await window.api.instruments.umbrellaSource().catch(() => '')
+        if (umbrella) {
+          await window.api.device.writeFile(SNAKIE_LIB_PATH, umbrella)
+          if (rootShadow) await window.api.device.writeFile(SNAKIE_ROOT_PATH, umbrella)
         }
         setLibState('present')
         // The device's files changed — tell every window so e.g. the Device

--- a/src/renderer/src/lib/instrumentsLib.ts
+++ b/src/renderer/src/lib/instrumentsLib.ts
@@ -26,6 +26,14 @@ export const INSTRUMENTS_ROOT_PATH = '/instruments.py'
 export const INSTRUMENTS_LIB_DIR = '/lib'
 
 /**
+ * The `snakie.py` hardware umbrella is installed beside `instruments.py` (it
+ * re-exports its hardware classes), so `from snakie import Servo, …` resolves on
+ * the board and can't be shadowed by a vendor `servo` module.
+ */
+export const SNAKIE_LIB_PATH = '/lib/snakie.py'
+export const SNAKIE_ROOT_PATH = '/snakie.py'
+
+/**
  * Install detection, cached per connection so we don't re-poll the raw REPL on
  * every dock open:
  *  - `'unknown'`   — not probed yet (or reset on disconnect); a probe is due.


### PR DESCRIPTION
## `from snakie import Servo`

Adds a small on-device module, **`snakie`**, that re-exports the **hardware** classes so board code reads cleanly and can't be shadowed by a vendor `servo` module (the Pimoroni frozen-`servo` collision that caused `can't convert PWM to int`):

```python
from snakie import Servo, Buzzer, Led, Pin, PWM

base = Servo(PWM(Pin(0)), pin=0)   # pin -> PWM -> Servo, and the 3-D model follows
base.angle(90)
```

- **Just the hardware classes** — `Servo`, `Buzzer`, `Led`, `Pin`, `PWM`. The *measurement* tools (scope / meter / plotter) stay in `instruments`, since they're how you *observe* hardware, not hardware you wire up. `snakie.Servo` **is** `instruments.Servo` (a thin re-export, single source of truth).
- **Auto-installed.** `micropython/snakie.py` is written to `/lib/snakie.py` alongside `instruments.py` by the Board View's library installer (new `instruments:umbrellaSource` IPC). `instruments.__version__` bumped `0.9.1 → 0.9.2` so existing boards show the "library outdated" banner and pick it up on update.
- **Demo:** `examples/buddyjr/pose_demo.py` — a runnable pose player using `from snakie import …` that tours the poses, eases between them, chirps a buzzer, and drives the 3-D model + Pose bench live.

### Note surfaced by this work
The test loads the module **by file path**, because under `PYTHONPATH=python` a bare `import snakie` resolves to the **host-side** `python/snakie` SDK package — the exact device/host name overlap I flagged. It's harmless at runtime (different runtimes) but worth knowing.

### Verification
- `typecheck` · `lint` · `test` (1681 JS) · **209 Python** (+4) · `build` all green.
- Test asserts the re-exports are the *same objects*, `__all__` is exactly the hardware set, measurement tools are absent, and `Servo` still accepts a `PWM` through the umbrella.

### Follow-up (not in this PR)
Flip the motion **codegen** from `from instruments import Servo` to `from snakie import Servo` — needs the export e2e test to also seed `/lib/snakie.py`. Generated code already works (it uses `instruments`, which is collision-proof), so this is cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)