### PR TITLE
feat: parts carry a real mass — mass_g + com_xyz (#554, epic #535 §1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Parts carry a real mass (#554, epic #535 §1).** Part definitions gain a
+  `mass_g` field (grams) plus optional `com_xyz` (centre of mass, mm) for
+  lopsided parts, round-tripped through `parts.yml`. The heaviest robot parts —
+  servos, motors, batteries, boards — aren't printed, so their weight can't be
+  estimated from mesh volume; now they carry a measured figure. The bundled
+  standard library ships real masses for the SG90 (9 g), HC-SR04 (8.5 g) and the
+  Pico family (3 g); parts whose mass varies too much to pin are left unset and
+  fall back to a volume estimate.
 - **URDF `<inertial>` read/write round-trip (#553, epic #535 §1).** Snakie's URDF
   layer can now read and write per-link mass + centre-of-mass as standard URDF
   `<inertial>` tags (`readInertial`/`setInertial`/`removeInertial`), so mass data

--- a/examples/parts/snakie-basics/pico-2w/parts.yml
+++ b/examples/parts/snakie-basics/pico-2w/parts.yml
@@ -1,4 +1,5 @@
 id: pico-2w
+mass_g: 3
 name: Raspberry Pi Pico 2 W
 description: RP2350 microcontroller board with CYW43439 wireless.
 manufacturer: Raspberry Pi

--- a/examples/parts/snakie-standard/hr-sr04/parts.yml
+++ b/examples/parts/snakie-standard/hr-sr04/parts.yml
@@ -1,4 +1,5 @@
 id: hr-sr04
+mass_g: 8.5
 help: help.md
 name: HR SR04
 manufacturer: Generic

--- a/examples/parts/snakie-standard/pico-w/parts.yml
+++ b/examples/parts/snakie-standard/pico-w/parts.yml
@@ -1,4 +1,5 @@
 id: pico-w
+mass_g: 3
 help: help.md
 name: Raspberry Pi Pico W
 description: RP2040 microcontroller board with CYW43439 2.4GHz wireless (Wi-Fi / BLE).

--- a/examples/parts/snakie-standard/pico/parts.yml
+++ b/examples/parts/snakie-standard/pico/parts.yml
@@ -1,4 +1,5 @@
 id: pico
+mass_g: 3
 help: help.md
 name: Raspberry Pi Pico
 description: RP2040 microcontroller board (40-pin, same header layout as the Pico W / 2 W).

--- a/examples/parts/snakie-standard/pico2w/parts.yml
+++ b/examples/parts/snakie-standard/pico2w/parts.yml
@@ -1,4 +1,5 @@
 id: pico2w
+mass_g: 3
 help: help.md
 name: Raspberry Pi Pico 2 W
 description: RP2350 microcontroller board with CYW43439 2.4GHz wireless (Wi-Fi / BLE).

--- a/examples/parts/snakie-standard/sg90/parts.yml
+++ b/examples/parts/snakie-standard/sg90/parts.yml
@@ -1,4 +1,5 @@
 id: sg90
+mass_g: 9
 name: SG90 Micro Servo
 description: 9g hobby micro servo, ~180° range, 50 Hz PWM control.
 manufacturer: TowerPro

--- a/src/renderer/src/components/part-editor.util.ts
+++ b/src/renderer/src/components/part-editor.util.ts
@@ -968,6 +968,18 @@ export function normalisePart(part: PartDefinition): PartDefinition {
   set('mesh', text(part.mesh))
   if (part.meshUnits === 'mm' || part.meshUnits === 'm') out.meshUnits = part.meshUnits
   if (typeof part.meshScale === 'number' && part.meshScale > 0) out.meshScale = part.meshScale
+  // Mass (grams) + optional CoM (mm) (#554). A non-positive mass is dropped, so
+  // "unset" and "zero" both mean fall back to a volume estimate downstream.
+  if (typeof part.mass_g === 'number' && Number.isFinite(part.mass_g) && part.mass_g > 0) {
+    out.mass_g = part.mass_g
+  }
+  if (
+    Array.isArray(part.com_xyz) &&
+    part.com_xyz.length === 3 &&
+    part.com_xyz.every((n) => typeof n === 'number' && Number.isFinite(n))
+  ) {
+    out.com_xyz = [part.com_xyz[0], part.com_xyz[1], part.com_xyz[2]]
+  }
   if (
     part.imageLayer &&
     [part.imageLayer.x, part.imageLayer.y, part.imageLayer.w, part.imageLayer.h].every(

--- a/src/shared/part-yaml.ts
+++ b/src/shared/part-yaml.ts
@@ -317,6 +317,9 @@ export function partToYaml(part: PartDefinition): string {
     mesh: part.mesh,
     meshUnits: part.meshUnits,
     meshScale: part.meshScale,
+    // Mass in grams + optional CoM in mm (#554).
+    mass_g: part.mass_g,
+    com_xyz: part.com_xyz,
     schematic: part.schematic,
     i2cAddresses: part.i2cAddresses,
     library: part.library,
@@ -530,6 +533,16 @@ export function partFromYaml(text: string): PartDefinition {
   const meshUnits = str(raw.meshUnits)
   if (meshUnits === 'mm' || meshUnits === 'm') assign('meshUnits', meshUnits)
   assign('meshScale', num(raw.meshScale))
+  // Mass in grams (#554); ignore non-positive/garbage so a bad file doesn't
+  // poison the CoM maths downstream.
+  const massG = num(raw.mass_g)
+  if (massG !== undefined && massG > 0) assign('mass_g', massG)
+  if (Array.isArray(raw.com_xyz) && raw.com_xyz.length === 3) {
+    const v = raw.com_xyz.map(num)
+    if (v.every((n): n is number => n !== undefined)) {
+      assign('com_xyz', [v[0], v[1], v[2]])
+    }
+  }
   if (raw.imageLayer && typeof raw.imageLayer === 'object') {
     const il = raw.imageLayer as Record<string, unknown>
     const x = num(il.x)

--- a/src/shared/part.ts
+++ b/src/shared/part.ts
@@ -510,6 +510,25 @@ export interface PartDefinition {
    */
   meshScale?: number
 
+  // --- Mass / centre of mass (#554, epic #535 §1) --------------------------
+  /**
+   * Real mass in **grams**, for the heavy off-the-shelf parts (servos, motors,
+   * batteries, boards) whose weight can't be estimated from a print — a printed
+   * link estimates its mass from mesh volume, but an SG90 is 9 g of gearbox no
+   * volume estimate can reach. Populated for bundled library parts where known.
+   * Absent ⇒ the link falls back to a volume estimate (or a manual override).
+   *
+   * When a part is placed, this flows into the URDF `<mass>` (converted to kg)
+   * and thence into `skeleton.json`'s `mass_g`.
+   */
+  mass_g?: number
+  /**
+   * Centre of mass in the part's own frame, **millimetres**, for lopsided parts
+   * whose real CoM isn't the mesh/body centroid (a geared motor's mass sits over
+   * its gearbox, not its centre). Absent ⇒ use the computed centroid.
+   */
+  com_xyz?: [number, number, number]
+
   // --- Editor display state (persisted) ------------------------------------
   /**
    * Which layers are shown when the part is drawn (Part Editor, Parts Library

--- a/test/partExamples.test.ts
+++ b/test/partExamples.test.ts
@@ -60,6 +60,15 @@ describe('example parts library', () => {
     expect(reg.libraries.map((l) => l.id)).toContain('snakie-basics')
     expect(reg.libraries[0].repo).toMatch(/^https?:\/\//)
   })
+
+  it.each([
+    ['snakie-standard', 'sg90', 9],
+    ['snakie-standard', 'hr-sr04', 8.5],
+    ['snakie-standard', 'pico', 3]
+  ])('%s/%s ships a real mass_g of %d grams (#554)', (lib, id, grams) => {
+    const part = partFromYaml(read(lib, id, 'parts.yml'))
+    expect(part.mass_g).toBe(grams)
+  })
 })
 
 describe('standard parts library (snakie-standard)', () => {

--- a/test/partYaml.test.ts
+++ b/test/partYaml.test.ts
@@ -560,4 +560,37 @@ describe('component rotation round-trip', () => {
     expect(back.shapes?.[0].rotation).toBeUndefined()
     expect(back.labels?.[0].rotation).toBeUndefined()
   })
+
+  describe('mass_g + com_xyz (#554)', () => {
+    const withMass = (extra: Partial<PartDefinition>): PartDefinition =>
+      partFromYaml(
+        partToYaml(normalisePart({ id: 'm', name: 'M', ...extra } as PartDefinition))
+      )
+
+    it('round-trips mass_g in grams', () => {
+      expect(withMass({ mass_g: 9 }).mass_g).toBe(9)
+      expect(withMass({ mass_g: 8.5 }).mass_g).toBe(8.5)
+    })
+
+    it('round-trips com_xyz as a 3-tuple in mm', () => {
+      expect(withMass({ com_xyz: [1, -2, 3.5] }).com_xyz).toEqual([1, -2, 3.5])
+    })
+
+    it('omits both when absent (no churn on parts without mass)', () => {
+      const yaml = partToYaml(normalisePart({ id: 'm', name: 'M' } as PartDefinition))
+      expect(yaml).not.toContain('mass_g')
+      expect(yaml).not.toContain('com_xyz')
+    })
+
+    it('ignores a non-positive or unparseable mass rather than storing it', () => {
+      expect(partFromYaml('id: m\nname: M\nmass_g: 0\n').mass_g).toBeUndefined()
+      expect(partFromYaml('id: m\nname: M\nmass_g: -5\n').mass_g).toBeUndefined()
+      expect(partFromYaml('id: m\nname: M\nmass_g: heavy\n').mass_g).toBeUndefined()
+    })
+
+    it('ignores a malformed com_xyz (wrong length or non-numeric)', () => {
+      expect(partFromYaml('id: m\nname: M\ncom_xyz: [1, 2]\n').com_xyz).toBeUndefined()
+      expect(partFromYaml('id: m\nname: M\ncom_xyz: [1, x, 3]\n').com_xyz).toBeUndefined()
+    })
+  })
 })


### PR DESCRIPTION
Closes #554. Third sub-issue under epic #535 (Mass, Centre of Gravity & Stability).

The heaviest parts on a robot — servos, motors, batteries, boards — **aren't
printed**, so their mass can't be estimated from mesh volume (a printed link
estimates its mass from volume × density × infill, but an SG90 is 9 g of gearbox
no volume estimate reaches). This makes user-/library-supplied mass first-class.

## Changes

- `PartDefinition` gains `mass_g` (grams) and optional `com_xyz` (centre of mass,
  mm) for lopsided parts whose real CoM isn't the body centroid.
- Round-tripped through `parts.yml` (`part-yaml.ts`) **and** preserved by
  `normalisePart` (the canonical-shape pass) — a bug I caught via a failing
  round-trip test: the YAML layer worked but `normalisePart` was silently
  dropping the fields, so a real save would have lost them.
- Validation is consistent across all three layers: a non-positive or
  unparseable mass is dropped (so "unset" and "0" both fall back to a volume
  estimate downstream), and a malformed `com_xyz` (wrong length / non-numeric)
  is ignored. Absent fields are omitted entirely — **no churn** on the ~20
  bundled parts that don't set a mass.

## Bundled masses

The standard library ships real, well-established figures — SG90 **9 g** (its
own description already said "9g"), HC-SR04 **8.5 g**, Pico family **3 g**.
Parts whose mass genuinely varies (gearmotors by ratio, sensor breakouts) are
**left unset on purpose** rather than guessed — absent means "fall back to
estimate", which is the safe default; a wrong hard number is worse than none.

## Units

Documented at each boundary: grams here → converted to URDF kilograms by #553's
`<mass>` writer → surfaced as `mass_g` in `skeleton.json` by #556. Nothing
non-standard reaches the `.urdf`.

## Tests

Round-trip (grams + com_xyz), omission when absent, and rejection of bad values,
plus an assertion in the bundled-library guard (`partExamples.test.ts`) that
SG90/HC-SR04/Pico ship their real masses.

`lint` / `typecheck` / `test` (1967 passing) / `build` / `build:web` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)