### PR TITLE
feat: reusable collapsible-panel primitive (#577, epic #573)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Reusable collapsible-panel primitive (#577, epic #573).** A shared
+  `CollapsiblePanel` (Soft Shell styled) so every panel owns its own collapse
+  control — a chevron in its own header, with an optional badge and header
+  actions, and a `keepMounted` mode for panels whose contents must survive a
+  collapse (a terminal's scrollback, a live plotter). Waves 3 adopt it across the
+  Code / Electronics / Build workspaces.
+
 ### Changed
 - **Chrome now speaks the Soft Shell UI font (#576, epic #573).** The toolbar,
   left icon rail, status bar, panel headers and tabs use **Plus Jakarta Sans**

--- a/src/renderer/src/components/CollapsiblePanel.css
+++ b/src/renderer/src/components/CollapsiblePanel.css
@@ -1,0 +1,72 @@
+/* Soft Shell collapsible panel (#577, epic #573). Uses the Soft Shell tokens
+   (#574) with fallbacks to the semantic tokens so it reads before waves 2–3
+   finish the migration. */
+.cpanel {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.cpanel__head {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.cpanel__toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex: 1 1 auto;
+  min-width: 0;
+  font-family: var(--font-ui, sans-serif);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--txt3, var(--text-muted));
+  background: transparent;
+  border: none;
+  padding: 0.28rem 0.3rem;
+  cursor: pointer;
+  text-align: left;
+}
+
+.cpanel__toggle:hover {
+  color: var(--head, var(--text));
+}
+
+.cpanel__chevron {
+  font-size: 0.7rem;
+  line-height: 1;
+  color: var(--txt4, var(--text-muted));
+}
+
+.cpanel__title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cpanel__badge {
+  margin-left: auto;
+  font-variant-numeric: tabular-nums;
+  color: var(--txt4, var(--text-muted));
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.cpanel__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+}
+
+.cpanel__body {
+  min-height: 0;
+}
+
+/* keepMounted + collapsed: keep the body in the tree but out of view. */
+.cpanel__body--hidden {
+  display: none;
+}

--- a/src/renderer/src/components/CollapsiblePanel.tsx
+++ b/src/renderer/src/components/CollapsiblePanel.tsx
@@ -1,0 +1,77 @@
+import type { ReactNode } from 'react'
+import './CollapsiblePanel.css'
+
+/**
+ * SOFT SHELL COLLAPSIBLE PANEL (#577, epic #573) — the one collapsible-panel
+ * primitive the workspaces share, so every panel owns its OWN collapse control
+ * (a chevron in its own header) and a control never means different things in
+ * different workspaces.
+ *
+ * Controlled: the caller owns `open` + `onToggle` (persist it however it likes —
+ * the layout store, localStorage, component state). The toggle is a real button
+ * with `aria-expanded`; header `actions` sit BESIDE it (never nested in it, so
+ * the markup stays valid).
+ *
+ * `keepMounted` keeps the body in the tree (hidden) when collapsed, for panels
+ * whose contents must survive a collapse — a terminal's scrollback, a live
+ * plotter. Otherwise the body unmounts.
+ */
+export interface CollapsiblePanelProps {
+  title: string
+  open: boolean
+  onToggle: () => void
+  /** A count / status shown after the title (e.g. an item count). */
+  badge?: ReactNode
+  /** Header actions (icon buttons), right-aligned, shown only when open. */
+  actions?: ReactNode
+  /** Keep the body mounted (hidden) when collapsed, to preserve its state. */
+  keepMounted?: boolean
+  /** Extra class on the panel root. */
+  className?: string
+  /** Extra class on the body wrapper (e.g. a list layout). */
+  bodyClassName?: string
+  children: ReactNode
+}
+
+export function CollapsiblePanel({
+  title,
+  open,
+  onToggle,
+  badge,
+  actions,
+  keepMounted = false,
+  className,
+  bodyClassName,
+  children
+}: CollapsiblePanelProps): JSX.Element {
+  const renderBody = open || keepMounted
+  return (
+    <div className={`cpanel${open ? '' : ' cpanel--collapsed'}${className ? ` ${className}` : ''}`}>
+      <div className="cpanel__head">
+        <button
+          type="button"
+          className="cpanel__toggle"
+          aria-expanded={open}
+          onClick={onToggle}
+          title={open ? `Hide ${title}` : `Show ${title}`}
+        >
+          <span className="cpanel__chevron" aria-hidden="true">
+            {open ? '▾' : '▸'}
+          </span>
+          <span className="cpanel__title">{title}</span>
+          {badge != null && <span className="cpanel__badge">{badge}</span>}
+        </button>
+        {open && actions && <div className="cpanel__actions">{actions}</div>}
+      </div>
+      {renderBody && (
+        <div
+          className={`cpanel__body${open ? '' : ' cpanel__body--hidden'}${
+            bodyClassName ? ` ${bodyClassName}` : ''
+          }`}
+        >
+          {children}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/test/collapsiblePanel.test.tsx
+++ b/test/collapsiblePanel.test.tsx
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { CollapsiblePanel } from '../src/renderer/src/components/CollapsiblePanel'
+
+/**
+ * The Soft Shell collapsible primitive (#577) rendered to static HTML — verifies
+ * its structure/behaviour without a DOM (vitest runs in node). SSR markup is
+ * exactly what the browser mounts.
+ */
+
+const html = (node: Parameters<typeof renderToStaticMarkup>[0]): string =>
+  renderToStaticMarkup(node)
+
+describe('CollapsiblePanel', () => {
+  it('open: renders the body, a ▾ chevron and aria-expanded=true', () => {
+    const out = html(
+      <CollapsiblePanel title="Files" open onToggle={() => {}}>
+        <span>tree</span>
+      </CollapsiblePanel>
+    )
+    expect(out).toContain('aria-expanded="true"')
+    expect(out).toContain('▾')
+    expect(out).toContain('tree') // body rendered
+    expect(out).not.toContain('cpanel--collapsed')
+  })
+
+  it('collapsed: drops the body, shows a ▸ chevron and aria-expanded=false', () => {
+    const out = html(
+      <CollapsiblePanel title="Files" open={false} onToggle={() => {}}>
+        <span>tree</span>
+      </CollapsiblePanel>
+    )
+    expect(out).toContain('aria-expanded="false"')
+    expect(out).toContain('▸')
+    expect(out).toContain('cpanel--collapsed')
+    expect(out).not.toContain('tree') // body unmounted
+  })
+
+  it('keepMounted: collapsed body stays in the tree but hidden', () => {
+    const out = html(
+      <CollapsiblePanel title="Console" open={false} keepMounted onToggle={() => {}}>
+        <span>scrollback</span>
+      </CollapsiblePanel>
+    )
+    expect(out).toContain('scrollback') // still mounted
+    expect(out).toContain('cpanel__body--hidden')
+  })
+
+  it('renders a badge after the title', () => {
+    const out = html(
+      <CollapsiblePanel title="Chain" badge={4} open onToggle={() => {}}>
+        <span>x</span>
+      </CollapsiblePanel>
+    )
+    expect(out).toContain('cpanel__badge')
+    expect(out).toContain('>4<')
+  })
+
+  it('shows actions when open, hides them when collapsed', () => {
+    const actions = <button type="button">refresh</button>
+    const openOut = html(
+      <CollapsiblePanel title="Files" open onToggle={() => {}} actions={actions}>
+        <span>x</span>
+      </CollapsiblePanel>
+    )
+    expect(openOut).toContain('cpanel__actions')
+    expect(openOut).toContain('refresh')
+
+    const closedOut = html(
+      <CollapsiblePanel title="Files" open={false} onToggle={() => {}} actions={actions}>
+        <span>x</span>
+      </CollapsiblePanel>
+    )
+    expect(closedOut).not.toContain('cpanel__actions')
+    expect(closedOut).not.toContain('refresh')
+  })
+
+  it('keeps action buttons OUTSIDE the toggle button (valid markup, no nesting)', () => {
+    const out = html(
+      <CollapsiblePanel title="Files" open onToggle={() => {}} actions={<button type="button">a</button>}>
+        <span>x</span>
+      </CollapsiblePanel>
+    )
+    // The toggle <button> must close before the actions' <button> opens.
+    const toggleStart = out.indexOf('cpanel__toggle')
+    const toggleClose = out.indexOf('</button>', toggleStart)
+    const actionBtn = out.indexOf('>a<')
+    expect(toggleClose).toBeLessThan(actionBtn)
+  })
+
+  it('passes through class names on the root and body', () => {
+    const out = html(
+      <CollapsiblePanel title="X" open onToggle={() => {}} className="mine" bodyClassName="rows">
+        <span>x</span>
+      </CollapsiblePanel>
+    )
+    expect(out).toMatch(/class="cpanel[^"]*\bmine\b/)
+    expect(out).toMatch(/class="cpanel__body[^"]*\brows\b/)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,10 +11,13 @@ import { defineConfig } from 'vitest/config'
  * are needed.
  */
 export default defineConfig({
+  // The app uses the automatic JSX runtime (no `import React`); match it so
+  // component tests (rendered to static markup) transform the same way (#577).
+  esbuild: { jsx: 'automatic' },
   test: {
     globals: false,
     environment: 'node',
-    include: ['test/**/*.test.ts'],
+    include: ['test/**/*.test.{ts,tsx}'],
     // Compile the sim's worker_threads worker once, and point the runtime at it
     // (integration tests spawn a real MicroPython interpreter in that worker).
     globalSetup: ['./test/setup/globalSetup.ts'],


### PR DESCRIPTION
Closes #577. Wave 2 foundation of the Soft Shell redesign — the one collapsible-panel primitive the workspaces will share, so **every panel owns its own collapse control** and a control never means different things in different workspaces.

## The primitive

`CollapsiblePanel` — controlled (`open` + `onToggle`, so callers persist however they like), with:
- an optional `badge` (item count) and header `actions` (icon buttons),
- **`keepMounted`** — keeps the body in the tree (hidden) when collapsed, for contents that must survive a collapse (a terminal's scrollback, a live plotter),
- action buttons **beside** the toggle button, never nested inside it, so the markup stays valid,
- Soft Shell styling via the #574 tokens (with fallbacks).

Shipped as a **foundation primitive** (like #574's tokens): waves 3 adopt it across Code / Electronics / Build. I deliberately did **not** wire it into a workspace panel here — doing so before #578–#580 would leave a half-restyled panel (e.g. the Build panel's parchment section headers) looking inconsistent.

## Testing

Verified with **`react-dom/server`** (`renderToStaticMarkup`) — no RTL/jsdom needed, runs in the existing node env; SSR markup is what the browser mounts. 7 tests: open renders the body + ▾ + `aria-expanded=true`; collapsed drops the body + ▸ + `false`; `keepMounted` keeps a hidden body; badge; actions only when open; **actions not nested in the toggle button**; class passthrough.

Enables `.test.tsx` + automatic JSX in the vitest config for component tests (no other tests affected — full suite 2042 green).

`lint` / `typecheck` / `test` (2042) / `build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)