### PR TITLE
feat: Soft Shell close-out — retire Data Lab + consistency audit (#581, epic #573)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- **Soft Shell close-out: Data Lab retired (#581, epic #573).** The never-surfaced
+  Data Lab workspace is removed — the switcher is exactly Code · Electronics ·
+  Build, and its instrument bench lives on in the Code/Build docks. A stale
+  persisted session that was in Data Lab (or the older `lab`/`data`) now lands on
+  Code instead of an unreachable layout with no active segment. Completes the
+  Soft Shell redesign epic; the three workspaces were audited cohesive in both
+  the light and dark skins.
+
 ### Added
 - **Reusable collapsible-panel primitive (#577, epic #573).** A shared
   `CollapsiblePanel` (Soft Shell styled) so every panel owns its own collapse

--- a/src/renderer/src/components/WorkspaceSwitcher.tsx
+++ b/src/renderer/src/components/WorkspaceSwitcher.tsx
@@ -11,12 +11,11 @@ import './WorkspaceSwitcher.css'
  * workspace to its factory preset — the always-available "Reset layout" escape hatch.
  *
  * Soft Shell (#575, epic #573) surfaces three: **Code · Electronics · Build**
- * (Electronics = the Board View; Build = the former Robot). Data Lab stays hidden
- * for now — its fate is the epic's close-out (#581). Reads the layout store directly.
+ * (Electronics = the Board View; Build = the former Robot). Data Lab was retired
+ * in the epic's close-out (#581), so all of WORKSPACE_IDS is shown. Reads the
+ * layout store directly.
  */
-const VISIBLE_WORKSPACES = WORKSPACE_IDS.filter(
-  (id) => id === 'code' || id === 'board' || id === 'robot'
-)
+const VISIBLE_WORKSPACES = WORKSPACE_IDS
 
 export function WorkspaceSwitcher(): JSX.Element {
   const layout = useWorkspaceLayout()

--- a/src/renderer/src/store/layout.ts
+++ b/src/renderer/src/store/layout.ts
@@ -38,10 +38,11 @@ import {
 } from 'react'
 import type { ActivityView } from '../components/ActivityBar'
 
-/** The named workspaces (Phase 1; slimmed 4 → 3 by the modes review). Order =
- *  the switcher's display order. Old `lab`/`data` envelopes migrate to
- *  `datalab` in {@link loadLayoutState}. */
-export const WORKSPACE_IDS = ['code', 'board', 'datalab', 'robot'] as const
+/** The named workspaces. Order = the switcher's display order (Code · Electronics
+ *  · Build). Soft Shell (#581, epic #573) retired the never-surfaced Data Lab —
+ *  its instrument bench lives on in the Code/Build docks. Stale `lab`/`data`/
+ *  `datalab` persisted state coerces to `code` in {@link loadLayoutState}. */
+export const WORKSPACE_IDS = ['code', 'board', 'robot'] as const
 export type WorkspaceId = (typeof WORKSPACE_IDS)[number]
 
 /** Display labels + a one-line description for the switcher tooltips. */
@@ -51,7 +52,6 @@ export type WorkspaceId = (typeof WORKSPACE_IDS)[number]
 export const WORKSPACE_INFO: Record<WorkspaceId, { label: string; hint: string }> = {
   code: { label: 'Code', hint: 'Editor-first: files, editor and console' },
   board: { label: 'Electronics', hint: 'Wire components to your board — the Board View beside your code' },
-  datalab: { label: 'Data Lab', hint: 'Instrument bench + a tall console/plotter' },
   robot: { label: 'Build', hint: 'Assemble the robot in 3D — joints, IK chains and poses' }
 }
 
@@ -112,18 +112,6 @@ export const WORKSPACE_PRESETS: Record<WorkspaceId, WorkspaceLayout> = {
     boardPaneOpen: true,
     horizontal: [0, 42, 58, 0],
     vertical: [65, 35]
-  },
-  // Data Lab (the old Lab + Data merged): the instrument bench — dock open —
-  // with a tall shell region (Console | Plotter | Problems) for data work.
-  datalab: {
-    activityView: 'files',
-    filesCollapsed: true,
-    shellCollapsed: false,
-    rightCollapsed: true,
-    dockOpen: true,
-    boardPaneOpen: false,
-    horizontal: [0, 100, 0, 0],
-    vertical: [50, 50]
   },
   // Robot (#320): the robotics cockpit — files collapsed, CODE ~⅓ on the left,
   // the Board View (breadboard) in the middle, and the dock on the right (which
@@ -288,18 +276,15 @@ export function loadLayoutState(storage: StorageLike): LayoutState {
       const parsed = JSON.parse(raw) as Partial<LayoutState>
       if (parsed && parsed.version === 1 && parsed.workspaces) {
         const state = defaultLayoutState()
-        // Modes review: the old `lab` and `data` workspaces merged into
-        // `datalab`. Map a stale active id, and seed datalab's geometry from
-        // the old data (preferred — it's the closer layout) else lab entry, so
-        // an existing user's sizes carry over.
+        // Any retired active workspace (`lab`/`data`/`datalab` — Data Lab was
+        // never surfaced and is retired in Soft Shell, #581) coerces to `code`
+        // via the WORKSPACE_IDS membership check below, so a stale session can't
+        // land on a workspace with no switcher segment.
         const saved = parsed.workspaces as Record<string, unknown>
-        const activeRaw = ['lab', 'data'].includes(parsed.active as string)
-          ? 'datalab'
-          : (parsed.active as WorkspaceId)
+        const activeRaw = parsed.active as WorkspaceId
         state.active = WORKSPACE_IDS.includes(activeRaw) ? activeRaw : 'code'
         for (const id of WORKSPACE_IDS) {
-          const legacy = id === 'datalab' ? (saved.datalab ?? saved.data ?? saved.lab) : saved[id]
-          state.workspaces[id] = sanitiseWorkspace(legacy, WORKSPACE_PRESETS[id])
+          state.workspaces[id] = sanitiseWorkspace(saved[id], WORKSPACE_PRESETS[id])
         }
         return state
       }

--- a/test/layoutStore.test.ts
+++ b/test/layoutStore.test.ts
@@ -17,7 +17,7 @@ const storage = (entries: Record<string, string> = {}): StorageLike => ({
 
 describe('workspace presets (epic #259; +Robot mode #320)', () => {
   it('defines the workspaces with valid geometry', () => {
-    expect(WORKSPACE_IDS).toEqual(['code', 'board', 'datalab', 'robot'])
+    expect(WORKSPACE_IDS).toEqual(['code', 'board', 'robot'])
     for (const id of WORKSPACE_IDS) {
       const p = WORKSPACE_PRESETS[id]
       expect(p.horizontal).toHaveLength(4)
@@ -53,23 +53,15 @@ describe('workspace presets (epic #259; +Robot mode #320)', () => {
     expect(code.filesCollapsed).toBe(false)
     expect(code.shellCollapsed).toBe(false)
     expect(code.rightCollapsed).toBe(true)
-    // Instrument dock: closed in Code + Board (the board is the star), open only
-    // in Data Lab (the instrument bench).
+    // Instrument dock: closed in Code + Board (the board is the star).
     expect(code.dockOpen).toBe(false)
     expect(WORKSPACE_PRESETS.board.dockOpen).toBe(false)
-    expect(WORKSPACE_PRESETS.datalab.dockOpen).toBe(true)
     // Board: the embedded Board View pane opens with a real share beside the
     // code; the other workspaces keep it closed at 0.
     expect(WORKSPACE_PRESETS.board.boardPaneOpen).toBe(true)
     expect(WORKSPACE_PRESETS.board.horizontal[2]).toBeGreaterThan(0)
-    for (const id of ['code', 'datalab'] as const) {
-      expect(WORKSPACE_PRESETS[id].boardPaneOpen, id).toBe(false)
-      expect(WORKSPACE_PRESETS[id].horizontal[2], id).toBe(0)
-    }
-    // Data Lab gives the shell a bigger share than Code (data work under the editor).
-    expect(WORKSPACE_PRESETS.datalab.vertical[1]).toBeGreaterThan(
-      WORKSPACE_PRESETS.code.vertical[1]
-    )
+    expect(WORKSPACE_PRESETS.code.boardPaneOpen).toBe(false)
+    expect(WORKSPACE_PRESETS.code.horizontal[2]).toBe(0)
   })
 
   it('defaultLayoutState deep-copies the presets (reset cannot alias them)', () => {
@@ -154,44 +146,23 @@ describe('loadLayoutState (corruption-safe, versioned)', () => {
 
   it('round-trips a valid envelope and keeps the active workspace', () => {
     const saved = defaultLayoutState()
-    saved.active = 'datalab'
-    saved.workspaces.datalab.vertical = [60, 40]
+    saved.active = 'robot'
+    saved.workspaces.robot.vertical = [60, 40]
     const s = loadLayoutState(storage({ [LAYOUT_STORAGE_KEY]: JSON.stringify(saved) }))
-    expect(s.active).toBe('datalab')
-    expect(s.workspaces.datalab.vertical).toEqual([60, 40])
+    expect(s.active).toBe('robot')
+    expect(s.workspaces.robot.vertical).toEqual([60, 40])
   })
 
-  it('migrates an old 4-workspace envelope: lab/data merge into datalab', () => {
-    // A pre-modes-review envelope with the old ids, `data` sized distinctively.
-    const old = {
-      version: 1,
-      active: 'lab',
-      workspaces: {
-        code: { ...WORKSPACE_PRESETS.code },
-        board: { ...WORKSPACE_PRESETS.board },
-        lab: { ...WORKSPACE_PRESETS.datalab, vertical: [75, 25] },
-        data: { ...WORKSPACE_PRESETS.datalab, vertical: [41, 59] }
+  it('coerces a retired active id (lab/data/datalab) to code (#581)', () => {
+    for (const stale of ['lab', 'data', 'datalab']) {
+      const old = {
+        version: 1,
+        active: stale,
+        workspaces: { code: { ...WORKSPACE_PRESETS.code } }
       }
+      const s = loadLayoutState(storage({ [LAYOUT_STORAGE_KEY]: JSON.stringify(old) }))
+      expect(s.active, stale).toBe('code')
     }
-    const s = loadLayoutState(storage({ [LAYOUT_STORAGE_KEY]: JSON.stringify(old) }))
-    // Stale active id maps to the merged workspace…
-    expect(s.active).toBe('datalab')
-    // …which seeds its geometry from the old `data` entry (preferred over lab).
-    expect(s.workspaces.datalab.vertical).toEqual([41, 59])
-  })
-
-  it('migrates active "data" too, and falls back to the lab entry when data is absent', () => {
-    const old = {
-      version: 1,
-      active: 'data',
-      workspaces: {
-        code: { ...WORKSPACE_PRESETS.code },
-        lab: { ...WORKSPACE_PRESETS.datalab, vertical: [76, 24] }
-      }
-    }
-    const s = loadLayoutState(storage({ [LAYOUT_STORAGE_KEY]: JSON.stringify(old) }))
-    expect(s.active).toBe('datalab')
-    expect(s.workspaces.datalab.vertical).toEqual([76, 24])
   })
 
   it('sanitises bad fields per-workspace back to the preset (not all-or-nothing)', () => {


### PR DESCRIPTION
Closes #581. Wave 4 — **finishes the Soft Shell redesign epic #573.**

## Data Lab — decision: retired

It was never surfaced in the switcher (only Code/Board/Robot were shown), but it stayed in `WORKSPACE_IDS` — so a stale persisted `active='datalab'` (or the older `lab`/`data`) would load an **unreachable layout with no active switcher segment**. Removing it from `WORKSPACE_IDS` makes that case coerce to `code` for free, and the switcher is now exactly **Code · Electronics · Build**. Its instrument bench lives on in the Code/Build docks.

- Dropped the `datalab` preset + `WORKSPACE_INFO` entry + the `lab`/`data`→`datalab` migration.
- Tests updated, plus a coercion regression test (`lab`/`data`/`datalab` → `code`).

## Consistency audit

The three restyled workspaces were checked **cohesive in both skins** (light + dark) under headless Chromium: no legacy leaks, exactly three switcher segments, **zero console errors**. The recent-feature surfaces (mass #555, contacts #557, CoM overlay #558, stability strip #559, exploded view #499) were restyled in #580.

## Known gaps carried forward (follow-ups, not this issue)
- `CollapsiblePanel` adoption for the Code **Files/Console/Dock** is blocked on the `react-resizable-panels` layout host (#578 flagged this).
- No **real-Electron** pass — verified on the web build throughout (headless dev box).

`lint` / `typecheck` / `test` (2041) / `build` / `build:web` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)