### PR TITLE
feat: robot mode on the web — real robot.yml backend + auto-connect (#267)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,28 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Robot mode works on the web (#267).** `window.api.robot` now has a real browser
+  backend: `robot.yml` loads and saves through the File System Access folder using the
+  same shared YAML pipeline as the desktop — so servo↔joint bindings, poses, the
+  timeline and the project-URDF link all round-trip. Open a robot project folder on
+  app.snakie.org, open its `.urdf`, and the 3-D robot renders with its STL meshes;
+  run a servo program on the simulator and `SNK SERVO` telemetry animates the joints.
+  Import STL also works (browser file picker → `meshes/`); with no folder open,
+  robot.yml persists to browser storage.
+- **The web app auto-connects to the simulated device on load (#267).** The sim is the
+  only port on the web, and the Connect control (shell-panel header) was easy to miss —
+  first-time users typed a program and found Run greyed out. Run now works out of the box.
+
 ### Fixed
+- **Files-panel "New file" is no longer dead without a folder.** With no folder open it
+  now creates an untitled buffer (same as the toolbar), instead of a disabled button.
+- **URDF mesh refs with `./` or `../` now load on the web** (path segments are
+  normalised before walking the picked folder's handles; `..` clamps at the root).
+- **Honest fallbacks when a backend is missing:** a stubbed robot save now reports
+  "save failed" instead of a false "saved ✓", and a missing motion plugin shows the
+  benign "install Python to sync poses" label instead of a spurious
+  "managed block broken" warning.
 - **Web app: the instruments library now installs, and `from snakie import …` just works (#267).**
   On app.snakie.org the "Install library" banner failed with _"library source unavailable"_ and
   the demos' first line (`from snakie import Servo` / `import instruments`) raised `ImportError`,

--- a/src/renderer/src/components/LocalFileTree.tsx
+++ b/src/renderer/src/components/LocalFileTree.tsx
@@ -214,7 +214,7 @@ interface MenuState {
 }
 
 export function LocalFileTree(): JSX.Element {
-  const { openFile, currentFolder, openFolder, openFolderPath } = useWorkspace()
+  const { openFile, currentFolder, openFolder, openFolderPath, newFile } = useWorkspace()
   const prompt = usePrompt()
   const deviceStatus = useDeviceStatus()
   const connected = deviceStatus.state === 'connected'
@@ -473,10 +473,12 @@ export function LocalFileTree(): JSX.Element {
           </button>
           <button
             className="btn btn--ghost btn--icon"
-            onClick={() => newFileIn(null)}
-            title="New file"
+            // With no folder open this used to be a dead button; fall back to an
+            // untitled buffer (same as the toolbar's New file) so "create a file
+            // and run it" always works — on the web there may be no folder at all.
+            onClick={() => (root ? newFileIn(null) : newFile())}
+            title={root ? 'New file' : 'New untitled file'}
             aria-label="New file"
-            disabled={!root}
           >
             <NewFileIcon />
           </button>

--- a/src/renderer/src/lib/preloadFallback.ts
+++ b/src/renderer/src/lib/preloadFallback.ts
@@ -159,7 +159,10 @@ if (!w.api) {
     },
     robot: {
       load: P({ parts: [], connections: [] }),
-      save: P({ ok: true }),
+      // ok:false so a genuinely-stubbed save shows "save failed" instead of a
+      // false "saved ✓" while writing nothing (the web build installs a real
+      // backend over this; see web/web-robot.ts).
+      save: P({ ok: false, error: 'Saving robot.yml is not available here.' }),
       importMesh: P({ cancelled: true }),
       importPartMesh: P({}),
       onChanged: unsub
@@ -222,7 +225,11 @@ if (!w.api) {
     plugins: {
       list: P([]),
       reload: P({ plugins: [] }),
-      runCommand: P({ ok: false })
+      runCommand: P({ ok: false }),
+      // pythonFound:false routes RobotView to the benign "install Python to sync
+      // poses" label; without this key the deepStub resolves [] and the view
+      // misreads it as a broken managed block (spurious warning).
+      motionRead: P({ ok: false, pythonFound: false })
     },
     git: {
       openRepo: P(null),

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -17,11 +17,19 @@ const render = (): void =>
 // In the WEB build (epic #267), swap the fallback's inert `device` stub for the
 // real MicroPython WASM simulator before rendering. Dynamic import so the Electron
 // bundle never pulls in the WASM; a failure still renders the (device-inert) shell.
+// After render, auto-connect the sim — it's the only port on the web, and Run
+// stays greyed out until connected, which reads as "the app can't run programs".
 if (import.meta.env.VITE_SNAKIE_WEB) {
   import('./web/install-web-api')
-    .then((m) => m.installWebApi())
-    .catch((err) => console.error('[Snakie] web backend install failed', err))
-    .finally(render)
+    .then((m) => {
+      m.installWebApi()
+      render()
+      m.autoConnectSimulator()
+    })
+    .catch((err) => {
+      console.error('[Snakie] web backend install failed', err)
+      render()
+    })
 } else {
   render()
 }

--- a/src/renderer/src/web/install-web-api.ts
+++ b/src/renderer/src/web/install-web-api.ts
@@ -14,7 +14,9 @@
  */
 import { createWebDeviceApi } from './web-device'
 import { createWebFsApi } from './web-fs'
+import { createWebRobotApi, type WebRobotFs } from './web-robot'
 import { INSTRUMENTS_PY, SNAKIE_PY } from './web-lib-sources'
+import { VIRTUAL_PORT_PATH } from '../../../shared/virtual-device'
 
 export function installWebApi(): void {
   const w = window as typeof window & { api?: Record<string, unknown> }
@@ -30,12 +32,39 @@ export function installWebApi(): void {
   w.api.instruments = instruments as unknown as Window['api']['instruments']
   // Local files via the File System Access API — only when the browser supports it
   // (Chromium); elsewhere the no-op fallback stays and "Open Folder" is inert.
+  // The robot.yml layer rides on the same backend (bindings/poses/urdf link), so
+  // it's gated with it — on other browsers the honest fallback stub remains.
   if ('showDirectoryPicker' in window) {
-    w.api.fs = createWebFsApi() as unknown as Window['api']['fs']
+    const fs = createWebFsApi()
+    w.api.fs = fs as unknown as Window['api']['fs']
+    w.api.robot = createWebRobotApi(fs as unknown as WebRobotFs) as unknown as Window['api']['robot']
   }
   // eslint-disable-next-line no-console
   console.info(
     '[Snakie] Web backend ready — Connect the "Simulated device (offline)" to run Python; ' +
       'Open Folder to edit local files.'
   )
+}
+
+/**
+ * Auto-connect to the simulated device shortly after first render (#267). On the
+ * web the sim is the ONLY port, and the Connect control lives in the shell-panel
+ * header where first-time users don't find it — they type a program and see a
+ * greyed-out Run button ("I'm not able to run a program"). Connecting for them
+ * makes Run work out of the box. The delay lets the shell terminal mount its
+ * data subscription first so the MicroPython banner lands on screen; the status
+ * check keeps us from double-connecting if the user beat us to the button.
+ */
+export function autoConnectSimulator(delayMs = 400): void {
+  window.setTimeout(() => {
+    void (async () => {
+      try {
+        const device = window.api.device
+        const status = await device.getStatus()
+        if (status.state === 'disconnected') await device.connect(VIRTUAL_PORT_PATH)
+      } catch {
+        // Auto-connect is best-effort — the manual Connect button still works.
+      }
+    })()
+  }, delayMs)
 }

--- a/src/renderer/src/web/web-fs-paths.ts
+++ b/src/renderer/src/web/web-fs-paths.ts
@@ -7,7 +7,10 @@
  * Split a renderer path into the segments RELATIVE to the open folder's root, so
  * they can be walked from the root directory handle. The renderer builds paths as
  * `<rootName>/sub/file.py` (root = what `openFolderDialog` returned). Tolerates a
- * leading "/", the bare root path (→ `[]`), and a plain relative path.
+ * leading "/", the bare root path (→ `[]`), and a plain relative path. `.` and
+ * `..` segments are normalised here (URDF mesh refs like `./meshes/x.stl` reach
+ * us verbatim — urdf-loader does no normalisation, and `getDirectoryHandle('.')`
+ * throws); `..` clamps at the picked root, which is also the sandbox boundary.
  */
 export function splitRelSegments(rootPath: string, path: string): string[] {
   let p = path.startsWith('/') ? path.slice(1) : path
@@ -15,7 +18,13 @@ export function splitRelSegments(rootPath: string, path: string): string[] {
     if (p === rootPath) return []
     if (p.startsWith(rootPath + '/')) p = p.slice(rootPath.length + 1)
   }
-  return p.split('/').filter(Boolean)
+  const out: string[] = []
+  for (const seg of p.split('/')) {
+    if (!seg || seg === '.') continue
+    if (seg === '..') out.pop()
+    else out.push(seg)
+  }
+  return out
 }
 
 /** Join a parent path + child name the way the renderer does (POSIX, no `//`). */

--- a/src/renderer/src/web/web-fs.ts
+++ b/src/renderer/src/web/web-fs.ts
@@ -156,6 +156,14 @@ export function createWebFsApi(): Record<string, unknown> {
       await ws.write(contents)
       await ws.close()
     },
+    // Not part of the preload `fs` namespace — a web-only extra the web robot
+    // backend uses to copy binary meshes (STL) without UTF-8 mangling.
+    writeFileBytes: async (path: string, bytes: Uint8Array): Promise<void> => {
+      const fh = await fileAt(path, true)
+      const ws = await fh.createWritable()
+      await ws.write(bytes)
+      await ws.close()
+    },
     mkdir: async (path: string): Promise<void> => {
       await dirAt(path, true)
     },

--- a/src/renderer/src/web/web-robot.ts
+++ b/src/renderer/src/web/web-robot.ts
@@ -1,0 +1,158 @@
+/**
+ * WEB robot-definition backend — epic #267.
+ * =============================================================================
+ *
+ * Implements `window.api.robot` in the browser over the web filesystem backend
+ * ({@link ./web-fs}), mirroring the Electron main-process layer
+ * (`src/main/robot/ipc.ts`): `load` reads `<folder>/robot.yml` →
+ * {@link robotFromYaml}; `save` writes {@link robotToYaml} with per-path write
+ * queueing so overlapping saves can't interleave. The (de)serialise + sanitise
+ * pipeline is the SAME shared, pure code the desktop uses — so servo↔joint
+ * bindings, poses, the timeline and the project-URDF link all round-trip
+ * identically. This is what lets the Robot view load a project's `servoJointMap`
+ * on the web, which in turn lets `SNK SERVO` telemetry from the WASM sim animate
+ * the 3-D model.
+ *
+ * Electron's no-folder fallback is `<userData>/robot.yml`; the web equivalent is
+ * a localStorage copy (survives reloads, no folder needed — e.g. the bundled
+ * demo arm).
+ *
+ * `onChanged` matches Electron's semantics exactly: it only ever notified OTHER
+ * windows (the saver is excluded), and the web app is single-window — so
+ * subscriptions are accepted but never fired. Firing them locally would make
+ * views reload in response to their own saves (a feedback-loop risk).
+ */
+import { robotFromYaml, robotToYaml } from '../../../shared/robot-yaml'
+import type { RobotDefinition } from '../../../shared/robot'
+
+/** The subset of the web fs backend this layer needs (see {@link ./web-fs}). */
+export interface WebRobotFs {
+  readFile(path: string): Promise<string>
+  writeFile(path: string, contents: string): Promise<void>
+  writeFileBytes(path: string, bytes: Uint8Array): Promise<void>
+  stat(path: string): Promise<{ isDir: boolean }>
+  mkdir(path: string): Promise<void>
+}
+
+/** No-folder fallback slot (the web twin of Electron's `<userData>/robot.yml`). */
+const LS_KEY = 'snakie.web.robot-yml'
+
+const blankRobot = (): RobotDefinition => ({ parts: [], connections: [] })
+
+const hasFolder = (folder?: string): folder is string =>
+  typeof folder === 'string' && folder.trim().length > 0
+
+const robotYmlPath = (folder: string): string => `${folder.replace(/[/\\]+$/, '')}/robot.yml`
+
+/** `parent/of/file.ext` → `parent/of` (empty string for a bare name). */
+const dirname = (path: string): string => {
+  const at = path.lastIndexOf('/')
+  return at > 0 ? path.slice(0, at) : ''
+}
+
+interface ImportMeshResult {
+  cancelled?: boolean
+  error?: string
+  rel?: string
+  name?: string
+}
+
+type PickedFile = { name: string; getFile(): Promise<File> }
+
+/** Build the `robot` Api object (assigned to `window.api.robot` on the web). */
+export function createWebRobotApi(fs: WebRobotFs): Record<string, unknown> {
+  // Per-path write queue — two overlapping saves must not interleave (a
+  // createWritable truncates before writing), mirroring main's queuedWrite.
+  const writeQueues = new Map<string, Promise<void>>()
+  const queuedWrite = (path: string, contents: string): Promise<void> => {
+    const prev = writeQueues.get(path) ?? Promise.resolve()
+    const next = prev.catch(() => undefined).then(() => fs.writeFile(path, contents))
+    writeQueues.set(path, next)
+    return next
+  }
+
+  const subs = new Set<() => void>()
+
+  return {
+    load: async (folder?: string): Promise<RobotDefinition> => {
+      try {
+        const text = hasFolder(folder)
+          ? await fs.readFile(robotYmlPath(folder))
+          : (window.localStorage.getItem(LS_KEY) ?? '')
+        return robotFromYaml(text)
+      } catch {
+        // Missing robot.yml / no folder open / unreadable — a blank definition,
+        // exactly like the desktop handler.
+        return blankRobot()
+      }
+    },
+
+    save: async (
+      folder: string | undefined,
+      def: RobotDefinition
+    ): Promise<{ ok: boolean; error?: string }> => {
+      try {
+        const text = robotToYaml(def)
+        if (hasFolder(folder)) await queuedWrite(robotYmlPath(folder), text)
+        else window.localStorage.setItem(LS_KEY, text)
+        return { ok: true }
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : String(err) }
+      }
+    },
+
+    importMesh: async (urdfPath: string, src?: string): Promise<ImportMeshResult> => {
+      if (!urdfPath) return { error: 'No robot file to import into' }
+      // `src` is an Electron-only path-copy (pulling a URDF's own external meshes
+      // into the project) — the browser can't read arbitrary disk paths.
+      if (src) return { error: "Copying external meshes isn't available in the browser" }
+      const picker = (
+        window as unknown as { showOpenFilePicker?: (o?: unknown) => Promise<PickedFile[]> }
+      ).showOpenFilePicker
+      if (!picker) return { error: 'Mesh import needs a browser with file pickers (Chromium)' }
+      let picked: PickedFile
+      try {
+        const [fh] = await picker({
+          types: [
+            { description: 'Mesh', accept: { 'application/octet-stream': ['.stl', '.dae'] } }
+          ]
+        })
+        picked = fh
+      } catch {
+        return { cancelled: true } // user closed the picker
+      }
+      try {
+        const file = await picked.getFile()
+        const bytes = new Uint8Array(await file.arrayBuffer())
+        const meshesDir = `${dirname(urdfPath) ? dirname(urdfPath) + '/' : ''}meshes`
+        await fs.mkdir(meshesDir)
+        // Collision-safe name: foo.stl, foo-1.stl, foo-2.stl … (like the desktop).
+        const dot = picked.name.lastIndexOf('.')
+        const stem = dot > 0 ? picked.name.slice(0, dot) : picked.name
+        const ext = dot > 0 ? picked.name.slice(dot) : ''
+        let name = picked.name
+        for (let n = 1; n < 1000; n++) {
+          try {
+            await fs.stat(`${meshesDir}/${name}`)
+            name = `${stem}-${n}${ext}` // taken — try the next
+          } catch {
+            break // free
+          }
+        }
+        await fs.writeFileBytes(`${meshesDir}/${name}`, bytes)
+        return { rel: `meshes/${name}`, name }
+      } catch (err) {
+        return { error: err instanceof Error ? err.message : String(err) }
+      }
+    },
+
+    // Parts libraries aren't on the web yet — RobotView treats a rel-less result
+    // as "no mesh to attach" and still writes a valid URDF.
+    importPartMesh: async (): Promise<Record<string, never>> => ({}),
+
+    onChanged: (cb: () => void): (() => void) => {
+      subs.add(cb)
+      return () => subs.delete(cb)
+    }
+  }
+}

--- a/test/webFsPaths.test.ts
+++ b/test/webFsPaths.test.ts
@@ -24,6 +24,15 @@ describe('splitRelSegments', () => {
     // "RootX/f" must NOT be treated as under root "Root".
     expect(splitRelSegments('Root', 'RootX/f')).toEqual(['RootX', 'f'])
   })
+  it('normalises "." segments (URDF mesh refs arrive as ./meshes/x.stl)', () => {
+    expect(splitRelSegments('bot', 'bot/./meshes/arm.stl')).toEqual(['meshes', 'arm.stl'])
+  })
+  it('resolves ".." segments against the parent', () => {
+    expect(splitRelSegments('bot', 'bot/urdf/../meshes/arm.stl')).toEqual(['meshes', 'arm.stl'])
+  })
+  it('clamps ".." at the picked root (the sandbox boundary)', () => {
+    expect(splitRelSegments('bot', 'bot/../../etc/passwd')).toEqual(['etc', 'passwd'])
+  })
 })
 
 describe('childPath', () => {

--- a/test/webRobot.test.ts
+++ b/test/webRobot.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, beforeAll } from 'vitest'
+import { createWebRobotApi, type WebRobotFs } from '../src/renderer/src/web/web-robot'
+import type { RobotDefinition } from '../src/shared/robot'
+
+// The suite runs in a plain node environment; web-robot only touches `window`
+// inside its methods (localStorage + the file picker), so a tiny shim suffices.
+beforeAll(() => {
+  const store = new Map<string, string>()
+  ;(globalThis as { window?: unknown }).window = {
+    localStorage: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, v),
+      clear: () => store.clear()
+    }
+  }
+})
+
+/**
+ * The WEB robot.yml backend (epic #267) — robot.load/save over the web
+ * filesystem using the SAME shared YAML pipeline as the desktop. This is what
+ * lets a project's servo↔joint bindings load in the browser (and therefore what
+ * lets SNK SERVO telemetry from the WASM sim animate the 3-D robot).
+ */
+
+type RobotApi = {
+  load(folder?: string): Promise<RobotDefinition>
+  save(folder: string | undefined, def: RobotDefinition): Promise<{ ok: boolean; error?: string }>
+  importMesh(urdfPath: string, src?: string): Promise<{ cancelled?: boolean; error?: string; rel?: string; name?: string }>
+  onChanged(cb: () => void): () => void
+}
+
+/** In-memory WebRobotFs — text + binary files keyed by path. */
+const memFs = (): WebRobotFs & { files: Map<string, string | Uint8Array> } => {
+  const files = new Map<string, string | Uint8Array>()
+  return {
+    files,
+    readFile: async (p) => {
+      const f = files.get(p)
+      if (typeof f !== 'string') throw new Error(`missing: ${p}`)
+      return f
+    },
+    writeFile: async (p, c) => void files.set(p, c),
+    writeFileBytes: async (p, b) => void files.set(p, b),
+    stat: async (p) => {
+      if (!files.has(p)) throw new Error(`missing: ${p}`)
+      return { isDir: false }
+    },
+    mkdir: async () => undefined
+  }
+}
+
+const BUDDY_YML = [
+  'parts:',
+  '  - id: servo-1',
+  '    lib: snakie-standard',
+  '    part: sg90',
+  'connections: []',
+  'robot:',
+  '  version: 1',
+  '  urdf: robot.urdf',
+  '  servoJointMap:',
+  '    - pin: "0"',
+  '      joint: shoulder_joint',
+  '      servoMin: 0',
+  '      servoMax: 180',
+  '      jointMin: -90',
+  '      jointMax: 90',
+  ''
+].join('\n')
+
+describe('createWebRobotApi', () => {
+  beforeEach(() => (window as unknown as { localStorage: { clear(): void } }).localStorage.clear())
+
+  it('loads <folder>/robot.yml through the shared YAML pipeline (bindings survive)', async () => {
+    const fs = memFs()
+    fs.files.set('buddyjr/robot.yml', BUDDY_YML)
+    const api = createWebRobotApi(fs) as unknown as RobotApi
+    const def = await api.load('buddyjr')
+    expect(def.parts).toHaveLength(1)
+    expect(def.robot?.urdf).toBe('robot.urdf')
+    expect(def.robot?.servoJointMap?.[0]).toMatchObject({ pin: '0', joint: 'shoulder_joint' })
+  })
+
+  it('returns a blank definition when robot.yml is missing (like the desktop)', async () => {
+    const api = createWebRobotApi(memFs()) as unknown as RobotApi
+    expect(await api.load('nowhere')).toEqual({ parts: [], connections: [] })
+  })
+
+  it('save → load round-trips through robotToYaml/robotFromYaml', async () => {
+    const fs = memFs()
+    const api = createWebRobotApi(fs) as unknown as RobotApi
+    const def: RobotDefinition = {
+      parts: [],
+      connections: [],
+      robot: {
+        version: 1,
+        urdf: 'robot.urdf',
+        servoJointMap: [
+          { pin: '2', joint: 'arm_joint', servoMin: 0, servoMax: 180, jointMin: -90, jointMax: 90 }
+        ]
+      }
+    }
+    expect(await api.save('bot', def)).toEqual({ ok: true })
+    expect(typeof fs.files.get('bot/robot.yml')).toBe('string')
+    const back = await api.load('bot')
+    expect(back.robot?.servoJointMap?.[0]).toMatchObject({ pin: '2', joint: 'arm_joint' })
+  })
+
+  it('falls back to localStorage when no folder is open (web twin of userData)', async () => {
+    const api = createWebRobotApi(memFs()) as unknown as RobotApi
+    const def: RobotDefinition = { parts: [], connections: [], robot: { version: 1, urdf: 'a.urdf' } }
+    expect(await api.save(undefined, def)).toEqual({ ok: true })
+    const back = await api.load(undefined)
+    expect(back.robot?.urdf).toBe('a.urdf')
+  })
+
+  it('reports save failures honestly (no false "saved ✓")', async () => {
+    const fs = memFs()
+    fs.writeFile = async () => {
+      throw new Error('disk says no')
+    }
+    const api = createWebRobotApi(fs) as unknown as RobotApi
+    const res = await api.save('bot', { parts: [], connections: [] })
+    expect(res.ok).toBe(false)
+    expect(res.error).toContain('disk says no')
+  })
+
+  it('importMesh copies picked bytes into <urdf-dir>/meshes with a collision-safe name', async () => {
+    const fs = memFs()
+    fs.files.set('bot/meshes/arm.stl', new Uint8Array([1])) // existing → forces -1 suffix
+    // Duck-typed picked file — web-robot only calls getFile().arrayBuffer().
+    const picked = {
+      name: 'arm.stl',
+      getFile: async () => ({ arrayBuffer: async () => new Uint8Array([9, 9]).buffer })
+    }
+    const w = window as unknown as { showOpenFilePicker?: unknown }
+    w.showOpenFilePicker = async () => [picked]
+    const api = createWebRobotApi(fs) as unknown as RobotApi
+    const res = await api.importMesh('bot/robot.urdf')
+    expect(res).toMatchObject({ rel: 'meshes/arm-1.stl', name: 'arm-1.stl' })
+    expect(fs.files.get('bot/meshes/arm-1.stl')).toBeInstanceOf(Uint8Array)
+    delete w.showOpenFilePicker
+  })
+
+  it('importMesh with an Electron src path fails gracefully in the browser', async () => {
+    const api = createWebRobotApi(memFs()) as unknown as RobotApi
+    const res = await api.importMesh('bot/robot.urdf', '/abs/path/mesh.stl')
+    expect(res.error).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## What & why

On **app.snakie.org** the user couldn't run a typed program, and wanted to simulate their robot (buddy_jr) in Robot mode. Two root causes:

1. **Run stays disabled until a device is connected**, and the Connect control (shell-panel header, bottom-right) is easy to miss. The journey itself worked — verified headless. **Fix: the web app auto-connects to the simulated device after first render** (it's the only port on the web). The Files-panel "New file" also now falls back to an untitled buffer instead of being a dead button with no folder open.

2. **`window.api.robot` was a no-op stub on the web** — `robot.yml` (servo↔joint bindings, poses, URDF link) never loaded, so `SNK SERVO` telemetry from the sim had no bindings to animate and "saved ✓" was a lie writing nothing.

## The web robot backend (`web-robot.ts`)

- `load`/`save` over the File System Access backend using the **same shared YAML pipeline as the desktop** (`robotFromYaml`/`robotToYaml` + the krf sanitiser) — bindings, poses, timeline, URDF link all round-trip.
- Per-path write queueing (mirrors main's `queuedWrite`); localStorage fallback when no folder is open (the web twin of `userData/robot.yml`).
- `importMesh` via the browser file picker → `meshes/` with collision-safe names (new `web-fs` `writeFileBytes` so binary STL doesn't get UTF-8-mangled).
- `onChanged` keeps Electron's exclude-the-sender semantics (single window → never fires).

Plus: `splitRelSegments` normalises `./`/`../` (URDF mesh refs arrive verbatim; `getDirectoryHandle('.')` throws; `..` clamps at the picked root = the sandbox boundary), and honest fallback stubs (`robot.save` → `ok:false`; `plugins.motionRead` → `pythonFound:false` so the benign "install Python to sync poses" label shows instead of a spurious "managed block broken" warning).

## Verification

Headless E2E on the built bundle (real buddy_jr project injected via a synthetic directory handle):

| step | result |
|---|---|
| auto-connect on load (no clicks) | PASS |
| new file → type → Run → output streams | PASS |
| Open Folder → tree shows the project | PASS |
| `robot.load` → 4 bindings, `robot.urdf` link, 5 poses | PASS |
| open `robot.urdf` → 3-D robot renders, all 7 STL meshes load | PASS |
| run a servo program → `SNK SERVO` telemetry streams | PASS |
| console errors | 0 |

Gates: typecheck ✓ · lint (0 errors) ✓ · **1711 tests** ✓ · electron build ✓ · web build ✓. New unit suites: `webRobot.test.ts` (7), `webFsPaths` `./`/`..` cases.

Part of epic #267. Auto-deploys to app.snakie.org on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)