### PR TITLE
feat: total mass + per-link breakdown table (#555, epic #535 §1) — part 2/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Total mass + per-link breakdown table (#555, epic #535 §1).** The Build panel
+  gains a Mass section: the robot's total mass at a glance, and a per-link table
+  you can sort by mass (what dominates) or by name. Rows with no mass show a dash,
+  with a hint that the total is a lower bound until they're weighed; clicking a
+  row opens that link's mass editor. Reads each link's stored `<inertial>`, so it
+  reflects what's actually set.
 - **Per-link mass in the robot inspector (#555, epic #535 §1).** A link's
   Properties now has a Mass section: pick a print material (PLA/PETG/ABS/resin)
   and an infill %, and Snakie estimates the mass from the mesh volume live; a

--- a/src/renderer/src/components/RobotBuildPanel.css
+++ b/src/renderer/src/components/RobotBuildPanel.css
@@ -607,3 +607,79 @@
 .robotbuild__newpose:hover {
   background: rgba(128, 128, 128, 0.14);
 }
+
+/* Mass summary (#555 part 2) — total readout + per-link breakdown table. */
+.robotbuild__masstotal {
+  color: var(--accent, #34ad4f);
+  font-weight: 700;
+}
+.robotbuild__masstable {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  padding: 0.15rem 0.2rem 0.3rem;
+}
+.robotbuild__masssort {
+  display: flex;
+  gap: 0.25rem;
+  margin-bottom: 0.2rem;
+}
+.robotbuild__masssort button {
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  font-size: 0.54rem;
+  color: var(--text-muted, #8b919b);
+  background: transparent;
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 4px;
+  padding: 0.05rem 0.3rem;
+  cursor: pointer;
+}
+.robotbuild__masssort button.is-on {
+  color: var(--accent-ink, #191a1d);
+  background: var(--accent, #d6a23f);
+  border-color: var(--accent, #d6a23f);
+}
+.robotbuild__massrow {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  gap: 0.4rem;
+  width: 100%;
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  font-size: 0.6rem;
+  color: var(--text, #cdd2d9);
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  padding: 0.12rem 0.3rem;
+  cursor: pointer;
+  text-align: left;
+}
+.robotbuild__massrow:hover {
+  background: var(--bg-sunken, rgba(255, 255, 255, 0.05));
+}
+.robotbuild__massrow-link {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.robotbuild__massrow-g {
+  font-variant-numeric: tabular-nums;
+  color: var(--text, #cdd2d9);
+}
+.robotbuild__massrow-src {
+  font-size: 0.52rem;
+  color: var(--text-muted, #8b919b);
+}
+.robotbuild__massrow-src--measured {
+  color: #7ec98f;
+}
+.robotbuild__massrow-src--none {
+  font-style: italic;
+}
+.robotbuild__masshint {
+  margin: 0.2rem 0.3rem 0;
+  font-size: 0.54rem;
+  font-style: italic;
+  color: var(--text-muted, #8b919b);
+}

--- a/src/renderer/src/components/RobotBuildPanel.tsx
+++ b/src/renderer/src/components/RobotBuildPanel.tsx
@@ -14,6 +14,7 @@ import { principalAxisName } from './robot-build'
 import { toDisplay, toNative, unitLabel, normPin, type MovableType } from './robot-pose'
 import { boundJoint, type BindableServo } from './servo-bind'
 import { shouldAutoHide } from './pin-overlay'
+import { sourceLabel, type MassBreakdown, type MassSort } from './robot-mass'
 import type { ServoJointBinding } from '../../../shared/robot'
 import type { NamedPoseLike } from './robot-pose'
 import type { PropsContext } from './RobotPropertiesDialog'
@@ -131,6 +132,11 @@ export interface RobotBuildPanelProps {
   canEdit: boolean
   /** Open a different robot `.urdf` via the native picker (works popped out). */
   onOpenRobot: () => void
+  /** Per-link mass breakdown + total (#555 part 2), or null when nothing has a mass. */
+  massSummary?: MassBreakdown | null
+  /** Current breakdown sort, and a setter (the table's "by mass / by name" toggle). */
+  massSort: MassSort
+  onSetMassSort: (sort: MassSort) => void
 }
 
 /** metres → integer mm (display) and back. */
@@ -499,6 +505,93 @@ function Section({
   )
 }
 
+/** Grams for the table, whole numbers once past ~10 g, else one decimal. */
+const fmtRowGrams = (g: number): string =>
+  g >= 10 ? Math.round(g).toString() : (Math.round(g * 10) / 10).toString()
+
+/**
+ * The Mass summary (#555 part 2): a total-mass readout + a per-link table you
+ * can sort by mass (what dominates) or name. Collapsible like the other tree
+ * sections; clicking a row opens that link's inspector. Rows with no mass show
+ * a dash so it's obvious what's still un-weighed.
+ */
+function MassSummary({
+  summary,
+  sort,
+  onSetSort,
+  collapsed,
+  onToggle,
+  onSelect
+}: {
+  summary: MassBreakdown
+  sort: MassSort
+  onSetSort: (s: MassSort) => void
+  collapsed: Record<string, boolean>
+  onToggle: (id: string) => void
+  onSelect: (link: string) => void
+}): JSX.Element {
+  const isCollapsed = !!collapsed.mass
+  return (
+    <div className="robotbuild__section">
+      <button
+        type="button"
+        className="robotbuild__branch"
+        aria-expanded={!isCollapsed}
+        onClick={() => onToggle('mass')}
+      >
+        <span className="robotbuild__caret">{isCollapsed ? '▸' : '▾'}</span>
+        <span className="robotbuild__branch-label">Mass</span>
+        <span className="robotbuild__branch-count robotbuild__masstotal">
+          {Math.round(summary.totalG)} g
+        </span>
+      </button>
+      {!isCollapsed && (
+        <div className="robotbuild__masstable">
+          <div className="robotbuild__masssort" role="group" aria-label="Sort mass table">
+            <button
+              type="button"
+              className={sort === 'mass' ? 'is-on' : ''}
+              onClick={() => onSetSort('mass')}
+            >
+              by mass
+            </button>
+            <button
+              type="button"
+              className={sort === 'name' ? 'is-on' : ''}
+              onClick={() => onSetSort('name')}
+            >
+              by name
+            </button>
+          </div>
+          {summary.rows.map((r) => (
+            <button
+              key={r.link}
+              type="button"
+              className="robotbuild__massrow"
+              onClick={() => onSelect(r.link)}
+              title={`Edit ${r.link}'s mass`}
+            >
+              <span className="robotbuild__massrow-link">{r.link}</span>
+              <span className="robotbuild__massrow-g">
+                {r.grams > 0 ? `${fmtRowGrams(r.grams)} g` : '—'}
+              </span>
+              <span className={`robotbuild__massrow-src robotbuild__massrow-src--${r.source}`}>
+                {r.grams > 0 ? sourceLabel(r.source) : 'not set'}
+              </span>
+            </button>
+          ))}
+          {summary.unsetCount > 0 && (
+            <p className="robotbuild__masshint">
+              {summary.unsetCount} link{summary.unsetCount === 1 ? '' : 's'} with no mass — the total
+              is a lower bound.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
 const INDENT = 14 // px of indent per depth level in the chain tree
 
 // A distinct glyph per joint type (#): a lock (fixed), a rotation arrow (hinge /
@@ -675,7 +768,10 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
     canExport,
     importing,
     canEdit,
-    onOpenRobot
+    onOpenRobot,
+    massSummary,
+    massSort,
+    onSetMassSort
   } = props
   const dockRef = useRef<HTMLElement | null>(null)
   const prompt = usePrompt()
@@ -836,6 +932,16 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
               </Fragment>
             ))}
           </Section>
+        )}
+        {massSummary && massSummary.rows.length > 0 && (
+          <MassSummary
+            summary={massSummary}
+            sort={massSort}
+            onSetSort={onSetMassSort}
+            collapsed={collapsed}
+            onToggle={toggle}
+            onSelect={onEdit}
+          />
         )}
         {rootLink === null && assembly.length > 1 && (
           <p className="robotbuild__hint">

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -159,9 +159,12 @@ import {
   kgToGrams,
   mmToM,
   mToMm,
+  summariseMass,
   DEFAULT_MATERIAL,
   DEFAULT_INFILL,
-  type MassEstimate
+  type MassEstimate,
+  type MassBreakdown,
+  type MassSort
 } from './robot-mass'
 import type { MassEditorProps } from './RobotPropertiesDialog'
 import type { MeshTriangles } from './robot-mass-geometry'
@@ -872,6 +875,7 @@ export function RobotView({
   // dragging the infill slider re-estimates live.
   const [massMaterial, setMassMaterial] = useState(DEFAULT_MATERIAL)
   const [massInfill, setMassInfill] = useState(DEFAULT_INFILL)
+  const [massSort, setMassSort] = useState<MassSort>('mass')
   useEffect(() => {
     const lm = editLink ? defRef.current?.robot?.linkMass?.[editLink] : undefined
     setMassMaterial(lm?.material ?? DEFAULT_MATERIAL)
@@ -993,6 +997,24 @@ export function RobotView({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editLink, dialogCtx, content, editMassEstimate, massMaterial, massInfill])
+
+  // The whole-robot mass breakdown (#555 part 2): each link's stored <inertial>
+  // mass + its provenance, totalled and sorted for the Build panel's table. Reads
+  // the authoritative persisted value (not a live estimate), so it's pure over
+  // `content`; the source label comes from robot.yml provenance.
+  const massSummary = useMemo<MassBreakdown | null>(() => {
+    const linkNames = parseAssembly(content).map((i) => i.link)
+    if (linkNames.length === 0) return null
+    const lm = defRef.current?.robot?.linkMass
+    const rows = linkNames.map((link) => {
+      const inertial = readInertial(content, link)
+      const grams = inertial ? kgToGrams(inertial.mass) : 0
+      const source = inertial ? lm?.[link]?.source ?? 'measured' : 'none'
+      return { link, grams, source }
+    })
+    return summariseMass(rows, massSort)
+  }, [content, massSort])
+
   // Colour a link (#405) — an inline URDF <material>, so it round-trips + undoes like
   // any other build edit; urdf-loader renders it, recolouring only this link.
   const handleSetColor = (link: string, hex: string): void => {
@@ -5040,6 +5062,9 @@ export function RobotView({
             importing={importing}
             canEdit={canEdit}
             onOpenRobot={() => void handleOpenRobotFile()}
+            massSummary={massSummary}
+            massSort={massSort}
+            onSetMassSort={setMassSort}
           />
         )}
         {showPanel && dialogCtx && (

--- a/src/renderer/src/components/robot-mass.ts
+++ b/src/renderer/src/components/robot-mass.ts
@@ -124,6 +124,46 @@ export const mmToM = (mm: number): number => mm / 1000
 /** URDF metres → millimetres (the editor's unit). */
 export const mToMm = (m: number): number => m * 1000
 
+/** One link's line in the mass breakdown (#555 part 2). */
+export interface MassRow {
+  link: string
+  /** Grams (0 ⇒ no mass set on this link). */
+  grams: number
+  source: MassSource
+}
+
+export interface MassBreakdown {
+  /** Rows, heaviest first by default (see {@link summariseMass}). */
+  rows: MassRow[]
+  /** Total mass in grams across every link that has one. */
+  totalG: number
+  /** How many links still have no mass — the "finish weighing these" count. */
+  unsetCount: number
+}
+
+/** How the breakdown table is ordered. */
+export type MassSort = 'mass' | 'name'
+
+/**
+ * Summarise per-link masses into a total + an ordered table (#555 part 2).
+ *
+ * `mass` order is heaviest-first so what dominates is obvious at a glance, with
+ * link name as a stable tiebreak; `name` order is alphabetical. Rows with no
+ * mass sink to the bottom in `mass` order (they contribute 0) but keep their
+ * place in `name` order. Pure — the caller reads each link's stored `<inertial>`.
+ */
+export function summariseMass(entries: MassRow[], sort: MassSort = 'mass'): MassBreakdown {
+  const rows = [...entries]
+  if (sort === 'name') {
+    rows.sort((a, b) => a.link.localeCompare(b.link))
+  } else {
+    rows.sort((a, b) => b.grams - a.grams || a.link.localeCompare(b.link))
+  }
+  const totalG = rows.reduce((sum, r) => sum + (r.grams > 0 ? r.grams : 0), 0)
+  const unsetCount = rows.reduce((n, r) => n + (r.grams > 0 ? 0 : 1), 0)
+  return { rows, totalG, unsetCount }
+}
+
 /** A short human label for a mass source, for the inspector's provenance chip. */
 export function sourceLabel(source: MassSource): string {
   switch (source) {

--- a/test/robotMass.test.ts
+++ b/test/robotMass.test.ts
@@ -9,7 +9,8 @@ import {
   mToMm,
   mmToM,
   resolveMass,
-  sourceLabel
+  sourceLabel,
+  summariseMass
 } from '../src/renderer/src/components/robot-mass'
 import type { MeshTriangles, Vec3 } from '../src/renderer/src/components/robot-mass-geometry'
 
@@ -118,6 +119,51 @@ describe('unit conversions', () => {
     expect(kgToGrams(0.009)).toBeCloseTo(9, 9)
     expect(mmToM(50)).toBeCloseTo(0.05, 9)
     expect(mToMm(0.05)).toBeCloseTo(50, 9)
+  })
+})
+
+describe('summariseMass — breakdown table', () => {
+  const rows = [
+    { link: 'base', grams: 300, source: 'estimated' as const },
+    { link: 'arm', grams: 9, source: 'measured' as const },
+    { link: 'gripper', grams: 0, source: 'none' as const },
+    { link: 'wrist', grams: 50, source: 'library' as const }
+  ]
+
+  it('sorts heaviest-first by default and totals the set masses', () => {
+    const b = summariseMass(rows)
+    expect(b.rows.map((r) => r.link)).toEqual(['base', 'wrist', 'arm', 'gripper'])
+    expect(b.totalG).toBe(359)
+    expect(b.unsetCount).toBe(1)
+  })
+
+  it('sorts by name when asked', () => {
+    const b = summariseMass(rows, 'name')
+    expect(b.rows.map((r) => r.link)).toEqual(['arm', 'base', 'gripper', 'wrist'])
+    expect(b.totalG).toBe(359)
+  })
+
+  it('breaks mass ties by link name for a stable order', () => {
+    const b = summariseMass([
+      { link: 'z', grams: 10, source: 'measured' },
+      { link: 'a', grams: 10, source: 'measured' }
+    ])
+    expect(b.rows.map((r) => r.link)).toEqual(['a', 'z'])
+  })
+
+  it('an all-empty robot totals zero with everything unset', () => {
+    const b = summariseMass([
+      { link: 'a', grams: 0, source: 'none' },
+      { link: 'b', grams: 0, source: 'none' }
+    ])
+    expect(b.totalG).toBe(0)
+    expect(b.unsetCount).toBe(2)
+  })
+
+  it('does not mutate the caller’s array', () => {
+    const input = [...rows]
+    summariseMass(input)
+    expect(input.map((r) => r.link)).toEqual(['base', 'arm', 'gripper', 'wrist'])
   })
 })
 


### PR DESCRIPTION
Part 2 of 2 for #555 — **closes the issue**. Fifth sub-issue under epic #535.

Adds the whole-robot view of mass on top of part 1's per-link editor: a **Mass
section in the Build panel** with the total and a sortable per-link breakdown, so
you can instantly see what dominates the robot's weight.

## What's here

- **`summariseMass`** (pure, tested) — sorts rows heaviest-first with a stable
  name tiebreak (or alphabetical), totals the set masses, counts the unset links.
  Non-mutating.
- **`MassSummary`** in `RobotBuildPanel` — collapsible like the other tree
  sections; a `by mass` / `by name` toggle; each row is *link · grams · source*,
  with a dash + "not set" for un-weighed links and a hint that the total is a
  **lower bound** until they're weighed. Clicking a row opens that link's mass
  editor (part 1).
- **RobotView** computes the breakdown from each link's stored `<inertial>` — the
  authoritative persisted value, not a live estimate — so it's pure over the URDF;
  the source label comes from `robot.yml` provenance.

## Verification

Driven in the web build under headless Chromium:

| Check | Result |
|---|---|
| Section renders | all 4 demo-arm links, **0 G** total, every row "— not set" |
| Empty-state hint | "4 links with no mass — the total is a lower bound" |
| Sort toggle | by mass ↔ by name both work |
| Row click | opens that link's inspector |
| Errors | none |

The populated behaviour — sorting, ties, totals, unset counting — is exhaustively
unit-tested (a live populated table needs a saved robot with masses, which the
same `commitUrdf` guard blocks in the demo).

**The `cssThemeTokens` test caught a real bug** — I'd used `--bg-hover`, which
isn't a defined theme token, so the row hover would have broken in one skin.
Fixed to `--bg-sunken`.

`lint` / `typecheck` / `test` (1986 passing) / `build` / `build:web` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)