### PR TITLE
feat: mesh volume + true centroid for mass estimation (#552, epic #535 §1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Mesh volume + true centroid for mass estimation (#552, epic #535 §1).** New
+  pure module `robot-mass-geometry.ts` computing a mesh's volume and its
+  *volumetric* centroid by the divergence theorem, plus a watertight check.
+  Volume × a material density preset (PLA/PETG/ABS/resin) × an infill factor
+  gives the estimated grams a printed link weighs. Meshes with holes have no
+  well-defined interior, so the estimate degrades deliberately — mesh → convex
+  hull → bounding box — and reports which method it used so the UI can label an
+  estimate honestly rather than quietly showing a wrong number. Note this is
+  *not* the bounding-box "centroid" the exploded view uses, which is visibly
+  wrong for asymmetric parts like a servo with a horn.
+
 ## [0.33.1] - 2026-07-18
 
 ### Fixed

--- a/src/renderer/src/components/robot-mass-geometry.ts
+++ b/src/renderer/src/components/robot-mass-geometry.ts
@@ -1,0 +1,302 @@
+/**
+ * MESH VOLUME + TRUE CENTROID (#552, epic #535 §1) — the geometry half of "how
+ * heavy is this link?".
+ *
+ * Mass estimation needs two numbers from a mesh: its VOLUME (multiplied by a
+ * material density and an infill factor to get grams) and its true volumetric
+ * CENTROID (where that mass acts, for centre-of-mass maths).
+ *
+ * Both come from the divergence theorem: fan every triangle to the origin and
+ * sum the signed tetrahedron volumes. Triangles facing away contribute negative
+ * volume and cancel the overhang exactly, so a closed surface gives the right
+ * answer regardless of how it is tessellated — and the winding direction only
+ * flips the sign, which cancels in the centroid's division.
+ *
+ * That identity holds ONLY for a closed surface. A mesh with holes has no
+ * well-defined interior, so the sum is meaningless rather than merely
+ * imprecise. Hence {@link isWatertight} gates it, and {@link massGeometry}
+ * degrades deliberately: mesh -> convex hull -> bounding box, reporting which
+ * one it used so callers can label an estimate honestly.
+ *
+ * NOTE this is deliberately NOT the "centroid" the exploded view computes
+ * (`robot-explode.ts`, `RobotView.tsx`) — that one is a bounding-box centre,
+ * which is visibly wrong for an asymmetric part like a servo with a horn. Do
+ * not conflate them.
+ *
+ * The core maths is pure and dependency-free (arrays in, numbers out) so it
+ * unit-tests without a renderer, following `robot-holes.ts`. Only the convex
+ * hull fallback reaches for three.js, which already runs fine under vitest.
+ *
+ * UNITS: everything is in the cubic units of the positions handed in. A URDF
+ * mesh is metres, a raw STL is usually millimetres — callers apply `meshScale`
+ * / `meshUnits` and convert to cm3 before multiplying by a g/cm3 density.
+ */
+import { Vector3 } from 'three'
+import { ConvexHull } from 'three/examples/jsm/math/ConvexHull.js'
+
+export type Vec3 = [number, number, number]
+
+/** Which computation produced a {@link MassGeometry} — drives the UI's honesty. */
+export type MassGeometryMethod =
+  /** Closed mesh, exact volume + centroid. */
+  | 'mesh'
+  /** Mesh had holes; convex hull stood in. Over-estimates concave parts. */
+  | 'hull'
+  /** Hull unavailable too (degenerate//coplanar input); bounding box stood in. */
+  | 'bbox'
+  /** No usable triangles at all — volume 0, centroid at the origin. */
+  | 'empty'
+
+export interface MassGeometry {
+  /** Volume, in the cubed units of the input positions. Never negative. */
+  volume: number
+  /** Volumetric centroid, in the mesh's LOCAL frame. */
+  centroid: Vec3
+  method: MassGeometryMethod
+  /** Whether the source mesh was a closed surface. */
+  watertight: boolean
+}
+
+/**
+ * Triangle vertex positions, flat `[x,y,z, x,y,z, …]`, optionally indexed —
+ * matching a three.js BufferGeometry's `position` / `index` attributes, which
+ * is what both STLLoader and ColladaLoader hand back.
+ */
+export interface MeshTriangles {
+  positions: ArrayLike<number>
+  index?: ArrayLike<number> | null
+}
+
+/** Number of triangles described by `positions`/`index`. */
+const triangleCount = ({ positions, index }: MeshTriangles): number =>
+  index ? Math.floor(index.length / 3) : Math.floor(positions.length / 9)
+
+/** Read triangle `t`'s three corners. */
+const triangleAt = ({ positions, index }: MeshTriangles, t: number): [Vec3, Vec3, Vec3] => {
+  const corner = (k: number): Vec3 => {
+    const v = index ? index[t * 3 + k] : t * 3 + k
+    return [positions[v * 3], positions[v * 3 + 1], positions[v * 3 + 2]]
+  }
+  return [corner(0), corner(1), corner(2)]
+}
+
+/**
+ * Weld vertices by QUANTISED position, not by index.
+ *
+ * An STL is a triangle soup: neighbouring faces repeat a shared corner as
+ * separate floats, so index-based edge matching would see every edge as
+ * unshared and call every mesh open. Quantising to a tolerance makes the
+ * duplicates collide into one id.
+ */
+const weldKey = (p: Vec3, tolerance: number): string => {
+  const q = (n: number): number => Math.round(n / tolerance)
+  // -0 and 0 quantise to different strings otherwise.
+  return `${q(p[0]) + 0},${q(p[1]) + 0},${q(p[2]) + 0}`
+}
+
+/**
+ * A closed surface has every edge shared by exactly two triangles. Anything
+ * else — a boundary edge used once, or a non-manifold edge used three or more
+ * times — means the volume integral has no meaning.
+ *
+ * `tolerance` is the vertex weld distance, in the input's units.
+ */
+export function isWatertight(mesh: MeshTriangles, tolerance = 1e-6): boolean {
+  const n = triangleCount(mesh)
+  if (n === 0) return false
+
+  const ids = new Map<string, number>()
+  const idOf = (p: Vec3): number => {
+    const k = weldKey(p, tolerance)
+    let id = ids.get(k)
+    if (id === undefined) {
+      id = ids.size
+      ids.set(k, id)
+    }
+    return id
+  }
+
+  const edges = new Map<string, number>()
+  for (let t = 0; t < n; t++) {
+    const [a, b, c] = triangleAt(mesh, t)
+    const tri = [idOf(a), idOf(b), idOf(c)]
+    // A degenerate triangle (two corners welded together) has a zero-length
+    // edge; it contributes no volume and would break the parity count.
+    if (tri[0] === tri[1] || tri[1] === tri[2] || tri[2] === tri[0]) continue
+    for (let k = 0; k < 3; k++) {
+      const u = tri[k]
+      const v = tri[(k + 1) % 3]
+      const key = u < v ? `${u}_${v}` : `${v}_${u}`
+      edges.set(key, (edges.get(key) ?? 0) + 1)
+    }
+  }
+  if (edges.size === 0) return false
+  for (const count of edges.values()) if (count !== 2) return false
+  return true
+}
+
+/**
+ * Signed volume and volumetric centroid by the divergence theorem.
+ *
+ * Each triangle forms a tetrahedron with the origin: signed volume
+ * `a · (b × c) / 6`, centroid `(a + b + c + origin) / 4`. Summing the
+ * volume-weighted centroids and dividing by the total gives the solid's
+ * centroid — and because a flipped winding negates both sums, the centroid is
+ * winding-independent while the volume merely changes sign.
+ *
+ * Meaningful only for a closed surface; callers gate on {@link isWatertight}.
+ */
+export function signedVolumeAndCentroid(mesh: MeshTriangles): {
+  volume: number
+  centroid: Vec3
+} {
+  const n = triangleCount(mesh)
+  let vol = 0
+  let cx = 0
+  let cy = 0
+  let cz = 0
+
+  for (let t = 0; t < n; t++) {
+    const [a, b, c] = triangleAt(mesh, t)
+    // a · (b × c) / 6
+    const v =
+      (a[0] * (b[1] * c[2] - b[2] * c[1]) +
+        a[1] * (b[2] * c[0] - b[0] * c[2]) +
+        a[2] * (b[0] * c[1] - b[1] * c[0])) /
+      6
+    vol += v
+    // Tetrahedron centroid, apex at the origin.
+    cx += v * ((a[0] + b[0] + c[0]) / 4)
+    cy += v * ((a[1] + b[1] + c[1]) / 4)
+    cz += v * ((a[2] + b[2] + c[2]) / 4)
+  }
+
+  if (Math.abs(vol) < Number.EPSILON) return { volume: vol, centroid: [0, 0, 0] }
+  return { volume: vol, centroid: [cx / vol, cy / vol, cz / vol] }
+}
+
+/** Axis-aligned bounds, or null when there are no finite points. */
+const boundsOf = ({ positions }: MeshTriangles): { min: Vec3; max: Vec3 } | null => {
+  if (positions.length < 3) return null
+  const min: Vec3 = [Infinity, Infinity, Infinity]
+  const max: Vec3 = [-Infinity, -Infinity, -Infinity]
+  for (let i = 0; i + 2 < positions.length; i += 3) {
+    for (let k = 0; k < 3; k++) {
+      const c = positions[i + k]
+      if (!Number.isFinite(c)) return null
+      if (c < min[k]) min[k] = c
+      if (c > max[k]) max[k] = c
+    }
+  }
+  return { min, max }
+}
+
+/**
+ * Convex hull of the mesh's points, re-measured as a closed mesh.
+ *
+ * The hull is watertight by construction, so the same integral applies. It
+ * OVER-estimates anything concave (a bracket with a slot reads as solid), which
+ * is why it is a labelled fallback rather than a default.
+ *
+ * Returns null when the points are degenerate (fewer than four, or all
+ * coplanar) and no hull exists.
+ */
+const hullGeometry = (mesh: MeshTriangles): { volume: number; centroid: Vec3 } | null => {
+  const { positions } = mesh
+  if (positions.length < 12) return null // fewer than 4 points — no volume
+  const points: Vector3[] = []
+  for (let i = 0; i + 2 < positions.length; i += 3) {
+    points.push(new Vector3(positions[i], positions[i + 1], positions[i + 2]))
+  }
+  try {
+    const hull = new ConvexHull().setFromPoints(points)
+    const flat: number[] = []
+    for (const face of hull.faces) {
+      // Each face is a closed edge loop; fan-triangulate from its first vertex.
+      const loop: Vector3[] = []
+      let edge = face.edge
+      do {
+        loop.push(edge.head().point)
+        edge = edge.next
+      } while (edge !== face.edge)
+      for (let k = 1; k + 1 < loop.length; k++) {
+        flat.push(
+          loop[0].x, loop[0].y, loop[0].z,
+          loop[k].x, loop[k].y, loop[k].z,
+          loop[k + 1].x, loop[k + 1].y, loop[k + 1].z
+        )
+      }
+    }
+    if (flat.length < 9) return null
+    const { volume, centroid } = signedVolumeAndCentroid({ positions: flat })
+    if (!Number.isFinite(volume) || Math.abs(volume) < Number.EPSILON) return null
+    return { volume: Math.abs(volume), centroid }
+  } catch {
+    // ConvexHull throws on fully degenerate input rather than returning empty.
+    return null
+  }
+}
+
+/**
+ * Volume + centroid for a link's mesh, degrading deliberately and reporting how.
+ *
+ * `mesh` -> closed surface, exact. `hull` -> had holes, convex hull stood in
+ * (over-estimates concave shapes; warn the user). `bbox` -> not even a hull was
+ * possible, bounding box stood in (rough). `empty` -> nothing usable.
+ */
+export function massGeometry(mesh: MeshTriangles, tolerance = 1e-6): MassGeometry {
+  if (triangleCount(mesh) === 0) {
+    return { volume: 0, centroid: [0, 0, 0], method: 'empty', watertight: false }
+  }
+
+  const watertight = isWatertight(mesh, tolerance)
+  if (watertight) {
+    const { volume, centroid } = signedVolumeAndCentroid(mesh)
+    if (Number.isFinite(volume) && Math.abs(volume) > Number.EPSILON) {
+      return { volume: Math.abs(volume), centroid, method: 'mesh', watertight: true }
+    }
+  }
+
+  const hull = hullGeometry(mesh)
+  if (hull) return { ...hull, method: 'hull', watertight }
+
+  const b = boundsOf(mesh)
+  if (b) {
+    const dx = b.max[0] - b.min[0]
+    const dy = b.max[1] - b.min[1]
+    const dz = b.max[2] - b.min[2]
+    return {
+      volume: Math.abs(dx * dy * dz),
+      centroid: [(b.min[0] + b.max[0]) / 2, (b.min[1] + b.max[1]) / 2, (b.min[2] + b.max[2]) / 2],
+      method: 'bbox',
+      watertight
+    }
+  }
+
+  return { volume: 0, centroid: [0, 0, 0], method: 'empty', watertight }
+}
+
+/** Cubic millimetres in a cubic centimetre — densities are quoted per cm3. */
+export const MM3_PER_CM3 = 1000
+
+/**
+ * Grams for a printed part: volume x density x infill.
+ *
+ * `volumeMm3` in mm3, `densityGCm3` from a material preset (PLA 1.24, PETG
+ * 1.27, ABS 1.04, resin ~1.1). `infill` is a 0..1 solidity factor — a printed
+ * part is mostly air, and infill dominates real mass, so this is an ESTIMATE
+ * and the UI must say so. A measured mass always wins.
+ */
+export function estimateMassGrams(volumeMm3: number, densityGCm3: number, infill = 1): number {
+  if (!Number.isFinite(volumeMm3) || volumeMm3 <= 0) return 0
+  const clamped = Math.min(Math.max(infill, 0), 1)
+  return (volumeMm3 / MM3_PER_CM3) * densityGCm3 * clamped
+}
+
+/** Material density presets in g/cm3 (#535 §1). */
+export const MATERIAL_DENSITY_G_CM3: Readonly<Record<string, number>> = Object.freeze({
+  PLA: 1.24,
+  PETG: 1.27,
+  ABS: 1.04,
+  Resin: 1.1
+})

--- a/test/robotMassGeometry.test.ts
+++ b/test/robotMassGeometry.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MATERIAL_DENSITY_G_CM3,
+  estimateMassGrams,
+  isWatertight,
+  massGeometry,
+  signedVolumeAndCentroid,
+  type MeshTriangles,
+  type Vec3
+} from '../src/renderer/src/components/robot-mass-geometry'
+
+/**
+ * Shapes with volumes and centroids known ANALYTICALLY, so the tests check the
+ * maths rather than just pinning whatever the code happens to return.
+ */
+
+/** Axis-aligned box as 12 triangles, corner at `min`, size `size`. */
+function boxMesh(min: Vec3, size: Vec3): MeshTriangles {
+  const [x, y, z] = min
+  const [w, h, d] = size
+  const v: Vec3[] = [
+    [x, y, z],
+    [x + w, y, z],
+    [x + w, y + h, z],
+    [x, y + h, z],
+    [x, y, z + d],
+    [x + w, y, z + d],
+    [x + w, y + h, z + d],
+    [x, y + h, z + d]
+  ]
+  // Outward winding (counter-clockwise seen from outside).
+  const faces: Array<[number, number, number]> = [
+    [0, 2, 1], [0, 3, 2], // -z
+    [4, 5, 6], [4, 6, 7], // +z
+    [0, 1, 5], [0, 5, 4], // -y
+    [3, 7, 6], [3, 6, 2], // +y
+    [0, 4, 7], [0, 7, 3], // -x
+    [1, 2, 6], [1, 6, 5] //  +x
+  ]
+  const positions: number[] = []
+  for (const [a, b, c] of faces) positions.push(...v[a], ...v[b], ...v[c])
+  return { positions }
+}
+
+/** Regular tetrahedron on the given corners. */
+function tetraMesh(a: Vec3, b: Vec3, c: Vec3, d: Vec3): MeshTriangles {
+  const positions: number[] = []
+  for (const [p, q, r] of [
+    [a, c, b],
+    [a, b, d],
+    [b, c, d],
+    [c, a, d]
+  ] as Array<[Vec3, Vec3, Vec3]>) {
+    positions.push(...p, ...q, ...r)
+  }
+  return { positions }
+}
+
+const close = (got: number, want: number, tol = 1e-6): void => {
+  expect(Math.abs(got - want)).toBeLessThan(tol)
+}
+const closeVec = (got: Vec3, want: Vec3, tol = 1e-6): void => {
+  for (let i = 0; i < 3; i++) close(got[i], want[i], tol)
+}
+
+describe('isWatertight', () => {
+  it('accepts a closed box', () => {
+    expect(isWatertight(boxMesh([0, 0, 0], [2, 3, 4]))).toBe(true)
+  })
+
+  it('accepts a closed box built from a triangle SOUP with duplicated corners', () => {
+    // STLs repeat shared corners as separate floats; welding by position is
+    // what makes the edge-parity check work at all.
+    const box = boxMesh([0, 0, 0], [1, 1, 1])
+    expect(box.index).toBeUndefined()
+    expect(isWatertight(box)).toBe(true)
+  })
+
+  it('rejects a box with a face removed (a hole)', () => {
+    const box = boxMesh([0, 0, 0], [2, 2, 2])
+    const open = { positions: Array.from(box.positions).slice(0, -18) } // drop 2 tris
+    expect(isWatertight(open)).toBe(false)
+  })
+
+  it('rejects a single open triangle', () => {
+    expect(isWatertight({ positions: [0, 0, 0, 1, 0, 0, 0, 1, 0] })).toBe(false)
+  })
+
+  it('rejects an empty mesh', () => {
+    expect(isWatertight({ positions: [] })).toBe(false)
+  })
+})
+
+describe('signedVolumeAndCentroid', () => {
+  it('measures a unit cube at the origin', () => {
+    const { volume, centroid } = signedVolumeAndCentroid(boxMesh([0, 0, 0], [1, 1, 1]))
+    close(Math.abs(volume), 1)
+    closeVec(centroid, [0.5, 0.5, 0.5])
+  })
+
+  it('measures a box far from the origin (divergence theorem, not bbox)', () => {
+    const { volume, centroid } = signedVolumeAndCentroid(boxMesh([10, -4, 7], [2, 3, 4]))
+    close(Math.abs(volume), 24)
+    closeVec(centroid, [11, -2.5, 9])
+  })
+
+  it('measures a tetrahedron: V = 1/6 for the unit corner tetra', () => {
+    const { volume, centroid } = signedVolumeAndCentroid(
+      tetraMesh([0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1])
+    )
+    close(Math.abs(volume), 1 / 6)
+    closeVec(centroid, [0.25, 0.25, 0.25])
+  })
+
+  it('is winding-independent for the centroid, sign-flipped for the volume', () => {
+    const box = boxMesh([1, 2, 3], [2, 2, 2])
+    const flipped: number[] = []
+    const p = Array.from(box.positions)
+    // Reverse each triangle's winding.
+    for (let t = 0; t * 9 < p.length; t++) {
+      const s = t * 9
+      flipped.push(p[s], p[s + 1], p[s + 2], p[s + 6], p[s + 7], p[s + 8], p[s + 3], p[s + 4], p[s + 5])
+    }
+    const a = signedVolumeAndCentroid(box)
+    const b = signedVolumeAndCentroid({ positions: flipped })
+    close(a.volume, -b.volume)
+    closeVec(a.centroid, b.centroid)
+  })
+
+  it('reads an INDEXED mesh identically to the same soup', () => {
+    const box = boxMesh([0, 0, 0], [2, 2, 2])
+    const p = Array.from(box.positions)
+    const index = p.map((_, i) => i).filter((i) => i % 3 === 0).map((i) => i / 3)
+    const soup = signedVolumeAndCentroid(box)
+    const indexed = signedVolumeAndCentroid({ positions: p, index })
+    close(soup.volume, indexed.volume)
+    closeVec(soup.centroid, indexed.centroid)
+  })
+})
+
+describe('massGeometry', () => {
+  it('uses the exact mesh for a closed box', () => {
+    const g = massGeometry(boxMesh([0, 0, 0], [2, 2, 2]))
+    expect(g.method).toBe('mesh')
+    expect(g.watertight).toBe(true)
+    close(g.volume, 8)
+    closeVec(g.centroid, [1, 1, 1])
+  })
+
+  it('never reports a negative volume, whatever the winding', () => {
+    const box = boxMesh([0, 0, 0], [1, 2, 3])
+    const p = Array.from(box.positions)
+    const flipped: number[] = []
+    for (let t = 0; t * 9 < p.length; t++) {
+      const s = t * 9
+      flipped.push(p[s], p[s + 1], p[s + 2], p[s + 6], p[s + 7], p[s + 8], p[s + 3], p[s + 4], p[s + 5])
+    }
+    expect(massGeometry({ positions: flipped }).volume).toBeGreaterThan(0)
+  })
+
+  it('falls back to the convex hull when the mesh has holes', () => {
+    const box = boxMesh([0, 0, 0], [2, 2, 2])
+    const open = { positions: Array.from(box.positions).slice(0, -18) }
+    const g = massGeometry(open)
+    expect(g.method).toBe('hull')
+    expect(g.watertight).toBe(false)
+    // The hull of a box-minus-a-face is still the box.
+    close(g.volume, 8, 1e-4)
+  })
+
+  it('falls back to the bounding box for coplanar input (no hull exists)', () => {
+    // A flat sheet: hull is degenerate, bbox volume is zero but well-defined.
+    const g = massGeometry({
+      positions: [0, 0, 0, 4, 0, 0, 4, 3, 0, 0, 0, 0, 4, 3, 0, 0, 3, 0]
+    })
+    expect(g.method).toBe('bbox')
+    expect(g.watertight).toBe(false)
+    closeVec(g.centroid, [2, 1.5, 0])
+  })
+
+  it('reports empty for a mesh with no triangles', () => {
+    const g = massGeometry({ positions: [] })
+    expect(g.method).toBe('empty')
+    expect(g.volume).toBe(0)
+  })
+
+  it('sums two disjoint solids — both are closed, so the mesh path still applies', () => {
+    const a = boxMesh([0, 0, 0], [1, 1, 1]) // V=1, centre (0.5,0.5,0.5)
+    const b = boxMesh([9, 0, 0], [1, 1, 1]) // V=1, centre (9.5,0.5,0.5)
+    const g = massGeometry({ positions: [...Array.from(a.positions), ...Array.from(b.positions)] })
+    expect(g.method).toBe('mesh')
+    close(g.volume, 2)
+    closeVec(g.centroid, [5, 0.5, 0.5]) // midway — equal masses
+  })
+
+  it('the hull genuinely OVER-estimates a concave shape — why it is labelled', () => {
+    // Two boxes far apart span a large empty gap. Their true combined volume is
+    // 2; the convex hull swallows the gap and is an order of magnitude bigger.
+    const a = boxMesh([0, 0, 0], [1, 1, 1])
+    const b = boxMesh([9, 0, 0], [1, 1, 1])
+    const both = [...Array.from(a.positions), ...Array.from(b.positions)]
+    const trueVolume = massGeometry({ positions: both }).volume
+    close(trueVolume, 2)
+
+    // Punch a hole so the closed-mesh path is unavailable and the hull stands in.
+    const holed = { positions: both.slice(0, -18) }
+    const g = massGeometry(holed)
+    expect(g.method).toBe('hull')
+    expect(g.volume).toBeGreaterThan(trueVolume * 4)
+  })
+
+  it('centroid of an asymmetric solid is mass-weighted, NOT the bounding-box centre', () => {
+    // The property this whole module exists for: a big block beside a small one
+    // pulls the centroid toward the big block, while a bbox centre sits midway.
+    const big = boxMesh([0, 0, 0], [4, 4, 4]) // V=64, centre x=2
+    const small = boxMesh([8, 0, 0], [1, 4, 4]) // V=16, centre x=8.5
+    const g = massGeometry({
+      positions: [...Array.from(big.positions), ...Array.from(small.positions)]
+    })
+    expect(g.method).toBe('mesh')
+    close(g.volume, 80)
+    // (64*2 + 16*8.5) / 80 = 3.3
+    close(g.centroid[0], 3.3, 1e-6)
+    // The bounding box spans x 0..9, so its centre would be 4.5 — clearly different.
+    expect(Math.abs(g.centroid[0] - 4.5)).toBeGreaterThan(1)
+  })
+})
+
+describe('estimateMassGrams', () => {
+  it('converts mm3 x density x infill to grams', () => {
+    // 1000 mm3 = 1 cm3; PLA at 100% infill = 1.24 g.
+    close(estimateMassGrams(1000, MATERIAL_DENSITY_G_CM3.PLA, 1), 1.24)
+    close(estimateMassGrams(1000, MATERIAL_DENSITY_G_CM3.PLA, 0.2), 0.248)
+  })
+
+  it('clamps infill to 0..1 and rejects nonsense volumes', () => {
+    close(estimateMassGrams(1000, 1.24, 5), 1.24)
+    expect(estimateMassGrams(1000, 1.24, -1)).toBe(0)
+    expect(estimateMassGrams(-5, 1.24, 1)).toBe(0)
+    expect(estimateMassGrams(Number.NaN, 1.24, 1)).toBe(0)
+  })
+
+  it('ships the documented material presets', () => {
+    expect(MATERIAL_DENSITY_G_CM3.PLA).toBe(1.24)
+    expect(MATERIAL_DENSITY_G_CM3.PETG).toBe(1.27)
+    expect(MATERIAL_DENSITY_G_CM3.ABS).toBe(1.04)
+  })
+})


