### PR TITLE
feat: Learn Snakie — in-app guided tutorials (#479)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Learn Snakie — guided tutorials in the app (#479).** A new **📚 Learn** button
+  opens a MakeCode-style **Projects gallery** of tutorial courses. A floating
+  tutorial dialog walks you through each lesson with **Back / Next**, position
+  **dots** and a **💡 tip**; opening a lesson drops its starter code straight into
+  the editor so you can press **Run**. Ships **three courses × 10 lessons** — *First
+  Steps with MicroPython*, *Build a Robot on the Breadboard*, and *Build a Robot in
+  3-D*. Courses are plain `course.yml` + Markdown, bundled into the app (web + desktop).
+
+### Added
 - **Export a clean URDF from the Robot View (#315).** An **Export URDF** button (in
   the build panel, beside Import STL) writes a tidy, consistently-indented copy of
   the robot's URDF into the project's `urdf/` folder — a clean artifact to share or

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -7,6 +7,7 @@ import { SettingsProvider } from './store/settings'
 import { ConsoleProvider } from './store/console'
 import { SyncProvider } from './store/sync'
 import { LayoutProvider } from './store/layout'
+import { TutorialsProvider } from './store/tutorials'
 
 function App(): JSX.Element {
   return (
@@ -17,8 +18,10 @@ function App(): JSX.Element {
             <SyncProvider>
               <DiagnosticsProvider>
                 <ConsoleProvider>
-                  <AppShell />
-                  <UpdateNotifier />
+                  <TutorialsProvider>
+                    <AppShell />
+                    <UpdateNotifier />
+                  </TutorialsProvider>
                 </ConsoleProvider>
               </DiagnosticsProvider>
             </SyncProvider>

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -47,6 +47,8 @@ import { OPEN_SETTINGS_EVENT } from './settingsBus'
 import { HELP_EVENT, type HelpEventDetail } from './editorBridge'
 import { InstrumentLibBanner } from './InstrumentLibBanner'
 import { PartsImportBanner } from './PartsImportBanner'
+import { ProjectsGallery } from './ProjectsGallery'
+import { TutorialDialog } from './TutorialDialog'
 import {
   requiredPartModules,
   missingImports as computeMissingImports,
@@ -1148,6 +1150,10 @@ export function AppShell(): JSX.Element {
           onClose={() => setSettingsOpen(false)}
         />
       )}
+
+      {/* Tutorials (#479): the Projects gallery + the floating lesson dialog. */}
+      <ProjectsGallery />
+      <TutorialDialog />
     </div>
   )
 }

--- a/src/renderer/src/components/ProjectsGallery.tsx
+++ b/src/renderer/src/components/ProjectsGallery.tsx
@@ -1,0 +1,73 @@
+/**
+ * PROJECTS gallery (#479) — a MakeCode-style grid of tutorial courses.
+ * =============================================================================
+ *
+ * A full-window overlay of course tiles (emoji thumbnail + title + lesson count),
+ * grouped by track. Picking one closes the gallery and starts its tutorial (the
+ * floating {@link ./TutorialDialog}). Opened from the toolbar's **Learn** button.
+ */
+import { useTutorials } from '../store/tutorials'
+import type { Course, CourseTrack } from '../lib/courses'
+import './Tutorials.css'
+
+const TRACK_LABEL: Record<CourseTrack, string> = {
+  beginner: 'Start here',
+  robotics: 'Robotics on the breadboard',
+  urdf: 'Build a robot in 3-D'
+}
+
+export function ProjectsGallery(): JSX.Element | null {
+  const { galleryOpen, closeGallery, openCourse, courses } = useTutorials()
+  if (!galleryOpen) return null
+
+  const tracks: CourseTrack[] = ['beginner', 'robotics', 'urdf']
+  const byTrack = (t: CourseTrack): Course[] => courses.filter((c) => c.track === t)
+
+  return (
+    <div className="pg__overlay" role="dialog" aria-modal="true" aria-label="Tutorials">
+      <div className="pg__panel">
+        <header className="pg__head">
+          <div>
+            <h1 className="pg__title">Learn Snakie</h1>
+            <p className="pg__sub">Pick a project and follow along — each one runs on the simulator, no hardware needed.</p>
+          </div>
+          <button className="pg__close" onClick={closeGallery} aria-label="Close tutorials" title="Close">
+            ✕
+          </button>
+        </header>
+
+        <div className="pg__scroll">
+          {courses.length === 0 && <p className="pg__empty">No tutorials are bundled in this build yet.</p>}
+          {tracks.map((t) => {
+            const list = byTrack(t)
+            if (!list.length) return null
+            return (
+              <section key={t} className="pg__section">
+                <h2 className="pg__section-title">{TRACK_LABEL[t]}</h2>
+                <div className="pg__grid">
+                  {list.map((c) => (
+                    <button
+                      key={c.id}
+                      className="pg__card"
+                      style={{ '--accent': c.accent } as React.CSSProperties}
+                      onClick={() => openCourse(c)}
+                    >
+                      <div className="pg__card-emoji" aria-hidden>
+                        {c.emoji}
+                      </div>
+                      <div className="pg__card-body">
+                        <div className="pg__card-title">{c.title}</div>
+                        <div className="pg__card-desc">{c.description}</div>
+                        <div className="pg__card-meta">{c.lessons.length} lessons</div>
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              </section>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -4,6 +4,7 @@ import { WorkspaceSwitcher } from './WorkspaceSwitcher'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { useWorkspace } from '../store/workspace'
 import { useConsole } from '../store/console'
+import { useTutorials } from '../store/tutorials'
 import './RunControls.css'
 import './Toolbar.css'
 
@@ -160,6 +161,7 @@ export function Toolbar({
   const status = useDeviceStatus()
   const { openFiles, activeId, newFile, openFolder, saveFile } = useWorkspace()
   const { markRun } = useConsole()
+  const { openGallery } = useTutorials()
   const connected = status.state === 'connected'
   const activeFile = openFiles.find((f) => f.id === activeId)
   const canRun = connected && activeFile != null
@@ -321,6 +323,17 @@ export function Toolbar({
       </div>
 
       <div className="toolbar__spacer" />
+
+      {/* Learn (#479): open the Projects gallery of guided tutorials. */}
+      <button
+        type="button"
+        className="btn btn--ghost"
+        onClick={openGallery}
+        title="Guided tutorials — learn Snakie step by step"
+        aria-label="Open tutorials"
+      >
+        📚 Learn
+      </button>
 
       {/* Workspace layouts (epic #259): Code / Board / Lab / Data + reset. */}
       <WorkspaceSwitcher />

--- a/src/renderer/src/components/TutorialDialog.tsx
+++ b/src/renderer/src/components/TutorialDialog.tsx
@@ -1,0 +1,121 @@
+/**
+ * TUTORIAL dialog (#479) — the floating lesson panel over the app.
+ * =============================================================================
+ *
+ * Shows the current lesson's Markdown with **prev / next**, position **dots**, and
+ * a **tip** lightbulb (a popup with a hint or snippet). Opening a course shows a
+ * SPLASH card first (`lessonIndex === -1`). When a lesson opens, its starter
+ * `code` is seeded into a fresh editor buffer so the learner can Run it right away.
+ */
+import { useEffect, useRef, useState } from 'react'
+import { useTutorials } from '../store/tutorials'
+import { useWorkspace } from '../store/workspace'
+import { Markdown } from './Markdown'
+import './Tutorials.css'
+
+export function TutorialDialog(): JSX.Element | null {
+  const { course, lessonIndex, next, prev, goto, start, close, openGallery } = useTutorials()
+  const { openBuffer } = useWorkspace()
+  const [tipOpen, setTipOpen] = useState(false)
+  // Seed the editor once per (course, lesson) — not on every re-render.
+  const seeded = useRef<string>('')
+
+  const lesson = course && lessonIndex >= 0 ? course.lessons[lessonIndex] : null
+
+  useEffect(() => {
+    setTipOpen(false)
+    if (!course || !lesson) return
+    const key = `${course.id}#${lessonIndex}`
+    if (seeded.current === key) return
+    seeded.current = key
+    if (lesson.code) {
+      openBuffer(`${course.id}-${String(lessonIndex + 1).padStart(2, '0')}.py`, lesson.code)
+    }
+  }, [course, lesson, lessonIndex, openBuffer])
+
+  if (!course) return null
+  const accent = { '--accent': course.accent } as React.CSSProperties
+
+  return (
+    <aside className="td" style={accent} role="dialog" aria-label={`${course.title} tutorial`}>
+      <header className="td__head">
+        <span className="td__emoji" aria-hidden>
+          {course.emoji}
+        </span>
+        <span className="td__course">{course.title}</span>
+        <button className="td__icon" onClick={openGallery} title="All tutorials" aria-label="All tutorials">
+          ☰
+        </button>
+        <button className="td__icon" onClick={close} title="Close tutorial" aria-label="Close tutorial">
+          ✕
+        </button>
+      </header>
+
+      {lessonIndex === -1 ? (
+        // ── Splash ──────────────────────────────────────────────────────────
+        <div className="td__splash">
+          <div className="td__splash-emoji" aria-hidden>
+            {course.emoji}
+          </div>
+          <h2 className="td__splash-title">{course.title}</h2>
+          <p className="td__splash-desc">{course.description}</p>
+          <p className="td__splash-meta">{course.lessons.length} lessons</p>
+          <button className="td__start" onClick={start}>
+            Start →
+          </button>
+        </div>
+      ) : (
+        // ── Lesson ──────────────────────────────────────────────────────────
+        <>
+          <div className="td__body">
+            <h3 className="td__lesson-title">{lesson?.title}</h3>
+            <Markdown source={lesson?.body ?? ''} className="td__md" />
+          </div>
+
+          {tipOpen && lesson?.tip && (
+            <div className="td__tip" role="note">
+              <span className="td__tip-bulb" aria-hidden>
+                💡
+              </span>
+              <Markdown source={lesson.tip} className="td__tip-md" />
+            </div>
+          )}
+
+          <footer className="td__foot">
+            <button className="td__nav" onClick={prev} title="Previous">
+              ‹ Back
+            </button>
+            <div className="td__dots" role="tablist" aria-label="Lesson">
+              {course.lessons.map((_, i) => (
+                <button
+                  key={i}
+                  className={`td__dot${i === lessonIndex ? ' td__dot--on' : ''}`}
+                  onClick={() => goto(i)}
+                  aria-label={`Lesson ${i + 1}`}
+                  aria-selected={i === lessonIndex}
+                />
+              ))}
+            </div>
+            {lesson?.tip && (
+              <button
+                className={`td__tipbtn${tipOpen ? ' td__tipbtn--on' : ''}`}
+                onClick={() => setTipOpen((v) => !v)}
+                title="Tip"
+                aria-label="Show a tip"
+                aria-pressed={tipOpen}
+              >
+                💡
+              </button>
+            )}
+            <button
+              className="td__nav td__nav--next"
+              onClick={lessonIndex >= course.lessons.length - 1 ? close : next}
+            >
+              {lessonIndex >= course.lessons.length - 1 ? 'Finish ✓' : 'Next ›'}
+            </button>
+          </footer>
+        </>
+      )}
+    </aside>
+  )
+}

--- a/src/renderer/src/components/Tutorials.css
+++ b/src/renderer/src/components/Tutorials.css
@@ -1,0 +1,286 @@
+/* Projects gallery + tutorial dialog (#479). Uses theme tokens so it reads in
+   both the dark and light (skeuomorph) skins. */
+
+/* ── Projects gallery (full-window overlay) ─────────────────────────────── */
+.pg__overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(3px);
+}
+.pg__panel {
+  width: min(1040px, 94vw);
+  height: min(760px, 90vh);
+  display: flex;
+  flex-direction: column;
+  border-radius: 16px;
+  background: var(--bg, #1b1f26);
+  color: var(--fg, #e6edf3);
+  border: 1px solid var(--border, #333a44);
+  box-shadow: 0 24px 60px -12px rgba(0, 0, 0, 0.6);
+  overflow: hidden;
+}
+.pg__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 22px 26px 14px;
+  border-bottom: 1px solid var(--border, #333a44);
+}
+.pg__title {
+  margin: 0;
+  font-size: 26px;
+  font-weight: 800;
+}
+.pg__sub {
+  margin: 6px 0 0;
+  font-size: 14px;
+  opacity: 0.75;
+  max-width: 640px;
+}
+.pg__close {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 18px;
+  cursor: pointer;
+  opacity: 0.7;
+  padding: 4px 8px;
+  border-radius: 8px;
+}
+.pg__close:hover {
+  opacity: 1;
+  background: var(--hover, rgba(255, 255, 255, 0.08));
+}
+.pg__scroll {
+  overflow-y: auto;
+  padding: 18px 26px 30px;
+}
+.pg__empty {
+  opacity: 0.7;
+}
+.pg__section {
+  margin-top: 18px;
+}
+.pg__section-title {
+  margin: 0 0 12px;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  opacity: 0.6;
+}
+.pg__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 16px;
+}
+.pg__card {
+  display: flex;
+  gap: 14px;
+  align-items: stretch;
+  text-align: left;
+  padding: 16px;
+  border-radius: 14px;
+  cursor: pointer;
+  color: inherit;
+  background: var(--panel, #232a33);
+  border: 1px solid var(--border, #333a44);
+  border-left: 5px solid var(--accent, #34ad4f);
+  transition: transform 0.08s ease, box-shadow 0.12s ease;
+}
+.pg__card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 24px -12px rgba(0, 0, 0, 0.55);
+}
+.pg__card-emoji {
+  font-size: 40px;
+  line-height: 1;
+  align-self: center;
+}
+.pg__card-title {
+  font-size: 16px;
+  font-weight: 700;
+}
+.pg__card-desc {
+  font-size: 13px;
+  opacity: 0.78;
+  margin-top: 4px;
+  line-height: 1.4;
+}
+.pg__card-meta {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--accent, #34ad4f);
+  margin-top: 8px;
+}
+
+/* ── Floating tutorial dialog ───────────────────────────────────────────── */
+.td {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  z-index: 1100;
+  width: 380px;
+  max-width: calc(100vw - 40px);
+  max-height: min(70vh, 640px);
+  display: flex;
+  flex-direction: column;
+  border-radius: 14px;
+  background: var(--bg, #1b1f26);
+  color: var(--fg, #e6edf3);
+  border: 1px solid var(--border, #333a44);
+  border-top: 4px solid var(--accent, #34ad4f);
+  box-shadow: 0 18px 44px -14px rgba(0, 0, 0, 0.6);
+  overflow: hidden;
+}
+.td__head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 12px;
+  border-bottom: 1px solid var(--border, #333a44);
+}
+.td__emoji {
+  font-size: 18px;
+}
+.td__course {
+  font-weight: 700;
+  font-size: 14px;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.td__icon {
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  opacity: 0.65;
+  font-size: 14px;
+  padding: 3px 6px;
+  border-radius: 6px;
+}
+.td__icon:hover {
+  opacity: 1;
+  background: var(--hover, rgba(255, 255, 255, 0.08));
+}
+.td__body {
+  overflow-y: auto;
+  padding: 14px 16px;
+}
+.td__lesson-title {
+  margin: 0 0 8px;
+  font-size: 16px;
+}
+.td__md {
+  font-size: 13.5px;
+  line-height: 1.55;
+}
+.td__md pre {
+  overflow-x: auto;
+}
+.td__splash {
+  padding: 26px 20px;
+  text-align: center;
+}
+.td__splash-emoji {
+  font-size: 52px;
+}
+.td__splash-title {
+  margin: 12px 0 6px;
+  font-size: 19px;
+}
+.td__splash-desc {
+  font-size: 13.5px;
+  opacity: 0.8;
+  line-height: 1.5;
+}
+.td__splash-meta {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--accent, #34ad4f);
+  margin: 10px 0 18px;
+}
+.td__start,
+.td__nav--next {
+  background: var(--accent, #34ad4f);
+  color: #fff;
+  border: none;
+  border-radius: 20px;
+  padding: 8px 20px;
+  font-weight: 700;
+  cursor: pointer;
+}
+.td__tip {
+  display: flex;
+  gap: 8px;
+  margin: 0 12px 8px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--accent, #34ad4f) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent, #34ad4f) 40%, transparent);
+  font-size: 13px;
+}
+.td__tip-bulb {
+  flex: none;
+}
+.td__foot {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 12px;
+  border-top: 1px solid var(--border, #333a44);
+}
+.td__nav {
+  background: transparent;
+  color: inherit;
+  border: 1px solid var(--border, #333a44);
+  border-radius: 18px;
+  padding: 6px 12px;
+  font-weight: 600;
+  font-size: 13px;
+  cursor: pointer;
+}
+.td__nav:hover {
+  background: var(--hover, rgba(255, 255, 255, 0.08));
+}
+.td__dots {
+  flex: 1;
+  display: flex;
+  gap: 6px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+.td__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  background: var(--border, #4a5260);
+}
+.td__dot--on {
+  background: var(--accent, #34ad4f);
+  transform: scale(1.25);
+}
+.td__tipbtn {
+  border: 1px solid var(--border, #333a44);
+  background: transparent;
+  border-radius: 50%;
+  width: 30px;
+  height: 30px;
+  cursor: pointer;
+  font-size: 15px;
+  line-height: 1;
+}
+.td__tipbtn--on {
+  background: color-mix(in srgb, var(--accent, #34ad4f) 22%, transparent);
+  border-color: var(--accent, #34ad4f);
+}

--- a/src/renderer/src/courses/beginner/01-hello.md
+++ b/src/renderer/src/courses/beginner/01-hello.md
@@ -1,0 +1,26 @@
+## Hello, Snakie 🐣
+
+Welcome! Let's make the computer say something.
+
+The code on the right is already loaded into the editor. It has one line:
+
+```python
+print("Hello from Snakie!")
+```
+
+`print(...)` tells the board to show a message in the **console** — the black
+panel at the bottom of the screen.
+
+### Try it
+
+1. Make sure the device says **connected** (the simulator connects on its own).
+2. Press the green **Run ▶** button.
+3. Look at the console — you should see `Hello from Snakie!`
+
+### Now you
+
+Change the words inside the quote marks to your own message, then press **Run**
+again. The console shows whatever you typed.
+
+> Everything between the `"` quotes is called a *string* — just text for the
+> computer to show.

--- a/src/renderer/src/courses/beginner/02-variables.md
+++ b/src/renderer/src/courses/beginner/02-variables.md
@@ -1,0 +1,29 @@
+## Variables
+
+A **variable** is a labelled box that remembers a value for later.
+
+```python
+name = "Ada"
+age = 9
+print("Hi", name, "- you are", age)
+```
+
+- `name = "Ada"` puts the text `Ada` into a box called `name`.
+- `age = 9` puts the number `9` into a box called `age`.
+- `print` can show several things at once if you separate them with commas.
+
+### Try it
+
+Press **Run ▶**. You should see:
+
+```
+Hi Ada - you are 9
+```
+
+### Now you
+
+Change `name` to your own name and `age` to your age, then **Run** again. The
+message updates — you didn't change the `print` line at all, just the boxes it
+reads from.
+
+> Numbers (like `9`) have no quotes. Text (like `"Ada"`) needs quotes.

--- a/src/renderer/src/courses/beginner/03-maths.md
+++ b/src/renderer/src/courses/beginner/03-maths.md
@@ -1,0 +1,32 @@
+## Doing maths 🧮
+
+Your computer is a super-fast calculator. Python can add, multiply, and divide for you in a blink — just type the sum and press Run.
+
+The starter code prints three sums:
+
+- `2 + 2` — a plus adds numbers together.
+- `10 * 3` — the `*` star means "times".
+- `7 / 2` — the `/` slash divides. Watch this one: you get `3.5`, a number with a dot!
+
+```python
+print(2 + 2)
+print(10 * 3)
+print(7 / 2)
+```
+
+### Try it
+
+1. Press Run ▶.
+2. Look in the console. You should see `4`, then `30`, then `3.5`.
+3. See how `7 / 2` gave a dot-number? Sharing 7 things between 2 people leaves a half each.
+
+### Now you
+
+Two new tools for dividing:
+
+- `//` gives the **whole** part only. Try `print(7 // 2)` → `3`.
+- `%` gives the **remainder** (what's left over). Try `print(7 % 2)` → `1`.
+
+Change one line, press Run, and see what pops up!
+
+> A `/` gives a dot-number, but `//` and `%` split it into "how many whole" and "how many left over" — just like sharing sweets.

--- a/src/renderer/src/courses/beginner/04-for-loops.md
+++ b/src/renderer/src/courses/beginner/04-for-loops.md
@@ -1,0 +1,37 @@
+## Repeating with for 🔁
+
+A **for loop** does the same job over and over, without you writing it out lots
+of times.
+
+```python
+for i in range(5):
+    print("count", i)
+```
+
+- `range(5)` hands the loop five numbers, one at a time.
+- `i` is a box that holds the current number on each turn.
+- The indented line runs once for every number — so `print` fires five times.
+
+### Try it
+
+1. Make sure the device says **connected** (the simulator connects on its own).
+2. Press **Run ▶**.
+3. Watch the console count out five lines:
+
+```
+count 0
+count 1
+count 2
+count 3
+count 4
+```
+
+Notice it started at `0` and stopped *before* `5`.
+
+### Now you
+
+Change `range(5)` to `range(10)` and **Run** again — now it counts ten lines.
+The indented line never changed; the loop just repeated more times.
+
+> The indent (those spaces at the start) is what tells Python "this line belongs
+> inside the loop." Line it up neatly!

--- a/src/renderer/src/courses/beginner/05-while-sleep.md
+++ b/src/renderer/src/courses/beginner/05-while-sleep.md
@@ -1,0 +1,24 @@
+## while and sleep ⏳
+
+A `while` loop repeats code again and again, as long as something is true. `time.sleep` puts in a pause so you can watch it happen.
+
+Here's what the starter code does:
+
+- `n = 3` sets a counter to start at 3.
+- `while n > 0:` keeps looping while `n` is bigger than 0.
+- Each time round, it prints `n`, waits 1 second, then makes `n` one smaller.
+- When `n` hits 0, the loop stops and it prints `"Lift off!"`.
+
+It's a rocket countdown!
+
+### Try it
+
+1. Press **Run ▶**.
+2. Watch the **console**. See `3`, then `2`, then `1` appear — one per second.
+3. Wait for `"Lift off!"` to blast off at the end.
+
+### Now you
+
+Change `n = 3` to `n = 10` for a longer countdown. Then try `time.sleep(0.2)` to make it speedy, or `time.sleep(2)` to make it slow and dramatic.
+
+> A loop that never makes its condition false runs *forever*. If that happens, just press **Stop** ⏹ — you're always in control.

--- a/src/renderer/src/courses/beginner/06-if-else.md
+++ b/src/renderer/src/courses/beginner/06-if-else.md
@@ -1,0 +1,32 @@
+## Making decisions 🔀
+
+Programs can look at something and choose what to do next. That's what `if` and `else` are for — they let your code pick a path.
+
+The starter code checks a `score` and reacts:
+
+- `score = 7` puts the number 7 in a box called `score`.
+- `if score >= 5:` asks a yes/no question — "is score 5 or more?"
+- If the answer is **yes**, Python runs the `print("You passed!")` line.
+- `else:` is the backup plan. If the answer is **no**, it runs `print("Try again")` instead.
+
+Notice how only **one** of the two messages ever prints. Python picks a lane and sticks to it.
+
+### Try it
+
+1. Press **Run** ▶.
+2. Watch the **console** — you should see `You passed!`
+3. Change the first line to `score = 2` and press **Run** again.
+4. Now the console says `Try again` — a different path!
+
+### Now you
+
+Add a middle path. Between the `if` and the `else`, try an `elif` (else-if):
+
+```python
+elif score >= 3:
+    print("So close!")
+```
+
+Run it with `score = 4` and see which message wins.
+
+> `>=` means "greater than or equal to". Swap it for `>`, `<`, or `==` (is it exactly equal?) to ask different questions.

--- a/src/renderer/src/courses/beginner/07-functions.md
+++ b/src/renderer/src/courses/beginner/07-functions.md
@@ -1,0 +1,32 @@
+## Functions 🍳
+
+A function is your own little command. You give it a name, teach it a job once, then call that name whenever you want the job done.
+
+The starter code makes a function called `greet`:
+
+- `def greet(who):` starts the recipe. `who` is a box that fills in when you call it.
+- `print("Hello,", who)` is the job — it says hello to whoever `who` is.
+- `greet("world")` and `greet("robot")` *call* the function. Each call fills `who` with a different word.
+
+```python
+def greet(who):
+    print("Hello,", who)
+```
+
+### Try it
+
+1. Press Run ▶.
+2. Watch the console. You wrote `print` once, but it ran twice, with two names.
+3. Notice how the same recipe gave two different messages.
+
+### Now you
+
+Add one more line at the bottom that greets *you*:
+
+```python
+greet("Sam")
+```
+
+Swap in your own name and Run again. Can you add three friends without writing `print` three times?
+
+> Write it once, use it forever. A good function is a tool you can pick up again and again — that is how big programs stay small.

--- a/src/renderer/src/courses/beginner/08-lists.md
+++ b/src/renderer/src/courses/beginner/08-lists.md
@@ -1,0 +1,27 @@
+## Lists 📋
+
+A list is one box that holds many things, kept in the order you put them. Perfect for a bunch of pets, high scores, or colours.
+
+Look at the starter code:
+
+- `pets = ["cat", "dog", "fish"]` makes a list with three items inside the square brackets `[ ]`.
+- `for pet in pets:` walks through the list one item at a time, calling each one `pet`.
+- `len(pets)` counts how many items are in the list — here that's `3`.
+
+### Try it
+
+1. Press Run ▶.
+2. Watch the console print a line for each pet: "I have a cat", then dog, then fish.
+3. The last line shows `Total: 3` — that's `len()` counting for you.
+
+### Now you
+
+Add another animal to the list, like `"rabbit"`. Put it inside the brackets with a comma before it:
+
+```python
+pets = ["cat", "dog", "fish", "rabbit"]
+```
+
+Run again. The loop prints an extra line, and `Total:` climbs to `4` all by itself — you didn't have to change anything else!
+
+> A list keeps things in order, and `len()` always tells you how many. Change the list, and your loop just follows along.

--- a/src/renderer/src/courses/beginner/09-pins.md
+++ b/src/renderer/src/courses/beginner/09-pins.md
@@ -1,0 +1,30 @@
+## Talking to pins 💡
+
+Your board has little metal legs called **pins**. `Pin` lets your code switch one on or off, like flicking a light switch.
+
+The starter code, one line at a time:
+
+- `from machine import Pin` — borrows the `Pin` tool from MicroPython.
+- `Pin(25, Pin.OUT)` — picks pin number **25** and sets it to **OUT** (it *sends* signals, like a switch, instead of listening).
+- `led.on()` — pushes the pin high, turning it on.
+- `led.value()` — asks the pin how it feels right now: `1` for on, `0` for off.
+
+### Try it
+
+1. Make sure your simulated board is connected (Snakie auto-connects it).
+2. Press **Run ▶**.
+3. Read the console — it should say `LED value: 1`.
+4. Open the **Board View** to see pin 25 light up on the drawing.
+
+### Now you
+
+Add a new line after `led.on()`:
+
+```python
+led.off()
+print("Now:", led.value())
+```
+
+Run again. Did the second number drop to `0`? You just turned your pin back off.
+
+> `on()` and `off()` are just friendly words for the numbers `1` and `0` — the board only ever thinks in on/off.

--- a/src/renderer/src/courses/beginner/10-project-countdown.md
+++ b/src/renderer/src/courses/beginner/10-project-countdown.md
@@ -1,0 +1,22 @@
+## Project: countdown light 🚦
+
+Let's build a little countdown, like a rocket launch! The number counts down from 5, the light blinks each time, and then... "Go!"
+
+Here's what the starter code does:
+
+- `led = Pin(25, Pin.OUT)` — sets up pin 25 as an output, ready to control a light.
+- `for i in range(5, 0, -1):` — counts backwards: 5, 4, 3, 2, 1. The `-1` is the step that goes *down*.
+- Inside the loop we `print(i)`, flip the light with `led.toggle()`, then wait half a second with `time.sleep_ms(500)`.
+- After the loop finishes, it prints `"Go!"`.
+
+### Try it
+
+1. The simulated device auto-connects — press Run ▶.
+2. Watch the console count 5, 4, 3, 2, 1, then "Go!".
+3. Open the **Board View** to see pin 25 blink as the light toggles.
+
+### Now you
+
+Make it a *bigger* rocket! Change `range(5, 0, -1)` to `range(10, 0, -1)` so it counts down from 10. Can you also change `500` to `1000` to make each blink last a whole second?
+
+> You just combined pins, loops, and timing into one real program — string a few of these together and you're steering a robot.

--- a/src/renderer/src/courses/beginner/course.yml
+++ b/src/renderer/src/courses/beginner/course.yml
@@ -1,0 +1,89 @@
+title: First Steps with MicroPython
+description: Write your very first programs — no board needed. Runs on the simulator.
+emoji: "🐣"
+accent: "#34ad4f"
+track: beginner
+lessons:
+  - title: Hello, Snakie
+    file: 01-hello.md
+    code: |
+      # Press Run ▶ to send this to the board (or the simulator).
+      print("Hello from Snakie!")
+    tip: "`print()` shows text in the console at the bottom of the screen."
+  - title: Variables
+    file: 02-variables.md
+    code: |
+      name = "Ada"
+      age = 9
+      print("Hi", name, "- you are", age)
+    tip: "A variable is a labelled box that remembers a value."
+  - title: Doing maths
+    file: 03-maths.md
+    code: |
+      print(2 + 2)
+      print(10 * 3)
+      print(7 / 2)
+    tip: "Try `//` for whole-number division and `%` for the remainder."
+  - title: Repeating with for
+    file: 04-for-loops.md
+    code: |
+      for i in range(5):
+          print("count", i)
+    tip: "`range(5)` gives 0, 1, 2, 3, 4 — five numbers starting at zero."
+  - title: while and sleep
+    file: 05-while-sleep.md
+    code: |
+      import time
+      n = 3
+      while n > 0:
+          print(n)
+          time.sleep(1)
+          n = n - 1
+      print("Lift off!")
+    tip: "Press **Stop** ⏹ to end a program that loops forever."
+  - title: Making decisions
+    file: 06-if-else.md
+    code: |
+      score = 7
+      if score >= 5:
+          print("You passed!")
+      else:
+          print("Try again")
+    tip: "Indentation (the spaces) tells Python which lines belong to the `if`."
+  - title: Functions
+    file: 07-functions.md
+    code: |
+      def greet(who):
+          print("Hello,", who)
+
+      greet("world")
+      greet("robot")
+    tip: "A function is a reusable recipe — write it once, call it many times."
+  - title: Lists
+    file: 08-lists.md
+    code: |
+      pets = ["cat", "dog", "fish"]
+      for pet in pets:
+          print("I have a", pet)
+      print("Total:", len(pets))
+    tip: "A list holds many values in order. `len()` counts them."
+  - title: Talking to pins
+    file: 09-pins.md
+    code: |
+      from machine import Pin
+      led = Pin(25, Pin.OUT)
+      led.on()
+      print("LED value:", led.value())
+    tip: "`Pin` is how MicroPython controls the board's legs (its GPIO pins)."
+  - title: "Project: countdown light"
+    file: 10-project-countdown.md
+    code: |
+      from machine import Pin
+      import time
+      led = Pin(25, Pin.OUT)
+      for i in range(5, 0, -1):
+          print(i)
+          led.toggle()
+          time.sleep_ms(500)
+      print("Go!")
+    tip: "You've combined pins, loops and timing — that's real robot code!"

--- a/src/renderer/src/courses/robotics/01-simulator.md
+++ b/src/renderer/src/courses/robotics/01-simulator.md
@@ -1,0 +1,26 @@
+## Meet the simulator 🤖
+
+Every robot starts with one tiny "hello" from its brain. Here you'll wake up a pretend robot board — no real wires, no batteries, just Snakie doing the work for you.
+
+The starter code is one line:
+
+```python
+print("Board is alive!")
+```
+
+- `print(...)` sends a message to the **console** so you can read it.
+- The words inside the quotes are yours to change.
+- The **Simulated device (offline)** is a make-believe board that lives inside Snakie. It runs your code exactly like a real one would, so you can practise safely and never break anything.
+
+### Try it
+
+1. Look at the top for **Simulated device (offline)** and press **Connect** (it may connect on its own — a little dot goes green).
+2. Press **Run ▶**.
+3. Watch the **console** at the bottom. Your message `Board is alive!` appears — that came from the robot's brain!
+4. Open the **Board View** to see the empty board waiting for parts.
+
+### Now you
+
+Change the words in the quotes to your own robot's name, like `print("Hello, I am Beep!")`, then press **Run ▶** again and read it back.
+
+> The simulator is your training wheels: try wild ideas here first, then move them to real hardware when you're ready.

--- a/src/renderer/src/courses/robotics/02-board-view.md
+++ b/src/renderer/src/courses/robotics/02-board-view.md
@@ -1,0 +1,22 @@
+## See your board 🔌
+
+Code tells your board what to do — but where does pin 15 actually live? The **Board View** draws your wiring so you can see it, not just imagine it.
+
+Your starter code lights up a pin:
+
+- `from machine import Pin` brings in the tool for talking to pins.
+- `led = Pin(15, Pin.OUT)` says "pin 15 is an output" — it sends power out.
+- `led.on()` switches that pin on, like flicking a light switch.
+
+### Try it
+
+1. Press **Run** ▶ (your simulated board connects on its own).
+2. Open the **Board View** from the side panel.
+3. Find **pin 15** on the drawing — spot the little wire and LED that Snakie has sketched for you.
+4. See how it lights up? That picture matches your code exactly.
+
+### Now you
+
+Change `Pin(15, Pin.OUT)` to a different number, like `Pin(16, Pin.OUT)`, and press **Run** again. Watch the Board View jump to the new pin. Which pins can you reach?
+
+> The Board View is a mirror of your code — change a number, and the wiring redraws itself. No screwdriver needed!

--- a/src/renderer/src/courses/robotics/03-blink.md
+++ b/src/renderer/src/courses/robotics/03-blink.md
@@ -1,0 +1,28 @@
+## Blink an LED 💡
+
+Making a light flash on and off is the "hello world" of robots. Let's tell your board's LED to wink at you.
+
+The starter code, one idea at a time:
+
+- `Pin(15, Pin.OUT)` grabs pin **15** and sets it to **OUT**, so the board sends power *out* to the LED.
+- `while True:` means "keep doing this forever".
+- `led.toggle()` flips the LED. The tip says it swaps on↔off each loop — so on, off, on, off, like a light switch you can't stop pressing.
+- `time.sleep_ms(400)` waits 400 milliseconds (a bit under half a second) between flips. That pause is what makes it *blink* instead of blur.
+
+### Try it
+
+1. Press **Run ▶**. Your simulated board auto-connects.
+2. Open the **Board View** and find pin 15 — watch the LED there pulse on and off.
+3. Count the beats. Roughly one flash every second.
+
+### Now you
+
+Make it flash faster. Change `400` to `100`:
+
+```python
+time.sleep_ms(100)
+```
+
+Press Run again. Now try a slow, sleepy `1000`. Which one feels like a heartbeat?
+
+> The pause is the secret. Without `sleep_ms`, the LED flips so fast it just looks *on*.

--- a/src/renderer/src/courses/robotics/04-button.md
+++ b/src/renderer/src/courses/robotics/04-button.md
@@ -1,0 +1,25 @@
+## Read a button 🔘
+
+Buttons let your robot listen to *you*. This code watches a pin and shouts back the moment you press.
+
+Here's what the starter code does:
+
+- `Pin(14, Pin.IN, ...)` sets pin **14** as an **input** — it listens instead of sending power.
+- `Pin.PULL_UP` keeps the pin resting at **1**. When you press the button, it drops to **0**.
+- The `while True` loop checks the button over and over, super fast.
+- `if button.value() == 0:` means "if it's pressed right now, print `Pressed!`".
+
+Why the "pull-up"? Without it, an unpressed pin floats and reads random junk. The pull-up gently holds it at 1 so 0 always means "pressed on purpose".
+
+### Try it
+
+1. Let the simulated device **Connect** (it does this on its own).
+2. Press **Run ▶**.
+3. Open the **Board View** and find your button on pin **14**.
+4. Click the button in the Board View and watch the **console** fill with `Pressed!`.
+
+### Now you
+
+Change the message to something fun, like `print("Ouch! You poked me!")`. Run it and press again.
+
+> A `while True` loop that checks a button is your robot's way of waiting patiently for you.

--- a/src/renderer/src/courses/robotics/05-pwm.md
+++ b/src/renderer/src/courses/robotics/05-pwm.md
@@ -1,0 +1,30 @@
+## Fading with PWM 💡
+
+An LED is either on or off — so how do you make it *glow* softly? You blink it so fast your eyes can't see the flicker, only a dimmer light. That trick is called PWM.
+
+Look at the starter code:
+
+- `PWM(Pin(15))` turns pin 15 into a fast on/off pin.
+- `led.freq(1000)` sets it to flick 1000 times a second.
+- `led.duty_u16(duty)` sets brightness. `0` is off, `65535` is full glow, and anything in between is a dimmer shade.
+- The `for` loop steps `duty` up in jumps of 4000, waiting 50ms each time — so the LED fades from dark to bright.
+
+### Try it
+
+1. Press Run ▶ (your simulated board auto-connects).
+2. Open the **Board View** — find pin 15 and watch the LED brighten step by step.
+3. Open the **Plotter** to see the duty value climb like a staircase.
+
+### Now you
+
+Make it fade *back down* too. Add a second loop after the first that counts the other way:
+
+```python
+for duty in range(65535, 0, -4000):
+    led.duty_u16(duty)
+    time.sleep_ms(50)
+```
+
+Now your LED breathes in and out.
+
+> Smaller jumps than 4000 make a smoother, silkier fade — try 1000.

--- a/src/renderer/src/courses/robotics/06-servo.md
+++ b/src/renderer/src/courses/robotics/06-servo.md
@@ -1,0 +1,22 @@
+## Drive a servo 🤖
+
+A servo is a little motor that turns to an *exact* angle and holds there — perfect for a robot arm or a wiggling leg.
+
+Your starter code:
+
+- `Servo(PWM(Pin(0)), pin=0)` makes a servo on pin 0. PWM is the fast on/off signal that tells the servo where to point.
+- `s.angle(90)` turns it to 90 degrees — halfway.
+- The `for` loop steps through `0, 90, 180, 90`, pausing 600ms each time, so the servo sweeps and comes back.
+
+### Try it
+
+1. Make sure the simulated device is **Connected** (it usually auto-connects — check the status bar).
+2. Press **Run ▶**.
+3. Open the **Pose bench** and watch the servo arm swing to each angle and hold.
+4. Peek at the **Board View** to see the wire from pin 0 to your servo.
+
+### Now you
+
+Change the angles to make a slow nod: try `(0, 45, 0, 45)`. Then make the pauses longer with `time.sleep_ms(1000)` so it moves gently. Can you get it to point straight up and stay there?
+
+> Angles go from 0 to 180 — that's your servo's whole world. Ask for 200 and it just stops at 180!

--- a/src/renderer/src/courses/robotics/07-buzzer.md
+++ b/src/renderer/src/courses/robotics/07-buzzer.md
@@ -1,0 +1,20 @@
+## Make some noise 🎵
+
+A buzzer turns electricity into sound. By sending it different frequencies, one after another, you can play a little tune!
+
+Here's what the starter code does:
+
+- `Buzzer(PWM(Pin(16)))` connects a buzzer to pin 16. PWM is what lets the pin "wiggle" fast enough to make a note.
+- The numbers `262, 330, 392, 523` are frequencies in hertz — that's how many wiggles per second. They spell out C, E, G, and high C.
+- `buz.tone(note)` plays one note; `time.sleep_ms(250)` holds it for a quarter of a second before the next.
+- `buz.off()` stops the sound at the end so it doesn't keep humming.
+
+### Try it
+1. Make sure the simulated device is **connected** (it auto-connects).
+2. Press **Run ▶** and listen — four notes climb up like a doorbell.
+3. Open the **Board View** and find pin 16 to see where the buzzer is wired.
+
+### Now you
+Change the loop to `(523, 392, 330, 262)` so the notes climb **down** instead of up. Can you add two more numbers to make it longer?
+
+> Higher number = higher pitch. A melody is just the right numbers in the right order.

--- a/src/renderer/src/courses/robotics/08-plot-sensor.md
+++ b/src/renderer/src/courses/robotics/08-plot-sensor.md
@@ -1,0 +1,23 @@
+## Plot a sensor 📈
+
+A light sensor sends back a number that goes up in bright light and down in the dark. Numbers scrolling past are hard to read, so let's turn them into a picture.
+
+Here's what the starter code does:
+
+- `ADC(26)` reads an **analog** pin — one that gives a whole range of values, not just on/off.
+- `sensor.read_u16()` reads the light as a big number from 0 up to 65535.
+- The magic word `SNK PLOT light` tells Snakie's **Plotter** to graph the number that follows it, and call the line "light".
+- The loop reads and prints every 100 ms, forever.
+
+### Try it
+
+1. The simulated device auto-connects — press **Run ▶**.
+2. Numbers race down the **console**. Now open the **Plotter** instrument.
+3. Watch a wiggly line draw itself in real time.
+4. Wave your hand over the sensor (or drag the light slider in **Board View**) and watch the line dip and climb.
+
+### Now you
+
+Add a second reading! Put another sensor on `ADC(27)` and print `SNK PLOT dark` with its value. The Plotter draws **two** coloured lines at once — spot which one is which.
+
+> A graph turns a river of numbers into a story your eyes can read in a glance.

--- a/src/renderer/src/courses/robotics/09-multimeter.md
+++ b/src/renderer/src/courses/robotics/09-multimeter.md
@@ -1,0 +1,22 @@
+## The multimeter 🔌
+
+A multimeter measures voltage — how hard electricity is being "pushed". Your board can read a voltage on a pin and show it on a dial, just like a real one.
+
+The starter code turns pin **26** into an ADC (that's an *analog-to-digital converter*, a pin that reads voltages instead of just on/off):
+
+- `pin.read_u16()` gives a big number from 0 to 65535.
+- We do the maths to turn that into **volts** (0 V up to 3.3 V).
+- Each line prints `SNK METER volts` — that special tag is what feeds the on-screen Multimeter needle.
+
+### Try it
+
+1. Make sure the simulated device is **Connected** (it auto-connects — look for the green dot).
+2. Press **Run ▶**.
+3. Open the **Multimeter** instrument. Watch the needle settle on a voltage.
+4. In the **Board View**, find pin 26 — that's the pin you're measuring.
+
+### Now you
+
+Change the sleep to `time.sleep_ms(50)` so it reads faster, then round to `round(volts, 3)` for extra decimal places. Does the needle wobble more?
+
+> A multimeter is a maker's most-used tool — if a wire is dead or a battery is flat, the voltage tells you first.

--- a/src/renderer/src/courses/robotics/10-project-wave.md
+++ b/src/renderer/src/courses/robotics/10-project-wave.md
@@ -1,0 +1,23 @@
+## Project: wave hello 👋
+
+Time to put it all together! You'll make a servo arm swing back and forth, like it's waving at you.
+
+Here's how the starter code works:
+
+- `arm = Servo(...)` sets up one servo on pin 0 — that's your robot's arm.
+- The `for _ in range(3):` loop repeats **3 times**, so the wave happens three times.
+- Inside the loop, `arm.angle(60)` then `arm.angle(120)` tips the arm one way, then the other. The `time.sleep_ms(300)` waits between each move so the wave isn't too fast to see.
+- At the end, `arm.angle(90)` parks the arm back in the middle, resting.
+
+### Try it
+
+1. Make sure the simulated device is connected (it usually connects on its own).
+2. Press **Run ▶**.
+3. Open the **Board View** to see pin 0 lighting up as the arm moves.
+4. Open the **Pose bench** and watch the servo swing to 60, then 120, three times, then settle at 90.
+
+### Now you
+
+Make it a **big, slow** wave! Change `60` to `30` and `120` to `150`, and change both `300` values to `500`. Press Run again — a wider, friendlier wave.
+
+> One servo, one loop, and a few angles — that's real robot behaviour. Every robot dance starts exactly here.

--- a/src/renderer/src/courses/robotics/course.yml
+++ b/src/renderer/src/courses/robotics/course.yml
@@ -1,0 +1,101 @@
+title: Build a Robot on the Breadboard
+description: Wire up LEDs, buttons, servos and sensors — see them on the Board View and instruments.
+emoji: "🤖"
+accent: "#e6ab30"
+track: robotics
+lessons:
+  - title: Meet the simulator
+    file: 01-simulator.md
+    code: |
+      print("Board is alive!")
+    tip: "Connect the **Simulated device (offline)** — no real hardware needed."
+  - title: See your board
+    file: 02-board-view.md
+    code: |
+      from machine import Pin
+      led = Pin(15, Pin.OUT)
+      led.on()
+    tip: "Open the **Board View** to see your wiring drawn out."
+  - title: Blink an LED
+    file: 03-blink.md
+    code: |
+      from machine import Pin
+      import time
+      led = Pin(15, Pin.OUT)
+      while True:
+          led.toggle()
+          time.sleep_ms(400)
+    tip: "`toggle()` flips the LED on↔off each time round the loop."
+  - title: Read a button
+    file: 04-button.md
+    code: |
+      from machine import Pin
+      button = Pin(14, Pin.IN, Pin.PULL_UP)
+      while True:
+          if button.value() == 0:
+              print("Pressed!")
+    tip: "`PULL_UP` means the pin reads 1 normally, and 0 when pressed."
+  - title: Fading with PWM
+    file: 05-pwm.md
+    code: |
+      from machine import Pin, PWM
+      import time
+      led = PWM(Pin(15))
+      led.freq(1000)
+      for duty in range(0, 65535, 4000):
+          led.duty_u16(duty)
+          time.sleep_ms(50)
+    tip: "PWM switches a pin on/off fast to dim an LED or drive a motor."
+  - title: Drive a servo
+    file: 06-servo.md
+    code: |
+      from snakie import Servo, Pin, PWM
+      import time
+      s = Servo(PWM(Pin(0)), pin=0)
+      for angle in (0, 90, 180, 90):
+          s.angle(angle)
+          time.sleep_ms(600)
+    tip: "A servo turns to an exact angle. Watch the Pose bench move with it!"
+  - title: Make some noise
+    file: 07-buzzer.md
+    code: |
+      from snakie import Buzzer, Pin, PWM
+      import time
+      buz = Buzzer(PWM(Pin(16)))
+      for note in (262, 330, 392, 523):
+          buz.tone(note)
+          time.sleep_ms(250)
+      buz.off()
+    tip: "Different frequencies make different musical notes."
+  - title: Plot a sensor
+    file: 08-plot-sensor.md
+    code: |
+      from machine import ADC
+      import time
+      sensor = ADC(26)
+      while True:
+          print("SNK PLOT light", sensor.read_u16())
+          time.sleep_ms(100)
+    tip: "Open the **Plotter** instrument to see the value as a live graph."
+  - title: The multimeter
+    file: 09-multimeter.md
+    code: |
+      from machine import ADC
+      import time
+      pin = ADC(26)
+      while True:
+          volts = pin.read_u16() / 65535 * 3.3
+          print("SNK METER volts", round(volts, 2))
+          time.sleep_ms(200)
+    tip: "`SNK METER` lines drive the on-screen **Multimeter**."
+  - title: "Project: wave hello"
+    file: 10-project-wave.md
+    code: |
+      from snakie import Servo, Pin, PWM
+      import time
+      arm = Servo(PWM(Pin(0)), pin=0)
+      for _ in range(3):
+          arm.angle(60); time.sleep_ms(300)
+          arm.angle(120); time.sleep_ms(300)
+      arm.angle(90)
+    tip: "You've made a real robot behaviour — a friendly wave!"

--- a/src/renderer/src/courses/urdf/01-open-robot-view.md
+++ b/src/renderer/src/courses/urdf/01-open-robot-view.md
@@ -1,0 +1,24 @@
+## Open the Robot View 🤖
+
+Snakie can build robots in 3-D! Before you make one, let's open the room where robots live: the **Robot View**.
+
+The Robot View is a 3-D stage. A robot sits in the middle, and you get to move the camera around it like you're walking about the room:
+
+- **Spin** it to see every side.
+- **Zoom** in for the little parts, out for the whole robot.
+- **Pose** it later by dragging sliders that bend the joints.
+
+There's no code to run here — this lesson is all clicking and looking. Get comfy moving the camera now, and every robot you build next will be easy to check.
+
+### Try it
+
+1. Open the **Robot View** panel (look in the activity bar on the left).
+2. **Drag** anywhere on the stage with your mouse to spin the camera around the robot.
+3. **Scroll** your mouse wheel to zoom in and out.
+4. Find the **build panel** on the side — that's where you'll add parts in the next lesson. Just peek for now!
+
+### Now you
+
+Try to line the robot up so you're looking at it straight from the **front**. Then spin all the way round to see its **back**. Can you get back to the front again?
+
+> A good robot-builder spins their robot often — problems hide on the side you can't see!

--- a/src/renderer/src/courses/urdf/02-what-is-urdf.md
+++ b/src/renderer/src/courses/urdf/02-what-is-urdf.md
@@ -1,0 +1,23 @@
+## A robot is a URDF 🤖
+
+Every robot you build in the Robot View is really one tidy text file called a **URDF**. It's the robot's recipe — no code to run, just parts and how they connect.
+
+A URDF holds two kinds of things:
+
+- **Links** — the solid parts (a body, an arm, a wheel). Each link is a shape, like a box or a cylinder.
+- **Joints** — the bendy or sliding spots that hold two links together and let them move.
+
+So a robot arm is just links (the pieces) plus joints (the elbows) written down in order.
+
+### Try it
+
+1. Open the **Robot View** from the activity bar.
+2. In the **build panel**, add a primitive — pick a **box**. That's your first link!
+3. Add a **cylinder** and use the **Join tool** to mate its face to the box. That join is a joint.
+4. Spin the model with your mouse to see both parts move as one robot.
+
+### Now you
+
+Add a second box on top and join it. You've made a 3-link robot — all inside one URDF, with zero typing.
+
+> Links are the bones, joints are the bendy bits — and the URDF is the whole robot written on one page.

--- a/src/renderer/src/courses/urdf/03-primitives.md
+++ b/src/renderer/src/courses/urdf/03-primitives.md
@@ -1,0 +1,22 @@
+## Add a box link 📦
+
+Every robot is made of **links** — the solid pieces. The simplest way to make one is to drop in a **primitive** shape. Let's add a box.
+
+A primitive is a shape the app can draw for you, no STL file needed:
+- **Box** — great for bodies, arms, and platforms
+- **Cylinder** — good for wheels and posts
+- **Sphere** — perfect for a head or a joint ball
+
+We'll start with a box, because it's the easiest to line other parts up against later.
+
+### Try it
+1. Open the **Robot View** on the right.
+2. In the **build panel**, click **Add primitive → Box**.
+3. A box appears in the 3-D scene — spin the view by dragging to see all its faces.
+4. Find the **size** boxes and change the width, height, and depth. Watch the box grow and shrink live.
+5. Give it a colour so it's easy to spot.
+
+### Now you
+Make the box long and flat, like a robot's base plate — try a big width and depth but a small height. Then add a **second** box on top for the body!
+
+> Boxes have six flat faces. Flat faces are easy to **join** other parts onto — that's your next lesson.

--- a/src/renderer/src/courses/urdf/04-second-link.md
+++ b/src/renderer/src/courses/urdf/04-second-link.md
@@ -1,0 +1,25 @@
+## A second part 🧩
+
+One box is a start, but a robot needs pieces stuck together. Let's add a **second link** and use the **Join tool** to snap it onto the first.
+
+The Join tool mates one part's **face** to another's, so they line up perfectly — no guessing with numbers:
+
+- You pick a **parent** part first, then the **child** part that attaches to it.
+- Then you click a **face** on each — the child slides over so the faces kiss.
+- A **swap** button flips which part is the parent if you picked them the wrong way round.
+
+Pick order decides who holds whom, so choose the part that stays still first.
+
+### Try it
+
+1. Open the **Robot View** and make sure your box from last lesson is there.
+2. In the **build panel**, click **Add primitive → Box** to drop in a second box.
+3. Click the **Join tool**, then click your **first** box (the parent), then the **second** box (the child).
+4. Click the **top face** of the parent, then the **bottom face** of the child. Watch them snap together!
+5. Spin the view to check the join from every side.
+
+### Now you
+
+Made a tower? Now join a **cylinder** to the side face of your box instead — like an arm sticking out.
+
+> Faces snap flat-to-flat. If a part looks crooked, you joined the wrong face — undo and pick again.

--- a/src/renderer/src/courses/urdf/05-joints.md
+++ b/src/renderer/src/courses/urdf/05-joints.md
@@ -1,0 +1,23 @@
+## Connect with a joint 🔩
+
+You've built two parts. Now let's link them with a **joint** so one can move against the other, like an elbow bending or a drawer sliding out.
+
+A joint always connects a **parent** part (stays put) to a **child** part (the one that moves). Picking the right joint type decides *how* it moves.
+
+- **Revolute** = spins around a hinge (a wheel, a wrist, a door).
+- **Prismatic** = glides in a straight line (a lift, a drawer, a piston).
+- **Fixed** = glued solid, no movement — handy for decoration.
+
+### Try it
+
+1. Open the **Robot View** and find the **build panel** on the left.
+2. Click the **Join tool**, then click your parent part, then the child part.
+3. In the joint settings, choose **Revolute** for a spin (or **Prismatic** for a slide).
+4. Use the Join tool to **mate the faces** so the parts snap together neatly.
+5. Drag the **posing slider** and watch your child part move!
+
+### Now you
+
+Set **joint limits** so it can't go too far. Try a min of `-45` and a max of `45` degrees, then drag the slider again — feel it stop at the edges.
+
+> The parent holds still, the child does the moving — pick your parent first!

--- a/src/renderer/src/courses/urdf/06-joint-limits.md
+++ b/src/renderer/src/courses/urdf/06-joint-limits.md
@@ -1,0 +1,23 @@
+## Set joint limits 🛑
+
+A joint limit is a fence for a joint. It says "you may turn this far, and no further" — so your robot can't bend a leg backwards or spin a servo past where the real one stops.
+
+Every revolute joint (a hinge) turns around a spot. A prismatic joint (a slider) moves along a line. Without limits they'd keep going forever!
+
+- **Lower limit** — the smallest angle (or distance) allowed.
+- **Upper limit** — the biggest allowed.
+- The pose slider will only move *between* those two numbers.
+
+### Try it
+
+1. Open the **Robot View** and click a joint you made earlier (a revolute one is easiest).
+2. In the build panel, find the **Limits** boxes.
+3. Set **Lower** to `-90` and **Upper** to `90`.
+4. Drag the **pose slider** all the way left, then all the way right — watch the part stop right at the fence.
+5. Try tighter numbers, like `-30` and `45`, and drag again.
+
+### Now you
+
+Give an arm a "no droop" rule: set a shoulder joint's **Lower** to `0` so it can lift up but never sag below level. Then **Export URDF** to save it.
+
+> Real servos have limits too. Matching them here means your robot moves the same on screen as it does on the bench. 🦾

--- a/src/renderer/src/courses/urdf/07-pose-sliders.md
+++ b/src/renderer/src/courses/urdf/07-pose-sliders.md
@@ -1,0 +1,22 @@
+## Pose with sliders 🎚️
+
+A **pose** is just a position for your robot — arm up, arm down, head turned. The quickest way to strike one is to grab a slider and move a joint by hand.
+
+Every joint you added has its own slider in the **Robot View**:
+- A **revolute** joint's slider swings it round in degrees (like a wrist).
+- A **prismatic** joint's slider slides it in and out in a straight line.
+- The **limits** you set last lesson keep the slider from going too far — it stops at the min and max.
+
+Nothing is saved yet; you're just trying positions to see what looks good.
+
+### Try it
+1. Open the **Robot View** on the right.
+2. Find the **posing sliders** panel — one row per joint.
+3. Slowly drag a joint's slider and watch that part move live in the 3-D scene.
+4. Drag it all the way to each end — feel it bump against your limits.
+5. Spin the view by dragging the background to check the pose from every side.
+
+### Now you
+Try to make your robot **wave**: set one joint near its middle, another near its top. Nudge two sliders until it looks like a friendly hello.
+
+> Sliders are for playing — move things until the pose feels right, *then* you can save it and drive it with a real servo.

--- a/src/renderer/src/courses/urdf/08-bind-servo.md
+++ b/src/renderer/src/courses/urdf/08-bind-servo.md
@@ -1,0 +1,23 @@
+## Bind a servo to a joint 🤖
+
+A joint can turn on its own with the pose slider — but a real robot uses a **servo** motor. Binding tells Snakie "this servo drives this joint," so when the servo moves, the 3-D joint moves with it.
+
+Before you bind, you need two things ready:
+- A **revolute** joint in your Robot View (the elbow, wheel, or head you built earlier).
+- A **servo** wired on the breadboard, so Snakie knows which pin it lives on.
+
+Binding links the servo's pin to the joint's name. That link gets saved right inside your robot, so it remembers next time.
+
+### Try it
+
+1. Open the **Parts Library** and drag a **servo** onto the breadboard in **Board View**.
+2. Note the **pin** it connects to (Board View draws the wire for you).
+3. Open **Robot View** and click your revolute joint to select it.
+4. In the joint's panel, find **Bind servo** and pick that same pin.
+5. Move the joint's **pose slider** — the servo on the board swings to match. They're linked!
+
+### Now you
+
+Add a **second** servo on a fresh pin and bind it to another joint. Now two motors drive two joints. Nudge both sliders — your robot moves in two places at once.
+
+> A bound servo and joint share one number: the joint's angle *is* the servo's angle. Move one, the other follows.

--- a/src/renderer/src/courses/urdf/09-save-pose.md
+++ b/src/renderer/src/courses/urdf/09-save-pose.md
@@ -1,0 +1,22 @@
+## Save a pose 📸
+
+You've been dragging joint sliders to move your robot. A **pose** lets you keep one of those positions — a named snapshot of every joint, ready to use again.
+
+Think of it like a photo. Once you like the way your robot is standing, save it as "stand", "wave", or "crouch". Later you can jump straight back to it instead of nudging every slider by hand.
+
+- A pose remembers *all* your joint numbers at once — arms, legs, everything.
+- The name is yours to pick, so make it easy to remember.
+- Saved poses live with your robot, right next to its joints.
+
+### Try it
+
+1. Open the **Robot View** and drag the **posing sliders** until your robot looks the way you want.
+2. Find the **Pose bench** in the build panel and click **Save pose**.
+3. Type a name like `wave` and confirm.
+4. Now drag the sliders somewhere silly, then click your saved **wave** pose — snap, it's back!
+
+### Now you
+
+Make two poses: one called `up` with a joint high, one called `down` with it low. Click between them and watch your robot flip-flop. Then **Export URDF** to keep them.
+
+> A saved pose isn't just for clicking — your code can call it by name, so "wave" in the editor really waves. 👋

--- a/src/renderer/src/courses/urdf/10-project-export.md
+++ b/src/renderer/src/courses/urdf/10-project-export.md
@@ -1,0 +1,25 @@
+## Project: export your robot 🚀
+
+You've built it, jointed it, and posed it. Now let's turn your robot into a real **URDF file** you can save, share, and reuse.
+
+A URDF is just a tidy description of your robot: its parts, how they join, and how each joint moves. Snakie writes it for you.
+
+Before exporting, give things good names so future-you understands them:
+
+- Click each part in the **Robot View** build panel and rename blobs like `link_3` to `arm`, `base`, or `head`.
+- Do the same for joints: `shoulder`, `elbow`, `wrist`.
+- Double-check your joint **limits** so nothing bends the wrong way.
+
+### Try it
+
+1. Open the **Robot View** and select your robot's root (base) part.
+2. In the build panel, tidy the part and joint names.
+3. Drag a posing slider to confirm each joint still moves nicely.
+4. Press **Export URDF**.
+5. Watch the console — Snakie saves a clean `.urdf` into your `urdf/` folder.
+
+### Now you
+
+Rename one joint from something dull to something clear, then Export again. Open the new file — can you spot your name inside the URDF text?
+
+> A URDF is your robot's recipe. Save it in `urdf/` and you can rebuild your robot any time, or share it with a friend!

--- a/src/renderer/src/courses/urdf/course.yml
+++ b/src/renderer/src/courses/urdf/course.yml
@@ -1,0 +1,36 @@
+title: Build a Robot in 3-D
+description: Make a robot model from primitives and STL parts, add joints, and pose it in the Robot View.
+emoji: "🦾"
+accent: "#2f7c70"
+track: urdf
+lessons:
+  - title: Open the Robot View
+    file: 01-open-robot-view.md
+    tip: "The Robot View shows a 3-D robot you can spin, zoom and pose."
+  - title: A robot is a URDF
+    file: 02-what-is-urdf.md
+    tip: "URDF = a text file describing a robot's parts (links) and joints."
+  - title: Add a box link
+    file: 03-primitives.md
+    tip: "Primitives (box, cylinder, sphere) are the building blocks of a link."
+  - title: A second part
+    file: 04-second-link.md
+    tip: "Use the Join tool to mate one part's face to another's."
+  - title: Connect with a joint
+    file: 05-joints.md
+    tip: "A **revolute** joint rotates; a **prismatic** joint slides."
+  - title: Set joint limits
+    file: 06-joint-limits.md
+    tip: "Limits stop the model (and your servo) moving past a safe angle."
+  - title: Pose with sliders
+    file: 07-pose-sliders.md
+    tip: "Drag a joint slider to pose the robot live on screen."
+  - title: Bind a servo to a joint
+    file: 08-bind-servo.md
+    tip: "Wire a servo on the breadboard, then pick the joint it drives."
+  - title: Save a pose
+    file: 09-save-pose.md
+    tip: "A pose is a named snapshot of every joint — reuse it in code."
+  - title: "Project: export your robot"
+    file: 10-project-export.md
+    tip: "Export a clean URDF into `urdf/` to share or version your robot."

--- a/src/renderer/src/lib/courses.ts
+++ b/src/renderer/src/lib/courses.ts
@@ -1,0 +1,104 @@
+/**
+ * Bundled tutorial COURSES for the Projects gallery + tutorial dialog (#479).
+ * =============================================================================
+ *
+ * Each course is a folder under `src/renderer/src/courses/<id>/` with a
+ * `course.yml` (the kevsrobots-style structure) + one Markdown file per lesson.
+ * They're inlined at build time via Vite `?raw` globs (so both the web and the
+ * Electron build ship them, no server), parsed here into {@link Course}s.
+ *
+ * A lesson can carry starter `code` (seeds the editor when you open the lesson)
+ * and a `tip` (a lightbulb popup). Thumbnails are an emoji + accent colour, so no
+ * image assets need authoring.
+ */
+import { parse } from 'yaml'
+
+export interface Lesson {
+  title: string
+  /** Rendered Markdown body (resolved from the lesson's `file`). */
+  body: string
+  /** Optional starter code — opened in the editor when the lesson opens. */
+  code?: string
+  /** Optional tip shown behind the lightbulb (Markdown). */
+  tip?: string
+}
+
+export type CourseTrack = 'beginner' | 'robotics' | 'urdf'
+
+export interface Course {
+  id: string
+  title: string
+  description: string
+  emoji: string
+  accent: string
+  track: CourseTrack
+  lessons: Lesson[]
+}
+
+interface RawLesson {
+  title: string
+  file: string
+  code?: string
+  tip?: string
+}
+interface RawCourse {
+  title: string
+  description: string
+  emoji?: string
+  accent?: string
+  track?: CourseTrack
+  lessons: RawLesson[]
+}
+
+// Inlined at build time. Keys are absolute-from-root module paths.
+const courseYml = import.meta.glob('../courses/*/course.yml', {
+  query: '?raw',
+  import: 'default',
+  eager: true
+}) as Record<string, string>
+const lessonMd = import.meta.glob('../courses/*/*.md', {
+  query: '?raw',
+  import: 'default',
+  eager: true
+}) as Record<string, string>
+
+/** `../courses/<id>/course.yml` → `<id>`. */
+const idOf = (path: string): string => path.replace(/.*\/courses\/([^/]+)\/.*/, '$1')
+
+let cache: Course[] | null = null
+
+/** All bundled courses, in track order (beginner → robotics → urdf), parsed once. */
+export function loadCourses(): Course[] {
+  if (cache) return cache
+  const out: Course[] = []
+  for (const [ymlPath, yml] of Object.entries(courseYml)) {
+    const id = idOf(ymlPath)
+    let raw: RawCourse
+    try {
+      raw = parse(yml) as RawCourse
+    } catch {
+      continue
+    }
+    if (!raw || !Array.isArray(raw.lessons)) continue
+    const dir = ymlPath.slice(0, ymlPath.lastIndexOf('/'))
+    const lessons: Lesson[] = raw.lessons
+      .map((l): Lesson | null => {
+        const body = lessonMd[`${dir}/${l.file}`]
+        if (body == null) return null
+        return { title: l.title, body, code: l.code, tip: l.tip }
+      })
+      .filter((l): l is Lesson => l !== null)
+    if (!lessons.length) continue
+    out.push({
+      id,
+      title: raw.title ?? id,
+      description: raw.description ?? '',
+      emoji: raw.emoji ?? '📘',
+      accent: raw.accent ?? '#34ad4f',
+      track: raw.track ?? 'beginner',
+      lessons
+    })
+  }
+  const order: CourseTrack[] = ['beginner', 'robotics', 'urdf']
+  return (cache = out.sort((a, b) => order.indexOf(a.track) - order.indexOf(b.track) || a.title.localeCompare(b.title)))
+}

--- a/src/renderer/src/store/tutorials.tsx
+++ b/src/renderer/src/store/tutorials.tsx
@@ -1,0 +1,67 @@
+/**
+ * Tutorials store (#479) — the Projects gallery + floating lesson dialog state.
+ * =============================================================================
+ *
+ * Holds which course is open and which lesson you're on. `lessonIndex === -1` is
+ * the course SPLASH (intro card); `0..n-1` are the lessons. Kept separate from
+ * the editor: the {@link ../components/TutorialDialog} seeds the editor buffer
+ * from the lesson's starter `code` when the lesson changes.
+ */
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react'
+import { loadCourses, type Course } from '../lib/courses'
+
+interface TutorialsApi {
+  courses: Course[]
+  galleryOpen: boolean
+  course: Course | null
+  /** -1 = splash, 0..n-1 = a lesson. */
+  lessonIndex: number
+  openGallery: () => void
+  closeGallery: () => void
+  openCourse: (course: Course) => void
+  start: () => void
+  next: () => void
+  prev: () => void
+  goto: (i: number) => void
+  close: () => void
+}
+
+const Ctx = createContext<TutorialsApi | null>(null)
+
+export function TutorialsProvider({ children }: { children: ReactNode }): JSX.Element {
+  const courses = useMemo(() => loadCourses(), [])
+  const [galleryOpen, setGalleryOpen] = useState(false)
+  const [course, setCourse] = useState<Course | null>(null)
+  const [lessonIndex, setLessonIndex] = useState(-1)
+
+  const openGallery = useCallback(() => setGalleryOpen(true), [])
+  const closeGallery = useCallback(() => setGalleryOpen(false), [])
+  const openCourse = useCallback((c: Course) => {
+    setCourse(c)
+    setLessonIndex(-1) // splash first
+    setGalleryOpen(false)
+  }, [])
+  const start = useCallback(() => setLessonIndex(0), [])
+  const goto = useCallback(
+    (i: number) => setLessonIndex((cur) => (course ? Math.max(-1, Math.min(course.lessons.length - 1, i)) : cur)),
+    [course]
+  )
+  const next = useCallback(() => setLessonIndex((i) => (course ? Math.min(course.lessons.length - 1, i + 1) : i)), [course])
+  const prev = useCallback(() => setLessonIndex((i) => Math.max(-1, i - 1)), [])
+  const close = useCallback(() => {
+    setCourse(null)
+    setLessonIndex(-1)
+  }, [])
+
+  const api = useMemo<TutorialsApi>(
+    () => ({ courses, galleryOpen, course, lessonIndex, openGallery, closeGallery, openCourse, start, next, prev, goto, close }),
+    [courses, galleryOpen, course, lessonIndex, openGallery, closeGallery, openCourse, start, next, prev, goto, close]
+  )
+  return <Ctx.Provider value={api}>{children}</Ctx.Provider>
+}
+
+export function useTutorials(): TutorialsApi {
+  const v = useContext(Ctx)
+  if (!v) throw new Error('useTutorials must be used within a TutorialsProvider')
+  return v
+}


### PR DESCRIPTION
A **Projects gallery** + **floating tutorial dialog** that teaches Snakie step by step — aimed at classroom beginners on the web app (works on desktop too).

## What's here
- **📚 Learn** toolbar button → a MakeCode-style **Projects gallery** of course tiles (emoji thumbnail, grouped by track).
- A **floating tutorial dialog**: rendered Markdown lesson, **Back / Next**, position **dots**, and a **💡 tip** popup. A course opens on a **splash** card, then its lessons.
- Opening a lesson **seeds its starter code** into a fresh editor buffer — press **Run** right away.
- **3 courses × 10 lessons**: *First Steps with MicroPython*, *Build a Robot on the Breadboard*, *Build a Robot in 3-D*. Content is plain `course.yml` + Markdown, bundled via `?raw` globs (both web + desktop).

## Architecture
`lib/courses.ts` (loader) · `store/tutorials.tsx` (state) · `ProjectsGallery.tsx` · `TutorialDialog.tsx` · `Tutorials.css` (themed for dark + light) · `courses/<track>/course.yml` + lesson `.md`s.

## Verified (headless, on the build)
| check | result |
|---|---|
| Learn → gallery | **3 courses**, "10 lessons" each |
| open a course | splash → **10 lessons**, working **dots** |
| Back / Next / **tip** popup | all work |
| open a lesson | starter code lands in the editor |
| page errors | **0** |

Gates: typecheck ✓ · lint 0 errors ✓ · **1730 tests** ✓ · electron + web builds ✓.

Completes milestone **0.28 — Web Serial & close-outs** (the 4th of 4). More lessons drop in as new `course.yml` folders over time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)