### PR TITLE
feat: dock MiniViewer — Board/3D toggle for Code & Electronics (#595)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Dock mini viewer with Board/3D toggle (#595, epic #573 Soft Shell).** The
+  Code and Electronics workspaces now get a MiniViewer card at the top of the
+  instrument dock: a gold-active **Board / 3D** segmented toggle over the app's
+  real mini-board and mini-3-D renders, plus an expand ⤢ that jumps to the
+  matching full workspace (Board → Electronics, 3D → Build). The choice persists
+  across sessions. The Build workspace keeps its full 3-D cockpit unchanged.
 - **Part-level ground-contact authoring (#569, epic #535 §2).** A part definition
   can now carry `contacts` — the foot/wheel points (mm, part frame) where it
   touches the floor — authored once in the Part Editor's Details ▸ Ground contacts

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -16,6 +16,7 @@ const BoardPane = lazy(() => import('./BoardPane'))
 // The mini 3-D Robot panel (Robot mode, #320) — lazy so three.js only loads
 // when you enter Robot mode.
 const RobotDockPanel = lazy(() => import('./RobotDockPanel'))
+import { MiniViewer } from './MiniViewer'
 import { useTheme } from '../hooks/useTheme'
 import { Toolbar } from './Toolbar'
 import { ActivityBar, ActivityView, DESKTOP_ONLY_VIEWS } from './ActivityBar'
@@ -1148,7 +1149,7 @@ export function AppShell(): JSX.Element {
             Instruments button or an incoming `instruments:open`. */}
         {instrumentsVisible && (
           <aside
-            className={`shell__dock${layout.active === 'robot' ? ' shell__dock--robot' : ''}`}
+            className={`shell__dock${layout.active === 'robot' ? ' shell__dock--robot' : ' shell__dock--mini'}`}
             aria-label="Instrument dock"
           >
             {/* Per-panel collapse (#592) — the dock hides itself; the toolbar
@@ -1171,11 +1172,19 @@ export function AppShell(): JSX.Element {
                 />
               </svg>
             </button>
-            {layout.active === 'robot' && (
+            {/* Dock-top slot (#595): the Robot/Build workspace gets the full
+                3-D cockpit; every other workspace (Code, Electronics) gets the
+                MiniViewer card — a Board/3D peek that expands to the matching
+                workspace. Either way there's a top panel, so the dock stacks. */}
+            {layout.active === 'robot' ? (
               <div className="shell__robot3d">
                 <Suspense fallback={<div className="shell__robot3d-loading">Loading 3D…</div>}>
                   <RobotDockPanel />
                 </Suspense>
+              </div>
+            ) : (
+              <div className="shell__miniviewer">
+                <MiniViewer source={boardSource} isPython={boardIsPython} />
               </div>
             )}
             <InstrumentDockRegion
@@ -1183,7 +1192,7 @@ export function AppShell(): JSX.Element {
               vis={visibility}
               inUse={inUse}
               onToggleVisible={toggleVisible}
-              hideMiniBoard={layout.workspace.boardPaneOpen}
+              hideMiniBoard={layout.active !== 'robot' || layout.workspace.boardPaneOpen}
             />
           </aside>
         )}

--- a/src/renderer/src/components/MiniViewer.css
+++ b/src/renderer/src/components/MiniViewer.css
@@ -1,0 +1,84 @@
+/* Mini viewer card (#595, Soft Shell) — the Board/3D peek at the top of the dock.
+   Soft Shell tokens with fallbacks to the semantic tokens. */
+.miniviewer {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: 100%;
+  background: var(--panel, var(--bg-elevated));
+}
+
+.miniviewer__head {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.4rem;
+  border-bottom: var(--border-w, 1px) solid var(--shellbd, var(--border));
+}
+
+/* Board / 3D segmented toggle — gold-active, matching the workspace switcher. */
+.miniviewer__seg {
+  display: inline-flex;
+  gap: 2px;
+  padding: 2px;
+  border: var(--border-w, 1px) solid var(--shellbd, var(--border));
+  border-radius: 9px;
+  background: var(--panel2, var(--bg-sunken));
+}
+.miniviewer__seg-btn {
+  font-family: var(--font-ui, sans-serif);
+  font-size: 0.62rem;
+  font-weight: 600;
+  color: var(--txt3, var(--text-muted));
+  background: transparent;
+  border: none;
+  border-radius: 7px;
+  padding: 0.14rem 0.55rem;
+  cursor: pointer;
+}
+.miniviewer__seg-btn:hover {
+  color: var(--head, var(--text));
+}
+.miniviewer__seg-btn.is-active {
+  background: var(--grad-gold, var(--accent));
+  color: var(--goldink, var(--accent-contrast));
+  font-weight: 700;
+}
+
+.miniviewer__expand {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  color: var(--txt3, var(--text-muted));
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.miniviewer__expand:hover {
+  color: var(--head, var(--text));
+  border-color: var(--shellbd, var(--border));
+  background: var(--card, var(--bg-elevated));
+}
+
+.miniviewer__body {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.miniviewer__loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--txt3, var(--text-muted));
+}

--- a/src/renderer/src/components/MiniViewer.tsx
+++ b/src/renderer/src/components/MiniViewer.tsx
@@ -66,7 +66,7 @@ export function MiniViewer({ source, isPython }: { source: string; isPython: boo
           <MiniBoardView source={source} isPython={isPython} />
         ) : (
           <Suspense fallback={<div className="miniviewer__loading">Loading 3D…</div>}>
-            <RobotDockPanel />
+            <RobotDockPanel embedded />
           </Suspense>
         )}
       </div>

--- a/src/renderer/src/components/MiniViewer.tsx
+++ b/src/renderer/src/components/MiniViewer.tsx
@@ -1,0 +1,75 @@
+import { lazy, Suspense } from 'react'
+import { MiniBoardView } from './MiniBoardView'
+import { useWorkspaceLayout } from '../store/layout'
+import { useLocalStorage } from '../hooks/useLocalStorage'
+import './MiniViewer.css'
+
+const RobotDockPanel = lazy(() => import('./RobotDockPanel').then((m) => ({ default: m.RobotDockPanel })))
+
+/**
+ * MINI VIEWER (#595, Soft Shell) — a peek card at the top of the instrument dock
+ * in the Code / Electronics workspaces: a **Board / 3D** segmented toggle over
+ * the app's REAL mini-board (`MiniBoardView`) and mini-3D (`RobotDockPanel`)
+ * renders, plus an expand ⤢ that jumps to the matching full workspace
+ * (Board → Electronics, 3D → Build). Only the card chrome is new; the inner
+ * renders are the existing live components (handoff §"mini viewer fidelity").
+ *
+ * The Robot/Build workspace keeps `RobotDockPanel` directly (it IS the 3-D
+ * cockpit there); this card is for the workspaces that otherwise show neither.
+ */
+export function MiniViewer({ source, isPython }: { source: string; isPython: boolean }): JSX.Element {
+  const { switchWorkspace } = useWorkspaceLayout()
+  const [mode, setMode] = useLocalStorage<'board' | '3d'>('snakie.miniViewer.mode', 'board')
+
+  return (
+    <div className="miniviewer">
+      <div className="miniviewer__head">
+        <div className="miniviewer__seg" role="group" aria-label="Mini viewer">
+          <button
+            type="button"
+            className={`miniviewer__seg-btn${mode === 'board' ? ' is-active' : ''}`}
+            aria-pressed={mode === 'board'}
+            onClick={() => setMode('board')}
+          >
+            Board
+          </button>
+          <button
+            type="button"
+            className={`miniviewer__seg-btn${mode === '3d' ? ' is-active' : ''}`}
+            aria-pressed={mode === '3d'}
+            onClick={() => setMode('3d')}
+          >
+            3D
+          </button>
+        </div>
+        <button
+          type="button"
+          className="miniviewer__expand"
+          title={mode === 'board' ? 'Open the Electronics workspace' : 'Open the Build workspace'}
+          aria-label={mode === 'board' ? 'Expand to the Electronics workspace' : 'Expand to the Build workspace'}
+          onClick={() => switchWorkspace(mode === 'board' ? 'board' : 'robot')}
+        >
+          <svg width="14" height="14" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+            <path
+              d="M6 3H3v10h10v-3M9.5 2.5H13.5V6.5M13 3 8 8"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+      </div>
+      <div className="miniviewer__body">
+        {mode === 'board' ? (
+          <MiniBoardView source={source} isPython={isPython} />
+        ) : (
+          <Suspense fallback={<div className="miniviewer__loading">Loading 3D…</div>}>
+            <RobotDockPanel />
+          </Suspense>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/RobotDockPanel.tsx
+++ b/src/renderer/src/components/RobotDockPanel.tsx
@@ -17,7 +17,7 @@ import './RobotDockPanel.css'
  * compact chrome. An **expand** button opens the project's `.urdf` full-screen
  * as the Pose tool (#312).
  */
-export function RobotDockPanel(): JSX.Element {
+export function RobotDockPanel({ embedded = false }: { embedded?: boolean } = {}): JSX.Element {
   const { currentFolder, openFile, openBuffer, openFolderPath } = useWorkspace()
   const { setFocus } = useWorkspaceLayout()
   const [urdf, setUrdf] = useState<string>(demoArm)
@@ -230,7 +230,9 @@ export function RobotDockPanel(): JSX.Element {
   return (
     <div className="robotdock">
       <RobotView urdfContent={urdf} basePath={base} compact />
-      <div className="robotdock__actions">
+      {/* Embedded in the MiniViewer (#595): the card's own expand ⤢ is the single
+          "go bigger" control, so hide this row to avoid duplicate affordances. */}
+      {!embedded && <div className="robotdock__actions">
         <button
           type="button"
           className={`robotdock__btn${hasProjectRobot ? '' : ' robotdock__btn--cta'}`}
@@ -255,7 +257,7 @@ export function RobotDockPanel(): JSX.Element {
         >
           ⤢ Pop out
         </button>
-      </div>
+      </div>}
     </div>
   )
 }

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -2248,9 +2248,23 @@ body {
   display: flex;
 }
 
-/* Robot mode (#320): the mini 3-D Robot panel sits ABOVE the instrument dock. */
-.shell__main .shell__dock--robot {
+/* Robot mode (#320): the mini 3-D Robot panel sits ABOVE the instrument dock.
+   Mini viewer (#595): the Code/Electronics dock stacks the same way, with the
+   MiniViewer card in the top slot. */
+.shell__main .shell__dock--robot,
+.shell__main .shell__dock--mini {
   flex-direction: column;
+}
+/* Mini viewer slot (#595): mirrors the robot 3-D slot's sizing. */
+.shell__miniviewer {
+  flex: 0 0 42%;
+  min-height: 160px;
+  position: relative;
+  border-bottom: var(--border-w) solid var(--border);
+  overflow: hidden;
+}
+.shell__dock--mini .instr-dock {
+  min-height: 0;
 }
 .shell__robot3d {
   flex: 0 0 42%;


### PR DESCRIPTION
Closes #595.

Adds the **MiniViewer** peek card at the top of the instrument dock in the Code
and Electronics workspaces — a **Board / 3D** segmented toggle over the app's
real mini-board (`MiniBoardView`) and mini-3D (`RobotDockPanel`) renders, plus an
expand ⤢ that jumps to the matching full workspace (Board → Electronics,
3D → Build). Mode persists via `snakie.miniViewer.mode`. The Robot/Build
workspace keeps `RobotDockPanel` directly.

Polish: in 3D mode the embedded `RobotDockPanel` hides its own New robot / Open /
Pop out action row (`embedded` prop) so the card's single expand ⤢ is the only
"go bigger" affordance; the full Build cockpit is unchanged.

Verified headless (Chromium/swiftshader): dock → MiniViewer with Board/3D toggle,
Board-expand → Electronics, 3D-expand → Build, embedded action row hidden, Build
workspace RobotDockPanel keeps its actions, zero page errors. lint / typecheck /
2045 tests / build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)