### PR DESCRIPTION
Closes #552. First of eight sub-issues under epic #535 (Mass, Centre of Gravity & Stability).

Mass estimation needs two numbers from a link's mesh: its **volume** (× material
density × infill = grams) and its true **volumetric centroid** (where that mass
acts, for the CoM maths in §2).

## Approach

Both come from the divergence theorem — fan every triangle to the origin and sum
the signed tetrahedron volumes. Triangles facing away contribute negative volume
and cancel the overhang exactly, so the answer is independent of how the mesh is
tessellated. Winding direction only flips the sign, which cancels in the
centroid's division.

That identity holds **only for a closed surface**. A mesh with holes has no
well-defined interior, so the sum is meaningless rather than merely imprecise.
Hence `isWatertight()` gates it and `massGeometry()` degrades deliberately:

| Method | When | Caveat |
|---|---|---|
| `mesh` | closed surface | exact |
| `hull` | has holes | over-estimates concave parts |
| `bbox` | no hull possible (coplanar) | rough |
| `empty` | no usable triangles | volume 0 |

It **reports which method it used**, so the UI can label an estimate honestly
instead of showing a confident wrong number.

## Notes

- **Deliberately not** reusing the exploded view's per-link "centroid"
  (`robot-explode.ts`, `RobotView.tsx:2564-2572`) — that is a *bounding-box*
  centre, visibly wrong for an asymmetric part like a servo with a horn. A test
  pins the distinction: a big block beside a small one puts the true centroid at
  x=3.3 where the bbox centre would be 4.5.
- **Watertightness welds by quantised position, not index.** An STL is a triangle
  soup that repeats shared corners as separate floats, so index-based edge
  matching would report every mesh as open.
- **Core maths is dependency-free** (arrays in, numbers out) so it unit-tests
  without a renderer, following `robot-holes.ts`. Only the hull fallback imports
  three.js — its `ConvexHull` is already present and runs fine under vitest, so
  no new dependency and no hand-rolled quickhull.
- **Units** are the cubed units of the input positions, documented rather than
  assumed — a URDF mesh is metres, a raw STL usually millimetres, and callers
  already hold `meshScale`/`meshUnits`.

## Tests

21 tests against **analytically known** shapes rather than pinned outputs: unit
cube, corner tetrahedron (V = 1/6), boxes offset from the origin (proving it is
an integral, not a bbox), winding independence, indexed vs soup equivalence,
disjoint solids, genuine hull over-estimation, and the infill/density conversion.

`lint` / `typecheck` / `test` (1947 passing) / `build` / `build:web` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)