### PR TITLE
fix: run the offline sim in a worker thread so a while-True can't freeze it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ __pycache__/
 
 # Web build (epic #267 — Snakie for Web)
 dist-web/
+.mp-node-worker.built.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Fixed
+- **The offline simulator no longer freezes on a `while True:` loop.** Running a
+  program with a perpetual loop (e.g. the Buddy Jr pose demo) locked up the whole
+  app and spewed `OSError` in the console, because the interpreter ran on the main
+  thread and a loop that only yields via `time.sleep` starves the event loop. The
+  sim now runs the MicroPython interpreter in a worker thread (like the web build),
+  so the app stays responsive, a running program's output/telemetry streams live,
+  and **Stop** reliably halts even a tight loop (it restarts the interpreter, so
+  the RAM filesystem resets — exactly like a reconnect).
 - **Web: installing a part's driver now works (#475).** On the web, installing a
   part driver from the banner (e.g. sg90 → `servo.py`) failed with "Could not read
   driver file" because the driver source wasn't available in the browser. The

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -18,7 +18,14 @@ export default defineConfig({
     build: {
       rollupOptions: {
         input: {
-          index: resolve(__dirname, 'src/main/index.ts')
+          index: resolve(__dirname, 'src/main/index.ts'),
+          // The simulated device runs the MicroPython WASM in a worker_threads
+          // worker so a `while True:` can't freeze the main process. It's loaded
+          // by filename from out/main, so keep entry names unhashed.
+          'mp-node-worker': resolve(__dirname, 'src/main/device/mp-node-worker.ts')
+        },
+        output: {
+          entryFileNames: '[name].js'
         }
       }
     }

--- a/src/main/device/MicroPythonRuntime.ts
+++ b/src/main/device/MicroPythonRuntime.ts
@@ -1,21 +1,11 @@
-import { createRequire } from 'module'
-import { reportError } from '../report-error'
-import { SIM_MACHINE_PY } from '../../shared/sim-machine'
-import type {
-  LoadMicroPythonOptions,
-  MicroPythonInstance
-} from '@micropython/micropython-webassembly-pyscript/micropython.mjs'
+import { Worker } from 'worker_threads'
+import { fileURLToPath } from 'url'
+import { dirname, join } from 'path'
 
-// The main bundle is ESM, so reconstruct a `require` for resolving the package's
-// `.wasm` file path (works in dev, in the packaged asar, and under vitest).
-const require = createRequire(import.meta.url)
-
-/** Specifier of the MicroPython WebAssembly ESM loader + its binary. */
-const MP_MJS = '@micropython/micropython-webassembly-pyscript/micropython.mjs'
-const MP_WASM = '@micropython/micropython-webassembly-pyscript/micropython.wasm'
-
-/** How often buffered interpreter output is flushed to the consumer (ms). */
-const FLUSH_INTERVAL_MS = 16
+// The worker file is emitted alongside this bundle (electron.vite builds
+// `mp-node-worker` as a second main entry → out/main/mp-node-worker.js).
+const WORKER_FILE = 'mp-node-worker.js'
+const defaultWorkerPath = join(dirname(fileURLToPath(import.meta.url)), WORKER_FILE)
 
 /**
  * A REPL backend the {@link SimulatedDevice} drives. Abstracted so the device
@@ -33,126 +23,149 @@ export interface ReplRuntime {
    * snippet raises a Python exception.
    */
   runCaptured(code: string): Promise<string>
+  /**
+   * Stop whatever's running (Stop button). When idle this is a gentle Ctrl-C
+   * that keeps REPL state; when a program is running it reboots the interpreter
+   * (the only way to break a no-yield / tight loop), resetting the RAM VFS —
+   * exactly like a reconnect.
+   */
+  interrupt(): Promise<void>
   /** Tear the runtime down. */
   dispose(): void
 }
 
+type Pending = { resolve: (v: string) => void; reject: (e: Error) => void; kind: 'feed' | 'run' }
+type OutMsg =
+  | { type: 'out'; bytes: Uint8Array }
+  | { type: 'ready' }
+  | { type: 'done'; id: number; error?: string }
+  | { type: 'result'; id: number; value?: string; error?: string }
+
 /**
- * REAL MicroPython interpreter, compiled to WebAssembly (issue #135).
+ * REAL MicroPython interpreter (WebAssembly, issue #135), run in a Node
+ * worker_threads worker so a perpetual `while True:` loop can't freeze the
+ * Electron main process. This is the main-thread proxy — the twin of the web
+ * build's `WorkerMicroPythonRuntime` — driving {@link ./mp-node-worker} over
+ * messages: `init` boots the interpreter (+ the simulated `machine` module),
+ * `feed` streams REPL/paste-mode input, `run` executes a captured snippet.
  *
- * Wraps the official `@micropython/micropython-webassembly-pyscript` build so the
- * simulated device runs ACTUAL Python: `init()` boots the interpreter and prints
- * the friendly banner + prompt, and `feed()` pushes input bytes through the
- * genuine MicroPython REPL — so interactive typing, **paste mode** (how the Run
- * button ships a file: Ctrl-E … Ctrl-D), Ctrl-C and Ctrl-D all work natively.
- *
- * Output arrives one byte at a time from Emscripten; we buffer it and flush on a
- * short timer so a running program streams without firing an IPC message per
- * character. Hardware modules (`machine`, etc.) don't exist in the WASM port, so
- * importing them raises `ImportError` — exactly like a board with no such device.
+ * `interrupt()` is smart: idle → a queued Ctrl-C (keeps the VFS); running → a
+ * worker reboot (the only way to break a loop that never yields to JS), which
+ * resets the RAM filesystem like a reconnect.
  */
 export class MicroPythonRuntime implements ReplRuntime {
-  private mp: MicroPythonInstance | null = null
+  private worker: Worker | null = null
   private onOutput: ((chunk: Buffer) => void) | null = null
-  private pending: number[] = []
-  /** When set, interpreter output is diverted here instead of the console. */
-  private capturing: number[] | null = null
-  private flushTimer: ReturnType<typeof setInterval> | null = null
-  /** Serializes input so bytes are processed strictly in order. */
-  private queue: Promise<unknown> = Promise.resolve()
+  private nextId = 1
+  private readonly pending = new Map<number, Pending>()
+  private readyResolve: (() => void) | null = null
+  /** In-flight feed/run count — >0 means the interpreter is busy/running. */
+  private busy = 0
+  private readonly workerPath: string
+
+  /** `workerFile` overrides the bundled worker path. Falls back to
+   *  `SNAKIE_MP_WORKER` (set by the vitest setup, which compiles the worker to a
+   *  temp file since tests have no built `out/main`), then the bundled path. */
+  constructor(workerFile?: string) {
+    this.workerPath = workerFile ?? process.env.SNAKIE_MP_WORKER ?? defaultWorkerPath
+  }
 
   async init(onOutput: (chunk: Buffer) => void): Promise<void> {
     this.onOutput = onOutput
-    const wasmPath = require.resolve(MP_WASM)
-    const { loadMicroPython } = await import(MP_MJS)
-    const options: LoadMicroPythonOptions = {
-      url: wasmPath,
-      linebuffer: false,
-      stdout: (bytes) => this.collect(bytes),
-      stderr: (bytes) => this.collect(bytes)
-    }
-    const mp = await loadMicroPython(options)
-    this.mp = mp
-    // The WASM port ships no `machine` module — install a simulated one so
-    // `from machine import Pin` (the first line of most lessons) works (#267).
-    try {
-      mp.runPython(SIM_MACHINE_PY)
-    } catch {
-      /* best-effort — without it, `import machine` just raises as before */
-    }
-    // Stream buffered output on a short cadence so long-running programs show
-    // progress instead of dumping everything when they finish.
-    this.flushTimer = setInterval(() => this.flush(), FLUSH_INTERVAL_MS)
-    this.flushTimer.unref?.()
-    // Print the banner + first prompt.
-    mp.replInit()
-    this.flush()
+    await this.spawn()
   }
 
-  feed(data: string): Promise<void> {
-    const op = this.queue.then(async () => {
-      const mp = this.mp
-      if (!mp) return
-      for (const byte of Buffer.from(data, 'utf8')) {
-        await mp.replProcessCharWithAsyncify(byte)
-      }
-      this.flush()
+  private spawn(): Promise<void> {
+    const worker = new Worker(this.workerPath)
+    this.worker = worker
+    worker.on('message', (m: OutMsg) => this.handle(m))
+    // A worker-level error rejects the boot / any in-flight request rather than
+    // hanging the device layer.
+    worker.on('error', (err) => {
+      const e = err instanceof Error ? err : new Error(String(err))
+      for (const p of this.pending.values()) p.reject(e)
+      this.pending.clear()
+      this.busy = 0
+      this.readyResolve?.()
+      this.readyResolve = null
     })
-    // Keep the queue alive even if one feed rejects — but log it (#225) so a
-    // silently-failing REPL feed isn't invisible.
-    this.queue = op.catch((err) => reportError('sim runtime feed', err))
-    return op
+    const ready = new Promise<void>((res) => {
+      this.readyResolve = res
+    })
+    worker.postMessage({ type: 'init' })
+    return ready
+  }
+
+  private handle(msg: OutMsg): void {
+    if (msg.type === 'out') {
+      this.onOutput?.(Buffer.from(msg.bytes))
+      return
+    }
+    if (msg.type === 'ready') {
+      this.readyResolve?.()
+      this.readyResolve = null
+      return
+    }
+    // 'done' (feed) or 'result' (run) — settle the matching request.
+    this.busy = Math.max(0, this.busy - 1)
+    const p = this.pending.get(msg.id)
+    if (!p) return
+    this.pending.delete(msg.id)
+    if (msg.error) p.reject(new Error(msg.error))
+    else p.resolve(msg.type === 'result' ? (msg.value ?? '') : '')
+  }
+
+  private request(payload: { type: 'feed'; data: string } | { type: 'run'; code: string }): Promise<string> {
+    const worker = this.worker
+    if (!worker) return Promise.reject(new Error('MicroPython runtime is not running'))
+    const id = this.nextId++
+    this.busy += 1
+    return new Promise<string>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject, kind: payload.type })
+      worker.postMessage({ ...payload, id })
+    })
+  }
+
+  async feed(data: string): Promise<void> {
+    await this.request({ type: 'feed', data })
   }
 
   runCaptured(code: string): Promise<string> {
-    const op = this.queue.then(() => {
-      const mp = this.mp
-      if (!mp) throw new Error('MicroPython runtime is not running')
-      // Emit any console output buffered so far, then divert this snippet's
-      // output into a private buffer so it stays off the console.
-      this.flush()
-      this.capturing = []
-      try {
-        // Run SYNCHRONOUSLY (mp_js_do_exec), NOT the Asyncify path. The FS
-        // helpers (listdir/read/write/stat/…) are plain synchronous Python, and
-        // the sync exec avoids the Asyncify reentrancy that can make a nested
-        // call return a NULL object — surfaced as "NULL object" on the simulated
-        // device's file ops and the instruments-library install. Output is
-        // captured the same way; a Python exception throws (rejecting the op).
-        mp.runPython(code)
-        return Buffer.from(this.capturing).toString('utf8')
-      } finally {
-        this.capturing = null
-      }
-    })
-    this.queue = op.catch((err) => reportError('sim runtime exec', err))
-    return op
+    return this.request({ type: 'run', code })
+  }
+
+  async interrupt(): Promise<void> {
+    // Idle → a gentle Ctrl-C keeps REPL + VFS state. Busy (a program is running,
+    // possibly a no-yield loop) → reboot the worker: the only way to break it.
+    if (this.busy <= 0) {
+      await this.feed('\x03').catch(() => undefined)
+      return
+    }
+    await this.reboot()
+  }
+
+  private async reboot(): Promise<void> {
+    // The in-flight FEED is the running program itself (the Run) — stopping it is
+    // a normal completion, so RESOLVE it (rejecting would surface a spurious
+    // "couldn't send your program" from the Run button's catch). In-flight RUNs
+    // (FS ops / probes) genuinely didn't complete — reject so callers can retry.
+    for (const p of this.pending.values()) {
+      if (p.kind === 'feed') p.resolve('')
+      else p.reject(new Error('interrupted'))
+    }
+    this.pending.clear()
+    this.busy = 0
+    await this.worker?.terminate()
+    this.worker = null
+    this.onOutput?.(Buffer.from('\r\n[stopped — simulator restarted]\r\n', 'utf8'))
+    await this.spawn()
   }
 
   dispose(): void {
-    if (this.flushTimer) {
-      clearInterval(this.flushTimer)
-      this.flushTimer = null
-    }
-    this.flush()
-    this.mp = null
+    void this.worker?.terminate()
+    this.worker = null
     this.onOutput = null
-    this.pending = []
-    this.capturing = null
-  }
-
-  /** Accumulate interpreter output — into the capture buffer if one is active
-   * (a `runCaptured` snippet), otherwise the console-bound pending buffer. */
-  private collect(bytes: Uint8Array): void {
-    const sink = this.capturing ?? this.pending
-    for (const b of bytes) sink.push(b)
-  }
-
-  /** Emit any buffered output as a single chunk. */
-  private flush(): void {
-    if (this.pending.length === 0 || !this.onOutput) return
-    const chunk = Buffer.from(this.pending)
-    this.pending = []
-    this.onOutput(chunk)
+    this.pending.clear()
+    this.busy = 0
   }
 }

