### PR TITLE
feat: Code workspace restyle (#578, epic #573)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Code / Electronics / Build workspaces.
 
 ### Changed
+- **Code workspace restyled to Soft Shell (#578, epic #573).** The editor tab
+  bar, the Console/shell (a parchment `--panel` frame cradling the near-black
+  terminal, warmed Console/Problems toggle) and the file trees now speak the Soft
+  Shell palette — parchment `--panel`/`--card`/`--editor` surfaces, `--shellbd`/
+  `--line` borders, `--head`/`--txt3` text, a gold unsaved-tab dot, a green editor
+  active-tab accent, and a green flash-usage gauge. The live renders (Monaco,
+  xterm terminal, serial plotter) are untouched — only their card chrome; the
+  plotter now sits in a `--card` sub-card with its dark phosphor scope intact. The
+  dark theme, previously left on the old semantic tokens, is carried onto Soft
+  Shell surfaces too (via token fallbacks).
 - **Chrome now speaks the Soft Shell UI font (#576, epic #573).** The toolbar,
   left icon rail, status bar, panel headers and tabs use **Plus Jakarta Sans**
   (`--font-ui`) in both themes, replacing the old Helvetica chrome font — pairing

--- a/src/renderer/src/components/DeviceFileTree.css
+++ b/src/renderer/src/components/DeviceFileTree.css
@@ -94,7 +94,7 @@
   align-items: center;
   gap: 0.5rem;
   padding: 0.35rem 0.6rem 0.4rem;
-  border-top: 1px solid var(--border);
+  border-top: 1px solid var(--shellbd, var(--border));
 }
 .devicetree__disk-bar {
   flex: 1 1 auto;
@@ -107,7 +107,9 @@
 .devicetree__disk-fill {
   height: 100%;
   border-radius: 3px;
-  background: var(--accent, #6aa9ff);
+  /* Soft Shell (#578): a green fill for the healthy flash gauge, amber/red as it
+     fills up (below). */
+  background: var(--green, var(--accent, #6aa9ff));
   transition: width 0.3s ease;
 }
 .devicetree__disk-fill.is-high {

--- a/src/renderer/src/components/EditorTabs.css
+++ b/src/renderer/src/components/EditorTabs.css
@@ -2,11 +2,17 @@
    actions (e.g. the Find button, issue #137). The tabs grow and scroll; the
    actions stay pinned to the right. The bottom border lives here so it spans
    the whole row, not just the tabs. */
+/* Soft Shell (#578, epic #573): the tab bar reads as a parchment `--panel`
+   strip over the editor card, with a hairline `--line` rule below. All rules
+   fall back to the old semantic tokens for any theme that hasn't defined the
+   Soft Shell palette; the `skeuomorph` light theme's fuller treatment lives in
+   index.css and out-specifies these base rules, so these mainly carry the dark
+   theme onto Soft Shell surfaces. */
 .editor-header {
   display: flex;
   align-items: stretch;
-  background: var(--bg-sunken);
-  border-bottom: 1px solid var(--border);
+  background: var(--panel, var(--bg-sunken));
+  border-bottom: 1px solid var(--line, var(--border));
 }
 
 .editor-header__actions {
@@ -61,10 +67,10 @@
   gap: 6px;
   padding: 0 8px 0 12px;
   max-width: 200px;
-  background: var(--bg-sunken);
-  color: var(--text-muted);
+  background: var(--panel, var(--bg-sunken));
+  color: var(--txt3, var(--text-muted));
   border: none;
-  border-right: 1px solid var(--border);
+  border-right: 1px solid var(--line, var(--border));
   font-size: 13px;
   cursor: pointer;
   user-select: none;
@@ -72,13 +78,15 @@
 }
 
 .editor-tab:hover {
-  background: var(--bg);
+  background: var(--editor, var(--bg));
 }
 
+/* Active tab sits on the raised editor surface with the head text colour and a
+   thin green Soft Shell accent along its top edge. */
 .editor-tab--active {
-  background: var(--bg-elevated);
-  color: var(--text);
-  box-shadow: inset 0 2px 0 var(--accent);
+  background: var(--editor, var(--bg-elevated));
+  color: var(--head, var(--text));
+  box-shadow: inset 0 2px 0 var(--green, var(--accent));
 }
 
 .editor-tab__label {
@@ -86,12 +94,14 @@
   text-overflow: ellipsis;
 }
 
+/* Gold status dot on the unsaved tab (Soft Shell spec: the active tab carries a
+   gold `●` dirty indicator). */
 .editor-tab__dirty {
   flex: 0 0 auto;
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: var(--accent);
+  background: var(--gold, var(--accent));
 }
 
 .editor-tab__close {
@@ -112,8 +122,8 @@
 }
 
 .editor-tab__close:hover {
-  background: var(--border);
-  color: var(--text);
+  background: var(--shellbd, var(--border));
+  color: var(--head, var(--text));
 }
 
 .editor-tabs__new {
@@ -128,13 +138,13 @@
   border: none;
   border-radius: var(--radius);
   background: transparent;
-  color: var(--text-muted);
+  color: var(--txt3, var(--text-muted));
   font-size: 18px;
   line-height: 1;
   cursor: pointer;
 }
 
 .editor-tabs__new:hover {
-  background: var(--border);
-  color: var(--text);
+  background: var(--shellbd, var(--border));
+  color: var(--head, var(--text));
 }

--- a/src/renderer/src/components/LocalFileTree.css
+++ b/src/renderer/src/components/LocalFileTree.css
@@ -94,8 +94,8 @@
 }
 
 .localtree__crumb:hover:not(:disabled) {
-  color: var(--text);
-  background: var(--bg-elevated);
+  color: var(--head, var(--text));
+  background: var(--card, var(--bg-elevated));
 }
 
 /* The last (current) segment is non-interactive but still legible. */

--- a/src/renderer/src/components/Plotter.css
+++ b/src/renderer/src/components/Plotter.css
@@ -18,7 +18,9 @@
   box-sizing: border-box;
   padding: 10px;
   gap: 10px;
-  background: var(--bg-sunken);
+  /* Soft Shell (#578): the plotter's frame reads as a `--card` sub-card cradling
+     the dark phosphor scope (the screen keeps its intrinsic near-black look). */
+  background: var(--card, var(--bg-sunken));
   font-family: var(--font-mono), 'JetBrains Mono', monospace;
 }
 
@@ -100,7 +102,7 @@
 
 .plotter__status {
   font-size: 11px;
-  color: #4a4f57;
+  color: var(--txt3, #4a4f57);
 }
 
 .plotter__clear {

--- a/src/renderer/src/components/ShellPanel.css
+++ b/src/renderer/src/components/ShellPanel.css
@@ -8,10 +8,14 @@
  * toggle. (The live Plotter moved to the instrument dock, right of chat.)
  */
 
+/* Soft Shell (#578, epic #573): the Console / Problems segmented toggle reads as
+   a recessed `--panel2` track whose active segment lifts onto a `--card`
+   surface. Fallbacks preserve the look on themes without the Soft Shell palette;
+   the skeuomorph light theme's warmer treatment is scoped below the base rules. */
 .shell-toggle {
   display: inline-flex;
   align-items: stretch;
-  border: 1px solid var(--border);
+  border: 1px solid var(--shellbd, var(--border));
   border-radius: var(--radius);
   overflow: hidden;
 }
@@ -19,8 +23,8 @@
 .shell-toggle__btn {
   appearance: none;
   border: none;
-  background: var(--bg-sunken);
-  color: var(--text-muted);
+  background: var(--panel2, var(--bg-sunken));
+  color: var(--txt3, var(--text-muted));
   font-size: 0.8rem;
   padding: 0.2rem 0.6rem;
   cursor: pointer;
@@ -28,17 +32,58 @@
 }
 
 .shell-toggle__btn + .shell-toggle__btn {
-  border-left: 1px solid var(--border);
+  border-left: 1px solid var(--shellbd, var(--border));
 }
 
 .shell-toggle__btn:hover {
-  background: var(--bg);
-  color: var(--text);
+  background: var(--card, var(--bg));
+  color: var(--head, var(--text));
 }
 
 .shell-toggle__btn--active {
-  background: var(--accent);
-  color: var(--accent-contrast);
+  background: var(--card, var(--accent));
+  color: var(--head, var(--accent-contrast));
+  box-shadow: inset 0 0 0 1px var(--shellbd, transparent);
+}
+
+/* --- Soft Shell shell frame ------------------------------------------------
+ * The shell region is a parchment `--panel` card cradling the near-black
+ * console screen (the terminal keeps its own recessed dark-glass treatment).
+ * The base rule carries the dark theme; the higher-specificity skeuomorph rule
+ * supersedes the legacy brushed-metal grey frame defined in index.css. */
+.region--shell {
+  background: var(--panel, var(--bg));
+}
+
+:root[data-theme='skeuomorph'] .region.region--shell {
+  background: var(--panel);
+}
+
+/* Warm the segmented toggle to parchment on the skeuomorph light theme, so it
+   sits on the parchment frame instead of the legacy grey metal (index.css).
+   Scoped under `.shell-actions` to out-specify the legacy rules. */
+:root[data-theme='skeuomorph'] .shell-actions .shell-toggle {
+  border-color: var(--shellbd);
+  box-shadow:
+    inset 0 1px 0 var(--pillinset),
+    0 1px 2px rgba(0, 0, 0, 0.08);
+}
+
+:root[data-theme='skeuomorph'] .shell-actions .shell-toggle__btn {
+  background: var(--panel2);
+  color: var(--txt3);
+  text-shadow: none;
+}
+
+:root[data-theme='skeuomorph'] .shell-actions .shell-toggle__btn:hover {
+  background: var(--card);
+  color: var(--head);
+}
+
+:root[data-theme='skeuomorph'] .shell-actions .shell-toggle__btn--active {
+  background: var(--card);
+  color: var(--head);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
 /* The shell body. A single full-body view fills it (Console or Problems); the
@@ -233,9 +278,9 @@
   width: 1.6rem;
   height: 1.6rem;
   padding: 0;
-  color: var(--text);
-  background: var(--bg-elevated);
-  border: 1px solid var(--border);
+  color: var(--head, var(--text));
+  background: var(--card, var(--bg-elevated));
+  border: 1px solid var(--shellbd, var(--border));
   border-radius: var(--radius);
   cursor: pointer;
   opacity: 0;
@@ -250,7 +295,7 @@
 
 .shell-popout:hover {
   opacity: 1;
-  background: var(--bg);
+  background: var(--panel, var(--bg));
 }
 
 /* Placeholder shown in the docked area while the console is popped out. */


### PR DESCRIPTION
Restyles the **Code workspace**'s distinctive panels to the Soft Shell parchment palette (epic #573, wave for #578). Localized to co-located component CSS + one CHANGELOG bullet.

## What was restyled (owned files only)
- **Editor tab bar** (`EditorTabs.css`) — parchment `--panel` tab strip, `--line`/`--shellbd` borders, `--head`/`--txt3` text, **gold unsaved-tab dot**, **green active-tab accent**.
- **Console / shell** (`ShellPanel.css`) — the shell region is now a parchment `--panel` frame cradling the near-black terminal. A base rule carries the dark theme; a higher-specificity `[data-theme='skeuomorph']` rule supersedes the **legacy brushed-metal grey frame** still defined in `index.css`. The Console/Problems segmented toggle is warmed onto `--panel2`/`--card`, and the pop-out button takes `--card`/`--shellbd` chrome.
- **Plotter** (`Plotter.css`) — now a `--card` sub-card with a `--txt3` footer; the dark phosphor scope is untouched.
- **File trees** (`DeviceFileTree.css` / `LocalFileTree.css`) — green Soft Shell flash-usage gauge, `--shellbd` divider, warm `--card` breadcrumb hover.

All rules **fall back to the old semantic tokens**, which also carries the **dark theme** (previously left on the old charcoal semantic tokens) onto Soft Shell surfaces.

## Live renders preserved
No live component was reimplemented — **Monaco editor, the xterm terminal, and the live serial plotter** all keep their real components; only the surrounding card chrome changed. Verified on-screen that the editor, console (green MicroPython REPL) and the instrument dock + live plotter still render and function.

## Left out (shared seams — noted, not edited)
- **CollapsiblePanel adoption for Files / Console / Instrument Dock is not feasible here.** Their collapse is driven by `react-resizable-panels` (`Panel collapsible`) in **AppShell.tsx**, the **Toolbar**, and **store/layout.ts** — all on the DO-NOT-EDIT list. Rewiring them to `CollapsiblePanel` would require editing those shared seams, so it's left for a chrome-level change.
- **Instrument dock container + instrument bezels** (`InstrumentWindow.css`) — the dock is a deliberate "near-black island in every theme" (documented in that file) shared by the Code **and** Build docks, and the CRT/bezel/knob bodies are the intended tactile-instrument look. Restyling that container is cross-cutting, not a Code-localized change, so it's left as-is (only the Plotter card, which I own, was Soft-Shelled).

## Verification (all green, run in the foreground)
- `npm run lint` — 0 errors (1 pre-existing warning in an untouched file)
- `npm run typecheck` — clean
- `npm test` — 2042 passed (138 files)
- `npm run build` and `npm run build:web` — both succeed
- Headless Chromium screenshots of the Code workspace in **both** the skeuomorph (light) and dark themes: editor, console and instruments all render; `.monaco-editor`, `.terminal`, `.region--shell`, `.instr-dock`, `.plotter` all present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)