### PR TITLE
feat: export a clean URDF into the project's urdf/ folder (#315)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Export a clean URDF from the Robot View (#315).** An **Export URDF** button (in
+  the build panel, beside Import STL) writes a tidy, consistently-indented copy of
+  the robot's URDF into the project's `urdf/` folder — a clean artifact to share or
+  version. It re-loads unchanged in the viewer (same tags, just formatted). Closes
+  out epic #309 Phase 5.
+
+### Added
 - **Connect a real board over Web Serial, in the browser (#465).** On a Chromium
   browser (Chrome, Edge, a Chromebook), app.snakie.org can now talk to a real
   Pico / ESP over USB — the REPL, Run/Stop, the device file tree, module installs

--- a/src/renderer/src/components/RobotBuildPanel.tsx
+++ b/src/renderer/src/components/RobotBuildPanel.tsx
@@ -123,6 +123,8 @@ export interface RobotBuildPanelProps {
   onDelete: (link: string) => void
   onImportStl: () => void
   canImport: boolean
+  onExportUrdf: () => void
+  canExport: boolean
   importing: boolean
   /** Editing needs a saved project file — disables add/edit with a hint. */
   canEdit: boolean
@@ -668,6 +670,8 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
     onDelete,
     onImportStl,
     canImport,
+    onExportUrdf,
+    canExport,
     importing,
     canEdit,
     onOpenRobot
@@ -978,6 +982,19 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
           title={canImport ? 'Import an STL / DAE mesh' : 'Save the robot to a project folder to import meshes'}
         >
           {importing ? 'Importing…' : '+ STL / DAE'}
+        </button>
+        <button
+          type="button"
+          className="robotbuild__stl"
+          disabled={!canExport}
+          onClick={onExportUrdf}
+          title={
+            canExport
+              ? 'Write a clean, tidy copy of this URDF into the project’s urdf/ folder'
+              : 'Open the robot from a project folder to export it'
+          }
+        >
+          ⬇ Export URDF
         </button>
       </div>
       {menu && (

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -113,6 +113,7 @@ import {
   type ManagedSequenceStep
 } from '../../../shared/managed-blocks'
 import { jointToServo } from '../../../shared/krf'
+import { prettyUrdf, robotNameOf, urdfExportPath } from '../../../shared/urdf-export'
 import { buildServosPayload } from '../../../shared/control'
 import { bindableServos, bindServoJoint, type BindableServo } from './servo-bind'
 import { onServoDrive } from './servo-drive-bus'
@@ -1988,6 +1989,27 @@ export function RobotView({
     if (!m || m.isMimic) return
     commitTimeline(upsertKey(timelineRef.current, joint, t, toDisplay(m.type, valuesRef.current[joint] ?? 0)))
     setSelectedKey({ joint, t })
+  }
+
+  // Export a clean, tidy copy of the current URDF into the project's `urdf/`
+  // folder (#315). Re-loads unchanged in the viewer; just consistently formatted.
+  const canExport = !!activeFile && activeFile.source === 'local' && !!activeFile.path && !!content.trim()
+  const handleExportUrdf = async (): Promise<void> => {
+    if (!activeFile || activeFile.source !== 'local' || !activeFile.path) return
+    const name = robotNameOf(content)
+    const path = urdfExportPath(dirname(activeFile.path), name)
+    const dir = path.slice(0, path.lastIndexOf('/'))
+    try {
+      await window.api.fs.mkdir(dir)
+    } catch {
+      /* already exists — fine */
+    }
+    try {
+      await window.api.fs.writeFile(path, prettyUrdf(content))
+      setSavingLabel(`exported → urdf/${name}.urdf`)
+    } catch (err) {
+      setSavingLabel(`export failed: ${err instanceof Error ? err.message : String(err)}`)
+    }
   }
 
   const handleImportStl = async (): Promise<void> => {
@@ -4234,6 +4256,8 @@ export function RobotView({
             onDelete={handleDeleteLink}
             onImportStl={() => void handleImportStl()}
             canImport={!!canImport}
+            onExportUrdf={() => void handleExportUrdf()}
+            canExport={canExport}
             importing={importing}
             canEdit={canEdit}
             onOpenRobot={() => void handleOpenRobotFile()}

--- a/src/shared/urdf-export.ts
+++ b/src/shared/urdf-export.ts
@@ -1,0 +1,48 @@
+/**
+ * Clean-URDF export for the Robot View builder (#315, epic #309 Phase 5).
+ * =============================================================================
+ *
+ * The Robot View edits its URDF in place with targeted string surgery, so the
+ * live file can accumulate irregular whitespace. "Export URDF" writes a tidy,
+ * consistently-indented copy into the project's `urdf/` folder — a clean artifact
+ * to share, version, or hand to another tool, that re-loads unchanged in the
+ * viewer. Dependency-free (no DOMParser) so it runs in the renderer AND is
+ * unit-testable in node.
+ */
+
+/** Pretty-print URDF/XML with two-space indentation per nesting level. */
+export function prettyUrdf(xml: string): string {
+  // Collapse whitespace that sits purely BETWEEN tags, then split one tag/line.
+  const compact = xml.replace(/>\s+</g, '><').trim()
+  const tokens = compact.replace(/></g, '>\n<').split('\n')
+  const pad = (n: number): string => '  '.repeat(Math.max(0, n))
+  const out: string[] = []
+  let depth = 0
+  for (const raw of tokens) {
+    const line = raw.trim()
+    if (!line) continue
+    const isDecl = line.startsWith('<?') || line.startsWith('<!')
+    const isClose = line.startsWith('</')
+    const isSelfClose = line.endsWith('/>')
+    // `<tag ...>text</tag>` collapsed onto one line — no net depth change.
+    const isInline = /^<[^/!?][^>]*>[^<]*<\/[^>]+>$/.test(line)
+    const isOpen = line.startsWith('<') && !isClose && !isSelfClose && !isDecl && !isInline
+    if (isClose) depth--
+    out.push(pad(depth) + line)
+    if (isOpen) depth++
+  }
+  return out.join('\n') + '\n'
+}
+
+/** The robot's `name` from `<robot name="…">`, or `'robot'`. */
+export function robotNameOf(xml: string): string {
+  const m = /<robot\b[^>]*\bname\s*=\s*"([^"]*)"/i.exec(xml)
+  return (m?.[1] || 'robot').trim() || 'robot'
+}
+
+/** `<baseDir>/urdf/<safe-name>.urdf` — the canonical export location. */
+export function urdfExportPath(baseDir: string, name: string): string {
+  const safe = (name || 'robot').replace(/[^A-Za-z0-9_.-]+/g, '_').replace(/^_+|_+$/g, '') || 'robot'
+  const dir = baseDir.replace(/[/\\]+$/, '')
+  return `${dir ? dir + '/' : ''}urdf/${safe}.urdf`
+}

--- a/test/urdfExport.test.ts
+++ b/test/urdfExport.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { prettyUrdf, robotNameOf, urdfExportPath } from '../src/shared/urdf-export'
+
+/** Clean-URDF export helpers (#315). */
+describe('urdf-export', () => {
+  it('pretty-prints with consistent nesting + re-loads unchanged in structure', () => {
+    const messy =
+      '<?xml version="1.0"?><robot name="arm"><link name="base"><visual><geometry><box size="1 1 1"/></geometry></visual></link><joint name="j" type="revolute"><parent link="base"/><child link="arm"/></joint></robot>'
+    const out = prettyUrdf(messy)
+    expect(out).toContain('<?xml version="1.0"?>\n')
+    expect(out).toContain('<robot name="arm">')
+    // nesting: <link> at depth 1, <visual> at 2, <geometry> at 3, <box/> at 4.
+    expect(out).toContain('\n  <link name="base">')
+    expect(out).toContain('\n    <visual>')
+    expect(out).toContain('\n      <geometry>')
+    expect(out).toContain('\n        <box size="1 1 1"/>')
+    expect(out).toContain('\n  <joint name="j" type="revolute">')
+    expect(out).toContain('\n    <parent link="base"/>')
+    // Balanced: same tag counts as the input (idempotent structure).
+    const tags = (s: string): number => (s.match(/<[^/?!][^>]*[^/]>/g) || []).length
+    expect(tags(out)).toBe(tags(messy))
+    // Idempotent: prettifying twice is stable.
+    expect(prettyUrdf(out)).toBe(out)
+  })
+
+  it('keeps inline <tag>text</tag> on one line without extra depth', () => {
+    const out = prettyUrdf('<robot name="a"><material name="red"><color rgba="1 0 0 1"/></material></robot>')
+    expect(out).toContain('\n  <material name="red">')
+    expect(out).toContain('\n    <color rgba="1 0 0 1"/>')
+  })
+
+  it('robotNameOf reads the robot name (or a default)', () => {
+    expect(robotNameOf('<robot name="buddy_jr">')).toBe('buddy_jr')
+    expect(robotNameOf('<robot>')).toBe('robot')
+  })
+
+  it('urdfExportPath sanitises the name into <base>/urdf/', () => {
+    expect(urdfExportPath('proj', 'my robot!')).toBe('proj/urdf/my_robot.urdf')
+    expect(urdfExportPath('proj/', 'arm')).toBe('proj/urdf/arm.urdf')
+    expect(urdfExportPath('', 'arm')).toBe('urdf/arm.urdf')
+  })
+
+  it('re-loads unchanged: the bundled demo-arm URDF keeps all its tags + is idempotent', () => {
+    const src = readFileSync(resolve(__dirname, '../src/renderer/src/assets/demo-arm.urdf'), 'utf8')
+    const out = prettyUrdf(src)
+    const tags = (s: string): string[] => (s.match(/<\/?[A-Za-z][^>]*>/g) || []).map((t) => t.replace(/\s+/g, ' '))
+    // Every tag in, every tag out (nothing dropped or duplicated) — so it re-loads
+    // structurally identical in the Phase 1 viewer.
+    expect(tags(out)).toEqual(tags(src))
+    expect(prettyUrdf(out)).toBe(out) // stable
+    expect(robotNameOf(src)).toBeTruthy()
+  })
+})


### PR DESCRIPTION
The last open box of **epic #309 Phase 5**. The Robot View edits its URDF in place with targeted string surgery, so the live file accumulates irregular whitespace. An **Export URDF** button (build panel, next to Import STL) now writes a tidy, consistently-indented copy into `<project>/urdf/<name>.urdf`.

- **`src/shared/urdf-export.ts`** — `prettyUrdf()` (dependency-free XML pretty-printer — runs in the renderer *and* is unit-testable in node), `robotNameOf()`, `urdfExportPath()`.
- **RobotView** — `handleExportUrdf` (`mkdir urdf/` + `writeFile` the pretty URDF, with a status label) behind a `canExport` gate; wired through `RobotBuildPanel`.

## Verified
The pretty-printer is **idempotent** and **preserves every tag/attribute** — the bundled `demo-arm.urdf` round-trips with an identical tag set, so the export re-loads **structurally unchanged** in the Phase 1 viewer (the issue's acceptance criterion). 5 unit tests. Gates: typecheck ✓ · lint 0 errors ✓ · **1729 tests** ✓ · electron + web builds ✓.

Part of milestone **0.28 — Web Serial & close-outs**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)