### PR TITLE
fix: OPFS-backed projects folder where the browser has no folder picker (iPad)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Fixed
+- **"New robot" / "Open Folder" now work on iPad (part of #525).** iPadOS
+  Safari has no folder picker (`showDirectoryPicker`), so the web fs backend
+  never installed and both buttons silently did nothing. Where the pickers are
+  missing but OPFS is usable (feature-detected incl. `createWritable`), the
+  same fs api is now backed by an origin-private `Projects/` folder in browser
+  storage: Open Folder adopts it with no dialog, it re-adopts silently on every
+  visit, and the robot.yml layer rides along — so New robot creates and links a
+  real `robot.urdf` that survives reloads.
 - **All catalog modules install on the web app (#522).** The six bundled module
   stubs (`hcsr04`, `mpu6050`, `neopixel_ws2812`, `rotary`, `buzzer`, `teleop`)
   are now inlined into the web build — they used to fail with *"isn't bundled

--- a/src/renderer/src/web/install-web-api.ts
+++ b/src/renderer/src/web/install-web-api.ts
@@ -13,7 +13,7 @@
  * MicroPython WASM.
  */
 import { createWebDeviceRouter } from './web-device-router'
-import { createWebFsApi } from './web-fs'
+import { createWebFsApi, opfsFallbackAvailable } from './web-fs'
 import { createWebRobotApi, type WebRobotFs } from './web-robot'
 import { createWebPartsApi } from './web-parts'
 import { INSTRUMENTS_PY, SNAKIE_PY } from './web-lib-sources'
@@ -76,11 +76,12 @@ export function installWebApi(): void {
   const parts = (w.api.parts ?? {}) as Record<string, unknown>
   Object.assign(parts, createWebPartsApi())
   w.api.parts = parts as unknown as Window['api']['parts']
-  // Local files via the File System Access API — only when the browser supports it
-  // (Chromium); elsewhere the no-op fallback stays and "Open Folder" is inert.
-  // The robot.yml layer rides on the same backend (bindings/poses/urdf link), so
-  // it's gated with it — on other browsers the honest fallback stub remains.
-  if ('showDirectoryPicker' in window) {
+  // Local files via the File System Access API (Chromium), or — where the picker
+  // doesn't exist but OPFS does (iPadOS Safari, #525) — an origin-private
+  // `Projects/` folder in browser storage, so Open Folder / New robot work there
+  // too. The robot.yml layer rides on the same backend (bindings/poses/urdf
+  // link), so it's gated with it — elsewhere the honest fallback stub remains.
+  if ('showDirectoryPicker' in window || opfsFallbackAvailable()) {
     const fs = createWebFsApi()
     w.api.fs = fs as unknown as Window['api']['fs']
     w.api.robot = createWebRobotApi(fs as unknown as WebRobotFs) as unknown as Window['api']['robot']

--- a/src/renderer/src/web/web-fs.ts
+++ b/src/renderer/src/web/web-fs.ts
@@ -10,9 +10,19 @@
  * files opened via `openFileDialog` / `saveFileDialog` are tracked by name.
  *
  * The picker needs a user gesture, so `openFolderDialog` must be called from a
- * click (it is — the "Open Folder" button). Where the API is unavailable the
- * methods return empty/null and the UI degrades. The pure path helpers are
- * exported for unit tests (the interactive picker itself can't be automated).
+ * click (it is — the "Open Folder" button). The pure path helpers are exported
+ * for unit tests (the interactive picker itself can't be automated).
+ *
+ * **No picker (iPadOS Safari — #525): fall back to OPFS.** WebKit ships no
+ * `showDirectoryPicker`, which used to leave this whole backend uninstalled and
+ * made "Open Folder" / "New robot" silently do nothing. Where the pickers are
+ * missing but the origin-private file system is available (and its file handles
+ * support `createWritable`), we back the SAME api with an OPFS `Projects/`
+ * directory instead: `openFolderDialog` adopts it without any dialog, and it is
+ * silently re-adopted on every visit so the file tree survives reloads. Files
+ * then live in browser storage rather than on disk — real persistence on an
+ * iPad, same path/token semantics everywhere else. Loose-file pickers
+ * (`openFileDialog`/`saveFileDialog`) still return null there.
  */
 import { splitRelSegments, childPath } from './web-fs-paths'
 import { saveFolderHandle, loadFolderHandle, clearFolderHandle } from './web-idb'
@@ -48,11 +58,43 @@ type FileHandleLike = {
   createWritable(): Promise<{ write(data: Uint8Array | string): Promise<void>; close(): Promise<void> }>
 }
 
+/** The OPFS folder that plays the role of the picked project folder. Its name
+ *  is what users see as the file-tree root (and what path tokens start with). */
+const OPFS_PROJECTS_DIR = 'Projects'
+
+/**
+ * True when the OPFS fallback can back the fs api: no folder picker (so there
+ * is nothing better), but `navigator.storage.getDirectory` exists AND file
+ * handles support `createWritable` (WebKit gained it well after OPFS itself —
+ * without it every save would fail).
+ */
+export function opfsFallbackAvailable(): boolean {
+  if ('showDirectoryPicker' in window) return false // real folders win
+  const FileHandle = (globalThis as { FileSystemFileHandle?: { prototype: object } })
+    .FileSystemFileHandle
+  return (
+    typeof navigator !== 'undefined' &&
+    typeof navigator.storage?.getDirectory === 'function' &&
+    !!FileHandle &&
+    'createWritable' in FileHandle.prototype
+  )
+}
+
 export function createWebFsApi(): Record<string, unknown> {
   const w = window as unknown as {
     showDirectoryPicker?: (o?: unknown) => Promise<DirHandle>
     showOpenFilePicker?: (o?: unknown) => Promise<FileHandleLike[]>
     showSaveFilePicker?: (o?: unknown) => Promise<FileHandleLike>
+  }
+
+  /** Get (create) the OPFS projects directory. Only called when
+   *  {@link opfsFallbackAvailable} said the pieces exist. */
+  const opfsProjects = async (): Promise<DirHandle> => {
+    const opfsRoot = (await navigator.storage.getDirectory()) as unknown as DirHandle
+    // Ask the browser to exempt this origin from storage eviction (Safari can
+    // otherwise clear it after periods of disuse). Best-effort, no gesture needed.
+    void navigator.storage.persist?.().catch(() => undefined)
+    return opfsRoot.getDirectoryHandle(OPFS_PROJECTS_DIR, { create: true })
   }
 
   let root: DirHandle | null = null
@@ -86,6 +128,18 @@ export function createWebFsApi(): Record<string, unknown> {
   // Kick off silent restore immediately (before render). fs ops await this so the
   // first stat/readDir sees a rehydrated root when permission was already granted.
   const ready = (async () => {
+    // OPFS mode: the projects folder needs no picker and no permission, so
+    // re-adopt it on every visit — the file tree and the persisted open-folder
+    // token ('Projects') work from the first frame.
+    if (opfsFallbackAvailable()) {
+      try {
+        root = await opfsProjects()
+        rootPath = root.name
+      } catch {
+        /* storage blocked (e.g. private mode with OPFS disabled) — stay degraded */
+      }
+      return
+    }
     try {
       const handle = (await loadFolderHandle()) as DirHandle | null
       if (!handle) return
@@ -160,7 +214,19 @@ export function createWebFsApi(): Record<string, unknown> {
 
   return {
     openFolderDialog: async (): Promise<string | null> => {
-      if (!w.showDirectoryPicker) return null
+      if (!w.showDirectoryPicker) {
+        // No picker (iPad) → "open" the OPFS projects folder instead. No dialog
+        // to cancel; null only when OPFS is unusable too (stay degraded).
+        if (!opfsFallbackAvailable()) return null
+        try {
+          await ready // don't race the silent re-adopt above
+          root = await opfsProjects()
+          rootPath = root.name
+          return rootPath
+        } catch {
+          return null
+        }
+      }
       try {
         return adopt(await w.showDirectoryPicker({ mode: 'readwrite' }))
       } catch {


### PR DESCRIPTION
## What

Fixes the iPad report: **"New robot" (and "Open Folder") did nothing on app.snakie.org.**

iPadOS Safari has no File System Access pickers (`showDirectoryPicker`), so the web fs backend never installed — `openFolderDialog()` resolved `null` from the no-op stub and `newRobot()` treated it as a user cancel. Silent no-op, no error.

## How

Where the pickers are missing but OPFS is usable (`navigator.storage.getDirectory` **and** `FileSystemFileHandle.createWritable`, feature-detected because WebKit gained the latter well after OPFS itself), the same `window.api.fs` is backed by an origin-private **`Projects/`** folder in browser storage:

- **Open Folder** adopts it instantly — no dialog; it re-adopts silently on every visit (OPFS needs no permission grant), so with the existing last-folder localStorage restore (#177) projects reopen automatically.
- The robot.yml layer rides the same install gate, so **New robot** creates and links a real `robot.urdf` that survives reloads.
- `navigator.storage.persist()` is requested best-effort against storage eviction.
- Chromium/desktop are untouched — a real folder picker always wins when present.

Known limits (called out in the code): loose-file pickers (`openFileDialog`/`saveFileDialog`) still return null on iPad, files live in that browser's storage (a "download project as zip" follow-up is filed), and an older Safari without `createWritable` keeps today's degraded behaviour rather than half-working saves.

## Verification

Headless Chromium with the picker APIs stripped (iPad simulation, fresh origin storage): Open Folder → `Projects` tree with no dialog → New robot → `robot.urdf` + `robot.yml` created, Robot View tab opens → reload → everything persists → raw OPFS readback matches → second New robot confirms, then creates `robot-2.urdf`. `lint` / `typecheck` / `test` (1759) / `build:web` green.

Part of #525 (touch-compatible app.snakie.org).

🤖 Generated with [Claude Code](https://claude.com/claude-code)