### PR TITLE
feat: workspace switch → Code · Electronics · Build (#575, epic #573)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- **Workspaces are now Code · Electronics · Build (#575, epic #573 Soft Shell).**
+  The top-toolbar switcher surfaces three workspaces: **Electronics** promotes the
+  Board View to a first-class segment (wire components beside your code), and
+  **Build** is the former Robot workspace (renamed so it won't collide with the
+  coming electronics simulator). The switcher takes the Soft Shell look — a soft
+  parchment track with a gold-gradient active segment in Plus Jakarta Sans. Data
+  Lab stays hidden for now; its fate is decided in the epic's close-out.
+
 ## [0.34.0] - 2026-07-21
 
 ### Added

--- a/src/renderer/src/components/WorkspaceSwitcher.css
+++ b/src/renderer/src/components/WorkspaceSwitcher.css
@@ -7,38 +7,39 @@
   gap: 0.3rem;
 }
 
+/* Soft Shell (#575): a soft --panel2 track with a gold-gradient active segment. */
 .ws-switcher__seg {
   display: inline-flex;
-  border: var(--border-w) solid var(--border);
-  border-radius: var(--radius);
-  background: var(--bg-sunken);
+  border: var(--border-w) solid var(--shellbd, var(--border));
+  border-radius: 10px;
+  background: var(--panel2, var(--bg-sunken));
+  padding: 2px;
+  gap: 2px;
   overflow: hidden;
 }
 
 .ws-switcher__btn {
-  font-family: var(--font-mono);
-  font-size: 0.62rem;
+  font-family: var(--font-ui, var(--font-mono));
+  font-size: 0.7rem;
   font-weight: 600;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  color: var(--text-muted);
+  letter-spacing: 0.01em;
+  color: var(--txt3, var(--text-muted));
   background: transparent;
   border: none;
-  padding: 0.32rem 0.55rem;
+  border-radius: 8px;
+  padding: 0.3rem 0.7rem;
   cursor: pointer;
 }
 
-.ws-switcher__btn + .ws-switcher__btn {
-  border-left: var(--border-w) solid var(--border);
-}
-
 .ws-switcher__btn:hover {
-  color: var(--text);
+  color: var(--head, var(--text));
 }
 
 .ws-switcher__btn.is-active {
-  background: var(--accent);
-  color: var(--accent-contrast);
+  background: var(--grad-gold, var(--accent));
+  color: var(--goldink, var(--accent-contrast));
+  font-weight: 700;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18);
 }
 
 /* Reset-to-preset: a small ghost icon button beside the segments. */

--- a/src/renderer/src/components/WorkspaceSwitcher.tsx
+++ b/src/renderer/src/components/WorkspaceSwitcher.tsx
@@ -10,11 +10,13 @@ import './WorkspaceSwitcher.css'
  * console scrollback, instruments) is lost. The ↺ button restores the active
  * workspace to its factory preset — the always-available "Reset layout" escape hatch.
  *
- * The Board + Data Lab workspaces are hidden from the switcher (the Board View is
- * still reachable via its pop-out window and the Robot workspace); a follow-up issue
- * tracks removing the underlying views. Reads the layout store directly.
+ * Soft Shell (#575, epic #573) surfaces three: **Code · Electronics · Build**
+ * (Electronics = the Board View; Build = the former Robot). Data Lab stays hidden
+ * for now — its fate is the epic's close-out (#581). Reads the layout store directly.
  */
-const VISIBLE_WORKSPACES = WORKSPACE_IDS.filter((id) => id === 'code' || id === 'robot')
+const VISIBLE_WORKSPACES = WORKSPACE_IDS.filter(
+  (id) => id === 'code' || id === 'board' || id === 'robot'
+)
 
 export function WorkspaceSwitcher(): JSX.Element {
   const layout = useWorkspaceLayout()

--- a/src/renderer/src/store/layout.ts
+++ b/src/renderer/src/store/layout.ts
@@ -45,11 +45,14 @@ export const WORKSPACE_IDS = ['code', 'board', 'datalab', 'robot'] as const
 export type WorkspaceId = (typeof WORKSPACE_IDS)[number]
 
 /** Display labels + a one-line description for the switcher tooltips. */
+// Soft Shell (#575, epic #573) renamed the switcher's three workspaces to
+// Code / Electronics / Build. "Electronics" surfaces the Board View; "Build"
+// (was "Robot") won't collide with the upcoming electronics simulator.
 export const WORKSPACE_INFO: Record<WorkspaceId, { label: string; hint: string }> = {
   code: { label: 'Code', hint: 'Editor-first: files, editor and console' },
-  board: { label: 'Board', hint: 'Focused Board View beside your code' },
+  board: { label: 'Electronics', hint: 'Wire components to your board — the Board View beside your code' },
   datalab: { label: 'Data Lab', hint: 'Instrument bench + a tall console/plotter' },
-  robot: { label: 'Robot', hint: 'Code · board · a 3D robot over the instruments' }
+  robot: { label: 'Build', hint: 'Assemble the robot in 3D — joints, IK chains and poses' }
 }
 
 /** One workspace's remembered geometry. */


### PR DESCRIPTION
Closes #575. Wave 2 of the Soft Shell redesign — the top-toolbar workspace switcher.

## Change

- **Three workspaces** in the switcher (was Code · Robot):
  - **Electronics** promotes the existing Board View (`board` workspace) to a
    first-class segment — wire components beside your code.
  - **Build** renames the Robot workspace (per the design; won't collide with the
    coming electronics *simulator*).
  - **Data Lab** stays hidden for now — its fate is the epic close-out (#581).
- `WORKSPACE_INFO` labels/hints updated; `VISIBLE_WORKSPACES` = code/board/robot.
- Switcher restyled to **Soft Shell**: soft `--panel2` track, gold-gradient
  (`--grad-gold` / `--goldink`) active segment, **Plus Jakarta Sans** (`--font-ui`),
  rounded segments — all via the #574 tokens, with fallbacks to the semantic
  tokens so it degrades cleanly.

The deprecated standalone gold "electronics" button + right-side refresh the
handoff mentions **don't exist** in the app (it's ahead of the mock there), so
nothing to remove. The rest of the toolbar chrome — brushed-metal, already
cohesively skeuomorphic — is left as-is; a deeper surface migration to the
flatter Soft Shell parchment is incremental and can follow.

## Verification

Web build under headless Chromium: Code / Electronics / Build render with the
gold active segment; clicking **Electronics** switches to the board tri-split and
**Build** to the 3D view; **zero console errors**. Screenshot of the styled
switcher captured.

`lint` / `typecheck` / `test` (2035) / `build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)