### PR TITLE
feat: per-link mass in the robot inspector (#555, epic #535 §1) — part 1/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Per-link mass in the robot inspector (#555, epic #535 §1).** A link's
+  Properties now has a Mass section: pick a print material (PLA/PETG/ABS/resin)
+  and an infill %, and Snakie estimates the mass from the mesh volume live; a
+  measured weight you type in beats the estimate, and a chip shows which source
+  is active. Non-watertight meshes are flagged as rough. The value is written to
+  the URDF `<inertial>` (#553); the estimate settings persist in `robot.yml`
+  (`linkMass`) so the estimate stays reproducible. Library-part mass is modelled
+  but not yet wired — URDF links carry no source-part id, so that lookup is a
+  follow-up. (The total-mass readout + sortable breakdown table land next.)
 - **Parts carry a real mass (#554, epic #535 §1).** Part definitions gain a
   `mass_g` field (grams) plus optional `com_xyz` (centre of mass, mm) for
   lopsided parts, round-tripped through `parts.yml`. The heaviest robot parts —

--- a/src/renderer/src/components/RobotPropertiesDialog.css
+++ b/src/renderer/src/components/RobotPropertiesDialog.css
@@ -376,3 +376,76 @@
   width: 100%;
   margin-top: 0.15rem;
 }
+
+/* Mass section (#555) — estimate controls, source chip, measured override. */
+.robotprops__masssrc {
+  margin-left: 0.4rem;
+  padding: 0.02rem 0.3rem;
+  border-radius: 999px;
+  font-size: 0.54rem;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--text, #cdd2d9);
+  background: var(--bg-sunken, rgba(0, 0, 0, 0.25));
+  border: 1px solid var(--border, #3a3d44);
+}
+.robotprops__masssrc--measured {
+  color: #b9f6c9;
+  border-color: #2f7d47;
+}
+.robotprops__masssrc--none {
+  color: var(--text-muted, #8b919b);
+  font-style: italic;
+}
+.robotprops__massrow {
+  display: flex;
+  gap: 0.5rem;
+}
+.robotprops__masssub {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  flex: 1;
+  font-size: 0.56rem;
+  color: var(--text-muted, #8b919b);
+}
+.robotprops__masssub--wide {
+  flex: none;
+}
+.robotprops__masssub input[type='range'] {
+  width: 100%;
+}
+.robotprops__sel--sm {
+  font-size: 0.62rem;
+  padding: 0.12rem 0.2rem;
+}
+.robotprops__text--sm {
+  width: 5rem;
+}
+.robotprops__massest {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.6rem;
+  color: var(--text, #cdd2d9);
+}
+.robotprops__minibtn {
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  font-size: 0.56rem;
+  color: var(--accent-ink, #191a1d);
+  background: var(--accent, #d6a23f);
+  border: none;
+  border-radius: 4px;
+  padding: 0.15rem 0.4rem;
+  cursor: pointer;
+}
+.robotprops__minibtn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.robotprops__masswarn {
+  margin: 0;
+  font-size: 0.56rem;
+  color: var(--danger, #e06c5a);
+}

--- a/src/renderer/src/components/RobotPropertiesDialog.tsx
+++ b/src/renderer/src/components/RobotPropertiesDialog.tsx
@@ -13,6 +13,8 @@ import {
 } from './robot-pose'
 import { SizeForm, JointForm } from './RobotBuildPanel'
 import { SwatchPicker } from './SwatchPicker'
+import { MATERIAL_NAMES, sourceLabel } from './robot-mass'
+import type { MassSource } from '../../../shared/robot'
 import './RobotPropertiesDialog.css'
 
 /**
@@ -44,6 +46,32 @@ function contextTitle(ctx: PropsContext): string {
   }
 }
 
+/**
+ * Everything the Mass section of a link shows and edits (#555). Bundled so the
+ * dialog's prop list doesn't balloon. `null` ⇒ this link can't carry a mass
+ * (e.g. the context isn't a link).
+ */
+export interface MassEditorProps {
+  /** Active resolved mass in grams (0 ⇒ unset). */
+  grams: number
+  source: MassSource
+  /** A live mesh-volume estimate in grams, or undefined when there's no mesh. */
+  estimateG?: number
+  /** Estimate settings, echoed back so the controls are controlled. */
+  material: string
+  infill: number
+  /** Estimate-quality warning (holey mesh etc.), or null when clean. */
+  warning?: string | null
+  /** Current centre of mass in mm (from `<inertial>`, or the mesh centroid). */
+  comMm?: [number, number, number]
+  /** Set a measured mass in grams; null clears it (falls back to the estimate). */
+  onSetMeasured: (grams: number | null) => void
+  /** Adopt the current estimate as this link's mass. */
+  onUseEstimate: () => void
+  onSetMaterial: (material: string) => void
+  onSetInfill: (infill: number) => void
+}
+
 export interface RobotPropertiesDialogProps {
   context: PropsContext
   // link / joint
@@ -51,6 +79,8 @@ export interface RobotPropertiesDialogProps {
   joint: JointDef | null
   jointNames: string[]
   onSetSize: (link: string, dims: number[]) => void
+  /** Mass editor for the open link (#555), or null when not applicable. */
+  massEditor?: MassEditorProps | null
   /** The edited link's colour (#rrggbb), or undefined for the default. */
   linkColor?: string
   /** Whether this link can be recoloured (a primitive, or an STL mesh — not DAE). */
@@ -152,6 +182,121 @@ export interface JointPickView {
  *
  * Mounted with a per-node `key` so switching nodes gives fresh local state.
  */
+/** Round a gram value for display without trailing float noise. */
+const fmtGrams = (g: number): string => (Math.round(g * 100) / 100).toString()
+
+/**
+ * The Mass section of a link's Properties (#555). Shows the active mass + where
+ * it came from, a mesh-volume estimate you can tune (material + infill) and
+ * adopt, and a measured override that beats everything. The centre of mass is
+ * shown read-only here — a numeric override lands with the breakdown table.
+ */
+function MassForm({ mass }: { mass: MassEditorProps }): JSX.Element {
+  const {
+    grams,
+    source,
+    estimateG,
+    material,
+    infill,
+    warning,
+    comMm,
+    onSetMeasured,
+    onUseEstimate,
+    onSetMaterial,
+    onSetInfill
+  } = mass
+  const [measured, setMeasured] = useState(source === 'measured' && grams > 0 ? fmtGrams(grams) : '')
+
+  const commitMeasured = (): void => {
+    const t = measured.trim()
+    if (t === '') return onSetMeasured(null)
+    const n = Number(t)
+    if (Number.isFinite(n) && n > 0) onSetMeasured(n)
+  }
+
+  return (
+    <section className="robotprops__section">
+      <div className="robotprops__label">
+        Mass
+        <span className={`robotprops__masssrc robotprops__masssrc--${source}`}>
+          {grams > 0 ? `${fmtGrams(grams)} g · ${sourceLabel(source)}` : 'not set'}
+        </span>
+      </div>
+
+      {estimateG !== undefined ? (
+        <div className="robotprops__massrow">
+          <label className="robotprops__masssub" title="What the print is made of">
+            <span>Material</span>
+            <select
+              className="robotprops__sel robotprops__sel--sm"
+              value={material}
+              onChange={(e) => onSetMaterial(e.target.value)}
+              aria-label="Material"
+            >
+              {MATERIAL_NAMES.map((m) => (
+                <option key={m} value={m}>
+                  {m}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="robotprops__masssub" title="How solid the print is (a print is mostly air)">
+            <span>Infill {Math.round(infill * 100)}%</span>
+            <input
+              type="range"
+              min={5}
+              max={100}
+              step={5}
+              value={Math.round(infill * 100)}
+              onChange={(e) => onSetInfill(Number(e.target.value) / 100)}
+              aria-label="Infill"
+            />
+          </label>
+        </div>
+      ) : (
+        <p className="robotprops__note">No mesh to estimate from — enter a measured weight below.</p>
+      )}
+
+      {estimateG !== undefined && (
+        <div className="robotprops__massest">
+          <span>Estimated {fmtGrams(estimateG)} g</span>
+          <button
+            type="button"
+            className="robotprops__minibtn"
+            onClick={onUseEstimate}
+            disabled={source === 'estimated'}
+          >
+            Use estimate
+          </button>
+        </div>
+      )}
+      {warning && <p className="robotprops__masswarn">⚠ {warning}</p>}
+
+      <label className="robotprops__masssub robotprops__masssub--wide" title="Weighed on a scale — beats the estimate">
+        <span>Measured (g)</span>
+        <input
+          className="robotprops__text robotprops__text--sm"
+          type="number"
+          min={0}
+          step="0.1"
+          value={measured}
+          placeholder="weigh it"
+          onChange={(e) => setMeasured(e.target.value)}
+          onBlur={commitMeasured}
+          onKeyDown={(e) => e.key === 'Enter' && commitMeasured()}
+          aria-label="Measured mass in grams"
+        />
+      </label>
+
+      {comMm && grams > 0 && (
+        <p className="robotprops__note">
+          Centre of mass: {comMm.map((n) => Math.round(n)).join(', ')} mm
+        </p>
+      )}
+    </section>
+  )
+}
+
 export function RobotPropertiesDialog(props: RobotPropertiesDialogProps): JSX.Element {
   const { context, onOk, onCancel } = props
 
@@ -297,6 +442,7 @@ function LinkBody({
   joint,
   jointNames,
   onSetSize,
+  massEditor,
   onSetJoint,
   onRenameJoint,
   onSetJointOrigin,
@@ -323,6 +469,7 @@ function LinkBody({
               <SizeForm geom={geom} onChange={(d) => onSetSize(link, d)} />
             </section>
           )}
+          {massEditor && <MassForm mass={massEditor} />}
           {colorable ? (
             // Primitives + STL meshes recolour via the inline URDF <material>. (DAE/
             // Collada meshes carry their own materials, so they fall through to the note.)

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -39,6 +39,9 @@ import {
   readJoint,
   readPrimitive,
   readVisualOrigin,
+  readInertial,
+  setInertial,
+  removeInertial,
   removeJoint,
   removeLink,
   renameLink,
@@ -149,6 +152,19 @@ import {
   RulerIcon,
   LockIcon
 } from './ui-icons'
+import {
+  estimateFromMesh,
+  estimateWarning,
+  gramsToKg,
+  kgToGrams,
+  mmToM,
+  mToMm,
+  DEFAULT_MATERIAL,
+  DEFAULT_INFILL,
+  type MassEstimate
+} from './robot-mass'
+import type { MassEditorProps } from './RobotPropertiesDialog'
+import type { MeshTriangles } from './robot-mass-geometry'
 import './RobotView.css'
 
 /** An empty motion clip (2 s, ease-in-out, looping). */
@@ -201,6 +217,49 @@ function placeholderMesh(material: THREE.Material | null): THREE.Mesh {
   const mat =
     material ?? new THREE.MeshStandardMaterial({ color: 0xb4544e, wireframe: true })
   return new THREE.Mesh(new THREE.BoxGeometry(0.04, 0.04, 0.04), mat)
+}
+
+/** The `urdfName` of the URDFLink an object belongs to, or null (#555). */
+function ownerLink(obj: THREE.Object3D | null): string | null {
+  let o = obj
+  while (o && !(o as unknown as { isURDFLink?: boolean }).isURDFLink) o = o.parent
+  return (o as unknown as { urdfName?: string } | null)?.urdfName ?? null
+}
+
+/**
+ * Extract a link's OWN mesh triangles in its LOCAL frame, in metres (#555).
+ *
+ * A joined child nests under its parent in the scene graph, so we keep only
+ * meshes this link actually owns (`ownerLink`). Each vertex is pushed through
+ * `mesh.matrixWorld` then back into the link's local frame, which bakes in the
+ * mesh's `scale` (mm→m etc.) — so the caller measures volume in metres and
+ * converts with a fixed unitScaleToMm of 1000, regardless of authored units.
+ * Returns null when the link has no triangle geometry (a primitive-only link
+ * is handled elsewhere; a bare/empty link has no mesh to estimate from).
+ */
+function linkLocalTriangles(robot: URDFRobot, link: string): MeshTriangles | null {
+  const linkObj = robot.links[link]
+  if (!linkObj) return null
+  robot.updateMatrixWorld(true)
+  const toLocal = new THREE.Matrix4().copy(linkObj.matrixWorld).invert()
+  const positions: number[] = []
+  const v = new THREE.Vector3()
+  linkObj.traverse((o) => {
+    const mesh = o as THREE.Mesh
+    if (!mesh.isMesh || ownerLink(mesh) !== link) return
+    const geom = mesh.geometry as THREE.BufferGeometry
+    const pos = geom.getAttribute('position') as THREE.BufferAttribute | undefined
+    if (!pos) return
+    const toLinkLocal = new THREE.Matrix4().multiplyMatrices(toLocal, mesh.matrixWorld)
+    const index = geom.getIndex()
+    const emit = (i: number): void => {
+      v.fromBufferAttribute(pos, i).applyMatrix4(toLinkLocal)
+      positions.push(v.x, v.y, v.z)
+    }
+    if (index) for (let i = 0; i < index.count; i++) emit(index.getX(i))
+    else for (let i = 0; i < pos.count; i++) emit(i)
+  })
+  return positions.length >= 9 ? { positions } : null
 }
 
 export function RobotView({
@@ -805,6 +864,135 @@ export function RobotView({
   const handleSetSize = (link: string, dims: number[]): void => {
     commitUrdf(setPrimitiveSize(content, link, dims))
   }
+
+  // ── Per-link mass (#555, epic #535 §1) ────────────────────────────────────
+  // The value lives in the URDF <inertial>; the estimate settings (material +
+  // infill) live in robot.yml so the estimate stays reproducible. Material/infill
+  // are held in React state, seeded from robot.yml when the open link changes, so
+  // dragging the infill slider re-estimates live.
+  const [massMaterial, setMassMaterial] = useState(DEFAULT_MATERIAL)
+  const [massInfill, setMassInfill] = useState(DEFAULT_INFILL)
+  useEffect(() => {
+    const lm = editLink ? defRef.current?.robot?.linkMass?.[editLink] : undefined
+    setMassMaterial(lm?.material ?? DEFAULT_MATERIAL)
+    setMassInfill(typeof lm?.infill === 'number' ? lm.infill : DEFAULT_INFILL)
+    // editLink is the only real dependency; the ref read is intentional.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editLink])
+
+  /** Estimate the open link's mass from its mesh, in the current material/infill. */
+  const estimateLink = useCallback(
+    (link: string, material: string, infill: number): MassEstimate | null => {
+      const robot = robotRef.current
+      if (!robot) return null
+      const tris = linkLocalTriangles(robot, link)
+      if (!tris) return null
+      return estimateFromMesh(tris, { material, infill, unitScaleToMm: 1000 })
+    },
+    []
+  )
+
+  /** The CoM (URDF metres) to store with a mass: an existing one wins, else the
+   *  estimate's centroid, else the origin. */
+  const comForLink = (link: string, est: MassEstimate | null): [number, number, number] => {
+    const existing = readInertial(contentRef.current, link)
+    if (existing) return existing.com
+    if (est) return [mmToM(est.centroidMm[0]), mmToM(est.centroidMm[1]), mmToM(est.centroidMm[2])]
+    return [0, 0, 0]
+  }
+
+  const handleSetMeasured = (link: string, grams: number | null): void => {
+    if (grams === null) {
+      commitUrdf(removeInertial(contentRef.current, link))
+      void persist((m) => {
+        if (m.linkMass) delete m.linkMass[link]
+      })
+      return
+    }
+    commitUrdf(setInertial(contentRef.current, link, { mass: gramsToKg(grams), com: comForLink(link, null) }))
+    void persist((m) => {
+      m.linkMass = { ...(m.linkMass ?? {}), [link]: { source: 'measured' } }
+    })
+  }
+
+  const handleUseEstimate = (link: string): void => {
+    const est = estimateLink(link, massMaterial, massInfill)
+    if (!est) return
+    const com: [number, number, number] = [
+      mmToM(est.centroidMm[0]),
+      mmToM(est.centroidMm[1]),
+      mmToM(est.centroidMm[2])
+    ]
+    commitUrdf(setInertial(contentRef.current, link, { mass: gramsToKg(est.grams), com }))
+    void persist((m) => {
+      m.linkMass = {
+        ...(m.linkMass ?? {}),
+        [link]: { source: 'estimated', material: massMaterial, infill: massInfill }
+      }
+    })
+  }
+
+  /** Persist new estimate settings; if this link's mass IS the estimate, re-apply
+   *  it so the stored value tracks the sliders. */
+  const handleSetMassSettings = (link: string, material: string, infill: number): void => {
+    const wasEstimate = defRef.current?.robot?.linkMass?.[link]?.source === 'estimated'
+    if (wasEstimate) {
+      const est = estimateLink(link, material, infill)
+      if (est) {
+        const com: [number, number, number] = [
+          mmToM(est.centroidMm[0]),
+          mmToM(est.centroidMm[1]),
+          mmToM(est.centroidMm[2])
+        ]
+        commitUrdf(setInertial(contentRef.current, link, { mass: gramsToKg(est.grams), com }))
+      }
+    }
+    void persist((m) => {
+      const prev = m.linkMass?.[link]
+      m.linkMass = { ...(m.linkMass ?? {}), [link]: { source: prev?.source ?? 'none', material, infill } }
+    })
+  }
+
+  // Live mass estimate for the open link (#555). Recomputes when the link, the
+  // material/infill, or the geometry (content) changes; robotRef is populated by
+  // the time a link dialog is open.
+  const editMassEstimate = useMemo<MassEstimate | null>(() => {
+    if (!editLink || dialogCtx?.kind !== 'link') return null
+    return estimateLink(editLink, massMaterial, massInfill)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editLink, dialogCtx, massMaterial, massInfill, content, estimateLink])
+
+  const massEditor = useMemo<MassEditorProps | null>(() => {
+    if (!editLink || dialogCtx?.kind !== 'link') return null
+    const inertial = readInertial(content, editLink)
+    const provenance = defRef.current?.robot?.linkMass?.[editLink]
+    // The URDF <inertial> holds the authoritative value; provenance labels it.
+    const grams = inertial ? kgToGrams(inertial.mass) : 0
+    const source = inertial ? provenance?.source ?? 'measured' : 'none'
+    const comMm: [number, number, number] | undefined = inertial
+      ? [mToMm(inertial.com[0]), mToMm(inertial.com[1]), mToMm(inertial.com[2])]
+      : editMassEstimate?.centroidMm
+    return {
+      grams,
+      source,
+      estimateG: editMassEstimate?.grams,
+      material: massMaterial,
+      infill: massInfill,
+      warning: editMassEstimate ? estimateWarning(editMassEstimate) : null,
+      comMm,
+      onSetMeasured: (g) => handleSetMeasured(editLink, g),
+      onUseEstimate: () => handleUseEstimate(editLink),
+      onSetMaterial: (m) => {
+        setMassMaterial(m)
+        handleSetMassSettings(editLink, m, massInfill)
+      },
+      onSetInfill: (i) => {
+        setMassInfill(i)
+        handleSetMassSettings(editLink, massMaterial, i)
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editLink, dialogCtx, content, editMassEstimate, massMaterial, massInfill])
   // Colour a link (#405) — an inline URDF <material>, so it round-trips + undoes like
   // any other build edit; urdf-loader renders it, recolouring only this link.
   const handleSetColor = (link: string, hex: string): void => {
@@ -4872,6 +5060,7 @@ export function RobotView({
             joint={editJoint}
             jointNames={allJointNames}
             onSetSize={handleSetSize}
+            massEditor={massEditor}
             linkColor={editLinkColor}
             colorable={editColorable}
             usedColors={usedLinkColors}

--- a/src/renderer/src/components/robot-mass.ts
+++ b/src/renderer/src/components/robot-mass.ts
@@ -1,0 +1,139 @@
+/**
+ * PER-LINK MASS RESOLUTION (#555, epic #535 §1) — turns the three possible
+ * sources of a link's mass into one number the editor shows and the URDF stores.
+ *
+ * A link's mass can come from three places, in descending trust:
+ *   1. MEASURED — the user weighed the real part and typed it. Beats everything.
+ *   2. LIBRARY  — the placed part carries a real `mass_g` (#554). (Wiring the
+ *      link→part lookup is deferred — URDF links record no source-part id — so
+ *      this is modelled here and consumed once that mapping exists.)
+ *   3. ESTIMATED — mesh volume × material density × infill. A printed part is
+ *      mostly air, so this is explicitly an estimate.
+ *
+ * The physical VALUE is persisted in the URDF `<inertial>` (#553) — portable,
+ * standard, readable by ROS. This module holds only the pure maths: producing an
+ * estimate from geometry, and picking which source is active. The authoring
+ * METADATA (which source, and the material/infill an estimate used) is persisted
+ * separately in `robot.yml` (`LinkMassSpec`) so an estimate stays reproducible.
+ *
+ * All maths is dependency-light (numbers/arrays in, numbers out) so it unit-tests
+ * without a renderer, following `robot-mass-geometry.ts` / `robot-explode.ts`.
+ */
+import {
+  MATERIAL_DENSITY_G_CM3,
+  estimateMassGrams,
+  massGeometry,
+  type MassGeometryMethod,
+  type MeshTriangles,
+  type Vec3
+} from './robot-mass-geometry'
+
+/** Where a link's active mass came from. `none` ⇒ no mass known yet. */
+export type MassSource = 'measured' | 'library' | 'estimated' | 'none'
+
+/** The default material when a link has never picked one. */
+export const DEFAULT_MATERIAL = 'PLA'
+/** The default infill fraction (20 % — a common slicer default). */
+export const DEFAULT_INFILL = 0.2
+
+/** Ordered material names for a dropdown (keys of {@link MATERIAL_DENSITY_G_CM3}). */
+export const MATERIAL_NAMES: readonly string[] = Object.keys(MATERIAL_DENSITY_G_CM3)
+
+export interface MassEstimate {
+  /** Estimated mass in grams (0 when the mesh yields no volume). */
+  grams: number
+  /** Volumetric centroid in millimetres, the CoM default. */
+  centroidMm: Vec3
+  /** How the volume was obtained — drives the honesty warning. */
+  method: MassGeometryMethod
+  /** Whether the source mesh was a closed surface. */
+  watertight: boolean
+}
+
+/**
+ * Estimate a link's mass from its mesh triangles.
+ *
+ * `mesh` positions are in the mesh's own authored units; `unitScaleToMm`
+ * converts one of those units to a millimetre (a metre-authored URDF mesh → 1000,
+ * a millimetre STL → 1). Volume scales by the cube of that, the centroid linearly.
+ */
+export function estimateFromMesh(
+  mesh: MeshTriangles,
+  opts: { material?: string; infill?: number; unitScaleToMm: number }
+): MassEstimate {
+  const g = massGeometry(mesh)
+  const s = opts.unitScaleToMm
+  const volumeMm3 = g.volume * s * s * s
+  const density = MATERIAL_DENSITY_G_CM3[opts.material ?? DEFAULT_MATERIAL] ??
+    MATERIAL_DENSITY_G_CM3[DEFAULT_MATERIAL]
+  const infill = opts.infill ?? DEFAULT_INFILL
+  return {
+    grams: estimateMassGrams(volumeMm3, density, infill),
+    centroidMm: [g.centroid[0] * s, g.centroid[1] * s, g.centroid[2] * s],
+    method: g.method,
+    watertight: g.watertight
+  }
+}
+
+/** A warning string for an estimate whose mesh wasn't a clean closed solid, or
+ *  null when the estimate is trustworthy. */
+export function estimateWarning(est: MassEstimate): string | null {
+  if (est.method === 'hull') return 'Mesh has holes — volume is a convex-hull over-estimate.'
+  if (est.method === 'bbox') return 'Mesh has no solid volume — using its bounding box, a rough guess.'
+  if (est.method === 'empty') return 'No mesh geometry — estimate unavailable.'
+  return null
+}
+
+export interface MassInputs {
+  /** A user-entered measured mass in grams, if any (highest trust). */
+  measuredG?: number
+  /** The placed part's library mass in grams, if any (#554). */
+  libraryG?: number
+  /** A mesh-volume estimate in grams, if computable. */
+  estimateG?: number
+}
+
+export interface ResolvedMass {
+  /** The grams the editor shows and the URDF stores (0 when nothing is known). */
+  grams: number
+  source: MassSource
+}
+
+/**
+ * Pick the active mass + source by trust order: measured → library → estimated.
+ *
+ * A source counts only when it is a finite, positive number — a 0 g "measured"
+ * value is treated as unset (fall through), matching how the parts library and
+ * URDF layers drop non-positive masses.
+ */
+export function resolveMass(inputs: MassInputs): ResolvedMass {
+  const usable = (n: number | undefined): n is number =>
+    typeof n === 'number' && Number.isFinite(n) && n > 0
+  if (usable(inputs.measuredG)) return { grams: inputs.measuredG, source: 'measured' }
+  if (usable(inputs.libraryG)) return { grams: inputs.libraryG, source: 'library' }
+  if (usable(inputs.estimateG)) return { grams: inputs.estimateG, source: 'estimated' }
+  return { grams: 0, source: 'none' }
+}
+
+/** Grams → URDF kilograms (`<mass value>` is SI). */
+export const gramsToKg = (g: number): number => g / 1000
+/** URDF kilograms → grams (the editor's unit). */
+export const kgToGrams = (kg: number): number => kg * 1000
+/** Millimetres → URDF metres (`<origin xyz>` is SI). */
+export const mmToM = (mm: number): number => mm / 1000
+/** URDF metres → millimetres (the editor's unit). */
+export const mToMm = (m: number): number => m * 1000
+
+/** A short human label for a mass source, for the inspector's provenance chip. */
+export function sourceLabel(source: MassSource): string {
+  switch (source) {
+    case 'measured':
+      return 'measured'
+    case 'library':
+      return 'from part'
+    case 'estimated':
+      return 'estimated'
+    case 'none':
+      return 'not set'
+  }
+}

--- a/src/shared/krf.ts
+++ b/src/shared/krf.ts
@@ -20,6 +20,8 @@
 import {
   blankRobot,
   type JointConfig,
+  type LinkMassSpec,
+  type MassSource,
   type MirrorPair,
   type MotionEasing,
   type MotionKey,
@@ -249,6 +251,21 @@ export function sanitiseRobotModel(raw: unknown): RobotModel | undefined {
 
   const normals = sanitiseVec3Map(r.jointNormal)
   if (Object.keys(normals).length) model.jointNormal = normals
+
+  if (r.linkMass && typeof r.linkMass === 'object') {
+    const SOURCES: readonly MassSource[] = ['measured', 'library', 'estimated', 'none']
+    const linkMass: Record<string, LinkMassSpec> = {}
+    for (const [link, raw] of Object.entries(r.linkMass as Record<string, unknown>)) {
+      const lm = (raw ?? {}) as Record<string, unknown>
+      const source = SOURCES.includes(lm.source as MassSource) ? (lm.source as MassSource) : 'none'
+      const spec: LinkMassSpec = { source }
+      if (isStr(lm.material) && lm.material) spec.material = lm.material
+      // Infill is a fraction; clamp a hand-edited value into 0…1.
+      if (isFiniteNum(lm.infill)) spec.infill = Math.min(1, Math.max(0, lm.infill))
+      linkMass[link] = spec
+    }
+    if (Object.keys(linkMass).length) model.linkMass = linkMass
+  }
 
   if (Array.isArray(r.poses)) {
     const poses = r.poses

--- a/src/shared/robot.ts
+++ b/src/shared/robot.ts
@@ -61,6 +61,11 @@ export interface RobotModel {
   servoJointMap?: ServoJointBinding[]
   /** Per-joint limit / calibration overrides edited in-app (Phase 2). */
   joints?: Record<string, JointConfig>
+  /** Per-link mass AUTHORING metadata (#555, epic #535 §1). The physical value
+   *  lives in the URDF `<inertial>` (portable); this remembers HOW it was set —
+   *  the active source, and the material/infill an estimate used so it stays
+   *  reproducible. Keyed by link name. Absent ⇒ the link has no authored mass. */
+  linkMass?: Record<string, LinkMassSpec>
   /** Per-joint absolute roll about its own normal axis, in DEGREES (#354). The URDF
    *  `<origin rpy>` already bakes this in; it's remembered here so the joint editor
    *  can show the current roll and edit it absolutely (deltas re-applied to the rpy),
@@ -84,6 +89,20 @@ export interface RobotModel {
   /** Left↔right joint mirror pairs, for symmetric gaits (Phase 4). */
   mirror?: MirrorPair[]
 }
+
+/** How a link's mass was authored (#555). The number itself is in the URDF. */
+export interface LinkMassSpec {
+  /** Which source is active: measured / library / estimated (or none). */
+  source: MassSource
+  /** Material preset name for the estimate (e.g. `PLA`), when source-relevant. */
+  material?: string
+  /** Infill fraction 0…1 the estimate used, when source-relevant. */
+  infill?: number
+}
+
+/** Where a link's mass came from — mirrors the union in `robot-mass.ts`, kept
+ *  here so the shared model type has no renderer dependency. */
+export type MassSource = 'measured' | 'library' | 'estimated' | 'none'
 
 /** A servo(pin) ↔ URDF joint binding with angle-range calibration (Phase 3). */
 export interface ServoJointBinding {

--- a/test/krf.test.ts
+++ b/test/krf.test.ts
@@ -161,6 +161,27 @@ describe('sanitiseRobotModel — corruption-safe (#310)', () => {
     const m = readRobotModel({ parts: [], connections: [], robot: { urdf: 'urdf/a.urdf' } })
     expect(m!.urdf).toBe('urdf/a.urdf')
   })
+
+  it('sanitises linkMass provenance (#555): validates source, clamps infill', () => {
+    const m = sanitiseRobotModel({
+      linkMass: {
+        arm: { source: 'estimated', material: 'PETG', infill: 0.3 },
+        base: { source: 'measured' },
+        foot: { source: 'nonsense', infill: 5 }, // bad source → none; infill clamps to 1
+        bad: 'junk'
+      }
+    })
+    expect(m!.linkMass!.arm).toEqual({ source: 'estimated', material: 'PETG', infill: 0.3 })
+    expect(m!.linkMass!.base).toEqual({ source: 'measured' })
+    expect(m!.linkMass!.foot).toEqual({ source: 'none', infill: 1 })
+    expect(m!.linkMass!.bad).toEqual({ source: 'none' })
+  })
+
+  it('a linkMass-only model round-trips (regression: never silently dropped)', () => {
+    const m = sanitiseRobotModel({ linkMass: { arm: { source: 'measured' } } })
+    expect(m).toBeDefined()
+    expect(m!.linkMass!.arm.source).toBe('measured')
+  })
 })
 
 describe('scaffoldKrf (#310)', () => {

--- a/test/robotMass.test.ts
+++ b/test/robotMass.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_INFILL,
+  MATERIAL_NAMES,
+  estimateFromMesh,
+  estimateWarning,
+  gramsToKg,
+  kgToGrams,
+  mToMm,
+  mmToM,
+  resolveMass,
+  sourceLabel
+} from '../src/renderer/src/components/robot-mass'
+import type { MeshTriangles, Vec3 } from '../src/renderer/src/components/robot-mass-geometry'
+
+/** A closed axis-aligned box, corner at min, given size — reused from the
+ *  geometry tests' shape but inline so this file stands alone. */
+function boxMesh(min: Vec3, size: Vec3): MeshTriangles {
+  const [x, y, z] = min
+  const [w, h, d] = size
+  const v: Vec3[] = [
+    [x, y, z], [x + w, y, z], [x + w, y + h, z], [x, y + h, z],
+    [x, y, z + d], [x + w, y, z + d], [x + w, y + h, z + d], [x, y + h, z + d]
+  ]
+  const faces: Array<[number, number, number]> = [
+    [0, 2, 1], [0, 3, 2], [4, 5, 6], [4, 6, 7], [0, 1, 5], [0, 5, 4],
+    [3, 7, 6], [3, 6, 2], [0, 4, 7], [0, 7, 3], [1, 2, 6], [1, 6, 5]
+  ]
+  const positions: number[] = []
+  for (const [a, b, c] of faces) positions.push(...v[a], ...v[b], ...v[c])
+  return { positions }
+}
+
+describe('estimateFromMesh', () => {
+  it('estimates a printed cube: volume × density × infill', () => {
+    // A 10 mm cube authored in mm (scale 1) → 1000 mm³ = 1 cm³.
+    // PLA 1.24 g/cm³ at 100 % infill = 1.24 g.
+    const est = estimateFromMesh(boxMesh([0, 0, 0], [10, 10, 10]), {
+      material: 'PLA',
+      infill: 1,
+      unitScaleToMm: 1
+    })
+    expect(est.grams).toBeCloseTo(1.24, 6)
+    expect(est.method).toBe('mesh')
+    est.centroidMm.forEach((c) => expect(c).toBeCloseTo(5, 6))
+  })
+
+  it('applies infill linearly', () => {
+    const full = estimateFromMesh(boxMesh([0, 0, 0], [10, 10, 10]), { material: 'PLA', infill: 1, unitScaleToMm: 1 })
+    const fifth = estimateFromMesh(boxMesh([0, 0, 0], [10, 10, 10]), { material: 'PLA', infill: 0.2, unitScaleToMm: 1 })
+    expect(fifth.grams).toBeCloseTo(full.grams * 0.2, 6)
+  })
+
+  it('scales volume by the CUBE of unitScaleToMm (a metre-authored mesh)', () => {
+    // A 0.01 m cube authored in metres, scale 1000 → 10 mm cube = 1 cm³.
+    const est = estimateFromMesh(boxMesh([0, 0, 0], [0.01, 0.01, 0.01]), {
+      material: 'PLA',
+      infill: 1,
+      unitScaleToMm: 1000
+    })
+    expect(est.grams).toBeCloseTo(1.24, 5)
+    est.centroidMm.forEach((c) => expect(c).toBeCloseTo(5, 5)) // 0.005 m → 5 mm
+  })
+
+  it('defaults material to PLA and infill to 20%', () => {
+    const withDefaults = estimateFromMesh(boxMesh([0, 0, 0], [10, 10, 10]), { unitScaleToMm: 1 })
+    const explicit = estimateFromMesh(boxMesh([0, 0, 0], [10, 10, 10]), {
+      material: 'PLA',
+      infill: DEFAULT_INFILL,
+      unitScaleToMm: 1
+    })
+    expect(withDefaults.grams).toBeCloseTo(explicit.grams, 6)
+    expect(withDefaults.grams).toBeCloseTo(1.24 * 0.2, 6)
+  })
+})
+
+describe('estimateWarning', () => {
+  it('is null for a clean closed mesh', () => {
+    const est = estimateFromMesh(boxMesh([0, 0, 0], [10, 10, 10]), { unitScaleToMm: 1 })
+    expect(estimateWarning(est)).toBeNull()
+  })
+
+  it('warns about a hull (holey mesh) and a bbox (no volume)', () => {
+    const box = boxMesh([0, 0, 0], [10, 10, 10])
+    const holey = estimateFromMesh({ positions: Array.from(box.positions).slice(0, -18) }, { unitScaleToMm: 1 })
+    expect(estimateWarning(holey)).toMatch(/hull|holes/i)
+
+    const flat = estimateFromMesh(
+      { positions: [0, 0, 0, 4, 0, 0, 4, 3, 0, 0, 0, 0, 4, 3, 0, 0, 3, 0] },
+      { unitScaleToMm: 1 }
+    )
+    expect(estimateWarning(flat)).toMatch(/bounding box/i)
+  })
+})
+
+describe('resolveMass — trust order', () => {
+  it('measured beats library beats estimated', () => {
+    expect(resolveMass({ measuredG: 9, libraryG: 8, estimateG: 5 })).toEqual({ grams: 9, source: 'measured' })
+    expect(resolveMass({ libraryG: 8, estimateG: 5 })).toEqual({ grams: 8, source: 'library' })
+    expect(resolveMass({ estimateG: 5 })).toEqual({ grams: 5, source: 'estimated' })
+  })
+
+  it('falls through non-positive / non-finite values', () => {
+    expect(resolveMass({ measuredG: 0, libraryG: 8 })).toEqual({ grams: 8, source: 'library' })
+    expect(resolveMass({ measuredG: -1, estimateG: 5 })).toEqual({ grams: 5, source: 'estimated' })
+    expect(resolveMass({ measuredG: Number.NaN, libraryG: 8 })).toEqual({ grams: 8, source: 'library' })
+  })
+
+  it('reports none when nothing is known', () => {
+    expect(resolveMass({})).toEqual({ grams: 0, source: 'none' })
+    expect(resolveMass({ estimateG: 0 })).toEqual({ grams: 0, source: 'none' })
+  })
+})
+
+describe('unit conversions', () => {
+  it('grams ↔ kilograms and mm ↔ metres round-trip', () => {
+    expect(gramsToKg(9)).toBeCloseTo(0.009, 9)
+    expect(kgToGrams(0.009)).toBeCloseTo(9, 9)
+    expect(mmToM(50)).toBeCloseTo(0.05, 9)
+    expect(mToMm(0.05)).toBeCloseTo(50, 9)
+  })
+})
+
+describe('presentation', () => {
+  it('labels each source', () => {
+    expect(sourceLabel('measured')).toBe('measured')
+    expect(sourceLabel('library')).toBe('from part')
+    expect(sourceLabel('estimated')).toBe('estimated')
+    expect(sourceLabel('none')).toBe('not set')
+  })
+
+  it('exposes the material presets in order', () => {
+    expect(MATERIAL_NAMES).toContain('PLA')
+    expect(MATERIAL_NAMES).toContain('PETG')
+  })
+})


### PR DESCRIPTION
Part 1 of 2 for #555 (the mass editor UI is split so each half is reviewable —
this is the per-link inspector section; the total + sortable breakdown table
follow in part 2). Fourth sub-issue under epic #535.

The first slice of §1 with a **visible surface**: a Mass section in a link's
Properties dialog.

## What's here

- **`robot-mass.ts`** (pure, tested) — `estimateFromMesh` (unit-aware wrapper
  over #552's volume × density × infill), `resolveMass` (trust order
  measured → library → estimated), material presets, unit conversions.
- **Provenance in `robot.yml`** — a new `RobotModel.linkMass` map holds
  `{ source, material, infill }` per link, sanitised in `krf.ts` (validates the
  source enum, clamps infill to 0…1). The **value** stays in the URDF
  `<inertial>` (#553, portable/standard); `robot.yml` only remembers *how* it was
  derived, so an estimate stays reproducible across reloads.
- **Inspector UI** — material dropdown + infill slider drive a live estimate;
  "Use estimate" adopts it; a measured (g) field overrides everything; a chip
  shows the active source; non-watertight meshes warn.
- **RobotView wiring** — `linkLocalTriangles` pulls a link's own mesh into its
  local frame via three.js matrices (baking in mesh scale, so volume is measured
  in metres whatever the authored units); handlers write `<inertial>` + `linkMass`
  through the same `commitUrdf`/`persist` paths as the existing size/colour editors.

## Deferred (noted in the issue)

**Library-part mass** is modelled (`resolveMass` accepts it) but **not wired** —
URDF links record no source-part id, so the link→part lookup is a follow-up. The
epic-map flagged this; it isn't a clean extension of anything that exists.

## Verification

Driven in the web build under **headless Chromium**:

| Check | Result |
|---|---|
| Estimate correct | 90×50 mm base cylinder → **313 g** at 20% PLA (matches π·r²·h·ρ·infill) |
| Infill linear | 100% → **1566 g** (exactly ×5) |
| Material rescales | PETG → **1604 g** (×1.27/1.24) |
| Errors | none (no console / page errors) |

Material + infill re-estimate live. The write path is gated by the same
"saved local file" guard as every URDF edit (so it no-ops on an unsaved demo,
as size edits do); `setInertial`/`readInertial`/`resolveMass`/`estimateFromMesh`
are unit-tested, and the URDF round-trip is verified against the real
`demo-arm.urdf`.

`lint` / `typecheck` / `test` (1981 passing) / `build` / `build:web` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)