### PR TITLE
feat: Motion Studio stability strip (#559, epic #535 §3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Motion Studio stability strip (#559, epic #535 §3).** The Keyframes timeline
+  gains a **balance** heat-strip: each frame of the clip is sampled and coloured
+  green / amber / red by whether the centre-of-mass projection stays over the
+  support polygon (#558) at that pose — so a sequence that tips is obvious *before*
+  you flash it to hardware. Honest scoping in the tooltip: this is *static*
+  stability, and a dynamic gait (trot, run) can be statically unstable and still
+  walk, so amber/red is a heads-up, not an error. The strip only appears once
+  links have masses; it recomputes on timeline, contact or mass edits, never per
+  frame. (Per-frame CSV export + the ground-path draw are follow-ups.)
 - **Centre-of-mass + support-polygon overlay (#558, epic #535 §2).** The headline
   of the mass epic: a new ⚖ Balance toggle in Robot View drops a marker on the
   robot's live centre of mass, a plumb line down to the ground, and the support

--- a/src/renderer/src/components/RobotTimeline.css
+++ b/src/renderer/src/components/RobotTimeline.css
@@ -180,3 +180,53 @@
   font-size: 0.64rem;
   margin: 0.2rem 0;
 }
+
+/* Static-stability heat-strip (#559) — one cell per sampled frame, coloured by
+   whether the CoM projection stays over the support polygon. */
+.robottimeline__stab {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  height: 0.7rem;
+  margin: 0.1rem 0 0.15rem;
+}
+.robottimeline__stab-label {
+  flex: 0 0 6rem;
+  width: 6rem;
+  font-size: 0.56rem;
+  color: var(--text-muted, #9aa0a6);
+  cursor: help;
+}
+.robottimeline__stab-cells {
+  position: relative;
+  flex: 1 1 auto;
+  display: flex;
+  height: 100%;
+  border: 1px solid var(--border, #2c2e33);
+  border-radius: 4px;
+  overflow: hidden;
+}
+.robottimeline__stab-cell {
+  flex: 1 1 0;
+}
+.robottimeline__stab-cell--stable {
+  background: #3f9b52;
+}
+.robottimeline__stab-cell--marginal {
+  background: #d99a1a;
+}
+.robottimeline__stab-cell--unstable {
+  background: #cf4436;
+}
+.robottimeline__stab-cell--none {
+  background: var(--bg-sunken, #2b2d32);
+}
+.robottimeline__stab-playhead {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--accent);
+  pointer-events: none;
+  z-index: 2;
+}

--- a/src/renderer/src/components/RobotTimeline.tsx
+++ b/src/renderer/src/components/RobotTimeline.tsx
@@ -1,12 +1,16 @@
 import { useRef } from 'react'
 import type { MirrorPair, MotionEasing, MotionTimeline } from '../../../shared/robot'
 import type { NamedPoseLike } from './robot-pose'
+import type { StabilityState } from './robot-support'
 import './RobotTimeline.css'
 
 export interface RobotTimelineProps {
   timeline: MotionTimeline
   /** Movable (non-mimic) joint names — the track rows. */
   movableJoints: string[]
+  /** Per-frame static-stability samples across the clip (#559), left→right in
+   *  time. Empty when nothing is weighed — the strip hides. */
+  stabilityStrip?: StabilityState[]
   playhead: number // seconds
   playing: boolean
   /** The selected keyframe, if any. */
@@ -46,6 +50,7 @@ export function RobotTimeline(props: RobotTimelineProps): JSX.Element {
   const {
     timeline,
     movableJoints,
+    stabilityStrip,
     playhead,
     playing,
     selected,
@@ -249,6 +254,27 @@ export function RobotTimeline(props: RobotTimelineProps): JSX.Element {
           Export .py
         </button>
       </div>
+
+      {stabilityStrip && stabilityStrip.length > 0 && (
+        <div className="robottimeline__stab" role="group" aria-label="Static stability">
+          <span
+            className="robottimeline__stab-label"
+            title="Static stability: the centre of mass over the support polygon at each frame. A dynamic gait (trot, run) can be statically unstable and still walk — amber/red is a heads-up, not an error."
+          >
+            balance
+          </span>
+          <div className="robottimeline__stab-cells">
+            {stabilityStrip.map((s, i) => (
+              <span key={i} className={`robottimeline__stab-cell robottimeline__stab-cell--${s}`} />
+            ))}
+            <div
+              className="robottimeline__stab-playhead"
+              style={{ left: `${(Math.min(playhead, duration) / duration) * 100}%` }}
+              aria-hidden="true"
+            />
+          </div>
+        </div>
+      )}
 
       <div className="robottimeline__tracks">
         <div

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -62,8 +62,9 @@ import {
 } from './robot-assembly'
 import { canReRoot, reRoot } from './robot-reroot'
 import { createBoneMode, duplicateNames, type BoneModeHandle } from './robot-bone-mode'
-import { createComOverlay, type ComOverlayHandle, type ComStatus } from './robot-com-overlay'
+import { createComOverlay, poseBalance, type ComOverlayHandle, type ComStatus } from './robot-com-overlay'
 import { readLinkMasses } from './robot-com'
+import type { StabilityState } from './robot-support'
 import { usePrompt } from './PromptModal'
 import { createViewCube } from './robot-viewcube'
 import {
@@ -1926,6 +1927,47 @@ export function RobotView({
   const applyTimelineAt = (t: number, commitState = false): void => {
     applyDisplayPose(sampleTimeline(timelineRef.current, t), commitState)
   }
+
+  // Motion Studio stability strip (#559, epic #535 §3): sample the timeline at N
+  // points and classify each pose's static stability, for a green/amber/red
+  // heat-strip beside the tracks. Poses the robot to each sample WITHOUT React
+  // churn (applyDisplayPose commit=false) and restores the live pose after.
+  // Recomputes only when the timeline / contacts / masses change — never per
+  // frame. Empty when nothing is weighed (no meaningful stability).
+  const [stabilityStrip, setStabilityStrip] = useState<StabilityState[]>([])
+  useEffect(() => {
+    const r = robotRef.current
+    const tl = timelineRef.current
+    if (!r || tl.tracks.length === 0 || tl.duration <= 0) {
+      setStabilityStrip([])
+      return
+    }
+    const links = parseAssembly(contentRef.current).map((i) => i.link)
+    const masses = readLinkMasses(contentRef.current, links)
+    if (Object.keys(masses).length === 0) {
+      setStabilityStrip([])
+      return
+    }
+    const contactsNow = contactsRef.current
+    const matOf = (l: string): THREE.Matrix4 | null => r.links[l]?.matrixWorld ?? null
+    const N = 48
+    const states: StabilityState[] = []
+    for (let i = 0; i < N; i++) {
+      applyDisplayPose(sampleTimeline(tl, tl.duration * (i / (N - 1))), false)
+      r.updateMatrixWorld(true)
+      const balance = poseBalance(matOf, masses, contactsNow)
+      states.push(balance ? balance.stability.state : 'none')
+    }
+    // Restore the live pose (native joint values) the sampling perturbed.
+    for (const m of metaRef.current) {
+      if (m.isMimic) continue
+      const v = valuesRef.current[m.name]
+      if (typeof v === 'number') r.setJointValue(m.name, v)
+    }
+    r.updateMatrixWorld(true)
+    setStabilityStrip(states)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [timeline, contacts, content])
 
   // Playback: a rAF loop drives setJointValue every frame; the scrubber/playhead
   // React state is throttled to ~20 Hz so it never causes a per-frame re-render.
@@ -5313,6 +5355,7 @@ export function RobotView({
                 <RobotTimeline
                   timeline={timeline}
                   movableJoints={movableNames}
+                  stabilityStrip={stabilityStrip}
                   playhead={playhead}
                   playing={playing}
                   selected={selectedKey}

--- a/src/renderer/src/components/robot-com-overlay.ts
+++ b/src/renderer/src/components/robot-com-overlay.ts
@@ -17,9 +17,41 @@
  */
 import * as THREE from 'three'
 import type { URDFRobot } from 'urdf-loader'
-import { robotWorldCoM, type LinkMass } from './robot-com'
+import { robotWorldCoM, type CoMResult, type LinkMass } from './robot-com'
 import { contactWorldPoints } from './robot-contacts'
-import { comStability, supportPolygon, type Pt2, type StabilityState } from './robot-support'
+import {
+  comStability,
+  supportPolygon,
+  type Pt2,
+  type Stability,
+  type StabilityState
+} from './robot-support'
+
+/** The full balance picture at one pose: CoM, support polygon, verdict. */
+export interface PoseBalance {
+  com: CoMResult
+  hull: Pt2[]
+  stability: Stability
+}
+
+/**
+ * Compute a pose's balance from the live scene (#558/#559) — the shared core the
+ * overlay draws from and the Motion Studio strip (#559) samples. `matOf(link)`
+ * gives each link's `matrixWorld`. Null when nothing is weighed (no CoM).
+ */
+export function poseBalance(
+  matOf: (link: string) => THREE.Matrix4 | null | undefined,
+  masses: Record<string, LinkMass>,
+  contacts: Record<string, [number, number, number][]>,
+  marginFrac = 0.1
+): PoseBalance | null {
+  const com = robotWorldCoM(matOf, masses)
+  if (!com) return null
+  const world = contactWorldPoints(matOf, contacts).map((c) => c.world)
+  const hull = supportPolygon(world)
+  const stability = comStability([com.comWorld[0], com.comWorld[2]], hull, marginFrac)
+  return { com, hull, stability }
+}
 
 /** What the overlay needs each frame — supplied by RobotView. */
 export interface ComOverlayData {
@@ -147,8 +179,8 @@ export function createComOverlay(
     const matOf = (l: string): THREE.Matrix4 | null => robot.links[l]?.matrixWorld ?? null
 
     const data = getData()
-    const com = robotWorldCoM(matOf, data.masses)
-    if (!com) {
+    const balance = poseBalance(matOf, data.masses, data.contacts, data.marginFrac)
+    if (!balance) {
       // Nothing weighed — hide everything, report nothing.
       comMarker.visible = false
       plumb.visible = false
@@ -160,15 +192,13 @@ export function createComOverlay(
     plumb.visible = true
     groundMarker.visible = true
 
+    const { com, hull, stability } = balance
     const [cx, cy, cz] = com.comWorld
     comMarker.position.set(cx, cy, cz)
     groundMarker.position.set(cx, data.groundY + 0.0005, cz)
     lineGeom.setFromPoints([new THREE.Vector3(cx, cy, cz), new THREE.Vector3(cx, data.groundY, cz)])
     lineGeom.computeBoundingSphere()
 
-    const worldContacts = contactWorldPoints(matOf, data.contacts).map((c) => c.world)
-    const hull = supportPolygon(worldContacts)
-    const stability = comStability([cx, cz], hull, data.marginFrac)
     drawPolygon(hull, data.groundY, STATE_COLOR[stability.state])
 
     return { state: stability.state, marginMm: stability.marginMm, massKg: com.massKg }

--- a/test/robotComOverlay.test.ts
+++ b/test/robotComOverlay.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import * as THREE from 'three'
 import type { URDFRobot } from 'urdf-loader'
-import { createComOverlay, type ComOverlayData } from '../src/renderer/src/components/robot-com-overlay'
+import {
+  createComOverlay,
+  poseBalance,
+  type ComOverlayData
+} from '../src/renderer/src/components/robot-com-overlay'
 
 /**
  * Integration test for the CoM overlay's three.js glue (#558) — exercised with
@@ -134,5 +138,56 @@ describe('createComOverlay', () => {
     }))
     expect(overlay.update()).toBeNull() // never enabled
     overlay.dispose()
+  })
+})
+
+describe('poseBalance — shared by the overlay and the Motion Studio strip (#559)', () => {
+  const matOf =
+    (links: Record<string, THREE.Object3D>) =>
+    (l: string): THREE.Matrix4 | null =>
+      links[l]?.matrixWorld ?? null
+
+  const linkAt = (x: number, y: number, z: number): THREE.Object3D => {
+    const o = new THREE.Object3D()
+    o.position.set(x, y, z)
+    o.updateMatrixWorld(true)
+    return o
+  }
+
+  it('classifies a centred CoM over a foot square as stable', () => {
+    const links = {
+      m: linkAt(0.1, 0.1, 0),
+      f1: linkAt(0, 0, -0.1),
+      f2: linkAt(0.2, 0, -0.1),
+      f3: linkAt(0.2, 0, 0.1),
+      f4: linkAt(0, 0, 0.1)
+    }
+    const b = poseBalance(
+      matOf(links),
+      { m: { massKg: 1, comLocalM: [0, 0, 0] } },
+      { f1: [[0, 0, 0]], f2: [[0, 0, 0]], f3: [[0, 0, 0]], f4: [[0, 0, 0]] }
+    )
+    expect(b!.stability.state).toBe('stable')
+    expect(b!.hull).toHaveLength(4)
+    expect(b!.com.comWorld[0]).toBeCloseTo(0.1, 6)
+  })
+
+  it('classifies a CoM off the side as unstable', () => {
+    const links = {
+      m: linkAt(1, 0.1, 0),
+      f1: linkAt(0, 0, -0.05),
+      f2: linkAt(0.1, 0, -0.05),
+      f3: linkAt(0.05, 0, 0.05)
+    }
+    const b = poseBalance(
+      matOf(links),
+      { m: { massKg: 1, comLocalM: [0, 0, 0] } },
+      { f1: [[0, 0, 0]], f2: [[0, 0, 0]], f3: [[0, 0, 0]] }
+    )
+    expect(b!.stability.state).toBe('unstable')
+  })
+
+  it('is null when nothing is weighed', () => {
+    expect(poseBalance(matOf({ a: linkAt(0, 0, 0) }), {}, {})).toBeNull()
   })
 })


### PR DESCRIPTION
Closes #559. The last sub-issue of epic #535's §1–§3 first-build scope — §3.

Makes static instability visible **before flashing to hardware**: a **balance**
heat-strip beside the Keyframes tracks, one cell per sampled frame of the clip,
coloured green / amber / red by whether the CoM projection stays over the support
polygon (#558) at that pose. A sequence that tips is obvious at a glance.

## What's here

- **`poseBalance()`** — extracted the "one pose → { com, hull, stability }" core
  that #558's overlay computed inline, so the overlay **and** this strip share it.
  Takes a `matrixWorld` accessor (not the robot), so it's unit-testable with plain
  three.js `Object3D`s.
- **Strip sampler** (RobotView) — poses the robot to N=48 timeline samples via
  `applyDisplayPose(commit=false)` (no React churn), computes each frame's balance,
  then **restores the live pose**. Runs in an effect on timeline / contact / mass
  edits — never per render frame. Hidden until links have masses.
- **Heat-strip UI** (RobotTimeline) — cells aligned to the track area with their
  own playhead, and an **honest-scoping tooltip**: this is *static* stability, and
  a dynamic gait (trot, run) can be statically unstable and still walk — so
  amber/red is a heads-up, not an error.

## Scope note

The issue's per-frame **CSV export to Data View** and the **ground CoM-path draw**
are deliberately left as follow-ups — the heat-strip is the headline "obvious at a
glance" payoff and stands alone. Happy to file them.

## Verification

- **Live** (web build): the Keyframes timeline renders with the strip code, 3 demo
  tracks, **zero console errors**; the strip is correctly hidden because the demo
  has no masses (same unsaved-file limit as the rest of §2).
- **Unit** (`robotComOverlay.test.ts`): `poseBalance` — the strip's per-frame
  classifier — is tested for **stable** (CoM centred over a foot square),
  **unstable** (CoM off the side) and **null** (unweighed) with real three.js link
  objects. The stability maths underneath has 16 pure tests (#558).

`lint` / `typecheck` / `test` (2035 passing) / `build` / `build:web` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)