### PR TITLE
fix: web driver install — serve bundled driver sources (servo.py) (#475)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **Web: installing a part's driver now works (#475).** On the web, installing a
+  part driver from the banner (e.g. sg90 → `servo.py`) failed with "Could not read
+  driver file" because the driver source wasn't available in the browser. The
+  bundled driver files are now inlined at build time and served to the installer,
+  so `import servo` works after one click.
+
 ### Added
 - **The Standard Parts library ships with the web app (#475).** On the web, placed
   parts (servos, sensors, boards) had no library to resolve against, so a wired-up

--- a/src/renderer/src/web/web-env.d.ts
+++ b/src/renderer/src/web/web-env.d.ts
@@ -9,4 +9,6 @@ declare module 'virtual:snakie-standard-parts' {
   import type { PartLibraryWithParts } from '../../../shared/part'
   const libraries: PartLibraryWithParts[]
   export default libraries
+  /** Bundled part driver file contents, keyed `<partId>/<source>`. */
+  export const driverSources: Record<string, string>
 }

--- a/src/renderer/src/web/web-parts.ts
+++ b/src/renderer/src/web/web-parts.ts
@@ -13,14 +13,33 @@
  * (listLibraries + a no-op update check); authoring/registry writes stay stubbed
  * (no per-user library storage on the web yet).
  */
-import standardLibraries from 'virtual:snakie-standard-parts'
+import standardLibraries, { driverSources } from 'virtual:snakie-standard-parts'
 import type { PartLibraryWithParts } from '../../../shared/part'
+
+interface DriverSourceResult {
+  ok: boolean
+  contents?: string
+  error?: string
+}
 
 /** Build the read-only `parts` Api object (merged onto `window.api.parts`). */
 export function createWebPartsApi(): Record<string, unknown> {
   const libraries = standardLibraries as PartLibraryWithParts[]
   return {
     listLibraries: async (): Promise<PartLibraryWithParts[]> => libraries,
+    // Serve a bundled part's driver file (e.g. sg90 → servo.py) so the
+    // "install driver" banner works on the web (#475/#476 follow-up). The
+    // desktop reads it off disk past the CSP; here it's inlined at build time.
+    readDriverSource: async (
+      _libraryId: string,
+      partId: string,
+      source: string
+    ): Promise<DriverSourceResult> => {
+      const contents = (driverSources as Record<string, string>)[`${partId}/${source}`]
+      return contents != null
+        ? { ok: true, contents }
+        : { ok: false, error: `No bundled driver "${source}" for ${partId}.` }
+    },
     // Read-only on the web: no per-user library storage, nothing to update.
     checkUpdates: async () => [],
     cachedUpdates: async () => []

--- a/vite-plugin-standard-parts.ts
+++ b/vite-plugin-standard-parts.ts
@@ -68,6 +68,9 @@ export function standardPartsPlugin(): Plugin {
 
       const parts: Record<string, unknown>[] = []
       const emitted: EmittedImage[] = []
+      // Driver file contents keyed `<partId>/<source>`, served by the web
+      // readDriverSource so the "install driver" banner works (e.g. sg90 → servo.py).
+      const driverSources: Record<string, string> = {}
 
       for (const partId of partDirs) {
         const partDir = join(libRoot, partId)
@@ -90,6 +93,21 @@ export function standardPartsPlugin(): Plugin {
           }
         }
 
+        // Bundle each declared driver file's source (a bundled filename, not a
+        // `mip:` spec or URL) so readDriverSource can serve it on the web.
+        if (Array.isArray(part.drivers)) {
+          for (const d of part.drivers as { source?: string }[]) {
+            const src = d?.source
+            if (typeof src === 'string' && !src.includes(':') && !src.startsWith('http')) {
+              try {
+                driverSources[`${partId}/${src}`] = readFileSync(join(partDir, src), 'utf-8')
+              } catch {
+                /* unreadable driver — install will report it can't be read */
+              }
+            }
+          }
+        }
+
         // Emit the raster image (if any) as a hashed asset; reference by URL.
         if (typeof part.image === 'string' && IMAGE_EXTS.some((e) => (part.image as string).toLowerCase().endsWith('.' + e))) {
           try {
@@ -103,9 +121,7 @@ export function standardPartsPlugin(): Plugin {
             /* unreadable image — part still renders from shapes */
           }
         }
-        // Drop fields the board view never needs (keep the payload lean).
-        delete part.drivers
-        delete part.help
+        delete part.help // helpText carries it now
         parts.push(part)
       }
 
@@ -134,6 +150,7 @@ for (const p of PARTS) {
   const u = IMAGE_URLS[p.id]
   if (u) p.imageData = u
 }
+export const driverSources = ${JSON.stringify(driverSources)}
 export default [{ ...${JSON.stringify(libMeta)}, parts: PARTS }]
 `
     }


### PR DESCRIPTION
## Bug (web app)
Installing a part's driver from the banner (e.g. buddy_jr's sg90 → `servo.py`) always failed with **"Could not read driver file."** Root cause: `window.api.parts.readDriverSource` was the empty deep-stub on the web, so `installPartDriver` got no contents. (Reported as "first attempt fails, reconnect works" — the driver half never worked; only the auto-seeded `instruments.py` did, which is why reconnecting *looked* like it helped.)

## Fix
- `vite-plugin-standard-parts` now bundles each part's declared **driver file contents** (a bundled filename — not a `mip:` spec or URL) into the virtual module as `driverSources`, and no longer deletes `part.drivers` (so the banner still knows which driver a placed part needs).
- `web-parts` implements `readDriverSource(libraryId, partId, source)`, returning the inlined contents.

## Verified (headless, built bundle)
`readDriverSource('snakie-standard','sg90','servo.py')` → **3849 bytes**; a first-attempt install writes `/lib/servo.py`; `import servo` → `OK True`; the board still renders sg90 (**8 shapes**) with its driver metadata intact; 20 parts total.

Gates: typecheck ✓ · lint 0 errors ✓ · **1714 tests** ✓ · electron + web builds ✓.

Follow-up to #475. Auto-deploys to app.snakie.org on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)