### PR TITLE
fix: detached instrument pop-out windows no longer render blank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **Popped-out instruments no longer open blank.** Undocking the Wi-Fi scanner (or the Bluetooth,
+  Buzzer, Display, SAM or Range instruments) into its own window showed an empty window: those
+  panels read the editor workspace with a hook that *throws* when there's no provider — and a
+  detached OS window has none, so the render crashed. They now read the workspace safely (the
+  workspace-only extras, like "insert a demo file", are simply inert in a detached window), so the
+  pop-out renders normally.
+
 ## [0.25.1] - 2026-07-11
 
 ### Fixed

--- a/src/renderer/src/components/BluetoothInstrument.tsx
+++ b/src/renderer/src/components/BluetoothInstrument.tsx
@@ -4,7 +4,7 @@ import { type InstrumentDef } from './instruments-registry'
 import { useTelemetryStream } from './instrument-telemetry-subscribe'
 import { useSnakiePresence } from './snakie-presence'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
-import { useWorkspace } from '../store/workspace'
+import { useInstrumentWorkspace } from '../store/workspace'
 import { BT_SCAN_DEMO, BT_SCAN_DEMO_NAME } from './bt-scan-demo'
 import {
   MAX_SIGNAL_BARS,
@@ -60,7 +60,7 @@ export function BluetoothInstrument({
   const status = useDeviceStatus()
   const connected = status.state === 'connected'
   const { present } = useSnakiePresence()
-  const { openBuffer } = useWorkspace()
+  const { openBuffer } = useInstrumentWorkspace()
 
   const [devices, setDevices] = useState<BluetoothTelemetry[]>([])
   const [scanning, setScanning] = useState(false)

--- a/src/renderer/src/components/BuzzerInstrument.tsx
+++ b/src/renderer/src/components/BuzzerInstrument.tsx
@@ -4,7 +4,7 @@ import { InstrumentWindow, PhosphorScreen, type FloatProps } from './InstrumentW
 import { type InstrumentDef } from './instruments-registry'
 import { useSnakiePresence } from './snakie-presence'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
-import { useWorkspace } from '../store/workspace'
+import { useInstrumentWorkspace } from '../store/workspace'
 import { buzzerDemo, BUZZER_DEMO_NAME } from './buzzer-demo'
 import {
   CHROMATIC,
@@ -108,7 +108,7 @@ export function BuzzerInstrument({
   const deviceStatus = useDeviceStatus()
   const connected = deviceStatus.state === 'connected'
   const { present } = useSnakiePresence()
-  const { openBuffer, openFiles, activeId, updateContent } = useWorkspace()
+  const { openBuffer, openFiles, activeId, updateContent } = useInstrumentWorkspace()
 
   // The active editor buffer (if any) — the target for "Paste to code" + the
   // source we scan for a declared buzzer pin to warn on a mismatch.

--- a/src/renderer/src/components/DisplayInstrument.tsx
+++ b/src/renderer/src/components/DisplayInstrument.tsx
@@ -5,7 +5,7 @@ import { type InstrumentDef } from './instruments-registry'
 import { useTelemetryStream } from './instrument-telemetry-subscribe'
 import { useSnakiePresence } from './snakie-presence'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
-import { useWorkspace } from '../store/workspace'
+import { useInstrumentWorkspace } from '../store/workspace'
 import { displayDemo, DISPLAY_DEMO_NAME, displaySpiDemo, DISPLAY_SPI_DEMO_NAME } from './display-demo'
 import {
   DISPLAY_GEOMETRIES,
@@ -98,7 +98,7 @@ export function DisplayInstrument({
   const deviceStatus = useDeviceStatus()
   const connected = deviceStatus.state === 'connected'
   const { present } = useSnakiePresence()
-  const { openBuffer, openFiles, activeId, updateContent } = useWorkspace()
+  const { openBuffer, openFiles, activeId, updateContent } = useInstrumentWorkspace()
 
   // The active editor buffer (if any) — the target for the code-sync update + the
   // source we scan for declared SCREEN_SDA / SCREEN_SCL pins to warn on a mismatch.

--- a/src/renderer/src/components/RangeInstrument.tsx
+++ b/src/renderer/src/components/RangeInstrument.tsx
@@ -6,7 +6,7 @@ import type { InstrumentDef } from './range-instrument-def'
 import { useTelemetryStream, type DistanceTelemetry } from './range-telemetry'
 import { useSnakiePresence } from './snakie-presence'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
-import { useWorkspace } from '../store/workspace'
+import { useInstrumentWorkspace } from '../store/workspace'
 import { rangeDemo, RANGE_DEMO_NAME } from './range-demo'
 import {
   blipOpacity,
@@ -117,7 +117,7 @@ export function RangeInstrument({
   const deviceStatus = useDeviceStatus()
   const connected = deviceStatus.state === 'connected'
   const { present } = useSnakiePresence()
-  const { openBuffer, openFiles, activeId, updateContent } = useWorkspace()
+  const { openBuffer, openFiles, activeId, updateContent } = useInstrumentWorkspace()
 
   // The active editor buffer (if any) — the target for the code-sync update + the
   // source we scan for declared RANGE_TRIG / RANGE_ECHO pins to warn on a mismatch.

--- a/src/renderer/src/components/SamInstrument.tsx
+++ b/src/renderer/src/components/SamInstrument.tsx
@@ -4,7 +4,7 @@ import { InstrumentWindow, type FloatProps } from './InstrumentWindow'
 import { type InstrumentDef } from './instruments-registry'
 import { useBoards } from './use-boards'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
-import { useWorkspace } from '../store/workspace'
+import { useInstrumentWorkspace } from '../store/workspace'
 import { SAM_DEMO, SAM_DEMO_NAME } from './sam-demo'
 import './SamInstrument.css'
 
@@ -61,7 +61,7 @@ type SamState = 'idle' | 'installing' | 'speaking'
 export function SamInstrument({ def, onClose, docked = true, onToggleDock, float }: SamInstrumentProps): JSX.Element {
   const status = useDeviceStatus()
   const connected = status.state === 'connected'
-  const { openBuffer } = useWorkspace()
+  const { openBuffer } = useInstrumentWorkspace()
   // The GPIO pins of the currently-selected board (the picker persists its id),
   // for the buzzer-pin dropdown.
   const boards = useBoards()

--- a/src/renderer/src/components/WifiScanInstrument.tsx
+++ b/src/renderer/src/components/WifiScanInstrument.tsx
@@ -4,7 +4,7 @@ import { type InstrumentDef } from './instruments-registry'
 import { useTelemetryStream } from './instrument-telemetry-subscribe'
 import { useSnakiePresence } from './snakie-presence'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
-import { useWorkspace } from '../store/workspace'
+import { useInstrumentWorkspace } from '../store/workspace'
 import { WIFI_SCAN_DEMO, WIFI_SCAN_DEMO_NAME } from './wifi-scan-demo'
 import {
   MAX_SIGNAL_BARS,
@@ -72,7 +72,7 @@ export function WifiScanInstrument({
   const status = useDeviceStatus()
   const connected = status.state === 'connected'
   const { present } = useSnakiePresence()
-  const { openBuffer } = useWorkspace()
+  const { openBuffer } = useInstrumentWorkspace()
 
   const [nets, setNets] = useState<WifiTelemetry[]>([])
   const [scanning, setScanning] = useState(false)

--- a/src/renderer/src/store/workspace.ts
+++ b/src/renderer/src/store/workspace.ts
@@ -541,3 +541,32 @@ export function useWorkspace(): WorkspaceStore {
 export function useWorkspaceOptional(): WorkspaceStore | null {
   return useContext(WorkspaceContext)
 }
+
+/** Stable empty list so a detached instrument doesn't re-render on every read. */
+const EMPTY_OPEN_FILES: OpenFile[] = []
+const NOOP_WRITE = (): void => undefined
+
+/**
+ * Workspace access for an instrument that ALSO renders in a DETACHED OS window
+ * (which has no `WorkspaceProvider`). Returns the live workspace bits when docked,
+ * or safe no-ops / empties when detached — so the instrument renders instead of
+ * crashing on the throwing {@link useWorkspace} (a blank pop-out window). The
+ * workspace-backed extras (insert a demo file, edit the active file) simply become
+ * inert in the detached window; `detached` lets a caller hide/disable them.
+ */
+export function useInstrumentWorkspace(): {
+  openBuffer: (name: string, content: string) => void
+  updateContent: (id: string, content: string) => void
+  openFiles: OpenFile[]
+  activeId: string | null
+  detached: boolean
+} {
+  const ws = useWorkspaceOptional()
+  return {
+    openBuffer: ws?.openBuffer ?? NOOP_WRITE,
+    updateContent: ws?.updateContent ?? NOOP_WRITE,
+    openFiles: ws?.openFiles ?? EMPTY_OPEN_FILES,
+    activeId: ws?.activeId ?? null,
+    detached: !ws
+  }
+}

--- a/test/detachedInstruments.test.ts
+++ b/test/detachedInstruments.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { createElement, type FunctionComponent } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { INSTRUMENTS, type InstrumentDef } from '../src/renderer/src/components/instruments-registry'
+import { WifiScanInstrument } from '../src/renderer/src/components/WifiScanInstrument'
+import { BluetoothInstrument } from '../src/renderer/src/components/BluetoothInstrument'
+import { BuzzerInstrument } from '../src/renderer/src/components/BuzzerInstrument'
+import { DisplayInstrument } from '../src/renderer/src/components/DisplayInstrument'
+import { SamInstrument } from '../src/renderer/src/components/SamInstrument'
+import { RangeInstrument } from '../src/renderer/src/components/RangeInstrument'
+
+/**
+ * A detached instrument OS window has NO WorkspaceProvider. Rendering these
+ * components with no provider mimics that pop-out. Before the fix they called the
+ * throwing `useWorkspace()`, so the render threw and the pop-out window was BLANK.
+ * Now they read the workspace optionally, so they render. Server-render is enough:
+ * `useEffect` (the telemetry subscription / any `window.api` use) does not run, so
+ * no board/DOM is needed — a throw here is exactly the blank-window crash.
+ */
+const defOf = (id: string): InstrumentDef => {
+  const d = INSTRUMENTS.find((x) => x.id === id)
+  if (!d) throw new Error(`no instrument def for ${id}`)
+  return d
+}
+
+const cases: [string, FunctionComponent<{ def: InstrumentDef }>][] = [
+  ['wifi-scan', WifiScanInstrument],
+  ['bluetooth', BluetoothInstrument],
+  ['buzzer', BuzzerInstrument],
+  ['i2c-display', DisplayInstrument],
+  ['sam', SamInstrument],
+  ['range', RangeInstrument]
+]
+
+describe('instruments render in a detached window (no WorkspaceProvider)', () => {
+  for (const [id, Comp] of cases) {
+    it(`${id} renders without a workspace provider (not a blank pop-out)`, () => {
+      const def = defOf(id)
+      const html = renderToStaticMarkup(createElement(Comp, { def }))
+      expect(html.length).toBeGreaterThan(0)
+      expect(html).toContain(def.name.toUpperCase()) // the title-bar name is drawn
+    })
+  }
+})


### PR DESCRIPTION
## The bug
Undocking the **Wi-Fi scanner** into its own OS window showed a **blank window**. Same for **Bluetooth, Buzzer, Display, SAM and Range** — all six.

## Root cause
Those instruments read the editor workspace with the **throwing `useWorkspace()`** (it `throw`s "must be used within a WorkspaceProvider"). A detached instrument window is a bare renderer with **no `WorkspaceProvider`**, so the hook threw during render and the window came up empty. (`ServoInstrument` already avoided this with `useWorkspaceOptional()`.)

## Fix
- **`store/workspace.ts`** — new `useInstrumentWorkspace()`: returns the live workspace bits when docked, or safe **no-ops / empties** when detached (plus a `detached` flag). Never throws.
- The **six** affected instruments now use it. The workspace-only extras (insert-a-demo-file, edit the active file) become inert in a detached window; the panel renders normally.

## Verification
- **`test/detachedInstruments.test.ts`** — server-renders all six with **no provider** (mimicking the pop-out) and asserts each produces markup. A throw there is exactly the blank-window crash, so this is a real regression test.
- `typecheck` · `lint` · `test` (**1692**, +6) · `build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)