### PR TITLE
feat: centre-of-mass computation service (#556, epic #535 §2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Centre-of-mass computation service (#556, epic #535 §2).** New
+  `robot-com.ts`: the robot's total mass and mass-weighted centre of mass at its
+  current pose. Split so the maths is pure and unit-tested (`centreOfMass` —
+  weighted average of point masses; `readLinkMasses` — per-link mass + local CoM
+  from the URDF `<inertial>`) with a thin three.js layer (`robotWorldCoM`) that
+  transforms each link's local CoM by its live `matrixWorld`, so it's cheap to
+  recompute every frame as joints move. The shared engine the CoM +
+  support-polygon overlay, the stability strip and the balance parameters all
+  build on. No visible UI yet — that's the overlay (#558).
 - **Total mass + per-link breakdown table (#555, epic #535 §1).** The Build panel
   gains a Mass section: the robot's total mass at a glance, and a per-link table
   you can sort by mass (what dominates) or by name. Rows with no mass show a dash,

--- a/src/renderer/src/components/robot-com.ts
+++ b/src/renderer/src/components/robot-com.ts
@@ -1,0 +1,122 @@
+/**
+ * ROBOT CENTRE OF MASS (#556, epic #535 §2) — the shared service the CoM +
+ * support-polygon overlay (#558), the stability strip (#535 §3), the balance
+ * parameters (§4) and the runtime export (§6) all build on.
+ *
+ * The robot's centre of mass is the mass-weighted average of its links' CoMs at
+ * the CURRENT pose. Two pieces, deliberately separated so the maths tests
+ * without a renderer (like `robot-explode.ts` / `robot-mass-geometry.ts`):
+ *
+ *  1. {@link centreOfMass} — pure: weighted average of `{massKg, comWorld}`.
+ *  2. {@link robotWorldCoM} — thin three.js glue that transforms each link's
+ *     LOCAL CoM (from its `<inertial>`) by the link's `matrixWorld` and feeds
+ *     the pure function. Per-link world transforms are read straight from the
+ *     `urdf-loader` scene graph — no FK walker (see #536 Bone Mode) — so this is
+ *     cheap enough to recompute every frame as joints move.
+ *
+ * NOTE this lives outside `src/shared/ik/`: that module is planar/2-D and
+ * mirrored 1:1 by `snakie_ik.py`; 3-D mass maths there would break its contract.
+ *
+ * UNITS: kilograms + metres throughout, matching the URDF `<inertial>` the mass
+ * data comes from. Callers presenting grams/mm convert at their boundary.
+ */
+import { Matrix4, Vector3 } from 'three'
+import { readInertial } from './robot-assembly'
+
+export type Vec3 = [number, number, number]
+
+/** A link's mass + the world position its mass acts at. */
+export interface MassPoint {
+  massKg: number
+  comWorld: Vec3
+}
+
+/** The whole robot's mass + centre of mass (world frame). */
+export interface CoMResult {
+  massKg: number
+  comWorld: Vec3
+}
+
+/**
+ * Mass-weighted centre of a set of point masses, or null when the total mass is
+ * zero (no CoM is defined — the caller shows "no mass set yet" rather than a
+ * point at the origin). Non-positive or non-finite masses are skipped, so a
+ * half-weighed robot still yields the CoM of the parts that DO have a mass.
+ */
+export function centreOfMass(points: readonly MassPoint[]): CoMResult | null {
+  let total = 0
+  let x = 0
+  let y = 0
+  let z = 0
+  for (const p of points) {
+    const m = p.massKg
+    if (!Number.isFinite(m) || m <= 0) continue
+    total += m
+    x += m * p.comWorld[0]
+    y += m * p.comWorld[1]
+    z += m * p.comWorld[2]
+  }
+  if (total <= 0) return null
+  return { massKg: total, comWorld: [x / total, y / total, z / total] }
+}
+
+/** A link's static mass data: its mass and the CoM in its OWN (local) frame. */
+export interface LinkMass {
+  massKg: number
+  comLocalM: Vec3
+}
+
+/**
+ * Read every named link's `<inertial>` mass + local CoM from the URDF text.
+ *
+ * Static (pose-independent), so a caller reads this once per edit and reuses it
+ * across frames; only {@link robotWorldCoM}'s transform step runs per frame.
+ * Links without a usable `<inertial>` are omitted.
+ */
+export function readLinkMasses(urdf: string, links: readonly string[]): Record<string, LinkMass> {
+  const out: Record<string, LinkMass> = {}
+  for (const link of links) {
+    const inertial = readInertial(urdf, link)
+    if (inertial && inertial.mass > 0) {
+      out[link] = { massKg: inertial.mass, comLocalM: inertial.com }
+    }
+  }
+  return out
+}
+
+/**
+ * The robot's world-frame CoM at its current pose.
+ *
+ * `linkMatrix(link)` returns the link's `matrixWorld` (or null if absent) —
+ * in the app, `(l) => robot.links[l]?.matrixWorld ?? null` after
+ * `robot.updateMatrixWorld(true)`. Taking an accessor (not the robot) keeps this
+ * unit-testable with plain three.js objects. Returns null when nothing is
+ * weighed or no matrices resolve.
+ */
+export function robotWorldCoM(
+  linkMatrix: (link: string) => Matrix4 | null | undefined,
+  masses: Record<string, LinkMass>
+): CoMResult | null {
+  const points: MassPoint[] = []
+  const v = new Vector3()
+  for (const [link, m] of Object.entries(masses)) {
+    const mat = linkMatrix(link)
+    if (!mat) continue
+    v.set(m.comLocalM[0], m.comLocalM[1], m.comLocalM[2]).applyMatrix4(mat)
+    points.push({ massKg: m.massKg, comWorld: [v.x, v.y, v.z] })
+  }
+  return centreOfMass(points)
+}
+
+/**
+ * Drop the CoM straight down onto the ground plane — the projection point the
+ * support-polygon check (#558) compares against.
+ *
+ * Snakie's world is Y-up (the loaded robot is rotated so URDF Z-up becomes scene
+ * Y-up, baked into `matrixWorld`), so "down" zeroes Y. The ground isn't always at
+ * y = 0 — the grid sits at the robot's lowest point — so the overlay passes the
+ * real ground height; it defaults to 0.
+ */
+export function groundProjection(com: Vec3, groundY = 0): Vec3 {
+  return [com[0], groundY, com[2]]
+}

--- a/test/robotCom.test.ts
+++ b/test/robotCom.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest'
+import { Object3D } from 'three'
+import {
+  centreOfMass,
+  groundProjection,
+  readLinkMasses,
+  robotWorldCoM,
+  type Vec3
+} from '../src/renderer/src/components/robot-com'
+import { setInertial } from '../src/renderer/src/components/robot-assembly'
+
+const closeVec = (got: Vec3, want: Vec3, tol = 1e-6): void => {
+  for (let i = 0; i < 3; i++) expect(Math.abs(got[i] - want[i])).toBeLessThan(tol)
+}
+
+describe('centreOfMass — pure weighted average', () => {
+  it('two equal masses balance at the midpoint', () => {
+    const r = centreOfMass([
+      { massKg: 1, comWorld: [0, 0, 0] },
+      { massKg: 1, comWorld: [10, 0, 0] }
+    ])
+    expect(r!.massKg).toBe(2)
+    closeVec(r!.comWorld, [5, 0, 0])
+  })
+
+  it('a heavier mass pulls the CoM toward it', () => {
+    // 3 kg at x=0, 1 kg at x=8 → CoM = (3*0 + 1*8)/4 = 2.
+    const r = centreOfMass([
+      { massKg: 3, comWorld: [0, 0, 0] },
+      { massKg: 1, comWorld: [8, 0, 0] }
+    ])
+    expect(r!.massKg).toBe(4)
+    closeVec(r!.comWorld, [2, 0, 0])
+  })
+
+  it('combines all three axes', () => {
+    const r = centreOfMass([
+      { massKg: 2, comWorld: [1, 2, 3] },
+      { massKg: 2, comWorld: [3, 6, 9] }
+    ])
+    closeVec(r!.comWorld, [2, 4, 6])
+  })
+
+  it('skips non-positive / non-finite masses (a half-weighed robot)', () => {
+    const r = centreOfMass([
+      { massKg: 5, comWorld: [4, 0, 0] },
+      { massKg: 0, comWorld: [100, 0, 0] },
+      { massKg: Number.NaN, comWorld: [200, 0, 0] }
+    ])
+    expect(r!.massKg).toBe(5)
+    closeVec(r!.comWorld, [4, 0, 0])
+  })
+
+  it('returns null when nothing has mass', () => {
+    expect(centreOfMass([])).toBeNull()
+    expect(centreOfMass([{ massKg: 0, comWorld: [1, 1, 1] }])).toBeNull()
+  })
+})
+
+describe('robotWorldCoM — transforms local CoMs by matrixWorld', () => {
+  /** A link object at a world translation, with matrixWorld computed. */
+  const linkAt = (x: number, y: number, z: number): Object3D => {
+    const o = new Object3D()
+    o.position.set(x, y, z)
+    o.updateMatrixWorld(true)
+    return o
+  }
+
+  it('applies each link’s world transform to its local CoM', () => {
+    // Link A sits at world (10,0,0) with local CoM at origin → world (10,0,0).
+    // Link B sits at world (0,0,0) with local CoM at (2,0,0) → world (2,0,0).
+    // Equal masses → CoM at (6,0,0).
+    const links: Record<string, Object3D> = {
+      a: linkAt(10, 0, 0),
+      b: linkAt(0, 0, 0)
+    }
+    const r = robotWorldCoM(
+      (l) => links[l]?.matrixWorld ?? null,
+      { a: { massKg: 1, comLocalM: [0, 0, 0] }, b: { massKg: 1, comLocalM: [2, 0, 0] } }
+    )
+    expect(r!.massKg).toBe(2)
+    closeVec(r!.comWorld, [6, 0, 0])
+  })
+
+  it('skips links whose matrix is missing', () => {
+    const links: Record<string, Object3D> = { a: linkAt(4, 0, 0) }
+    const r = robotWorldCoM((l) => links[l]?.matrixWorld ?? null, {
+      a: { massKg: 2, comLocalM: [0, 0, 0] },
+      gone: { massKg: 99, comLocalM: [0, 0, 0] }
+    })
+    expect(r!.massKg).toBe(2)
+    closeVec(r!.comWorld, [4, 0, 0])
+  })
+
+  it('returns null when no masses resolve', () => {
+    expect(robotWorldCoM(() => null, {})).toBeNull()
+  })
+
+  it('respects a rotated link frame', () => {
+    // A link rotated 90° about Y, local CoM at (1,0,0), placed at world origin.
+    const o = new Object3D()
+    o.rotation.y = Math.PI / 2
+    o.updateMatrixWorld(true)
+    // +X rotated +90° about Y → -Z (three.js right-handed).
+    const r = robotWorldCoM(() => o.matrixWorld, { a: { massKg: 1, comLocalM: [1, 0, 0] } })
+    closeVec(r!.comWorld, [0, 0, -1], 1e-6)
+  })
+})
+
+describe('readLinkMasses — pulls mass + local CoM from the URDF', () => {
+  const BASE =
+    `<?xml version="1.0"?>\n<robot name="r">\n` +
+    `  <link name="a"><visual><geometry><box size="0.1 0.1 0.1"/></geometry></visual></link>\n` +
+    `  <link name="b"><visual><geometry><box size="0.1 0.1 0.1"/></geometry></visual></link>\n` +
+    `</robot>\n`
+
+  it('reads the inertials that are set, omits the rest', () => {
+    let urdf = setInertial(BASE, 'a', { mass: 0.5, com: [0, 0, 0.02] })
+    urdf = setInertial(urdf, 'b', { mass: 0.009, com: [0, 0, 0] })
+    const masses = readLinkMasses(urdf, ['a', 'b'])
+    expect(masses.a).toEqual({ massKg: 0.5, comLocalM: [0, 0, 0.02] })
+    expect(masses.b.massKg).toBeCloseTo(0.009, 6)
+  })
+
+  it('omits a link with no inertial', () => {
+    const urdf = setInertial(BASE, 'a', { mass: 1, com: [0, 0, 0] })
+    const masses = readLinkMasses(urdf, ['a', 'b'])
+    expect(masses.a).toBeDefined()
+    expect(masses.b).toBeUndefined()
+  })
+})
+
+describe('groundProjection', () => {
+  it('zeroes the up (Y) axis by default', () => {
+    expect(groundProjection([3, 5, 7])).toEqual([3, 0, 7])
+  })
+
+  it('drops onto a given ground height', () => {
+    expect(groundProjection([3, 5, 7], -0.2)).toEqual([3, -0.2, 7])
+  })
+})


### PR DESCRIPTION
Closes #556. Sixth sub-issue under epic #535, and the first of §2 — the shared
engine §2's overlay, §3's stability strip, §4's balance parameters and §6's
runtime export all build on.

Computes the robot's **total mass** and **mass-weighted centre of mass** at its
current pose. Split so the maths tests without a renderer (like
`robot-mass-geometry.ts`):

| Function | Kind | Role |
|---|---|---|
| `centreOfMass` | pure | weighted average of `{massKg, comWorld}` point masses |
| `readLinkMasses` | pure (regex) | per-link mass + LOCAL CoM from the URDF `<inertial>` |
| `robotWorldCoM` | thin three.js | transforms each link's local CoM by its live `matrixWorld` |

## Design

- **Static vs per-frame split.** `readLinkMasses` reads the pose-independent mass
  data once per edit; only `robotWorldCoM`'s transform runs per frame. Per-link
  world transforms come straight from the `urdf-loader` scene graph — no FK walker,
  same as Bone Mode (#536) — so it's cheap to recompute as joints move.
- **`robotWorldCoM` takes a `linkMatrix` accessor, not the robot**, so it
  unit-tests with plain three.js `Object3D`s instead of a full `URDFRobot`.
- **Half-weighed robots work**: non-positive / non-finite masses are skipped, and
  the result is `null` when nothing is weighed (the caller shows "no mass set"
  rather than a misleading point at the origin).
- **Axis correctness**: `groundProjection` zeroes the up axis. Snakie's world is
  **Y-up** — the robot is rotated so URDF Z-up becomes scene Y-up (`RobotView.tsx:3272`),
  baked into `matrixWorld` — and the ground height (the robot's `minY`) is passed
  in by the overlay rather than assumed to be 0.
- **kg + metres throughout**, matching the URDF the data comes from.

Deliberately **not** in `src/shared/ik/` — that module is planar/2-D and mirrored
1:1 by `snakie_ik.py`; 3-D mass maths there would break its cross-language contract.

## Tests

13 tests: weighted averages (equal, unequal, all-3-axes), skip-empty, null-when-none,
matrix transforms **including a rotated link frame** (a 90°-about-Y link puts a
local +X CoM at world −Z — proving the glue handles orientation, not just
translation), and `readLinkMasses` round-tripping real `<inertial>` tags.

No visible UI — that's the overlay (#558).

`lint` / `typecheck` / `test` (1999 passing) / `build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)