### PR TITLE
feat: ground-contact tagging (#557, epic #535 §2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Ground-contact tagging (#557, epic #535 §2).** A link's Properties gain a
+  Ground Contacts section: mark the points where a part (a foot or wheel) touches
+  the floor, so the support-polygon check (coming in #558) has vertices to hull.
+  "Add contact point" drops one at the link's lowest point automatically; each is
+  editable by x/y/z (mm) and removable. Points are stored per link in `robot.yml`
+  (`contacts`, link-local metres) and transform with the pose, so a lifted foot
+  moves with it. New pure `robot-contacts.ts` (world-transform + immutable edits).
+  Part-level authoring on the parts library is a follow-up (it needs the
+  link→part mapping URDF links don't yet carry).
 - **Centre-of-mass computation service (#556, epic #535 §2).** New
   `robot-com.ts`: the robot's total mass and mass-weighted centre of mass at its
   current pose. Split so the maths is pure and unit-tested (`centreOfMass` —

--- a/src/renderer/src/components/RobotPropertiesDialog.css
+++ b/src/renderer/src/components/RobotPropertiesDialog.css
@@ -449,3 +449,43 @@
   font-size: 0.56rem;
   color: var(--danger, #e06c5a);
 }
+
+/* Ground-contact rows (#557) — x/y/z mm inputs + delete. */
+.robotprops__contactrow {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.3rem;
+}
+.robotprops__contactaxis {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  flex: 1;
+  font-size: 0.52rem;
+  color: var(--text-muted, #8b919b);
+}
+.robotprops__contactaxis input {
+  width: 100%;
+  box-sizing: border-box;
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  font-size: 0.62rem;
+  color: var(--text, #cdd2d9);
+  background: var(--bg-sunken, rgba(0, 0, 0, 0.25));
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 4px;
+  padding: 0.12rem 0.2rem;
+}
+.robotprops__contactdel {
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  font-size: 0.62rem;
+  color: var(--text-muted, #8b919b);
+  background: transparent;
+  border: 1px solid var(--border, #3a3d44);
+  border-radius: 4px;
+  padding: 0.12rem 0.3rem;
+  cursor: pointer;
+}
+.robotprops__contactdel:hover {
+  color: var(--danger, #e06c5a);
+  border-color: var(--danger, #e06c5a);
+}

--- a/src/renderer/src/components/RobotPropertiesDialog.tsx
+++ b/src/renderer/src/components/RobotPropertiesDialog.tsx
@@ -72,6 +72,20 @@ export interface MassEditorProps {
   onSetInfill: (infill: number) => void
 }
 
+/**
+ * The Ground-contacts editor for a link (#557) — the foot/wheel points the
+ * support polygon is hulled from. Points are in the link's own frame, MM (the
+ * editor's unit; stored as metres). `null` ⇒ not applicable.
+ */
+export interface ContactsEditorProps {
+  /** This link's contact points, in mm. */
+  pointsMm: Array<[number, number, number]>
+  /** Add a point — at the link's lowest mesh vertex where known, else the origin. */
+  onAdd: () => void
+  onRemove: (index: number) => void
+  onSet: (index: number, pointMm: [number, number, number]) => void
+}
+
 export interface RobotPropertiesDialogProps {
   context: PropsContext
   // link / joint
@@ -81,6 +95,8 @@ export interface RobotPropertiesDialogProps {
   onSetSize: (link: string, dims: number[]) => void
   /** Mass editor for the open link (#555), or null when not applicable. */
   massEditor?: MassEditorProps | null
+  /** Ground-contact editor for the open link (#557), or null when not applicable. */
+  contactsEditor?: ContactsEditorProps | null
   /** The edited link's colour (#rrggbb), or undefined for the default. */
   linkColor?: string
   /** Whether this link can be recoloured (a primitive, or an STL mesh — not DAE). */
@@ -297,6 +313,60 @@ function MassForm({ mass }: { mass: MassEditorProps }): JSX.Element {
   )
 }
 
+/**
+ * The Ground-contacts section (#557): the points on a link that touch the floor,
+ * so the support polygon has vertices. Each is x/y/z in mm; "Add" drops one at
+ * the link's lowest point (or origin) to nudge, and each row deletes.
+ */
+function ContactsForm({ contacts }: { contacts: ContactsEditorProps }): JSX.Element {
+  const { pointsMm, onAdd, onRemove, onSet } = contacts
+  return (
+    <section className="robotprops__section">
+      <div className="robotprops__label">
+        Ground contacts
+        <span className="robotprops__masssrc">
+          {pointsMm.length ? `${pointsMm.length} pt${pointsMm.length === 1 ? '' : 's'}` : 'none'}
+        </span>
+      </div>
+      {pointsMm.map((p, i) => (
+        <div className="robotprops__contactrow" key={i}>
+          {(['x', 'y', 'z'] as const).map((axis, a) => (
+            <label key={axis} className="robotprops__contactaxis">
+              <span>{axis}</span>
+              <input
+                type="number"
+                step="1"
+                value={Math.round(p[a] * 10) / 10}
+                onChange={(e) => {
+                  const next: [number, number, number] = [...p]
+                  next[a] = Number(e.target.value)
+                  onSet(i, next)
+                }}
+                aria-label={`Contact ${i + 1} ${axis} (mm)`}
+              />
+            </label>
+          ))}
+          <button
+            type="button"
+            className="robotprops__contactdel"
+            onClick={() => onRemove(i)}
+            title="Remove this contact point"
+            aria-label={`Remove contact ${i + 1}`}
+          >
+            ✕
+          </button>
+        </div>
+      ))}
+      <button type="button" className="robotprops__minibtn" onClick={onAdd}>
+        + Add contact point
+      </button>
+      {pointsMm.length === 0 && (
+        <p className="robotprops__note">Mark where this part touches the floor (a foot or wheel).</p>
+      )}
+    </section>
+  )
+}
+
 export function RobotPropertiesDialog(props: RobotPropertiesDialogProps): JSX.Element {
   const { context, onOk, onCancel } = props
 
@@ -443,6 +513,7 @@ function LinkBody({
   jointNames,
   onSetSize,
   massEditor,
+  contactsEditor,
   onSetJoint,
   onRenameJoint,
   onSetJointOrigin,
@@ -470,6 +541,7 @@ function LinkBody({
             </section>
           )}
           {massEditor && <MassForm mass={massEditor} />}
+          {contactsEditor && <ContactsForm contacts={contactsEditor} />}
           {colorable ? (
             // Primitives + STL meshes recolour via the inline URDF <material>. (DAE/
             // Collada meshes carry their own materials, so they fall through to the note.)

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -166,8 +166,9 @@ import {
   type MassBreakdown,
   type MassSort
 } from './robot-mass'
-import type { MassEditorProps } from './RobotPropertiesDialog'
+import type { MassEditorProps, ContactsEditorProps } from './RobotPropertiesDialog'
 import type { MeshTriangles } from './robot-mass-geometry'
+import { addContact, removeContact, setContact } from './robot-contacts'
 import './RobotView.css'
 
 /** An empty motion clip (2 s, ease-in-out, looping). */
@@ -265,6 +266,40 @@ function linkLocalTriangles(robot: URDFRobot, link: string): MeshTriangles | nul
   return positions.length >= 9 ? { positions } : null
 }
 
+/**
+ * The link's LOCAL-frame point that sits lowest in the WORLD (#557) — the
+ * natural spot to seed a ground-contact for a foot. Scans the link's own mesh
+ * vertices, tracks the one with the smallest world Y (Snakie's up axis), and
+ * returns it back in link-local coordinates. Null when the link has no mesh.
+ */
+function lowestLinkPointLocal(robot: URDFRobot, link: string): [number, number, number] | null {
+  const linkObj = robot.links[link]
+  if (!linkObj) return null
+  robot.updateMatrixWorld(true)
+  const toWorld = new THREE.Matrix4().copy(linkObj.matrixWorld)
+  const toLocal = new THREE.Matrix4().copy(toWorld).invert()
+  const world = new THREE.Vector3()
+  let best: THREE.Vector3 | null = null
+  let bestY = Infinity
+  linkObj.traverse((o) => {
+    const mesh = o as THREE.Mesh
+    if (!mesh.isMesh || ownerLink(mesh) !== link) return
+    const geom = mesh.geometry as THREE.BufferGeometry
+    const pos = geom.getAttribute('position') as THREE.BufferAttribute | undefined
+    if (!pos) return
+    for (let i = 0; i < pos.count; i++) {
+      world.fromBufferAttribute(pos, i).applyMatrix4(mesh.matrixWorld)
+      if (world.y < bestY) {
+        bestY = world.y
+        best = world.clone()
+      }
+    }
+  })
+  if (!best) return null
+  const local = (best as THREE.Vector3).applyMatrix4(toLocal)
+  return [local.x, local.y, local.z]
+}
+
 export function RobotView({
   urdfContent,
   basePath,
@@ -296,6 +331,9 @@ export function RobotView({
   const [overrides, setOverrides] = useState<Record<string, { min?: number; max?: number }>>({})
   const [poses, setPoses] = useState<NamedPoseLike[]>([])
   const posesRef = useRef<NamedPoseLike[]>([])
+  // Per-link ground-contact points (#557), link-local metres — mirrors robot.yml
+  // `contacts`, kept reactive so the inspector reflects edits immediately.
+  const [contacts, setContacts] = useState<Record<string, [number, number, number][]>>({})
   posesRef.current = poses
   // Managed sequences (#413) parsed from an opened motion.py — round-tripped
   // losslessly on re-export even though the sequence editor UI (#415) is pending.
@@ -1015,6 +1053,40 @@ export function RobotView({
     return summariseMass(rows, massSort)
   }, [content, massSort])
 
+  // ── Ground-contact points (#557, epic #535 §2) ───────────────────────────
+  const persistContacts = (next: Record<string, [number, number, number][]>): void => {
+    setContacts(next)
+    void persist((m) => {
+      if (Object.keys(next).length) m.contacts = next
+      else delete m.contacts
+    })
+  }
+  const handleAddContact = (link: string): void => {
+    const robot = robotRef.current
+    const local = robot ? lowestLinkPointLocal(robot, link) : null
+    persistContacts(addContact(contacts, link, local ?? [0, 0, 0]))
+  }
+  const handleRemoveContact = (link: string, index: number): void => {
+    persistContacts(removeContact(contacts, link, index))
+  }
+  const handleSetContactMm = (link: string, index: number, mm: [number, number, number]): void => {
+    persistContacts(setContact(contacts, link, index, [mmToM(mm[0]), mmToM(mm[1]), mmToM(mm[2])]))
+  }
+
+  const contactsEditor = useMemo<ContactsEditorProps | null>(() => {
+    if (!editLink || dialogCtx?.kind !== 'link') return null
+    const pointsMm = (contacts[editLink] ?? []).map(
+      (p): [number, number, number] => [mToMm(p[0]), mToMm(p[1]), mToMm(p[2])]
+    )
+    return {
+      pointsMm,
+      onAdd: () => handleAddContact(editLink),
+      onRemove: (i) => handleRemoveContact(editLink, i),
+      onSet: (i, mm) => handleSetContactMm(editLink, i, mm)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editLink, dialogCtx, contacts])
+
   // Colour a link (#405) — an inline URDF <material>, so it round-trips + undoes like
   // any other build edit; urdf-loader renders it, recolouring only this link.
   const handleSetColor = (link: string, hex: string): void => {
@@ -1584,6 +1656,7 @@ export function RobotView({
         defRef.current = def // seed so persist() never clobbers an unloaded robot.yml
         setBindings(def.robot?.servoJointMap ?? [])
         setControls(def.robot?.controls ?? []) // puppet controls (#416)
+        setContacts(def.robot?.contacts ?? {}) // ground contacts (#557)
         setPlacedParts(def.parts ?? []) // breadboard parts (for the bindable-servos list)
         setPlacedConns(def.connections ?? [])
       } catch {
@@ -5086,6 +5159,7 @@ export function RobotView({
             jointNames={allJointNames}
             onSetSize={handleSetSize}
             massEditor={massEditor}
+            contactsEditor={contactsEditor}
             linkColor={editLinkColor}
             colorable={editColorable}
             usedColors={usedLinkColors}

--- a/src/renderer/src/components/robot-contacts.ts
+++ b/src/renderer/src/components/robot-contacts.ts
@@ -1,0 +1,98 @@
+/**
+ * GROUND-CONTACT POINTS (#557, epic #535 §2) — the feet/wheels the support
+ * polygon (#558) is hulled from.
+ *
+ * A robot's ground contacts are stored per link in `robot.yml`
+ * (`RobotModel.contacts`), each a point in that LINK's own frame, in metres. As
+ * the robot poses, a foot's world position changes, so the world contact set is
+ * recomputed per frame by transforming each point by its link's `matrixWorld` —
+ * exactly like the CoM service (#556).
+ *
+ * Pure maths + a thin three.js transform, split so the geometry tests without a
+ * renderer. UNITS: metres (scene/URDF native); the editor UI converts mm↔m.
+ */
+import { Matrix4, Vector3 } from 'three'
+
+export type Vec3 = [number, number, number]
+
+/** A contact point resolved to the world frame, tagged with its owning link. */
+export interface WorldContact {
+  link: string
+  world: Vec3
+}
+
+/**
+ * Transform every link's local contact points into the world frame at the
+ * current pose.
+ *
+ * `linkMatrix(link)` returns the link's `matrixWorld` (or null if absent) — in
+ * the app, `(l) => robot.links[l]?.matrixWorld ?? null` after
+ * `robot.updateMatrixWorld(true)`. An accessor (not the robot) keeps this
+ * unit-testable with plain three.js objects.
+ */
+export function contactWorldPoints(
+  linkMatrix: (link: string) => Matrix4 | null | undefined,
+  contacts: Record<string, Vec3[]>
+): WorldContact[] {
+  const out: WorldContact[] = []
+  const v = new Vector3()
+  for (const [link, pts] of Object.entries(contacts)) {
+    const mat = linkMatrix(link)
+    if (!mat) continue
+    for (const p of pts) {
+      v.set(p[0], p[1], p[2]).applyMatrix4(mat)
+      out.push({ link, world: [v.x, v.y, v.z] })
+    }
+  }
+  return out
+}
+
+/** Total number of contact points across all links. */
+export function contactCount(contacts: Record<string, Vec3[]> | undefined): number {
+  if (!contacts) return 0
+  let n = 0
+  for (const pts of Object.values(contacts)) n += pts.length
+  return n
+}
+
+/**
+ * Add a contact point to a link, returning a NEW map (never mutates the input) —
+ * the immutable-update shape the robot.yml persist path expects.
+ */
+export function addContact(
+  contacts: Record<string, Vec3[]> | undefined,
+  link: string,
+  point: Vec3
+): Record<string, Vec3[]> {
+  const next = { ...(contacts ?? {}) }
+  next[link] = [...(next[link] ?? []), point]
+  return next
+}
+
+/** Remove the contact at `index` from a link; drops the link key when it empties. */
+export function removeContact(
+  contacts: Record<string, Vec3[]> | undefined,
+  link: string,
+  index: number
+): Record<string, Vec3[]> {
+  const next = { ...(contacts ?? {}) }
+  const pts = (next[link] ?? []).filter((_, i) => i !== index)
+  if (pts.length) next[link] = pts
+  else delete next[link]
+  return next
+}
+
+/** Replace one contact point's coordinates (in metres), returning a new map. */
+export function setContact(
+  contacts: Record<string, Vec3[]> | undefined,
+  link: string,
+  index: number,
+  point: Vec3
+): Record<string, Vec3[]> {
+  const next = { ...(contacts ?? {}) }
+  const pts = [...(next[link] ?? [])]
+  if (index < 0 || index >= pts.length) return next
+  pts[index] = point
+  next[link] = pts
+  return next
+}

--- a/src/shared/krf.ts
+++ b/src/shared/krf.ts
@@ -211,6 +211,25 @@ function sanitiseVec3Map(raw: unknown): Record<string, [number, number, number]>
   return out
 }
 
+/** A map of key → LIST of vec3s (e.g. per-link ground-contact points, #557).
+ *  Drops malformed points, and keys whose list ends up empty. */
+function sanitiseVec3ListMap(raw: unknown): Record<string, [number, number, number][]> {
+  const out: Record<string, [number, number, number][]> = {}
+  if (raw && typeof raw === 'object') {
+    for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+      if (!Array.isArray(v)) continue
+      const pts = v
+        .filter(
+          (p): p is [number, number, number] =>
+            Array.isArray(p) && p.length === 3 && p.every(isFiniteNum)
+        )
+        .map((p) => [p[0], p[1], p[2]] as [number, number, number])
+      if (pts.length) out[k] = pts
+    }
+  }
+  return out
+}
+
 /**
  * Validate the robot-model section, corruption-safe: unknown/legacy shapes and
  * bad fields are dropped, never thrown. Returns `undefined` when there's no
@@ -266,6 +285,9 @@ export function sanitiseRobotModel(raw: unknown): RobotModel | undefined {
     }
     if (Object.keys(linkMass).length) model.linkMass = linkMass
   }
+
+  const contacts = sanitiseVec3ListMap(r.contacts)
+  if (Object.keys(contacts).length) model.contacts = contacts
 
   if (Array.isArray(r.poses)) {
     const poses = r.poses

--- a/src/shared/robot.ts
+++ b/src/shared/robot.ts
@@ -66,6 +66,10 @@ export interface RobotModel {
    *  the active source, and the material/infill an estimate used so it stays
    *  reproducible. Keyed by link name. Absent ⇒ the link has no authored mass. */
   linkMass?: Record<string, LinkMassSpec>
+  /** Per-link GROUND-CONTACT points (#557, epic #535 §2), in the link's own
+   *  frame, METRES — the feet/wheels the support-polygon hull is built from.
+   *  Keyed by link name; a link with none doesn't touch the ground. */
+  contacts?: Record<string, [number, number, number][]>
   /** Per-joint absolute roll about its own normal axis, in DEGREES (#354). The URDF
    *  `<origin rpy>` already bakes this in; it's remembered here so the joint editor
    *  can show the current roll and edit it absolutely (deltas re-applied to the rpy),

--- a/test/krf.test.ts
+++ b/test/krf.test.ts
@@ -182,6 +182,27 @@ describe('sanitiseRobotModel — corruption-safe (#310)', () => {
     expect(m).toBeDefined()
     expect(m!.linkMass!.arm.source).toBe('measured')
   })
+
+  it('sanitises ground contacts (#557): keeps valid vec3 lists, drops junk', () => {
+    const m = sanitiseRobotModel({
+      contacts: {
+        foot_l: [[0, 0, 0], [0.02, 0, 0.01]],
+        foot_r: [[1, 2, 3]],
+        bad: [[0, 0], 'nope', [1, 2, 3, 4]], // all malformed → key dropped
+        empty: []
+      }
+    })
+    expect(m!.contacts!.foot_l).toEqual([[0, 0, 0], [0.02, 0, 0.01]])
+    expect(m!.contacts!.foot_r).toEqual([[1, 2, 3]])
+    expect(m!.contacts!.bad).toBeUndefined()
+    expect(m!.contacts!.empty).toBeUndefined()
+  })
+
+  it('a contacts-only model round-trips (regression: never silently dropped)', () => {
+    const m = sanitiseRobotModel({ contacts: { foot: [[0, 0, 0]] } })
+    expect(m).toBeDefined()
+    expect(m!.contacts!.foot).toEqual([[0, 0, 0]])
+  })
 })
 
 describe('scaffoldKrf (#310)', () => {

--- a/test/robotContacts.test.ts
+++ b/test/robotContacts.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import { Object3D } from 'three'
+import {
+  addContact,
+  contactCount,
+  contactWorldPoints,
+  removeContact,
+  setContact,
+  type Vec3
+} from '../src/renderer/src/components/robot-contacts'
+
+const closeVec = (got: Vec3, want: Vec3, tol = 1e-6): void => {
+  for (let i = 0; i < 3; i++) expect(Math.abs(got[i] - want[i])).toBeLessThan(tol)
+}
+
+describe('contactWorldPoints', () => {
+  const linkAt = (x: number, y: number, z: number): Object3D => {
+    const o = new Object3D()
+    o.position.set(x, y, z)
+    o.updateMatrixWorld(true)
+    return o
+  }
+
+  it('transforms each link’s local contacts by its world matrix', () => {
+    const links: Record<string, Object3D> = { foot: linkAt(1, 0, 3) }
+    const out = contactWorldPoints((l) => links[l]?.matrixWorld ?? null, {
+      foot: [
+        [0, 0, 0],
+        [0.5, 0, 0]
+      ]
+    })
+    expect(out).toHaveLength(2)
+    expect(out[0].link).toBe('foot')
+    closeVec(out[0].world, [1, 0, 3])
+    closeVec(out[1].world, [1.5, 0, 3])
+  })
+
+  it('spans multiple links (both feet of the polygon)', () => {
+    const links: Record<string, Object3D> = { l: linkAt(-1, 0, 0), r: linkAt(1, 0, 0) }
+    const out = contactWorldPoints((k) => links[k]?.matrixWorld ?? null, {
+      l: [[0, 0, 0]],
+      r: [[0, 0, 0]]
+    })
+    expect(out.map((c) => c.world[0]).sort()).toEqual([-1, 1])
+  })
+
+  it('skips a link whose matrix is missing', () => {
+    const links: Record<string, Object3D> = { a: linkAt(2, 0, 0) }
+    const out = contactWorldPoints((k) => links[k]?.matrixWorld ?? null, {
+      a: [[0, 0, 0]],
+      gone: [[0, 0, 0]]
+    })
+    expect(out).toHaveLength(1)
+  })
+
+  it('applies a rotated link frame', () => {
+    const o = new Object3D()
+    o.rotation.y = Math.PI / 2
+    o.updateMatrixWorld(true)
+    const out = contactWorldPoints(() => o.matrixWorld, { a: [[1, 0, 0]] })
+    closeVec(out[0].world, [0, 0, -1]) // +X about +90° Y → -Z
+  })
+})
+
+describe('contactCount', () => {
+  it('counts across links', () => {
+    expect(contactCount({ a: [[0, 0, 0], [1, 0, 0]], b: [[0, 0, 0]] })).toBe(3)
+    expect(contactCount({})).toBe(0)
+    expect(contactCount(undefined)).toBe(0)
+  })
+})
+
+describe('immutable edits', () => {
+  it('addContact appends without mutating', () => {
+    const before = { foot: [[0, 0, 0] as Vec3] }
+    const after = addContact(before, 'foot', [1, 2, 3])
+    expect(after.foot).toHaveLength(2)
+    expect(before.foot).toHaveLength(1) // untouched
+  })
+
+  it('addContact starts a new link', () => {
+    expect(addContact(undefined, 'foot', [0, 0, 0])).toEqual({ foot: [[0, 0, 0]] })
+  })
+
+  it('removeContact drops one point, and the key when it empties', () => {
+    const c = { foot: [[0, 0, 0] as Vec3, [1, 0, 0] as Vec3] }
+    expect(removeContact(c, 'foot', 0).foot).toEqual([[1, 0, 0]])
+    expect(removeContact({ foot: [[0, 0, 0] as Vec3] }, 'foot', 0).foot).toBeUndefined()
+  })
+
+  it('setContact replaces one point in place', () => {
+    const c = { foot: [[0, 0, 0] as Vec3, [1, 0, 0] as Vec3] }
+    const out = setContact(c, 'foot', 1, [9, 9, 9])
+    expect(out.foot).toEqual([[0, 0, 0], [9, 9, 9]])
+    expect(c.foot[1]).toEqual([1, 0, 0]) // original untouched
+  })
+
+  it('setContact ignores an out-of-range index', () => {
+    const c = { foot: [[0, 0, 0] as Vec3] }
+    expect(setContact(c, 'foot', 5, [9, 9, 9]).foot).toEqual([[0, 0, 0]])
+  })
+})


### PR DESCRIPTION
Closes #557. Seventh sub-issue under epic #535 (§2), and the last thing #558's
support polygon needs before it can be built.

Mark the points where a part (a foot, a wheel) touches the floor, so the
support-polygon hull has vertices.

## Scope

Per the epic-map correction, there is **no anchor/contact concept in the
codebase** to extend — this is a new data model. Scoped (with your call) to the
**robot-level per-link model**, which is fully wireable and unblocks #558.
Part-level authoring on the parts library is a **follow-up**: auto-applying a
part's contacts to a link needs the link→part mapping URDF links don't carry
(the same gap as library-mass).

## What's here

- **Data model** — `RobotModel.contacts` (`Record<link, vec3[]>`), link-local
  **metres**, sanitised in `krf.ts` (`sanitiseVec3ListMap` drops malformed points
  and empty keys), round-tripped like the other model maps.
- **`robot-contacts.ts`** (pure) — `contactWorldPoints` transforms each link's
  local points by its live `matrixWorld` (accessor-based, so it tests with plain
  `Object3D`s); `addContact` / `removeContact` / `setContact` are immutable edits
  for the persist path.
- **Inspector UI** — a Ground Contacts section: x/y/z (mm) rows, per-point delete,
  "+ Add contact point". A reactive `contacts` state mirrors `robot.yml` so edits
  show immediately.
- **`lowestLinkPointLocal`** — "Add" seeds a point at the link's lowest **world-Y**
  vertex (converted back to link-local), so a foot's contact places itself; falls
  back to the origin for a mesh-less link.

Points are stored in the link frame and transform with the pose, so a lifted foot
carries its contact — exactly what #558's per-frame polygon needs.

## Verification

Driven in the web build under headless Chromium: adding a contact to the demo
base cylinder seeds **[0, −90, −25] mm** — its bottom rim (radius 90 mm) — and the
point edits and removes; chip goes none → "1 pt" → none. No console errors. The
pure helpers and `krf` sanitise are unit-tested, including a rotated-frame
transform.

`lint` / `typecheck` / `test` (2011 passing) / `build` / `build:web` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)