### PR TITLE
feat: CoM + support-polygon overlay in Robot View (#558, epic #535 §2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Centre-of-mass + support-polygon overlay (#558, epic #535 §2).** The headline
+  of the mass epic: a new ⚖ Balance toggle in Robot View drops a marker on the
+  robot's live centre of mass, a plumb line down to the ground, and the support
+  polygon — the convex hull of the grounded contact points (#557). It colours by
+  static stability: green while the CoM projection sits inside the polygon, amber
+  near the edge, red once it leaves and the robot would tip, with the clearance in
+  mm on a HUD pill. Everything recomputes each frame, so it tracks joint sliders,
+  Motion Studio playback and IK drags; a lifted foot leaves the polygon. Composes
+  with Bone Mode. Pure geometry (`robot-support.ts`: 2-D hull, point-in-polygon,
+  stability) kept separate from the three.js overlay and unit-tested.
 - **Ground-contact tagging (#557, epic #535 §2).** A link's Properties gain a
   Ground Contacts section: mark the points where a part (a foot or wheel) touches
   the floor, so the support-polygon check (coming in #558) has vertices to hull.

--- a/src/renderer/src/components/RobotView.css
+++ b/src/renderer/src/components/RobotView.css
@@ -412,3 +412,17 @@
   color: var(--accent-ink);
   border-color: var(--accent);
 }
+
+/* CoM overlay stability pill (#558) — colour tracks the stability state. */
+.robotview__hud-com--stable {
+  color: #b9f6c9;
+  border-color: #2f7d47;
+}
+.robotview__hud-com--marginal {
+  color: #ffe0a3;
+  border-color: #b07d1e;
+}
+.robotview__hud-com--unstable {
+  color: #ffc2bb;
+  border-color: #b23b2e;
+}

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -62,6 +62,8 @@ import {
 } from './robot-assembly'
 import { canReRoot, reRoot } from './robot-reroot'
 import { createBoneMode, duplicateNames, type BoneModeHandle } from './robot-bone-mode'
+import { createComOverlay, type ComOverlayHandle, type ComStatus } from './robot-com-overlay'
+import { readLinkMasses } from './robot-com'
 import { usePrompt } from './PromptModal'
 import { createViewCube } from './robot-viewcube'
 import {
@@ -147,6 +149,7 @@ import {
   ExplodeIcon,
   ClapperIcon,
   BoneIcon,
+  BalanceIcon,
   TargetIcon,
   CameraIcon,
   RulerIcon,
@@ -333,6 +336,12 @@ export function RobotView({
   // Per-link ground-contact points (#557), link-local metres — mirrors robot.yml
   // `contacts`, kept reactive so the inspector reflects edits immediately.
   const [contacts, setContacts] = useState<Record<string, [number, number, number][]>>({})
+  const contactsRef = useRef<Record<string, [number, number, number][]>>({})
+  contactsRef.current = contacts
+  // The scene ground-plane Y (the grid's height) + the per-link masses, held in
+  // refs so the CoM overlay's per-frame getData reads them without re-closing (#558).
+  const groundYRef = useRef(0)
+  const linkMassesRef = useRef<ReturnType<typeof readLinkMasses>>({})
   posesRef.current = poses
   // Managed sequences (#413) parsed from an opened motion.py — round-tripped
   // losslessly on re-export even though the sequence editor UI (#415) is pending.
@@ -346,6 +355,10 @@ export function RobotView({
   const [boneMode, setBoneMode] = useState(false) // skeleton overlay (#536)
   const boneModeRef = useRef(false)
   const boneApiRef = useRef<BoneModeHandle | null>(null)
+  const [comMode, setComMode] = useState(false) // CoM + support-polygon overlay (#558)
+  const comModeRef = useRef(false)
+  const comApiRef = useRef<ComOverlayHandle | null>(null)
+  const [comStatus, setComStatus] = useState<ComStatus | null>(null)
   // Interactive IK goal gizmo (#540, epic #533 §5): a draggable end-effector goal
   // that live-solves the selected chain (shared planar solver).
   const [ikGoal, setIkGoal] = useState(false)
@@ -1051,6 +1064,12 @@ export function RobotView({
     // Sort order is irrelevant now only the total is shown (#567), but the
     // breakdown is kept for a future stats surface; default (by mass) is fine.
     return summariseMass(rows)
+  }, [content])
+
+  // Per-link masses for the CoM overlay (#558) — recomputed only on edit, held in
+  // a ref so the render loop reads them without re-parsing the URDF every frame.
+  useEffect(() => {
+    linkMassesRef.current = readLinkMasses(content, parseAssembly(content).map((i) => i.link))
   }, [content])
 
   // ── Ground-contact points (#557, epic #535 §2) ───────────────────────────
@@ -2485,6 +2504,18 @@ export function RobotView({
     highlightApiRef.current?.apply(selectedLinkRef.current)
   }, [boneMode])
 
+  // CoM + support-polygon overlay toggle (#558). Live status is pushed to the HUD
+  // from the render loop (only when it changes), so just arm/disarm here.
+  const comStatusRef = useRef<string>('')
+  useEffect(() => {
+    comModeRef.current = comMode
+    comApiRef.current?.setEnabled(comMode)
+    if (!comMode) {
+      comStatusRef.current = ''
+      setComStatus(null)
+    }
+  }, [comMode])
+
   // Arm/disarm the interactive IK goal gizmo (#540).
   useEffect(() => {
     ikGoalRef.current = ikGoal
@@ -2531,6 +2562,7 @@ export function RobotView({
     const layGrid = (size: number, minY: number): void => {
       disposeGrid()
       gridParams = { size, minY }
+      groundYRef.current = minY // feed the CoM overlay's ground plane (#558)
       const light = themeIsLight()
       const minorC = light ? 0xd7d3c6 : 0x2b2d32
       const majorC = light ? 0xbcb6a4 : 0x40434a
@@ -2595,6 +2627,17 @@ export function RobotView({
     const boneModeApi = createBoneMode(scene, () => robotRef.current)
     boneApiRef.current = boneModeApi
     boneModeApi.setEnabled(boneModeRef.current)
+
+    // CoM + support-polygon overlay (#558): also built once, driven per-frame.
+    // Composes with Bone Mode. getData reads live refs so it tracks every edit.
+    const comOverlayApi = createComOverlay(scene, () => robotRef.current, () => ({
+      masses: linkMassesRef.current,
+      contacts: contactsRef.current,
+      groundY: groundYRef.current,
+      marginFrac: 0.1
+    }))
+    comApiRef.current = comOverlayApi
+    comOverlayApi.setEnabled(comModeRef.current)
 
     // Interactive IK goal gizmo (#540): drag a goal, the shared planar solver
     // poses the chain live, streams to a connected board, and feeds Capture Pose.
@@ -4729,6 +4772,15 @@ export function RobotView({
       controls.update()
       boneModeApi.update() // live skeleton overlay (#536) — follows every joint drive
       ikGizmoApi.update() // interactive IK goal gizmo (#540) — composes with Bone Mode
+      const cs = comOverlayApi.update() // CoM + support polygon (#558)
+      if (comModeRef.current) {
+        // Push to the HUD only when the readout actually changes — no per-frame renders.
+        const key = cs ? `${cs.state}:${cs.marginMm}:${Math.round(cs.massKg * 1000)}` : ''
+        if (key !== comStatusRef.current) {
+          comStatusRef.current = key
+          setComStatus(cs)
+        }
+      }
       renderer.render(scene, camera)
       if (viewCube) {
         viewCube.sync(camera.quaternion)
@@ -4759,6 +4811,7 @@ export function RobotView({
       zoomApiRef.current = null
       boneApiRef.current = null
       boneModeApi.dispose()
+      comOverlayApi.dispose()
       ikApiRef.current = null
       ikGizmoApi.dispose()
       if (viewCube) {
@@ -5052,6 +5105,17 @@ export function RobotView({
             >
               <BoneIcon />
             </button>
+            {/* CoM + support-polygon overlay (#558): balance point + stability. */}
+            <button
+              type="button"
+              className={`robotview__zbtn${comMode ? ' is-active' : ''}`}
+              onClick={() => setComMode((v) => !v)}
+              title="Balance — centre of mass, ground projection and support polygon"
+              aria-label="Centre of mass overlay"
+              aria-pressed={comMode}
+            >
+              <BalanceIcon />
+            </button>
             {/* Interactive IK goal gizmo (#540): drag a goal, the chain follows. */}
             <button
               type="button"
@@ -5217,16 +5281,25 @@ export function RobotView({
         )}
         {/* Floating status pills (formerly hosted in the retired pose sidebar): the
             save state, and the measure tool's live readout. */}
-        {showPanel && (savingLabel || (measureActive && measureDist != null)) && (
-          <div className="robotview__hud-status">
-            {measureActive && measureDist != null && (
-              <span className="robotview__hud-pill">
-                <RulerIcon size={13} /> {Math.round(measureDist)} mm
-              </span>
-            )}
-            {savingLabel && <span className="robotview__hud-pill">{savingLabel}</span>}
-          </div>
-        )}
+        {showPanel &&
+          (savingLabel || (measureActive && measureDist != null) || (comMode && comStatus)) && (
+            <div className="robotview__hud-status">
+              {measureActive && measureDist != null && (
+                <span className="robotview__hud-pill">
+                  <RulerIcon size={13} /> {Math.round(measureDist)} mm
+                </span>
+              )}
+              {comMode && comStatus && (
+                <span className={`robotview__hud-pill robotview__hud-com robotview__hud-com--${comStatus.state}`}>
+                  <BalanceIcon size={13} />{' '}
+                  {comStatus.state === 'none'
+                    ? `${Math.round(comStatus.massKg * 1000)} g · tag feet for stability`
+                    : `${Math.round(comStatus.massKg * 1000)} g · ${comStatus.state} · ${comStatus.marginMm} mm`}
+                </span>
+              )}
+              {savingLabel && <span className="robotview__hud-pill">{savingLabel}</span>}
+            </div>
+          )}
       </div>
       </div>
       {showTimeline && (

--- a/src/renderer/src/components/robot-com-overlay.ts
+++ b/src/renderer/src/components/robot-com-overlay.ts
@@ -1,0 +1,199 @@
+/**
+ * CoM + SUPPORT-POLYGON OVERLAY (#558, epic #535 §2) — the headline of §2, no
+ * physics. A toggleable Robot View overlay showing where the robot balances and
+ * whether it stays up.
+ *
+ *  • a marker at the live mass-weighted centre of mass (#556),
+ *  • a plumb line down to the ground + a ground marker,
+ *  • the SUPPORT POLYGON: the convex hull of the grounded contact points (#557),
+ *  • coloured by static stability — green inside, amber near the edge, red once
+ *    the CoM projection leaves the polygon and the robot would tip.
+ *
+ * Everything recomputes each frame from the live scene, so it tracks sliders,
+ * Motion Studio playback, IK drags and board telemetry alike. Follows the same
+ * factory lifecycle as Bone Mode (`create*`/`setEnabled`/`update`/`dispose`) and
+ * composes with it. The maths is all in the pure `robot-com` / `robot-contacts`
+ * / `robot-support` modules; this file is only the three.js glue.
+ */
+import * as THREE from 'three'
+import type { URDFRobot } from 'urdf-loader'
+import { robotWorldCoM, type LinkMass } from './robot-com'
+import { contactWorldPoints } from './robot-contacts'
+import { comStability, supportPolygon, type Pt2, type StabilityState } from './robot-support'
+
+/** What the overlay needs each frame — supplied by RobotView. */
+export interface ComOverlayData {
+  /** Per-link mass + local CoM (`readLinkMasses(content)`), static per edit. */
+  masses: Record<string, LinkMass>
+  /** Per-link ground-contact points, link-local metres (robot.yml `contacts`). */
+  contacts: Record<string, [number, number, number][]>
+  /** The ground-plane height in the scene (the grid's Y). */
+  groundY: number
+  /** Amber-band width as a fraction of polygon size (default 0.1). */
+  marginFrac?: number
+}
+
+/** The live stability readout, for a HUD pill. Null when nothing's computed. */
+export interface ComStatus {
+  state: StabilityState
+  marginMm: number
+  massKg: number
+}
+
+export interface ComOverlayHandle {
+  setEnabled(on: boolean): void
+  /** Per-frame: recompute + redraw; returns the current status (or null). */
+  update(): ComStatus | null
+  dispose(): void
+}
+
+const STATE_COLOR: Record<StabilityState, number> = {
+  stable: 0x4caf50,
+  marginal: 0xffb300,
+  unstable: 0xe53935,
+  none: 0x8b919b
+}
+
+export function createComOverlay(
+  scene: THREE.Scene,
+  getRobot: () => URDFRobot | null,
+  getData: () => ComOverlayData
+): ComOverlayHandle {
+  const root = new THREE.Group()
+  root.visible = false
+  root.renderOrder = 3
+  scene.add(root)
+
+  // CoM marker — a small bright sphere, drawn on top (depthTest off) so it's
+  // never hidden inside the mesh.
+  const comMat = new THREE.MeshBasicMaterial({ color: 0xffffff, depthTest: false })
+  const comMarker = new THREE.Mesh(new THREE.SphereGeometry(0.006, 16, 12), comMat)
+  comMarker.renderOrder = 5
+  root.add(comMarker)
+
+  // Plumb line CoM → ground + a ground marker ring.
+  const lineMat = new THREE.LineBasicMaterial({ color: 0xffffff, transparent: true, opacity: 0.7, depthTest: false })
+  const lineGeom = new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(), new THREE.Vector3()])
+  const plumb = new THREE.Line(lineGeom, lineMat)
+  plumb.renderOrder = 4
+  root.add(plumb)
+
+  const groundMat = new THREE.MeshBasicMaterial({ color: 0xffffff, depthTest: false, side: THREE.DoubleSide })
+  const groundMarker = new THREE.Mesh(new THREE.RingGeometry(0.004, 0.008, 20), groundMat)
+  groundMarker.rotation.x = -Math.PI / 2
+  groundMarker.renderOrder = 4
+  root.add(groundMarker)
+
+  // Support polygon — a translucent fill + a crisp outline, both rebuilt per
+  // frame (the hull changes as feet lift). Colour tracks stability.
+  const fillMat = new THREE.MeshBasicMaterial({
+    color: STATE_COLOR.none,
+    transparent: true,
+    opacity: 0.18,
+    side: THREE.DoubleSide,
+    depthWrite: false
+  })
+  const fill = new THREE.Mesh(new THREE.BufferGeometry(), fillMat)
+  fill.renderOrder = 2
+  root.add(fill)
+
+  const edgeMat = new THREE.LineBasicMaterial({ color: STATE_COLOR.none, transparent: true, opacity: 0.9 })
+  const edge = new THREE.LineLoop(new THREE.BufferGeometry(), edgeMat)
+  edge.renderOrder = 3
+  root.add(edge)
+
+  let enabled = false
+
+  /** Rebuild the polygon fill (fan-triangulated) + outline from a hull. */
+  const drawPolygon = (hull: Pt2[], groundY: number, color: number): void => {
+    fillMat.color.setHex(color)
+    edgeMat.color.setHex(color)
+    if (hull.length < 3) {
+      fill.visible = false
+      edge.visible = false
+      return
+    }
+    fill.visible = true
+    edge.visible = true
+
+    // Outline: the hull vertices on the ground plane.
+    const loop: number[] = []
+    for (const [x, z] of hull) loop.push(x, groundY + 0.0005, z)
+    const eg = edge.geometry
+    eg.setAttribute('position', new THREE.Float32BufferAttribute(loop, 3))
+    eg.computeBoundingSphere()
+
+    // Fill: fan from vertex 0 (valid for a convex polygon).
+    const verts: number[] = []
+    for (let i = 1; i < hull.length - 1; i++) {
+      verts.push(hull[0][0], groundY, hull[0][1])
+      verts.push(hull[i][0], groundY, hull[i][1])
+      verts.push(hull[i + 1][0], groundY, hull[i + 1][1])
+    }
+    const fg = fill.geometry
+    fg.setAttribute('position', new THREE.Float32BufferAttribute(verts, 3))
+    fg.computeBoundingSphere()
+  }
+
+  const update = (): ComStatus | null => {
+    if (!enabled) return null
+    const robot = getRobot()
+    if (!robot) {
+      root.visible = false
+      return null
+    }
+    root.visible = true
+    robot.updateMatrixWorld(true)
+    const matOf = (l: string): THREE.Matrix4 | null => robot.links[l]?.matrixWorld ?? null
+
+    const data = getData()
+    const com = robotWorldCoM(matOf, data.masses)
+    if (!com) {
+      // Nothing weighed — hide everything, report nothing.
+      comMarker.visible = false
+      plumb.visible = false
+      groundMarker.visible = false
+      drawPolygon([], data.groundY, STATE_COLOR.none)
+      return null
+    }
+    comMarker.visible = true
+    plumb.visible = true
+    groundMarker.visible = true
+
+    const [cx, cy, cz] = com.comWorld
+    comMarker.position.set(cx, cy, cz)
+    groundMarker.position.set(cx, data.groundY + 0.0005, cz)
+    lineGeom.setFromPoints([new THREE.Vector3(cx, cy, cz), new THREE.Vector3(cx, data.groundY, cz)])
+    lineGeom.computeBoundingSphere()
+
+    const worldContacts = contactWorldPoints(matOf, data.contacts).map((c) => c.world)
+    const hull = supportPolygon(worldContacts)
+    const stability = comStability([cx, cz], hull, data.marginFrac)
+    drawPolygon(hull, data.groundY, STATE_COLOR[stability.state])
+
+    return { state: stability.state, marginMm: stability.marginMm, massKg: com.massKg }
+  }
+
+  return {
+    setEnabled(on: boolean): void {
+      enabled = on
+      root.visible = on
+      if (!on) return
+      update()
+    },
+    update,
+    dispose(): void {
+      scene.remove(root)
+      comMarker.geometry.dispose()
+      comMat.dispose()
+      lineGeom.dispose()
+      lineMat.dispose()
+      groundMarker.geometry.dispose()
+      groundMat.dispose()
+      fill.geometry.dispose()
+      fillMat.dispose()
+      edge.geometry.dispose()
+      edgeMat.dispose()
+    }
+  }
+}

--- a/src/renderer/src/components/robot-support.ts
+++ b/src/renderer/src/components/robot-support.ts
@@ -1,0 +1,147 @@
+/**
+ * SUPPORT POLYGON + STABILITY (#558, epic #535 §2) — the pure geometry behind
+ * the CoM overlay: hull the ground-contact points into a support polygon, and
+ * decide whether the centre-of-mass projection keeps the robot upright.
+ *
+ * Static stability, no physics: a robot is statically stable exactly while its
+ * CoM's vertical projection stays inside the convex hull of its ground contacts
+ * (the "support polygon"). Near the edge it's marginal; outside, it tips.
+ *
+ * All 2-D on the ground plane. Snakie's world is Y-up, so a world point drops to
+ * the ground by taking its X and Z — points here are `[x, z]`. Pure (arrays in,
+ * verdict out) so it unit-tests without a renderer, like `robot-explode.ts`.
+ */
+
+/** A ground-plane point `[x, z]`, metres. */
+export type Pt2 = [number, number]
+
+/** Cross product of OA×OB — >0 left turn, <0 right, 0 collinear. */
+const cross = (o: Pt2, a: Pt2, b: Pt2): number =>
+  (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0])
+
+/**
+ * Convex hull (Andrew's monotone chain), returned counter-clockwise. Fewer than
+ * three distinct points yields the input (a point or a segment — no polygon).
+ */
+export function convexHull2D(points: readonly Pt2[]): Pt2[] {
+  const sorted = [...points].sort((a, b) => a[0] - b[0] || a[1] - b[1])
+  const uniq = sorted.filter(
+    (p, i) => i === 0 || p[0] !== sorted[i - 1][0] || p[1] !== sorted[i - 1][1]
+  )
+  if (uniq.length <= 2) return uniq
+
+  const lower: Pt2[] = []
+  for (const p of uniq) {
+    while (lower.length >= 2 && cross(lower[lower.length - 2], lower[lower.length - 1], p) <= 0) {
+      lower.pop()
+    }
+    lower.push(p)
+  }
+  const upper: Pt2[] = []
+  for (let i = uniq.length - 1; i >= 0; i--) {
+    const p = uniq[i]
+    while (upper.length >= 2 && cross(upper[upper.length - 2], upper[upper.length - 1], p) <= 0) {
+      upper.pop()
+    }
+    upper.push(p)
+  }
+  lower.pop()
+  upper.pop()
+  return lower.concat(upper)
+}
+
+/** Whether `p` is inside (or on) a CONVEX, CCW hull. False for a degenerate hull. */
+export function pointInHull(p: Pt2, hull: readonly Pt2[]): boolean {
+  if (hull.length < 3) return false
+  for (let i = 0; i < hull.length; i++) {
+    const a = hull[i]
+    const b = hull[(i + 1) % hull.length]
+    // A CCW hull keeps its interior to the LEFT of every edge; a strictly-right
+    // point is outside. A tiny epsilon keeps on-edge points inside.
+    if (cross(a, b, p) < -1e-9) return false
+  }
+  return true
+}
+
+/** Distance from `p` to segment `a–b`. */
+function distToSegment(p: Pt2, a: Pt2, b: Pt2): number {
+  const dx = b[0] - a[0]
+  const dz = b[1] - a[1]
+  const len2 = dx * dx + dz * dz
+  if (len2 === 0) return Math.hypot(p[0] - a[0], p[1] - a[1])
+  let t = ((p[0] - a[0]) * dx + (p[1] - a[1]) * dz) / len2
+  t = Math.max(0, Math.min(1, t))
+  return Math.hypot(p[0] - (a[0] + t * dx), p[1] - (a[1] + t * dz))
+}
+
+/** Shortest distance from `p` to the hull's boundary (any edge). 0 for <2 pts. */
+export function distanceToHullEdge(p: Pt2, hull: readonly Pt2[]): number {
+  if (hull.length < 2) return 0
+  let min = Infinity
+  for (let i = 0; i < hull.length; i++) {
+    const d = distToSegment(p, hull[i], hull[(i + 1) % hull.length])
+    if (d < min) min = d
+  }
+  return min
+}
+
+/** Polygon area (shoelace), always non-negative. */
+export function polygonArea(hull: readonly Pt2[]): number {
+  if (hull.length < 3) return 0
+  let a = 0
+  for (let i = 0; i < hull.length; i++) {
+    const p = hull[i]
+    const q = hull[(i + 1) % hull.length]
+    a += p[0] * q[1] - q[0] * p[1]
+  }
+  return Math.abs(a) / 2
+}
+
+/** Stability verdict for the CoM projection against a support polygon. */
+export type StabilityState = 'stable' | 'marginal' | 'unstable' | 'none'
+
+export interface Stability {
+  state: StabilityState
+  /** Signed clearance to the boundary, MM: + inside, − outside. 0 when `none`. */
+  marginMm: number
+}
+
+/**
+ * Classify the CoM ground-projection against the support polygon.
+ *
+ * `stable` — comfortably inside. `marginal` — inside but within `marginFrac` of
+ * the polygon's characteristic size (√area) from an edge, the tipping-soon warn.
+ * `unstable` — outside, it tips. `none` — no polygon (fewer than three contacts).
+ */
+export function comStability(
+  comXZ: Pt2,
+  hull: readonly Pt2[],
+  marginFrac = 0.1
+): Stability {
+  if (hull.length < 3) return { state: 'none', marginMm: 0 }
+  const inside = pointInHull(comXZ, hull)
+  const dist = distanceToHullEdge(comXZ, hull)
+  const marginMm = Math.round(dist * 1000 * (inside ? 1 : -1))
+  if (!inside) return { state: 'unstable', marginMm }
+  const charSize = Math.sqrt(polygonArea(hull))
+  const state: StabilityState = dist < marginFrac * charSize ? 'marginal' : 'stable'
+  return { state, marginMm }
+}
+
+/**
+ * Build the support polygon from world-frame contact points.
+ *
+ * Only contacts within `groundTolM` of the lowest contact count — a lifted foot
+ * (well above the others) leaves the polygon, which is what makes a creep gait's
+ * stability change as it steps. Projects the survivors to the ground plane (drop
+ * Y) and hulls them.
+ */
+export function supportPolygon(
+  worldContacts: readonly [number, number, number][],
+  groundTolM = 0.002
+): Pt2[] {
+  if (worldContacts.length === 0) return []
+  const minY = Math.min(...worldContacts.map((c) => c[1]))
+  const grounded = worldContacts.filter((c) => c[1] <= minY + groundTolM)
+  return convexHull2D(grounded.map((c): Pt2 => [c[0], c[2]]))
+}

--- a/src/renderer/src/components/ui-icons.tsx
+++ b/src/renderer/src/components/ui-icons.tsx
@@ -282,6 +282,20 @@ export const CourseIcon = ({ emoji, size }: { emoji: string; size?: number }): J
   return Icon ? <Icon size={size} /> : <>{emoji}</>
 }
 
+/** A plumb bob over a base line — the centre-of-mass / balance overlay (#558). */
+export const BalanceIcon = ({ size }: { size?: number }): JSX.Element =>
+  svg(
+    g(
+      <>
+        <circle cx="12" cy="7" r="3" />
+        <path d="M12 10v7.5" strokeDasharray="1.5 2" />
+        <path d="M5 20.5h14" strokeWidth="2" />
+        <path d="M12 17.5l-2.4 3h4.8z" fill="currentColor" stroke="none" />
+      </>
+    ),
+    size
+  )
+
 /** A cylinder — the "add a tube" build primitive. */
 export const CylinderIcon = ({ size }: { size?: number }): JSX.Element =>
   svg(

--- a/test/robotComOverlay.test.ts
+++ b/test/robotComOverlay.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest'
+import * as THREE from 'three'
+import type { URDFRobot } from 'urdf-loader'
+import { createComOverlay, type ComOverlayData } from '../src/renderer/src/components/robot-com-overlay'
+
+/**
+ * Integration test for the CoM overlay's three.js glue (#558) — exercised with
+ * real data, which the unsaved demo in the browser harness can't provide. Uses
+ * plain three.js Object3Ds as the robot's links.
+ */
+
+/** A minimal URDFRobot stand-in: named links at world positions. */
+function fakeRobot(linkPos: Record<string, [number, number, number]>): URDFRobot {
+  const rootGroup = new THREE.Group()
+  const links: Record<string, THREE.Object3D> = {}
+  for (const [name, p] of Object.entries(linkPos)) {
+    const o = new THREE.Object3D()
+    o.position.set(p[0], p[1], p[2])
+    rootGroup.add(o)
+    links[name] = o
+  }
+  rootGroup.updateMatrixWorld(true)
+  return {
+    links,
+    updateMatrixWorld: (force?: boolean) => rootGroup.updateMatrixWorld(force)
+  } as unknown as URDFRobot
+}
+
+/** Find the polygon fill mesh (the one with the most vertices) under a scene. */
+function fillVertexCount(scene: THREE.Scene): number {
+  let max = 0
+  scene.traverse((o) => {
+    const m = o as THREE.Mesh
+    const pos = (m.geometry as THREE.BufferGeometry | undefined)?.getAttribute?.('position')
+    if (pos && pos.count > max) max = pos.count
+  })
+  return max
+}
+
+describe('createComOverlay', () => {
+  it('computes a stable verdict for a CoM inside the support polygon', () => {
+    const scene = new THREE.Scene()
+    // Two equal masses at x=0 and x=0.2 → CoM projects to (0.1, 0). Four feet in a
+    // 0.2 × 0.2 square centred there → the projection sits dead centre, stable.
+    const robot = fakeRobot({
+      a: [0, 0.1, 0],
+      b: [0.2, 0.1, 0],
+      f1: [0, 0, -0.1],
+      f2: [0.2, 0, -0.1],
+      f3: [0.2, 0, 0.1],
+      f4: [0, 0, 0.1]
+    })
+    const data: ComOverlayData = {
+      masses: {
+        a: { massKg: 1, comLocalM: [0, 0, 0] },
+        b: { massKg: 1, comLocalM: [0, 0, 0] }
+      },
+      contacts: {
+        f1: [[0, 0, 0]],
+        f2: [[0, 0, 0]],
+        f3: [[0, 0, 0]],
+        f4: [[0, 0, 0]]
+      },
+      groundY: 0
+    }
+    const overlay = createComOverlay(scene, () => robot, () => data)
+    overlay.setEnabled(true)
+    const status = overlay.update()
+
+    expect(status).not.toBeNull()
+    expect(status!.state).toBe('stable')
+    expect(status!.massKg).toBeCloseTo(2, 6)
+    // The polygon fill got triangulated (a triangle → 3 vertices).
+    expect(fillVertexCount(scene)).toBeGreaterThanOrEqual(3)
+    overlay.dispose()
+  })
+
+  it('reports unstable when the CoM leaves the polygon', () => {
+    const scene = new THREE.Scene()
+    // Mass sits far out at x=1; the feet cluster near the origin → CoM outside.
+    const robot = fakeRobot({
+      heavy: [1, 0.1, 0],
+      foot_l: [0, 0, 0],
+      foot_r: [0.1, 0, 0],
+      foot_b: [0.05, 0, 0.1]
+    })
+    const data: ComOverlayData = {
+      masses: { heavy: { massKg: 1, comLocalM: [0, 0, 0] } },
+      contacts: { foot_l: [[0, 0, 0]], foot_r: [[0, 0, 0]], foot_b: [[0, 0, 0]] },
+      groundY: 0
+    }
+    const overlay = createComOverlay(scene, () => robot, () => data)
+    overlay.setEnabled(true)
+    const status = overlay.update()
+    expect(status!.state).toBe('unstable')
+    expect(status!.marginMm).toBeLessThan(0)
+    overlay.dispose()
+  })
+
+  it('returns null and stays silent when nothing is weighed', () => {
+    const scene = new THREE.Scene()
+    const robot = fakeRobot({ a: [0, 0, 0] })
+    const overlay = createComOverlay(scene, () => robot, () => ({
+      masses: {},
+      contacts: {},
+      groundY: 0
+    }))
+    overlay.setEnabled(true)
+    expect(overlay.update()).toBeNull()
+    overlay.dispose()
+  })
+
+  it('reports "none" when weighed but with too few contacts to form a polygon', () => {
+    const scene = new THREE.Scene()
+    const robot = fakeRobot({ a: [0, 0.1, 0], foot: [0, 0, 0] })
+    const overlay = createComOverlay(scene, () => robot, () => ({
+      masses: { a: { massKg: 1, comLocalM: [0, 0, 0] } },
+      contacts: { foot: [[0, 0, 0]] }, // one point — no polygon
+      groundY: 0
+    }))
+    overlay.setEnabled(true)
+    const status = overlay.update()
+    expect(status!.state).toBe('none')
+    overlay.dispose()
+  })
+
+  it('does nothing while disabled', () => {
+    const scene = new THREE.Scene()
+    const robot = fakeRobot({ a: [0, 0.1, 0] })
+    const overlay = createComOverlay(scene, () => robot, () => ({
+      masses: { a: { massKg: 1, comLocalM: [0, 0, 0] } },
+      contacts: {},
+      groundY: 0
+    }))
+    expect(overlay.update()).toBeNull() // never enabled
+    overlay.dispose()
+  })
+})

--- a/test/robotSupport.test.ts
+++ b/test/robotSupport.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+import {
+  comStability,
+  convexHull2D,
+  distanceToHullEdge,
+  pointInHull,
+  polygonArea,
+  supportPolygon,
+  type Pt2
+} from '../src/renderer/src/components/robot-support'
+
+describe('convexHull2D', () => {
+  it('hulls a square, dropping an interior point', () => {
+    const hull = convexHull2D([
+      [0, 0],
+      [2, 0],
+      [2, 2],
+      [0, 2],
+      [1, 1] // interior — must be excluded
+    ])
+    expect(hull).toHaveLength(4)
+    expect(polygonArea(hull)).toBeCloseTo(4, 9)
+  })
+
+  it('returns the input for < 3 distinct points', () => {
+    expect(convexHull2D([[0, 0]])).toEqual([[0, 0]])
+    expect(convexHull2D([[0, 0], [1, 1]])).toHaveLength(2)
+    expect(convexHull2D([[0, 0], [0, 0], [0, 0]])).toHaveLength(1)
+  })
+
+  it('is counter-clockwise (positive signed area order)', () => {
+    const hull = convexHull2D([[0, 0], [2, 0], [2, 2], [0, 2]])
+    // Shoelace signed area > 0 ⇒ CCW.
+    let signed = 0
+    for (let i = 0; i < hull.length; i++) {
+      const p = hull[i]
+      const q = hull[(i + 1) % hull.length]
+      signed += p[0] * q[1] - q[0] * p[1]
+    }
+    expect(signed).toBeGreaterThan(0)
+  })
+})
+
+describe('pointInHull', () => {
+  const square: Pt2[] = [[0, 0], [2, 0], [2, 2], [0, 2]]
+
+  it('accepts an interior point, rejects an exterior one', () => {
+    expect(pointInHull([1, 1], square)).toBe(true)
+    expect(pointInHull([3, 1], square)).toBe(false)
+    expect(pointInHull([-0.1, 1], square)).toBe(false)
+  })
+
+  it('counts an on-edge point as inside', () => {
+    expect(pointInHull([2, 1], square)).toBe(true)
+    expect(pointInHull([0, 0], square)).toBe(true)
+  })
+
+  it('is false for a degenerate hull', () => {
+    expect(pointInHull([0, 0], [[0, 0], [1, 1]])).toBe(false)
+  })
+})
+
+describe('distanceToHullEdge', () => {
+  const square: Pt2[] = [[0, 0], [2, 0], [2, 2], [0, 2]]
+
+  it('is the distance to the nearest edge from inside', () => {
+    expect(distanceToHullEdge([0.5, 1], square)).toBeCloseTo(0.5, 9) // 0.5 from the left edge
+    expect(distanceToHullEdge([1, 1], square)).toBeCloseTo(1, 9) // centre → 1 to any edge
+  })
+
+  it('is the distance to the nearest edge from outside', () => {
+    expect(distanceToHullEdge([3, 1], square)).toBeCloseTo(1, 9)
+  })
+})
+
+describe('comStability', () => {
+  // A 200 mm × 200 mm foot square (metres), √area = 0.2 m, 10% margin = 0.02 m.
+  const foot: Pt2[] = [[0, 0], [0.2, 0], [0.2, 0.2], [0, 0.2]]
+
+  it('is stable well inside', () => {
+    const s = comStability([0.1, 0.1], foot)
+    expect(s.state).toBe('stable')
+    expect(s.marginMm).toBe(100) // 0.1 m to each edge
+  })
+
+  it('is marginal within 10% of the edge', () => {
+    const s = comStability([0.01, 0.1], foot) // 10 mm inside the left edge < 20 mm band
+    expect(s.state).toBe('marginal')
+    expect(s.marginMm).toBe(10)
+  })
+
+  it('is unstable outside, with a negative margin', () => {
+    const s = comStability([0.25, 0.1], foot) // 50 mm past the right edge
+    expect(s.state).toBe('unstable')
+    expect(s.marginMm).toBe(-50)
+  })
+
+  it('is "none" with no polygon (fewer than three contacts)', () => {
+    expect(comStability([0, 0], [[0, 0], [1, 0]]).state).toBe('none')
+  })
+
+  it('honours a custom margin fraction', () => {
+    // With a 0 margin band, a point just inside the edge is stable, not marginal.
+    expect(comStability([0.01, 0.1], foot, 0).state).toBe('stable')
+  })
+})
+
+describe('supportPolygon', () => {
+  it('hulls contacts near the ground and drops a lifted foot', () => {
+    // Three feet on the ground (y≈0) + one lifted 10 mm up → triangle, not quad.
+    const poly = supportPolygon([
+      [0, 0, 0],
+      [0.2, 0, 0],
+      [0.1, 0, 0.2],
+      [0.1, 0.01, 0.1] // lifted 10 mm — excluded (tol 2 mm)
+    ])
+    expect(poly).toHaveLength(3)
+    expect(polygonArea(poly)).toBeCloseTo(0.02, 6) // ½·0.2·0.2
+  })
+
+  it('keeps feet within the ground tolerance', () => {
+    const poly = supportPolygon([
+      [0, 0, 0],
+      [0.2, 0, 0],
+      [0.2, 0.001, 0.2], // 1 mm — within 2 mm tol, kept
+      [0, 0.0015, 0.2]
+    ])
+    expect(poly).toHaveLength(4)
+  })
+
+  it('is empty with no contacts', () => {
+    expect(supportPolygon([])).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #558. The **headline of the mass epic** — composes #556 (CoM service) and
#557 (contacts) into the visual payoff.

A new **⚖ Balance** toggle in Robot View drops:
- a marker on the robot's live **centre of mass**,
- a **plumb line** down to the ground + a ground marker,
- the **support polygon** — the convex hull of the grounded contact points,
- coloured by **static stability**: green while the CoM projection is inside the
  polygon, amber near the edge, red once it leaves and the robot would tip, with
  the clearance in mm on a HUD pill.

Everything recomputes each frame, so it tracks joint sliders, Motion Studio
playback and IK drags — and a **lifted foot leaves the polygon** (contacts within
2 mm of the lowest one count as grounded). Composes with Bone Mode.

## Structure

Same pure-core / thin-glue split as the rest of §2:

- **`robot-support.ts`** (pure, tested) — 2-D convex hull (Andrew's monotone
  chain), point-in-hull, distance-to-edge, polygon area, `comStability`
  (stable / marginal / unstable / none, configurable margin band), and
  `supportPolygon` (ground-filter + hull).
- **`robot-com-overlay.ts`** — a `create*`/`setEnabled`/`update`/`dispose` factory
  like Bone Mode: CoM marker (depth-test off so it's never hidden), plumb line +
  ground ring, and a fan-triangulated polygon fill + outline, recoloured and
  rebuilt each frame. `update()` returns a status for the HUD.
- **RobotView wiring** — Balance toggle in the zoom cluster (new `BalanceIcon`);
  per-frame `update()` in the render loop with the HUD pushed **only when it
  changes** (no per-frame React renders); masses/contacts/groundY fed via refs so
  `getData` never re-parses the URDF per frame.

## Verification

Two ways, because the browser demo can't set masses (unsaved-file guard):

1. **Live** — the Balance toggle arms in the web build and the scene renders with
   **zero console errors**; it shows nothing only because the demo has no masses.
2. **Integration test** (`robotComOverlay.test.ts`) — drives the overlay with real
   three.js link objects + masses + contacts, asserting **stable** (CoM centred in
   a foot square), **unstable** (negative margin, CoM outside), **none** (too few
   contacts), **null** (unweighed), disabled-noop, and that the polygon
   triangulates.

Plus 16 pure-geometry tests (`robotSupport.test.ts`): hull, point-in-polygon,
edge distance, the three stability states, and the lifted-foot exclusion.

`lint` / `typecheck` / `test` (2032 passing) / `build` / `build:web` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)