### PR TITLE
fix: serve + auto-seed the MicroPython library on the web sim (#267)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **Web app: the instruments library now installs, and `from snakie import …` just works (#267).**
+  On app.snakie.org the "Install library" banner failed with _"library source unavailable"_ and
+  the demos' first line (`from snakie import Servo` / `import instruments`) raised `ImportError`,
+  because the web build had no source for the bundled MicroPython library. The web sim now inlines
+  `instruments.py` + `snakie.py` (via `?raw`), auto-seeds them into its in-memory `/lib` on connect
+  (so imports work with no install step), and serves them to the banner + its version check.
+
 ## [0.25.2] - 2026-07-11
 
 ### Fixed

--- a/src/renderer/src/web/install-web-api.ts
+++ b/src/renderer/src/web/install-web-api.ts
@@ -14,11 +14,20 @@
  */
 import { createWebDeviceApi } from './web-device'
 import { createWebFsApi } from './web-fs'
+import { INSTRUMENTS_PY, SNAKIE_PY } from './web-lib-sources'
 
 export function installWebApi(): void {
   const w = window as typeof window & { api?: Record<string, unknown> }
   if (!w.api) return // the fallback runs first and sets this; guard defensively
   w.api.device = createWebDeviceApi() as unknown as Window['api']['device']
+  // Serve the bundled MicroPython library sources so the "Install library" banner
+  // + its version check work on the web (the fallback returns '' → the install
+  // failed with "library source unavailable"). The sim also auto-seeds these into
+  // its VFS on connect (see the worker), so imports work without an install step.
+  const instruments = (w.api.instruments ?? {}) as Record<string, unknown>
+  instruments.librarySource = async (): Promise<string> => INSTRUMENTS_PY
+  instruments.umbrellaSource = async (): Promise<string> => SNAKIE_PY
+  w.api.instruments = instruments as unknown as Window['api']['instruments']
   // Local files via the File System Access API — only when the browser supports it
   // (Chromium); elsewhere the no-op fallback stays and "Open Folder" is inert.
   if ('showDirectoryPicker' in window) {

--- a/src/renderer/src/web/mp.worker.ts
+++ b/src/renderer/src/web/mp.worker.ts
@@ -18,6 +18,7 @@ import { loadMicroPython } from '@micropython/micropython-webassembly-pyscript/m
 import type { MicroPythonInstance } from '@micropython/micropython-webassembly-pyscript/micropython.mjs'
 import mpWasmUrl from '@micropython/micropython-webassembly-pyscript/micropython.wasm?url'
 import { SIM_MACHINE_PY } from '../../../shared/sim-machine'
+import { INSTRUMENTS_PY, SNAKIE_PY } from './web-lib-sources'
 
 type InMsg =
   | { type: 'init' }
@@ -25,6 +26,33 @@ type InMsg =
   | { type: 'run'; id: number; code: string }
 
 const enc = new TextEncoder()
+
+/**
+ * Write a text file into the sim's in-memory VFS via a hex-encoded snippet
+ * (MicroPython has no bulk file API from JS). The hex + paths are all ASCII, so
+ * `JSON.stringify` yields valid Python string literals.
+ */
+const writeVfsFile = (mpi: MicroPythonInstance, path: string, source: string): void => {
+  const hex = Array.from(enc.encode(source))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+  const dir = path.slice(0, path.lastIndexOf('/')) || '/'
+  mpi.runPython(
+    `import os\ntry:\n    os.mkdir(${JSON.stringify(dir)})\nexcept OSError:\n    pass\n` +
+      `_d = bytes.fromhex(${JSON.stringify(hex)})\n` +
+      `_f = open(${JSON.stringify(path)}, 'wb')\n_f.write(_d)\n_f.close()\ndel _d, _f`
+  )
+}
+
+/**
+ * Seed `/lib/instruments.py` + `/lib/snakie.py` so `import instruments` /
+ * `from snakie import Servo` work with no install step. The RAM VFS resets on a
+ * worker reboot (Stop), so this re-runs on every init — exactly like a reconnect.
+ */
+const installLibrary = (mpi: MicroPythonInstance): void => {
+  writeVfsFile(mpi, '/lib/instruments.py', INSTRUMENTS_PY)
+  writeVfsFile(mpi, '/lib/snakie.py', SNAKIE_PY)
+}
 let mp: MicroPythonInstance | null = null
 let pending: number[] = []
 let capturing: number[] | null = null
@@ -57,6 +85,13 @@ self.onmessage = async (e: MessageEvent<InMsg>): Promise<void> => {
       mp.runPython(SIM_MACHINE_PY)
     } catch {
       /* best-effort — a missing machine stub just means the ImportError returns */
+    }
+    // Seed the bundled `instruments` + `snakie` libraries into the VFS so the
+    // demos' `from snakie import Servo` / `import instruments` just work (#267).
+    try {
+      installLibrary(mp)
+    } catch {
+      /* best-effort — the install banner can still write them on demand */
     }
     mp.replInit()
     flush()

--- a/src/renderer/src/web/web-lib-sources.ts
+++ b/src/renderer/src/web/web-lib-sources.ts
@@ -1,0 +1,27 @@
+/**
+ * Bundled MicroPython library sources for the WEB sim (epic #267).
+ * =============================================================================
+ *
+ * On the desktop, `window.api.instruments.librarySource()` reads the bundled
+ * `micropython/instruments.py` (+ the `snakie.py` hardware umbrella) from disk in
+ * the main process. The browser has no filesystem, so we inline the SAME sources
+ * at build time via Vite `?raw`, then:
+ *
+ *  - auto-load them into the sim's in-memory VFS on connect (see the worker), so
+ *    `from snakie import Servo` / `import instruments` — how the bundled demos and
+ *    most projects start — work with no install step, and
+ *  - answer `librarySource()` / `umbrellaSource()` (see {@link ./install-web-api}),
+ *    so the "Install library" banner + its version check behave like the desktop
+ *    instead of failing with "library source unavailable".
+ *
+ * These are the single source of truth for the two files; nothing here is
+ * MicroPython-version-specific beyond what the desktop bundles.
+ */
+import instrumentsPy from '../../../../micropython/instruments.py?raw'
+import snakiePy from '../../../../micropython/snakie.py?raw'
+
+/** The `instruments` library (Servo/Buzzer/Led/… + the control loop). */
+export const INSTRUMENTS_PY: string = instrumentsPy
+
+/** The `snakie` hardware umbrella that re-exports the classes (shadow-proof imports). */
+export const SNAKIE_PY: string = snakiePy

--- a/test/webLibSources.test.ts
+++ b/test/webLibSources.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { INSTRUMENTS_PY, SNAKIE_PY } from '../src/renderer/src/web/web-lib-sources'
+
+/**
+ * Guards the `?raw` inlining of the MicroPython library into the web bundle
+ * (#267). If these silently resolved to '' the web sim's "Install library" would
+ * fail with "library source unavailable" and `from snakie import Servo` would
+ * ImportError — so assert they carry the real classes.
+ */
+describe('web lib sources (?raw inlined for the web sim)', () => {
+  it('bundles the real instruments.py (has the hardware classes)', () => {
+    expect(INSTRUMENTS_PY.length).toBeGreaterThan(1000)
+    expect(INSTRUMENTS_PY).toContain('class Servo')
+  })
+  it('bundles the snakie umbrella that re-exports Servo', () => {
+    expect(SNAKIE_PY.length).toBeGreaterThan(20)
+    expect(SNAKIE_PY).toContain('Servo')
+  })
+})

--- a/vite.web.config.ts
+++ b/vite.web.config.ts
@@ -38,6 +38,13 @@ export default defineConfig({
       '@renderer': resolve(__dirname, 'src/renderer/src')
     }
   },
+  // The web sim inlines `micropython/instruments.py` + `snakie.py` via `?raw`, and
+  // that folder sits ABOVE the renderer root — allow the dev server to read it.
+  server: {
+    fs: {
+      allow: [resolve(__dirname)]
+    }
+  },
   build: {
     outDir: resolve(__dirname, 'dist-web'),
     emptyOutDir: true,


### PR DESCRIPTION
## What & why

On **app.snakie.org**, clicking **Install library** failed with _"Couldn't install the library: library source unavailable"_, and the bundled demos' first line — `from snakie import Servo` / `import instruments` — raised `ImportError`.

Root cause: the web build only swapped `window.api.device` and `.fs` over the preload fallback, so `window.api.instruments.librarySource()` was still the empty `''` stub. The web had **no source** for the bundled MicroPython library, so nothing could install it and the sim's `/lib` was empty.

## Fix

- **`web-lib-sources.ts`** — inlines `micropython/instruments.py` + `snakie.py` into the web bundle via Vite `?raw` (single source of truth).
- **Sim worker** — auto-seeds `/lib/instruments.py` + `/lib/snakie.py` into the in-memory VFS on every init (re-runs on a Stop-reboot, like a reconnect), so `import instruments` / `from snakie import …` **just work with no install step**.
- **`install-web-api.ts`** — overrides `instruments.librarySource` / `umbrellaSource` so the **Install library** banner + its version check behave like the desktop.
- **`vite.web.config.ts`** — lets the dev server read `micropython/` (it sits above the renderer root).

## Verification

Headless on the built web bundle (`dist-web`):

| check | result |
|---|---|
| `librarySource()` / `umbrellaSource()` | return the real sources (no longer `''`) |
| `import instruments` | `instruments OK` |
| `from snakie import Servo, Pin, PWM` | `snakie OK` |
| drive a servo | emits `SNK PWM servo …` + `SNK SERVO …` telemetry |
| `os.listdir('/lib')` | `['instruments.py', 'snakie.py']` |

Gates: typecheck ✓ · lint (0 errors) ✓ · **1701 tests** ✓ · electron build ✓ · web build ✓. Adds `test/webLibSources.test.ts` to guard against the `?raw` import silently resolving to `''`.

Part of epic #267 (Snakie for Web). Auto-deploys to app.snakie.org on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)