### PR TITLE
fix: readable Source Control panel text on the green felt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Fixed
+- **Source Control panel text is readable again.** The muted text on the green-felt
+  Source Control panel was a low-contrast sage grey; it's now a near-white that
+  reads clearly on the green in both the dark and skeuomorph themes.
+
+### Fixed
 - **Web Serial: the port dropdown now shows the connected board, and unplugging is
   handled gracefully (#465).** After picking a real USB board it was still showing
   "Simulated device (offline)" (the just-granted port wasn't in the list yet, so the

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -378,7 +378,9 @@
   background-color: #2f5d44;
   background-image: radial-gradient(rgba(255, 255, 255, 0.05) 1px, transparent 1px);
   background-size: 3px 3px;
-  color: #e8f1ea;
+  color: #f2f8f4;
+  /* Muted text must stay readable on the green felt — near-white, not grey. */
+  --text-muted: #d8e8de;
   border-left: 3px solid #1c3b2a;
   box-shadow: inset 0 2px 6px rgba(0, 0, 0, 0.3);
 }
@@ -410,7 +412,7 @@
 :root[data-theme='skeuomorph'] .git__notice,
 :root[data-theme='skeuomorph'] .git__file-dir,
 :root[data-theme='skeuomorph'] .git__repo-path {
-  color: #bcd4c4;
+  color: #d8e8de;
 }
 
 :root[data-theme='skeuomorph'] .git__branch-select,
@@ -1092,7 +1094,9 @@
   background-color: #1a3326;
   background-image: radial-gradient(rgba(255, 255, 255, 0.04) 1px, transparent 1px);
   background-size: 3px 3px;
-  color: #cfe0d4;
+  color: #eef6f0;
+  /* Muted text must stay readable on the dark green felt — near-white, not grey. */
+  --text-muted: #cfe4d8;
   border-left: 3px solid #0c1c14;
   box-shadow: inset 0 2px 6px rgba(0, 0, 0, 0.55);
 }
@@ -1124,7 +1128,7 @@
 :root[data-theme='dark'] .git__notice,
 :root[data-theme='dark'] .git__file-dir,
 :root[data-theme='dark'] .git__repo-path {
-  color: #9bbfa6;
+  color: #cfe4d8;
 }
 
 :root[data-theme='dark'] .git__branch-select,


### PR DESCRIPTION
The grey text on the green-felt **Source Control** panel wasn't readable against the dark green background. Brightened the muted text from a low-contrast sage (`#9bbfa6` dark / `#bcd4c4` skeuomorph) to a near-white, and redefined `--text-muted` within the `.git` panel so **every** muted element (branch info, file dirs, notices, diff meta, empty-state) reads clearly — in both the dark and skeuomorph themes.

Verified: on the `#2f5d44` green felt, muted text computes to `#d8e8de` (near-white, high contrast); dark theme uses `#cfe4d8` on `#1a3326`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)