### PR TITLE
fix: seed a new servo binding's joint range from the joint's limits (#459)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **Binding a servo now takes the joint's real range, so the 3-D model doesn't clamp (#459).**
+  A new servo↔joint binding used to default the joint range to a flat `0…180`, ignoring the
+  joint's actual limits. On a joint limited to, say, `±90°` that made the on-screen model **stop
+  halfway** — the physical servo swept fully but the 3-D joint hit its limit and clamped for half
+  the travel. New bindings now seed the joint range from the joint's URDF `<limit>` (degrees for a
+  rotating joint, mm for a sliding one) in **both** the Board View and Robot View pickers. Existing
+  bindings are unchanged; fix one by setting its **Joint range** in the servo dialog.
+
 ## [0.25.0] - 2026-07-11
 
 ### Added

--- a/src/renderer/src/board-main.tsx
+++ b/src/renderer/src/board-main.tsx
@@ -32,7 +32,7 @@ import { PartEditor } from './components/PartEditor'
 import { blankRobot, type RobotDefinition } from '../../shared/robot'
 import { readRobotModel } from '../../shared/krf'
 import { attachPartMesh } from './components/robot-part-mesh'
-import { jointNames } from './components/robot-assembly'
+import { jointNames, jointDisplayLimits } from './components/robot-assembly'
 import type {
   BoardDefinition,
   BoardSourcePayload,
@@ -217,20 +217,29 @@ function BoardWindowApp(): JSX.Element {
   // The URDF's joint names — read the linked `.urdf` so a servo's inspector can
   // offer a "drives joint" picker (#). Empty when there's no URDF / no folder yet.
   const [joints, setJoints] = useState<string[]>([])
+  // Each joint's real travel (deg / mm) — seeds a new binding's joint range so the
+  // 3-D model doesn't clamp (a flat 0…180 default did).
+  const [jointLimits, setJointLimits] = useState<Record<string, { min: number; max: number }>>({})
   const urdfPath = robot.robot?.urdf
   useEffect(() => {
     if (!folder || !urdfPath) {
       setJoints([])
+      setJointLimits({})
       return
     }
     let live = true
     window.api.fs
       .readFile(`${folder}/${urdfPath}`)
       .then((content) => {
-        if (live) setJoints(jointNames(content))
+        if (!live) return
+        setJoints(jointNames(content))
+        setJointLimits(jointDisplayLimits(content))
       })
       .catch(() => {
-        if (live) setJoints([])
+        if (live) {
+          setJoints([])
+          setJointLimits({})
+        }
       })
     return () => {
       live = false
@@ -322,6 +331,7 @@ function BoardWindowApp(): JSX.Element {
         robot={robot}
         onChangeRobot={saveRobot}
         joints={joints}
+        jointLimits={jointLimits}
         libraries={libraries}
         onAddToProject={addToProject}
       />

--- a/src/renderer/src/components/BoardGraph.tsx
+++ b/src/renderer/src/components/BoardGraph.tsx
@@ -114,6 +114,8 @@ export interface BoardGraphProps {
   onChangeRobot?: (next: RobotDefinition) => void
   /** The linked URDF's joint names — for a servo's "drives joint" picker (#). */
   joints?: string[]
+  /** Each joint's real travel (deg / mm) — seeds a new binding's joint range (#). */
+  jointLimits?: Record<string, { min: number; max: number }>
   /** Installed part libraries (to resolve placed parts' pins). */
   libraries?: PartLibraryWithParts[]
   /** Append a library part to the project. When set, the library dock shows. `pos`
@@ -319,6 +321,7 @@ export function BoardGraph({
   robot,
   onChangeRobot,
   joints,
+  jointLimits,
   libraries,
   onAddToProject
 }: BoardGraphProps): JSX.Element {
@@ -883,6 +886,7 @@ export function BoardGraph({
               robot={robot as RobotDefinition}
               onChange={onChangeRobot as (next: RobotDefinition) => void}
               joints={joints ?? []}
+              jointLimits={jointLimits ?? {}}
               libraries={libraries ?? []}
               usedByCode={usedByCode}
               onDropPart={onAddToProject ? handleAddToProject : undefined}

--- a/src/renderer/src/components/BoardPane.tsx
+++ b/src/renderer/src/components/BoardPane.tsx
@@ -4,7 +4,7 @@ import { PartEditor } from './PartEditor'
 import { OPEN_PART_EDITOR_EVENT, PARTS_CHANGED_EVENT, type OpenPartEditorDetail } from './PartsPanel'
 import { blankRobot, type RobotDefinition } from '../../../shared/robot'
 import { readRobotModel } from '../../../shared/krf'
-import { jointNames } from './robot-assembly'
+import { jointNames, jointDisplayLimits } from './robot-assembly'
 import { attachPartMesh } from './robot-part-mesh'
 import { useWorkspace } from '../store/workspace'
 import { useEditorSettings } from '../store/settings'
@@ -110,20 +110,29 @@ export function BoardPane(): JSX.Element {
   // no URDF link / folder yet (then the picker shows "no joints"). Without this
   // the in-window board pane ALWAYS showed "no joints", even with a linked rig.
   const [joints, setJoints] = useState<string[]>([])
+  // Each joint's real travel (deg / mm) — seeds a new binding's joint range so the
+  // 3-D model doesn't clamp (a flat 0…180 default did).
+  const [jointLimits, setJointLimits] = useState<Record<string, { min: number; max: number }>>({})
   const urdfPath = robot.robot?.urdf
   useEffect(() => {
     if (!folder || !urdfPath) {
       setJoints([])
+      setJointLimits({})
       return
     }
     let live = true
     window.api.fs
       .readFile(`${folder}/${urdfPath}`)
       .then((content) => {
-        if (live) setJoints(jointNames(content))
+        if (!live) return
+        setJoints(jointNames(content))
+        setJointLimits(jointDisplayLimits(content))
       })
       .catch(() => {
-        if (live) setJoints([])
+        if (live) {
+          setJoints([])
+          setJointLimits({})
+        }
       })
     return () => {
       live = false
@@ -243,6 +252,7 @@ export function BoardPane(): JSX.Element {
         onChangeRobot={saveRobot}
         libraries={libraries}
         joints={joints}
+        jointLimits={jointLimits}
         onAddToProject={addToProject}
       />
       {editing && (

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -30,6 +30,7 @@ import {
   externalMeshes,
   rewriteMeshFilename,
   jointNames,
+  jointDisplayLimits,
   looseLinks,
   parseAssembly,
   readAllJoints,
@@ -570,6 +571,9 @@ export function RobotView({
     [content, editLink]
   )
   const allJointNames = useMemo(() => jointNames(content), [content])
+  // Each joint's real travel (deg / mm), to seed a new servo binding's joint range
+  // from the joint's limits instead of a flat 0…180 (which clamped the 3-D model).
+  const jointLimits = useMemo(() => jointDisplayLimits(content), [content])
   // The edited link's colour + the palette of colours already on the robot (#405).
   const editLinkColor = useMemo(
     () => (editLink ? readLinkColor(content, editLink) ?? undefined : undefined),
@@ -1489,7 +1493,7 @@ export function RobotView({
   // Bind a breadboard servo's GPIO to a joint from the URDF editor (#) — the same
   // servoJointMap the Board View writes; '' unbinds. Mirrors the board-side picker.
   const handleBindServo = (pin: string, joint: string): void => {
-    const next = bindServoJoint(bindingsRef.current, pin, joint)
+    const next = bindServoJoint(bindingsRef.current, pin, joint, jointLimits[joint])
     setBindings(next)
     void persist((mm) => {
       mm.servoJointMap = next

--- a/src/renderer/src/components/WiringCanvas.tsx
+++ b/src/renderer/src/components/WiringCanvas.tsx
@@ -530,6 +530,9 @@ export interface WiringCanvasProps {
   onChange: (next: RobotDefinition) => void
   /** The linked URDF's joint names — lets a servo's inspector bind to a joint (#). */
   joints?: string[]
+  /** Each joint's real travel (deg / mm), to seed a new binding's joint range from
+   *  the joint's limits instead of a flat 0…180 (which clamped the 3-D model). */
+  jointLimits?: Record<string, { min: number; max: number }>
   /** Installed libraries (to resolve a placed part's pins). */
   libraries: PartLibraryWithParts[]
   /** The microcontroller to show as the board (the board view's selection). */
@@ -579,7 +582,7 @@ interface Drag {
   cy?: number
 }
 
-export function WiringCanvas({ robot, onChange, joints = [], libraries, boardDef, boardPart, renderMode, usedByCode, onDropPart, onShowHelp, focusedChrome = false }: WiringCanvasProps): JSX.Element {
+export function WiringCanvas({ robot, onChange, joints = [], jointLimits = {}, libraries, boardDef, boardPart, renderMode, usedByCode, onDropPart, onShowHelp, focusedChrome = false }: WiringCanvasProps): JSX.Element {
   const svgRef = useRef<SVGSVGElement>(null)
   const dragRef = useRef<Drag | null>(null)
   const [view, setView] = useState({ tx: 0, ty: 0, scale: 1 })
@@ -1444,7 +1447,7 @@ export function WiringCanvas({ robot, onChange, joints = [], libraries, boardDef
       ...robot,
       robot: {
         ...(robot.robot ?? {}),
-        servoJointMap: bindServoJoint(robot.robot?.servoJointMap, selServoGpio, joint)
+        servoJointMap: bindServoJoint(robot.robot?.servoJointMap, selServoGpio, joint, jointLimits[joint])
       }
     })
   }

--- a/src/renderer/src/components/robot-assembly.ts
+++ b/src/renderer/src/components/robot-assembly.ts
@@ -528,6 +528,27 @@ export function readAllJoints(urdf: string): JointFull[] {
   return out
 }
 
+/**
+ * Each movable joint's limit in DISPLAY units — degrees for a rotating joint,
+ * millimetres for a sliding one — keyed by joint name (`{ base_joint: { min: -90,
+ * max: 90 } }`). Only joints that declare a `<limit>` are included. Used to seed a
+ * new servo↔joint binding's joint range from the joint's REAL travel, so the servo
+ * maps onto exactly what the model can do (a hard-coded 0…180 default made the
+ * 3-D model clamp when the joint was limited to, say, ±90°).
+ */
+export function jointDisplayLimits(urdf: string): Record<string, { min: number; max: number }> {
+  const out: Record<string, { min: number; max: number }> = {}
+  for (const j of readAllJoints(urdf)) {
+    if (!j.limit || !j.name) continue
+    // rad → deg for revolute/continuous; m → mm for prismatic. (Fixed joints have
+    // no meaningful travel, but they carry no `<limit>` anyway.)
+    const scale = j.type === 'prismatic' ? 1000 : 180 / Math.PI
+    const round2 = (n: number): number => Math.round(n * 100) / 100 // 1.5708 rad → 90, not 89.9954
+    out[j.name] = { min: round2(j.limit.lower * scale), max: round2(j.limit.upper * scale) }
+  }
+  return out
+}
+
 /** One row of the kinematic chain view (#354): a link, its depth in the tree, and
  *  the joint that attaches it to its parent (null for the base / a loose root). */
 export interface ChainNode {

--- a/src/renderer/src/components/servo-bind.ts
+++ b/src/renderer/src/components/servo-bind.ts
@@ -55,23 +55,29 @@ export function boundJoint(map: ServoJointBinding[] | undefined, gpio: string): 
 
 /**
  * Return an updated servo map that binds `gpio` → `joint` (replacing any existing
- * binding on that pin). An empty `joint` UNBINDS the pin. New bindings get a neutral
- * 0…180 servo + joint range; the Robot View's servo editor tunes it against the
- * joint's real limits.
+ * binding on that pin). An empty `joint` UNBINDS the pin. A NEW binding takes a
+ * neutral 0…180 servo range and, when `jointRange` (the joint's real limits in
+ * deg / mm) is given, that joint range — so the full servo sweep maps onto exactly
+ * what the joint can do. Without it we fell back to a flat 0…180, which made the
+ * 3-D model CLAMP on a joint limited to, say, ±90° (the servo moved, the model
+ * stopped halfway). Re-binding a pin to the SAME joint keeps its existing calibration.
  */
 export function bindServoJoint(
   map: ServoJointBinding[] | undefined,
   gpio: string,
-  joint: string
+  joint: string,
+  jointRange?: { min: number; max: number }
 ): ServoJointBinding[] {
   const rest = (map ?? []).filter((x) => normPin(x.pin) !== normPin(gpio))
   if (!joint) return rest
   const prev = (map ?? []).find((x) => normPin(x.pin) === normPin(gpio))
+  const jointMin = jointRange ? jointRange.min : 0
+  const jointMax = jointRange ? jointRange.max : 180
   return [
     ...rest,
     prev && prev.joint === joint
       ? prev
-      : { pin: gpio, joint, servoMin: 0, servoMax: 180, jointMin: 0, jointMax: 180 }
+      : { pin: gpio, joint, servoMin: 0, servoMax: 180, jointMin, jointMax }
   ]
 }
 

--- a/test/robotAssembly.test.ts
+++ b/test/robotAssembly.test.ts
@@ -15,6 +15,7 @@ import {
   orientJoint,
   buildChainTree,
   meshImportScale,
+  jointDisplayLimits,
   setLinkColor,
   readLinkColor,
   collectLinkColors,
@@ -550,5 +551,32 @@ describe('meshImportScale — declared units vs bbox heuristic (#406)', () => {
     expect(meshImportScale({}, 40)).toBe(0.001)
     expect(meshImportScale({}, 0.5)).toBe(1)
     expect(meshImportScale({})).toBe(1) // nothing known ⇒ leave at 1
+  })
+})
+
+describe('jointDisplayLimits (#)', () => {
+  const urdf = `
+    <robot name="r">
+      <link name="base"/><link name="arm"/><link name="slide"/><link name="tip"/>
+      <joint name="shoulder" type="revolute">
+        <parent link="base"/><child link="arm"/>
+        <limit lower="-1.5708" upper="1.5708" effort="1" velocity="1"/>
+      </joint>
+      <joint name="lift" type="prismatic">
+        <parent link="arm"/><child link="slide"/>
+        <limit lower="0" upper="0.05" effort="1" velocity="1"/>
+      </joint>
+      <joint name="weld" type="fixed">
+        <parent link="slide"/><child link="tip"/>
+      </joint>
+    </robot>`
+
+  it('converts revolute limits rad → deg (rounded) and prismatic m → mm', () => {
+    const lim = jointDisplayLimits(urdf)
+    expect(lim.shoulder).toEqual({ min: -90, max: 90 }) // ±1.5708 rad → ±90° (not ±89.9954)
+    expect(lim.lift).toEqual({ min: 0, max: 50 }) // 0…0.05 m → 0…50 mm
+  })
+  it('skips joints without a <limit> (a fixed joint has no travel)', () => {
+    expect(jointDisplayLimits(urdf).weld).toBeUndefined()
   })
 })

--- a/test/servoBind.test.ts
+++ b/test/servoBind.test.ts
@@ -76,6 +76,24 @@ describe('boundJoint + bindServoJoint (#)', () => {
   it('unbinds on an empty joint', () => {
     expect(bindServoJoint(map, '16', '')).toEqual([])
   })
+  it('seeds a NEW binding\'s joint range from the joint limits when given', () => {
+    const b = bindServoJoint(map, '17', 'elbow', { min: -90, max: 90 }).find((x) => x.pin === '17')!
+    expect(b.jointMin).toBe(-90)
+    expect(b.jointMax).toBe(90)
+    expect(b.servoMin).toBe(0) // servo range stays the neutral 0..180
+    expect(b.servoMax).toBe(180)
+  })
+  it('defaults a new binding to 0..180 when no limits are given', () => {
+    const b = bindServoJoint(map, '17', 'elbow').find((x) => x.pin === '17')!
+    expect([b.jointMin, b.jointMax]).toEqual([0, 180])
+  })
+  it('ignores the range when RE-binding the same joint (keeps calibration)', () => {
+    const cal: ServoJointBinding[] = [
+      { pin: '16', joint: 'shoulder', servoMin: 10, servoMax: 170, jointMin: -45, jointMax: 45, invert: true }
+    ]
+    const next = bindServoJoint(cal, '16', 'shoulder', { min: -90, max: 90 })
+    expect(next[0]).toBe(cal[0]) // same object — existing calibration untouched
+  })
 })
 
 describe('bindableServos (#)', () => {


### PR DESCRIPTION
Fixes #459.

## The bug
Driving a servo swept the **physical** servo through its whole range, but the **3-D model** stopped halfway. Only the on-screen model was affected.

## Root cause
When you bind a servo to a joint, the binding defaulted the joint range to a flat **`jointMin: 0, jointMax: 180`**, ignoring the joint's real URDF `<limit>`. For a joint limited to `±90°`, servo positions that map past 90° push the joint beyond its limit, and the URDF-loader **clamps** it — so half the servo sweep does nothing on screen. (In the reporter's rig, three of four joints were at the `0…180` default against `±90°` limits.)

## The fix
Seed a **new** binding's joint range from the joint's actual limits:
- `robot-assembly.ts` — new `jointDisplayLimits(urdf)`: each joint's travel in display units (rad→deg for revolute/continuous, m→mm for prismatic), rounded (`1.5708` rad → `90`, not `89.9954`).
- `servo-bind.ts` — `bindServoJoint(..., jointRange?)` uses it for `jointMin`/`jointMax`; **re-binding the same joint keeps existing calibration** (no churn).
- Wired into **both** binding paths for parity: Robot View (`jointLimits` memo → `handleBindServo`) and the board view (`jointLimits` threaded through `board-main` + `BoardPane` → `BoardGraph` → `WiringCanvas`).

Existing bindings are intentionally left as-is; you fix one by setting its **Joint range** in the servo dialog.

## Verification
- `typecheck` · `lint` · `test` (**1686**, +5) · `build` all green.
- New tests: `bindServoJoint` range-seeding (+ keeps calibration on re-bind) and `jointDisplayLimits` (rad→deg / m→mm, rounding, skips limitless joints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)