### PR TITLE
fix: web workspace switch — map panel layouts to the rendered panels (#528)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and re-adopt-after-reload semantics match the desktop.
 
 ### Fixed
+- **CODE→ROBOT workspace switch no longer throws on the web app (#528).** The
+  layout store always keeps four horizontal panel shares (files, centre,
+  board, chat) but the chat pane doesn't exist on the web build, so applying a
+  workspace pushed a stray fourth value into a three-panel group —
+  react-resizable-panels rejected it (`Invalid 3 panel layout`) and dragged
+  sizes were never recorded on the web. Layouts are now mapped to exactly the
+  rendered panels in both directions (apply + record).
 - **"New robot" / "Open Folder" now work on iPad (part of #525).** iPadOS
   Safari has no folder picker (`showDirectoryPicker`), so the web fs backend
   never installed and both buttons silently did nothing. Where the pickers are

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -8,12 +8,15 @@ import { ConsoleProvider } from './store/console'
 import { SyncProvider } from './store/sync'
 import { LayoutProvider } from './store/layout'
 import { TutorialsProvider } from './store/tutorials'
+import { IS_WEB } from './lib/env'
 
 function App(): JSX.Element {
   return (
     <PromptProvider>
       <SettingsProvider>
-        <LayoutProvider>
+        {/* No chat right-pane on the web build — the layout store must know so
+            panel sizes map to the right slots (#528). */}
+        <LayoutProvider chatPane={!IS_WEB}>
           <WorkspaceProvider>
             <SyncProvider>
               <DiagnosticsProvider>

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -7,7 +7,7 @@ import {
   PanelResizeHandle
 } from 'react-resizable-panels'
 import { useLocalStorage } from '../hooks/useLocalStorage'
-import { useWorkspaceLayout, type WorkspaceId } from '../store/layout'
+import { appliedHorizontal, useWorkspaceLayout, type WorkspaceId } from '../store/layout'
 
 // The embedded Board View pane (the Board workspace's tri-split, #259) is
 // code-split: the whole board subsystem (BoardGraph + wiring + Part Editor)
@@ -344,14 +344,11 @@ export function AppShell(): JSX.Element {
     // the "board pane opens tiny" bug). After rAF the group knows all panels.
     const raf = requestAnimationFrame(() => {
       // The horizontal group's setLayout array must match the RENDERED panels:
-      // 4 with the board pane open, 3 (board slot elided) when it's closed.
-      // In focus mode the board pane elides, so the editor takes its share.
+      // the board slot elides when the pane is closed (and in focus mode, where
+      // the editor takes its share), and the chat slot doesn't exist on the web
+      // build (#528) — a stray extra size makes react-resizable-panels throw.
       const boardOn = ws.boardPaneOpen && !focus
-      hGroupRef.current?.setLayout(
-        boardOn
-          ? [...ws.horizontal]
-          : [ws.horizontal[0], ws.horizontal[1] + ws.horizontal[2], ws.horizontal[3]]
-      )
+      hGroupRef.current?.setLayout(appliedHorizontal(ws.horizontal, boardOn, !IS_WEB))
       vGroupRef.current?.setLayout([...ws.vertical])
       // Sync each collapsible panel BOTH ways to the target workspace, so the RRP
       // panel state can't drift from the store flag (which would strand the

--- a/src/renderer/src/store/layout.ts
+++ b/src/renderer/src/store/layout.ts
@@ -186,6 +186,46 @@ function sanitiseWorkspace(raw: unknown, preset: WorkspaceLayout): WorkspaceLayo
   return ws
 }
 
+/**
+ * The horizontal PanelGroup renders a VARIABLE number of panels — the board
+ * pane elides when closed (or in focus mode) and the chat pane doesn't exist
+ * at all on the web build (#528). These two helpers translate between the
+ * canonical 4-slot store layout `[files, centre, board, chat]` and whatever
+ * the group actually renders, so setLayout never receives a stray slot and
+ * onLayout sizes always land back in the right slots.
+ */
+
+/** The setLayout array for the RENDERED panels: elided slots fold into the
+ *  centre so the shares still sum to 100. */
+export function appliedHorizontal(
+  horizontal: readonly [number, number, number, number],
+  boardOn: boolean,
+  chatOn: boolean
+): number[] {
+  const [files, centre, board, chat] = horizontal
+  const sizes = [files, centre + (boardOn ? 0 : board) + (chatOn ? 0 : chat)]
+  if (boardOn) sizes.push(board)
+  if (chatOn) sizes.push(chat)
+  return sizes
+}
+
+/** Map an onLayout report back into the canonical 4 slots (elided slots → 0),
+ *  or null when the report doesn't match the rendered panel count. */
+export function recordedHorizontal(
+  sizes: number[],
+  boardOn: boolean,
+  chatOn: boolean
+): [number, number, number, number] | null {
+  const n = 2 + (boardOn ? 1 : 0) + (chatOn ? 1 : 0)
+  if (!validSizes(sizes, n)) return null
+  return [
+    sizes[0],
+    sizes[1],
+    boardOn ? sizes[2] : 0,
+    chatOn ? sizes[boardOn ? 3 : 2] : 0
+  ]
+}
+
 /** A fresh factory-default state (every workspace at its preset). */
 export function defaultLayoutState(): LayoutState {
   const workspaces = {} as Record<WorkspaceId, WorkspaceLayout>
@@ -327,7 +367,15 @@ const LayoutContext = createContext<LayoutStore | null>(null)
 /** Debounce for localStorage writes while dragging (ms). */
 const SAVE_DEBOUNCE_MS = 300
 
-export function LayoutProvider({ children }: { children: ReactNode }): JSX.Element {
+export function LayoutProvider({
+  children,
+  chatPane = true
+}: {
+  children: ReactNode
+  /** Whether the chat right-pane exists in this build (false on web, #528) —
+   *  recordSizes needs it to slot onLayout reports back into the 4-slot store. */
+  chatPane?: boolean
+}): JSX.Element {
   // The full envelope lives in a ref (sizes mutate every drag frame); the
   // pieces React must re-render on (active id + the active workspace's
   // non-size fields) are mirrored into state.
@@ -374,12 +422,13 @@ export function LayoutProvider({ children }: { children: ReactNode }): JSX.Eleme
     (group: 'horizontal' | 'vertical', sizes: number[]): void => {
       const s = stateRef.current as LayoutState
       const ws = s.workspaces[s.active]
-      if (group === 'horizontal' && ws.boardPaneOpen && validSizes(sizes, 4)) {
-        ws.horizontal = sizes as [number, number, number, number]
-      } else if (group === 'horizontal' && !ws.boardPaneOpen && validSizes(sizes, 3)) {
-        // The board Panel isn't rendered — the group reports [files, centre,
-        // chat]; slot the closed pane's 0 back into index 2.
-        ws.horizontal = [sizes[0], sizes[1], 0, sizes[2]]
+      if (group === 'horizontal') {
+        // Elided panels (closed board pane; no chat pane on web) report fewer
+        // sizes — map them back into the canonical 4 slots. A count mismatch
+        // (e.g. transient focus mode) is ignored, as before.
+        const mapped = recordedHorizontal(sizes, ws.boardPaneOpen, chatPane)
+        if (!mapped) return
+        ws.horizontal = mapped
       } else if (group === 'vertical' && validSizes(sizes, 2)) {
         ws.vertical = sizes as [number, number]
       } else {
@@ -388,7 +437,7 @@ export function LayoutProvider({ children }: { children: ReactNode }): JSX.Eleme
       // Sizes deliberately DON'T touch React state (per-frame drags); persist only.
       persist()
     },
-    [persist]
+    [persist, chatPane]
   )
 
   const switchWorkspace = useCallback(

--- a/test/layoutStore.test.ts
+++ b/test/layoutStore.test.ts
@@ -3,8 +3,10 @@ import {
   WORKSPACE_IDS,
   WORKSPACE_PRESETS,
   LAYOUT_STORAGE_KEY,
+  appliedHorizontal,
   defaultLayoutState,
   loadLayoutState,
+  recordedHorizontal,
   type StorageLike
 } from '../src/renderer/src/store/layout'
 
@@ -75,6 +77,62 @@ describe('workspace presets (epic #259; +Robot mode #320)', () => {
     a.workspaces.code.horizontal[0] = 99
     expect(WORKSPACE_PRESETS.code.horizontal[0]).not.toBe(99)
     expect(defaultLayoutState().workspaces.code.horizontal[0]).not.toBe(99)
+  })
+})
+
+describe('horizontal slot mapping — elided board/chat panels (#528)', () => {
+  const h: [number, number, number, number] = [10, 30, 40, 20]
+
+  it('appliedHorizontal matches the rendered panel count in every combination', () => {
+    // Desktop (chat rendered): 4 panels with the board, 3 without.
+    expect(appliedHorizontal(h, true, true)).toEqual([10, 30, 40, 20])
+    expect(appliedHorizontal(h, false, true)).toEqual([10, 70, 20])
+    // Web (no chat pane): 3 panels with the board, 2 without — the extra 0
+    // here is exactly what threw 'Invalid 3 panel layout: 0%, 34%, 66%, 0%'.
+    expect(appliedHorizontal(h, true, false)).toEqual([10, 50, 40])
+    expect(appliedHorizontal(h, false, false)).toEqual([10, 90])
+  })
+
+  it('applied sizes always sum to 100 (folded slots go to the centre)', () => {
+    for (const boardOn of [true, false]) {
+      for (const chatOn of [true, false]) {
+        const sizes = appliedHorizontal(h, boardOn, chatOn)
+        expect(sizes.reduce((a, b) => a + b, 0)).toBeCloseTo(100)
+        expect(sizes).toHaveLength(2 + (boardOn ? 1 : 0) + (chatOn ? 1 : 0))
+      }
+    }
+  })
+
+  it('recordedHorizontal slots an onLayout report back into the 4-slot store', () => {
+    expect(recordedHorizontal([10, 30, 40, 20], true, true)).toEqual([10, 30, 40, 20])
+    expect(recordedHorizontal([10, 70, 20], false, true)).toEqual([10, 70, 0, 20])
+    expect(recordedHorizontal([10, 50, 40], true, false)).toEqual([10, 50, 40, 0])
+    expect(recordedHorizontal([10, 90], false, false)).toEqual([10, 90, 0, 0])
+  })
+
+  it('recordedHorizontal rejects a count mismatch (e.g. transient focus mode)', () => {
+    // Focus mode elides the board pane while boardPaneOpen stays true — the
+    // report is one short and must be ignored, not mis-slotted.
+    expect(recordedHorizontal([10, 70, 20], true, true)).toBeNull()
+    expect(recordedHorizontal([10, 90], true, false)).toBeNull()
+    // Bad shares are rejected too.
+    expect(recordedHorizontal([10, 20, 30, 5], true, true)).toBeNull()
+  })
+
+  it('round-trips: applied sizes record back losslessly (chat/board at 0 when elided)', () => {
+    for (const boardOn of [true, false]) {
+      for (const chatOn of [true, false]) {
+        const expected = [
+          h[0],
+          h[1] + (boardOn ? 0 : h[2]) + (chatOn ? 0 : h[3]),
+          boardOn ? h[2] : 0,
+          chatOn ? h[3] : 0
+        ]
+        expect(recordedHorizontal(appliedHorizontal(h, boardOn, chatOn), boardOn, chatOn)).toEqual(
+          expected
+        )
+      }
+    }
   })
 })
 


### PR DESCRIPTION
## What

Fixes #528 — clicking **ROBOT** (or back to **CODE**) on app.snakie.org threw a react-resizable-panels pageerror:

```
Error: Invalid 3 panel layout: 0%, 34%, 66%, 0%
```

## Why

The layout store keeps a canonical **4-slot** horizontal layout `[files, centre, board, chat]`, but the chat right-pane is desktop-only (`!IS_WEB` in `AppShell`) — on the web the group renders one panel fewer than the store assumes:

- **Apply path:** workspace switch/reset called `setLayout` with the stray chat share included → the library rejects the layout, so per-workspace sizes were never honoured on the web.
- **Record path:** `onLayout` reported one size fewer than `recordSizes` expected → every report was silently dropped, so dragged sizes never persisted on the web either.

## How

Two pure, unit-tested helpers in `store/layout.ts` translate between the canonical 4 slots and whatever is actually rendered:

- `appliedHorizontal(h, boardOn, chatOn)` — the `setLayout` array; elided slots fold into the centre (shares still sum to 100).
- `recordedHorizontal(sizes, boardOn, chatOn)` — maps an `onLayout` report back into the 4 slots; a count mismatch (e.g. transient focus mode) is still ignored, as before.

`LayoutProvider` gains a `chatPane` prop (`App` passes `!IS_WEB`); desktop behaviour is unchanged (`chatPane` defaults to `true`, and the desktop paths reduce to the exact arrays the old code built).

## Verification (headless Chromium against `dist-web`)

Drove the built web app through CODE→ROBOT→CODE plus the layout-reset button:

```
STEP initial (code) sizes: [ 30, 70 ] errors: 0
STEP after ROBOT sizes: [ 0, 34, 66 ] errors: 0
STEP back to CODE sizes: [ 30, 70 ] errors: 0
STEP after RESET (code) sizes: [ 30, 70 ] errors: 0
STEP persisted store: {"active":"robot","robotH":[0,34,66,0],"codeH":[18,82,0,0]}
DONE no pageerrors
```

The Robot workspace now renders its full tri-split on the web (code · breadboard · robot + instrument dock) and the store records sizes for both workspaces. Also: `lint` (one pre-existing warning in `DriverInstallBanner.tsx`), `typecheck`, `test` (1764 passed, incl. 5 new helper tests), `build`, `build:web` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)