### PR TITLE
feat: Snakie for Web — local files via File System Access (#464)

### DIFF
--- a/src/renderer/src/web/install-web-api.ts
+++ b/src/renderer/src/web/install-web-api.ts
@@ -13,13 +13,20 @@
  * MicroPython WASM.
  */
 import { createWebDeviceApi } from './web-device'
+import { createWebFsApi } from './web-fs'
 
 export function installWebApi(): void {
   const w = window as typeof window & { api?: Record<string, unknown> }
   if (!w.api) return // the fallback runs first and sets this; guard defensively
   w.api.device = createWebDeviceApi() as unknown as Window['api']['device']
+  // Local files via the File System Access API — only when the browser supports it
+  // (Chromium); elsewhere the no-op fallback stays and "Open Folder" is inert.
+  if ('showDirectoryPicker' in window) {
+    w.api.fs = createWebFsApi() as unknown as Window['api']['fs']
+  }
   // eslint-disable-next-line no-console
   console.info(
-    '[Snakie] Web simulated device ready — pick "Simulated device (offline)" and Connect to run Python.'
+    '[Snakie] Web backend ready — Connect the "Simulated device (offline)" to run Python; ' +
+      'Open Folder to edit local files.'
   )
 }

--- a/src/renderer/src/web/web-fs-paths.ts
+++ b/src/renderer/src/web/web-fs-paths.ts
@@ -1,0 +1,24 @@
+/**
+ * Pure path helpers for the web filesystem ({@link ./web-fs}) — kept separate so
+ * they're unit-testable (the interactive folder picker can't be automated).
+ */
+
+/**
+ * Split a renderer path into the segments RELATIVE to the open folder's root, so
+ * they can be walked from the root directory handle. The renderer builds paths as
+ * `<rootName>/sub/file.py` (root = what `openFolderDialog` returned). Tolerates a
+ * leading "/", the bare root path (→ `[]`), and a plain relative path.
+ */
+export function splitRelSegments(rootPath: string, path: string): string[] {
+  let p = path.startsWith('/') ? path.slice(1) : path
+  if (rootPath) {
+    if (p === rootPath) return []
+    if (p.startsWith(rootPath + '/')) p = p.slice(rootPath.length + 1)
+  }
+  return p.split('/').filter(Boolean)
+}
+
+/** Join a parent path + child name the way the renderer does (POSIX, no `//`). */
+export function childPath(parent: string, name: string): string {
+  return parent.endsWith('/') ? parent + name : `${parent}/${name}`
+}

--- a/src/renderer/src/web/web-fs.ts
+++ b/src/renderer/src/web/web-fs.ts
@@ -1,0 +1,177 @@
+/**
+ * WEB local-filesystem backend — epic #267, Phase W1.
+ * =============================================================================
+ *
+ * Implements `window.api.fs` in the browser with the **File System Access API**
+ * (`showDirectoryPicker`), so a student can Open a real folder on their
+ * Chromebook, edit files, and save straight back to disk — genuine persistence,
+ * no server. Paths are the POSIX-ish strings the renderer already uses
+ * (`<rootName>/sub/file.py`), resolved against the picked directory handle. Loose
+ * files opened via `openFileDialog` / `saveFileDialog` are tracked by name.
+ *
+ * The picker needs a user gesture, so `openFolderDialog` must be called from a
+ * click (it is — the "Open Folder" button). Where the API is unavailable the
+ * methods return empty/null and the UI degrades. The pure path helpers are
+ * exported for unit tests (the interactive picker itself can't be automated).
+ */
+import { splitRelSegments, childPath } from './web-fs-paths'
+
+interface FsEntry {
+  name: string
+  path: string
+  isDir: boolean
+}
+interface FsStat {
+  isDir: boolean
+  size: number
+  mtimeMs: number
+}
+
+// The File System Access types aren't in every TS DOM lib version, so treat the
+// handles structurally.
+type DirHandle = {
+  name: string
+  getDirectoryHandle(name: string, opts?: { create?: boolean }): Promise<DirHandle>
+  getFileHandle(name: string, opts?: { create?: boolean }): Promise<FileHandleLike>
+  removeEntry(name: string, opts?: { recursive?: boolean }): Promise<void>
+  entries(): AsyncIterableIterator<[string, DirHandle | FileHandleLike]>
+  kind: 'directory'
+}
+type FileHandleLike = {
+  name: string
+  kind: 'file'
+  getFile(): Promise<File>
+  createWritable(): Promise<{ write(data: Uint8Array | string): Promise<void>; close(): Promise<void> }>
+}
+
+export function createWebFsApi(): Record<string, unknown> {
+  const w = window as unknown as {
+    showDirectoryPicker?: (o?: unknown) => Promise<DirHandle>
+    showOpenFilePicker?: (o?: unknown) => Promise<FileHandleLike[]>
+    showSaveFilePicker?: (o?: unknown) => Promise<FileHandleLike>
+  }
+
+  let root: DirHandle | null = null
+  let rootPath = ''
+  const loose = new Map<string, FileHandleLike>()
+
+  const dirAt = async (path: string, create = false): Promise<DirHandle> => {
+    if (!root) throw new Error('No folder is open')
+    let h = root
+    for (const seg of splitRelSegments(rootPath, path)) h = await h.getDirectoryHandle(seg, { create })
+    return h
+  }
+  const fileAt = async (path: string, create = false): Promise<FileHandleLike> => {
+    if (loose.has(path)) return loose.get(path)!
+    if (!root) throw new Error('No folder is open')
+    const segs = splitRelSegments(rootPath, path)
+    const name = segs.pop()
+    if (name === undefined) throw new Error(`Not a file path: ${path}`)
+    let h = root
+    for (const seg of segs) h = await h.getDirectoryHandle(seg, { create })
+    return h.getFileHandle(name, { create })
+  }
+  const readBytes = async (h: FileHandleLike): Promise<Uint8Array> => {
+    const file = await h.getFile()
+    const buf: ArrayBuffer = await file.arrayBuffer()
+    return new Uint8Array(buf)
+  }
+  const removePath = async (path: string): Promise<void> => {
+    if (loose.delete(path)) return
+    if (!root) return
+    const segs = splitRelSegments(rootPath, path)
+    const name = segs.pop()
+    if (name === undefined) return
+    let h = root
+    for (const seg of segs) h = await h.getDirectoryHandle(seg)
+    await h.removeEntry(name, { recursive: true })
+  }
+  const copyPath = async (from: string, to: string): Promise<void> => {
+    let isFile = true
+    try {
+      await fileAt(from)
+    } catch {
+      isFile = false
+    }
+    if (isFile) {
+      const bytes = await readBytes(await fileAt(from))
+      const dst = await fileAt(to, true)
+      const ws = await dst.createWritable()
+      await ws.write(bytes)
+      await ws.close()
+      return
+    }
+    const src = await dirAt(from)
+    await dirAt(to, true)
+    for await (const [name] of src.entries()) await copyPath(childPath(from, name), childPath(to, name))
+  }
+
+  return {
+    openFolderDialog: async (): Promise<string | null> => {
+      if (!w.showDirectoryPicker) return null
+      try {
+        const handle = await w.showDirectoryPicker({ mode: 'readwrite' })
+        root = handle
+        rootPath = handle.name
+        loose.clear()
+        return rootPath
+      } catch {
+        return null // user cancelled / denied
+      }
+    },
+    openFileDialog: async (): Promise<string | null> => {
+      if (!w.showOpenFilePicker) return null
+      try {
+        const [fh] = await w.showOpenFilePicker()
+        loose.set(fh.name, fh)
+        return fh.name
+      } catch {
+        return null
+      }
+    },
+    saveFileDialog: async (defaultName?: string): Promise<string | null> => {
+      if (!w.showSaveFilePicker) return null
+      try {
+        const fh = await w.showSaveFilePicker({ suggestedName: defaultName })
+        loose.set(fh.name, fh)
+        return fh.name
+      } catch {
+        return null
+      }
+    },
+    readDir: async (path: string): Promise<FsEntry[]> => {
+      const dir = await dirAt(path)
+      const out: FsEntry[] = []
+      for await (const [name, handle] of dir.entries()) {
+        out.push({ name, path: childPath(path, name), isDir: handle.kind === 'directory' })
+      }
+      // Folders first, then alphabetical — matches the desktop tree.
+      return out.sort((a, b) => (a.isDir === b.isDir ? a.name.localeCompare(b.name) : a.isDir ? -1 : 1))
+    },
+    readFile: async (path: string): Promise<string> => (await fileAt(path)).getFile().then((f) => f.text()),
+    readFileBytes: async (path: string): Promise<Uint8Array> => readBytes(await fileAt(path)),
+    writeFile: async (path: string, contents: string): Promise<void> => {
+      const fh = await fileAt(path, true)
+      const ws = await fh.createWritable()
+      await ws.write(contents)
+      await ws.close()
+    },
+    mkdir: async (path: string): Promise<void> => {
+      await dirAt(path, true)
+    },
+    rename: async (from: string, to: string): Promise<void> => {
+      await copyPath(from, to)
+      await removePath(from)
+    },
+    remove: async (path: string): Promise<void> => removePath(path),
+    stat: async (path: string): Promise<FsStat> => {
+      try {
+        const f = await (await fileAt(path)).getFile()
+        return { isDir: false, size: f.size, mtimeMs: f.lastModified }
+      } catch {
+        await dirAt(path)
+        return { isDir: true, size: 0, mtimeMs: 0 }
+      }
+    }
+  }
+}

--- a/test/webFsPaths.test.ts
+++ b/test/webFsPaths.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { splitRelSegments, childPath } from '../src/renderer/src/web/web-fs-paths'
+
+// Path resolution for the web File System Access backend (epic #267). The
+// interactive picker can't be automated, but the pure path math can — and it's
+// where the bugs would be (walking the wrong segments off the root handle).
+describe('splitRelSegments', () => {
+  it('strips the root name and splits into segments', () => {
+    expect(splitRelSegments('MyProject', 'MyProject/src/main.py')).toEqual(['src', 'main.py'])
+  })
+  it('returns [] for the bare root path (the root handle itself)', () => {
+    expect(splitRelSegments('MyProject', 'MyProject')).toEqual([])
+  })
+  it('tolerates a leading slash', () => {
+    expect(splitRelSegments('Root', '/Root/a/b.py')).toEqual(['a', 'b.py'])
+  })
+  it('drops empty segments (double / or trailing /)', () => {
+    expect(splitRelSegments('R', 'R//x/')).toEqual(['x'])
+  })
+  it('handles a path that is not under the root (loose relative)', () => {
+    expect(splitRelSegments('Root', 'a/b')).toEqual(['a', 'b'])
+  })
+  it('does not mis-strip a root that is only a name PREFIX', () => {
+    // "RootX/f" must NOT be treated as under root "Root".
+    expect(splitRelSegments('Root', 'RootX/f')).toEqual(['RootX', 'f'])
+  })
+})
+
+describe('childPath', () => {
+  it('joins parent + name without a double slash', () => {
+    expect(childPath('a/b', 'c.py')).toBe('a/b/c.py')
+    expect(childPath('a/b/', 'c.py')).toBe('a/b/c.py')
+  })
+})


### PR DESCRIPTION
Part of epic #267 / #464. Students on a Chromebook can now **Open a real folder** in the web build, edit files, and **save straight back to disk** — genuine persistence, no server.

## What
Implements `window.api.fs` with the **File System Access API** (`showDirectoryPicker`), resolving the renderer's existing POSIX-ish paths (`<root>/sub/file.py`) against the picked directory handle.

- **`web/web-fs.ts`** — `openFolderDialog` / `openFileDialog` / `saveFileDialog`, `readDir`, `readFile`/`readFileBytes`, `writeFile`, `mkdir`, `rename` (copy+remove), `remove`, `stat`. Installed **only** when the browser supports the picker (Chromium); elsewhere the no-op fallback stays and Open Folder is inert.
- **`web/web-fs-paths.ts`** — the pure path resolver (root-relative segments + child join).
- **`install-web-api.ts`** — wires `fs` alongside the device.

## Verification
- `typecheck` · `lint` · `test` (**1699**, +7) · both builds green.
- **`test/webFsPaths.test.ts`** covers the path math (where the bugs hide — walking the wrong segments off the root, root-name-prefix edge, etc.).
- Headless load confirms `window.api.fs` is installed and the app renders.
- ⚠️ The **picker flow itself** needs a manual click on the deployed site — headless Chromium can't drive the native directory picker. (The logic it feeds is unit-tested.)

Desktop unaffected; web-only, tree-shaken from Electron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)