### PR TITLE
feat: Snakie for Web — Phase W0 build target (epic #267)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,6 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Build (web)
+        run: npm run build:web

--- a/.github/workflows/web-deploy.yml
+++ b/.github/workflows/web-deploy.yml
@@ -1,0 +1,45 @@
+name: Deploy Web App
+
+# Builds the browser build of the Snakie renderer (epic #267) and publishes it to
+# GitHub Pages at the custom domain app.snakie.org.
+#
+# Manual for now (workflow_dispatch) so it never fails on a repo where Pages
+# isn't enabled yet, and so the first publish is deliberate. Once GitHub Pages is
+# enabled (Settings → Pages → Source: GitHub Actions) and the DNS CNAME for
+# app.snakie.org is in place, add `push: { branches: [master] }` here to keep it
+# fresh automatically.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Only one Pages deploy at a time; a newer run supersedes an in-flight one.
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build:web
+      # Keep the custom domain on every deploy (GitHub Pages reads dist/CNAME).
+      - run: echo 'app.snakie.org' > dist-web/CNAME
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist-web
+      - id: deploy
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ __pycache__/
 *.pyc
 # TypeScript incremental build cache
 *.tsbuildinfo
+
+# Web build (epic #267 — Snakie for Web)
+dist-web/

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "scripts": {
     "dev": "electron-vite dev",
     "build": "electron-vite build",
+    "dev:web": "vite --config vite.web.config.ts",
+    "build:web": "vite build --config vite.web.config.ts",
+    "preview:web": "vite preview --config vite.web.config.ts",
     "preview": "electron-vite preview",
     "start": "electron-vite preview",
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json --composite false",

--- a/src/renderer/src/lib/preloadFallback.ts
+++ b/src/renderer/src/lib/preloadFallback.ts
@@ -2,15 +2,22 @@
  * Preload-bridge fallback.
  *
  * In Electron, `window.api` / `window.electron` are injected by the preload
- * script. Outside Electron — a plain browser, or if the preload ever fails to
- * load — they are `undefined`, and any component that touches them on mount
- * (e.g. the Toolbar via `useDeviceStatus`) would throw and crash the whole
- * renderer to a blank screen.
+ * script. Outside Electron — a plain browser (the web build, epic #267), or if the
+ * preload ever fails to load — they are `undefined`, and any component that
+ * touches them on mount (e.g. the Toolbar via `useDeviceStatus`) would throw and
+ * crash the whole renderer to a blank screen.
  *
- * This installs a no-op fallback that returns "disconnected / empty" defaults
- * so the UI still renders and degrades gracefully. It is imported for its side
- * effect from `main.tsx` BEFORE React renders. In real Electron the bridge is
- * already present, so this is a safety net only (and logs a warning if used).
+ * This installs a no-op fallback that returns "disconnected / empty" defaults so
+ * the UI still renders and degrades gracefully. It is imported for its side effect
+ * from `main.tsx` BEFORE React renders. In real Electron the bridge is already
+ * present, so this is a safety net only (and logs a warning if used).
+ *
+ * The explicit map below gives correct SHAPES for the methods the UI reads on
+ * mount (so `.map`/destructuring don't blow up). Everything is then wrapped in a
+ * self-healing Proxy ({@link fill}) so that ANY namespace or method the map misses
+ * — including ones added to the `Api` later — still returns a safe no-op instead
+ * of throwing. That keeps the browser build rendering as the API grows, without
+ * having to mirror every method here by hand.
  */
 const noop = (): void => {}
 const unsub = (): (() => void) => noop
@@ -18,6 +25,45 @@ const P =
   <T>(value: T) =>
   (): Promise<T> =>
     Promise.resolve(value)
+
+/**
+ * A stub that is safe to (a) CALL → resolves to an empty array (also fine to
+ * destructure / read a missing key off), (b) index DEEPER → another stub, and
+ * (c) use as a SUBSCRIPTION (`onX`) → returns an unsubscribe. So any
+ * `window.api.<ns>.<method>(...)` the explicit map doesn't cover is inert, not a
+ * crash. `[]` is the universal empty: `.map`/`.forEach`/`.length` all work, and
+ * `const { ok } = await x()` just yields `undefined`.
+ */
+const deepStub = (): unknown => {
+  const target = (): Promise<unknown> => Promise.resolve([])
+  return new Proxy(target, {
+    get: (_t, prop) => {
+      const name = typeof prop === 'string' ? prop : ''
+      if (name === 'then') return undefined // not thenable — awaiting a namespace won't hang
+      if (name.startsWith('on')) return unsub // a subscription → an unsubscribe
+      return deepStub()
+    },
+    apply: () => Promise.resolve([])
+  })
+}
+
+/** Wrap an explicit stub namespace so any MISSING property is filled by {@link deepStub}. */
+const fill = (target: Record<string, unknown>): unknown =>
+  new Proxy(target, {
+    get: (t, prop) => {
+      if (prop in t) {
+        const v = t[prop as string]
+        // Recurse into nested namespace OBJECTS so their missing methods fill too.
+        return v && typeof v === 'object' && !Array.isArray(v) && typeof v !== 'function'
+          ? fill(v as Record<string, unknown>)
+          : v
+      }
+      const name = typeof prop === 'string' ? prop : ''
+      if (name === 'then') return undefined
+      if (name.startsWith('on')) return unsub
+      return deepStub()
+    }
+  })
 
 // Read through a widened type so TS doesn't treat the (declared non-optional)
 // globals as always-present — outside Electron they genuinely are not.
@@ -38,10 +84,14 @@ if (!w.api) {
       `firmware, LLM, package and Git features are inert. ` +
       (inElectron
         ? 'Running in Electron, so the PRELOAD FAILED TO LOAD — check the preload path / sandbox setting.'
-        : 'Not running inside Electron (e.g. a browser preview).')
+        : 'Not running inside Electron (e.g. the web build / a browser preview).')
   )
 
   const api = {
+    // Top-level app methods (the Proxy net covers any not listed).
+    ping: P(''),
+    appVersion: P(''),
+    openExternal: P(undefined),
     versions: {},
     device: {
       listPorts: P([]),
@@ -82,8 +132,10 @@ if (!w.api) {
       onProgress: unsub
     },
     llm: {
+      listProviders: P([]),
       getKeyStatus: P({ hasKey: false, secure: false }),
       setKey: P(undefined),
+      saveKey: P(undefined),
       sendMessage: P(''),
       onStream: unsub
     },
@@ -96,12 +148,21 @@ if (!w.api) {
       catalog: P([]),
       installPlan: P({ id: '', importName: '', mechanism: 'mip', notes: [] }),
       install: P({ id: '', ok: false, log: '', notes: [] }),
-      probeInstalled: P([])
+      probeInstalled: P([]),
+      notifyChanged: noop,
+      onChanged: unsub
     },
     updates: {
       check: P(undefined),
       quitAndInstall: P(undefined),
       onStatus: unsub
+    },
+    robot: {
+      load: P({ parts: [], connections: [] }),
+      save: P({ ok: true }),
+      importMesh: P({ cancelled: true }),
+      importPartMesh: P({}),
+      onChanged: unsub
     },
     board: {
       open: P(undefined),
@@ -110,6 +171,7 @@ if (!w.api) {
       requestSource: P(null),
       onSource: unsub,
       onClosed: unsub,
+      onOpened: unsub,
       listUserBoards: P([]),
       openBoardsFolder: P(undefined),
       saveUserBoard: P({ ok: true }),
@@ -118,13 +180,30 @@ if (!w.api) {
     instruments: {
       open: noop,
       onOpen: unsub,
-      librarySource: P('')
+      librarySource: P(''),
+      umbrellaSource: P(''),
+      openWindow: P(undefined),
+      closeWindow: noop,
+      requestWindowPayload: P(null),
+      onWindowPayload: unsub,
+      onWindowClosed: unsub
     },
     console: {
       open: P(undefined),
       requestSeed: P(''),
       close: noop,
       onClosed: unsub
+    },
+    find: {
+      open: P(undefined),
+      close: noop,
+      sendCommand: noop,
+      onCommand: unsub,
+      sendStatus: noop,
+      onStatus: unsub
+    },
+    feedback: {
+      submitBugReport: P({ ok: false, error: 'window.api is unavailable (web build).' })
     },
     parts: {
       listLibraries: P([]),
@@ -139,6 +218,11 @@ if (!w.api) {
       installLibrary: P({ ok: false }),
       checkUpdates: P([]),
       cachedUpdates: P([])
+    },
+    plugins: {
+      list: P([]),
+      reload: P({ plugins: [] }),
+      runCommand: P({ ok: false })
     },
     git: {
       openRepo: P(null),
@@ -166,16 +250,16 @@ if (!w.api) {
     }
   }
 
-  w.api = api as unknown as Window['api']
+  w.api = fill(api) as unknown as Window['api']
   w.electron = {
     process: { versions: {} },
-    ipcRenderer: {
+    ipcRenderer: fill({
       on: unsub,
       once: noop,
       send: noop,
       invoke: P(undefined),
       removeListener: noop,
       removeAllListeners: noop
-    }
+    })
   } as unknown as Window['electron']
 }

--- a/vite.web.config.ts
+++ b/vite.web.config.ts
@@ -1,0 +1,54 @@
+import { resolve } from 'path'
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+/**
+ * STANDALONE WEB BUILD of the Snakie renderer — epic #267 (Snakie for Web), Phase W0.
+ * =============================================================================
+ *
+ * The SAME React renderer, built as a plain static SPA for the browser (no
+ * Electron shell). It reuses the exact renderer sources; the electron-vite build
+ * (`electron.vite.config.ts`) still produces the desktop app unchanged.
+ *
+ * In the browser there is no preload, so `window.api` is absent — the renderer's
+ * `preloadFallback` (already imported in `main.tsx`) installs no-op stubs, so the
+ * UI renders and degrades gracefully. Device / file / sim features are INERT until
+ * the web backend lands (Phase W1: `web-api.ts` + the MicroPython WASM Worker).
+ *
+ * Output: `dist-web/` — static assets, deployable to app.snakie.org (see the
+ * deploy issue on the epic). `base: '/'` targets a subdomain root; for a subpath
+ * (e.g. snakie.org/app) set `base: '/app/'`.
+ *
+ * Run:  npm run build:web   (or  npm run dev:web  for a live server)
+ */
+export default defineConfig({
+  root: resolve(__dirname, 'src/renderer'),
+  base: '/',
+  resolve: {
+    alias: {
+      '@renderer': resolve(__dirname, 'src/renderer/src')
+    }
+  },
+  build: {
+    outDir: resolve(__dirname, 'dist-web'),
+    emptyOutDir: true,
+    // Monaco is a big, lazily-loaded, independently-cacheable chunk (mirrors the
+    // electron build), so raise the warning limit past its size.
+    chunkSizeWarningLimit: 4000,
+    rollupOptions: {
+      // Only the main app entry for the web MVP. The Electron detached windows
+      // (board / find / instrument / console) become in-page panes on the web
+      // (Phase W1/dockview), so they are not separate HTML entries here.
+      input: {
+        index: resolve(__dirname, 'src/renderer/index.html')
+      },
+      output: {
+        manualChunks(id: string) {
+          if (id.includes('node_modules/monaco-editor')) return 'monaco'
+          return undefined
+        }
+      }
+    }
+  },
+  plugins: [react()]
+})


### PR DESCRIPTION
First concrete step of epic #267 (Snakie for Web) toward hosting at **app.snakie.org**.

## What this does
Builds the **same** React renderer as a plain static SPA for the browser — **no UI fork**. The desktop electron-vite build is untouched.

- **`vite.web.config.ts`** — standalone Vite config building `src/renderer` → `dist-web/` (reuses the `@renderer` alias + monaco chunking). New scripts: `build:web`, `dev:web`, `preview:web`.
- **`preloadFallback`** — completed into a **self-healing stub**. `window.api` doesn't exist in the browser; the fallback now covers the full `Api` (robot / find / feedback / instruments-window / llm / appVersion / …) **and** wraps everything in a Proxy net so any method the map misses — or that's added to the `Api` later — returns a safe no-op instead of crashing the render.
- **`.github/workflows/web-deploy.yml`** — GitHub Pages deploy of `dist-web` with the `app.snakie.org` CNAME (manual dispatch until Pages + DNS are set up; see the deploy issue on the epic).
- **CI** builds the web target too, so it can't silently break.

## Verified
`npm run build:web` produces `dist-web/`, and served in a headless Chromium it **renders the full Snakie UI** — toolbar, activity bar, editor, console, status bar. Device/sim show "disconnected / no ports" (inert) — that's the Phase W1 backend work.

Desktop unchanged: `typecheck` · `lint` · `test` (1692) · `build` all green (the fallback only runs when `window.api` is absent, i.e. never in Electron).

![web shell](https://user-images.githubusercontent.com/placeholder) <!-- screenshot in the PR thread -->

Part of #267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)