### PR TITLE
fix: web serial — show the connected board + detect unplug (#465)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **Web Serial: the port dropdown now shows the connected board, and unplugging is
+  handled gracefully (#465).** After picking a real USB board it was still showing
+  "Simulated device (offline)" (the just-granted port wasn't in the list yet, so the
+  dropdown fell back to the first entry) — it now refreshes and shows the board's
+  name. And physically unplugging the board is detected: the connection drops to
+  *disconnected* and the console prints a "board disconnected" notice instead of
+  hanging on a dead port.
+
 ## [0.28.0] - 2026-07-12
 
 ### Added

--- a/src/renderer/src/components/ConnectionControl.tsx
+++ b/src/renderer/src/components/ConnectionControl.tsx
@@ -41,9 +41,14 @@ export function ConnectionControl({ status }: ConnectionControlProps): JSX.Eleme
   }, [refreshPorts])
 
   // Keep the dropdown showing the active port while connected.
+  // Keep the dropdown showing the active port while connected. A board picked via
+  // Web Serial's chooser isn't in the list yet (it was only just granted), so pull
+  // the ports again — otherwise the <select> falls back to showing the first option.
   useEffect(() => {
-    if (connected && status.path) setSelected(status.path)
-  }, [connected, status.path])
+    if (!connected || !status.path) return
+    setSelected(status.path)
+    void refreshPorts()
+  }, [connected, status.path, refreshPorts])
 
   const handleToggle = useCallback(async (): Promise<void> => {
     setError(null)
@@ -82,9 +87,14 @@ export function ConnectionControl({ status }: ConnectionControlProps): JSX.Eleme
             )
           }
           const detail = p.friendlyName ?? p.manufacturer
+          // A Web Serial board's `webserial://n` path is a synthetic index, not a
+          // real device node — show just its USB name. OS serial paths (e.g.
+          // /dev/ttyACM0) DO identify the port, so keep those.
+          const isWebSerial = p.path.startsWith('webserial://')
+          const label = isWebSerial ? detail || 'USB board' : detail ? `${p.path} — ${detail}` : p.path
           return (
             <option key={p.path} value={p.path}>
-              {detail ? `${p.path} — ${detail}` : p.path}
+              {label}
             </option>
           )
         })}

--- a/src/renderer/src/web/web-serial.ts
+++ b/src/renderer/src/web/web-serial.ts
@@ -39,6 +39,7 @@ export const webSerialSupported = (): boolean => navSerial() !== null
 export class WebSerialTransport implements SerialTransport {
   private reader: ReadableStreamDefaultReader<Uint8Array> | null = null
   private dataCb: ((c: Uint8Array) => void) | null = null
+  private closeCb: (() => void) | null = null
   private closed = false
 
   constructor(private readonly port: WebSerialPort) {}
@@ -58,14 +59,21 @@ export class WebSerialTransport implements SerialTransport {
           if (value && value.length) this.dataCb?.(value)
         }
       } catch {
-        /* stream broke (unplug) — fall through; close() flips `closed` */
+        /* stream broke (unplug) — fall through */
       } finally {
         reader.releaseLock()
       }
     }
+    // The loop only ends when we close() OR the device vanished (readable → null,
+    // read() rejects). If we didn't close it ourselves, the board was unplugged.
+    if (!this.closed) this.closeCb?.()
   }
   onData(cb: (c: Uint8Array) => void): void {
     this.dataCb = cb
+  }
+  /** Called when the stream ends WITHOUT an explicit close() — i.e. an unplug. */
+  onClose(cb: () => void): void {
+    this.closeCb = cb
   }
   async write(data: Uint8Array): Promise<void> {
     if (!this.port.writable) throw new Error('Serial port is not writable')
@@ -104,6 +112,8 @@ interface DeviceStatus {
 export const WEBSERIAL_PREFIX = 'webserial://'
 export const WEBSERIAL_PICK = 'webserial://pick'
 
+const enc = new TextEncoder()
+
 /**
  * Build the Web Serial device backend. Returns the `window.api.device` method
  * surface (a subset — the {@link ./web-device-router} routes to it when a real
@@ -116,6 +126,7 @@ export function createWebSerialBackend(): Record<string, unknown> {
   let path = ''
   let transport: WebSerialTransport | null = null
   let client: RawReplClient | null = null
+  let activePort: WebSerialPort | null = null
   // Synthetic path → granted port, so the dropdown can re-select one.
   const known = new Map<string, WebSerialPort>()
 
@@ -131,9 +142,30 @@ export function createWebSerialBackend(): Record<string, unknown> {
     return client
   }
 
+  // The board vanished (unplugged, or the stream died) while we were connected:
+  // tear down and tell the shell so the console/port dropdown recover gracefully.
+  const handleLost = (): void => {
+    if (state === 'disconnected') return
+    transport = null
+    client = null
+    activePort = null
+    emitData(enc.encode('\r\n[board disconnected — USB unplugged]\r\n'))
+    setState('disconnected', '')
+  }
+
+  // A granted device being physically removed fires `disconnect` on navigator.serial.
+  const serial = navSerial()
+  serial &&
+    (serial as unknown as EventTarget).addEventListener?.('disconnect', (e: Event) => {
+      const gone = (e as unknown as { target?: WebSerialPort }).target
+      if (activePort && gone === activePort) handleLost()
+    })
+
   const openPort = async (port: WebSerialPort, p: string): Promise<void> => {
     setState('connecting', p)
+    activePort = port
     transport = new WebSerialTransport(port)
+    transport.onClose(handleLost) // stream ended without our close() → unplug
     await transport.open(115200)
     client = new RawReplClient(transport, emitData)
     setState('connected', p)
@@ -176,6 +208,7 @@ export function createWebSerialBackend(): Record<string, unknown> {
       await transport?.close()
       transport = null
       client = null
+      activePort = null
       if (state !== 'disconnected') setState('disconnected', '')
     },
 


### PR DESCRIPTION
Two bugs you spotted in the Web Serial support:

**1. The port dropdown stayed on "Simulated device (offline)" after connecting a real board.** The just-granted port wasn't in the dropdown's options yet (`listPorts` hadn't re-run since `requestPort` granted it), so the `<select>` value had no matching option and fell back to the first entry. `ConnectionControl` now **refreshes the port list when the connection becomes active**, and Web Serial ports show just their **USB name** (the synthetic `webserial://n` path is hidden; OS paths like `/dev/ttyACM0` still show, since those identify the port).

**2. Unplugging the board wasn't detected.** `WebSerialTransport` now fires an `onClose` when its read loop ends without an explicit `close()` (the stream dies on unplug), and the backend also listens for `navigator.serial`'s `disconnect` event. Either one **tears the connection down, flips status to *disconnected*, and prints a "board disconnected" notice** to the console — instead of appearing stuck on a dead port.

## Verified (headless, mock board)
Newly-granted board via the picker + a simulated unplug:
- dropdown label → **"Raspberry Pi (Pico / RP2040) · 2e8a:0005"** (was "Simulated device")
- unplug → status **connected → disconnected**, console shows the **"board disconnected"** notice

Gates: typecheck ✓ · lint 0 errors ✓ · **1730 tests** ✓ · electron + web builds ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)