### PR TITLE
fix: replace tofu-rendering emoji with SVG icons on Linux (#549)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Learn-panel course cards are covered too: courses still declare a thumbnail
   `emoji:` in their `course.yml`, but it now resolves through a small
   emoji→icon map, falling back to the raw glyph for an unmapped value so
-  authored courses keep working.
+  authored courses keep working. Also the build checklist's completion message
+  and the Robot View snap tooltip's "locked" label — the latter needed
+  `setBuildDim`'s `text` widened from `string` to `ReactNode` so the label can
+  carry an inline padlock icon.
 
 ### Added
 - **Interactive IK goal gizmo + Capture Pose in Robot View (#540, epic #533 §5).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the existing book icons), the shell's "Send to chat", SAM's SPEAK button and
   the build toolbar's tube primitive. Glyphs DejaVu *does* cover (✓ ✕ ⚙ ⚠ ★ ▦ ●
   and the arrows) are deliberately left as text — they already render fine.
+  Learn-panel course cards are covered too: courses still declare a thumbnail
+  `emoji:` in their `course.yml`, but it now resolves through a small
+  emoji→icon map, falling back to the raw glyph for an unmapped value so
+  authored courses keep working.
 
 ### Added
 - **Interactive IK goal gizmo + Capture Pose in Robot View (#540, epic #533 §5).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,20 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [0.33.0] - 2026-07-18
+### Fixed
+- **UI icons no longer vanish on Linux (#549).** Raspberry Pi OS ships no
+  colour-emoji font, so DejaVu Sans is the fallback and every glyph in the
+  U+1F300+ plane rendered as a blank box — most visibly the 🦴 Bone Mode and
+  💥 exploded-view buttons added in 0.33.0. Those glyphs are now SVG line icons
+  in a new `ui-icons.tsx` (same conventions as `help-icons.tsx`: 24×24 viewBox,
+  `currentColor`, `aria-hidden` since each call site already carries its own
+  `title`/`aria-label`). Covers the Robot View toolbar (exploded view, save
+  explosion video, Bone Mode, IK goal, Capture Pose, the measure readout), the
+  status-bar and tutorial tip bulbs, Part Editor lock/unlock and delete, the
+  build checklist header, the "Open…" buttons, Help Panel doc links (reusing
+  the existing book icons), the shell's "Send to chat", SAM's SPEAK button and
+  the build toolbar's tube primitive. Glyphs DejaVu *does* cover (✓ ✕ ⚙ ⚠ ★ ▦ ●
+  and the arrows) are deliberately left as text — they already render fine.
 
 ### Added
 - **Interactive IK goal gizmo + Capture Pose in Robot View (#540, epic #533 §5).**

--- a/src/renderer/src/components/BuildChecklist.css
+++ b/src/renderer/src/components/BuildChecklist.css
@@ -143,3 +143,7 @@
   font-weight: 700;
   color: var(--success);
 }
+/* Keep the trailing confetti icon (#549) on the text's optical line. */
+.bcl__congrats svg {
+  vertical-align: -0.15em;
+}

--- a/src/renderer/src/components/BuildChecklist.tsx
+++ b/src/renderer/src/components/BuildChecklist.tsx
@@ -30,7 +30,7 @@ import {
   type StickyRecord
 } from './build-checklist'
 import type { RobotDefinition } from '../../../shared/robot'
-import { TrophyIcon, RobotIcon } from './ui-icons'
+import { TrophyIcon, RobotIcon, ConfettiIcon } from './ui-icons'
 import './BuildChecklist.css'
 
 /** Collapse preference — global (not per-project), like the motion dock's. */
@@ -220,7 +220,10 @@ export function BuildChecklist(): JSX.Element {
         </ol>
       )}
       {!collapsed && complete && (
-        <p className="bcl__congrats">Robot complete — you built, posed and simulated it. Amazing work! 🎉</p>
+        <p className="bcl__congrats">
+          Robot complete — you built, posed and simulated it. Amazing work!{' '}
+          <ConfettiIcon size={13} />
+        </p>
       )}
     </section>
   )

--- a/src/renderer/src/components/BuildChecklist.tsx
+++ b/src/renderer/src/components/BuildChecklist.tsx
@@ -30,6 +30,7 @@ import {
   type StickyRecord
 } from './build-checklist'
 import type { RobotDefinition } from '../../../shared/robot'
+import { TrophyIcon, RobotIcon } from './ui-icons'
 import './BuildChecklist.css'
 
 /** Collapse preference — global (not per-project), like the motion dock's. */