--- a/src/main/device/SimulatedDevice.ts
+++ b/src/main/device/SimulatedDevice.ts
@@ -183,9 +183,13 @@ export class SimulatedDevice extends EventEmitter implements SnakieDevice {
     this.control.set(target, payload)
   }
 
-  /** Ctrl-C — interrupt the running program in the real REPL. */
+  /** Stop the running program. Goes to the runtime (not through `sendData`): the
+   *  sim runs the interpreter in a worker, and a `while True:` can only be broken
+   *  by rebooting it — a queued Ctrl-C would never be read. When idle it's a
+   *  gentle Ctrl-C that keeps state. */
   async interrupt(): Promise<void> {
-    await this.sendData('\x03')
+    if (this.state !== 'connected') return
+    await this.runtime.interrupt()
   }
 
   /** Ctrl-D — soft-reset the real REPL. */

--- a/src/main/device/mp-node-worker.ts
+++ b/src/main/device/mp-node-worker.ts
@@ -1,0 +1,119 @@
+/**
+ * MicroPython sim NODE WORKER (worker_threads) — #135 / desktop twin of the web's
+ * {@link ../../renderer/src/web/mp.worker}.
+ * =============================================================================
+ *
+ * Runs the MicroPython WASM interpreter OFF the Electron MAIN thread. A student's
+ * `while True:` loop yields to JS only via Asyncify, which — crucially — does NOT
+ * let the event loop's macrotasks run until the loop ends. In-process that froze
+ * the whole main process (IPC, Stop button, everything) on any perpetual loop; in
+ * a worker it only saturates the worker thread, and the main process stays live.
+ * {@link MicroPythonRuntime} drives this over `parentPort`, and stops a runaway
+ * loop by terminating + re-spawning the worker (the only reliable way — Ctrl-C
+ * can't be delivered while the loop monopolises the worker's event loop).
+ */
+import { parentPort } from 'worker_threads'
+import { createRequire } from 'module'
+import { SIM_MACHINE_PY } from '../../shared/sim-machine'
+import type { MicroPythonInstance } from '@micropython/micropython-webassembly-pyscript/micropython.mjs'
+
+const require = createRequire(import.meta.url)
+const MP_MJS = '@micropython/micropython-webassembly-pyscript/micropython.mjs'
+const MP_WASM = '@micropython/micropython-webassembly-pyscript/micropython.wasm'
+
+type InMsg =
+  | { type: 'init' }
+  | { type: 'feed'; id: number; data: string }
+  | { type: 'run'; id: number; code: string }
+
+const port = parentPort
+if (!port) throw new Error('mp-node-worker must run as a worker_threads Worker')
+
+/** Flush console output once it reaches this many bytes without a newline. */
+const FLUSH_BYTES = 256
+
+const enc = new TextEncoder()
+let mp: MicroPythonInstance | null = null
+let pending: number[] = []
+let capturing: number[] | null = null
+
+const flush = (): void => {
+  if (capturing || pending.length === 0) return
+  const chunk = Uint8Array.from(pending)
+  pending = []
+  port.postMessage({ type: 'out', bytes: chunk })
+}
+
+const collect = (bytes: Uint8Array): void => {
+  if (capturing) {
+    for (const b of bytes) capturing.push(b)
+    return
+  }
+  let sawNewline = false
+  for (const b of bytes) {
+    pending.push(b)
+    if (b === 10) sawNewline = true
+  }
+  // A `while True:` with time.sleep starves the flush TIMER (Asyncify doesn't
+  // yield to macrotasks until the loop ends), but this stdout callback IS called
+  // as the program prints — so pump here, batched per line, to keep a running
+  // program's output + `SNK …` telemetry streaming instead of stalling.
+  if (sawNewline || pending.length >= FLUSH_BYTES) flush()
+}
+
+port.on('message', async (msg: InMsg): Promise<void> => {
+  if (msg.type === 'init') {
+    const { loadMicroPython } = await import(MP_MJS)
+    const loaded: MicroPythonInstance = await loadMicroPython({
+      url: require.resolve(MP_WASM),
+      linebuffer: false,
+      stdout: collect,
+      stderr: collect
+    })
+    mp = loaded
+    const timer = setInterval(flush, 16)
+    timer.unref?.()
+    // The WASM port has no `machine` module — install a simulated one so
+    // `from machine import Pin` (every lesson's first line) works (#267).
+    try {
+      loaded.runPython(SIM_MACHINE_PY)
+    } catch {
+      /* best-effort — a missing machine stub just means the ImportError returns */
+    }
+    loaded.replInit()
+    flush()
+    port.postMessage({ type: 'ready' })
+    return
+  }
+  const instance = mp
+  if (!instance) return
+  if (msg.type === 'feed') {
+    try {
+      for (const byte of enc.encode(msg.data)) {
+        await instance.replProcessCharWithAsyncify(byte)
+      }
+      flush()
+      port.postMessage({ type: 'done', id: msg.id })
+    } catch (err) {
+      flush()
+      port.postMessage({ type: 'done', id: msg.id, error: String(err) })
+    }
+    return
+  }
+  if (msg.type === 'run') {
+    flush()
+    capturing = []
+    try {
+      instance.runPython(msg.code)
+      port.postMessage({
+        type: 'result',
+        id: msg.id,
+        value: new TextDecoder().decode(Uint8Array.from(capturing))
+      })
+    } catch (err) {
+      port.postMessage({ type: 'result', id: msg.id, error: String(err) })
+    } finally {
+      capturing = null
+    }
+  }
+})

