### PR TITLE
feat: Build (Robot) workspace restyle + re-home recent tools (#580, epic #573)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Code / Electronics / Build workspaces.
 
 ### Changed
+- **Build (Robot) workspace restyled to Soft Shell (#580, epic #573).** The 3-D
+  viewport chrome, overlay toolbar and zoom cluster, the CHAIN / URDF hierarchy
+  tree (now built on the shared `CollapsiblePanel`), the Pose Studio dock
+  (keyframe timeline, mirror/export, stability heat-strip) and the Properties
+  dialog (per-link mass + ground-contact editors) all take the warm parchment +
+  green/gold palette in both skins. Every recent tool is preserved — Bone Mode,
+  Exploded view, IK goal, the Balance / CoM + support-polygon overlay, the measure
+  tool, the stability strip and the mass/contacts editors — and the live three.js
+  scene and overlay behaviour are unchanged.
 - **Chrome now speaks the Soft Shell UI font (#576, epic #573).** The toolbar,
   left icon rail, status bar, panel headers and tabs use **Plus Jakarta Sans**
   (`--font-ui`) in both themes, replacing the old Helvetica chrome font — pairing

--- a/src/renderer/src/components/RobotBuildPanel.css
+++ b/src/renderer/src/components/RobotBuildPanel.css
@@ -148,48 +148,27 @@
   flex-direction: column;
   gap: 0.1rem;
 }
+/* A branch of the hierarchy tree (CHAIN / URDF / Poses) — rendered via the shared
+   Soft Shell CollapsiblePanel (#580). Give its header a subtle Soft Shell backing
+   so the disclosure row reads as an "edge" over the 3-D canvas (Fusion-style). */
 .robotbuild__section {
   display: flex;
   flex-direction: column;
 }
-/* A branch header: disclosure caret + label + a muted count. */
-.robotbuild__branch {
-  display: flex;
-  align-items: center;
-  gap: 0.3rem;
-  font-family: inherit;
-  font-size: 0.66rem;
-  font-weight: 700;
-  letter-spacing: 0.03em;
-  text-transform: uppercase;
-  color: var(--text-muted, #9aa0a6);
-  background: rgba(24, 26, 30, 0.62);
-  border: none;
+.robotbuild__section > .cpanel__head {
+  background: var(--panel2, rgba(24, 26, 30, 0.62));
   border-radius: 5px;
+}
+.robotbuild__section > .cpanel__head .cpanel__toggle {
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  font-size: 0.66rem;
   padding: 0.22rem 0.35rem 0.2rem;
-  cursor: pointer;
-  text-align: left;
 }
-.robotbuild__branch:hover {
-  color: var(--accent-ink);
+.robotbuild__section > .cpanel__head .cpanel__badge {
+  font-size: 0.62rem;
 }
-:root[data-theme='skeuomorph'] .robotbuild__branch {
-  background: rgba(246, 242, 232, 0.82);
-}
-.robotbuild__caret {
-  flex: 0 0 auto;
-  width: 0.7rem;
-  font-size: 0.6rem;
-}
-.robotbuild__branch-label {
-  flex: 1 1 auto;
-}
-.robotbuild__branch-count {
-  flex: 0 0 auto;
-  font-weight: 400;
-  /* Lean on the AA-tuned muted token directly — fading it with opacity dropped it
-     below AA on the parchment theme. */
-  color: var(--text-muted, #9aa0a6);
+.robotbuild__section-body {
+  min-width: 0;
 }
 .robotbuild__parts {
   list-style: none;

--- a/src/renderer/src/components/RobotBuildPanel.tsx
+++ b/src/renderer/src/components/RobotBuildPanel.tsx
@@ -21,6 +21,7 @@ import type { PropsContext } from './RobotPropertiesDialog'
 import { ContextMenu, type ContextMenuItem, type ContextMenuPosition } from './ContextMenu'
 import { usePrompt } from './PromptModal'
 import { FolderOpenIcon } from './ui-icons'
+import { CollapsiblePanel } from './CollapsiblePanel'
 import './RobotBuildPanel.css'
 
 /**
@@ -486,20 +487,20 @@ function Section({
   children: React.ReactNode
 }): JSX.Element {
   const isCollapsed = !!collapsed[id]
+  // Soft Shell (#580): the CHAIN / URDF / Poses branches now use the shared
+  // CollapsiblePanel primitive, so each owns its own header chevron + count badge
+  // and matches every other collapsible panel in the app.
   return (
-    <div className="robotbuild__section">
-      <button
-        type="button"
-        className="robotbuild__branch"
-        aria-expanded={!isCollapsed}
-        onClick={() => onToggle(id)}
-      >
-        <span className="robotbuild__caret">{isCollapsed ? '▸' : '▾'}</span>
-        <span className="robotbuild__branch-label">{label}</span>
-        <span className="robotbuild__branch-count">{count}</span>
-      </button>
-      {!isCollapsed && <ul className="robotbuild__parts">{children}</ul>}
-    </div>
+    <CollapsiblePanel
+      title={label}
+      open={!isCollapsed}
+      onToggle={() => onToggle(id)}
+      badge={count}
+      className="robotbuild__section"
+      bodyClassName="robotbuild__section-body"
+    >
+      <ul className="robotbuild__parts">{children}</ul>
+    </CollapsiblePanel>
   )
 }
 

--- a/src/renderer/src/components/RobotDockPanel.css
+++ b/src/renderer/src/components/RobotDockPanel.css
@@ -1,0 +1,35 @@
+/* SOFT SHELL restyle (#580, epic #573) — the Build viewport action row (New robot /
+   Open… / Pop out) that floats top-left over the 3-D stage. The base `.robotdock*`
+   layout lives in the shared index.css; these co-located rules only re-skin the
+   buttons to the Soft Shell palette (gold-gradient "New robot" CTA, parchment card
+   buttons), using selectors specific enough to win over the legacy brass rules in
+   index.css in both skins. */
+
+/* Open… / Pop out — parchment card buttons. */
+.robotdock .robotdock__btn,
+:root[data-theme='skeuomorph'] .robotdock .robotdock__btn {
+  color: var(--head, var(--text, #cdd2d9));
+  background: var(--card, rgba(20, 21, 24, 0.78));
+  border: 1px solid var(--shellbd, var(--border, #3a3d44));
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+}
+.robotdock .robotdock__btn:hover,
+:root[data-theme='skeuomorph'] .robotdock .robotdock__btn:hover {
+  color: var(--goldink, var(--accent-ink));
+  border-color: var(--gold, var(--accent));
+}
+
+/* New robot — the gold-gradient CTA when there's no project robot yet. */
+.robotdock .robotdock__btn--cta,
+.robotdock .robotdock__btn--cta:hover,
+:root[data-theme='skeuomorph'] .robotdock .robotdock__btn--cta,
+:root[data-theme='skeuomorph'] .robotdock .robotdock__btn--cta:hover {
+  color: var(--goldink, #191a1d);
+  background: var(--grad-gold, var(--accent, #c8a24a));
+  border: 1px solid var(--gold, var(--accent, #c8a24a));
+  font-weight: 700;
+}
+.robotdock .robotdock__btn--cta:hover,
+:root[data-theme='skeuomorph'] .robotdock .robotdock__btn--cta:hover {
+  filter: brightness(1.05);
+}

--- a/src/renderer/src/components/RobotDockPanel.tsx
+++ b/src/renderer/src/components/RobotDockPanel.tsx
@@ -7,6 +7,7 @@ import { useWorkspaceLayout } from '../store/layout'
 import { readRobotModel } from '../../../shared/krf'
 import demoArm from '../assets/demo-arm.urdf?raw'
 import { FolderOpenIcon } from './ui-icons'
+import './RobotDockPanel.css'
 
 /**
  * ROBOT DOCK PANEL (#320) — the mini 3-D Robot view that sits above the

--- a/src/renderer/src/components/RobotPropertiesDialog.css
+++ b/src/renderer/src/components/RobotPropertiesDialog.css
@@ -433,7 +433,9 @@
 .robotprops__minibtn {
   font-family: var(--font-mono, 'JetBrains Mono', monospace);
   font-size: 0.56rem;
-  color: var(--accent-ink, #191a1d);
+  /* Dark ink on the gold fill (reads in both skins — the gold-ink label would be
+     pale-on-gold in the dark skin). */
+  color: var(--accent-contrast, #191a1d);
   background: var(--accent, #d6a23f);
   border: none;
   border-radius: 4px;

--- a/src/renderer/src/components/RobotTimeline.css
+++ b/src/renderer/src/components/RobotTimeline.css
@@ -45,13 +45,13 @@
   color: #b4544e;
 }
 .robottimeline__btn--export {
-  color: #191a1d;
-  background: #6fae6f;
-  border-color: #6fae6f;
+  color: #fff;
+  background: var(--grad-run, var(--green, #6fae6f));
+  border-color: var(--green, #6fae6f);
   font-weight: 700;
 }
 .robottimeline__btn--export:hover:not(:disabled) {
-  background: #7cbe7c;
+  filter: brightness(1.06);
 }
 
 .robottimeline__loop {
@@ -159,13 +159,15 @@
   border-radius: 4px;
   cursor: copy;
 }
+/* Soft Shell keyframes: green blocks with a gold playhead sweeping across (per the
+   Build mock). The selected key inverts to white with a gold glow. */
 .robottimeline__key {
   position: absolute;
   top: 50%;
   width: 9px;
   height: 9px;
   transform: translate(-50%, -50%) rotate(45deg);
-  background: var(--accent);
+  background: var(--green, var(--accent-2, #3fae5a));
   border: 1px solid #191a1d;
   border-radius: 2px;
   padding: 0;

--- a/src/renderer/src/components/RobotToolbar.css
+++ b/src/renderer/src/components/RobotToolbar.css
@@ -8,13 +8,12 @@
   display: flex;
   gap: 0.2rem;
   padding: 0.2rem;
-  border: 1px solid var(--border, #3a3d44);
+  border: 1px solid var(--shellbd, var(--border, #3a3d44));
   border-radius: 8px;
-  background: rgba(20, 21, 24, 0.55);
+  /* Soft Shell glass — parchment in the light skin, dark glass in the dark skin. */
+  background: var(--glass, rgba(20, 21, 24, 0.55));
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
   backdrop-filter: blur(8px);
-}
-:root[data-theme='skeuomorph'] .robottool {
-  background: rgba(231, 226, 211, 0.78);
 }
 .robottool__btn {
   display: inline-flex;

--- a/src/renderer/src/components/RobotView.css
+++ b/src/renderer/src/components/RobotView.css
@@ -6,8 +6,28 @@
   flex-direction: column; /* [main row] over [timeline dock] */
   height: 100%;
   min-height: 0;
-  background: #191a1d;
+  /* Soft Shell parchment behind the canvas (was a hard #191a1d that flashed dark
+     under the light-grid scene in the skeuomorph skin). */
+  background: var(--shell, #191a1d);
   font-family: var(--font-mono), 'JetBrains Mono', monospace;
+
+  /* SOFT SHELL restyle (#580, epic #573) — the Build (Robot) workspace. Every
+     nested Build panel (build dock, pose studio, timeline, sequencer, properties,
+     toolbar) already reads the SEMANTIC surface/accent tokens below, so remapping
+     them here onto the Soft Shell palette (#574) restyles the whole workspace to
+     warm parchment + green/gold in one place — no per-rule churn, and the live
+     three.js scene + every overlay behaviour stay untouched. Fallbacks keep the
+     legacy brushed-metal look if a Soft Shell token is ever missing. */
+  --bg: var(--shell, #1d201a);
+  --bg-elevated: var(--panel, #2a2c30); /* panel / dock slabs */
+  --bg-sunken: var(--panel2, #202226); /* wells, tracks, inputs */
+  --border: var(--shellbd, #3a3d44);
+  --accent: var(--gold, #d6a23f); /* gold — active / selected / playhead */
+  --accent-ink: var(--goldink, #d6a23f); /* gold-ink — titles / labels on panels */
+  --accent-2: var(--green, #3fae5a); /* green — connected / run / saved */
+  /* Gold #d9a441 is a mid tone: dark ink reads on it in BOTH skins (the legacy
+     skeuomorph white-on-brass would be illegible on the lighter gold). */
+  --accent-contrast: #191a1d;
 }
 
 /* The main row: 3D stage + the pose sidebar beside it. */
@@ -240,6 +260,9 @@
 
 /* Bottom-right zoom cluster — identical to the node-graph viewport control
    (.boardgraph__viewport-ctl) so every zoom control in the app matches. */
+/* Soft Shell glass — a warm parchment cluster in the light skin, dark glass in the
+   dark skin (the legacy hard darks had no skeuomorph override and read black on the
+   light grid). */
 .robotview__zoom {
   position: absolute;
   right: 16px;
@@ -250,11 +273,11 @@
   gap: 4px;
   padding: 5px;
   border-radius: 12px;
-  background: rgba(31, 32, 36, 0.92);
-  border: 1px solid #3a3d44;
+  background: var(--glass, rgba(31, 32, 36, 0.92));
+  border: 1px solid var(--shellbd, #3a3d44);
   box-shadow:
-    0 8px 22px rgba(0, 0, 0, 0.5),
-    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+    0 8px 22px rgba(0, 0, 0, 0.18),
+    inset 0 1px 0 var(--pillinset, rgba(255, 255, 255, 0.04));
   backdrop-filter: blur(6px);
   user-select: none;
 }
@@ -268,19 +291,19 @@
   font-family: var(--font-mono), 'JetBrains Mono', monospace;
   font-size: 17px;
   line-height: 1;
-  color: #c2c7cf;
-  background: linear-gradient(180deg, #2c2f35, #232529);
-  border: 1px solid #3d414a;
+  color: var(--txt2, #c2c7cf);
+  background: var(--card, linear-gradient(180deg, #2c2f35, #232529));
+  border: 1px solid var(--shellbd, #3d414a);
   border-radius: 8px;
   cursor: pointer;
 }
 .robotview__zbtn:hover {
-  color: #fff;
-  border-color: #5a606b;
-  background: linear-gradient(180deg, #34373e, #292b30);
+  color: var(--head, #fff);
+  border-color: var(--accent, #5a606b);
+  background: var(--panel2, linear-gradient(180deg, #34373e, #292b30));
 }
 .robotview__zbtn:active {
-  background: #202227;
+  background: var(--panel2, #202227);
 }
 .robotview__zbtn--pct {
   min-width: 48px;
@@ -292,7 +315,7 @@
   width: 1px;
   height: 22px;
   margin: 0 2px;
-  background: #3d414a;
+  background: var(--shellbd, #3d414a);
   flex: 0 0 auto;
 }
 


### PR DESCRIPTION
Restyles the **Build** (Robot) 3-D workspace to the **Soft Shell** look (epic #573) — warm parchment surfaces, green primary + amber/gold accent — in both the skeuomorph (light) and dark skins, while keeping the live three.js scene and every recent tool fully intact. Implements #580 (Soft Shell 7/8).

## What was restyled
- **3D viewport chrome + overlay toolbar + zoom cluster.** The `.robotview` root now remaps the workspace's semantic surface/accent tokens (`--bg-elevated`/`--bg-sunken`/`--border`/`--accent`/`--accent-ink`/`--accent-contrast`) onto the Soft Shell palette (`--panel`/`--panel2`/`--shellbd`/`--gold`/`--goldink`/`--green`), so every nested Build panel reads parchment + green/gold in one place. The zoom cluster and the tool cluster (which were hard darks with no light override) are re-skinned to theme-aware Soft Shell glass (`--glass` + `--card` + `--shellbd`).
- **CHAIN / URDF hierarchy tree** (`RobotBuildPanel`) — the Chain/Servos/Poses branches now render through the shared **`CollapsiblePanel`** primitive (each owns its own chevron + count badge), with a Soft Shell header backing.
- **Pose Studio dock** (`RobotMotionDock` / `RobotTimeline` / `RobotSequencer`) — parchment surfaces; green keyframes + green **Export**, gold playhead; the **stability heat-strip (#559)** keeps its green/amber/red cells.
- **Properties dialog** (`RobotPropertiesDialog`) — parchment/gold form controls incl. the per-link **mass editor (#555)** and **ground-contact (#557)** sections; the mass-estimate button now uses dark ink so it reads on gold in both skins.
- **Viewport action row** (`RobotDockPanel`) — gold-gradient "New robot" CTA + parchment card "Open…" / "Pop out" buttons (co-located CSS; the base layout stays in the shared `index.css`).

## No feature regressions
Verified in the popped-out full-screen Build view that all recent tools are present and wired:
- **Bone Mode**, **Exploded view**, **IK goal**, **Balance / CoM + support-polygon overlay** (all in the zoom cluster), the **measure tool** and the build-tool cluster (add block / select / push-pull / move / joint / undo / redo).
- Stability heat-strip, per-link mass and ground-contact editors preserved.
- The live three.js render loop, overlays and HUD pills are untouched — only chrome/CSS changed.

## Verification (headless Pi)
- `npm run lint` — 0 errors (1 pre-existing warning in an untouched file).
- `npm run typecheck` — clean.
- `npm test` — 2042 tests pass (138 files).
- `npm run build` + `npm run build:web` — both succeed.
- **Visual** (headless Chromium + swiftshader WebGL against `dist-web`): switched to Build → Pop out → full 3-D scene renders (demo arm on the light grid); overlay toolbar interactive; zoom cluster resolves to Soft Shell `--glass`/`--card`; Pose Studio dock resolves to `--panel`; CHAIN tree renders via `CollapsiblePanel`. Confirmed both skins: light = parchment, dark stamps resolve to Soft Shell dark tokens (`--panel`/`--panel2`/`--card`/`--glass`/pale-gold `--goldink`). No page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)