### PR TITLE
feat: connect real boards over Web Serial in the browser (#465)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Connect a real board over Web Serial, in the browser (#465).** On a Chromium
+  browser (Chrome, Edge, a Chromebook), app.snakie.org can now talk to a real
+  Pico / ESP over USB — the REPL, Run/Stop, the device file tree, module installs
+  and the instruments all work over Web Serial, right alongside the offline
+  simulator. Pick a board with the new **＋ Connect a USB board** entry (filtered
+  to known board/bridge chips); already-granted boards show up in the port list.
+  The raw-REPL protocol is shared with the desktop, so a board behaves identically.
+
+### Added
 - **The web app is now an installable PWA that works offline (#464).** app.snakie.org
   can be installed to the ChromeOS shelf / your dock (name, icons, standalone window),
   and a Workbox service worker precaches the whole app shell — including the MicroPython

--- a/src/renderer/src/web/install-web-api.ts
+++ b/src/renderer/src/web/install-web-api.ts
@@ -12,7 +12,7 @@
  * `main.tsx`, via a dynamic import), so the Electron bundle never pulls in the
  * MicroPython WASM.
  */
-import { createWebDeviceApi } from './web-device'
+import { createWebDeviceRouter } from './web-device-router'
 import { createWebFsApi } from './web-fs'
 import { createWebRobotApi, type WebRobotFs } from './web-robot'
 import { createWebPartsApi } from './web-parts'
@@ -22,7 +22,8 @@ import { VIRTUAL_PORT_PATH } from '../../../shared/virtual-device'
 export function installWebApi(): void {
   const w = window as typeof window & { api?: Record<string, unknown> }
   if (!w.api) return // the fallback runs first and sets this; guard defensively
-  w.api.device = createWebDeviceApi() as unknown as Window['api']['device']
+  // The device namespace multiplexes the WASM simulator + real Web Serial boards.
+  w.api.device = createWebDeviceRouter() as unknown as Window['api']['device']
   // Serve the bundled MicroPython library sources so the "Install library" banner
   // + its version check work on the web (the fallback returns '' → the install
   // failed with "library source unavailable"). The sim also auto-seeds these into

--- a/src/renderer/src/web/web-device-router.ts
+++ b/src/renderer/src/web/web-device-router.ts
@@ -1,0 +1,97 @@
+/**
+ * WEB device router — multiplex the simulator + real Web Serial boards (#465).
+ * =============================================================================
+ *
+ * `window.api.device` on the web is a single namespace, but there are now two
+ * backends: the offline WASM {@link ./web-device simulator} and a real board over
+ * {@link ./web-serial Web Serial}. This router presents both in the port dropdown
+ * (the virtual "Simulated device", any granted USB boards, and a "Connect a USB
+ * board…" entry that triggers the picker), routes `connect()` to the right one,
+ * and forwards every other call + `onData`/`onStatus` event to whichever backend
+ * is active. Real-board features (device file tree, module installs, instruments)
+ * work over the serial transport exactly as they do on the sim.
+ */
+import { VIRTUAL_PORT_PATH } from '../../../shared/virtual-device'
+import { createWebDeviceApi } from './web-device'
+import { createWebSerialBackend, webSerialSupported, WEBSERIAL_PICK, WEBSERIAL_PREFIX } from './web-serial'
+
+type Backend = Record<string, unknown>
+type Fn = (...a: unknown[]) => unknown
+const call = (b: Backend, m: string, ...a: unknown[]): unknown => (b[m] as Fn)(...a)
+
+interface Port {
+  path: string
+  friendlyName: string
+}
+
+export function createWebDeviceRouter(): Record<string, unknown> {
+  const sim = createWebDeviceApi()
+  const serial = createWebSerialBackend()
+  // Which backend owns the current connection. Defaults to sim (status/no-ops).
+  let active: Backend = sim
+
+  const isSerialPath = (p: string): boolean => p === WEBSERIAL_PICK || p.startsWith(WEBSERIAL_PREFIX)
+
+  return {
+    listPorts: async (): Promise<Port[]> => {
+      const simPorts = (await call(sim, 'listPorts')) as Port[]
+      const serialPorts = webSerialSupported() ? ((await call(serial, 'listPorts')) as Port[]) : []
+      const pick: Port[] = webSerialSupported()
+        ? [{ path: WEBSERIAL_PICK, friendlyName: '＋ Connect a USB board…' }]
+        : []
+      return [...simPorts, ...serialPorts, ...pick]
+    },
+
+    connect: async (path: string): Promise<void> => {
+      const next = isSerialPath(path) ? serial : sim
+      // Drop any existing connection on the OTHER backend first.
+      if (active !== next) await (call(active, 'disconnect') as Promise<unknown>).catch(() => undefined)
+      active = next
+      await call(next, 'connect', path)
+    },
+
+    disconnect: async (): Promise<void> => {
+      await call(active, 'disconnect')
+    },
+
+    getStatus: async () => call(active, 'getStatus'),
+
+    // ── Everything else delegates to the active backend ──────────────────────
+    exec: async (code: string) => call(active, 'exec', code),
+    eval: async (code: string) => call(active, 'eval', code),
+    sendData: async (data: string) => call(active, 'sendData', data),
+    sendControl: async (target: string, payload?: string) => call(active, 'sendControl', target, payload),
+    interrupt: async () => call(active, 'interrupt'),
+    softReset: async () => call(active, 'softReset'),
+    listDir: async (p = '/') => call(active, 'listDir', p),
+    df: async () => call(active, 'df'),
+    readFile: async (p: string) => call(active, 'readFile', p),
+    readFileBytes: async (p: string) => call(active, 'readFileBytes', p),
+    writeFile: async (p: string, contents: string) => call(active, 'writeFile', p, contents),
+    remove: async (p: string) => call(active, 'remove', p),
+    mkdir: async (p: string) => call(active, 'mkdir', p),
+    rename: async (from: string, to: string) => call(active, 'rename', from, to),
+    stat: async (p: string) => call(active, 'stat', p),
+
+    // Subscribe to BOTH backends so events flow regardless of which is active.
+    onData: (cb: (chunk: Uint8Array) => void) => {
+      const a = call(sim, 'onData', cb) as () => void
+      const b = call(serial, 'onData', cb) as () => void
+      return () => {
+        a()
+        b()
+      }
+    },
+    onStatus: (cb: (s: unknown) => void) => {
+      const a = call(sim, 'onStatus', cb) as () => void
+      const b = call(serial, 'onStatus', cb) as () => void
+      return () => {
+        a()
+        b()
+      }
+    }
+  }
+}
+
+/** The sim's virtual port path, re-exported so callers don't reach past here. */
+export { VIRTUAL_PORT_PATH }

--- a/src/renderer/src/web/web-serial.ts
+++ b/src/renderer/src/web/web-serial.ts
@@ -1,0 +1,210 @@
+/**
+ * WEB Serial device backend — epic #267, Phase W2 (#465).
+ * =============================================================================
+ *
+ * Talks to a REAL MicroPython board (Pico / ESP / …) plugged into USB, from the
+ * browser, over the Web Serial API. It pairs a {@link WebSerialTransport} (the
+ * bytes) with the shared {@link RawReplClient} (the raw-REPL protocol) to present
+ * the SAME `window.api.device` surface as the sim, so the editor, Run, the device
+ * file tree and instruments all work against hardware with no code fork.
+ *
+ * Web Serial needs a Chromium browser and a user gesture to pick a port
+ * (`requestPort`); already-granted ports come back from `getPorts()`. The
+ * {@link ./web-device-router} multiplexes this with the sim backend.
+ */
+import { RawReplClient, type SerialTransport } from '../../../shared/raw-repl'
+import { SERIAL_USB_FILTERS, describeUsb } from '../../../shared/serial-filters'
+
+/** Structural Web Serial types (not in every TS DOM lib). */
+interface WebSerialPort {
+  open(opts: { baudRate: number }): Promise<void>
+  close(): Promise<void>
+  readable: ReadableStream<Uint8Array> | null
+  writable: WritableStream<Uint8Array> | null
+  getInfo(): { usbVendorId?: number; usbProductId?: number }
+  setSignals?(s: { dataTerminalReady?: boolean; requestToSend?: boolean }): Promise<void>
+}
+interface WebSerial {
+  requestPort(opts?: { filters?: { usbVendorId?: number; usbProductId?: number }[] }): Promise<WebSerialPort>
+  getPorts(): Promise<WebSerialPort[]>
+}
+
+const navSerial = (): WebSerial | null =>
+  (navigator as unknown as { serial?: WebSerial }).serial ?? null
+
+/** True when this browser can talk to USB serial devices (Chromium). */
+export const webSerialSupported = (): boolean => navSerial() !== null
+
+/** The Web Serial byte transport backing a {@link RawReplClient}. */
+export class WebSerialTransport implements SerialTransport {
+  private reader: ReadableStreamDefaultReader<Uint8Array> | null = null
+  private dataCb: ((c: Uint8Array) => void) | null = null
+  private closed = false
+
+  constructor(private readonly port: WebSerialPort) {}
+
+  async open(baudRate = 115200): Promise<void> {
+    await this.port.open({ baudRate })
+    void this.readLoop()
+  }
+  private async readLoop(): Promise<void> {
+    while (this.port.readable && !this.closed) {
+      const reader = this.port.readable.getReader()
+      this.reader = reader
+      try {
+        for (;;) {
+          const { value, done } = await reader.read()
+          if (done) break
+          if (value && value.length) this.dataCb?.(value)
+        }
+      } catch {
+        /* stream broke (unplug) — fall through; close() flips `closed` */
+      } finally {
+        reader.releaseLock()
+      }
+    }
+  }
+  onData(cb: (c: Uint8Array) => void): void {
+    this.dataCb = cb
+  }
+  async write(data: Uint8Array): Promise<void> {
+    if (!this.port.writable) throw new Error('Serial port is not writable')
+    const writer = this.port.writable.getWriter()
+    try {
+      await writer.write(data)
+    } finally {
+      writer.releaseLock()
+    }
+  }
+  async setSignals(s: { dataTerminalReady?: boolean; requestToSend?: boolean }): Promise<void> {
+    await this.port.setSignals?.(s)
+  }
+  async close(): Promise<void> {
+    this.closed = true
+    try {
+      await this.reader?.cancel()
+    } catch {
+      /* ignore */
+    }
+    try {
+      await this.port.close()
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+interface DeviceStatus {
+  state: 'disconnected' | 'connecting' | 'connected'
+  path: string
+  baudRate: number
+}
+
+/** Path scheme for Web Serial ports in the port dropdown. */
+export const WEBSERIAL_PREFIX = 'webserial://'
+export const WEBSERIAL_PICK = 'webserial://pick'
+
+/**
+ * Build the Web Serial device backend. Returns the `window.api.device` method
+ * surface (a subset — the {@link ./web-device-router} routes to it when a real
+ * board is the active connection).
+ */
+export function createWebSerialBackend(): Record<string, unknown> {
+  const dataSubs = new Set<(chunk: Uint8Array) => void>()
+  const statusSubs = new Set<(s: DeviceStatus) => void>()
+  let state: DeviceStatus['state'] = 'disconnected'
+  let path = ''
+  let transport: WebSerialTransport | null = null
+  let client: RawReplClient | null = null
+  // Synthetic path → granted port, so the dropdown can re-select one.
+  const known = new Map<string, WebSerialPort>()
+
+  const emitData = (chunk: Uint8Array): void => dataSubs.forEach((cb) => cb(chunk))
+  const setState = (s: DeviceStatus['state'], p = path): void => {
+    state = s
+    path = p
+    const st: DeviceStatus = { state, path, baudRate: 115200 }
+    statusSubs.forEach((cb) => cb(st))
+  }
+  const need = (): RawReplClient => {
+    if (!client) throw new Error('No board connected')
+    return client
+  }
+
+  const openPort = async (port: WebSerialPort, p: string): Promise<void> => {
+    setState('connecting', p)
+    transport = new WebSerialTransport(port)
+    await transport.open(115200)
+    client = new RawReplClient(transport, emitData)
+    setState('connected', p)
+    // Nudge the board to a fresh friendly prompt so the shell shows `>>>`.
+    await client.sendData('\r\x03').catch(() => undefined)
+  }
+
+  return {
+    listPorts: async (): Promise<{ path: string; friendlyName: string }[]> => {
+      const serial = navSerial()
+      if (!serial) return []
+      known.clear()
+      const ports = await serial.getPorts()
+      return ports.map((port, i) => {
+        const p = `${WEBSERIAL_PREFIX}${i}`
+        known.set(p, port)
+        const { usbVendorId, usbProductId } = port.getInfo()
+        return { path: p, friendlyName: describeUsb(usbVendorId, usbProductId) }
+      })
+    },
+
+    connect: async (p: string): Promise<void> => {
+      const serial = navSerial()
+      if (!serial) throw new Error('Web Serial needs a Chromium-based browser')
+      let port: WebSerialPort | undefined
+      if (p === WEBSERIAL_PICK) {
+        // MUST run inside the user gesture (the Connect click) — do it first.
+        port = await serial.requestPort({ filters: SERIAL_USB_FILTERS })
+        const idx = known.size
+        p = `${WEBSERIAL_PREFIX}${idx}`
+        known.set(p, port)
+      } else {
+        port = known.get(p) ?? (await serial.getPorts())[Number(p.slice(WEBSERIAL_PREFIX.length))]
+      }
+      if (!port) throw new Error('That serial port is no longer available')
+      await openPort(port, p)
+    },
+
+    disconnect: async (): Promise<void> => {
+      await transport?.close()
+      transport = null
+      client = null
+      if (state !== 'disconnected') setState('disconnected', '')
+    },
+
+    getStatus: async (): Promise<DeviceStatus> => ({ state, path, baudRate: 115200 }),
+
+    exec: async (code: string) => need().exec(code),
+    eval: async (code: string) => need().eval(code),
+    sendData: async (data: string) => need().sendData(data),
+    sendControl: async (target: string, payload?: string) => need().sendControl(target, payload ?? ''),
+    interrupt: async () => need().interrupt(),
+    softReset: async () => need().softReset(),
+
+    listDir: async (p = '/') => need().listDir(p),
+    df: async () => null,
+    readFile: async (p: string) => need().readFile(p),
+    readFileBytes: async (p: string) => need().readFileBytes(p),
+    writeFile: async (p: string, contents: string) => need().writeFile(p, contents),
+    remove: async (p: string) => need().remove(p),
+    mkdir: async (p: string) => need().mkdir(p),
+    rename: async (from: string, to: string) => need().rename(from, to),
+    stat: async (p: string) => need().stat(p),
+
+    onData: (cb: (chunk: Uint8Array) => void) => {
+      dataSubs.add(cb)
+      return () => dataSubs.delete(cb)
+    },
+    onStatus: (cb: (s: DeviceStatus) => void) => {
+      statusSubs.add(cb)
+      return () => statusSubs.delete(cb)
+    }
+  }
+}

--- a/src/shared/raw-repl.ts
+++ b/src/shared/raw-repl.ts
@@ -1,0 +1,310 @@
+/**
+ * Transport-agnostic MicroPython raw-REPL client (epic #267, Phase W2 / #465).
+ * =============================================================================
+ *
+ * The same raw-REPL protocol the desktop `MicroPythonDevice` speaks over
+ * `serialport`, but decoupled from Node so it can drive a REAL board over **Web
+ * Serial** in the browser. The transport is reduced to {@link SerialTransport}
+ * (`write` + `onData` + `close`, plus optional `setSignals`); everything else —
+ * the raw-REPL handshake, `exec`/`eval`, and the filesystem helpers — lives here,
+ * byte-for-byte matching the desktop so a Pico behaves identically on web.
+ *
+ * Browser-safe: `Uint8Array` + `TextEncoder`/`TextDecoder`, no `Buffer`/Node.
+ * Pure logic, unit-tested against a mock transport (no hardware needed).
+ *
+ * The raw REPL handshake (see MicroPython docs):
+ *   1. Ctrl-C ×2 — interrupt anything running.
+ *   2. Ctrl-A — enter raw REPL; the board replies `raw REPL; CTRL-B to exit\r\n>`.
+ *   3. code + Ctrl-D — execute; board replies `OK`, stdout, `\x04`, stderr, `\x04`, `>`.
+ *   4. Ctrl-B — back to the friendly REPL.
+ */
+import { buildControlLine } from './control'
+
+const CTRL_A = '\x01'
+const CTRL_B = '\x02'
+const CTRL_C = '\x03'
+const CTRL_D = '\x04'
+
+/** The minimal byte transport a {@link RawReplClient} drives. */
+export interface SerialTransport {
+  write(data: Uint8Array): Promise<void>
+  onData(cb: (chunk: Uint8Array) => void): void
+  close(): Promise<void>
+  /** Toggle DTR/RTS — used to hard-reset some boards. Optional. */
+  setSignals?(signals: { dataTerminalReady?: boolean; requestToSend?: boolean }): Promise<void>
+}
+
+export interface ExecResult {
+  stdout: string
+  stderr: string
+}
+export interface DirEntry {
+  name: string
+  isDir: boolean
+  size: number
+}
+export interface StatResult {
+  isDir: boolean
+  size: number
+  mtime?: number
+}
+
+/** A JS string → a MicroPython single-quoted string literal (safe for snippets). */
+export function pyStr(value: string): string {
+  const escaped = value
+    .replace(/\\/g, '\\\\')
+    .replace(/'/g, "\\'")
+    .replace(/\r/g, '\\r')
+    .replace(/\n/g, '\\n')
+  return `'${escaped}'`
+}
+
+const enc = new TextEncoder()
+const dec = new TextDecoder()
+
+/** latin1 string → bytes (control bytes + protocol markers are latin1). */
+const bin = (s: string): Uint8Array => Uint8Array.from(s, (c) => c.charCodeAt(0) & 0xff)
+
+/** Index of `needle` bytes within `hay`, or -1. */
+function indexOfBytes(hay: Uint8Array, needle: Uint8Array): number {
+  if (needle.length === 0) return 0
+  outer: for (let i = 0; i + needle.length <= hay.length; i++) {
+    for (let j = 0; j < needle.length; j++) if (hay[i + j] !== needle[j]) continue outer
+    return i
+  }
+  return -1
+}
+
+function concat(a: Uint8Array, b: Uint8Array): Uint8Array {
+  const out = new Uint8Array(a.length + b.length)
+  out.set(a)
+  out.set(b, a.length)
+  return out
+}
+
+type Pending = {
+  marker: Uint8Array
+  resolve: (v: Uint8Array) => void
+  reject: (e: Error) => void
+  timer: ReturnType<typeof setTimeout>
+}
+
+export class RawReplClient {
+  private rxBuffer: Uint8Array = new Uint8Array(0)
+  private pending: Pending | null = null
+  private inRawRepl = false
+  /** While an exec drives the raw REPL, its bytes must NOT reach the console. */
+  private execActive = false
+  private opQueue: Promise<unknown> = Promise.resolve()
+
+  /**
+   * @param transport the byte transport (Web Serial in the browser).
+   * @param onConsole receives user-facing REPL bytes (everything not consumed by
+   *        an in-flight exec) — wire to the terminal.
+   */
+  constructor(
+    private readonly transport: SerialTransport,
+    private readonly onConsole: (chunk: Uint8Array) => void
+  ) {
+    transport.onData((chunk) => this.handleData(chunk))
+  }
+
+  private handleData(chunk: Uint8Array): void {
+    this.rxBuffer = concat(this.rxBuffer, chunk)
+    this.tryResolvePending()
+    if (!this.execActive) this.onConsole(chunk)
+  }
+
+  private tryResolvePending(): void {
+    if (!this.pending) return
+    const idx = indexOfBytes(this.rxBuffer, this.pending.marker)
+    if (idx === -1) return
+    const end = idx + this.pending.marker.length
+    const data = this.rxBuffer.slice(0, end)
+    this.rxBuffer = this.rxBuffer.slice(end)
+    const { resolve, timer } = this.pending
+    clearTimeout(timer)
+    this.pending = null
+    resolve(data)
+  }
+
+  private write(data: string | Uint8Array): Promise<void> {
+    return this.transport.write(typeof data === 'string' ? bin(data) : data)
+  }
+
+  private readUntil(marker: string, timeoutMs = 5000): Promise<Uint8Array> {
+    if (this.pending) return Promise.reject(new Error('A read is already in progress'))
+    return new Promise<Uint8Array>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending = null
+        reject(new Error(`Timed out waiting for ${JSON.stringify(marker)}`))
+      }, timeoutMs)
+      this.pending = { marker: bin(marker), resolve, reject, timer }
+      this.tryResolvePending()
+    })
+  }
+
+  // ── Friendly-REPL passthrough (typing, Run paste, control bytes) ──────────
+  async sendData(data: string): Promise<void> {
+    await this.write(data)
+  }
+  async sendControl(target: string, payload = ''): Promise<void> {
+    await this.write(buildControlLine(target, payload))
+  }
+  async interrupt(): Promise<void> {
+    await this.write(CTRL_C)
+  }
+  async softReset(): Promise<void> {
+    await this.write(CTRL_D)
+  }
+
+  // ── Raw REPL ──────────────────────────────────────────────────────────────
+  private async enterRawRepl(): Promise<void> {
+    this.rxBuffer = new Uint8Array(0)
+    await this.write(CTRL_C)
+    await this.write(CTRL_C)
+    await this.write(CTRL_A)
+    await this.readUntil('raw REPL; CTRL-B to exit\r\n>')
+    this.inRawRepl = true
+  }
+  private async exitRawRepl(): Promise<void> {
+    await this.write(CTRL_B)
+    this.inRawRepl = false
+  }
+
+  exec(code: string, timeoutMs = 10000): Promise<ExecResult> {
+    const op = this.opQueue.then(() => this.execLocked(code, timeoutMs))
+    this.opQueue = op.catch(() => undefined)
+    return op
+  }
+
+  private async execLocked(code: string, timeoutMs: number): Promise<ExecResult> {
+    this.execActive = true
+    try {
+      const enteredHere = !this.inRawRepl
+      if (enteredHere) await this.enterRawRepl()
+      try {
+        await this.write(code)
+        await this.write(CTRL_D)
+        const ack = await this.readUntil('OK', timeoutMs)
+        if (!dec.decode(ack).includes('OK')) throw new Error('Device did not acknowledge code (no "OK")')
+        const stdoutRaw = await this.readUntil(CTRL_D, timeoutMs)
+        const stdout = dec.decode(stdoutRaw.subarray(0, stdoutRaw.length - 1))
+        const stderrRaw = await this.readUntil(CTRL_D, timeoutMs)
+        const stderr = dec.decode(stderrRaw.subarray(0, stderrRaw.length - 1))
+        await this.readUntil('>', timeoutMs)
+        return { stdout, stderr }
+      } finally {
+        if (enteredHere) await this.exitRawRepl().catch(() => undefined)
+      }
+    } finally {
+      this.execActive = false
+    }
+  }
+
+  async eval(code: string, timeoutMs = 10000): Promise<string> {
+    const { stdout, stderr } = await this.exec(code, timeoutMs)
+    if (stderr.trim().length > 0) throw new Error(stderr.trim())
+    return stdout
+  }
+
+  // ── Filesystem helpers (same snippets as the desktop) ──────────────────────
+  async listDir(path = '/'): Promise<DirEntry[]> {
+    const code = [
+      'import os, json',
+      'def _ls(p):',
+      '    out=[]',
+      '    try:',
+      '        it=os.ilistdir(p)',
+      '    except AttributeError:',
+      '        it=[(n,0,0) for n in os.listdir(p)]',
+      '    for e in it:',
+      '        name=e[0]; typ=e[1] if len(e)>1 else 0',
+      '        full=(p.rstrip("/")+"/"+name) if p else name',
+      '        isdir=(typ & 0x4000)!=0',
+      '        try: size=0 if isdir else os.stat(full)[6]',
+      '        except OSError: size=0',
+      '        out.append([name,isdir,size])',
+      '    return out',
+      `print(json.dumps(_ls(${pyStr(path)})))`
+    ].join('\n')
+    const raw = (await this.eval(code)).trim()
+    const parsed = (raw ? JSON.parse(raw) : []) as [string, boolean, number][]
+    return parsed.map(([name, isDir, size]) => ({ name, isDir, size }))
+  }
+
+  async readFile(path: string): Promise<string> {
+    return dec.decode(await this.readFileBytes(path))
+  }
+
+  async readFileBytes(path: string): Promise<Uint8Array> {
+    const code = [
+      'import sys',
+      'try:\n import ubinascii\nexcept ImportError:\n import binascii as ubinascii',
+      `with open(${pyStr(path)},'rb') as f:`,
+      '    while True:',
+      '        b=f.read(256)',
+      '        if not b: break',
+      '        sys.stdout.write(ubinascii.hexlify(b))'
+    ].join('\n')
+    const hex = (await this.eval(code)).trim()
+    const out = new Uint8Array(hex.length / 2)
+    for (let i = 0; i < out.length; i++) out[i] = parseInt(hex.substr(i * 2, 2), 16)
+    return out
+  }
+
+  async writeFile(path: string, contents: string | Uint8Array, chunkSize = 256): Promise<void> {
+    const bytes = typeof contents === 'string' ? enc.encode(contents) : contents
+    await this.eval(
+      ['try:\n import ubinascii\nexcept ImportError:\n import binascii as ubinascii', `_f=open(${pyStr(path)},'wb')`].join('\n')
+    )
+    try {
+      for (let i = 0; i < bytes.length || i === 0; i += chunkSize) {
+        const slice = bytes.subarray(i, i + chunkSize)
+        if (slice.length === 0 && i > 0) break
+        let hex = ''
+        for (const b of slice) hex += b.toString(16).padStart(2, '0')
+        await this.eval(`_f.write(ubinascii.unhexlify(${pyStr(hex)}))`)
+        if (slice.length < chunkSize) break
+      }
+    } finally {
+      await this.eval('_f.close()').catch(() => undefined)
+    }
+  }
+
+  async mkdir(path: string): Promise<void> {
+    await this.eval(`import os\nos.mkdir(${pyStr(path)})`)
+  }
+  async rename(from: string, to: string): Promise<void> {
+    await this.eval(`import os\nos.rename(${pyStr(from)}, ${pyStr(to)})`)
+  }
+  async remove(path: string): Promise<void> {
+    await this.eval(
+      [
+        'import os',
+        `_s = [${pyStr(path)}]`,
+        'while _s:',
+        '    _p = _s[-1]',
+        '    if (os.stat(_p)[0] & 0x4000) != 0:',
+        '        _c = os.listdir(_p)',
+        '        if _c:',
+        "            _s.extend([_p + '/' + _x for _x in _c])",
+        '        else:',
+        '            os.rmdir(_p); _s.pop()',
+        '    else:',
+        '        os.remove(_p); _s.pop()'
+      ].join('\n')
+    )
+  }
+  async stat(path: string): Promise<StatResult> {
+    const code = [
+      'import os, json',
+      `st=os.stat(${pyStr(path)})`,
+      'isdir=(st[0] & 0x4000)!=0',
+      'mtime=st[8] if len(st)>8 else None',
+      'print(json.dumps([isdir, st[6], mtime]))'
+    ].join('\n')
+    const [isDir, size, mtime] = JSON.parse((await this.eval(code)).trim()) as [boolean, number, number | null]
+    return { isDir, size, mtime: mtime ?? undefined }
+  }
+}

--- a/src/shared/serial-filters.ts
+++ b/src/shared/serial-filters.ts
@@ -1,0 +1,35 @@
+/**
+ * USB VID/PID filters + labels for the Web Serial port picker (#465).
+ * =============================================================================
+ *
+ * Passed to `navigator.serial.requestPort({ filters })` so the browser's device
+ * chooser only offers plausible MicroPython boards + their USB-serial bridge
+ * chips — the same families the desktop's `firmware/detect.ts` knows about, plus
+ * the Raspberry Pi Pico. Numeric (Web Serial wants decimal/number VIDs).
+ */
+export interface UsbFilter {
+  usbVendorId: number
+  label: string
+}
+
+/** Known board / bridge-chip vendors. */
+export const USB_VENDORS: UsbFilter[] = [
+  { usbVendorId: 0x2e8a, label: 'Raspberry Pi (Pico / RP2040)' },
+  { usbVendorId: 0x303a, label: 'Espressif (ESP32-S2/S3, native USB)' },
+  { usbVendorId: 0x239a, label: 'Adafruit board' },
+  { usbVendorId: 0x10c4, label: 'Silicon Labs CP210x bridge (ESP32)' },
+  { usbVendorId: 0x1a86, label: 'WCH CH340 bridge' },
+  { usbVendorId: 0x0403, label: 'FTDI bridge' },
+  { usbVendorId: 0x067b, label: 'Prolific PL2303 bridge' }
+]
+
+/** `filters` for `requestPort` — narrows the chooser to likely boards. */
+export const SERIAL_USB_FILTERS = USB_VENDORS.map((v) => ({ usbVendorId: v.usbVendorId }))
+
+/** A friendly name for a granted port from its USB VID/PID. */
+export function describeUsb(vendorId?: number, productId?: number): string {
+  const known = USB_VENDORS.find((v) => v.usbVendorId === vendorId)
+  const hex = (n?: number): string => (n == null ? '????' : n.toString(16).padStart(4, '0'))
+  const id = `${hex(vendorId)}:${hex(productId)}`
+  return known ? `${known.label} · ${id}` : `USB serial device · ${id}`
+}

--- a/test/rawRepl.test.ts
+++ b/test/rawRepl.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest'
+import { RawReplClient, pyStr, type SerialTransport } from '../src/shared/raw-repl'
+
+/**
+ * The transport-agnostic raw-REPL client (#465) against a MOCK board — proves the
+ * protocol handshake, exec output framing, and the filesystem helpers work with
+ * no hardware. The mock speaks the real raw-REPL byte protocol back.
+ */
+const enc = new TextEncoder()
+const dec = new TextDecoder()
+
+/** A fake MicroPython board that answers the raw-REPL handshake over a transport. */
+class MockBoard implements SerialTransport {
+  private cb: ((c: Uint8Array) => void) | null = null
+  private buf = ''
+  private raw = false
+  /** stdout the next exec should return (default: empty). */
+  nextStdout = ''
+  nextStderr = ''
+  closed = false
+
+  onData(cb: (c: Uint8Array) => void): void {
+    this.cb = cb
+  }
+  private emit(s: string): void {
+    this.cb?.(enc.encode(s))
+  }
+  async write(data: Uint8Array): Promise<void> {
+    const s = dec.decode(data)
+    for (const ch of s) {
+      if (ch === '\x01') {
+        // Ctrl-A → enter raw REPL, reply with the banner.
+        this.raw = true
+        this.buf = ''
+        this.emit('\r\nraw REPL; CTRL-B to exit\r\n>')
+      } else if (ch === '\x02') {
+        this.raw = false
+      } else if (ch === '\x04' && this.raw) {
+        // Ctrl-D in raw mode → execute the buffered code, frame the response.
+        this.buf = ''
+        this.emit('OK' + this.nextStdout + '\x04' + this.nextStderr + '\x04>')
+      } else if (ch !== '\x03') {
+        this.buf += ch
+      }
+    }
+  }
+  async close(): Promise<void> {
+    this.closed = true
+  }
+}
+
+const setup = (): { board: MockBoard; client: RawReplClient; console: string } => {
+  const board = new MockBoard()
+  const state = { console: '' }
+  const client = new RawReplClient(board, (c) => (state.console += dec.decode(c)))
+  return { board, client, get console() { return state.console } } as never
+}
+
+describe('RawReplClient', () => {
+  it('pyStr escapes for a MicroPython string literal', () => {
+    expect(pyStr('/lib/x.py')).toBe("'/lib/x.py'")
+    expect(pyStr("a'b\\c")).toBe("'a\\'b\\\\c'")
+  })
+
+  it('exec captures stdout + stderr through the raw-REPL frame', async () => {
+    const { board, client } = setup()
+    board.nextStdout = 'hello\n'
+    board.nextStderr = ''
+    const r = await client.exec('print("hello")')
+    expect(r.stdout).toBe('hello\n')
+    expect(r.stderr).toBe('')
+  })
+
+  it('eval throws on a traceback (stderr)', async () => {
+    const { board, client } = setup()
+    board.nextStdout = ''
+    board.nextStderr = 'Traceback: NameError'
+    await expect(client.eval('boom')).rejects.toThrow(/NameError/)
+  })
+
+  it('listDir parses the ilistdir JSON snippet', async () => {
+    const { board, client } = setup()
+    board.nextStdout = JSON.stringify([['main.py', false, 42], ['lib', true, 0]]) + '\n'
+    const entries = await client.listDir('/')
+    expect(entries).toEqual([
+      { name: 'main.py', isDir: false, size: 42 },
+      { name: 'lib', isDir: true, size: 0 }
+    ])
+  })
+
+  it('readFileBytes decodes the hex the board prints', async () => {
+    const { board, client } = setup()
+    board.nextStdout = '68656c6c6f' // "hello"
+    expect(dec.decode(await client.readFileBytes('/x'))).toBe('hello')
+  })
+
+  it('does not leak exec/handshake bytes to the console', async () => {
+    const board = new MockBoard()
+    let consoleOut = ''
+    const client = new RawReplClient(board, (c) => (consoleOut += dec.decode(c)))
+    board.nextStdout = 'x'
+    await client.exec('1')
+    // The raw-REPL banner + OK/framing must NOT reach the user console.
+    expect(consoleOut).not.toContain('raw REPL')
+    expect(consoleOut).not.toContain('OK')
+    // But a normal sendData passthrough does reach the board (and echoes).
+    await client.sendData('print(1)\r')
+    expect(board).toBeTruthy()
+  })
+
+  it('serialises concurrent exec calls (opQueue)', async () => {
+    const { board, client } = setup()
+    board.nextStdout = 'a'
+    const [a, b] = await Promise.all([client.exec('1'), client.exec('2')])
+    expect(a.stdout).toBe('a')
+    expect(b.stdout).toBe('a')
+  })
+})

--- a/test/serialFilters.test.ts
+++ b/test/serialFilters.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { SERIAL_USB_FILTERS, describeUsb, USB_VENDORS } from '../src/shared/serial-filters'
+
+/** The Web Serial picker's VID/PID filters + labels (#465). */
+describe('serial-filters', () => {
+  it('filters are numeric usbVendorId entries for requestPort', () => {
+    expect(SERIAL_USB_FILTERS.length).toBe(USB_VENDORS.length)
+    for (const f of SERIAL_USB_FILTERS) expect(typeof f.usbVendorId).toBe('number')
+    // Raspberry Pi Pico must be offered.
+    expect(SERIAL_USB_FILTERS.some((f) => f.usbVendorId === 0x2e8a)).toBe(true)
+  })
+
+  it('describeUsb names a known vendor + shows the VID:PID', () => {
+    expect(describeUsb(0x2e8a, 0x0005)).toContain('Raspberry Pi')
+    expect(describeUsb(0x2e8a, 0x0005)).toContain('2e8a:0005')
+  })
+
+  it('describeUsb falls back gracefully for an unknown device', () => {
+    const d = describeUsb(0x1234, 0x5678)
+    expect(d).toContain('USB serial device')
+    expect(d).toContain('1234:5678')
+  })
+})


### PR DESCRIPTION
**Phase W2 of Snakie for Web** — a real Pico / ESP over USB, in a Chromium browser, alongside the offline simulator.

## Approach: zero desktop risk
The desktop's proven `serialport` path (`MicroPythonDevice.ts`) is **untouched**. The raw-REPL protocol is ported into a new **unit-tested shared module** and driven over Web Serial:

- **`src/shared/raw-repl.ts`** — the MicroPython raw-REPL protocol (Ctrl-A/…/Ctrl-D handshake, `exec`/`eval`, filesystem helpers), **transport-agnostic + browser-safe** (`Uint8Array`, no `Buffer`), byte-for-byte matching the desktop. Transport reduced to a `SerialTransport` interface.
- **`src/shared/serial-filters.ts`** — USB VID/PID filters + labels (Pico `2e8a`, ESP `303a`, CP210x/CH340/FTDI bridges).
- **`web/web-serial.ts`** — `WebSerialTransport` over `navigator.serial` + a device backend (`getPorts`, `requestPort` picker, exec/FS/streaming).
- **`web/web-device-router.ts`** — multiplexes the sim + serial backends behind one `window.api.device`: the port list shows the virtual sim, granted boards, and a **＋ Connect a USB board** entry; `connect()` routes to the right backend; `onData`/`onStatus` forward from whichever is active.

## Verified (headless, mock board over a fake `navigator.serial`)
| check | result |
|---|---|
| `listPorts` | sim + `webserial://0` + "Connect a USB board" |
| connect the board + `exec('print(2+2)')` | **4** (over the raw-REPL) |
| `listDir` / `readFile` | `['main.py','lib']` / `"hi\n"` |
| switch back to the sim + `exec('print(6*7)')` | **42** |

Protocol unit-tested against a mock (7 tests) + filters (3 tests). Gates: typecheck ✓ · lint 0 errors ✓ · **1725 tests** ✓ · electron + web builds ✓.

> ⚠️ **Real-hardware smoke test recommended before release.** I verified the full plumbing with a simulated board, but not a physical Pico (no board in CI). The raw-REPL bytes are a faithful port of the desktop's, so behaviour should match.

Part of milestone **0.28 — Web Serial & close-outs**. Classroom admin-console docs (`SerialAllowUsbDevicesForUrls`) to follow in snakie-docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)