### PR TITLE
feat: Board View on the web app — board icon pops out a browser window

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: verify
+description: Verify Snakie changes end-to-end on this headless Pi — web build in headless Chromium via puppeteer-core; desktop renderer via the browser preview.
+---
+
+# Verifying Snakie on the headless dev Pi
+
+No display, no hardware. Two surfaces are drivable:
+
+## Web build (app.snakie.org bundle) — full interaction
+
+```bash
+npm run build:web                      # emits dist-web/ (index.html + board.html)
+python3 -m http.server 5174 -d dist-web   # serve (0.0.0.0 — user can also preview)
+```
+
+Drive with **puppeteer-core + system Chromium** (`/usr/bin/chromium`, no
+playwright/puppeteer download needed on ARM64):
+
+```js
+import puppeteer from 'puppeteer-core'
+const browser = await puppeteer.launch({
+  executablePath: '/usr/bin/chromium',
+  headless: 'new',
+  args: ['--no-sandbox', '--disable-dev-shm-usage']
+})
+```
+
+Install `puppeteer-core` in the session scratchpad, NOT the repo.
+
+Gotchas learned the hard way:
+- The editor starts with **no file open** — click the "New file" button
+  (`aria-label`/`title` "New file") before looking for `.monaco-editor`.
+- The board icon is `button[aria-label="Toggle Board View"]`; it opens
+  `board.html` as a popup — grab it via `browser.once('targetcreated', …)`.
+- Cross-window relay is `BroadcastChannel('snakie.board.v1')` — you can post
+  `{t:'request'}` from any page and observe the `{t:'source', payload}` reply.
+- Keys that close a window (Esc in the popup) race the CDP dispatch — wrap
+  `keyboard.press` in `.catch()`.
+- The sim auto-connects ~400ms after load; give the page ~1.5s before driving.
+- Register `page.on('dialog', d => d.accept())` BEFORE clicking anything —
+  the app uses `window.confirm`, which blocks the page and times out CDP.
+- To simulate iPad Safari storage: `evaluateOnNewDocument` deleting
+  `showDirectoryPicker`/`showOpenFilePicker`/`showSaveFilePicker` — the app
+  then falls back to the OPFS `Projects/` folder.
+- Headless WebGL (Robot View / 3-D) needs `--use-angle=swiftshader
+  --enable-unsafe-swiftshader` in the launch args.
+
+## Desktop renderer (no Electron possible here)
+
+`vite.preview.config.mjs` serves the renderer with the no-op `window.api`
+fallback on :5174 (`npx vite --config vite.preview.config.mjs`). Good for
+layout/UI checks only — device/fs features are inert. Real Electron behavior
+(preload, IPC, serial) cannot be verified on this box; say so rather than
+faking it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Board View on the web app — pops out into its own browser window.** The
+  toolbar's board icon (previously desktop-only) now works on app.snakie.org:
+  `board.html` ships as a second web entry and a `BroadcastChannel` relay
+  replaces the Electron IPC layer, streaming the active file, board selection,
+  instrument launches and robot.yml changes between the windows. Toggle, Esc
+  and re-adopt-after-reload semantics match the desktop.
+
 ### Fixed
 - **All catalog modules install on the web app (#522).** The six bundled module
   stubs (`hcsr04`, `mpu6050`, `neopixel_ws2812`, `rotary`, `buzzer`, `teleop`)

--- a/src/renderer/board.html
+++ b/src/renderer/board.html
@@ -8,6 +8,7 @@
       http-equiv="Content-Security-Policy"
       content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:"
     />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Board View</title>
   </head>
   <body>

--- a/src/renderer/src/board-main.tsx
+++ b/src/renderer/src/board-main.tsx
@@ -353,4 +353,22 @@ function BoardWindowApp(): JSX.Element {
   )
 }
 
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(<BoardWindowApp />)
+const render = (): void =>
+  ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(<BoardWindowApp />)
+
+// In the WEB build this window is a browser popup (no preload): install the web
+// backends (parts / fs / robot) + the BroadcastChannel relay to the main window
+// BEFORE rendering, mirroring main.tsx. A failure still renders the bare viewer.
+if (import.meta.env.VITE_SNAKIE_WEB) {
+  import('./web/install-web-api')
+    .then((m) => {
+      m.installWebApi('board')
+      render()
+    })
+    .catch((err) => {
+      console.error('[Snakie] web backend install failed', err)
+      render()
+    })
+} else {
+  render()
+}

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -319,9 +319,8 @@ export function Toolbar({
 
       <span className="toolbar__divider" aria-hidden="true" />
 
-      {/* Board View pops out into its own OS window — desktop only (no pop-out
-          windows on the web build, where the button would do nothing). */}
-      {!IS_WEB && (
+      {/* Board View pops out into its own window — an OS BrowserWindow on the
+          desktop, a browser popup on the web (see web/web-board.ts). */}
       <div className="toolbar__group">
         <button
           type="button"
@@ -347,7 +346,6 @@ export function Toolbar({
           </svg>
         </button>
       </div>
-      )}
 
       <div className="toolbar__spacer" />
 

--- a/src/renderer/src/lib/preloadFallback.ts
+++ b/src/renderer/src/lib/preloadFallback.ts
@@ -175,6 +175,8 @@ if (!w.api) {
       onSource: unsub,
       onClosed: unsub,
       onOpened: unsub,
+      selectBoard: noop,
+      onSelectBoard: unsub,
       listUserBoards: P([]),
       openBoardsFolder: P(undefined),
       saveUserBoard: P({ ok: true }),

--- a/src/renderer/src/web/install-web-api.ts
+++ b/src/renderer/src/web/install-web-api.ts
@@ -19,9 +19,14 @@ import { createWebPartsApi } from './web-parts'
 import { INSTRUMENTS_PY, SNAKIE_PY } from './web-lib-sources'
 import { createWebFeedbackApi, captureTabScreenshot } from './web-feedback'
 import { createWebModulesApi } from './web-modules'
+import { installWebBoardMain, installWebBoardWindow } from './web-board'
 import { VIRTUAL_PORT_PATH } from '../../../shared/virtual-device'
 
-export function installWebApi(): void {
+/** Which renderer entry is installing: the main editor (`main.tsx`) or the
+ *  popped-out Board View window (`board-main.tsx`). */
+export type WebWindowKind = 'main' | 'board'
+
+export function installWebApi(kind: WebWindowKind = 'main'): void {
   const w = window as typeof window & { api?: Record<string, unknown> }
   if (!w.api) return // the fallback runs first and sets this; guard defensively
   // Report the real app version (injected from package.json by vite.web.config) so
@@ -85,6 +90,11 @@ export function installWebApi(): void {
     w.api.fs = fs as unknown as Window['api']['fs']
     w.api.robot = createWebRobotApi(fs as unknown as WebRobotFs) as unknown as Window['api']['robot']
   }
+  // Board View popup (the desktop's floating BrowserWindow, as a browser window):
+  // each side gets its half of the BroadcastChannel relay. AFTER the robot api
+  // above, so the relay can wrap `robot.save` with the cross-window notify.
+  if (kind === 'board') installWebBoardWindow()
+  else installWebBoardMain()
   // eslint-disable-next-line no-console
   console.info(
     '[Snakie] Web backend ready — Connect the "Simulated device (offline)" to run Python; ' +

--- a/src/renderer/src/web/web-board.ts
+++ b/src/renderer/src/web/web-board.ts
@@ -1,0 +1,212 @@
+/**
+ * WEB Board View window — epic #267.
+ * =============================================================================
+ *
+ * On the desktop the Board View is a separate Electron `BrowserWindow` and the
+ * main process relays messages between it and the editor window
+ * (`src/main/board.ts`). On the web the same `board.html` bundle opens as a
+ * plain browser popup (`window.open`), and this module replaces the Electron
+ * IPC relay with a same-origin `BroadcastChannel`:
+ *
+ *   source      main → board   the streamed {source,fileName,…} payload
+ *   request     board → main   pull the buffered payload on mount
+ *   close       main → board   close the popup (toolbar toggle)
+ *   opened      board → main   the popup mounted (flips the toolbar state)
+ *   closed      board → main   the popup closed (pagehide)
+ *   select      either → other the chosen board id (mini board ↔ full viewer)
+ *   instruments board → main   launch a scope/meter in the MAIN window
+ *   robot       either → other robot.yml changed (reload project parts/wiring)
+ *
+ * The channel never echoes to its sender, which is exactly the Electron relay's
+ * "notify every OTHER window" semantics — no self-feedback loops.
+ *
+ * Storage is shared per-origin (localStorage theme, IndexedDB folder handle,
+ * the localStorage robot.yml fallback), so the popup sees the same project. A
+ * folder picked via the File System Access API re-grants silently within the
+ * same browser session; a popup opened in a FRESH session may not get read
+ * access until the main window re-opens the folder (#476's pending-handle flow).
+ */
+import type { BoardSourcePayload, InstrumentOpenPayload } from '../../../preload/index.d'
+
+const CHANNEL = 'snakie.board.v1'
+
+/** Wire shape on the BroadcastChannel — a tagged union per relay message. */
+type BoardMessage =
+  | { t: 'source'; payload: BoardSourcePayload }
+  | { t: 'request' }
+  | { t: 'close' }
+  | { t: 'opened' }
+  | { t: 'closed' }
+  | { t: 'select'; id: string }
+  | { t: 'instruments'; payload: InstrumentOpenPayload }
+  | { t: 'robot' }
+
+type Listener<T> = (value: T) => void
+
+/** One shared channel + tiny pub/sub per message tag. */
+function makeBus(): {
+  post: (m: BoardMessage) => void
+  on: <T extends BoardMessage['t']>(
+    tag: T,
+    cb: Listener<Extract<BoardMessage, { t: T }>>
+  ) => () => void
+} {
+  const channel = new BroadcastChannel(CHANNEL)
+  const listeners = new Map<string, Set<Listener<never>>>()
+  channel.onmessage = (e: MessageEvent<BoardMessage>) => {
+    const set = listeners.get(e.data?.t)
+    if (set) for (const cb of [...set]) (cb as Listener<BoardMessage>)(e.data)
+  }
+  return {
+    post: (m) => channel.postMessage(m),
+    on: (tag, cb) => {
+      let set = listeners.get(tag)
+      if (!set) listeners.set(tag, (set = new Set()))
+      set.add(cb as Listener<never>)
+      return () => set.delete(cb as Listener<never>)
+    }
+  }
+}
+
+/** Wrap `robot.save` to broadcast a change to the other window, and `onChanged`
+ *  to receive it — the web twin of Electron's `robot:didChange` relay (which
+ *  also only ever notified windows OTHER than the saver). Both windows call
+ *  this, so a part placed in the popup reloads the main window's mini board,
+ *  and vice versa. */
+function bridgeRobotChanges(bus: ReturnType<typeof makeBus>): void {
+  const w = window as typeof window & { api?: Record<string, unknown> }
+  const robot = w.api?.robot as
+    | { save?: (...args: unknown[]) => Promise<unknown>; onChanged?: (cb: () => void) => () => void }
+    | undefined
+  if (!robot?.save) return
+  const save = robot.save.bind(robot)
+  robot.save = async (...args: unknown[]): Promise<unknown> => {
+    const result = await save(...args)
+    bus.post({ t: 'robot' })
+    return result
+  }
+  robot.onChanged = (cb: () => void): (() => void) => bus.on('robot', () => cb())
+}
+
+/**
+ * Install the MAIN-window side over the fallback stubs: `board.open()` pops
+ * `board.html` out as a browser window and the rest of the namespace talks to
+ * it over the channel. Called from {@link installWebApi} in the main entry.
+ */
+export function installWebBoardMain(): void {
+  const w = window as typeof window & { api?: Record<string, unknown> }
+  if (!w.api) return
+  const bus = makeBus()
+
+  let popup: Window | null = null
+  /** Buffered latest payload so a freshly-opened popup can pull it on mount
+   *  (same open-time race as the desktop's `board:requestSource`). */
+  let lastPayload: BoardSourcePayload | null = null
+
+  const openedListeners = new Set<() => void>()
+  const closedListeners = new Set<() => void>()
+  const emit = (set: Set<() => void>): void => {
+    for (const cb of [...set]) cb()
+  }
+
+  bus.on('request', () => {
+    if (lastPayload) bus.post({ t: 'source', payload: lastPayload })
+  })
+  bus.on('opened', () => emit(openedListeners))
+  bus.on('closed', () => {
+    popup = null
+    emit(closedListeners)
+  })
+
+  const board = (w.api.board ?? {}) as Record<string, unknown>
+  board.open = async (): Promise<void> => {
+    if (popup && !popup.closed) {
+      popup.focus()
+      emit(openedListeners)
+      return
+    }
+    // Named window: if the user still has an orphaned board window (e.g. after
+    // an editor reload), this re-adopts it instead of stacking a second one.
+    popup = window.open('board.html', 'snakie-board', 'popup=yes,width=980,height=720')
+    if (!popup) {
+      // Popup blocked — reset the toolbar's "open" state and surface the error.
+      emit(closedListeners)
+      throw new Error('The browser blocked the Board View popup.')
+    }
+    emit(openedListeners)
+  }
+  board.close = (): void => {
+    // Broadcast too: after an editor reload the handle is stale, but an
+    // orphaned popup still hears the channel and closes itself.
+    bus.post({ t: 'close' })
+    if (popup && !popup.closed) popup.close() // its pagehide broadcasts 'closed'
+    else emit(closedListeners) // stale handle — still reset the toolbar state
+    popup = null
+  }
+  board.update = (payload: BoardSourcePayload): void => {
+    lastPayload = payload
+    bus.post({ t: 'source', payload })
+  }
+  board.requestSource = async (): Promise<BoardSourcePayload | null> => lastPayload
+  board.onOpened = (cb: () => void): (() => void) => {
+    openedListeners.add(cb)
+    return () => openedListeners.delete(cb)
+  }
+  board.onClosed = (cb: () => void): (() => void) => {
+    closedListeners.add(cb)
+    return () => closedListeners.delete(cb)
+  }
+  board.selectBoard = (id: string): void => bus.post({ t: 'select', id })
+  board.onSelectBoard = (cb: (id: string) => void): (() => void) =>
+    bus.on('select', (m) => cb(m.id))
+  w.api.board = board as unknown as Window['api']['board']
+
+  // A scope/meter launched from a board node in the POPUP renders in the MAIN
+  // window's instrument dock (desktop parity: the `instruments:open` relay).
+  const instruments = (w.api.instruments ?? {}) as Record<string, unknown>
+  instruments.onOpen = (cb: (payload: InstrumentOpenPayload) => void): (() => void) =>
+    bus.on('instruments', (m) => cb(m.payload))
+  w.api.instruments = instruments as unknown as Window['api']['instruments']
+
+  bridgeRobotChanges(bus)
+}
+
+/**
+ * Install the BOARD-window side (the popup itself, `board-main.tsx`): receive
+ * the streamed payload, pull the buffered one on mount, and relay instrument
+ * launches / board selections back. Announces `opened`/`closed` so the main
+ * window's toolbar toggle tracks the popup's real lifecycle.
+ */
+export function installWebBoardWindow(): void {
+  const w = window as typeof window & { api?: Record<string, unknown> }
+  if (!w.api) return
+  const bus = makeBus()
+
+  bus.on('close', () => window.close())
+  window.addEventListener('pagehide', () => bus.post({ t: 'closed' }))
+
+  const board = (w.api.board ?? {}) as Record<string, unknown>
+  board.close = (): void => window.close()
+  board.onSource = (cb: (payload: BoardSourcePayload) => void): (() => void) =>
+    bus.on('source', (m) => cb(m.payload))
+  board.requestSource = async (): Promise<BoardSourcePayload | null> => {
+    // Fire-and-forget pull: the main window answers with a 'source' broadcast,
+    // which lands via `onSource` above (there is no request/response pairing).
+    bus.post({ t: 'request' })
+    return null
+  }
+  board.selectBoard = (id: string): void => bus.post({ t: 'select', id })
+  board.onSelectBoard = (cb: (id: string) => void): (() => void) =>
+    bus.on('select', (m) => cb(m.id))
+  w.api.board = board as unknown as Window['api']['board']
+
+  const instruments = (w.api.instruments ?? {}) as Record<string, unknown>
+  instruments.open = (payload: InstrumentOpenPayload): void =>
+    bus.post({ t: 'instruments', payload })
+  w.api.instruments = instruments as unknown as Window['api']['instruments']
+
+  bridgeRobotChanges(bus)
+
+  // Announce AFTER the handlers exist so the main window's reply can land.
+  bus.post({ t: 'opened' })
+}

--- a/vite.web.config.ts
+++ b/vite.web.config.ts
@@ -68,11 +68,13 @@ export default defineConfig({
     // electron build), so raise the warning limit past its size.
     chunkSizeWarningLimit: 4000,
     rollupOptions: {
-      // Only the main app entry for the web MVP. The Electron detached windows
-      // (board / find / instrument / console) become in-page panes on the web
-      // (Phase W1/dockview), so they are not separate HTML entries here.
+      // The main app entry plus the Board View, which pops out as a browser
+      // window (`window.open('board.html')` + a BroadcastChannel relay — see
+      // src/renderer/src/web/web-board.ts). The other Electron detached windows
+      // (find / instrument / console) remain in-page panes on the web.
       input: {
-        index: resolve(__dirname, 'src/renderer/index.html')
+        index: resolve(__dirname, 'src/renderer/index.html'),
+        board: resolve(__dirname, 'src/renderer/board.html')
       },
       output: {
         manualChunks(id: string) {


### PR DESCRIPTION
## What

Brings the toolbar **board icon back on app.snakie.org** — it now opens the full Board Viewer (breadboard / schematic / node graph + parts library) in its **own browser window**, live-fed from the editor, matching the desktop pop-out.

## How

- `board.html` ships as a second entry of the web build (`vite.web.config.ts`).
- New `src/renderer/src/web/web-board.ts` replaces the Electron IPC relay (`src/main/board.ts`) with a same-origin **`BroadcastChannel`**: streamed `{source, fileName, theme, …}` payloads with a buffered pull on popup mount (same open-time race handling as the desktop), board-selection sync, instrument launches relayed to the main window's dock, and cross-window robot.yml change notifications.
- `board-main.tsx` installs the web backends (parts / fs / robot + the relay) before rendering in the web build, mirroring `main.tsx`.
- Toggle semantics match desktop: click opens/focuses, click again or Esc closes. After an editor reload the orphaned popup is re-adopted by window name (no stacking) and still closes over the channel.
- `preloadFallback` gains the missing `selectBoard`/`onSelectBoard` stubs (`BoardGraph`/`MiniBoardView` call them unguarded).

## Verification

Driven headlessly (chromium + puppeteer-core) against the built `dist-web`:
- board icon present on web → popup opens `board.html` with the full viewer
- typed marker source streams into the popup (`hasMarker: true`, node graph shows the live file)
- main-window reload + reclick **re-adopts** the popup — 0 new windows
- toggle-close and Esc-close both work; popup favicon 404 fixed
- `lint` / `typecheck` / `test` (1759) / `build` / `build:web` all green

Part of epic #267 (Snakie for Web); follows up #513's desktop-only sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)