### PR TITLE
feat: web parts library + persistent folder (#475, #476)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **The Standard Parts library ships with the web app (#475).** On the web, placed
+  parts (servos, sensors, boards) had no library to resolve against, so a wired-up
+  servo in the board view rendered as just its title. The build now inlines the
+  bundled `snakie-standard` library (part geometry as JSON, images as served
+  assets), so `parts.listLibraries` returns real definitions and the board draws
+  parts as authored. Read-only — authoring/registry writes stay desktop-only.
+- **The web app remembers your folder across reloads (#476).** The picked folder's
+  handle is stored in IndexedDB; on the next visit it's rehydrated automatically
+  when the browser still grants access, and otherwise the Files panel offers a
+  one-click **Reopen &lt;folder&gt;** (browsers require a click to re-grant access).
+
 ## [0.26.0] - 2026-07-12
 
 ### Added

--- a/src/renderer/src/components/LocalFileTree.tsx
+++ b/src/renderer/src/components/LocalFileTree.tsx
@@ -261,6 +261,36 @@ export function LocalFileTree(): JSX.Element {
     }
   }, [openFolder])
 
+  // Web only (#476): a folder persisted from a previous visit that needs a click
+  // to re-grant permission. `reopenFolderName` is absent on desktop, so this
+  // stays null there and the "Reopen" button never renders.
+  const [reopenName, setReopenName] = useState<string | null>(null)
+  useEffect(() => {
+    if (root) {
+      setReopenName(null)
+      return
+    }
+    const fsx = window.api.fs as unknown as { reopenFolderName?: () => Promise<string | null> }
+    if (!fsx.reopenFolderName) return
+    let live = true
+    void fsx.reopenFolderName().then((n) => live && setReopenName(n)).catch(() => undefined)
+    return () => {
+      live = false
+    }
+  }, [root])
+
+  const handleReopenFolder = useCallback(async (): Promise<void> => {
+    const fsx = window.api.fs as unknown as { reopenFolder?: () => Promise<string | null> }
+    if (!fsx.reopenFolder) return
+    try {
+      const path = await fsx.reopenFolder()
+      if (path) openFolderPath(path)
+      else setReopenName(null) // denied/dismissed — drop the offer
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }, [openFolderPath])
+
   const handleSelect = useCallback((path: string, isDir: boolean): void => {
     setSelectedPath(path)
     setSelectedIsDir(isDir)
@@ -554,7 +584,19 @@ export function LocalFileTree(): JSX.Element {
       ) : (
         <div className="localtree__empty">
           {error && <div className="localtree__error">{error}</div>}
-          <button className="btn btn--primary" onClick={handleOpenFolder}>
+          {reopenName && (
+            <button
+              className="btn btn--primary"
+              onClick={() => void handleReopenFolder()}
+              title={`Reopen ${reopenName} from your last visit`}
+            >
+              <span aria-hidden>{'↻'}</span> Reopen {reopenName}
+            </button>
+          )}
+          <button
+            className={reopenName ? 'btn btn--ghost' : 'btn btn--primary'}
+            onClick={handleOpenFolder}
+          >
             <span aria-hidden>{'▸'}</span> Open Folder
           </button>
         </div>

--- a/src/renderer/src/web/install-web-api.ts
+++ b/src/renderer/src/web/install-web-api.ts
@@ -15,6 +15,7 @@
 import { createWebDeviceApi } from './web-device'
 import { createWebFsApi } from './web-fs'
 import { createWebRobotApi, type WebRobotFs } from './web-robot'
+import { createWebPartsApi } from './web-parts'
 import { INSTRUMENTS_PY, SNAKIE_PY } from './web-lib-sources'
 import { VIRTUAL_PORT_PATH } from '../../../shared/virtual-device'
 
@@ -30,6 +31,12 @@ export function installWebApi(): void {
   instruments.librarySource = async (): Promise<string> => INSTRUMENTS_PY
   instruments.umbrellaSource = async (): Promise<string> => SNAKIE_PY
   w.api.instruments = instruments as unknown as Window['api']['instruments']
+  // Serve the bundled Standard Parts library (read-only) so the board view can
+  // resolve a placed part's shapes/pins — otherwise a wired servo shows only its
+  // title (#475). Authoring/registry writes keep the honest fallback stub.
+  const parts = (w.api.parts ?? {}) as Record<string, unknown>
+  Object.assign(parts, createWebPartsApi())
+  w.api.parts = parts as unknown as Window['api']['parts']
   // Local files via the File System Access API — only when the browser supports it
   // (Chromium); elsewhere the no-op fallback stays and "Open Folder" is inert.
   // The robot.yml layer rides on the same backend (bindings/poses/urdf link), so

--- a/src/renderer/src/web/web-env.d.ts
+++ b/src/renderer/src/web/web-env.d.ts
@@ -2,3 +2,11 @@
 
 // Vite's client types provide `*?url` asset imports (the MicroPython .wasm) and
 // `import.meta.env` for the web build (epic #267, Phase W1).
+
+// The bundled Standard Parts library, inlined at build time by
+// vite-plugin-standard-parts (#475).
+declare module 'virtual:snakie-standard-parts' {
+  import type { PartLibraryWithParts } from '../../../shared/part'
+  const libraries: PartLibraryWithParts[]
+  export default libraries
+}

--- a/src/renderer/src/web/web-fs.ts
+++ b/src/renderer/src/web/web-fs.ts
@@ -15,6 +15,7 @@
  * exported for unit tests (the interactive picker itself can't be automated).
  */
 import { splitRelSegments, childPath } from './web-fs-paths'
+import { saveFolderHandle, loadFolderHandle, clearFolderHandle } from './web-idb'
 
 interface FsEntry {
   name: string
@@ -29,12 +30,15 @@ interface FsStat {
 
 // The File System Access types aren't in every TS DOM lib version, so treat the
 // handles structurally.
+type PermState = 'granted' | 'denied' | 'prompt'
 type DirHandle = {
   name: string
   getDirectoryHandle(name: string, opts?: { create?: boolean }): Promise<DirHandle>
   getFileHandle(name: string, opts?: { create?: boolean }): Promise<FileHandleLike>
   removeEntry(name: string, opts?: { recursive?: boolean }): Promise<void>
   entries(): AsyncIterableIterator<[string, DirHandle | FileHandleLike]>
+  queryPermission?(opts?: { mode?: string }): Promise<PermState>
+  requestPermission?(opts?: { mode?: string }): Promise<PermState>
   kind: 'directory'
 }
 type FileHandleLike = {
@@ -54,8 +58,41 @@ export function createWebFsApi(): Record<string, unknown> {
   let root: DirHandle | null = null
   let rootPath = ''
   const loose = new Map<string, FileHandleLike>()
+  // A folder handle rehydrated from IndexedDB (#476) that still needs a user
+  // gesture to re-grant permission. Held here so the empty-state "Reopen" button
+  // can promote it to `root` without re-navigating the picker.
+  let pending: DirHandle | null = null
+
+  const adopt = (handle: DirHandle): string => {
+    root = handle
+    rootPath = handle.name
+    pending = null
+    loose.clear()
+    void saveFolderHandle(handle) // persist for next visit
+    return rootPath
+  }
+
+  // Kick off silent restore immediately (before render). fs ops await this so the
+  // first stat/readDir sees a rehydrated root when permission was already granted.
+  const ready = (async () => {
+    try {
+      const handle = (await loadFolderHandle()) as DirHandle | null
+      if (!handle) return
+      // No queryPermission (e.g. always-usable handles) → treat as granted.
+      const perm = (await handle.queryPermission?.({ mode: 'readwrite' })) ?? 'granted'
+      if (perm === 'granted') {
+        root = handle
+        rootPath = handle.name
+      } else {
+        pending = handle // needs a gesture — offered via reopenFolderName/reopenFolder
+      }
+    } catch {
+      /* nothing persisted / IDB blocked */
+    }
+  })()
 
   const dirAt = async (path: string, create = false): Promise<DirHandle> => {
+    await ready
     if (!root) throw new Error('No folder is open')
     let h = root
     for (const seg of splitRelSegments(rootPath, path)) h = await h.getDirectoryHandle(seg, { create })
@@ -63,6 +100,7 @@ export function createWebFsApi(): Record<string, unknown> {
   }
   const fileAt = async (path: string, create = false): Promise<FileHandleLike> => {
     if (loose.has(path)) return loose.get(path)!
+    await ready
     if (!root) throw new Error('No folder is open')
     const segs = splitRelSegments(rootPath, path)
     const name = segs.pop()
@@ -110,13 +148,36 @@ export function createWebFsApi(): Record<string, unknown> {
     openFolderDialog: async (): Promise<string | null> => {
       if (!w.showDirectoryPicker) return null
       try {
-        const handle = await w.showDirectoryPicker({ mode: 'readwrite' })
-        root = handle
-        rootPath = handle.name
-        loose.clear()
-        return rootPath
+        return adopt(await w.showDirectoryPicker({ mode: 'readwrite' }))
       } catch {
         return null // user cancelled / denied
+      }
+    },
+    // #476: the name of a folder rehydrated from IndexedDB that needs a click to
+    // re-grant permission (null when none pending or already restored). The file
+    // tree's empty state uses this to offer a one-click "Reopen <name>".
+    reopenFolderName: async (): Promise<string | null> => {
+      await ready
+      return pending?.name ?? null
+    },
+    // #476: promote the pending handle to the open root, requesting permission.
+    // MUST be called from a user gesture (button click) — Chromium requires one
+    // to re-grant a persisted directory handle. Returns the root path or null.
+    reopenFolder: async (): Promise<string | null> => {
+      await ready
+      if (!pending) return null
+      try {
+        const perm = (await pending.requestPermission?.({ mode: 'readwrite' })) ?? 'granted'
+        if (perm !== 'granted') {
+          if (perm === 'denied') {
+            pending = null
+            void clearFolderHandle() // stop offering a folder the user won't grant
+          }
+          return null
+        }
+        return adopt(pending)
+      } catch {
+        return null
       }
     },
     openFileDialog: async (): Promise<string | null> => {

--- a/src/renderer/src/web/web-idb.ts
+++ b/src/renderer/src/web/web-idb.ts
@@ -1,0 +1,74 @@
+/**
+ * Tiny IndexedDB slot for ONE value — epic #267 / #476.
+ * =============================================================================
+ *
+ * `FileSystemDirectoryHandle`s are structured-cloneable, so a picked folder can
+ * be stashed in IndexedDB and re-hydrated on the next visit (localStorage can't
+ * hold a handle). We only ever keep the most-recently-opened folder handle, so a
+ * one-row store keyed by a constant is all we need. All calls resolve to a safe
+ * fallback rather than reject, so a private-mode / blocked-IDB browser just loses
+ * persistence instead of breaking the app.
+ */
+const DB_NAME = 'snakie-web'
+const STORE = 'kv'
+const KEY = 'lastFolderHandle'
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 1)
+    req.onupgradeneeded = () => {
+      if (!req.result.objectStoreNames.contains(STORE)) req.result.createObjectStore(STORE)
+    }
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error)
+  })
+}
+
+/** Store the picked directory handle (best-effort; overwrites the previous one). */
+export async function saveFolderHandle(handle: unknown): Promise<void> {
+  try {
+    const db = await openDb()
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE, 'readwrite')
+      tx.objectStore(STORE).put(handle, KEY)
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => reject(tx.error)
+    })
+    db.close()
+  } catch {
+    /* IndexedDB unavailable — folder just won't persist across reloads */
+  }
+}
+
+/** Read the last stored directory handle, or null if none / IDB unavailable. */
+export async function loadFolderHandle(): Promise<unknown | null> {
+  try {
+    const db = await openDb()
+    const value = await new Promise<unknown>((resolve, reject) => {
+      const tx = db.transaction(STORE, 'readonly')
+      const req = tx.objectStore(STORE).get(KEY)
+      req.onsuccess = () => resolve(req.result ?? null)
+      req.onerror = () => reject(req.error)
+    })
+    db.close()
+    return value ?? null
+  } catch {
+    return null
+  }
+}
+
+/** Forget the stored handle (e.g. the folder was moved/deleted). */
+export async function clearFolderHandle(): Promise<void> {
+  try {
+    const db = await openDb()
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE, 'readwrite')
+      tx.objectStore(STORE).delete(KEY)
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => reject(tx.error)
+    })
+    db.close()
+  } catch {
+    /* best-effort */
+  }
+}

--- a/src/renderer/src/web/web-parts.ts
+++ b/src/renderer/src/web/web-parts.ts
@@ -1,0 +1,28 @@
+/**
+ * WEB parts-library backend — epic #267 / #475.
+ * =============================================================================
+ *
+ * Implements the read side of `window.api.parts` in the browser. The desktop
+ * reads installed part libraries off disk (`examples/parts/snakie-standard` +
+ * the user's `my-parts`); the browser has none, so we serve the bundled Standard
+ * Parts library that the {@link ../../../../vite-plugin-standard-parts} plugin
+ * inlined at build time (part geometry as JSON, images as emitted assets).
+ *
+ * This is what lets the board view resolve a placed part's shapes/pins — without
+ * it, a wired-up servo renders as just its title. Only READ operations are real
+ * (listLibraries + a no-op update check); authoring/registry writes stay stubbed
+ * (no per-user library storage on the web yet).
+ */
+import standardLibraries from 'virtual:snakie-standard-parts'
+import type { PartLibraryWithParts } from '../../../shared/part'
+
+/** Build the read-only `parts` Api object (merged onto `window.api.parts`). */
+export function createWebPartsApi(): Record<string, unknown> {
+  const libraries = standardLibraries as PartLibraryWithParts[]
+  return {
+    listLibraries: async (): Promise<PartLibraryWithParts[]> => libraries,
+    // Read-only on the web: no per-user library storage, nothing to update.
+    checkUpdates: async () => [],
+    cachedUpdates: async () => []
+  }
+}

--- a/test/webIdb.test.ts
+++ b/test/webIdb.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { loadFolderHandle, saveFolderHandle, clearFolderHandle } from '../src/renderer/src/web/web-idb'
+
+/**
+ * The IndexedDB folder-handle slot (#476) must degrade gracefully where IDB is
+ * unavailable (private mode, blocked storage, or — as here — a plain node test
+ * env with no `indexedDB` global): reads resolve to null and writes resolve
+ * without throwing, so persistence is simply skipped rather than crashing boot.
+ */
+describe('web-idb graceful fallback (no IndexedDB)', () => {
+  it('load resolves to null when IndexedDB is unavailable', async () => {
+    expect(await loadFolderHandle()).toBeNull()
+  })
+  it('save resolves (no-op) rather than throwing', async () => {
+    await expect(saveFolderHandle({ any: 'handle' })).resolves.toBeUndefined()
+  })
+  it('clear resolves (no-op) rather than throwing', async () => {
+    await expect(clearFolderHandle()).resolves.toBeUndefined()
+  })
+})

--- a/vite-plugin-standard-parts.ts
+++ b/vite-plugin-standard-parts.ts
@@ -1,0 +1,141 @@
+import { readFileSync, readdirSync, statSync } from 'fs'
+import { resolve, join } from 'path'
+import type { Plugin } from 'vite'
+
+/**
+ * Vite plugin (WEB build, epic #267 / #475) that bundles the bundled Standard
+ * Parts library into the browser app.
+ * =============================================================================
+ *
+ * On the desktop, `parts.listLibraries` reads `examples/parts/snakie-standard`
+ * off disk in the main process (image assets inlined as data URLs). The browser
+ * has no filesystem, so this plugin reads that library at BUILD time and exposes
+ * it as the virtual module `virtual:snakie-standard-parts`, whose default export
+ * is a ready-to-serve `PartLibraryWithParts[]`.
+ *
+ * Part geometry (shapes/pins/labels) is inlined as JSON so the board view can
+ * draw parts (servos etc.). Raster `image.<ext>` assets are EMITTED as normal
+ * hashed build assets and referenced by URL (kept out of the JS payload — they
+ * total a few MB), which an SVG `<image href>` renders under `img-src 'self'`.
+ * `help.md` is inlined as `helpText` (small, powers the help panel).
+ *
+ * Parsing intentionally lives in the plugin (Node/build side) using the `yaml`
+ * package, mirroring the desktop's `partFromYaml`/`libraryFromYaml`, so the
+ * shipped data is already validated JSON and the runtime does zero YAML work.
+ */
+
+const VIRTUAL_ID = 'virtual:snakie-standard-parts'
+const RESOLVED_ID = '\0' + VIRTUAL_ID
+const IMAGE_EXTS = ['png', 'jpg', 'jpeg', 'webp', 'svg']
+
+interface EmittedImage {
+  partId: string
+  refId: string
+}
+
+export function standardPartsPlugin(): Plugin {
+  const libRoot = resolve(__dirname, 'examples/parts/snakie-standard')
+
+  return {
+    name: 'snakie-standard-parts',
+
+    resolveId(id) {
+      if (id === VIRTUAL_ID) return RESOLVED_ID
+      return null
+    },
+
+    async load(id) {
+      if (id !== RESOLVED_ID) return null
+
+      // Lazy import so the plugin file itself stays cheap to load.
+      const { parse } = await import('yaml')
+
+      let manifest: Record<string, unknown> = { id: 'snakie-standard', name: 'Standard Parts' }
+      try {
+        manifest = parse(readFileSync(join(libRoot, 'library.yml'), 'utf-8')) as Record<string, unknown>
+      } catch {
+        /* synthesise from defaults */
+      }
+      if (!manifest.id) manifest.id = 'snakie-standard'
+
+      const partDirs = readdirSync(libRoot).filter((name) => {
+        try {
+          return statSync(join(libRoot, name)).isDirectory()
+        } catch {
+          return false
+        }
+      })
+
+      const parts: Record<string, unknown>[] = []
+      const emitted: EmittedImage[] = []
+
+      for (const partId of partDirs) {
+        const partDir = join(libRoot, partId)
+        let part: Record<string, unknown>
+        try {
+          part = parse(readFileSync(join(partDir, 'parts.yml'), 'utf-8')) as Record<string, unknown>
+        } catch {
+          continue // no valid parts.yml — skip (like the desktop reader)
+        }
+        if (!part || typeof part !== 'object') continue
+        if (!part.id) part.id = partId
+        if (!Array.isArray(part.headers)) part.headers = []
+
+        // Inline help.md → helpText (small; powers the help panel).
+        if (typeof part.help === 'string') {
+          try {
+            part.helpText = readFileSync(join(partDir, part.help as string), 'utf-8')
+          } catch {
+            /* missing help — ignore */
+          }
+        }
+
+        // Emit the raster image (if any) as a hashed asset; reference by URL.
+        if (typeof part.image === 'string' && IMAGE_EXTS.some((e) => (part.image as string).toLowerCase().endsWith('.' + e))) {
+          try {
+            const refId = this.emitFile({
+              type: 'asset',
+              name: `parts/${partId}-${part.image as string}`,
+              source: readFileSync(join(partDir, part.image as string))
+            })
+            emitted.push({ partId, refId })
+          } catch {
+            /* unreadable image — part still renders from shapes */
+          }
+        }
+        // Drop fields the board view never needs (keep the payload lean).
+        delete part.drivers
+        delete part.help
+        parts.push(part)
+      }
+
+      // Build the module. Image URLs come from import.meta.ROLLUP_FILE_URL_<ref>
+      // so they carry the final hashed, base-prefixed path.
+      const urlMap = emitted
+        .map((e) => `  ${JSON.stringify(e.partId)}: import.meta.ROLLUP_FILE_URL_${e.refId}`)
+        .join(',\n')
+
+      const libMeta = {
+        id: manifest.id,
+        name: manifest.name ?? 'Standard Parts',
+        description: manifest.description,
+        author: manifest.author,
+        homepage: manifest.homepage,
+        version: manifest.version,
+        source: 'registry'
+      }
+
+      return `
+const IMAGE_URLS = {
+${urlMap}
+}
+const PARTS = ${JSON.stringify(parts)}
+for (const p of PARTS) {
+  const u = IMAGE_URLS[p.id]
+  if (u) p.imageData = u
+}
+export default [{ ...${JSON.stringify(libMeta)}, parts: PARTS }]
+`
+    }
+  }
+}

--- a/vite.web.config.ts
+++ b/vite.web.config.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { standardPartsPlugin } from './vite-plugin-standard-parts'
 
 /**
  * STANDALONE WEB BUILD of the Snakie renderer — epic #267 (Snakie for Web), Phase W0.
@@ -71,6 +72,7 @@ export default defineConfig({
   },
   plugins: [
     react(),
+    standardPartsPlugin(),
     {
       // Relax the renderer CSP for the WEB build ONLY (Electron keeps its strict
       // one): `'wasm-unsafe-eval'` lets the MicroPython WASM instantiate, and


### PR DESCRIPTION
Both changes are **web-only** (desktop reads parts off disk and has no folder-handle concept — unaffected).

## #475 — Standard Parts library on the web
You reported: opening buddy_jr's `.urdf` and going to **breadboard mode**, the servos showed *just their titles, not the parts*. Root cause: `parts.listLibraries` was the empty `[]` stub on the web, so the board couldn't resolve a placed part's shapes/pins.

A new Vite plugin (`vite-plugin-standard-parts.ts`) reads `examples/parts/snakie-standard` at build time and exposes it as `virtual:snakie-standard-parts`:
- part **geometry inlined as JSON** (shapes/pins/labels/dimensions),
- raster **images emitted as hashed assets** and referenced by URL — kept out of the JS payload (~3 MB), rendered by an SVG `<image href>` under `img-src 'self'`.

`web-parts.ts` serves it read-only via `window.api.parts.listLibraries`. Authoring/registry writes stay stubbed (no per-user library storage on the web).

## #476 — Remember the folder across reloads
File System Access handles weren't persisted, so every reload forgot the open folder. Now the picked handle is stored in **IndexedDB** (`web-idb.ts`) and rehydrated on boot:
- **silently** when the browser still grants access (fs ops await the restore before the first `stat`, so the existing `lastFolder` restore just works), and
- otherwise the Files-panel empty state offers a one-click **↻ Reopen &lt;folder&gt;** (Chromium requires a user gesture to re-grant a persisted handle).

## Verification (headless, on the built bundle)

| check | result |
|---|---|
| `parts.listLibraries` | 1 library, **20 parts**; `sg90` = 8 shapes + 3 pins |
| part image serves under `img-src 'self'` | `200 image/png` |
| buddy_jr board render | **15 sg90 body shapes** (was 0 — title-only) |
| OPFS folder persisted → page reload | **silent restore** (`readDir`/`readFile` work, no re-pick) |

Gates: typecheck ✓ · lint 0 errors ✓ · **1714 tests** ✓ · electron + web builds ✓. New tests: `webIdb` fallback, `webFsPaths` `./`/`..` cases (from the prior PR).

Closes #475, closes #476. Part of epic #267. Auto-deploys to app.snakie.org on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)