### PR TITLE
feat: move mass out of the hierarchy to a total readout (#567)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   recompute every frame as joints move. The shared engine the CoM +
   support-polygon overlay, the stability strip and the balance parameters all
   build on. No visible UI yet — that's the overlay (#558).
-- **Total mass + per-link breakdown table (#555, epic #535 §1).** The Build panel
-  gains a Mass section: the robot's total mass at a glance, and a per-link table
-  you can sort by mass (what dominates) or by name. Rows with no mass show a dash,
-  with a hint that the total is a lower bound until they're weighed; clicking a
-  row opens that link's mass editor. Reads each link's stored `<inertial>`, so it
-  reflects what's actually set.
+- **Total mass readout (#555 / #567, epic #535 §1).** The Build panel shows the
+  robot's total mass in a compact bar above the footer (a `+` when some links are
+  still un-weighed, so the total reads as a lower bound). Per-link mass is edited
+  in each item's Properties dialog — the hierarchy stays a list of physical items
+  (#567).
 - **Per-link mass in the robot inspector (#555, epic #535 §1).** A link's
   Properties now has a Mass section: pick a print material (PLA/PETG/ABS/resin)
   and an infill %, and Snakie estimates the mass from the mesh volume live; a

--- a/src/renderer/src/components/RobotBuildPanel.css
+++ b/src/renderer/src/components/RobotBuildPanel.css
@@ -608,78 +608,20 @@
   background: rgba(128, 128, 128, 0.14);
 }
 
-/* Mass summary (#555 part 2) — total readout + per-link breakdown table. */
-.robotbuild__masstotal {
-  color: var(--accent, #34ad4f);
-  font-weight: 700;
-}
-.robotbuild__masstable {
+/* Total-mass readout (#555 / #567) — a compact bar above the panel footer.
+   Per-link mass lives in the Properties dialog; this is just the robot-level sum. */
+.robotbuild__masstotal-bar {
   display: flex;
-  flex-direction: column;
-  gap: 0.1rem;
-  padding: 0.15rem 0.2rem 0.3rem;
-}
-.robotbuild__masssort {
-  display: flex;
-  gap: 0.25rem;
-  margin-bottom: 0.2rem;
-}
-.robotbuild__masssort button {
-  font-family: var(--font-mono, 'JetBrains Mono', monospace);
-  font-size: 0.54rem;
-  color: var(--text-muted, #8b919b);
-  background: transparent;
-  border: 1px solid var(--border, #3a3d44);
-  border-radius: 4px;
-  padding: 0.05rem 0.3rem;
-  cursor: pointer;
-}
-.robotbuild__masssort button.is-on {
-  color: var(--accent-ink, #191a1d);
-  background: var(--accent, #d6a23f);
-  border-color: var(--accent, #d6a23f);
-}
-.robotbuild__massrow {
-  display: grid;
-  grid-template-columns: 1fr auto auto;
   align-items: center;
-  gap: 0.4rem;
-  width: 100%;
+  justify-content: space-between;
+  padding: 0.25rem 0.5rem;
   font-family: var(--font-mono, 'JetBrains Mono', monospace);
   font-size: 0.6rem;
-  color: var(--text, #cdd2d9);
-  background: transparent;
-  border: none;
-  border-radius: 4px;
-  padding: 0.12rem 0.3rem;
-  cursor: pointer;
-  text-align: left;
+  color: var(--text-muted, #8b919b);
+  border-top: 1px solid var(--border, #3a3d44);
 }
-.robotbuild__massrow:hover {
-  background: var(--bg-sunken, rgba(255, 255, 255, 0.05));
-}
-.robotbuild__massrow-link {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.robotbuild__massrow-g {
+.robotbuild__masstotal-g {
+  color: var(--accent, #34ad4f);
+  font-weight: 700;
   font-variant-numeric: tabular-nums;
-  color: var(--text, #cdd2d9);
-}
-.robotbuild__massrow-src {
-  font-size: 0.52rem;
-  color: var(--text-muted, #8b919b);
-}
-.robotbuild__massrow-src--measured {
-  color: #7ec98f;
-}
-.robotbuild__massrow-src--none {
-  font-style: italic;
-}
-.robotbuild__masshint {
-  margin: 0.2rem 0.3rem 0;
-  font-size: 0.54rem;
-  font-style: italic;
-  color: var(--text-muted, #8b919b);
 }

--- a/src/renderer/src/components/RobotBuildPanel.tsx
+++ b/src/renderer/src/components/RobotBuildPanel.tsx
@@ -14,7 +14,7 @@ import { principalAxisName } from './robot-build'
 import { toDisplay, toNative, unitLabel, normPin, type MovableType } from './robot-pose'
 import { boundJoint, type BindableServo } from './servo-bind'
 import { shouldAutoHide } from './pin-overlay'
-import { sourceLabel, type MassBreakdown, type MassSort } from './robot-mass'
+import type { MassBreakdown } from './robot-mass'
 import type { ServoJointBinding } from '../../../shared/robot'
 import type { NamedPoseLike } from './robot-pose'
 import type { PropsContext } from './RobotPropertiesDialog'
@@ -132,11 +132,9 @@ export interface RobotBuildPanelProps {
   canEdit: boolean
   /** Open a different robot `.urdf` via the native picker (works popped out). */
   onOpenRobot: () => void
-  /** Per-link mass breakdown + total (#555 part 2), or null when nothing has a mass. */
+  /** The robot's total mass in grams + how many links are still un-weighed (#555 /
+   *  #567) — a compact footer readout; per-link mass lives in the Properties dialog. */
   massSummary?: MassBreakdown | null
-  /** Current breakdown sort, and a setter (the table's "by mass / by name" toggle). */
-  massSort: MassSort
-  onSetMassSort: (sort: MassSort) => void
 }
 
 /** metres → integer mm (display) and back. */
@@ -505,93 +503,6 @@ function Section({
   )
 }
 
-/** Grams for the table, whole numbers once past ~10 g, else one decimal. */
-const fmtRowGrams = (g: number): string =>
-  g >= 10 ? Math.round(g).toString() : (Math.round(g * 10) / 10).toString()
-
-/**
- * The Mass summary (#555 part 2): a total-mass readout + a per-link table you
- * can sort by mass (what dominates) or name. Collapsible like the other tree
- * sections; clicking a row opens that link's inspector. Rows with no mass show
- * a dash so it's obvious what's still un-weighed.
- */
-function MassSummary({
-  summary,
-  sort,
-  onSetSort,
-  collapsed,
-  onToggle,
-  onSelect
-}: {
-  summary: MassBreakdown
-  sort: MassSort
-  onSetSort: (s: MassSort) => void
-  collapsed: Record<string, boolean>
-  onToggle: (id: string) => void
-  onSelect: (link: string) => void
-}): JSX.Element {
-  const isCollapsed = !!collapsed.mass
-  return (
-    <div className="robotbuild__section">
-      <button
-        type="button"
-        className="robotbuild__branch"
-        aria-expanded={!isCollapsed}
-        onClick={() => onToggle('mass')}
-      >
-        <span className="robotbuild__caret">{isCollapsed ? '▸' : '▾'}</span>
-        <span className="robotbuild__branch-label">Mass</span>
-        <span className="robotbuild__branch-count robotbuild__masstotal">
-          {Math.round(summary.totalG)} g
-        </span>
-      </button>
-      {!isCollapsed && (
-        <div className="robotbuild__masstable">
-          <div className="robotbuild__masssort" role="group" aria-label="Sort mass table">
-            <button
-              type="button"
-              className={sort === 'mass' ? 'is-on' : ''}
-              onClick={() => onSetSort('mass')}
-            >
-              by mass
-            </button>
-            <button
-              type="button"
-              className={sort === 'name' ? 'is-on' : ''}
-              onClick={() => onSetSort('name')}
-            >
-              by name
-            </button>
-          </div>
-          {summary.rows.map((r) => (
-            <button
-              key={r.link}
-              type="button"
-              className="robotbuild__massrow"
-              onClick={() => onSelect(r.link)}
-              title={`Edit ${r.link}'s mass`}
-            >
-              <span className="robotbuild__massrow-link">{r.link}</span>
-              <span className="robotbuild__massrow-g">
-                {r.grams > 0 ? `${fmtRowGrams(r.grams)} g` : '—'}
-              </span>
-              <span className={`robotbuild__massrow-src robotbuild__massrow-src--${r.source}`}>
-                {r.grams > 0 ? sourceLabel(r.source) : 'not set'}
-              </span>
-            </button>
-          ))}
-          {summary.unsetCount > 0 && (
-            <p className="robotbuild__masshint">
-              {summary.unsetCount} link{summary.unsetCount === 1 ? '' : 's'} with no mass — the total
-              is a lower bound.
-            </p>
-          )}
-        </div>
-      )}
-    </div>
-  )
-}
-
 const INDENT = 14 // px of indent per depth level in the chain tree
 
 // A distinct glyph per joint type (#): a lock (fixed), a rotation arrow (hinge /
@@ -769,9 +680,7 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
     importing,
     canEdit,
     onOpenRobot,
-    massSummary,
-    massSort,
-    onSetMassSort
+    massSummary
   } = props
   const dockRef = useRef<HTMLElement | null>(null)
   const prompt = usePrompt()
@@ -933,16 +842,6 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
             ))}
           </Section>
         )}
-        {massSummary && massSummary.rows.length > 0 && (
-          <MassSummary
-            summary={massSummary}
-            sort={massSort}
-            onSetSort={onSetMassSort}
-            collapsed={collapsed}
-            onToggle={toggle}
-            onSelect={onEdit}
-          />
-        )}
         {rootLink === null && assembly.length > 1 && (
           <p className="robotbuild__hint">
             Several parts, no base yet — right-click a part ▸ <b>Make base</b> to start the chain.
@@ -1071,6 +970,22 @@ export function RobotBuildPanel(props: RobotBuildPanelProps): JSX.Element {
           <p className="robotbuild__hint">Add a block or import an STL to start building.</p>
         )}
       </div>
+
+      {massSummary && massSummary.totalG > 0 && (
+        <div
+          className="robotbuild__masstotal-bar"
+          title={
+            massSummary.unsetCount > 0
+              ? `${massSummary.unsetCount} link(s) still un-weighed — the total is a lower bound. Set a link's mass in its Properties.`
+              : 'Sum of every link’s mass'
+          }
+        >
+          <span>Total mass</span>
+          <span className="robotbuild__masstotal-g">
+            {Math.round(massSummary.totalG)} g{massSummary.unsetCount > 0 ? '+' : ''}
+          </span>
+        </div>
+      )}
 
       <div className="robotbuild__foot">
         <button

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -163,8 +163,7 @@ import {
   DEFAULT_MATERIAL,
   DEFAULT_INFILL,
   type MassEstimate,
-  type MassBreakdown,
-  type MassSort
+  type MassBreakdown
 } from './robot-mass'
 import type { MassEditorProps, ContactsEditorProps } from './RobotPropertiesDialog'
 import type { MeshTriangles } from './robot-mass-geometry'
@@ -913,7 +912,6 @@ export function RobotView({
   // dragging the infill slider re-estimates live.
   const [massMaterial, setMassMaterial] = useState(DEFAULT_MATERIAL)
   const [massInfill, setMassInfill] = useState(DEFAULT_INFILL)
-  const [massSort, setMassSort] = useState<MassSort>('mass')
   useEffect(() => {
     const lm = editLink ? defRef.current?.robot?.linkMass?.[editLink] : undefined
     setMassMaterial(lm?.material ?? DEFAULT_MATERIAL)
@@ -1050,8 +1048,10 @@ export function RobotView({
       const source = inertial ? lm?.[link]?.source ?? 'measured' : 'none'
       return { link, grams, source }
     })
-    return summariseMass(rows, massSort)
-  }, [content, massSort])
+    // Sort order is irrelevant now only the total is shown (#567), but the
+    // breakdown is kept for a future stats surface; default (by mass) is fine.
+    return summariseMass(rows)
+  }, [content])
 
   // ── Ground-contact points (#557, epic #535 §2) ───────────────────────────
   const persistContacts = (next: Record<string, [number, number, number][]>): void => {
@@ -5136,8 +5136,6 @@ export function RobotView({
             canEdit={canEdit}
             onOpenRobot={() => void handleOpenRobotFile()}
             massSummary={massSummary}
-            massSort={massSort}
-            onSetMassSort={setMassSort}
           />
         )}
         {showPanel && dialogCtx && (


### PR DESCRIPTION
Closes #567.

Per your feedback: the hierarchy should list physical items, and mass is a
per-item property that belongs in the Properties dialog — where per-link mass
editing already lives (#555a). The Build-panel Mass **section** (#555b) put a
total + sortable per-link table *inside* the hierarchy tree, which is the part
that doesn't belong there.

## Change

- **Removed** the Mass section (total + sortable per-link table) from the
  hierarchy tree.
- **Added** a compact **Total mass** bar above the panel footer — a robot-level
  stat, not a hierarchy node: `<n> g`, or `<n> g+` when some links are still
  un-weighed (so the total reads as a lower bound; the tooltip explains).
- Per-link mass is seen/edited by opening a link's **Properties** (unchanged from
  #555a).
- `summariseMass` is kept (the total still uses it; only the sortable rows are no
  longer rendered), so a future stats surface can reuse the breakdown. Dropped the
  now-unused `massSort` state + sort props.

## Verification

Web build under headless Chromium: the hierarchy shows only **Chain** (no Mass
branch, no table rows, no sort toggle); the total bar hides when nothing is
weighed (`totalG === 0`).

`lint` / `typecheck` / `test` (2011 passing) / `build` / `build:web` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)