### PR TITLE
feat: Soft Shell UI font on the chrome — rail + status bar (#576, epic #573)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Changed
+- **Chrome now speaks the Soft Shell UI font (#576, epic #573).** The toolbar,
+  left icon rail, status bar, panel headers and tabs use **Plus Jakarta Sans**
+  (`--font-ui`) in both themes, replacing the old Helvetica chrome font — pairing
+  with IBM Plex Mono in the editor/console (#574). The rail (Files/Packages/Inspect
+  + Report/Learn/Help/Settings, dark with a gold active tile) and status bar
+  already matched the Soft Shell layout.
 - **Workspaces are now Code · Electronics · Build (#575, epic #573 Soft Shell).**
   The top-toolbar switcher surfaces three workspaces: **Electronics** promotes the
   Board View to a first-class segment (wire components beside your code), and

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -248,7 +248,7 @@
   --pillinset: rgba(255, 255, 255, 0.6);
 }
 
-/* Chrome speaks sans (Helvetica) in this skin; editor/console/trees stay mono. */
+/* Chrome speaks the Soft Shell UI font (Plus Jakarta Sans, #576); editor/console/trees stay mono. */
 :root[data-theme='skeuomorph'] .toolbar,
 :root[data-theme='skeuomorph'] .btn,
 :root[data-theme='skeuomorph'] .panel-header,
@@ -259,7 +259,7 @@
 :root[data-theme='skeuomorph'] .editor-tab,
 :root[data-theme='skeuomorph'] .localtree__title,
 :root[data-theme='skeuomorph'] .devicetree__title {
-  font-family: 'Helvetica Neue', Helvetica, Arial, system-ui, sans-serif;
+  font-family: var(--font-ui);
 }
 
 /* Metal backdrop shows through any seams between panels. */
@@ -974,7 +974,7 @@
  * dark-paper / phosphor palettes in their own components.
  * ========================================================================= */
 
-/* Chrome speaks sans (Helvetica) in this skin too; editor/console/trees mono. */
+/* Chrome speaks the Soft Shell UI font (Plus Jakarta Sans, #576); editor/console/trees mono. */
 :root[data-theme='dark'] .toolbar,
 :root[data-theme='dark'] .btn,
 :root[data-theme='dark'] .panel-header,
@@ -985,7 +985,7 @@
 :root[data-theme='dark'] .editor-tab,
 :root[data-theme='dark'] .localtree__title,
 :root[data-theme='dark'] .devicetree__title {
-  font-family: 'Helvetica Neue', Helvetica, Arial, system-ui, sans-serif;
+  font-family: var(--font-ui);
 }
 
 /* Metal backdrop shows through any seams between panels. */


### PR DESCRIPTION
Closes #576. Wave 2 of the Soft Shell redesign — the left icon rail + status bar.

The rail and status bar **already matched the Soft Shell layout** (the design was drawn from the app): a 72px dark rail with Files/Packages/Inspect up top and Report/Learn/Help/Settings pinned at the bottom, gold active tile; a status bar with the device dot, tagline, lines/dirty/version and the green Flash-firmware pill. So the real Soft Shell delta here is **typographic**:

- The chrome — toolbar, **left rail**, **status bar**, panel headers, tabs — now uses **Plus Jakarta Sans** (`--font-ui`) in both themes, replacing the old Helvetica chrome font. Pairs with IBM Plex Mono in the editor/console (#574); editor/console/trees stay mono.

## Verification

Web build under headless Chromium: the rail (`.activitybar__item`) and status bar (`.statusbar`) both compute to `"Plus Jakarta Sans", …`; the rail reads cleanly (screenshot captured); **zero console errors**.

`lint` / `typecheck` / `test` (2035) / `build` / `build:web` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)