### PR TITLE
feat: per-panel collapse controls, remove global toolbar toggles (#592)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Changed
+- **Per-panel collapse controls (#592, epic #573 Soft Shell).** The four global toolbar toggle knobs (Files / Shell / Chat / Instruments) are gone — each panel collapses from its OWN header chevron, and a collapsed panel becomes its own reopen affordance: the Console leaves a slim reopen bar and the instrument dock a thin “Instruments” rail, so nothing is ever stranded. The Files panel keeps its activity-bar toggle.
+
+### Changed
 - **Soft Shell close-out: Data Lab retired (#581, epic #573).** The never-surfaced
   Data Lab workspace is removed — the switcher is exactly Code · Electronics ·
   Build, and its instrument bench lives on in the Code/Build docks. A stale

--- a/src/renderer/src/components/AppShell.css
+++ b/src/renderer/src/components/AppShell.css
@@ -1,0 +1,95 @@
+/* Per-panel collapse + reopen affordances (#592, epic #573 Soft Shell).
+   The global toolbar toggle knobs are gone; each panel collapses from its own
+   header, and a collapsed panel leaves a slim clickable reopen rail/bar. */
+
+/* Centre column wrapper so the console reopen bar can sit under the vertical
+   PanelGroup when the shell is collapsed to nothing. */
+.shell__center-col {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+.shell__vgroup {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* A slim reopen bar/rail — the collapsed panel's own reopen affordance. */
+.shell__reopen {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-family: var(--font-ui, sans-serif);
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--txt3, var(--text-muted));
+  background: var(--panel2, var(--bg-sunken));
+  border: none;
+  border-top: 1px solid var(--shellbd, var(--border));
+  cursor: pointer;
+}
+.shell__reopen:hover {
+  color: var(--head, var(--text));
+  background: var(--panel, var(--bg-elevated));
+}
+.shell__reopen--bottom {
+  width: 100%;
+  height: 24px;
+  padding: 0 0.6rem;
+}
+
+/* The instrument-dock reopen rail — a thin vertical strip at the far right. */
+.shell__dock-rail {
+  flex: 0 0 auto;
+  width: 26px;
+  writing-mode: vertical-rl;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  font-family: var(--font-ui, sans-serif);
+  font-size: 0.6rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: var(--txt3, var(--text-muted));
+  background: var(--panel2, var(--bg-sunken));
+  border: none;
+  border-left: 1px solid var(--shellbd, var(--border));
+  cursor: pointer;
+}
+.shell__dock-rail:hover {
+  color: var(--head, var(--text));
+  background: var(--panel, var(--bg-elevated));
+}
+.shell__dock-rail-label {
+  transform: rotate(180deg);
+}
+
+/* The dock's own collapse button, pinned top-right of the dock aside. */
+.shell__dock {
+  position: relative;
+}
+.shell__dock-collapse {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  z-index: 4;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  color: var(--txt3, var(--text-muted));
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.shell__dock-collapse:hover {
+  color: var(--head, var(--text));
+  border-color: var(--shellbd, var(--border));
+  background: var(--card, var(--bg-elevated));
+}

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -73,6 +73,7 @@ import {
 } from '../lib/instrumentsLib'
 import { useWorkspace } from '../store/workspace'
 import { useEditorSettings } from '../store/settings'
+import './AppShell.css'
 
 /**
  * Wrap a panel that lacks its own region chrome in a scrollable region.
@@ -304,8 +305,7 @@ export function AppShell(): JSX.Element {
   // workspace's geometry when it becomes active (nothing remounts — the editor,
   // xterm scrollback and instruments survive every switch).
   const layout = useWorkspaceLayout()
-  const { filesCollapsed, shellCollapsed, rightCollapsed, activityView, boardPaneOpen } =
-    layout.workspace
+  const { shellCollapsed, rightCollapsed, activityView, boardPaneOpen } = layout.workspace
   const dockOpen = layout.workspace.dockOpen
   // Transient editor focus (Robot pop-out): hide the board, instruments + console
   // around the URDF without touching the workspace (#320 follow-up).
@@ -524,9 +524,6 @@ export function AppShell(): JSX.Element {
   // part of the workspace layout (the Board/Data Lab workspaces open it).
   const setDockOpen = layout.setDockOpen
   const instrumentsVisible = dockOpen && !focus
-  const toggleInstruments = useCallback((): void => {
-    setDockOpen(!dockOpen)
-  }, [dockOpen, setDockOpen])
 
   // --- Board pop-out (modes review): the floating window and the Board MODE are
   // the same board in two homes, never both. Mirrors instrument undocking:
@@ -989,26 +986,9 @@ export function AppShell(): JSX.Element {
         )}
       </div>
       <Toolbar
-        filesCollapsed={filesCollapsed}
-        onToggleFiles={() => {
-          if (!exitFocus()) toggle(filesRef)
-        }}
-        shellCollapsed={shellCollapsed}
-        onToggleShell={() => {
-          if (!exitFocus()) toggle(shellRef)
-        }}
-        rightCollapsed={rightCollapsed}
-        onToggleRight={() => {
-          if (!exitFocus()) toggle(rightRef)
-        }}
         onOpenBoard={() => {
           if (!exitFocus()) toggleBoard()
         }}
-        onToggleInstruments={() => {
-          if (!exitFocus()) toggleInstruments()
-        }}
-        instrumentsVisible={instrumentsVisible}
-        instrumentCount={openInstruments.length}
       />
 
       <div className="shell__body shell__main">
@@ -1058,9 +1038,11 @@ export function AppShell(): JSX.Element {
           <PanelResizeHandle className="resize-handle resize-handle--vertical" />
 
           <Panel order={2} minSize={30}>
+            <div className="shell__center-col">
             <PanelGroup
               direction="vertical"
               ref={vGroupRef}
+              className="shell__vgroup"
               onLayout={(sizes) => layout.recordSizes('vertical', sizes)}
             >
               <Panel order={1} minSize={20}>
@@ -1081,9 +1063,38 @@ export function AppShell(): JSX.Element {
                 onCollapse={() => layout.setCollapsed('shell', true)}
                 onExpand={() => layout.setCollapsed('shell', false)}
               >
-                <ShellPanel chatOpen={!rightCollapsed} />
+                <ShellPanel
+                  chatOpen={!rightCollapsed}
+                  onCollapse={() => {
+                    if (!exitFocus()) toggle(shellRef)
+                  }}
+                />
               </Panel>
             </PanelGroup>
+            {/* Reopen rail (#592): when the console is collapsed to nothing, a
+                slim clickable bar is its own reopen affordance (the global
+                toolbar toggle is gone). */}
+            {shellCollapsed && !focus && (
+              <button
+                type="button"
+                className="shell__reopen shell__reopen--bottom"
+                onClick={() => openPanel(shellRef)}
+                title="Show the console"
+              >
+                <svg width="12" height="12" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+                  <path
+                    d="M4 6l4 4 4-4"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+                <span>Console</span>
+              </button>
+            )}
+            </div>
           </Panel>
 
           {/* The embedded Board View (the Board workspace's tri-split, #259):
@@ -1140,6 +1151,26 @@ export function AppShell(): JSX.Element {
             className={`shell__dock${layout.active === 'robot' ? ' shell__dock--robot' : ''}`}
             aria-label="Instrument dock"
           >
+            {/* Per-panel collapse (#592) — the dock hides itself; the toolbar
+                Instruments toggle is gone, so the reopen rail below takes over. */}
+            <button
+              type="button"
+              className="shell__dock-collapse"
+              onClick={() => setDockOpen(false)}
+              title="Hide the instrument dock"
+              aria-label="Hide the instrument dock"
+            >
+              <svg width="13" height="13" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+                <path
+                  d="M6 4l4 4-4 4"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.8"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </button>
             {layout.active === 'robot' && (
               <div className="shell__robot3d">
                 <Suspense fallback={<div className="shell__robot3d-loading">Loading 3D…</div>}>
@@ -1155,6 +1186,19 @@ export function AppShell(): JSX.Element {
               hideMiniBoard={layout.workspace.boardPaneOpen}
             />
           </aside>
+        )}
+        {/* Reopen rail (#592): when the dock is hidden, a slim clickable rail at
+            the far right is its own reopen affordance. */}
+        {!dockOpen && !focus && (
+          <button
+            type="button"
+            className="shell__dock-rail"
+            onClick={() => setDockOpen(true)}
+            title="Show the instrument dock"
+            aria-label="Show the instrument dock"
+          >
+            <span className="shell__dock-rail-label">Instruments</span>
+          </button>
         )}
       </div>
 

--- a/src/renderer/src/components/ShellPanel.css
+++ b/src/renderer/src/components/ShellPanel.css
@@ -313,3 +313,23 @@
 .shell-popped__text {
   font-size: 0.8rem;
 }
+
+/* Per-panel collapse chevron in the shell header (#592). */
+.panel-collapse-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  color: var(--txt3, var(--text-muted));
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.panel-collapse-btn:hover {
+  color: var(--head, var(--text));
+  border-color: var(--shellbd, var(--border));
+  background: var(--card, var(--bg-elevated));
+}

--- a/src/renderer/src/components/ShellPanel.tsx
+++ b/src/renderer/src/components/ShellPanel.tsx
@@ -18,6 +18,8 @@ type ShellView = 'console' | 'problems'
 interface ShellPanelProps {
   /** Whether the right-hand chat panel is open (controls the "Send to chat" button). */
   chatOpen?: boolean
+  /** Collapse this panel from its own header (Soft Shell per-panel control, #592). */
+  onCollapse?: () => void
 }
 
 /**
@@ -36,7 +38,7 @@ interface ShellPanelProps {
  * Both bodies (Terminal, Problems) stay mounted; the inactive one is hidden via
  * CSS so console scrollback survives toggling.
  */
-export function ShellPanel({ chatOpen = false }: ShellPanelProps): JSX.Element {
+export function ShellPanel({ chatOpen = false, onCollapse }: ShellPanelProps): JSX.Element {
   const status = useDeviceStatus()
   const terminalRef = useRef<TerminalHandle>(null)
   const [view, setView] = useState<ShellView>('console')
@@ -148,6 +150,26 @@ export function ShellPanel({ chatOpen = false }: ShellPanelProps): JSX.Element {
               </button>
             )}
             <ConnectionControl status={status} />
+            {onCollapse && (
+              <button
+                type="button"
+                className="panel-collapse-btn"
+                onClick={onCollapse}
+                title="Collapse the console"
+                aria-label="Collapse the console"
+              >
+                <svg width="13" height="13" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+                  <path
+                    d="M4 10l4-4 4 4"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </button>
+            )}
           </div>
         }
       />

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -5,7 +5,6 @@ import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { useWorkspace } from '../store/workspace'
 import { useConsole } from '../store/console'
 import { isVirtualPort } from '../../../shared/virtual-device'
-import { IS_WEB } from '../lib/env'
 import './RunControls.css'
 import './Toolbar.css'
 
@@ -26,16 +25,6 @@ const ToolIcon = (children: ReactNode): JSX.Element => (
   </svg>
 )
 
-/**
- * Inline SVG wrapper for the panel-collapse "knob" icons on the right of the
- * toolbar — a rounded-rect window with a filled bar on the edge of the panel it
- * toggles, plus a divider line (matches the Skeuomorph concept's hardware keys).
- */
-const PanelIcon = (children: ReactNode): JSX.Element => (
-  <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false">
-    {children}
-  </svg>
-)
 
 // page with a `+` (new file)
 const NEW_FILE_ICON = ToolIcon(
@@ -57,30 +46,6 @@ const SAVE_ICON = ToolIcon(
   </g>
 )
 
-// Window with a filled bar on the left edge — toggles the left (Files) panel.
-const PANEL_LEFT_ICON = PanelIcon(
-  <g>
-    <rect x="3" y="5" width="18" height="14" rx="2.2" fill="none" stroke="currentColor" strokeWidth="1.7" />
-    <rect x="4.2" y="6.2" width="4.6" height="11.6" rx="1" fill="currentColor" opacity="0.3" />
-    <line x1="9" y1="5" x2="9" y2="19" stroke="currentColor" strokeWidth="1.6" />
-  </g>
-)
-// Window with a filled bar on the bottom edge — toggles the bottom (Shell) panel.
-const PANEL_BOTTOM_ICON = PanelIcon(
-  <g>
-    <rect x="3" y="5" width="18" height="14" rx="2.2" fill="none" stroke="currentColor" strokeWidth="1.7" />
-    <rect x="4.2" y="14" width="15.6" height="3.8" rx="1" fill="currentColor" opacity="0.3" />
-    <line x1="3" y1="14" x2="21" y2="14" stroke="currentColor" strokeWidth="1.6" />
-  </g>
-)
-// Window with a filled bar on the right edge — toggles the right (Chat) panel.
-const PANEL_RIGHT_ICON = PanelIcon(
-  <g>
-    <rect x="3" y="5" width="18" height="14" rx="2.2" fill="none" stroke="currentColor" strokeWidth="1.7" />
-    <rect x="15.2" y="6.2" width="4.6" height="11.6" rx="1" fill="currentColor" opacity="0.3" />
-    <line x1="15" y1="5" x2="15" y2="19" stroke="currentColor" strokeWidth="1.6" />
-  </g>
-)
 
 /**
  * Glossy green snake brand mark from the Skeuomorph concept: a green
@@ -115,19 +80,7 @@ const SNAKE_LOGO = (
 )
 
 interface ToolbarProps {
-  filesCollapsed: boolean
-  onToggleFiles: () => void
-  shellCollapsed: boolean
-  onToggleShell: () => void
-  rightCollapsed: boolean
-  onToggleRight: () => void
   onOpenBoard: () => void
-  /** Toggle the visibility of the docked/floating instruments (#101 / #102). */
-  onToggleInstruments: () => void
-  /** Whether the instruments are currently shown (drives the pressed look). */
-  instrumentsVisible: boolean
-  /** Number of open instruments (for the button title; 0 ⇒ still toggles). */
-  instrumentCount: number
 }
 
 /**
@@ -142,23 +95,12 @@ interface ToolbarProps {
  * {@link StatusBar} (issue #71); this toolbar still reads {@link useDeviceStatus}
  * only to enable/disable the Run/Stop buttons.
  *
- * Also hosts the Board View knob next to Run/Stop and the right cluster of
- * panel-collapse knobs (Files / Shell / Chat), which render as pressable hardware
- * keys in the Skeuomorph skin (a pressed-in look marks the active / shown panel).
- * Settings and the theme picker now live on the activity bar + Settings dialog.
+ * Also hosts the Board View knob next to Run/Stop and the centred workspace
+ * switcher (Code · Electronics · Build). The old global panel-collapse knobs were
+ * removed in Soft Shell (#592) — each panel owns its own collapse control now.
+ * Settings and the theme picker live on the activity bar + Settings dialog.
  */
-export function Toolbar({
-  filesCollapsed,
-  onToggleFiles,
-  shellCollapsed,
-  onToggleShell,
-  rightCollapsed,
-  onToggleRight,
-  onOpenBoard,
-  onToggleInstruments,
-  instrumentsVisible,
-  instrumentCount
-}: ToolbarProps): JSX.Element {
+export function Toolbar({ onOpenBoard }: ToolbarProps): JSX.Element {
   const status = useDeviceStatus()
   const { openFiles, activeId, newFile, openFolder, saveFile } = useWorkspace()
   const { markRun } = useConsole()
@@ -349,73 +291,10 @@ export function Toolbar({
 
       <div className="toolbar__spacer" />
 
-      {/* Workspace layouts (epic #259): Code / Board / Lab / Data + reset. */}
+      {/* Workspace layouts (epic #259): Code · Electronics · Build + reset.
+          Per-panel collapse controls live IN each panel's own header now (#592),
+          so the old global Files/Shell/Chat/Instruments toggle knobs are gone. */}
       <WorkspaceSwitcher />
-
-      <div className="toolbar__group">
-        <button
-          type="button"
-          className={`btn btn--ghost btn--icon btn--knob ${filesCollapsed ? '' : 'is-active'}`}
-          aria-pressed={!filesCollapsed}
-          onClick={onToggleFiles}
-          title="Toggle Files panel"
-          aria-label="Toggle Files panel"
-        >
-          {PANEL_LEFT_ICON}
-        </button>
-        <button
-          type="button"
-          className={`btn btn--ghost btn--icon btn--knob ${shellCollapsed ? '' : 'is-active'}`}
-          aria-pressed={!shellCollapsed}
-          onClick={onToggleShell}
-          title="Toggle Shell panel"
-          aria-label="Toggle Shell panel"
-        >
-          {PANEL_BOTTOM_ICON}
-        </button>
-        {/* Chat panel — hidden on the web build (the LLM chat is desktop-only). */}
-        {!IS_WEB && (
-          <button
-            type="button"
-            className={`btn btn--ghost btn--icon btn--knob ${rightCollapsed ? '' : 'is-active'}`}
-            aria-pressed={!rightCollapsed}
-            onClick={onToggleRight}
-            title="Toggle Chat panel"
-            aria-label="Toggle Chat panel"
-          >
-            {PANEL_RIGHT_ICON}
-          </button>
-        )}
-        <button
-          type="button"
-          className={`btn btn--ghost btn--icon btn--knob ${instrumentsVisible ? 'is-active' : ''}`}
-          aria-pressed={instrumentsVisible}
-          onClick={onToggleInstruments}
-          title={
-            instrumentCount > 0
-              ? `${instrumentsVisible ? 'Hide' : 'Show'} instruments (${instrumentCount} open)`
-              : 'Toggle instruments — open a scope/meter from a PWM/ADC pin in the Board View'
-          }
-          aria-label="Toggle instruments"
-        >
-          {/* Instrument cluster: a CRT scope screen with a square-wave trace +
-              a gauge tick, marking the oscilloscope/multimeter dock. Placed right
-              of the Chat toggle so the buttons match the panel order on screen. */}
-          <svg viewBox="0 0 24 24" width="17" height="17" aria-hidden="true" focusable="false">
-            <rect x="3" y="4.5" width="18" height="13" rx="2" fill="none" stroke="currentColor" strokeWidth="1.7" />
-            <path
-              d="M5.5 12.5 L8 12.5 L8 9.5 L11 9.5 L11 12.5 L13.5 12.5"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinejoin="round"
-              strokeLinecap="round"
-            />
-            <line x1="15" y1="12.5" x2="18" y2="9.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-            <line x1="8" y1="20" x2="16" y2="20" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" />
-          </svg>
-        </button>
-      </div>
     </header>
   )
 }


### PR DESCRIPTION
Closes #592. The Soft Shell follow-up: the design wants every panel to own its collapse control (a chevron in its header) with the collapsed panel as its own reopen affordance — not the four **global** toggle buttons in the top toolbar. This finishes the collapse-model half of the redesign that wave 3 deferred (the panels' collapse is owned by the react-resizable-panels layout host, which the parallel workspace agents were told not to touch).

## Why it's more than a button-swap
Panels collapse to `collapsedSize={0}` — they **vanish**. The Files panel reopens via the activity bar, but the Console and Dock reopened *only* via the toolbar buttons. So removing those naively would **strand** them. Each collapsed panel now becomes its own reopen affordance first:
- **Console** → a slim "Console" reopen bar under the editor (expands the shell).
- **Dock** → a thin vertical "Instruments" rail at the far right (+ a collapse chevron in the open dock).
- **Files** → unchanged; its activity-bar icon already collapses/reopens it.

Then the four global toggles (Files / Shell / Chat / Instruments) + their props/handlers are removed from `Toolbar.tsx` and `AppShell.tsx`. The collapse **state + persistence** in `store/layout.ts` is untouched — only the controls moved.

## Verification (headless Chromium, mine — not just the implementer's)
- old toolbar toggles: **all gone**
- Console chevron → collapses → reopen bar appears → click → **console returns**
- dock rail → opens the dock → dock collapse chevron → **rail returns** (nothing stranded)
- workspace switching Code → Electronics → Build still works
- **zero console errors**; both themes

`lint` / `typecheck` / `test` (2041) / `build` / `build:web` green.

Note: Files keeps the activity-bar icon as its per-panel control rather than threading a chevron into the file tree — call it out if you'd prefer an explicit chevron there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)