@@ -180,7 +181,7 @@ export function BuildChecklist(): JSX.Element {
         title={collapsed ? 'Show the checklist' : 'Hide the checklist'}
       >
         <span className="bcl__head-emoji" aria-hidden>
-          {complete ? '🏆' : '🤖'}
+          {complete ? <TrophyIcon size={15} /> : <RobotIcon size={15} />}
         </span>
         <span className="bcl__head-title">Robot build checklist</span>
         <span className={`bcl__count${complete ? ' bcl__count--done' : ''}`}>

--- a/src/renderer/src/components/HelpPanel.tsx
+++ b/src/renderer/src/components/HelpPanel.tsx
@@ -271,7 +271,7 @@ export function HelpPanel({ target }: { target?: { id: string; nonce: number } }
                   onClick={() => void window.api?.openExternal?.(meta.guideUrl as string).catch(() => undefined)}
                   title={meta.guideUrl}
                 >
-                  📖 Full guide on kevsrobots.com →
+                  <OpenBookIcon size={13} /> Full guide on kevsrobots.com →
                 </button>
               )}
               {meta?.exampleCode && (
@@ -295,7 +295,7 @@ export function HelpPanel({ target }: { target?: { id: string; nonce: number } }
             onClick={openDocs}
             title={DOCS_URL}
           >
-            📚 More in the full documentation ↗
+            <TomeIcon size={13} /> More in the full documentation ↗
           </button>
         </div>
       </div>
@@ -327,7 +327,7 @@ export function HelpPanel({ target }: { target?: { id: string; nonce: number } }
         {tree.map((n) => renderNode(n, 0))}
       </div>
       <button type="button" className="help__docs" onClick={openDocs} title={DOCS_URL}>
-        📚 Full documentation at docs.snakie.org ↗
+        <TomeIcon size={13} /> Full documentation at docs.snakie.org ↗
       </button>
       {appVersion && (
         <div className="help__version" title="App version">

--- a/src/renderer/src/components/PartEditor.tsx
+++ b/src/renderer/src/components/PartEditor.tsx
@@ -62,6 +62,7 @@ import type {
 } from '../../../shared/part'
 import type { PartsWriteResult } from '../../../preload/index.d'
 import { Markdown } from './Markdown'
+import { LockIcon, UnlockIcon, TrashIcon } from './ui-icons'
 import './PartEditor.css'
 
 /** Per-capability bus/channel + signal controls shown when the capability is
@@ -1114,7 +1115,7 @@ function LayersPanel({
       aria-label={`${locked[key] ? 'Unlock' : 'Lock'} layer`}
       aria-pressed={locked[key]}
     >
-      {locked[key] ? '🔒' : '🔓'}
+      {locked[key] ? <LockIcon size={13} /> : <UnlockIcon size={13} />}
     </button>
   )
   const isOpen = (id: string): boolean => !collapsed[id]
@@ -1218,7 +1219,7 @@ function LayersPanel({
                 </button>
                 <span className="pe__flathelp">{sub}</span>
                 <button type="button" className="pe__trash" onClick={() => removeItem(it.kind, it.index)} title={`Remove ${name}`} aria-label={`Remove ${name}`}>
-                  🗑
+                  <TrashIcon size={13} />
                 </button>
               </li>
             )
@@ -1332,7 +1333,7 @@ function LayersPanel({
           </button>
           {part.imageData && (
             <button type="button" className="pe__trash" onClick={removeImage} title="Remove background image" aria-label="Remove background image">
-              🗑
+              <TrashIcon size={13} />
             </button>
           )}
         </div>

--- a/src/renderer/src/components/RobotBuildPanel.css
+++ b/src/renderer/src/components/RobotBuildPanel.css
@@ -583,6 +583,11 @@
 .robotbuild__dim {
   position: absolute;
   z-index: 5;
+  /* inline-flex so the "locked" label's padlock icon (#549) centres against
+     the text instead of sitting on the baseline. */
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
   pointer-events: none;
   font-family: var(--font-mono, 'JetBrains Mono', monospace);
   font-size: 0.66rem;

--- a/src/renderer/src/components/RobotBuildPanel.tsx
+++ b/src/renderer/src/components/RobotBuildPanel.tsx
@@ -19,6 +19,7 @@ import type { NamedPoseLike } from './robot-pose'
 import type { PropsContext } from './RobotPropertiesDialog'
 import { ContextMenu, type ContextMenuItem, type ContextMenuPosition } from './ContextMenu'
 import { usePrompt } from './PromptModal'
+import { FolderOpenIcon } from './ui-icons'
 import './RobotBuildPanel.css'
 
 /**
@@ -972,7 +973,7 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
           onClick={onOpenRobot}
           title="Open a different robot (.urdf) — works when popped out full-screen"
         >
-          📂 Open…
+          <FolderOpenIcon size={13} /> Open…
         </button>
         <button
           type="button"

--- a/src/renderer/src/components/RobotDockPanel.tsx
+++ b/src/renderer/src/components/RobotDockPanel.tsx
@@ -6,6 +6,7 @@ import { useWorkspace, announceSaved } from '../store/workspace'
 import { useWorkspaceLayout } from '../store/layout'
 import { readRobotModel } from '../../../shared/krf'
 import demoArm from '../assets/demo-arm.urdf?raw'
+import { FolderOpenIcon } from './ui-icons'
 
 /**
  * ROBOT DOCK PANEL (#320) — the mini 3-D Robot view that sits above the
@@ -243,7 +244,7 @@ export function RobotDockPanel(): JSX.Element {
           title="Open an existing robot (.urdf) full-screen"
           onClick={() => void openRobot()}
         >
-          📂 Open…
+          <FolderOpenIcon size={13} /> Open…
         </button>
         <button
           type="button"

--- a/src/renderer/src/components/RobotToolbar.tsx
+++ b/src/renderer/src/components/RobotToolbar.tsx
@@ -1,4 +1,6 @@
+import type { ReactNode } from 'react'
 import type { BuildTool, PrimitiveKind } from './robot-build'
+import { CylinderIcon } from './ui-icons'
 import './RobotToolbar.css'
 
 /**
@@ -34,9 +36,11 @@ const MEASURE_ICON = (
   </svg>
 )
 
-const ADD: Array<{ kind: PrimitiveKind; glyph: string; label: string }> = [
+// ▦ and ● are in DejaVu Sans so they survive a Linux box with no emoji font;
+// the tube glyph (U+2B2D) is not, so it uses an SVG icon instead (#549).
+const ADD: Array<{ kind: PrimitiveKind; glyph: ReactNode; label: string }> = [
   { kind: 'box', glyph: '▦', label: 'Add a box' },
-  { kind: 'cylinder', glyph: '⬭', label: 'Add a tube' },
+  { kind: 'cylinder', glyph: <CylinderIcon size={15} />, label: 'Add a tube' },
   { kind: 'sphere', glyph: '●', label: 'Add a ball' }
 ]
 

--- a/src/renderer/src/components/RobotView.css
+++ b/src/renderer/src/components/RobotView.css
@@ -370,6 +370,9 @@
   pointer-events: none;
 }
 .robotview__hud-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.28rem;
   font-family: var(--font-mono, 'JetBrains Mono', monospace);
   font-size: 0.6rem;
   color: var(--text, #cdd2d9);

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -139,6 +139,7 @@ import type {
   ServoJointBinding
 } from '../../../shared/robot'
 import type { PartDefinition } from '../../../preload/index.d'
+import { ExplodeIcon, ClapperIcon, BoneIcon, TargetIcon, CameraIcon, RulerIcon } from './ui-icons'
 import './RobotView.css'
 
 /** An empty motion clip (2 s, ease-in-out, looping). */
@@ -4671,7 +4672,7 @@ export function RobotView({
               aria-label="Exploded view"
               aria-pressed={explodeOpen}
             >
-              💥
+              <ExplodeIcon />
             </button>
             {explodeOpen && (
               <div className="robotview__explode" role="group" aria-label="Exploded view controls">
@@ -4729,7 +4730,7 @@ export function RobotView({
                   title="Save the explosion animation as a video (mp4/webm)"
                   aria-label="Save explosion video"
                 >
-                  🎬
+                  <ClapperIcon />
                 </button>
               </div>
             )}
@@ -4743,7 +4744,7 @@ export function RobotView({
               aria-label="Bone Mode"
               aria-pressed={boneMode}
             >
-              🦴
+              <BoneIcon />
             </button>
             {/* Interactive IK goal gizmo (#540): drag a goal, the chain follows. */}
             <button
@@ -4757,7 +4758,7 @@ export function RobotView({
               aria-label="Interactive IK goal"
               aria-pressed={ikGoal}
             >
-              🎯
+              <TargetIcon />
             </button>
             {ikGoal && (
               <button
@@ -4768,7 +4769,7 @@ export function RobotView({
                 title="Capture Pose — save the current IK-solved position as a Motion Studio pose"
                 aria-label="Capture IK pose"
               >
-                📸
+                <CameraIcon />
               </button>
             )}
           </div>
@@ -4910,7 +4911,9 @@ export function RobotView({
         {showPanel && (savingLabel || (measureActive && measureDist != null)) && (
           <div className="robotview__hud-status">
             {measureActive && measureDist != null && (
-              <span className="robotview__hud-pill">📏 {Math.round(measureDist)} mm</span>
+              <span className="robotview__hud-pill">
+                <RulerIcon size={13} /> {Math.round(measureDist)} mm
+              </span>
             )}
             {savingLabel && <span className="robotview__hud-pill">{savingLabel}</span>}
           </div>

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react'
+import type { ReactNode } from 'react'
 import * as THREE from 'three'
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
 import { STLLoader } from 'three/examples/jsm/loaders/STLLoader.js'
@@ -139,7 +140,15 @@ import type {
   ServoJointBinding
 } from '../../../shared/robot'
 import type { PartDefinition } from '../../../preload/index.d'
-import { ExplodeIcon, ClapperIcon, BoneIcon, TargetIcon, CameraIcon, RulerIcon } from './ui-icons'
+import {
+  ExplodeIcon,
+  ClapperIcon,
+  BoneIcon,
+  TargetIcon,
+  CameraIcon,
+  RulerIcon,
+  LockIcon
+} from './ui-icons'
 import './RobotView.css'
 
 /** An empty motion clip (2 s, ease-in-out, looping). */
@@ -550,7 +559,10 @@ export function RobotView({
   const [dialogCtx, setDialogCtx] = useState<PropsContext | null>(null)
   const editLink =
     dialogCtx?.kind === 'link' ? dialogCtx.link : dialogCtx?.kind === 'joint' ? dialogCtx.child : null
-  const [buildDim, setBuildDim] = useState<{ x: number; y: number; text: string } | null>(null)
+  // `text` is a ReactNode, not a string: the "locked" label carries an inline
+  // padlock ICON (#549) — an emoji there is invisible on Linux without an
+  // emoji font. Every other producer still passes a plain string.
+  const [buildDim, setBuildDim] = useState<{ x: number; y: number; text: ReactNode } | null>(null)
   // Join tool (#354): the two points picked in 3-D. Non-null = pick mode is armed.
   // `local` + `normal` are in the link's LOCAL frame (the point + its face normal).
   type JointPickPt = {
@@ -4251,7 +4263,11 @@ export function RobotView({
                 setBuildDim({
                   x: e.clientX - rect.left + 14,
                   y: e.clientY - rect.top + 14,
-                  text: `🔒 locked ${snapRoleLabel(role)}`
+                  text: (
+                    <>
+                      <LockIcon size={11} /> locked {snapRoleLabel(role)}
+                    </>
+                  )
                 })
                 return
               }
@@ -4292,7 +4308,14 @@ export function RobotView({
                 setBuildDim({
                   x: e.clientX - rect.left + 14,
                   y: e.clientY - rect.top + 14,
-                  text: lockedIndex !== null ? `🔒 locked ${snapRoleLabel(role)}` : `snap ✓ ${snapRoleLabel(role)}`
+                  text:
+                    lockedIndex !== null ? (
+                      <>
+                        <LockIcon size={11} /> locked {snapRoleLabel(role)}
+                      </>
+                    ) : (
+                      `snap ✓ ${snapRoleLabel(role)}`
+                    )
                 })
               } else {
                 clearHoverMarker()

--- a/src/renderer/src/components/SamInstrument.tsx
+++ b/src/renderer/src/components/SamInstrument.tsx
@@ -6,6 +6,7 @@ import { useBoards } from './use-boards'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { useInstrumentWorkspace } from '../store/workspace'
 import { SAM_DEMO, SAM_DEMO_NAME } from './sam-demo'
+import { SpeakerIcon } from './ui-icons'
 import './SamInstrument.css'
 
 /**
@@ -164,7 +165,15 @@ export function SamInstrument({ def, onClose, docked = true, onToggleDock, float
             disabled={!connected || busy || !text.trim()}
             title={connected ? 'Speak the text via the buzzer pin (Ctrl/Cmd+Enter)' : 'Connect a board first'}
           >
-            {state === 'speaking' ? 'SPEAKING…' : state === 'installing' ? 'INSTALLING…' : '🔊 SPEAK'}
+            {state === 'speaking' ? (
+              'SPEAKING…'
+            ) : state === 'installing' ? (
+              'INSTALLING…'
+            ) : (
+              <>
+                <SpeakerIcon size={13} /> SPEAK
+              </>
+            )}
           </button>
         </div>
 

--- a/src/renderer/src/components/SettingsDialog.tsx
+++ b/src/renderer/src/components/SettingsDialog.tsx
@@ -10,6 +10,7 @@ import { EDITOR_THEME_LIST } from '../store/editorThemes'
 import { useFocusTrap } from '../hooks/useFocusTrap'
 import type { Theme } from '../hooks/useTheme'
 import { ChatSettings } from './ChatSettings'
+import { BulbIcon } from './ui-icons'
 import './SettingsDialog.css'
 
 /**
@@ -200,7 +201,8 @@ function AppearanceTab({
       <section className="settings-section">
         <h3 className="settings-section__title">Status bar tips</h3>
         <p className="settings-section__hint">
-          Rotate a 💡 discovery tip through the status bar when it has nothing else to say.
+          Rotate a <BulbIcon size={12} /> discovery tip through the status bar when it has nothing
+          else to say.
         </p>
         <label className="settings-check">
           <input

--- a/src/renderer/src/components/ShellPanel.tsx
+++ b/src/renderer/src/components/ShellPanel.tsx
@@ -8,6 +8,7 @@ import { useDiagnostics } from '../store/diagnostics'
 import { useConsole } from '../store/console'
 import { useLocalStorage } from '../hooks/useLocalStorage'
 import { SEND_CONSOLE_EVENT } from './ChatPanel'
+import { ChatIcon } from './ui-icons'
 import './RunControls.css'
 import './ShellPanel.css'
 
@@ -127,7 +128,7 @@ export function ShellPanel({ chatOpen = false }: ShellPanelProps): JSX.Element {
                 aria-label="Send console output to chat"
               >
                 <span className="btn__glyph" aria-hidden="true">
-                  💬
+                  <ChatIcon size={13} />
                 </span>
                 <span>Send to chat</span>
               </button>

--- a/src/renderer/src/components/StatusBar.tsx
+++ b/src/renderer/src/components/StatusBar.tsx
@@ -23,6 +23,7 @@ import {
 } from './status-tips'
 import { isVirtualPort, VIRTUAL_PORT_SHORT } from '../../../shared/virtual-device'
 import type { FirmwareCatalog, UpdateStatus } from '../../../preload/index.d'
+import { BulbIcon } from './ui-icons'
 import './StatusBar.css'
 
 /**
@@ -393,7 +394,7 @@ export function StatusBar({
                 if (tip.href) void window.api.openExternal(tip.href)
               }}
             >
-              <span aria-hidden="true">💡</span>
+              <BulbIcon size={11} />
               <span className="statusbar__tip-text">{tip.text}</span>
             </button>
           ) : (
@@ -402,7 +403,7 @@ export function StatusBar({
                 tipFaded ? ' statusbar__tip--faded' : ''
               }`}
             >
-              <span aria-hidden="true">💡</span>
+              <BulbIcon size={11} />
               <span className="statusbar__tip-text">{tip.text}</span>
             </span>
           ))}

--- a/src/renderer/src/components/TutorialPanel.tsx
+++ b/src/renderer/src/components/TutorialPanel.tsx
@@ -19,7 +19,7 @@ import { useWorkspace } from '../store/workspace'
 import { Markdown } from './Markdown'
 import { BuildChecklist } from './BuildChecklist'
 import type { Course, CourseTrack } from '../lib/courses'
-import { BulbIcon } from './ui-icons'
+import { BulbIcon, CourseIcon } from './ui-icons'
 import './Tutorials.css'
 
 const TRACK_LABEL: Record<CourseTrack, string> = {
@@ -74,7 +74,7 @@ export function TutorialPanel(): JSX.Element {
                     onClick={() => openCourse(c)}
                   >
                     <span className="tp__card-emoji" aria-hidden>
-                      {c.emoji}
+                      <CourseIcon emoji={c.emoji} size={30} />
                     </span>
                     <span className="tp__card-body">
                       <span className="tp__card-title">{c.title}</span>

--- a/src/renderer/src/components/TutorialPanel.tsx
+++ b/src/renderer/src/components/TutorialPanel.tsx
@@ -19,6 +19,7 @@ import { useWorkspace } from '../store/workspace'
 import { Markdown } from './Markdown'
 import { BuildChecklist } from './BuildChecklist'
 import type { Course, CourseTrack } from '../lib/courses'
+import { BulbIcon } from './ui-icons'
 import './Tutorials.css'
 
 const TRACK_LABEL: Record<CourseTrack, string> = {
@@ -142,7 +143,7 @@ export function TutorialPanel(): JSX.Element {
             {tipOpen && lesson?.tip && (
               <div className="tp__tip" role="note">
                 <span className="tp__tip-bulb" aria-hidden>
-                  💡
+                  <BulbIcon size={14} />
                 </span>
                 <Markdown source={lesson.tip} className="tp__tip-md" />
               </div>
@@ -170,7 +171,7 @@ export function TutorialPanel(): JSX.Element {
                   aria-label="Show a tip"
                   aria-pressed={tipOpen}
                 >
-                  💡
+                  <BulbIcon size={14} />
                 </button>
               )}
               <button

--- a/src/renderer/src/components/Tutorials.css
+++ b/src/renderer/src/components/Tutorials.css
@@ -68,6 +68,10 @@
   box-shadow: 0 8px 20px -12px rgba(0, 0, 0, 0.5);
 }
 .tp__card-emoji {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  /* Sizes the emoji fallback for a course whose glyph has no mapped icon. */
   font-size: 30px;
   line-height: 1;
   align-self: center;

--- a/src/renderer/src/components/ui-icons.tsx
+++ b/src/renderer/src/components/ui-icons.tsx
@@ -1,4 +1,5 @@
 import type { JSX } from 'react'
+import { ClosedBookIcon } from './help-icons'
 
 /**
  * Line icons for UI chrome that previously used emoji (#549).
@@ -217,6 +218,57 @@ export const SpeakerIcon = ({ size }: { size?: number }): JSX.Element =>
     ),
     size
   )
+
+/** A chick — the beginner course track. */
+export const ChickIcon = ({ size }: { size?: number }): JSX.Element =>
+  svg(
+    g(
+      <>
+        <circle cx="11.4" cy="14.6" r="5.6" />
+        <circle cx="11.4" cy="6.7" r="3.7" />
+        <path d="M14.9 6.3 17.7 7.4 14.9 8.5z" />
+        <circle cx="12.7" cy="6" r="0.9" fill="currentColor" stroke="none" />
+        <path d="M9.2 19.9 8.3 21.6M13.6 19.9 14.5 21.6" />
+      </>
+    ),
+    size
+  )
+
+/** A jointed robot arm — the URDF / robot-building course track. */
+export const ArmIcon = ({ size }: { size?: number }): JSX.Element =>
+  svg(
+    g(
+      <>
+        <path d="M4.8 20.8h6.6" />
+        <path d="M8.1 20.8v-4.6" />
+        <circle cx="8.1" cy="14.6" r="1.7" />
+        <path d="M9.3 13.4 13.1 9.6" />
+        <circle cx="14.3" cy="8.4" r="1.7" />
+        <path d="M15.5 7.2 17.4 5.3" />
+        <path d="M17.4 5.3 20.3 4.8M17.4 5.3 17.9 2.4" />
+      </>
+    ),
+    size
+  )
+
+/**
+ * Course-card thumbnail for the Learn panel (#549).
+ *
+ * Courses declare a thumbnail as an emoji in their `course.yml`, which is
+ * invisible on a Linux box with no emoji font. Map the ones we ship to icons;
+ * anything else falls back to the raw emoji so a course author using an
+ * unmapped glyph still gets whatever their platform can render.
+ */
+export const CourseIcon = ({ emoji, size }: { emoji: string; size?: number }): JSX.Element => {
+  const known: Record<string, ({ size }: { size?: number }) => JSX.Element> = {
+    '🐣': ChickIcon,
+    '🤖': RobotIcon,
+    '🦾': ArmIcon,
+    '📘': ClosedBookIcon
+  }
+  const Icon = known[emoji]
+  return Icon ? <Icon size={size} /> : <>{emoji}</>
+}
 
 /** A cylinder — the "add a tube" build primitive. */
 export const CylinderIcon = ({ size }: { size?: number }): JSX.Element =>

--- a/src/renderer/src/components/ui-icons.tsx
+++ b/src/renderer/src/components/ui-icons.tsx
@@ -219,6 +219,18 @@ export const SpeakerIcon = ({ size }: { size?: number }): JSX.Element =>
     size
   )
 
+/** A confetti burst — the build checklist's completion message (#436). */
+export const ConfettiIcon = ({ size }: { size?: number }): JSX.Element =>
+  svg(
+    g(
+      <>
+        <path d="M4 20.4 9.6 8.9l5.5 5.5z" />
+        <path d="M14.6 3.6v2.6M19.2 4.9l-1.8 1.8M20.8 9.6h-2.6M19.9 14.2l-1.9-1.1M15.5 10.6l1.1 1.9" />
+      </>
+    ),
+    size
+  )
+
 /** A chick — the beginner course track. */
 export const ChickIcon = ({ size }: { size?: number }): JSX.Element =>
   svg(

--- a/src/renderer/src/components/ui-icons.tsx
+++ b/src/renderer/src/components/ui-icons.tsx
@@ -1,0 +1,231 @@
+import type { JSX } from 'react'
+
+/**
+ * Line icons for UI chrome that previously used emoji (#549).
+ *
+ * Emoji render as tofu on Linux desktops with no colour-emoji font installed —
+ * Raspberry Pi OS ships none, so DejaVu Sans is the fallback and everything in
+ * the U+1F300+ plane is a blank box. These are plain SVG so they render the
+ * same everywhere.
+ *
+ * Same conventions as {@link file://./help-icons.tsx}: 24×24 viewBox, stroked
+ * with `currentColor` so callers tint them via CSS `color`, and `aria-hidden`
+ * because every call site already carries its own `title`/`aria-label`.
+ */
+
+const svg = (children: JSX.Element, extra?: number): JSX.Element => (
+  <svg width={extra ?? 16} height={extra ?? 16} viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+    {children}
+  </svg>
+)
+
+/** Stroke defaults shared by every icon below. */
+const g = (children: JSX.Element): JSX.Element => (
+  <g fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+    {children}
+  </g>
+)
+
+/** Parts flying apart — exploded view (#499). */
+export const ExplodeIcon = ({ size }: { size?: number }): JSX.Element =>
+  svg(
+    g(
+      <>
+        <rect x="9.5" y="9.5" width="5" height="5" rx="1" />
+        <path d="M8.2 8.2 4.6 4.6M15.8 8.2l3.6-3.6M8.2 15.8l-3.6 3.6M15.8 15.8l3.6 3.6" />
+        <path d="M4 8.2V4h4.2M20 8.2V4h-4.2M4 15.8V20h4.2M20 15.8V20h-4.2" />
+      </>
+    ),
+    size
+  )
+
+/** Clapperboard — save the animation as a video. */
+export const ClapperIcon = ({ size }: { size?: number }): JSX.Element =>
+  svg(
+    g(
+      <>
+        <rect x="3" y="9.4" width="18" height="10.6" rx="1.6" />
+        <path d="M3.2 6.2 20.3 3.5l.6 3.8L3.8 10z" />
+        <path d="M8.4 5.4 6.9 9.2M13.6 4.6 12.1 8.4M18.6 3.8 17.1 7.6" />
+      </>
+    ),
+    size
+  )
+
+/** A bone — Bone Mode skeleton overlay (#536). */
+export const BoneIcon = ({ size }: { size?: number }): JSX.Element =>
+  svg(
+    g(
+      <>
+        <path d="M8.2 15.8 15.8 8.2" strokeWidth="2.2" />
+        <circle cx="8.5" cy="18.5" r="2" />
+        <circle cx="5.5" cy="15.5" r="2" />
+        <circle cx="18.5" cy="8.5" r="2" />
+        <circle cx="15.5" cy="5.5" r="2" />
+      </>
+    ),
+    size
+  )
+
+/** Concentric target — the interactive IK goal (#540). */
+export const TargetIcon = ({ size }: { size?: number }): JSX.Element =>
+  svg(
+    g(
+      <>
+        <circle cx="12" cy="12" r="8" />
+        <circle cx="12" cy="12" r="4" />
+        <circle cx="12" cy="12" r="1.1" fill="currentColor" stroke="none" />
+      </>
+    ),
+    size
+  )
+
+/** Camera — Capture Pose (#540). */
+export const CameraIcon = ({ size }: { size?: number }): JSX.Element =>
+  svg(
+    g(
+      <>
+        <path d="M4 8.2h3.1l1.6-2.4h6.6l1.6 2.4H20a1.5 1.5 0 0 1 1.5 1.5v8a1.5 1.5 0 0 1-1.5 1.5H4a1.5 1.5 0 0 1-1.5-1.5v-8A1.5 1.5 0 0 1 4 8.2z" />
+        <circle cx="12" cy="13.4" r="3.4" />
+      </>
+    ),
+    size
+  )
+
+/** Ruler — the measure HUD readout. */
+export const RulerIcon = ({ size }: { size?: number }): JSX.Element =>
+  svg(
+    g(
+      <>
+        <rect x="2.5" y="8.6" width="19" height="6.8" rx="1.2" />
+        <path d="M6.6 8.6v3M10.1 8.6v4.2M13.6 8.6v3M17.1 8.6v4.2" />
+      </>
+    ),
+    size
+  )
+
+/** Lightbulb — discovery tips (#434) and tutorial tips. */
+export const BulbIcon = ({ size }: { size?: number }): JSX.Element =>
+  svg(
+    g(
+      <>
+        <path d="M12 3.2a6 6 0 0 0-3.5 10.9c.5.4.8 1 .8 1.6v.4h5.4v-.4c0-.6.3-1.2.8-1.6A6 6 0 0 0 12 3.2z" />
+        <path d="M9.9 18.5h4.2M10.6 20.8h2.8" />
+      </>
+    ),
+    size
+  )
+
+/** An open folder — "Open…" buttons. */
+export const FolderOpenIcon = ({ size }: { size?: number }): JSX.Element =>
+  svg(
+    g(
+      <>
+        <path d="M3 18.5V5.9A1.4 1.4 0 0 1 4.4 4.5h4.1l2 2.6h6.6a1.4 1.4 0 0 1 1.4 1.4v1.3" />
+        <path d="M3.3 19.2 6 11.6a1.2 1.2 0 0 1 1.1-.8h13.6a.9.9 0 0 1 .85 1.2l-2.5 7a1.2 1.2 0 0 1-1.1.8H4.4a1.2 1.2 0 0 1-1.1-1.6z" />
+      </>
+    ),
+    size
+  )
+
+/** Trophy — the build checklist, complete (#436). */
+export const TrophyIcon = ({ size }: { size?: number }): JSX.Element =>
+  svg(
+    g(
+      <>
+        <path d="M8 4.2h8v4.9a4 4 0 0 1-8 0z" />
+        <path d="M8 5.8H5.4v1.3a3.1 3.1 0 0 0 3 3.1M16 5.8h2.6v1.3a3.1 3.1 0 0 1-3 3.1" />
+        <path d="M12 13.1v3.3" />
+        <path d="M9.6 16.4h4.8l.7 3.4H8.9z" />
+      </>
+    ),
+    size
+  )
+
+/** A robot head — the build checklist, in progress (#436). */
+export const RobotIcon = ({ size }: { size?: number }): JSX.Element =>
+  svg(
+    g(
+      <>
+        <rect x="4" y="8.2" width="16" height="11" rx="2.6" />
+        <path d="M12 8.2V5.4" />
+        <circle cx="12" cy="3.8" r="1.6" />
+        <path d="M2.4 12.2v3.2M21.6 12.2v3.2" />
+        <circle cx="9.2" cy="12.9" r="1.3" fill="currentColor" stroke="none" />
+        <circle cx="14.8" cy="12.9" r="1.3" fill="currentColor" stroke="none" />
+        <path d="M9.6 16.3h4.8" />
+      </>
+    ),
+    size
+  )
+
+/** Speech bubble — the shell's chat/ask affordance. */
+export const ChatIcon = ({ size }: { size?: number }): JSX.Element =>
+  svg(
+    g(
+      <path d="M20.5 12.2c0 3.8-3.8 6.9-8.5 6.9-1.1 0-2.1-.2-3.1-.5L4 20.4l1.4-3.5a6.5 6.5 0 0 1-1.9-4.7c0-3.8 3.8-6.9 8.5-6.9s8.5 3.1 8.5 6.9z" />
+    ),
+    size
+  )
+
+/** A closed padlock — a locked field in the Part Editor. */
+export const LockIcon = ({ size }: { size?: number }): JSX.Element =>
+  svg(
+    g(
+      <>
+        <rect x="4.9" y="10.6" width="14.2" height="9.4" rx="1.8" />
+        <path d="M8.3 10.6V7.9a3.7 3.7 0 0 1 7.4 0v2.7" />
+      </>
+    ),
+    size
+  )
+
+/** An open padlock — an unlocked field in the Part Editor. */
+export const UnlockIcon = ({ size }: { size?: number }): JSX.Element =>
+  svg(
+    g(
+      <>
+        <rect x="4.9" y="10.6" width="14.2" height="9.4" rx="1.8" />
+        <path d="M8.3 10.6V7.9a3.7 3.7 0 0 1 7.2-1.2" />
+      </>
+    ),
+    size
+  )
+
+/** A wastebasket — delete. */
+export const TrashIcon = ({ size }: { size?: number }): JSX.Element =>
+  svg(
+    g(
+      <>
+        <path d="M4.6 6.9h14.8" />
+        <path d="M9.6 6.9V4.7h4.8v2.2" />
+        <path d="M6.6 6.9l.85 12.2a1.5 1.5 0 0 0 1.5 1.4h6.1a1.5 1.5 0 0 0 1.5-1.4l.85-12.2" />
+        <path d="M10.3 10.4v6.4M13.7 10.4v6.4" />
+      </>
+    ),
+    size
+  )
+
+/** A speaker with waves — SAM's SPEAK button. */
+export const SpeakerIcon = ({ size }: { size?: number }): JSX.Element =>
+  svg(
+    g(
+      <>
+        <path d="M3.5 9.4h3.4L11.4 5.5v13L6.9 14.6H3.5z" />
+        <path d="M15 9.3a4 4 0 0 1 0 5.4M17.9 6.7a7.8 7.8 0 0 1 0 10.6" />
+      </>
+    ),
+    size
+  )
+
+/** A cylinder — the "add a tube" build primitive. */
+export const CylinderIcon = ({ size }: { size?: number }): JSX.Element =>
+  svg(
+    g(
+      <>
+        <ellipse cx="12" cy="6.6" rx="7" ry="2.8" />
+        <path d="M5 6.6v10.8c0 1.55 3.13 2.8 7 2.8s7-1.25 7-2.8V6.6" />
+      </>
+    ),
+    size
+  )


### PR DESCRIPTION
Fixes #549.

Raspberry Pi OS ships **no colour-emoji font**, so DejaVu Sans is the fallback
and every glyph in the U+1F300+ plane renders as a blank box. Most visible on
the 🦴 Bone Mode and 💥 exploded-view buttons added in 0.33.0.

## Scope

Rather than replace emoji wholesale, each glyph was checked against DejaVu's
cmap. Only **20 of the ~34** distinct glyphs in the renderer actually break:

- **Replaced** — the U+1F300+ plane plus ⬭ (U+2B2D)
- **Left as text** — `✓ ✕ ⚙ ⚠ ★ ☰ ⚡ ☕ ✂ ▦ ●` and the arrows; DejaVu covers
  these, so swapping them would be churn with no rendering fix
- **Left alone** — emoji in comments/JSDoc (invisible), the 🎉 in the build
  checklist's congratulations sentence, and the 🔒 inside the Robot View snap
  tooltip *string* (would need that call site restructured to accept JSX)

## Changes

New `ui-icons.tsx` following the existing `help-icons.tsx` conventions — 24×24
viewBox, `currentColor`, `aria-hidden` since every call site already carries
its own `title`/`aria-label`. `HelpPanel` reuses the existing book icons rather
than adding new art.

Covers: Robot View toolbar (exploded view, save video, Bone Mode, IK goal,
Capture Pose, measure readout), status-bar + tutorial tip bulbs, Part Editor
lock/unlock and delete, build checklist header, the "Open…" buttons, Help Panel
doc links, the shell's "Send to chat", SAM's SPEAK button, the build toolbar's
tube primitive, and the Learn-panel course thumbnails.

Course cards keep `emoji:` as the authored `course.yml` format but resolve it
through a `CourseIcon` map, falling back to the raw glyph for an unmapped value
so third-party course files keep working.

## Verification

Driven in the web build under **headless Chromium, which likewise has no emoji
font** — so it reproduces the reported conditions rather than approximating them.

| Surface | Result |
|---|---|
| Robot View toolbar | explode, clapper, bone, target, camera — all render an SVG, no text |
| Build toolbar | cylinder now SVG; ▦ ● correctly still text |
| Learn course cards | all three render an SVG |
| Learn / Help / Settings / Packages | scan clean for U+1F300+ text nodes |
| Both themes | `currentColor` inherits — dark + skeuomorph, incl. gold active states |

Visual review caught two things code review would not have: the first bone icon's
lobes overlapped into a single blob (read as a dumbbell), and the arm's
end-effector read as a mallet head. Both reshaped and re-verified.

`lint` / `typecheck` / `test` (1926 passing) / `build` / `build:web` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)