--- a/test/micropythonRuntime.test.ts
+++ b/test/micropythonRuntime.test.ts
@@ -3,9 +3,10 @@ import { MicroPythonRuntime } from '../src/main/device/MicroPythonRuntime'
 
 /**
  * Integration test for the REAL MicroPython WebAssembly runtime (issue #135) —
- * this actually loads + runs the interpreter, so it proves the offline device
- * executes Python (this is what makes "hello world" print). Generous timeouts
- * cover the one-off WASM load.
+ * this actually loads + runs the interpreter (in a worker_threads worker, so a
+ * `while True:` can't freeze the process), proving the offline device executes
+ * Python. The worker is compiled by the vitest globalSetup and located via
+ * `SNAKIE_MP_WORKER`. Generous timeouts cover the one-off WASM load.
  */
 describe('MicroPythonRuntime (real WebAssembly)', () => {
   it('runs a hello-world program via paste mode and streams its output', async () => {
@@ -16,7 +17,7 @@ describe('MicroPythonRuntime (real WebAssembly)', () => {
     // Exactly what the Run button sends: Ctrl-E (paste mode) … Ctrl-D (execute).
     const program = 'print("Hello, World!")\nfor i in range(3):\n    print("n", i)\n'
     await rt.feed('\x05' + program + '\x04')
-    await new Promise((r) => setTimeout(r, 50)) // let the flush timer drain
+    await new Promise((r) => setTimeout(r, 50)) // let the flush drain
 
     const text = Buffer.concat(out).toString('utf8')
     expect(text).toContain('Hello, World!')
@@ -44,6 +45,23 @@ describe('MicroPythonRuntime (real WebAssembly)', () => {
     const text = Buffer.concat(out).toString('utf8')
     expect(text).toContain('pinval 1')
     expect(text).not.toContain('ImportError')
+    rt.dispose()
+  }, 30000)
+
+  it('breaks a running loop via interrupt (worker reboot) and recovers (#135)', async () => {
+    const rt = new MicroPythonRuntime()
+    const out: Buffer[] = []
+    await rt.init((c) => out.push(c))
+    // Paste-run a perpetual loop (buddy_jr-style). Its feed never settles, and
+    // it can't freeze us because it runs in the worker.
+    const runP = rt.feed('\x05import time\r\nwhile True:\r\n    time.sleep_ms(20)\r\n\x04').catch(() => undefined)
+    await new Promise((r) => setTimeout(r, 500))
+    // Stop it — reboots the worker; the abandoned feed resolves.
+    await rt.interrupt()
+    await runP
+    // The runtime works again afterwards.
+    const result = await rt.runCaptured('print(6*7)')
+    expect(result).toContain('42')
     rt.dispose()
   }, 30000)
 })

--- a/test/setup/globalSetup.ts
+++ b/test/setup/globalSetup.ts
@@ -1,0 +1,19 @@
+import { build } from 'esbuild'
+import { rm } from 'fs/promises'
+import { TEST_WORKER_PATH, WORKER_ENTRY } from './mp-worker'
+
+/** Vitest globalSetup: compile the sim worker once for the whole run. */
+export async function setup(): Promise<void> {
+  await build({
+    entryPoints: [WORKER_ENTRY],
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    external: ['@micropython/*'],
+    outfile: TEST_WORKER_PATH
+  })
+}
+
+export async function teardown(): Promise<void> {
+  await rm(TEST_WORKER_PATH, { force: true })
+}

--- a/test/setup/mp-worker.ts
+++ b/test/setup/mp-worker.ts
@@ -1,0 +1,11 @@
+import { resolve } from 'path'
+
+/**
+ * The MicroPython sim runs its interpreter in a worker_threads worker (so a
+ * `while True:` can't freeze the process). worker_threads can't load a `.ts`
+ * file and tests have no built `out/main`, so the vitest globalSetup compiles
+ * the worker to this repo-root temp `.mjs` (where `@micropython` + the `.wasm`
+ * resolve), and the per-file setup points the runtime at it via env.
+ */
+export const TEST_WORKER_PATH = resolve(process.cwd(), '.mp-node-worker.built.mjs')
+export const WORKER_ENTRY = resolve(process.cwd(), 'src/main/device/mp-node-worker.ts')

--- a/test/setup/setupFile.ts
+++ b/test/setup/setupFile.ts
@@ -1,0 +1,7 @@
+import { TEST_WORKER_PATH } from './mp-worker'
+
+// Point the (worker-thread-backed) MicroPython runtime at the worker that
+// globalSetup compiled, so integration tests spawn a real interpreter. Runs in
+// each test worker before its file loads; globalSetup (main process) can't set
+// env across the process boundary, so we set it here.
+process.env.SNAKIE_MP_WORKER ??= TEST_WORKER_PATH

--- a/test/simulatedDevice.test.ts
+++ b/test/simulatedDevice.test.ts
@@ -32,6 +32,10 @@ class FakeRuntime implements ReplRuntime {
     this.capturedCalls.push(code)
     return this.nextCaptured
   }
+  interrupts = 0
+  async interrupt(): Promise<void> {
+    this.interrupts += 1
+  }
   dispose(): void {}
 }
 
@@ -87,10 +91,11 @@ describe('SimulatedDevice lifecycle', () => {
     expect(runtime.feeds).toContain('\x05print("hi")\x04')
     expect(data.join('')).toContain('echo:')
 
-    // interrupt / softReset feed the control bytes too.
+    // interrupt goes to the runtime (a queued Ctrl-C would deadlock behind a
+    // running program's feed); softReset still feeds Ctrl-D.
     await dev.interrupt()
     await dev.softReset()
-    expect(runtime.feeds).toContain('\x03')
+    expect(runtime.interrupts).toBe(1)
     expect(runtime.feeds).toContain('\x04')
 
     await dev.dispose()

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,10 @@ export default defineConfig({
   test: {
     globals: false,
     environment: 'node',
-    include: ['test/**/*.test.ts']
+    include: ['test/**/*.test.ts'],
+    // Compile the sim's worker_threads worker once, and point the runtime at it
+    // (integration tests spawn a real MicroPython interpreter in that worker).
+    globalSetup: ['./test/setup/globalSetup.ts'],
+    setupFiles: ['./test/setup/setupFile.ts']
   }
 })


### PR DESCRIPTION
## Bug (desktop)
Running a program with a perpetual loop — e.g. **buddy_jr.py**'s `while True:` — froze the whole app and spammed `[sim runtime exec] OSError 44/20`.

## Root cause
The MicroPython interpreter ran on the Electron **main thread**, and an Asyncify `time.sleep` loop does **not** yield to the JS macrotask queue until it ends. Proven headless: a bounded `for _ in range(40): time.sleep_ms(50)` blocked `setInterval` for its *entire* 2 s (macrotasks resumed only at t=2001 ms). So a `while True:` starved the event loop completely (IPC, the Stop button, even the output-flush timer), and Snakie's concurrent file ops re-entered the suspended interpreter and corrupted the VFS → the emscripten `ENOENT (44)` / `EEXIST (20)`.

The web build already avoids this by running the sim in a Web Worker; the desktop didn't.

## Fix — mirror the web build
- **`mp-node-worker.ts`** — the interpreter now runs in a `worker_threads` worker. Proven: with the loop in a worker, the main thread stayed fully responsive (heartbeat **19 ticks / 2 s** vs **0** in-process).
- **`MicroPythonRuntime`** becomes a main-thread proxy driving the worker over messages (`init`/`feed`/`run`) — the twin of the web's `WorkerMicroPythonRuntime`.
- **`interrupt()` is smart**: idle → a queued Ctrl-C (keeps REPL + VFS state); running → **terminate + respawn** the worker (the only way to break a no-yield loop), resetting the RAM filesystem like a reconnect. The abandoned Run feed **resolves** (not rejects), so Stop never shows a false _"couldn't send your program."_
- The worker **flushes stdout on each newline** (the flush timer is starved during a tight loop), so a running program's output + `SNK …` telemetry stream **live** — the 3-D model animates.
- **electron.vite**: emits `mp-node-worker.js` as a second main entry (unhashed, loaded by filename from `out/main`).
- Integration tests compile the worker via a vitest `globalSetup` and locate it with `SNAKIE_MP_WORKER`; added an interrupt-recovery case.

## Verified end-to-end (built worker, real interpreter)
| check | result |
|---|---|
| buddy_jr `while True:` running | main heartbeat **19/2s** (was frozen) |
| output during the loop | `pose:` streams; `SNK SERVO` telemetry streams (8 frames) |
| FS op during the run | queues (doesn't corrupt) |
| **Stop** (interrupt) | halts the loop; `exec` works again (`OK:42`) |
| console `OSError` | gone |

Gates: typecheck ✓ · lint 0 errors ✓ · **1715 tests** ✓ · electron + web builds ✓.

> Note: this changes desktop **Stop** of a *running* program to reset the sim's RAM filesystem (installed `/lib` files clear) — same as the web, and the only reliable way to break a tight loop. Stopping at an idle prompt still keeps state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)