### PR TITLE
feat: interactive IK goal gizmo + Capture Pose in Robot View (#533 §5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Interactive IK goal gizmo + Capture Pose in Robot View (#540, epic #533 §5).**
+  A new 🎯 toggle drops a draggable end-effector goal on the selected chain;
+  dragging it runs the shared planar solver (#538) live, poses the model in
+  real time, and — when a board is connected with servo bindings — streams the
+  solved angles over the same channel the puppet controls use (best-effort, a
+  no-op with no board). The goal handle recolours by status (reached / blocked
+  by limits / out of reach) and a translucent point cloud shades the chain's
+  reachable workspace so you can see why a goal can't be reached. 📸 Capture
+  Pose saves the current IK-solved posture as a Motion Studio pose. Composes
+  with Bone Mode (shared skeleton + live tick). Scope: planar arm/leg chains
+  (joints on a shared/parallel axis) — a non-planar chain is solved as its
+  best in-plane projection and flagged, not faked as full 3-D IK.
 - **Shared IK solver library (#538, epic #533 §3).** New pure-TypeScript
   planar inverse-kinematics module `src/shared/ik/` (no Three.js/DOM/Electron
   deps): an exact law-of-cosines 2-bone solver that picks between both elbow

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -23,6 +23,7 @@ import {
   uniquePoseName
 } from './robot-pose'
 import { solveCCD, type IkJoint } from './robot-ik'
+import { createIkGizmo, type IkChainRef, type IkGizmoHandle } from './robot-ik-gizmo'
 import {
   addMeshLink,
   addPrimitive,
@@ -57,6 +58,7 @@ import {
 } from './robot-assembly'
 import { canReRoot, reRoot } from './robot-reroot'
 import { createBoneMode, duplicateNames, type BoneModeHandle } from './robot-bone-mode'
+import { usePrompt } from './PromptModal'
 import { createViewCube } from './robot-viewcube'
 import {
   historyInit,
@@ -210,6 +212,7 @@ export function RobotView({
   const [error, setError] = useState<string | null>(null)
   const [info, setInfo] = useState<{ name: string; joints: number; links: number } | null>(null)
   const [meshNote, setMeshNote] = useState<string | null>(null)
+  const prompt = usePrompt() // in-app modal (window.prompt is dead in the renderer)
 
   const isEmpty = !content.trim()
   // The full-screen (non-compact) view is the Pose tool (#312): a joint sidebar,
@@ -234,6 +237,11 @@ export function RobotView({
   const [boneMode, setBoneMode] = useState(false) // skeleton overlay (#536)
   const boneModeRef = useRef(false)
   const boneApiRef = useRef<BoneModeHandle | null>(null)
+  // Interactive IK goal gizmo (#540, epic #533 §5): a draggable end-effector goal
+  // that live-solves the selected chain (shared planar solver).
+  const [ikGoal, setIkGoal] = useState(false)
+  const ikGoalRef = useRef(false)
+  const ikApiRef = useRef<IkGizmoHandle | null>(null)
   const [measureDist, setMeasureDist] = useState<number | null>(null)
   const [savingLabel, setSavingLabel] = useState<string | null>(null)
   // True while a running program's `SNK SERVO` telemetry is actively driving a
@@ -340,6 +348,41 @@ export function RobotView({
     // (Recall/Delete appear, the name locks in), instead of a stale new-pose draft.
     if (name) setDialogCtx({ kind: 'pose', name })
   }
+
+  // The IK goal gizmo's target chain (#540): the movable revolute/continuous
+  // joints from the selected link UP to the root, BASE-first (the shared planar
+  // solver's convention). Reused for both the gizmo and Capture Pose.
+  const ikGoalChain = (endLink: string | null): IkChainRef | null => {
+    if (!endLink) return null
+    const byChild = new Map(readAllJoints(contentRef.current).map((j) => [j.child, j]))
+    const names: string[] = []
+    const seen = new Set<string>()
+    let cur: string | undefined = endLink
+    while (cur && !seen.has(cur)) {
+      seen.add(cur)
+      const j = byChild.get(cur) // the joint whose child is `cur` (its parent joint)
+      if (!j) break
+      const m = metaRef.current.find((x) => x.name === j.name)
+      if (m && !m.isMimic && (m.type === 'revolute' || m.type === 'continuous')) names.push(j.name)
+      cur = j.parent
+    }
+    if (!names.length) return null
+    names.reverse() // walk was tip→base; the solver wants base→tip
+    return { joints: names, endLink }
+  }
+
+  // Capture the current IK-solved posture as a Motion Studio pose (#540) — a
+  // PARTIAL pose of just the chain the gizmo drove, so it composes with the rest.
+  const handleCaptureIkPose = async (): Promise<void> => {
+    const joints = ikApiRef.current?.chainJoints() ?? []
+    if (!joints.length) return
+    const name = await prompt('Name this IK pose', uniquePoseName('ik pose', posesRef.current.map((p) => p.name)))
+    if (name && name.trim()) handleSavePose(name.trim(), joints)
+  }
+  // Refs so the (stable-deps) three.js scene effect can call the latest chain
+  // resolver + board streamer without re-subscribing the whole scene each render.
+  const ikGoalChainRef = useRef(ikGoalChain)
+  ikGoalChainRef.current = ikGoalChain
 
   // Duplicate a pose under a unique "<name> copy" name, keeping the original and
   // never clobbering an existing entry (#414). Opens the copy for editing.
@@ -1759,6 +1802,9 @@ export function RobotView({
       }
     }
   }
+  // Ref so the scene effect (stable deps) can stream the latest bindings/board.
+  const streamServosRef = useRef(streamServos)
+  streamServosRef.current = streamServos
 
   // Apply a sampled sequence frame (mirrors auto-follow); `commitState` syncs the
   // sliders (scrub/pause only). Streams to the board when Live.
@@ -2143,6 +2189,12 @@ export function RobotView({
     highlightApiRef.current?.apply(selectedLinkRef.current)
   }, [boneMode])
 
+  // Arm/disarm the interactive IK goal gizmo (#540).
+  useEffect(() => {
+    ikGoalRef.current = ikGoal
+    ikApiRef.current?.setArmed(ikGoal)
+  }, [ikGoal])
+
   useEffect(() => {
     const mount = mountRef.current
     if (!mount) return
@@ -2247,6 +2299,35 @@ export function RobotView({
     const boneModeApi = createBoneMode(scene, () => robotRef.current)
     boneApiRef.current = boneModeApi
     boneModeApi.setEnabled(boneModeRef.current)
+
+    // Interactive IK goal gizmo (#540): drag a goal, the shared planar solver
+    // poses the chain live, streams to a connected board, and feeds Capture Pose.
+    const ikGizmoApi = createIkGizmo(scene, {
+      getRobot: () => robotRef.current,
+      camera,
+      controls,
+      dom: renderer.domElement,
+      getChain: () => ikGoalChainRef.current(selectedLinkRef.current),
+      getLimit: (name) => {
+        const m = metaRef.current.find((x) => x.name === name)
+        return m ? effectiveLimit(m, overridesRef.current[name]) : { lower: -Math.PI, upper: Math.PI }
+      },
+      // Per drag-frame: mirror the solved angles to a connected board (best-effort;
+      // no board / no bindings → a harmless no-op, same channel the puppet uses).
+      onLive: (native) => {
+        const disp: Record<string, number> = {}
+        for (const [name, val] of Object.entries(native)) {
+          const m = metaRef.current.find((x) => x.name === name)
+          if (m) disp[name] = toDisplay(m.type, val)
+        }
+        streamServosRef.current(disp)
+      },
+      // On release: commit the solved angles into React so the sliders + Save Pose
+      // reflect the new posture (native units, mirrors the Grab tool's finishGrab).
+      onCommit: (native) => setValues((v) => ({ ...v, ...native }))
+    })
+    ikApiRef.current = ikGizmoApi
+    ikGizmoApi.setArmed(ikGoalRef.current)
 
     // Navigation cube (top-right): mirrors the camera; a face-click snaps the
     // view to that orthographic direction. Its own canvas → no OrbitControls clash.
@@ -4340,6 +4421,7 @@ export function RobotView({
       stepAnim()
       controls.update()
       boneModeApi.update() // live skeleton overlay (#536) — follows every joint drive
+      ikGizmoApi.update() // interactive IK goal gizmo (#540) — composes with Bone Mode
       renderer.render(scene, camera)
       if (viewCube) {
         viewCube.sync(camera.quaternion)
@@ -4370,6 +4452,8 @@ export function RobotView({
       zoomApiRef.current = null
       boneApiRef.current = null
       boneModeApi.dispose()
+      ikApiRef.current = null
+      ikGizmoApi.dispose()
       if (viewCube) {
         viewCube.dom.remove()
         viewCube.dispose()
@@ -4661,6 +4745,32 @@ export function RobotView({
             >
               🦴
             </button>
+            {/* Interactive IK goal gizmo (#540): drag a goal, the chain follows. */}
+            <button
+              type="button"
+              className={`robotview__zbtn${ikGoal ? ' is-active' : ''}`}
+              disabled={
+                !jointMeta.some((m) => !m.isMimic && (m.type === 'revolute' || m.type === 'continuous'))
+              }
+              onClick={() => setIkGoal((v) => !v)}
+              title="IK goal — pick a part, then drag its goal and the chain solves to reach it"
+              aria-label="Interactive IK goal"
+              aria-pressed={ikGoal}
+            >
+              🎯
+            </button>
+            {ikGoal && (
+              <button
+                type="button"
+                className="robotview__zbtn"
+                disabled={!ikGoalChain(selectedLink)}
+                onClick={() => void handleCaptureIkPose()}
+                title="Capture Pose — save the current IK-solved position as a Motion Studio pose"
+                aria-label="Capture IK pose"
+              >
+                📸
+              </button>
+            )}
           </div>
         )}
         {showPanel && buildOpen && (

--- a/src/renderer/src/components/robot-ik-gizmo.ts
+++ b/src/renderer/src/components/robot-ik-gizmo.ts
@@ -1,0 +1,410 @@
+/**
+ * INTERACTIVE IK GOAL GIZMO (#540, epic #533 §5) — a draggable end-effector goal
+ * for Robot View. When armed it drops a handle at the selected chain's end
+ * effector; dragging it runs the shared PLANAR solver (`src/shared/ik`, via
+ * `robot-ik-planar.ts`) every frame, poses the live URDF model, and reports the
+ * solved joint angles so the caller can stream them to a connected board and
+ * commit them as a Motion Studio pose ("Capture Pose").
+ *
+ * It COMPOSES with Bone Mode (#536): a separate, raycast-inert scene child driven
+ * from the same per-frame tick, reading the same live URDF joints. The goal is
+ * dragged WITHIN the chain's working plane (the shared solver is planar), which
+ * also makes the reachable-workspace shading — a limit-shaped point cloud in that
+ * plane — line up with what the solver can actually reach.
+ *
+ * All the maths lives in `robot-ik-planar.ts` (pure, unit-tested); this file is
+ * just the three.js gizmo + pointer wiring, mirroring the Bone Mode overlay and
+ * the Grab-tool drag patterns already in RobotView.
+ */
+import * as THREE from 'three'
+import type { URDFRobot } from 'urdf-loader'
+import {
+  planarizeChain,
+  planarToWorld,
+  sampleWorkspace,
+  solveChainTarget,
+  type ChainJoint,
+  type ChainSolveResult,
+  type PlanarChainMap
+} from './robot-ik-planar'
+import type { IkStatus } from '../../../shared/ik'
+
+const ORDER_WORKSPACE = 999
+const ORDER_GOAL = 1004 // above the bone-mode overlay (labels at 1003)
+
+// Status → colour (matches the Bone Mode limit palette family).
+const STATUS_COLOR: Record<IkStatus, string> = {
+  reached: '#6ee76e',
+  blocked_by_limits: '#ffd23f',
+  out_of_reach: '#ff5a5a'
+}
+const IDLE_COLOR = '#8fb7ff' // armed, not yet dragged
+const NONPLANAR_COLOR = '#c792ea' // the chain isn't really planar — best-effort
+
+/** A joint chain to pose: base-first movable joints + the end-effector link. */
+export interface IkChainRef {
+  joints: string[]
+  endLink: string
+}
+
+export interface IkGizmoDeps {
+  getRobot: () => URDFRobot | null
+  camera: THREE.Camera
+  /** OrbitControls (or anything with `.enabled`) — disabled during a drag. */
+  controls: { enabled: boolean }
+  dom: HTMLElement
+  /** Base-first movable chain for the current target, or null when none. */
+  getChain: () => IkChainRef | null
+  /** Effective native limits (rad) for a joint. */
+  getLimit: (joint: string) => { lower: number; upper: number }
+  /** Per drag-frame, after the model is posed — stream to a board, etc. */
+  onLive?: (nativeByJoint: Record<string, number>) => void
+  /** On drag release — commit the solved pose into React state. */
+  onCommit?: (nativeByJoint: Record<string, number>) => void
+}
+
+export interface IkGizmoHandle {
+  setArmed(on: boolean): void
+  update(): void
+  /** Joint names the current goal chain drives (Capture Pose include-set). */
+  chainJoints(): string[]
+  /** Status of the most recent solve, for UI (null before any drag). */
+  status(): IkStatus | null
+  dispose(): void
+}
+
+/** A tiny billboarded status pill (canvas sprite), JetBrains Mono, depth-off. */
+class StatusLabel {
+  readonly sprite: THREE.Sprite
+  private readonly canvas = document.createElement('canvas')
+  private tex: THREE.CanvasTexture | null = null
+  private last = ''
+  private height = 0.03
+
+  constructor() {
+    const mat = new THREE.SpriteMaterial({ depthTest: false, depthWrite: false, transparent: true })
+    this.sprite = new THREE.Sprite(mat)
+    this.sprite.renderOrder = ORDER_GOAL + 1
+    this.sprite.raycast = () => {}
+    this.sprite.frustumCulled = false
+  }
+
+  set(text: string, color: string, height: number): void {
+    this.height = height
+    const key = `${text}|${color}`
+    if (key !== this.last) {
+      this.last = key
+      const ctx = this.canvas.getContext('2d')
+      if (!ctx) return
+      const font = '600 26px "JetBrains Mono", ui-monospace, monospace'
+      ctx.font = font
+      const w = Math.ceil(ctx.measureText(text).width)
+      const H = 44
+      this.canvas.width = w + 28
+      this.canvas.height = H
+      ctx.font = font
+      ctx.beginPath()
+      ctx.roundRect(1, 1, this.canvas.width - 2, H - 2, 10)
+      ctx.fillStyle = 'rgba(12, 14, 18, 0.78)'
+      ctx.fill()
+      ctx.strokeStyle = color
+      ctx.lineWidth = 2
+      ctx.stroke()
+      ctx.fillStyle = color
+      ctx.textAlign = 'center'
+      ctx.textBaseline = 'middle'
+      ctx.fillText(text, this.canvas.width / 2, H / 2 + 1)
+      this.tex?.dispose()
+      this.tex = new THREE.CanvasTexture(this.canvas)
+      this.tex.colorSpace = THREE.SRGBColorSpace
+      const m = this.sprite.material as THREE.SpriteMaterial
+      m.map = this.tex
+      m.needsUpdate = true
+    }
+    const aspect = this.canvas.height > 0 ? this.canvas.width / this.canvas.height : 3
+    this.sprite.scale.set(this.height * aspect, this.height, 1)
+  }
+
+  dispose(): void {
+    this.tex?.dispose()
+    ;(this.sprite.material as THREE.SpriteMaterial).dispose()
+  }
+}
+
+const STATUS_TEXT: Record<IkStatus, string> = {
+  reached: 'reached',
+  blocked_by_limits: 'blocked by limits',
+  out_of_reach: 'out of reach'
+}
+
+export function createIkGizmo(scene: THREE.Scene, deps: IkGizmoDeps): IkGizmoHandle {
+  const root = new THREE.Group()
+  root.visible = false
+  scene.add(root)
+
+  // Goal handle: a filled sphere + a bright ring (always-on-top), raycast-HITTABLE.
+  const goal = new THREE.Group()
+  goal.renderOrder = ORDER_GOAL
+  const ballGeo = new THREE.SphereGeometry(1, 20, 16)
+  const ballMat = new THREE.MeshBasicMaterial({
+    color: IDLE_COLOR,
+    transparent: true,
+    opacity: 0.5,
+    depthTest: false,
+    depthWrite: false
+  })
+  const ball = new THREE.Mesh(ballGeo, ballMat)
+  ball.renderOrder = ORDER_GOAL
+  goal.add(ball)
+  const ringGeo = new THREE.RingGeometry(1.25, 1.55, 28)
+  const ringMat = new THREE.MeshBasicMaterial({
+    color: IDLE_COLOR,
+    transparent: true,
+    opacity: 0.9,
+    side: THREE.DoubleSide,
+    depthTest: false,
+    depthWrite: false
+  })
+  const ring = new THREE.Mesh(ringGeo, ringMat)
+  ring.renderOrder = ORDER_GOAL
+  ring.raycast = () => {}
+  goal.add(ring)
+  root.add(goal)
+
+  const label = new StatusLabel()
+  root.add(label.sprite)
+
+  // Reachable-workspace point cloud, in the chain's working plane.
+  const wsGeo = new THREE.BufferGeometry()
+  const wsMat = new THREE.PointsMaterial({
+    color: 0x4aa3ff,
+    size: 4,
+    sizeAttenuation: false,
+    transparent: true,
+    opacity: 0.28,
+    depthTest: false,
+    depthWrite: false
+  })
+  const workspace = new THREE.Points(wsGeo, wsMat)
+  workspace.renderOrder = ORDER_WORKSPACE
+  workspace.raycast = () => {}
+  workspace.frustumCulled = false
+  root.add(workspace)
+
+  let armed = false
+  let dragging = false
+  const dragPlane = new THREE.Plane()
+  let scale = 0.02
+  let wsKey = '' // chain identity the workspace cloud was built for
+  let lastStatus: IkStatus | null = null
+  let lastNative: Record<string, number> = {}
+  let currentChain: IkChainRef | null = null
+
+  const raycaster = new THREE.Raycaster()
+  const ndc = new THREE.Vector2()
+  const tmpP = new THREE.Vector3()
+  const tmpA = new THREE.Vector3()
+  const tmpTarget = new THREE.Vector3()
+
+  const setNdc = (e: PointerEvent): void => {
+    const r = deps.dom.getBoundingClientRect()
+    ndc.set(((e.clientX - r.left) / r.width) * 2 - 1, -((e.clientY - r.top) / r.height) * 2 + 1)
+  }
+
+  const robotMaxDim = (robot: URDFRobot): number => {
+    const size = new THREE.Box3().setFromObject(robot).getSize(tmpP)
+    const d = Math.max(size.x, size.y, size.z)
+    return Number.isFinite(d) && d > 1e-6 ? d : 0.2
+  }
+
+  /** Build base-first world-space chain joints from the live robot. */
+  const chainJointsOf = (robot: URDFRobot, names: string[]): ChainJoint[] =>
+    names.map((name) => {
+      const j = robot.joints[name]
+      j.getWorldPosition(tmpP)
+      tmpA.copy(j.axis).transformDirection(j.matrixWorld).normalize()
+      const lim = deps.getLimit(name)
+      return {
+        name,
+        pivot: [tmpP.x, tmpP.y, tmpP.z],
+        axis: [tmpA.x, tmpA.y, tmpA.z],
+        angle: j.angle,
+        lower: lim.lower,
+        upper: lim.upper
+      }
+    })
+
+  const effectorWorld = (robot: URDFRobot, endLink: string): THREE.Vector3 => {
+    const link = robot.links[endLink]
+    if (link) link.getWorldPosition(tmpTarget)
+    return tmpTarget.clone()
+  }
+
+  /** Planarize the current chain from the live pose (null when not posable). */
+  const planarizeNow = (): PlanarChainMap | null => {
+    const robot = deps.getRobot()
+    const chain = deps.getChain()
+    currentChain = chain
+    if (!robot || !chain || chain.joints.length === 0) return null
+    robot.updateMatrixWorld(true)
+    const joints = chainJointsOf(robot, chain.joints)
+    return planarizeChain(joints, effectorWorld(robot, chain.endLink).toArray() as [number, number, number])
+  }
+
+  const applyStatus = (status: IkStatus | null, planarity: number): void => {
+    lastStatus = status
+    const color =
+      status == null
+        ? IDLE_COLOR
+        : planarity > 0.2
+          ? NONPLANAR_COLOR
+          : STATUS_COLOR[status]
+    ballMat.color.set(color)
+    ringMat.color.set(color)
+    const text =
+      status == null ? 'IK goal' : planarity > 0.2 ? `${STATUS_TEXT[status]} · non-planar` : STATUS_TEXT[status]
+    label.set(text, color, scale * 1.6)
+  }
+
+  /** Rebuild the workspace cloud for a chain (once per chain identity change). */
+  const rebuildWorkspace = (map: PlanarChainMap): void => {
+    const sample = sampleWorkspace(map.chain)
+    const arr = new Float32Array(sample.points.length * 3)
+    sample.points.forEach((p, i) => {
+      const w = planarToWorld(p, map.frame)
+      arr[i * 3] = w[0]
+      arr[i * 3 + 1] = w[1]
+      arr[i * 3 + 2] = w[2]
+    })
+    wsGeo.setAttribute('position', new THREE.BufferAttribute(arr, 3))
+    wsGeo.computeBoundingSphere()
+  }
+
+  const placeGoalAt = (w: THREE.Vector3): void => {
+    goal.position.copy(w)
+    goal.scale.setScalar(scale)
+  }
+
+  // ── Pointer drag ────────────────────────────────────────────────────────────
+  const onDown = (e: PointerEvent): void => {
+    if (!armed || dragging || e.button !== 0) return
+    if (!goal.visible) return
+    setNdc(e)
+    raycaster.setFromCamera(ndc, deps.camera)
+    // Only the goal ball is hittable; a miss leaves the event for orbit/other tools.
+    if (!raycaster.intersectObject(ball, false).length) return
+    const map = planarizeNow()
+    if (!map) return
+    // Freeze the working plane (base pivot is fixed, so it stays valid mid-drag).
+    const n = new THREE.Vector3(map.frame.normal[0], map.frame.normal[1], map.frame.normal[2])
+    const o = new THREE.Vector3(map.frame.origin[0], map.frame.origin[1], map.frame.origin[2])
+    dragPlane.setFromNormalAndCoplanarPoint(n, o)
+    dragging = true
+    deps.controls.enabled = false
+    ;(e.target as HTMLElement).setPointerCapture?.(e.pointerId)
+    e.stopImmediatePropagation()
+  }
+
+  const onMove = (e: PointerEvent): void => {
+    if (!dragging) return
+    const robot = deps.getRobot()
+    setNdc(e)
+    raycaster.setFromCamera(ndc, deps.camera)
+    if (!raycaster.ray.intersectPlane(dragPlane, tmpTarget)) return
+    placeGoalAt(tmpTarget)
+    // Re-planarize from the CURRENT pose each frame (base pivot fixed) and solve —
+    // the incremental re-solve converges like the Grab tool's re-snapshotting.
+    const map = planarizeNow()
+    if (!robot || !map) return
+    const res: ChainSolveResult = solveChainTarget(map, [tmpTarget.x, tmpTarget.y, tmpTarget.z], {
+      maxIterations: 24
+    })
+    for (const name of map.jointNames) robot.setJointValue(name, res.nativeByJoint[name])
+    robot.updateMatrixWorld(true)
+    lastNative = res.nativeByJoint
+    applyStatus(res.status, res.planarity)
+    deps.onLive?.(res.nativeByJoint)
+    e.stopImmediatePropagation()
+  }
+
+  const onUp = (e: PointerEvent): void => {
+    if (!dragging) return
+    dragging = false
+    deps.controls.enabled = true
+    ;(e.target as HTMLElement).releasePointerCapture?.(e.pointerId)
+    if (Object.keys(lastNative).length) deps.onCommit?.(lastNative)
+  }
+
+  deps.dom.addEventListener('pointerdown', onDown)
+  deps.dom.addEventListener('pointermove', onMove)
+  deps.dom.addEventListener('pointerup', onUp)
+
+  const update = (): void => {
+    const robot = deps.getRobot()
+    if (!armed || !robot) {
+      root.visible = false
+      return
+    }
+    const chain = deps.getChain()
+    currentChain = chain
+    if (!chain || chain.joints.length === 0) {
+      root.visible = false
+      return
+    }
+    root.visible = true
+    scale = Math.min(Math.max(robotMaxDim(robot) * 0.03, 0.006), 0.05)
+
+    // While NOT dragging, snap the goal handle to the live end effector and keep
+    // the workspace cloud current for this chain.
+    if (!dragging) {
+      const map = planarizeNow()
+      if (!map) {
+        root.visible = false
+        return
+      }
+      placeGoalAt(effectorWorld(robot, chain.endLink))
+      const key = `${chain.joints.join('>')}|${map.chain.boneLengths.map((l) => l.toFixed(4)).join(',')}`
+      if (key !== wsKey) {
+        wsKey = key
+        rebuildWorkspace(map)
+      }
+      if (lastStatus == null) applyStatus(null, map.planarity)
+    }
+    ring.quaternion.copy(deps.camera.quaternion) // billboard the ring toward the camera
+    goal.updateMatrixWorld(true)
+    goal.getWorldPosition(tmpP)
+    label.sprite.position.set(tmpP.x, tmpP.y + scale * 2.4, tmpP.z)
+  }
+
+  return {
+    setArmed(on: boolean): void {
+      armed = on
+      if (!on) {
+        root.visible = false
+        dragging = false
+        deps.controls.enabled = true
+        lastStatus = null
+      }
+    },
+    update,
+    chainJoints(): string[] {
+      return currentChain?.joints ?? []
+    },
+    status(): IkStatus | null {
+      return lastStatus
+    },
+    dispose(): void {
+      deps.dom.removeEventListener('pointerdown', onDown)
+      deps.dom.removeEventListener('pointermove', onMove)
+      deps.dom.removeEventListener('pointerup', onUp)
+      label.dispose()
+      ballGeo.dispose()
+      ballMat.dispose()
+      ringGeo.dispose()
+      ringMat.dispose()
+      wsGeo.dispose()
+      wsMat.dispose()
+      scene.remove(root)
+    }
+  }
+}

--- a/src/renderer/src/components/robot-ik-planar.ts
+++ b/src/renderer/src/components/robot-ik-planar.ts
@@ -1,0 +1,336 @@
+/**
+ * PLANAR IK MAPPING (#540, epic #533 §5) — glue between a robot's 3-D kinematic
+ * chain (URDF joints with arbitrary world axes) and the shared PLANAR solver in
+ * `src/shared/ik`. Pure maths (three.js vectors only, no scene / DOM / React) so
+ * the goal-gizmo logic stays unit-testable.
+ *
+ * ── Scope: PLANAR chains ────────────────────────────────────────────────────
+ * The shared solver is planar (all bones in one XY plane, relative angles about
+ * a single normal). A real arm/leg whose joints all spin about PARALLEL axes IS
+ * such a planar chain — its bones sweep one plane. We map that chain onto the
+ * solver like so:
+ *   • The working plane's NORMAL is the (shared) joint axis; its ORIGIN is the
+ *     base joint's pivot. An in-plane basis (u, v) gives 2-D coordinates.
+ *   • Each joint pivot + the end effector projects to the plane; consecutive
+ *     points give the planar bone lengths and current relative angles.
+ *   • A joint's NATIVE angle maps to the solver's RELATIVE angle up to a sign
+ *     `s = sign(axis · normal)` (a joint whose axis points the other way turns
+ *     the bone clockwise). So `native = nativeCurrent + s·Δrelative`, and native
+ *     joint limits map to a relative-angle window the solver clamps within.
+ * `planarity` reports how far the chain departs from a single plane (0 = perfect)
+ * so the caller can warn; a non-planar chain is still solved as its best planar
+ * projection rather than faking full 3-D IK — that's a deliberate v1 limitation.
+ */
+import * as THREE from 'three'
+import {
+  solveIk,
+  wrapToPi,
+  jointPositions,
+  type IkChain,
+  type IkResult,
+  type IkStatus,
+  type JointLimit,
+  type SolveOptions,
+  type Vec2
+} from '../../../shared/ik'
+import type { Vec3 } from './robot-build'
+
+/** One revolute/continuous joint of a chain, ordered BASE-first, world-space. */
+export interface ChainJoint {
+  name: string
+  /** World position of the joint's rotation centre. */
+  pivot: Vec3
+  /** World rotation axis (need not be pre-normalised). */
+  axis: Vec3
+  /** The joint's current NATIVE angle (radians). */
+  angle: number
+  /** Native lower/upper limit (radians). */
+  lower: number
+  upper: number
+}
+
+/** The plane a chain works in (base pivot origin + orthonormal frame). */
+export interface PlanarFrame {
+  origin: Vec3
+  normal: Vec3
+  u: Vec3
+  v: Vec3
+}
+
+/** A chain flattened onto the shared solver's planar convention. */
+export interface PlanarChainMap {
+  /** What `solveIk` consumes: planar bone lengths + relative-angle limits. */
+  chain: IkChain
+  frame: PlanarFrame
+  jointNames: string[]
+  /** Per joint: +1 if native +angle turns the bone CCW about `normal`, else −1. */
+  signs: number[]
+  /** Current relative planar angles — the solver's `currentAngles` seed. */
+  currentRelative: number[]
+  nativeCurrent: number[]
+  nativeLower: number[]
+  nativeUpper: number[]
+  /** Current end-effector position, in plane coordinates. */
+  effector: Vec2
+  /**
+   * Chain non-planarity: `max(1 − |axis·normal|)` over the joints (0 = every
+   * axis parallel to the plane normal → a true planar chain; →1 = perpendicular).
+   */
+  planarity: number
+}
+
+const EPS = 1e-9
+
+function v3(a: Vec3): THREE.Vector3 {
+  return new THREE.Vector3(a[0], a[1], a[2])
+}
+
+/** A unit vector perpendicular to `n` (stable: avoids the near-parallel axis). */
+function anyPerpendicular(n: THREE.Vector3): THREE.Vector3 {
+  const helper =
+    Math.abs(n.x) < 0.9 ? new THREE.Vector3(1, 0, 0) : new THREE.Vector3(0, 1, 0)
+  return helper.cross(n).normalize()
+}
+
+/** World point → plane coordinates `[u, v]` (relative to the frame origin). */
+export function worldToPlanar(p: Vec3, frame: PlanarFrame): Vec2 {
+  const d = v3(p).sub(v3(frame.origin))
+  return [d.dot(v3(frame.u)), d.dot(v3(frame.v))]
+}
+
+/** Plane coordinates `[u, v]` → world point. */
+export function planarToWorld(uv: Vec2, frame: PlanarFrame): Vec3 {
+  const o = v3(frame.origin)
+  o.addScaledVector(v3(frame.u), uv[0])
+  o.addScaledVector(v3(frame.v), uv[1])
+  return [o.x, o.y, o.z]
+}
+
+/**
+ * Map a joint's native `[lower, upper]` onto the solver's RELATIVE-angle window.
+ * Returns `null` (free joint) when the native span covers a full turn, or when
+ * the mapped window can't be represented inside `[-PI, PI]` — the solver treats
+ * `null` as unconstrained. `cr` is the joint's current relative angle, `nc` its
+ * current native angle, `s` its sign.
+ */
+export function relativeLimit(
+  cr: number,
+  nc: number,
+  lower: number,
+  upper: number,
+  s: number
+): JointLimit | null {
+  if (upper - lower >= 2 * Math.PI - 1e-6) return null
+  // native = nc + s·(rel − cr)  ⇒  rel = cr + s·(native − nc)
+  const a = cr + s * (lower - nc)
+  const b = cr + s * (upper - nc)
+  let lo = Math.min(a, b)
+  let hi = Math.max(a, b)
+  if (hi - lo >= 2 * Math.PI - 1e-6) return null
+  // The solver requires −PI ≤ min ≤ max ≤ PI; clamp the window into range. A
+  // window fully outside collapses — fall back to free rather than an empty span.
+  lo = Math.max(-Math.PI, Math.min(Math.PI, lo))
+  hi = Math.max(-Math.PI, Math.min(Math.PI, hi))
+  if (!(hi > lo)) return null
+  return [lo, hi]
+}
+
+/**
+ * Flatten a base-first chain of joints (+ its world end-effector point) onto the
+ * shared planar solver. Returns `null` for an empty chain. Bone lengths are the
+ * planar distances between consecutive pivots (and pivot→effector for the last);
+ * a degenerate zero-length bone is floored to a tiny positive so the solver's
+ * `invalid_bone_length` guard never trips.
+ */
+export function planarizeChain(joints: ChainJoint[], effector: Vec3): PlanarChainMap | null {
+  const n = joints.length
+  if (n === 0) return null
+
+  // Plane normal: the base joint's axis. Track each joint's turn direction and
+  // how far its axis departs from that normal (the planarity metric).
+  const normal = v3(joints[0].axis)
+  if (normal.lengthSq() < EPS) normal.set(0, 0, 1)
+  normal.normalize()
+  const signs: number[] = []
+  let planarity = 0
+  for (const j of joints) {
+    const ax = v3(j.axis)
+    if (ax.lengthSq() < EPS) {
+      signs.push(1)
+      continue
+    }
+    ax.normalize()
+    const dot = ax.dot(normal)
+    signs.push(dot < 0 ? -1 : 1)
+    planarity = Math.max(planarity, 1 - Math.abs(dot))
+  }
+
+  const u = anyPerpendicular(normal)
+  const vv = normal.clone().cross(u).normalize()
+  const origin = v3(joints[0].pivot)
+  const frame: PlanarFrame = {
+    origin: [origin.x, origin.y, origin.z],
+    normal: [normal.x, normal.y, normal.z],
+    u: [u.x, u.y, u.z],
+    v: [vv.x, vv.y, vv.z]
+  }
+
+  // Project pivots + the effector into plane coordinates: P0…P(n-1), P(n)=eff.
+  const pts2d: Vec2[] = joints.map((j) => worldToPlanar(j.pivot, frame))
+  pts2d.push(worldToPlanar(effector, frame))
+
+  const boneLengths: number[] = []
+  const headings: number[] = []
+  for (let i = 0; i < n; i++) {
+    const dx = pts2d[i + 1][0] - pts2d[i][0]
+    const dy = pts2d[i + 1][1] - pts2d[i][1]
+    const len = Math.hypot(dx, dy)
+    boneLengths.push(len < EPS ? EPS : len)
+    headings.push(Math.atan2(dy, dx))
+  }
+
+  const currentRelative: number[] = []
+  for (let i = 0; i < n; i++) {
+    currentRelative.push(i === 0 ? wrapToPi(headings[0]) : wrapToPi(headings[i] - headings[i - 1]))
+  }
+
+  const nativeCurrent = joints.map((j) => j.angle)
+  const nativeLower = joints.map((j) => j.lower)
+  const nativeUpper = joints.map((j) => j.upper)
+  const limits = joints.map((_, i) =>
+    relativeLimit(currentRelative[i], nativeCurrent[i], nativeLower[i], nativeUpper[i], signs[i])
+  )
+
+  return {
+    chain: { boneLengths, limits },
+    frame,
+    jointNames: joints.map((j) => j.name),
+    signs,
+    currentRelative,
+    nativeCurrent,
+    nativeLower,
+    nativeUpper,
+    effector: pts2d[n],
+    planarity
+  }
+}
+
+/** The result of solving a chain toward a world target. */
+export interface ChainSolveResult {
+  status: IkStatus
+  /** Native joint angles (radians), one per chain joint, clamped to limits. */
+  nativeAngles: number[]
+  /** Native angles keyed by joint name — ready for `setJointValue` / posing. */
+  nativeByJoint: Record<string, number>
+  /** The solver's achieved effector, back in world space (planar projection). */
+  effectorWorld: Vec3
+  /** The target, in plane coordinates. */
+  targetPlanar: Vec2
+  /** Distance (plane units) from the achieved effector to the target. */
+  error: number
+  planarity: number
+  raw: IkResult
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return v < lo ? lo : v > hi ? hi : v
+}
+
+/**
+ * Convert the solver's RELATIVE angles back to each joint's NATIVE angle,
+ * clamped to the native limits. `Δrelative` is wrapped so a joint never jumps a
+ * full turn between frames.
+ */
+export function nativeFromSolved(map: PlanarChainMap, solvedRelative: readonly number[]): number[] {
+  return map.jointNames.map((_, i) => {
+    const delta = wrapToPi(solvedRelative[i] - map.currentRelative[i])
+    const native = map.nativeCurrent[i] + map.signs[i] * delta
+    return clamp(native, map.nativeLower[i], map.nativeUpper[i])
+  })
+}
+
+/**
+ * Solve a planarized chain so its end effector reaches `targetWorld`, returning
+ * the native joint angles to apply (plus the solver's status for UI feedback).
+ * The target is projected onto the chain's working plane first, so a goal off
+ * the plane is solved by its in-plane shadow.
+ */
+export function solveChainTarget(
+  map: PlanarChainMap,
+  targetWorld: Vec3,
+  options: SolveOptions = {}
+): ChainSolveResult {
+  const targetPlanar = worldToPlanar(targetWorld, map.frame)
+  const raw = solveIk(map.chain, targetPlanar, {
+    currentAngles: map.currentRelative,
+    ...options
+  })
+  const nativeAngles = nativeFromSolved(map, raw.angles)
+  const nativeByJoint: Record<string, number> = {}
+  map.jointNames.forEach((name, i) => (nativeByJoint[name] = nativeAngles[i]))
+  return {
+    status: raw.status,
+    nativeAngles,
+    nativeByJoint,
+    effectorWorld: planarToWorld(raw.position, map.frame),
+    targetPlanar,
+    error: raw.error,
+    planarity: map.planarity,
+    raw
+  }
+}
+
+/** The outer (fully-stretched) and inner (fold-limited) reach of a planar chain. */
+export function reachBounds(boneLengths: readonly number[]): { outer: number; inner: number } {
+  let total = 0
+  let longest = 0
+  for (const l of boneLengths) {
+    total += l
+    if (l > longest) longest = l
+  }
+  return { outer: total, inner: Math.max(0, longest - (total - longest)) }
+}
+
+export interface WorkspaceSample {
+  /** Reachable end-effector points (plane coordinates), limit-shaped. */
+  points: Vec2[]
+  outer: number
+  inner: number
+}
+
+/**
+ * Sample a chain's REACHABLE workspace by sweeping each joint across its limits
+ * and recording the forward-kinematics effector — so the point cloud is shaped
+ * by the joint limits (why a goal is/ isn't reachable), not just an annulus.
+ * The per-joint step count is chosen so the total stays under `maxSamples`; a
+ * limitless joint sweeps `[-PI, PI]`.
+ */
+export function sampleWorkspace(chain: IkChain, maxSamples = 1200): WorkspaceSample {
+  const n = chain.boneLengths.length
+  const { outer, inner } = reachBounds(chain.boneLengths)
+  if (n === 0) return { points: [], outer, inner }
+
+  // Distribute the sample budget across joints (≥2 steps each).
+  const steps = Math.max(2, Math.floor(Math.pow(maxSamples, 1 / n)))
+  const ranges = chain.boneLengths.map((_, i) => {
+    const lim = chain.limits?.[i] ?? null
+    return lim ? { lo: lim[0], hi: lim[1] } : { lo: -Math.PI, hi: Math.PI }
+  })
+
+  const points: Vec2[] = []
+  const angles = new Array<number>(n).fill(0)
+  const sweep = (i: number): void => {
+    if (i === n) {
+      const pts = jointPositions(chain.boneLengths, angles)
+      points.push(pts[pts.length - 1])
+      return
+    }
+    const { lo, hi } = ranges[i]
+    for (let s = 0; s < steps; s++) {
+      angles[i] = steps === 1 ? lo : lo + ((hi - lo) * s) / (steps - 1)
+      sweep(i + 1)
+    }
+  }
+  sweep(0)
+  return { points, outer, inner }
+}

--- a/test/robotIkPlanar.test.ts
+++ b/test/robotIkPlanar.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest'
+import {
+  planarizeChain,
+  solveChainTarget,
+  nativeFromSolved,
+  relativeLimit,
+  sampleWorkspace,
+  reachBounds,
+  worldToPlanar,
+  planarToWorld,
+  type ChainJoint,
+  type PlanarFrame
+} from '../src/renderer/src/components/robot-ik-planar'
+import { capturePoseValues, type JointMeta } from '../src/renderer/src/components/robot-pose'
+
+// A 2-link planar arm in the world XY plane, both joints spinning about +Z:
+//   base j0 @ origin → bone (len 1) → elbow j1 @ [1,0,0] → bone (len 1) → eff @ [2,0,0]
+const twoLink = (opts: { axis1?: [number, number, number]; lim?: [number, number] } = {}): ChainJoint[] => {
+  const lim = opts.lim ?? [-Math.PI, Math.PI]
+  return [
+    { name: 'j0', pivot: [0, 0, 0], axis: [0, 0, 1], angle: 0, lower: lim[0], upper: lim[1] },
+    { name: 'j1', pivot: [1, 0, 0], axis: opts.axis1 ?? [0, 0, 1], angle: 0, lower: lim[0], upper: lim[1] }
+  ]
+}
+const EFF: [number, number, number] = [2, 0, 0]
+
+const near = (a: readonly number[], b: readonly number[], tol = 1e-3): void => {
+  expect(a.length).toBe(b.length)
+  a.forEach((v, i) => expect(Math.abs(v - b[i])).toBeLessThan(tol))
+}
+
+describe('planarizeChain — 3-D chain → planar solver mapping', () => {
+  it('projects a +Z-axis arm onto its working plane (unit bones)', () => {
+    const map = planarizeChain(twoLink(), EFF)!
+    expect(map).not.toBeNull()
+    near(map.chain.boneLengths, [1, 1])
+    expect(map.planarity).toBeLessThan(1e-9) // every axis parallel to the normal
+    expect(map.jointNames).toEqual(['j0', 'j1'])
+    expect(map.signs).toEqual([1, 1])
+  })
+
+  it('flags a non-planar chain via planarity (perpendicular joint axis)', () => {
+    const map = planarizeChain(twoLink({ axis1: [1, 0, 0] }), EFF)!
+    expect(map.planarity).toBeGreaterThan(0.9)
+  })
+
+  it('detects a reversed joint axis as sign −1', () => {
+    const map = planarizeChain(twoLink({ axis1: [0, 0, -1] }), EFF)!
+    expect(map.signs).toEqual([1, -1])
+  })
+
+  it('returns null for an empty chain', () => {
+    expect(planarizeChain([], EFF)).toBeNull()
+  })
+})
+
+describe('solveChainTarget — live target → native angles', () => {
+  it('reaches an in-workspace goal, back in world space', () => {
+    const map = planarizeChain(twoLink(), EFF)!
+    const res = solveChainTarget(map, [1, 1, 0])
+    expect(res.status).toBe('reached')
+    // The achieved effector, mapped back to world, lands on the goal.
+    near(res.effectorWorld, [1, 1, 0])
+    expect(res.nativeByJoint.j0).toBeTypeOf('number')
+    expect(res.nativeByJoint.j1).toBeTypeOf('number')
+  })
+
+  it('reports a goal past full stretch as out_of_reach', () => {
+    const map = planarizeChain(twoLink(), EFF)!
+    const res = solveChainTarget(map, [5, 0, 0])
+    expect(res.status).toBe('out_of_reach')
+  })
+
+  it('nativeFromSolved is the exact inverse of the native→relative mapping', () => {
+    const map = planarizeChain(twoLink({ axis1: [0, 0, -1] }), EFF)!
+    const res = solveChainTarget(map, [1, 0.6, 0])
+    const native = nativeFromSolved(map, res.raw.angles)
+    // Re-deriving relative from native must reproduce the solver's angles.
+    native.forEach((nv, i) => {
+      const rel = map.currentRelative[i] + map.signs[i] * (nv - map.nativeCurrent[i])
+      const wrapped = Math.atan2(Math.sin(rel - res.raw.angles[i]), Math.cos(rel - res.raw.angles[i]))
+      expect(Math.abs(wrapped)).toBeLessThan(1e-6)
+    })
+  })
+})
+
+describe('relativeLimit — native limit → solver relative window', () => {
+  it('passes a modest window through unchanged (sign +1, zero current)', () => {
+    expect(relativeLimit(0, 0, -1, 2, 1)).toEqual([-1, 2])
+  })
+  it('mirrors the window for a reversed axis (sign −1)', () => {
+    const lim = relativeLimit(0, 0, -1, 2, -1)!
+    near(lim as unknown as number[], [-2, 1])
+  })
+  it('treats a full-turn span as free (null)', () => {
+    expect(relativeLimit(0, 0, -Math.PI, Math.PI, 1)).toBeNull()
+  })
+})
+
+describe('reachable-workspace sampling', () => {
+  it('reachBounds gives the stretched + folded radii', () => {
+    expect(reachBounds([1, 1])).toEqual({ outer: 2, inner: 0 })
+    expect(reachBounds([3, 1])).toEqual({ outer: 4, inner: 2 })
+  })
+
+  it('samples effector points inside the annulus, limit-shaped', () => {
+    const full = sampleWorkspace({ boneLengths: [1, 1] }, 400)
+    expect(full.points.length).toBeGreaterThan(0)
+    for (const [x, y] of full.points) {
+      expect(Math.hypot(x, y)).toBeLessThanOrEqual(full.outer + 1e-9)
+    }
+    // A pinned base joint collapses the reachable spread in X.
+    const pinned = sampleWorkspace({ boneLengths: [1, 1], limits: [[0, 0.001], null] }, 400)
+    const spread = (pts: [number, number][]): number =>
+      Math.max(...pts.map((p) => p[0])) - Math.min(...pts.map((p) => p[0]))
+    expect(spread(pinned.points)).toBeLessThan(spread(full.points))
+  })
+})
+
+describe('capture-pose payload construction', () => {
+  it('builds a partial Motion-Studio pose (deg) from the IK-solved chain', () => {
+    const map = planarizeChain(twoLink(), EFF)!
+    const res = solveChainTarget(map, [1, 1, 0])
+    // After a drag-release the live model IS the solve → capture from those natives.
+    const meta: JointMeta[] = [
+      { name: 'j0', type: 'revolute', lower: -Math.PI, upper: Math.PI, isMimic: false },
+      { name: 'j1', type: 'revolute', lower: -Math.PI, upper: Math.PI, isMimic: false },
+      { name: 'other', type: 'revolute', lower: -Math.PI, upper: Math.PI, isMimic: false }
+    ]
+    const valuesNative = { ...res.nativeByJoint, other: 0.5 }
+    const payload = capturePoseValues(meta, valuesNative, res.raw.angles ? ['j0', 'j1'] : [])
+    // Partial: only the chain joints, in degrees, rounded to 2dp.
+    expect(Object.keys(payload).sort()).toEqual(['j0', 'j1'])
+    expect(payload.j0).toBeCloseTo((res.nativeByJoint.j0 * 180) / Math.PI, 1)
+    expect(payload.j1).toBeCloseTo((res.nativeByJoint.j1 * 180) / Math.PI, 1)
+  })
+})
+
+describe('worldToPlanar / planarToWorld round-trip', () => {
+  it('recovers a plane point through the frame (arbitrary basis)', () => {
+    const frame: PlanarFrame = {
+      origin: [0.2, -0.5, 1],
+      normal: [0, 1, 0],
+      u: [1, 0, 0],
+      v: [0, 0, 1]
+    }
+    const uv = worldToPlanar([1.2, -0.5, 3], frame)
+    near(uv as unknown as number[], [1, 2])
+    near(planarToWorld(uv, frame), [1.2, -0.5, 3])
+  })
+})


### PR DESCRIPTION
## What

Implements **§5 of the IK epic (#533)** — interactive inverse kinematics in Robot View, building on the shared planar solver (#538) and Bone Mode (#536).

A new 🎯 toggle in the Robot View overlay arms an **interactive IK goal gizmo**:

- **Pick a part, drag its goal.** The gizmo drops a draggable handle at the selected chain's end effector. Dragging it runs the shared planar solver every frame and poses the live URDF model in real time (same re-solve-per-frame feel as the existing Grab tool).
- **Live board posting.** When a board is connected with servo bindings, the solved angles stream over the **same reverse `SNKCMD servos` channel** the puppet controls / sequence Live preview use — throttled, best-effort, and a harmless no-op with no board or no bindings.
- **Status feedback.** The goal handle recolours by solver status: green `reached`, amber `blocked by limits`, red `out of reach` (plus a purple *non-planar* warning), with a small readout pill.
- **Reachable workspace shading.** A translucent point cloud in the chain's working plane shades where the chain can actually reach — shaped by the joint limits — so you can *see* why a goal can't be reached (the nice-to-have).
- **📸 Capture Pose.** Saves the current IK-solved posture as a **Motion Studio pose** (a partial pose of just the driven chain, named via the in-app `usePrompt()` modal — `window.prompt` is dead in the renderer).

Composes with **Bone Mode**: a separate raycast-inert scene child driven from the same per-frame tick, reading the same live URDF joints.

## Interactive vs stubbed

Everything above is interactive. Nothing is stubbed. Board posting degrades gracefully to model-only when no board/bindings are present.

## Planar-mapping scope decision

The shared solver (`src/shared/ik`) is **planar** (all bones in one XY plane, relative angles about a single normal). A real arm/leg whose joints spin about **parallel axes** *is* such a chain. The new pure module `robot-ik-planar.ts` maps a 3-D URDF chain onto the solver:

- Working-plane **normal** = the base joint's axis; **origin** = the base pivot. Joint pivots + the end effector project to that plane, giving planar bone lengths and current relative angles.
- A joint's **native** angle maps to the solver's **relative** angle up to a sign `s = sign(axis · normal)`; native joint limits map to a relative-angle window the solver clamps within.
- A `planarity` metric (`max(1 − |axis·normal|)`) reports how far the chain departs from a single plane. A **non-planar chain is still solved as its best in-plane projection and flagged** — deliberately *not* faked as full 3-D IK. Full-body / multi-axis IK is out of scope for this issue (and the epic).

## Scope / ownership

- New co-located files: `robot-ik-planar.ts` (pure maths) + `robot-ik-gizmo.ts` (three.js gizmo, mirrors the Bone Mode overlay + Grab-tool drag patterns).
- `RobotView.tsx`: minimal integration only — arm state, create/dispose in the scene effect, one `update()` in the tick, the toolbar toggle + Capture Pose button, and board/commit wiring (via refs so the scene effect keeps stable deps).
- No edits to `src/shared/ik/**`, `src/shared/skeleton.ts`, or `robot-bone-mode.ts`. No new dependencies. No `package.json` version bump. One CHANGELOG bullet under [Unreleased] → Added.

## Verification (all green, run in the foreground)

- `npm run lint` — clean (only the pre-existing DriverInstallBanner warning)
- `npm run typecheck` — clean
- `npm test` — **1902 passed** (129 files), incl. 14 new tests in `test/robotIkPlanar.test.ts` covering the 3-D↔planar mapping, target→angles glue, sign handling, reachable-workspace sampling, and capture-pose payload construction
- `npm run build` — ok
- `npm run build:web` — ok

Headless Pi: verified via unit tests + builds (no Electron launch).

Closes #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)