### PR TITLE
feat: focused Code · Electronics · Build workspaces + follow-ups (epic #573 Soft Shell)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,35 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- **Focused workspace layouts — Code · Electronics · Build (epic #573 Soft
+  Shell).** Each workspace now shows only what it's for, matching the design
+  handoff:
+  - **Code** — files + editor + console, with the mini-viewer / instrument dock
+    on the right (the dock is Code-only now).
+  - **Electronics** — the Board View (canvas + parts library) fills the whole
+    area in its own dedicated layout: no code editor, console, instrument dock or
+    mini viewer. The code panels are structurally absent, so no stale/persisted
+    layout can resurface them.
+  - **Build** — the URDF / 3-D pose editor is full-screen, likewise in its own
+    dedicated layout: no code, no board view, no instrument dock.
+  - In **Electronics** and **Build**, a tutorial / help lesson opened elsewhere
+    stays open in a slim panel beside the main surface across mode switches;
+    otherwise the sidebar is hidden (only the Learn/Help lessons open it there).
+  - The **workspace switcher** is centred and more prominent in the toolbar
+    (always keeping a margin from Run/Reset), the old **reset-layout** and
+    **pop-out Board View** toolbar buttons are removed, and the mini-viewer's
+    Board/3D toggle is centred with the instrument dock flush beneath it.
+  - The Code **console** opens taller by default (40%) so the REPL is usable at a
+    glance. Layout envelope bumped to **v2**: existing users keep their Code
+    layout but Electronics + Build reset to the new presets.
+
 ### Added
 - **Dock mini viewer with Board/3D toggle (#595, epic #573 Soft Shell).** The
-  Code and Electronics workspaces now get a MiniViewer card at the top of the
-  instrument dock: a gold-active **Board / 3D** segmented toggle over the app's
-  real mini-board and mini-3-D renders, plus an expand ⤢ that jumps to the
-  matching full workspace (Board → Electronics, 3D → Build). The choice persists
-  across sessions. The Build workspace keeps its full 3-D cockpit unchanged.
+  Code workspace gets a MiniViewer card at the top of the instrument dock: a
+  gold-active **Board / 3D** segmented toggle over the app's real mini-board and
+  mini-3-D renders, plus an expand ⤢ that jumps to the matching full workspace
+  (Board → Electronics, 3D → Build). The choice persists across sessions.
 - **Part-level ground-contact authoring (#569, epic #535 §2).** A part definition
   can now carry `contacts` — the foot/wheel points (mm, part frame) where it
   touches the floor — authored once in the Part Editor's Details ▸ Ground contacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Soft Shell cards (epic #573).** The Files panel, editor, console and
+  instrument dock now float as rounded cards on the parchment workspace (soft
+  shadow, radius, a parchment gap between them) — matching the design handoff.
 - **One board across every view (epic #573 Soft Shell).** The microcontroller
   selected in the mini-board (Code workspace) and the Board View (Electronics) now
   stay in sync — `robot.yml`'s `board` is the shared source of truth: the mini

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **One board across every view (epic #573 Soft Shell).** The microcontroller
+  selected in the mini-board (Code workspace) and the Board View (Electronics) now
+  stay in sync — `robot.yml`'s `board` is the shared source of truth: the mini
+  board reads and writes it (for the open project), the Board View adopts a pick
+  made anywhere and keeps the localStorage fallback in step. Picking a board in
+  either place updates both.
+- **Mini-viewer pop-outs switch workspaces (epic #573).** The mini-board's pop-out
+  now opens the **Electronics** workspace and the mini-3-D's opens **Build** —
+  in-app, instead of the standalone Board View window.
+- **Chat toggle in the console header (epic #573).** The AI chat pane (Code
+  workspace, desktop) gets a **Chat** button in the console header — the opener
+  that went missing when the global toolbar toggles were retired (#592).
+
+### Fixed
+- **No more demo-arm flash (epic #573).** Switching into the 3-D view no longer
+  briefly shows the bundled demo arm before the project's model loads — it shows a
+  short loading state, then the real model (demo arm only when there's no project
+  model).
+- **Build toolbar stays put (epic #573).** Hiding the URDF hierarchy no longer
+  hides the build toolbar (add primitive/joint, measure, undo/redo) — its tools
+  act on the viewport, not the tree.
+
 ### Changed
 - **Focused workspace layouts — Code · Electronics · Build (epic #573 Soft
   Shell).** Each workspace now shows only what it's for, matching the design

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   that went missing when the global toolbar toggles were retired (#592).
 
 ### Fixed
+- **Better Code defaults (epic #573).** The file panel opens at a comfortable
+  ~272px (was clamped ~30% too wide) and the console opens taller (~45%) so a
+  couple of REPL lines are clearly visible — the user recognises the console for
+  what it is. Existing layouts are migrated (envelope v3).
 - **No more demo-arm flash (epic #573).** Switching into the 3-D view no longer
   briefly shows the bundled demo arm before the project's model loads — it shows a
   short loading state, then the real model (demo arm only when there's no project

--- a/src/renderer/src/components/AppShell.css
+++ b/src/renderer/src/components/AppShell.css
@@ -42,6 +42,7 @@
 
 /* The instrument-dock reopen rail — a thin vertical strip at the far right. */
 .shell__dock-rail {
+  position: relative;
   flex: 0 0 auto;
   width: 26px;
   writing-mode: vertical-rl;
@@ -65,6 +66,15 @@
 }
 .shell__dock-rail-label {
   transform: rotate(180deg);
+}
+/* Expand chevron pinned to the top of the collapsed rail (horizontal, not in the
+   rail's vertical writing mode). */
+.shell__dock-rail-icon {
+  position: absolute;
+  top: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  writing-mode: horizontal-tb;
 }
 
 /* The dock's own collapse button, pinned top-right of the dock aside. */

--- a/src/renderer/src/components/AppShell.css
+++ b/src/renderer/src/components/AppShell.css
@@ -71,10 +71,13 @@
 .shell__dock {
   position: relative;
 }
+/* Collapse chevrons sit at the FAR EDGE of where the panel collapses to (#…):
+   the Files panel's is top-right; the instrument dock's is top-left (it collapses
+   off to the right). */
 .shell__dock-collapse {
   position: absolute;
   top: 6px;
-  right: 6px;
+  left: 6px;
   z-index: 4;
   display: inline-flex;
   align-items: center;

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -920,6 +920,15 @@ export function AppShell(): JSX.Element {
     return off
   }, [])
 
+  // The Files panel's own collapse chevron (in the LocalFileTree header, #…) is
+  // deep in the tree, so it signals the shell by event to collapse the RRP files
+  // Panel — leaving the activity-bar Files toggle to reopen it.
+  useEffect(() => {
+    const handler = (): void => toggle(filesRef)
+    window.addEventListener('snakie:toggle-files', handler)
+    return () => window.removeEventListener('snakie:toggle-files', handler)
+  }, [toggle])
+
   // Which view the left sidebar shows, driven by the ActivityBar — remembered
   // per workspace (part of the layout store).
   const setActivityView = layout.setActivityView

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -281,7 +281,8 @@ export function AppShell(): JSX.Element {
   // workspace's geometry when it becomes active (nothing remounts — the editor,
   // xterm scrollback and instruments survive every switch).
   const layout = useWorkspaceLayout()
-  const { shellCollapsed, rightCollapsed, activityView, boardPaneOpen } = layout.workspace
+  const { shellCollapsed, rightCollapsed, activityView, boardPaneOpen, filesCollapsed } =
+    layout.workspace
   // Build (#…): the centre column hosts the full-screen URDF/3-D editor instead of
   // the code editor + console — no code, no board view.
   const robotMain = layout.active === 'robot'
@@ -1100,14 +1101,19 @@ export function AppShell(): JSX.Element {
             collapsible
             collapsedSize={0}
             defaultSize={initialSizes.current.h[0]}
-            minSize={12}
+            minSize={16}
             onCollapse={() => layout.setCollapsed('files', true)}
             onExpand={() => layout.setCollapsed('files', false)}
           >
             <LeftView view={activityView} helpTarget={helpTarget} />
           </Panel>
 
-          <PanelResizeHandle className="resize-handle resize-handle--vertical" />
+          {/* Hide the stitch when Files is collapsed — the panel isn't reopened by
+              dragging this divider (any activity-bar button opens it for a purpose),
+              so a visible resize thread there would be misleading (#…). */}
+          <PanelResizeHandle
+            className={`resize-handle resize-handle--vertical resize-handle--files${filesCollapsed ? ' is-collapsed' : ''}`}
+          />
 
           <Panel
             ref={centreRef}
@@ -1163,9 +1169,10 @@ export function AppShell(): JSX.Element {
                   onClick={() => openPanel(shellRef)}
                   title="Show the console"
                 >
+                  {/* Collapsed → UP chevron (the console expands upward). */}
                   <svg width="12" height="12" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
                     <path
-                      d="M4 6l4 4 4-4"
+                      d="M4 10l4-4 4 4"
                       fill="none"
                       stroke="currentColor"
                       strokeWidth="1.8"
@@ -1281,6 +1288,25 @@ export function AppShell(): JSX.Element {
             title="Show the instrument dock"
             aria-label="Show the instrument dock"
           >
+            {/* Expand affordance at the top of the collapsed rail (#…) — signals the
+                panel can be opened (it slides back in from the right). */}
+            <svg
+              className="shell__dock-rail-icon"
+              width="13"
+              height="13"
+              viewBox="0 0 16 16"
+              aria-hidden="true"
+              focusable="false"
+            >
+              <path
+                d="M10 4L6 8l4 4"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
             <span className="shell__dock-rail-label">Instruments</span>
           </button>
         )}

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -230,34 +230,9 @@ export function AppShell(): JSX.Element {
   // Toggle the floating Board View window from the toolbar button: open (and
   // push the current file immediately so it isn't blank) if closed, or close it
   // if it's already open. `onClosed` resets `boardOpened` either way.
-  // Pop-out: opening while Board MODE is active hands the board to the window —
-  // the workspace switch happens HERE, in the same handler as the open, so both
-  // state updates land in one commit (no half-switched state for the re-dock
-  // effect to misread).
-  const toggleBoard = useCallback((): void => {
-    if (boardOpened) {
-      window.api.board.close()
-      return
-    }
-    if (activeWsRef.current === 'board') {
-      poppedFromBoardRef.current = true
-      switchWorkspaceRef.current('code')
-    }
-    setBoardOpened(true)
-    window.api.board
-      .open()
-      .then(() =>
-        window.api.board.update({
-          source: boardSource,
-          fileName: boardFileName,
-          isPython: boardIsPython,
-          theme,
-          breadboardBg,
-          folder: boardFolder
-        })
-      )
-      .catch(() => undefined)
-  }, [boardOpened, boardSource, boardFileName, boardIsPython, theme, breadboardBg, boardFolder])
+  // (The toolbar's pop-out board knob was removed (#…) now that the Board View is
+  // the Electronics workspace; the board window can still open via other paths —
+  // e.g. the web build — so the streaming/close subscriptions below stay.)
 
   // While the window is open, stream the active file / content / theme to it on
   // every change so it stays live.
@@ -307,13 +282,36 @@ export function AppShell(): JSX.Element {
   // xterm scrollback and instruments survive every switch).
   const layout = useWorkspaceLayout()
   const { shellCollapsed, rightCollapsed, activityView, boardPaneOpen } = layout.workspace
+  // Build (#…): the centre column hosts the full-screen URDF/3-D editor instead of
+  // the code editor + console — no code, no board view.
+  const robotMain = layout.active === 'robot'
+  // The instrument dock (mini-viewer peek + instruments + reopen rail) belongs to
+  // the CODE workspace only. Electronics fills the area with the Board View and
+  // Build with the URDF editor — both are self-contained, so neither shows the
+  // dock or the mini Board/3-D viewer.
+  const dockWorkspace = layout.active === 'code'
+  // Electronics + Build are "solo" workspaces: a single main surface (the Board
+  // View / the URDF 3-D editor) fills the area with NO code editor, console or
+  // instrument dock — a dedicated non-RRP layout, so a persisted flag can never
+  // resurface the code panels. Only Code uses the resizable panel group.
+  const soloWorkspace = robotMain || layout.active === 'board'
+  // A solo workspace hides the sidebar by default. ONLY a lesson (the Learn
+  // tutorials or the Help library) shows there — carried in from another workspace
+  // or opened from the activity bar — so a stale `filesCollapsed:false` for the
+  // plain Files view can't resurface a file tree in Electronics/Build.
+  const isLessonView = activityView === 'learn' || activityView === 'help'
+  const soloLessonOpen = soloWorkspace && isLessonView && !layout.workspace.filesCollapsed
   const dockOpen = layout.workspace.dockOpen
   // Transient editor focus (Robot pop-out): hide the board, instruments + console
   // around the URDF without touching the workspace (#320 follow-up).
   const focus = layout.focus
-  const boardPaneVisible = boardPaneOpen && !focus
+  // Build (robot) is the full-screen URDF editor ONLY — it structurally never
+  // shows the board pane, whatever a persisted `boardPaneOpen` says (belt-and-
+  // braces over the v2 layout migration).
+  const boardPaneVisible = boardPaneOpen && !focus && !robotMain
 
   const filesRef = useRef<ImperativePanelHandle>(null)
+  const centreRef = useRef<ImperativePanelHandle>(null)
   const shellRef = useRef<ImperativePanelHandle>(null)
   const rightRef = useRef<ImperativePanelHandle>(null)
   const hGroupRef = useRef<ImperativePanelGroupHandle>(null)
@@ -354,39 +352,55 @@ export function AppShell(): JSX.Element {
     return false
   }, [layout])
 
+  // Apply a workspace's geometry to the panel groups: setLayout drives the sizes;
+  // the explicit collapse()/expand() calls are belt-and-braces so a collapsible
+  // panel lands collapsed even if the group clamps a 0 size. Reads the LIVE store
+  // each call so re-applies (below) always use current state.
+  const applyWorkspaceGeometry = useCallback((): void => {
+    const ws = layout.workspace
+    const rMain = layout.active === 'robot'
+    // The horizontal group's setLayout array must match the RENDERED panels: the
+    // board slot elides when the pane is closed (or in Build), and the chat slot
+    // doesn't exist on web (#528) — a stray extra size makes RRP throw.
+    const boardOn = ws.boardPaneOpen && !focus && !rMain
+    hGroupRef.current?.setLayout(appliedHorizontal(ws.horizontal, boardOn, !IS_WEB))
+    vGroupRef.current?.setLayout([...ws.vertical])
+    // Then sync each collapsible panel's collapsed state (belt-and-braces over the
+    // sizes, so a panel lands collapsed even if the group clamped a 0 size). Order
+    // matters: sizes first, collapse/expand second — reversing it leaves Electronics'
+    // centre column at a 50/50 split instead of collapsed.
+    const sync = (ref: React.RefObject<ImperativePanelHandle>, collapsed: boolean): void => {
+      const panel = ref.current
+      if (!panel) return
+      if (collapsed) panel.collapse()
+      else panel.expand()
+    }
+    sync(filesRef, ws.filesCollapsed)
+    // Electronics collapses the centre column (code + console) so the Board View
+    // fills the main area; the editor stays mounted behind the 0-width panel.
+    sync(centreRef, ws.centreCollapsed)
+    sync(shellRef, focus || ws.shellCollapsed)
+    sync(rightRef, ws.rightCollapsed)
+  }, [layout.workspace, layout.active, focus])
+  const applyGeomRef = useRef(applyWorkspaceGeometry)
+  applyGeomRef.current = applyWorkspaceGeometry
+
   // Apply the active workspace's geometry whenever it changes (switch / reset).
-  // setLayout drives the sizes; the explicit collapse() calls are belt-and-braces
-  // so a collapsible panel lands collapsed even if the group clamps a 0 size.
+  // Deferred one frame: switching INTO Electronics mounts the board Panel in this
+  // same commit, and a setLayout before the group registers it is ignored (the
+  // "board pane opens tiny" bug). A second pass the next frame re-asserts after the
+  // content settles. (Build uses its own NON-RRP layout, so it isn't affected.)
   useEffect(() => {
     if (layout.applyNonce === 0) return // initial mount already used defaultSize
-    const ws = layout.workspace
-    // Deferred one frame: switching INTO the Board workspace mounts the board
-    // Panel in this same commit, and a setLayout issued before the group has
-    // registered the new panel is ignored (the pane then lands on defaultSize —
-    // the "board pane opens tiny" bug). After rAF the group knows all panels.
-    const raf = requestAnimationFrame(() => {
-      // The horizontal group's setLayout array must match the RENDERED panels:
-      // the board slot elides when the pane is closed (and in focus mode, where
-      // the editor takes its share), and the chat slot doesn't exist on the web
-      // build (#528) — a stray extra size makes react-resizable-panels throw.
-      const boardOn = ws.boardPaneOpen && !focus
-      hGroupRef.current?.setLayout(appliedHorizontal(ws.horizontal, boardOn, !IS_WEB))
-      vGroupRef.current?.setLayout([...ws.vertical])
-      // Sync each collapsible panel BOTH ways to the target workspace, so the RRP
-      // panel state can't drift from the store flag (which would strand the
-      // toggle button / activity icon on the next click). Focus also collapses
-      // the console so only the URDF shows.
-      const sync = (ref: React.RefObject<ImperativePanelHandle>, collapsed: boolean): void => {
-        const panel = ref.current
-        if (!panel) return
-        if (collapsed) panel.collapse()
-        else panel.expand()
-      }
-      sync(filesRef, ws.filesCollapsed)
-      sync(shellRef, focus || ws.shellCollapsed)
-      sync(rightRef, ws.rightCollapsed)
+    let raf2 = 0
+    const raf1 = requestAnimationFrame(() => {
+      applyGeomRef.current()
+      raf2 = requestAnimationFrame(() => applyGeomRef.current())
     })
-    return () => cancelAnimationFrame(raf)
+    return () => {
+      cancelAnimationFrame(raf1)
+      if (raf2) cancelAnimationFrame(raf2)
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- applyNonce IS the signal
   }, [layout.applyNonce])
 
@@ -986,11 +1000,7 @@ export function AppShell(): JSX.Element {
           />
         )}
       </div>
-      <Toolbar
-        onOpenBoard={() => {
-          if (!exitFocus()) toggleBoard()
-        }}
-      />
+      <Toolbar />
 
       <div className="shell__body shell__main">
         <ActivityBar
@@ -1000,6 +1010,23 @@ export function AppShell(): JSX.Element {
             // In focus mode, any activity click just restores the Robot layout.
             if (exitFocus()) {
               setActivityView(view)
+              return
+            }
+            // Solo workspaces (Electronics/Build) have no RRP files panel — only a
+            // lesson (Learn/Help) opens a sidebar there, driven by the store flag.
+            if (soloWorkspace) {
+              const lessonView = view === 'learn' || view === 'help'
+              if (!lessonView) {
+                // Files/Packages/etc. have no panel in a solo workspace — remember
+                // the choice but keep the sidebar hidden.
+                setActivityView(view)
+                layout.setCollapsed('files', true)
+              } else if (view === activityView && soloLessonOpen) {
+                layout.setCollapsed('files', true) // toggle the open lesson closed
+              } else {
+                setActivityView(view)
+                layout.setCollapsed('files', false) // open the lesson
+              }
               return
             }
             // Clicking the already-active view toggles the left panel collapse
@@ -1014,9 +1041,44 @@ export function AppShell(): JSX.Element {
             openPanel(filesRef)
           }}
         />
-        {/* Sizes are recorded into the ACTIVE workspace via onLayout and applied
+        {/* Electronics + Build (#…) get a dedicated, NON-RRP layout: a single main
+            surface (the Board View / the URDF 3-D pose editor) fills the whole area
+            — no code editor, console or instrument dock. A tutorial/help lesson
+            carried in from another workspace shows in a left panel beside it;
+            otherwise there's no sidebar. Keeping these out of the resizable panel
+            group makes the code panels structurally absent (no persisted flag can
+            resurface them) and avoids RRP collapse races. */}
+        {soloWorkspace ? (
+          <div className="shell__solo">
+            {soloLessonOpen && (
+              <aside className="shell__solo-lesson" aria-label="Lesson">
+                <LeftView view={activityView} helpTarget={helpTarget} />
+              </aside>
+            )}
+            {robotMain ? (
+              <div className="shell__robot-main">
+                <Suspense fallback={<div className="shell__robot3d-loading">Loading 3D…</div>}>
+                  <RobotDockPanel full />
+                </Suspense>
+              </div>
+            ) : (
+              <div className="shell__solo-board">
+                <Suspense
+                  fallback={
+                    <div className="board-pane__loading" role="status">
+                      Loading Board View…
+                    </div>
+                  }
+                >
+                  <BoardPane />
+                </Suspense>
+              </div>
+            )}
+          </div>
+        ) : (
+        /* Sizes are recorded into the ACTIVE workspace via onLayout and applied
             imperatively on workspace switch (setLayout) — the library's own
-            autoSaveId persistence is replaced by the layout store (#259). */}
+            autoSaveId persistence is replaced by the layout store (#259). */
         <PanelGroup
           direction="horizontal"
           ref={hGroupRef}
@@ -1038,63 +1100,72 @@ export function AppShell(): JSX.Element {
 
           <PanelResizeHandle className="resize-handle resize-handle--vertical" />
 
-          <Panel order={2} minSize={30}>
+          <Panel
+            ref={centreRef}
+            order={2}
+            collapsible
+            collapsedSize={0}
+            defaultSize={initialSizes.current.h[1]}
+            minSize={30}
+            onCollapse={() => layout.setCollapsed('centre', true)}
+            onExpand={() => layout.setCollapsed('centre', false)}
+          >
             <div className="shell__center-col">
-            <PanelGroup
-              direction="vertical"
-              ref={vGroupRef}
-              className="shell__vgroup"
-              onLayout={(sizes) => layout.recordSizes('vertical', sizes)}
-            >
-              <Panel order={1} minSize={20}>
-                <div className="shell__editor-region">
-                  <EditorArea />
-                </div>
-              </Panel>
-
-              <PanelResizeHandle className="resize-handle resize-handle--horizontal" />
-
-              <Panel
-                ref={shellRef}
-                order={2}
-                collapsible
-                collapsedSize={0}
-                defaultSize={initialSizes.current.v[1]}
-                minSize={12}
-                onCollapse={() => layout.setCollapsed('shell', true)}
-                onExpand={() => layout.setCollapsed('shell', false)}
+              <PanelGroup
+                direction="vertical"
+                ref={vGroupRef}
+                className="shell__vgroup"
+                onLayout={(sizes) => layout.recordSizes('vertical', sizes)}
               >
-                <ShellPanel
-                  chatOpen={!rightCollapsed}
-                  onCollapse={() => {
-                    if (!exitFocus()) toggle(shellRef)
-                  }}
-                />
-              </Panel>
-            </PanelGroup>
-            {/* Reopen rail (#592): when the console is collapsed to nothing, a
-                slim clickable bar is its own reopen affordance (the global
-                toolbar toggle is gone). */}
-            {shellCollapsed && !focus && (
-              <button
-                type="button"
-                className="shell__reopen shell__reopen--bottom"
-                onClick={() => openPanel(shellRef)}
-                title="Show the console"
-              >
-                <svg width="12" height="12" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
-                  <path
-                    d="M4 6l4 4 4-4"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="1.8"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
+                <Panel order={1} minSize={20}>
+                  <div className="shell__editor-region">
+                    <EditorArea />
+                  </div>
+                </Panel>
+
+                <PanelResizeHandle className="resize-handle resize-handle--horizontal" />
+
+                <Panel
+                  ref={shellRef}
+                  order={2}
+                  collapsible
+                  collapsedSize={0}
+                  defaultSize={initialSizes.current.v[1]}
+                  minSize={12}
+                  onCollapse={() => layout.setCollapsed('shell', true)}
+                  onExpand={() => layout.setCollapsed('shell', false)}
+                >
+                  <ShellPanel
+                    chatOpen={!rightCollapsed}
+                    onCollapse={() => {
+                      if (!exitFocus()) toggle(shellRef)
+                    }}
                   />
-                </svg>
-                <span>Console</span>
-              </button>
-            )}
+                </Panel>
+              </PanelGroup>
+              {/* Reopen rail (#592): when the console is collapsed to nothing, a
+                  slim clickable bar is its own reopen affordance (the global
+                  toolbar toggle is gone). */}
+              {shellCollapsed && !focus && (
+                <button
+                  type="button"
+                  className="shell__reopen shell__reopen--bottom"
+                  onClick={() => openPanel(shellRef)}
+                  title="Show the console"
+                >
+                  <svg width="12" height="12" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+                    <path
+                      d="M4 6l4 4 4-4"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.8"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                  <span>Console</span>
+                </button>
+              )}
             </div>
           </Panel>
 
@@ -1141,15 +1212,16 @@ export function AppShell(): JSX.Element {
             </>
           )}
         </PanelGroup>
+        )}
 
         {/* The INSTRUMENT DOCK lives OUTSIDE the PanelGroup — a fixed-width region
             to the right of the chat. Kept out of the group so toggling it (or the
             chat) never resizes the other (two collapsible panels in one group
             redistribute each other's freed space). Shown by the toolbar
             Instruments button or an incoming `instruments:open`. */}
-        {instrumentsVisible && (
+        {instrumentsVisible && dockWorkspace && (
           <aside
-            className={`shell__dock${layout.active === 'robot' ? ' shell__dock--robot' : ' shell__dock--mini'}`}
+            className="shell__dock shell__dock--mini"
             aria-label="Instrument dock"
           >
             {/* Per-panel collapse (#592) — the dock hides itself; the toolbar
@@ -1172,33 +1244,26 @@ export function AppShell(): JSX.Element {
                 />
               </svg>
             </button>
-            {/* Dock-top slot (#595): the Robot/Build workspace gets the full
-                3-D cockpit; every other workspace (Code, Electronics) gets the
-                MiniViewer card — a Board/3D peek that expands to the matching
-                workspace. Either way there's a top panel, so the dock stacks. */}
-            {layout.active === 'robot' ? (
-              <div className="shell__robot3d">
-                <Suspense fallback={<div className="shell__robot3d-loading">Loading 3D…</div>}>
-                  <RobotDockPanel />
-                </Suspense>
-              </div>
-            ) : (
-              <div className="shell__miniviewer">
-                <MiniViewer source={boardSource} isPython={boardIsPython} />
-              </div>
-            )}
+            {/* Dock-top slot (#595): the Code workspace gets the MiniViewer card —
+                a Board/3D peek that expands to the matching workspace. (Electronics
+                and Build are self-contained — the Board View / URDF editor fill the
+                area — so the whole dock is gated to Code above.) */}
+            <div className="shell__miniviewer">
+              <MiniViewer source={boardSource} isPython={boardIsPython} />
+            </div>
             <InstrumentDockRegion
               host={instruments}
               vis={visibility}
               inUse={inUse}
               onToggleVisible={toggleVisible}
-              hideMiniBoard={layout.active !== 'robot' || layout.workspace.boardPaneOpen}
+              hideMiniBoard
             />
           </aside>
         )}
         {/* Reopen rail (#592): when the dock is hidden, a slim clickable rail at
-            the far right is its own reopen affordance. */}
-        {!dockOpen && !focus && (
+            the far right is its own reopen affordance. Code only — Electronics and
+            Build have no instrument dock (the Board View / URDF editor fill the area). */}
+        {!dockOpen && !focus && dockWorkspace && (
           <button
             type="button"
             className="shell__dock-rail"

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -1137,6 +1137,7 @@ export function AppShell(): JSX.Element {
                 >
                   <ShellPanel
                     chatOpen={!rightCollapsed}
+                    onToggleChat={IS_WEB ? undefined : () => toggle(rightRef)}
                     onCollapse={() => {
                       if (!exitFocus()) toggle(shellRef)
                     }}

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -1131,7 +1131,7 @@ export function AppShell(): JSX.Element {
                   collapsible
                   collapsedSize={0}
                   defaultSize={initialSizes.current.v[1]}
-                  minSize={12}
+                  minSize={22}
                   onCollapse={() => layout.setCollapsed('shell', true)}
                   onExpand={() => layout.setCollapsed('shell', false)}
                 >

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -1091,7 +1091,7 @@ export function AppShell(): JSX.Element {
             collapsible
             collapsedSize={0}
             defaultSize={initialSizes.current.h[0]}
-            minSize={30}
+            minSize={12}
             onCollapse={() => layout.setCollapsed('files', true)}
             onExpand={() => layout.setCollapsed('files', false)}
           >

--- a/src/renderer/src/components/BoardGraph.tsx
+++ b/src/renderer/src/components/BoardGraph.tsx
@@ -489,6 +489,42 @@ export function BoardGraph({
     }
   }
 
+  // Follow a board picked in ANOTHER view (the mini board / Code workspace): adopt
+  // it live, keep this window's localStorage fallback in step, and — when wiring is
+  // enabled — persist to robot.yml so the pick sticks. Held in a ref so the
+  // once-registered listener always sees current state without re-subscribing.
+  const onExternalSelectRef = useRef<(id: string) => void>(() => {})
+  onExternalSelectRef.current = (id: string): void => {
+    if (id === boardId || !boards.some((b) => b.id === id)) return
+    setBoardId(id)
+    try {
+      window.localStorage.setItem(STORAGE_KEY, id)
+    } catch {
+      // ignore storage failures
+    }
+    if (wiringEnabled && robot && onChangeRobot && robot.board !== id) {
+      onChangeRobot({ ...robot, board: id })
+    }
+  }
+  useEffect(() => {
+    const off = window.api.board.onSelectBoard((id) => onExternalSelectRef.current(id))
+    return off
+  }, [])
+
+  // Keep the shared localStorage board id in step with this view's EFFECTIVE board
+  // (including one adopted from robot.yml on load), so any consumer that falls back
+  // to localStorage matches. No broadcast here — selectBoard / the handler above do
+  // that; this only syncs the fallback, so it can't echo.
+  useEffect(() => {
+    try {
+      if (window.localStorage.getItem(STORAGE_KEY) !== boardId) {
+        window.localStorage.setItem(STORAGE_KEY, boardId)
+      }
+    } catch {
+      // ignore storage failures
+    }
+  }, [boardId])
+
   // Re-parse on every source change → live update.
   const conns = useMemo(() => (isPython ? parsePins(source) : []), [source, isPython])
 

--- a/src/renderer/src/components/LocalFileTree.css
+++ b/src/renderer/src/components/LocalFileTree.css
@@ -19,14 +19,23 @@
  * actions stay reachable, and the title ellipsises rather than pushing past
  * the edge.
  */
+/* Two-row header (#…): title + collapse chevron on top, the 4 file-action icons
+   centred below. */
 .localtree__header {
-  flex-wrap: wrap;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.35rem;
+}
+.localtree__header-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 0.4rem;
 }
 
 .localtree__title {
   min-width: 0;
-  flex: 1 1 auto;
+  flex: 0 1 auto;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -37,6 +46,30 @@
   align-items: center;
   gap: 0.2rem;
   flex: 0 0 auto;
+}
+/* The 4 file-action icons sit CENTRED on their own row. */
+.localtree__header-actions--center {
+  justify-content: center;
+}
+/* Collapse-the-Files-panel chevron, pinned top-right. */
+.localtree__collapse {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  color: var(--txt3, var(--text-muted));
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.localtree__collapse:hover {
+  color: var(--head, var(--text));
+  border-color: var(--shellbd, var(--border));
+  background: var(--card, var(--bg-elevated));
 }
 
 /* Square icon-only buttons for the header actions. */

--- a/src/renderer/src/components/LocalFileTree.tsx
+++ b/src/renderer/src/components/LocalFileTree.tsx
@@ -500,10 +500,32 @@ export function LocalFileTree(): JSX.Element {
   return (
     <div className="localtree">
       <div className="localtree__header">
-        <span className="localtree__title">
-          <span aria-hidden>{'▣'}</span> Local files
-        </span>
-        <div className="localtree__header-actions">
+        <div className="localtree__header-top">
+          <span className="localtree__title">
+            <span aria-hidden>{'▣'}</span> Local files
+          </span>
+          {/* Collapse the whole Files panel from its own header (#…, #592 pattern),
+              top-right. The shell owns the RRP panel, so we signal it by event. */}
+          <button
+            type="button"
+            className="localtree__collapse"
+            onClick={() => window.dispatchEvent(new CustomEvent('snakie:toggle-files'))}
+            title="Collapse the Files panel"
+            aria-label="Collapse the Files panel"
+          >
+            <svg width="13" height="13" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+              <path
+                d="M10 4L6 8l4 4"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+        </div>
+        <div className="localtree__header-actions localtree__header-actions--center">
           <button
             className="btn btn--ghost btn--icon"
             onClick={() => void refresh()}

--- a/src/renderer/src/components/MiniBoardView.tsx
+++ b/src/renderer/src/components/MiniBoardView.tsx
@@ -20,6 +20,7 @@ import {
 import { PartBody, padPinNumber, partBodyBox } from './part-body'
 import { boardPartFor } from './part-editor.util'
 import { useBoards } from './use-boards'
+import { useWorkspace } from '../store/workspace'
 import { useConsole } from '../store/console'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { isVirtualPort } from '../../../shared/virtual-device'
@@ -166,7 +167,17 @@ const MAX_MINI_SCROLL_H = 640
  * board. Self-contained (no BoardGraph import) so it doesn't pull the board-window
  * subsystem into the main-window bundle.
  */
-export function MiniBoardView({ source, isPython }: { source: string; isPython: boolean }): JSX.Element {
+export function MiniBoardView({
+  source,
+  isPython,
+  onPopOut
+}: {
+  source: string
+  isPython: boolean
+  /** When set, the pop-out button switches to the Electronics workspace instead of
+   *  opening the standalone Board View window (used inside the MiniViewer). */
+  onPopOut?: () => void
+}): JSX.Element {
   const consoleStore = useConsole()
   // Connected to the built-in simulator rather than real hardware (#135)? Surface
   // it here so the board's pins/values are clearly understood as simulated.
@@ -175,6 +186,10 @@ export function MiniBoardView({ source, isPython }: { source: string; isPython: 
   // Boards from the installed parts libraries (microcontroller parts), built-ins
   // as a fallback — the same source the full Board Viewer uses (#52).
   const boards = useBoards()
+  // The open project folder — so this view reads/writes the SAME board authority
+  // (`robot.yml`'s `board`) that the full Board View uses (#…), keeping the mini
+  // board, the Board View and the Code workspace all on one board.
+  const { currentFolder } = useWorkspace()
   const [boardId, setBoardId] = useState<string>(() => {
     try {
       return window.localStorage.getItem(STORAGE_KEY) ?? DEFAULT_BOARD_ID
@@ -182,21 +197,60 @@ export function MiniBoardView({ source, isPython }: { source: string; isPython: 
       return DEFAULT_BOARD_ID
     }
   })
+  // Live refs so the once-registered listeners below read the latest values.
+  const boardIdRef = useRef(boardId)
+  boardIdRef.current = boardId
+  // Whether the project's robot.yml pins a board — the authoritative choice. When
+  // set, a REPL-detected board must NOT override it (the authored board wins).
+  const robotBoardRef = useRef<string | null>(null)
 
-  // Adopt a board inferred from REPL text, persisting it so the full Board Viewer
-  // picks it up too. Guarded to KNOWN boards + only when it actually changes.
+  // Adopt a board inferred from REPL text, and PROPAGATE it (localStorage +
+  // cross-view broadcast) so the Board View follows too. Guarded to KNOWN boards,
+  // only on a real change, and NEVER over an authored `robot.yml` board.
   const adopt = useRef<(text: string) => void>(() => {})
   adopt.current = (text: string): void => {
+    if (robotBoardRef.current) return // authored board wins over REPL detection
     const id = boardIdFromReplText(text, boards)
-    if (id && id !== boardId && boards.some((b) => b.id === id)) {
+    if (id && id !== boardIdRef.current && boards.some((b) => b.id === id)) {
       setBoardId(id)
       try {
         window.localStorage.setItem(STORAGE_KEY, id)
       } catch {
         // ignore storage failures
       }
+      window.api.board.selectBoard?.(id)
     }
   }
+
+  // Adopt the project's authored board (robot.yml `board`) — the shared source of
+  // truth — on mount and whenever robot.yml changes in any window. Keeps the mini
+  // board in step with the Board View without waiting for a broadcast.
+  useEffect(() => {
+    let live = true
+    const adoptFromRobot = async (): Promise<void> => {
+      try {
+        const def = await window.api.robot.load(currentFolder ?? undefined)
+        const b = typeof def.board === 'string' && def.board ? def.board : null
+        robotBoardRef.current = b
+        if (live && b && b !== boardIdRef.current && boards.some((x) => x.id === b)) {
+          setBoardId(b)
+          try {
+            window.localStorage.setItem(STORAGE_KEY, b)
+          } catch {
+            // ignore storage failures
+          }
+        }
+      } catch {
+        // no/unreadable robot.yml — leave the localStorage/broadcast choice as-is
+      }
+    }
+    void adoptFromRobot()
+    const off = window.api.robot.onChanged(() => void adoptFromRobot())
+    return () => {
+      live = false
+      off()
+    }
+  }, [currentFolder, boards])
 
   // Follow the full Board Viewer: when the user picks a different board there, it
   // broadcasts the id (via main) so this mini view switches to the same board.
@@ -232,7 +286,9 @@ export function MiniBoardView({ source, isPython }: { source: string; isPython: 
   const def = boards.find((b) => b.id === boardId) ?? boards[0] ?? BUILTIN_BOARDS[0]
 
   // User picked a microcontroller from the header dropdown: adopt it, persist it,
-  // and broadcast (via main) so the full Board Viewer + other consumers follow.
+  // broadcast (via main) so the full Board Viewer + other consumers follow, AND —
+  // when a project is open — write it into robot.yml (the shared authority) so the
+  // pick sticks for the wiring and can't be reverted by the robot.board adoption.
   const selectBoard = (id: string): void => {
     setBoardId(id)
     try {
@@ -241,6 +297,17 @@ export function MiniBoardView({ source, isPython }: { source: string; isPython: 
       // ignore storage failures
     }
     window.api.board.selectBoard?.(id)
+    if (currentFolder) {
+      robotBoardRef.current = id
+      void (async () => {
+        try {
+          const def = await window.api.robot.load(currentFolder)
+          if (def.board !== id) await window.api.robot.save(currentFolder, { ...def, board: id })
+        } catch {
+          // best-effort — the broadcast/localStorage still keep the views in sync
+        }
+      })()
+    }
   }
 
   // The installed libraries, so we can resolve the board's SOURCE part and draw it
@@ -414,9 +481,9 @@ export function MiniBoardView({ source, isPython }: { source: string; isPython: 
         <button
           type="button"
           className="mini-board__open"
-          title="Open the full Board Viewer"
-          aria-label="Open the full Board Viewer"
-          onClick={() => void window.api.board.open()}
+          title={onPopOut ? 'Open the Electronics workspace' : 'Open the full Board Viewer'}
+          aria-label={onPopOut ? 'Open the Electronics workspace' : 'Open the full Board Viewer'}
+          onClick={() => (onPopOut ? onPopOut() : void window.api.board.open())}
         >
           <svg width="13" height="13" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
             <path

--- a/src/renderer/src/components/MiniViewer.css
+++ b/src/renderer/src/components/MiniViewer.css
@@ -4,13 +4,16 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
-  height: 100%;
   background: var(--panel, var(--bg-elevated));
 }
 
 .miniviewer__head {
+  position: relative;
   display: flex;
   align-items: center;
+  /* The Board / 3D toggle is CENTRED in the column; the expand ⤢ floats at the
+     right so it doesn't push the toggle off-centre. */
+  justify-content: center;
   gap: 0.4rem;
   padding: 0.3rem 0.4rem;
   border-bottom: var(--border-w, 1px) solid var(--shellbd, var(--border));
@@ -46,7 +49,10 @@
 }
 
 .miniviewer__expand {
-  margin-left: auto;
+  position: absolute;
+  right: 0.4rem;
+  top: 50%;
+  transform: translateY(-50%);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -67,9 +73,19 @@
 
 .miniviewer__body {
   position: relative;
-  flex: 1 1 auto;
   min-height: 0;
   overflow: hidden;
+}
+/* Board mode: hug the mini-board island (which sizes to its own content /
+   resize handle), so the instrument dock below sits FLUSH — no parchment gap. */
+.miniviewer--board .miniviewer__body {
+  flex: 0 0 auto;
+}
+/* 3-D mode: the RobotDockPanel fills its box absolutely, so it needs an explicit
+   height. Fixed and compact; the dock stays flush beneath it. */
+.miniviewer--3d .miniviewer__body {
+  flex: 0 0 auto;
+  height: 240px;
 }
 
 .miniviewer__loading {

--- a/src/renderer/src/components/MiniViewer.tsx
+++ b/src/renderer/src/components/MiniViewer.tsx
@@ -42,31 +42,19 @@ export function MiniViewer({ source, isPython }: { source: string; isPython: boo
             3D
           </button>
         </div>
-        <button
-          type="button"
-          className="miniviewer__expand"
-          title={mode === 'board' ? 'Open the Electronics workspace' : 'Open the Build workspace'}
-          aria-label={mode === 'board' ? 'Expand to the Electronics workspace' : 'Expand to the Build workspace'}
-          onClick={() => switchWorkspace(mode === 'board' ? 'board' : 'robot')}
-        >
-          <svg width="14" height="14" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
-            <path
-              d="M6 3H3v10h10v-3M9.5 2.5H13.5V6.5M13 3 8 8"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-        </button>
       </div>
       <div className="miniviewer__body">
+        {/* Each mini viewer's own pop-out button switches to the matching full
+            workspace (Board → Electronics, 3D → Build) — no standalone window. */}
         {mode === 'board' ? (
-          <MiniBoardView source={source} isPython={isPython} />
+          <MiniBoardView
+            source={source}
+            isPython={isPython}
+            onPopOut={() => switchWorkspace('board')}
+          />
         ) : (
           <Suspense fallback={<div className="miniviewer__loading">Loading 3D…</div>}>
-            <RobotDockPanel embedded />
+            <RobotDockPanel embedded onPopOut={() => switchWorkspace('robot')} />
           </Suspense>
         )}
       </div>

--- a/src/renderer/src/components/MiniViewer.tsx
+++ b/src/renderer/src/components/MiniViewer.tsx
@@ -22,7 +22,7 @@ export function MiniViewer({ source, isPython }: { source: string; isPython: boo
   const [mode, setMode] = useLocalStorage<'board' | '3d'>('snakie.miniViewer.mode', 'board')
 
   return (
-    <div className="miniviewer">
+    <div className={`miniviewer miniviewer--${mode}`}>
       <div className="miniviewer__head">
         <div className="miniviewer__seg" role="group" aria-label="Mini viewer">
           <button

--- a/src/renderer/src/components/RobotDockPanel.tsx
+++ b/src/renderer/src/components/RobotDockPanel.tsx
@@ -17,7 +17,10 @@ import './RobotDockPanel.css'
  * compact chrome. An **expand** button opens the project's `.urdf` full-screen
  * as the Pose tool (#312).
  */
-export function RobotDockPanel({ embedded = false }: { embedded?: boolean } = {}): JSX.Element {
+export function RobotDockPanel({
+  embedded = false,
+  full = false
+}: { embedded?: boolean; full?: boolean } = {}): JSX.Element {
   const { currentFolder, openFile, openBuffer, openFolderPath } = useWorkspace()
   const { setFocus } = useWorkspaceLayout()
   const [urdf, setUrdf] = useState<string>(demoArm)
@@ -228,11 +231,14 @@ export function RobotDockPanel({ embedded = false }: { embedded?: boolean } = {}
   const hasProjectRobot = urdfPath !== null
 
   return (
-    <div className="robotdock">
-      <RobotView urdfContent={urdf} basePath={base} compact />
-      {/* Embedded in the MiniViewer (#595): the card's own expand ⤢ is the single
-          "go bigger" control, so hide this row to avoid duplicate affordances. */}
-      {!embedded && <div className="robotdock__actions">
+    <div className={`robotdock${full ? ' robotdock--full' : ''}`}>
+      {/* `full` (Build workspace): the URDF/pose editor fills the whole main area
+          — the non-compact RobotView (joint sidebar, poses, stability) and no dock
+          action row. Otherwise the compact mini viewer for the MiniViewer card. */}
+      <RobotView urdfContent={urdf} basePath={base} compact={!full} />
+      {/* Embedded in the MiniViewer (#595) or full-screen in Build: the card's own
+          expand ⤢ / the full pose tool is the single control, so hide this row. */}
+      {!embedded && !full && <div className="robotdock__actions">
         <button
           type="button"
           className={`robotdock__btn${hasProjectRobot ? '' : ' robotdock__btn--cta'}`}

--- a/src/renderer/src/components/RobotDockPanel.tsx
+++ b/src/renderer/src/components/RobotDockPanel.tsx
@@ -19,11 +19,22 @@ import './RobotDockPanel.css'
  */
 export function RobotDockPanel({
   embedded = false,
-  full = false
-}: { embedded?: boolean; full?: boolean } = {}): JSX.Element {
+  full = false,
+  onPopOut
+}: {
+  embedded?: boolean
+  full?: boolean
+  /** When set (MiniViewer 3-D mode), the pop-out button switches to the Build
+   *  workspace instead of opening the URDF full-screen in focus mode. */
+  onPopOut?: () => void
+}): JSX.Element {
   const { currentFolder, openFile, openBuffer, openFolderPath } = useWorkspace()
   const { setFocus } = useWorkspaceLayout()
-  const [urdf, setUrdf] = useState<string>(demoArm)
+  // `null` = not resolved yet. Starting undetermined (rather than the demo arm)
+  // means a project that HAS a linked model never flashes the bundled demo arm
+  // first — we show a brief loading state, then the real model (#…). The demo arm
+  // is only used once the async resolve confirms there's no project model.
+  const [urdf, setUrdf] = useState<string | null>(null)
   // The URDF's folder, so RobotView resolves the robot's meshes (#319). Empty
   // for the bundled demo arm (all primitives — no meshes to resolve).
   const [base, setBase] = useState<string>('')
@@ -87,7 +98,7 @@ export function RobotDockPanel({
   // the URDF fills the editor, restored when you switch modes or reopen a panel.
   const popOut = (): void => {
     if (urdfPath) void openFile('local', urdfPath)
-    else openBuffer('demo-arm.urdf', urdf)
+    else openBuffer('demo-arm.urdf', urdf ?? demoArm)
     setFocus(true)
   }
 
@@ -235,9 +246,35 @@ export function RobotDockPanel({
       {/* `full` (Build workspace): the URDF/pose editor fills the whole main area
           — the non-compact RobotView (joint sidebar, poses, stability) and no dock
           action row. Otherwise the compact mini viewer for the MiniViewer card. */}
-      <RobotView urdfContent={urdf} basePath={base} compact={!full} />
-      {/* Embedded in the MiniViewer (#595) or full-screen in Build: the card's own
-          expand ⤢ / the full pose tool is the single control, so hide this row. */}
+      {urdf === null ? (
+        <div className="robotdock__loading">Loading 3D…</div>
+      ) : (
+        <RobotView urdfContent={urdf} basePath={base} compact={!full} />
+      )}
+      {/* Embedded in the MiniViewer (#595) 3-D mode: a single pop-out button that
+          switches to the Build workspace (mirrors the mini-board → Electronics). */}
+      {embedded && onPopOut && (
+        <button
+          type="button"
+          className="robotdock__popout"
+          title="Open the Build workspace"
+          aria-label="Open the Build workspace"
+          onClick={onPopOut}
+        >
+          <svg width="13" height="13" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path
+              d="M14 4h6v6M20 4l-8 8M10 6H6a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-4"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+      )}
+      {/* Full-screen in Build: the full pose tool is the single control, so hide
+          this row. */}
       {!embedded && !full && <div className="robotdock__actions">
         <button
           type="button"

--- a/src/renderer/src/components/RobotView.css
+++ b/src/renderer/src/components/RobotView.css
@@ -166,7 +166,8 @@
 .robotview__minihome {
   position: absolute;
   top: 0.35rem;
-  right: 0.35rem;
+  /* Top-LEFT (#…) — the pop-out button lives top-right; keep them apart. */
+  left: 0.35rem;
   z-index: 2;
   display: inline-flex;
   align-items: center;

--- a/src/renderer/src/components/RobotView.tsx
+++ b/src/renderer/src/components/RobotView.tsx
@@ -5186,7 +5186,10 @@ export function RobotView({
             )}
           </div>
         )}
-        {showPanel && buildOpen && (
+        {/* The build toolbar stays available even when the hierarchy panel is
+            hidden (#…) — its tools (add primitive/joint, measure, undo/redo) act on
+            the viewport, not the tree. */}
+        {showPanel && (
           <RobotToolbar
             tool={buildTool}
             onSetTool={onSetTool}

--- a/src/renderer/src/components/ShellPanel.css
+++ b/src/renderer/src/components/ShellPanel.css
@@ -59,6 +59,30 @@
   background: var(--panel);
 }
 
+/* ── Console green treatment (#…) ────────────────────────────────────────────
+   The console reads as the app's green REPL rather than a grey card: a subtle
+   green frame with a DARKER green header (the terminal body stays dark). */
+.region.region--shell {
+  border-color: var(--green, #26a269);
+}
+.region--shell > .panel-header,
+:root[data-theme='skeuomorph'] .region.region--shell > .panel-header,
+:root[data-theme='dark'] .region.region--shell > .panel-header {
+  background: linear-gradient(180deg, #2f7d54, #235f40);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.3);
+  color: #eafff2;
+}
+/* Keep the header controls legible on the green header. */
+.region--shell > .panel-header .panel-collapse-btn,
+.region--shell > .panel-header .shell-actions {
+  color: #eafff2;
+}
+.region--shell > .panel-header .panel-collapse-btn:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.14);
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
 /* Warm the segmented toggle to parchment on the skeuomorph light theme, so it
    sits on the parchment frame instead of the legacy grey metal (index.css).
    Scoped under `.shell-actions` to out-specify the legacy rules. */

--- a/src/renderer/src/components/ShellPanel.css
+++ b/src/renderer/src/components/ShellPanel.css
@@ -60,10 +60,15 @@
 }
 
 /* ── Console green treatment (#…) ────────────────────────────────────────────
-   The console reads as the app's green REPL rather than a grey card: a subtle
-   green frame with a DARKER green header (the terminal body stays dark). */
-.region.region--shell {
+   The console reads as the app's green REPL: a light pastel-green card frame with
+   a DARKER green header (the terminal body itself stays near-black). */
+.region.region--shell,
+:root[data-theme='skeuomorph'] .region.region--shell {
   border-color: var(--green, #26a269);
+  background: #e7f2e4;
+}
+:root[data-theme='dark'] .region.region--shell {
+  background: #18231a;
 }
 .region--shell > .panel-header,
 :root[data-theme='skeuomorph'] .region.region--shell > .panel-header,
@@ -72,7 +77,6 @@
   border-bottom: 1px solid rgba(0, 0, 0, 0.3);
   color: #eafff2;
 }
-/* Keep the header controls legible on the green header. */
 .region--shell > .panel-header .panel-collapse-btn,
 .region--shell > .panel-header .shell-actions {
   color: #eafff2;
@@ -81,6 +85,60 @@
   color: #fff;
   background: rgba(255, 255, 255, 0.14);
   border-color: rgba(255, 255, 255, 0.25);
+}
+
+/* Console / Problems — a segmented control in the workspace-switcher style, but
+   green: a soft translucent track with a light-green active pill. */
+.region--shell .shell-actions .shell-toggle,
+:root[data-theme='skeuomorph'] .region--shell .shell-actions .shell-toggle {
+  border-color: rgba(255, 255, 255, 0.28);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.16);
+  padding: 2px;
+  gap: 2px;
+}
+.region--shell .shell-actions .shell-toggle__btn,
+:root[data-theme='skeuomorph'] .region--shell .shell-actions .shell-toggle__btn {
+  background: transparent;
+  border: none;
+  border-radius: 8px;
+  color: #dff2e6;
+  font-weight: 650;
+}
+.region--shell .shell-actions .shell-toggle__btn:hover {
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+}
+.region--shell .shell-actions .shell-toggle__btn--active,
+:root[data-theme='skeuomorph'] .region--shell .shell-actions .shell-toggle__btn--active {
+  background: linear-gradient(180deg, #eafff1, #c9e8d4);
+  color: #1f5b3c;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.22);
+}
+
+/* Clear + the connect/disconnect + device dropdown — subtle green chips on the
+   green header (no alarming red). */
+.region--shell .shell-actions__clear,
+.region--shell .conn-control .btn--ghost,
+.region--shell .conn-control__select {
+  color: #eafff2;
+  background: rgba(255, 255, 255, 0.14);
+  border-color: rgba(255, 255, 255, 0.24);
+}
+.region--shell .shell-actions__clear:hover,
+.region--shell .conn-control .btn--ghost:hover {
+  background: rgba(255, 255, 255, 0.22);
+  color: #fff;
+}
+.region--shell .conn-control .btn--danger,
+.region--shell .conn-control .btn--primary {
+  background: linear-gradient(180deg, #3fa06a, #2c7d4e);
+  border-color: rgba(0, 0, 0, 0.22);
+  color: #fff;
+}
+.region--shell .conn-control .btn--danger:hover,
+.region--shell .conn-control .btn--primary:hover {
+  background: linear-gradient(180deg, #46ac73, #327f52);
 }
 
 /* Warm the segmented toggle to parchment on the skeuomorph light theme, so it

--- a/src/renderer/src/components/ShellPanel.tsx
+++ b/src/renderer/src/components/ShellPanel.tsx
@@ -178,9 +178,10 @@ export function ShellPanel({ chatOpen = false, onToggleChat, onCollapse }: Shell
                 title="Collapse the console"
                 aria-label="Collapse the console"
               >
+                {/* Expanded → DOWN chevron (the console collapses downward). */}
                 <svg width="13" height="13" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
                   <path
-                    d="M4 10l4-4 4 4"
+                    d="M4 6l4 4 4-4"
                     fill="none"
                     stroke="currentColor"
                     strokeWidth="1.8"

--- a/src/renderer/src/components/ShellPanel.tsx
+++ b/src/renderer/src/components/ShellPanel.tsx
@@ -18,6 +18,9 @@ type ShellView = 'console' | 'problems'
 interface ShellPanelProps {
   /** Whether the right-hand chat panel is open (controls the "Send to chat" button). */
   chatOpen?: boolean
+  /** Toggle the AI chat panel open/closed. When provided (desktop), the console
+   *  header shows a Chat button — the single opener for the chat pane (#…). */
+  onToggleChat?: () => void
   /** Collapse this panel from its own header (Soft Shell per-panel control, #592). */
   onCollapse?: () => void
 }
@@ -38,7 +41,7 @@ interface ShellPanelProps {
  * Both bodies (Terminal, Problems) stay mounted; the inactive one is hidden via
  * CSS so console scrollback survives toggling.
  */
-export function ShellPanel({ chatOpen = false, onCollapse }: ShellPanelProps): JSX.Element {
+export function ShellPanel({ chatOpen = false, onToggleChat, onCollapse }: ShellPanelProps): JSX.Element {
   const status = useDeviceStatus()
   const terminalRef = useRef<TerminalHandle>(null)
   const [view, setView] = useState<ShellView>('console')
@@ -133,6 +136,23 @@ export function ShellPanel({ chatOpen = false, onCollapse }: ShellPanelProps): J
                   <ChatIcon size={13} />
                 </span>
                 <span>Send to chat</span>
+              </button>
+            )}
+            {/* Chat toggle (#…) — the single opener for the AI chat pane after the
+                global toolbar toggles were retired (#592). Console view only. */}
+            {view === 'console' && onToggleChat && (
+              <button
+                type="button"
+                className={`btn btn--ghost btn--sm${chatOpen ? ' is-active' : ''}`}
+                onClick={onToggleChat}
+                title={chatOpen ? 'Hide the AI chat panel' : 'Show the AI chat panel'}
+                aria-label={chatOpen ? 'Hide chat' : 'Show chat'}
+                aria-pressed={chatOpen}
+              >
+                <span className="btn__glyph" aria-hidden="true">
+                  <ChatIcon size={13} />
+                </span>
+                <span>Chat</span>
               </button>
             )}
             {view === 'console' && (

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -79,9 +79,6 @@ const SNAKE_LOGO = (
   </svg>
 )
 
-interface ToolbarProps {
-  onOpenBoard: () => void
-}
 
 /**
  * TOP TOOLBAR.
@@ -95,12 +92,13 @@ interface ToolbarProps {
  * {@link StatusBar} (issue #71); this toolbar still reads {@link useDeviceStatus}
  * only to enable/disable the Run/Stop buttons.
  *
- * Also hosts the Board View knob next to Run/Stop and the centred workspace
- * switcher (Code · Electronics · Build). The old global panel-collapse knobs were
- * removed in Soft Shell (#592) — each panel owns its own collapse control now.
- * Settings and the theme picker live on the activity bar + Settings dialog.
+ * Hosts the file actions (New / Open / Save), Run / Stop, and the centred
+ * workspace switcher (Code · Electronics · Build). The Board View lives in the
+ * Electronics workspace now, so the old pop-out board knob is gone (#…); the old
+ * global panel-collapse knobs went in Soft Shell (#592) — each panel owns its own
+ * collapse control. Settings + the theme picker live on the activity bar.
  */
-export function Toolbar({ onOpenBoard }: ToolbarProps): JSX.Element {
+export function Toolbar(): JSX.Element {
   const status = useDeviceStatus()
   const { openFiles, activeId, newFile, openFolder, saveFile } = useWorkspace()
   const { markRun } = useConsole()
@@ -176,6 +174,10 @@ export function Toolbar({ onOpenBoard }: ToolbarProps): JSX.Element {
 
   return (
     <header className="toolbar" role="toolbar" aria-label="Main toolbar">
+      {/* Left cluster: brand + file/run/board controls. Wrapped in a flex side
+          that's balanced by an empty side on the right, so the workspace
+          switcher sits CENTRED at the top of the toolbar (not shoved right). */}
+      <div className="toolbar__side">
       <div className="toolbar__brand">
         {SNAKE_LOGO}
         <span className="toolbar__wordmark">Snakie</span>
@@ -259,42 +261,14 @@ export function Toolbar({ onOpenBoard }: ToolbarProps): JSX.Element {
         </button>
       </div>
 
-      <span className="toolbar__divider" aria-hidden="true" />
-
-      {/* Board View pops out into its own window — an OS BrowserWindow on the
-          desktop, a browser popup on the web (see web/web-board.ts). */}
-      <div className="toolbar__group">
-        <button
-          type="button"
-          className="btn btn--ghost btn--icon btn--knob"
-          onClick={onOpenBoard}
-          title="Board View — pop out into its own window (toggle)"
-          aria-label="Toggle Board View"
-        >
-          {/* dev board: outlined PCB with two rows of header pads + a chip */}
-          <svg viewBox="0 0 24 24" width="17" height="17" aria-hidden="true" focusable="false">
-            <rect x="4" y="3" width="16" height="18" rx="2.2" fill="none" stroke="currentColor" strokeWidth="1.7" />
-            <rect x="9" y="9" width="6" height="6" rx="1" fill="currentColor" opacity="0.35" />
-            <g fill="currentColor">
-              <rect x="5.4" y="5.5" width="1.6" height="1.6" />
-              <rect x="5.4" y="8.5" width="1.6" height="1.6" />
-              <rect x="5.4" y="11.5" width="1.6" height="1.6" />
-              <rect x="5.4" y="14.5" width="1.6" height="1.6" />
-              <rect x="17" y="5.5" width="1.6" height="1.6" />
-              <rect x="17" y="8.5" width="1.6" height="1.6" />
-              <rect x="17" y="11.5" width="1.6" height="1.6" />
-              <rect x="17" y="14.5" width="1.6" height="1.6" />
-            </g>
-          </svg>
-        </button>
       </div>
-
-      <div className="toolbar__spacer" />
 
       {/* Workspace layouts (epic #259): Code · Electronics · Build + reset.
           Per-panel collapse controls live IN each panel's own header now (#592),
-          so the old global Files/Shell/Chat/Instruments toggle knobs are gone. */}
+          so the old global Files/Shell/Chat/Instruments toggle knobs are gone.
+          Centred between two equal-weight sides. */}
       <WorkspaceSwitcher />
+      <div className="toolbar__side toolbar__side--end" aria-hidden="true" />
     </header>
   )
 }

--- a/src/renderer/src/components/VariablesPanel.css
+++ b/src/renderer/src/components/VariablesPanel.css
@@ -77,6 +77,41 @@
   border-bottom: 1px solid var(--border);
 }
 
+/* Per-type glyph icon (#…) — colour-coded by the editor syntax palette so lists,
+   dicts, numbers, strings, etc. are distinguishable at a glance. */
+.vars__icon {
+  flex: 0 0 auto;
+  width: 1.7em;
+  text-align: center;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.72rem;
+  line-height: 1;
+  color: var(--txt3, var(--text-muted));
+}
+.vars__icon--num {
+  color: var(--num, #7fc4e0);
+}
+.vars__icon--str,
+.vars__icon--bytes {
+  color: var(--str, #d8b96e);
+}
+.vars__icon--bool,
+.vars__icon--func {
+  color: var(--kw, #e08b7d);
+}
+.vars__icon--list,
+.vars__icon--tuple {
+  color: var(--green, #26a269);
+}
+.vars__icon--dict,
+.vars__icon--set {
+  color: var(--gold, #d9a441);
+}
+.vars__icon--module,
+.vars__icon--class {
+  color: var(--ident, #cdd4cb);
+}
+
 .vars__name {
   flex: 0 0 auto;
   font-weight: 600;

--- a/src/renderer/src/components/VariablesPanel.tsx
+++ b/src/renderer/src/components/VariablesPanel.tsx
@@ -83,6 +83,50 @@ export function parseVariables(stdout: string): DeviceVariable[] {
   return vars
 }
 
+/**
+ * A compact glyph + colour category per Python built-in type, so the inspector
+ * distinguishes lists, dicts, numbers, strings, etc. at a glance instead of one
+ * uniform icon (#…). Unknown/user types fall back to a neutral object dot.
+ */
+export function typeGlyph(type: string): { glyph: string; kind: string } {
+  switch (type) {
+    case 'list':
+      return { glyph: '[ ]', kind: 'list' }
+    case 'tuple':
+      return { glyph: '( )', kind: 'tuple' }
+    case 'dict':
+      return { glyph: '{ }', kind: 'dict' }
+    case 'set':
+    case 'frozenset':
+      return { glyph: '{·}', kind: 'set' }
+    case 'str':
+      return { glyph: '" "', kind: 'str' }
+    case 'int':
+    case 'float':
+    case 'complex':
+      return { glyph: '#', kind: 'num' }
+    case 'bool':
+      return { glyph: '◑', kind: 'bool' }
+    case 'bytes':
+    case 'bytearray':
+    case 'memoryview':
+      return { glyph: '0x', kind: 'bytes' }
+    case 'NoneType':
+      return { glyph: '∅', kind: 'none' }
+    case 'module':
+      return { glyph: '☰', kind: 'module' }
+    case 'type':
+      return { glyph: '⬡', kind: 'class' }
+    case 'function':
+    case 'method':
+    case 'builtin_function_or_method':
+    case 'generator':
+      return { glyph: 'ƒ', kind: 'func' }
+    default:
+      return { glyph: '•', kind: 'obj' }
+  }
+}
+
 export function VariablesPanel(): JSX.Element {
   const status = useDeviceStatus()
   const connected = status.state === 'connected'
@@ -158,15 +202,21 @@ export function VariablesPanel(): JSX.Element {
       )}
 
       <ul className="vars__list" role="list">
-        {vars.map((v) => (
-          <li key={v.name} className="vars__item">
-            <span className="vars__name">{v.name}</span>
-            <span className="vars__type">{v.type}</span>
-            <span className="vars__value" title={v.value}>
-              {v.value}
-            </span>
-          </li>
-        ))}
+        {vars.map((v) => {
+          const g = typeGlyph(v.type)
+          return (
+            <li key={v.name} className="vars__item">
+              <span className={`vars__icon vars__icon--${g.kind}`} aria-hidden="true">
+                {g.glyph}
+              </span>
+              <span className="vars__name">{v.name}</span>
+              <span className="vars__type">{v.type}</span>
+              <span className="vars__value" title={v.value}>
+                {v.value}
+              </span>
+            </li>
+          )
+        })}
       </ul>
     </div>
   )

--- a/src/renderer/src/components/WiringCanvas.tsx
+++ b/src/renderer/src/components/WiringCanvas.tsx
@@ -630,8 +630,15 @@ export function WiringCanvas({ robot, onChange, joints = [], jointLimits = {}, l
     })
   // The floating project BROWSER's open state — lifted here so the fit math can
   // inset content to the right of it (so the leftmost item isn't hidden under it).
-  // Focused chrome (Board mode) starts it collapsed so the canvas gets the room.
-  const [browserOpen, setBrowserOpen] = useState(!focusedChrome)
+  // Defaults OPEN + PINNED, consistent with the Build panel's hierarchy (#…).
+  const [browserOpen, setBrowserOpen] = useState(true)
+  const [browserPinned, setBrowserPinnedState] = useState<boolean>(() =>
+    focusedChrome ? loadPin(window.localStorage, PIN_KEYS.browser, true) : true
+  )
+  const setBrowserPinned = (v: boolean): void => {
+    setBrowserPinnedState(v)
+    savePin(window.localStorage, PIN_KEYS.browser, v)
+  }
   const [, force] = useState(0) // re-render during a wire/pan/box drag (ref-driven)
   // What the pointer is over (breadboard view): a part (`pin: null`) reveals all
   // its pins' capability chips; a specific pin emphasises its own.
@@ -1974,6 +1981,8 @@ export function WiringCanvas({ robot, onChange, joints = [], jointLimits = {}, l
           open={browserOpen}
           onOpenChange={setBrowserOpen}
           onFocus={fitToKey}
+          pinned={focusedChrome ? browserPinned : undefined}
+          onPin={focusedChrome ? setBrowserPinned : undefined}
         />
 
         {!boardDef && robot.parts.length === 0 && (
@@ -2030,7 +2039,9 @@ function BoardBrowser({
   onRemovePart,
   open,
   onOpenChange,
-  onFocus
+  onFocus,
+  pinned,
+  onPin
 }: {
   name: string
   description: string
@@ -2043,16 +2054,26 @@ function BoardBrowser({
   onOpenChange: (open: boolean) => void
   /** Zoom the canvas to fit a subject: `'board'` or a placed part's instance id. */
   onFocus: (key: string) => void
+  /** Pin model (focused Board mode only) — matches the Build hierarchy: an
+   *  unpinned panel auto-hides on blur; `undefined` disables pinning entirely. */
+  pinned?: boolean
+  onPin?: (v: boolean) => void
 }): JSX.Element {
   const [compOpen, setCompOpen] = useState(true)
+  const asideRef = useRef<HTMLElement | null>(null)
   const count = parts.length + (board ? 1 : 0)
+  const pinnable = onPin !== undefined
 
   if (!open) {
     return (
       <button
         type="button"
         className="wc__browser-tab"
-        onClick={() => onOpenChange(true)}
+        onClick={() => {
+          onOpenChange(true)
+          // Focus so an unpinned panel can auto-hide on blur (like the Build panel).
+          if (pinnable) requestAnimationFrame(() => asideRef.current?.focus())
+        }}
         title="Show project browser"
         aria-label="Show project browser"
       >
@@ -2062,8 +2083,38 @@ function BoardBrowser({
   }
 
   return (
-    <aside className="wc__browser" aria-label="Project browser">
+    <aside
+      className={`wc__browser${pinnable && !pinned ? ' wc__browser--overlay' : ''}`}
+      aria-label="Project browser"
+      ref={asideRef}
+      tabIndex={pinnable ? -1 : undefined}
+      onBlur={(e) => {
+        if (pinnable && shouldAutoHide(!!pinned, asideRef.current, e.relatedTarget)) {
+          onOpenChange(false)
+        }
+      }}
+    >
       <div className="wc__browser-head">
+        {pinnable && (
+          <button
+            type="button"
+            className={`wc__pin${pinned ? ' is-pinned' : ''}`}
+            onClick={() => onPin?.(!pinned)}
+            aria-pressed={pinned}
+            title={pinned ? 'Unpin — hide the browser when it loses focus' : 'Pin the browser open'}
+            aria-label={pinned ? 'Unpin the browser' : 'Pin the browser open'}
+          >
+            <svg viewBox="0 0 16 16" width="11" height="11" aria-hidden="true">
+              <path
+                d="M9.5 1.5l5 5-2.2.6-2.5 2.5.4 3.1-1.8-.3-2.6-2.6L2 13.6 1.4 13l3.8-3.8L2.6 6.6l-.3-1.8 3.1.4L7.9 2.7z"
+                fill={pinned ? 'currentColor' : 'none'}
+                stroke="currentColor"
+                strokeWidth="1.3"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+        )}
         <span className="wc__browser-title">BROWSER</span>
         <button
           type="button"

--- a/src/renderer/src/components/WorkspaceSwitcher.css
+++ b/src/renderer/src/components/WorkspaceSwitcher.css
@@ -5,59 +5,50 @@
   display: inline-flex;
   align-items: center;
   gap: 0.3rem;
+  /* Never shrink — the toolbar's flanking sides absorb the slack, so the switcher
+     keeps its size and the toolbar `gap` stays a margin against Run/Reset (#…). */
+  flex: 0 0 auto;
 }
 
-/* Soft Shell (#575): a soft --panel2 track with a gold-gradient active segment. */
+/* Soft Shell (#575): a soft --panel2 track with a gold-gradient active segment.
+   Prominent — this is the app's primary mode switch (#…), so it's larger and
+   heavier than a normal toolbar control. */
 .ws-switcher__seg {
   display: inline-flex;
   border: var(--border-w) solid var(--shellbd, var(--border));
-  border-radius: 10px;
+  border-radius: 12px;
   background: var(--panel2, var(--bg-sunken));
-  padding: 2px;
-  gap: 2px;
+  padding: 3px;
+  gap: 3px;
   overflow: hidden;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.12);
 }
 
 .ws-switcher__btn {
   font-family: var(--font-ui, var(--font-mono));
-  font-size: 0.7rem;
-  font-weight: 600;
+  font-size: 0.86rem;
+  font-weight: 650;
   letter-spacing: 0.01em;
   color: var(--txt3, var(--text-muted));
   background: transparent;
   border: none;
-  border-radius: 8px;
-  padding: 0.3rem 0.7rem;
+  border-radius: 9px;
+  padding: 0.42rem 1.15rem;
   cursor: pointer;
+  transition: color 0.12s ease, background 0.12s ease;
 }
 
 .ws-switcher__btn:hover {
   color: var(--head, var(--text));
+  background: var(--card, rgba(0, 0, 0, 0.04));
 }
 
 .ws-switcher__btn.is-active {
   background: var(--grad-gold, var(--accent));
   color: var(--goldink, var(--accent-contrast));
-  font-weight: 700;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.18);
+  font-weight: 750;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.22);
 }
-
-/* Reset-to-preset: a small ghost icon button beside the segments. */
-.ws-switcher__reset {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.5rem;
-  height: 1.5rem;
-  padding: 0;
-  color: var(--text-muted);
-  background: transparent;
-  border: var(--border-w) solid transparent;
-  border-radius: var(--radius);
-  cursor: pointer;
-}
-
-.ws-switcher__reset:hover {
-  color: var(--text);
-  border-color: var(--border);
+.ws-switcher__btn.is-active:hover {
+  color: var(--goldink, var(--accent-contrast));
 }

--- a/src/renderer/src/components/WorkspaceSwitcher.tsx
+++ b/src/renderer/src/components/WorkspaceSwitcher.tsx
@@ -4,16 +4,16 @@ import './WorkspaceSwitcher.css'
 /**
  * WORKSPACE SWITCHER (epic #259, Phase 1) — one-click named layouts.
  *
- * A compact segmented control in the toolbar: **Code · Robot**. Each workspace
- * remembers its own geometry (sidebar view, panel sizes, collapse states,
- * instrument dock); switching restyles the SAME mounted tree so nothing (editor,
- * console scrollback, instruments) is lost. The ↺ button restores the active
- * workspace to its factory preset — the always-available "Reset layout" escape hatch.
+ * A prominent segmented control centred in the toolbar — the app's primary mode
+ * switch. Each workspace remembers its own geometry (sidebar view, panel sizes,
+ * collapse states, instrument dock); switching restyles the SAME mounted tree so
+ * nothing (editor, console scrollback, instruments) is lost.
  *
  * Soft Shell (#575, epic #573) surfaces three: **Code · Electronics · Build**
  * (Electronics = the Board View; Build = the former Robot). Data Lab was retired
  * in the epic's close-out (#581), so all of WORKSPACE_IDS is shown. Reads the
- * layout store directly.
+ * layout store directly. (The reset-layout icon was removed (#…) — resetting is
+ * still available via `layout.resetActive()` if a control is wired up later.)
  */
 const VISIBLE_WORKSPACES = WORKSPACE_IDS
 
@@ -36,24 +36,6 @@ export function WorkspaceSwitcher(): JSX.Element {
           </button>
         ))}
       </div>
-      <button
-        type="button"
-        className="ws-switcher__reset"
-        title={`Reset the ${WORKSPACE_INFO[layout.active].label} layout to its default`}
-        aria-label={`Reset the ${WORKSPACE_INFO[layout.active].label} workspace layout`}
-        onClick={() => layout.resetActive()}
-      >
-        <svg viewBox="0 0 16 16" width="13" height="13" aria-hidden="true" focusable="false">
-          <path
-            d="M13 8a5 5 0 1 1-1.5-3.6M13 2.5V5h-2.5"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.7"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
-      </button>
     </div>
   )
 }

--- a/src/renderer/src/components/pin-overlay.ts
+++ b/src/renderer/src/components/pin-overlay.ts
@@ -62,5 +62,6 @@ export function savePin(storage: PinStorage, key: string, value: boolean): void 
 export const PIN_KEYS = {
   library: 'snakie.board.pin.library',
   connections: 'snakie.board.pin.connections',
+  browser: 'snakie.board.pin.browser',
   builder: 'snakie.robot.pin.builder'
 } as const

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -159,6 +159,7 @@
   --panel: #21251f;
   --panel2: #171a14;
   --shellbd: #31352b;
+  --stitch: #6f6746;
   --card: #262a21;
   --rail: #2a2e24;
   --editor: #191c15;
@@ -207,6 +208,7 @@
   --panel: #f6f1e6;
   --panel2: #ece5d6;
   --shellbd: #e0d9c8;
+  --stitch: #cbb488;
   --card: #fff;
   --rail: #e3e6df;
   --editor: #f4eede;
@@ -2273,7 +2275,7 @@ body {
 .shell__editor-region,
 .region--shell {
   position: absolute;
-  inset: 7px;
+  inset: 5px;
   height: auto;
   border-radius: 14px;
   border: 1px solid var(--shellbd, var(--border));
@@ -2299,22 +2301,61 @@ body {
     0 6px 16px rgba(0, 0, 0, 0.06);
   background: var(--panel, var(--bg-elevated));
 }
-/* The resize handles live in the parchment gap — invisible tracks (so the divider
-   reads as pure parchment) but widened to be grabbable, with a faint hover hint. */
-.shell__panels > .resize-handle {
-  background: transparent;
-  width: 8px;
-}
+/* The resize handles read as a thin line of STITCHES running down the parchment
+   gap (a warm --stitch thread, not a grey bar). The handle stays a slim grabbable
+   track; a centred dashed pseudo-element draws the stitch. */
+.shell__panels > .resize-handle,
 .shell__vgroup > .resize-handle {
   background: transparent;
-  height: 8px;
+  position: relative;
 }
-.shell__panels > .resize-handle:hover,
-.shell__panels > .resize-handle[data-resize-handle-active],
-.shell__vgroup > .resize-handle:hover,
-.shell__vgroup > .resize-handle[data-resize-handle-active] {
-  background: var(--gold, var(--accent));
-  opacity: 0.35;
+.shell__panels > .resize-handle {
+  width: 5px;
+}
+.shell__vgroup > .resize-handle {
+  height: 5px;
+}
+.shell__panels > .resize-handle::before,
+.shell__vgroup > .resize-handle::before {
+  content: '';
+  position: absolute;
+  background: var(--stitch, var(--shellbd));
+  opacity: 0.55;
+  transition: opacity 0.12s ease;
+}
+/* Vertical divider → vertical dashed thread. */
+.shell__panels > .resize-handle::before {
+  top: 10px;
+  bottom: 10px;
+  left: 50%;
+  width: 2px;
+  transform: translateX(-50%);
+  background-image: repeating-linear-gradient(
+    to bottom,
+    var(--stitch, var(--shellbd)) 0 5px,
+    transparent 5px 9px
+  );
+  background-color: transparent;
+}
+/* Horizontal divider → horizontal dashed thread. */
+.shell__vgroup > .resize-handle::before {
+  left: 10px;
+  right: 10px;
+  top: 50%;
+  height: 2px;
+  transform: translateY(-50%);
+  background-image: repeating-linear-gradient(
+    to right,
+    var(--stitch, var(--shellbd)) 0 5px,
+    transparent 5px 9px
+  );
+  background-color: transparent;
+}
+.shell__panels > .resize-handle:hover::before,
+.shell__panels > .resize-handle[data-resize-handle-active]::before,
+.shell__vgroup > .resize-handle:hover::before,
+.shell__vgroup > .resize-handle[data-resize-handle-active]::before {
+  opacity: 1;
 }
 
 /* Build (#…): a NON-RRP solo layout — the URDF/3-D editor fills the area, with an

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -2246,6 +2246,10 @@ body {
  * ------------------------------------------------------------------------ */
 .shell__main {
   display: flex;
+  /* Soft Shell (#…): the workspace area (right of the dark activity bar) is
+     parchment; the panels float on it as rounded cards — see the card block
+     at the end of this file. */
+  background: var(--shell, var(--bg));
   height: 100%;
   min-height: 0;
 }
@@ -2253,6 +2257,64 @@ body {
 .shell__main .shell__panels {
   flex: 1 1 auto;
   min-width: 0;
+}
+
+/* ── Soft Shell cards (#…) ───────────────────────────────────────────────────
+   The Files panel, editor, console and instrument dock float as rounded cards on
+   the parchment workspace (matching the design handoff). RRP panel slots become
+   positioning contexts; each card is absolutely inset within its slot so the
+   parchment shows through as the gap, and the resize handles are transparent so
+   the gap reads as one continuous parchment margin. */
+.shell__panels > [data-panel-id],
+.shell__vgroup > [data-panel-id] {
+  position: relative;
+}
+.shell__panels > [data-panel-id] > .region,
+.shell__editor-region,
+.region--shell {
+  position: absolute;
+  inset: 7px;
+  height: auto;
+  border-radius: 14px;
+  border: 1px solid var(--shellbd, var(--border));
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.1),
+    0 6px 16px rgba(0, 0, 0, 0.06);
+  overflow: hidden;
+}
+/* Left panel + console cards sit on the raised --panel surface. */
+.shell__panels > [data-panel-id] > .region--files,
+.shell__panels > [data-panel-id] > .region:not(.region--right),
+.region--shell {
+  background: var(--panel, var(--bg-elevated));
+}
+/* The instrument dock is a flex sibling (fixed width), so it cards via margin —
+   flexbox subtracts the margin, no overflow. */
+.shell__main .shell__dock {
+  margin: 7px;
+  border-radius: 14px;
+  border: 1px solid var(--shellbd, var(--border));
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.1),
+    0 6px 16px rgba(0, 0, 0, 0.06);
+  background: var(--panel, var(--bg-elevated));
+}
+/* The resize handles live in the parchment gap — invisible tracks (so the divider
+   reads as pure parchment) but widened to be grabbable, with a faint hover hint. */
+.shell__panels > .resize-handle {
+  background: transparent;
+  width: 8px;
+}
+.shell__vgroup > .resize-handle {
+  background: transparent;
+  height: 8px;
+}
+.shell__panels > .resize-handle:hover,
+.shell__panels > .resize-handle[data-resize-handle-active],
+.shell__vgroup > .resize-handle:hover,
+.shell__vgroup > .resize-handle[data-resize-handle-active] {
+  background: var(--gold, var(--accent));
+  opacity: 0.35;
 }
 
 /* Build (#…): a NON-RRP solo layout — the URDF/3-D editor fills the area, with an

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -2366,6 +2366,41 @@ body {
   position: absolute;
   inset: 0;
 }
+/* Mini 3-D pop-out (#…) — top-right button that switches to the Build workspace,
+   mirroring the mini-board's Electronics pop-out. */
+.robotdock__popout {
+  position: absolute;
+  top: 0.4rem;
+  right: 0.4rem;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  color: var(--txt3, var(--text-muted));
+  background: var(--card, rgba(20, 21, 24, 0.7));
+  border: 1px solid var(--shellbd, var(--border));
+  border-radius: 6px;
+  cursor: pointer;
+}
+.robotdock__popout:hover {
+  color: var(--head, var(--text));
+  border-color: var(--gold, var(--accent));
+}
+/* Brief loading state shown while the project URDF resolves — replaces the old
+   demo-arm flash when a project has a linked model (#…). */
+.robotdock__loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--text-muted, var(--txt3));
+}
 .robotdock__actions {
   position: absolute;
   top: 0.35rem;

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -2357,6 +2357,10 @@ body {
 :root[data-theme] .shell__vgroup > .resize-handle[data-resize-handle-active]::before {
   opacity: 1;
 }
+/* Files collapsed → no stitch on its divider (it reopens from the activity bar). */
+:root[data-theme] .shell__panels > .resize-handle--files.is-collapsed::before {
+  display: none;
+}
 
 /* Build (#…): a NON-RRP solo layout — the URDF/3-D editor fills the area, with an
    optional lesson panel (tutorial/help) on the left. Sits where the panel group

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -2293,68 +2293,68 @@ body {
 /* The instrument dock is a flex sibling (fixed width), so it cards via margin —
    flexbox subtracts the margin, no overflow. */
 .shell__main .shell__dock {
-  margin: 7px;
+  margin: 5px;
   border-radius: 14px;
   border: 1px solid var(--shellbd, var(--border));
   box-shadow:
     0 1px 2px rgba(0, 0, 0, 0.1),
     0 6px 16px rgba(0, 0, 0, 0.06);
   background: var(--panel, var(--bg-elevated));
+  /* Clip the inner viewers/instruments to the rounded card. */
+  overflow: hidden;
 }
-/* The resize handles read as a thin line of STITCHES running down the parchment
-   gap (a warm --stitch thread, not a grey bar). The handle stays a slim grabbable
-   track; a centred dashed pseudo-element draws the stitch. */
-.shell__panels > .resize-handle,
-.shell__vgroup > .resize-handle {
+/* The resize handles read as a HAIRLINE dashed line of STITCHES down the parchment
+   gap (a warm --stitch thread — a darker parchment tone, NOT grey). The handle is
+   a transparent grabbable track; a centred dashed pseudo-element draws the stitch.
+   Theme-scoped so it out-specifies the skins' grey `.resize-handle` fill. */
+:root[data-theme] .shell__panels > .resize-handle,
+:root[data-theme] .shell__vgroup > .resize-handle {
   background: transparent;
   position: relative;
 }
-.shell__panels > .resize-handle {
+:root[data-theme] .shell__panels > .resize-handle {
   width: 5px;
 }
-.shell__vgroup > .resize-handle {
+:root[data-theme] .shell__vgroup > .resize-handle {
   height: 5px;
 }
-.shell__panels > .resize-handle::before,
-.shell__vgroup > .resize-handle::before {
+:root[data-theme] .shell__panels > .resize-handle::before,
+:root[data-theme] .shell__vgroup > .resize-handle::before {
   content: '';
   position: absolute;
-  background: var(--stitch, var(--shellbd));
-  opacity: 0.55;
+  opacity: 0.75;
   transition: opacity 0.12s ease;
 }
-/* Vertical divider → vertical dashed thread. */
-.shell__panels > .resize-handle::before {
+/* Vertical divider → vertical dashed thread (1px hairline). */
+:root[data-theme] .shell__panels > .resize-handle::before {
   top: 10px;
   bottom: 10px;
   left: 50%;
-  width: 2px;
+  width: 1px;
   transform: translateX(-50%);
   background-image: repeating-linear-gradient(
     to bottom,
-    var(--stitch, var(--shellbd)) 0 5px,
-    transparent 5px 9px
+    var(--stitch, var(--shellbd)) 0 4px,
+    transparent 4px 8px
   );
-  background-color: transparent;
 }
-/* Horizontal divider → horizontal dashed thread. */
-.shell__vgroup > .resize-handle::before {
+/* Horizontal divider → horizontal dashed thread (1px hairline). */
+:root[data-theme] .shell__vgroup > .resize-handle::before {
   left: 10px;
   right: 10px;
   top: 50%;
-  height: 2px;
+  height: 1px;
   transform: translateY(-50%);
   background-image: repeating-linear-gradient(
     to right,
-    var(--stitch, var(--shellbd)) 0 5px,
-    transparent 5px 9px
+    var(--stitch, var(--shellbd)) 0 4px,
+    transparent 4px 8px
   );
-  background-color: transparent;
 }
-.shell__panels > .resize-handle:hover::before,
-.shell__panels > .resize-handle[data-resize-handle-active]::before,
-.shell__vgroup > .resize-handle:hover::before,
-.shell__vgroup > .resize-handle[data-resize-handle-active]::before {
+:root[data-theme] .shell__panels > .resize-handle:hover::before,
+:root[data-theme] .shell__panels > .resize-handle[data-resize-handle-active]::before,
+:root[data-theme] .shell__vgroup > .resize-handle:hover::before,
+:root[data-theme] .shell__vgroup > .resize-handle[data-resize-handle-active]::before {
   opacity: 1;
 }
 
@@ -2409,7 +2409,8 @@ body {
   flex: 0 0 auto;
   width: 436px;
   max-width: 50vw;
-  height: 100%;
+  /* No explicit height — flex stretch sizes it to the row MINUS its margin, so the
+     card never overlaps the status bar (#…). */
   min-height: 0;
   display: flex;
 }

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -1723,6 +1723,25 @@ body {
   flex: 1;
 }
 
+/* Two equal-weight sides flank the workspace switcher so it sits centred at the
+ * top of the toolbar. The left side carries the brand + file/run controls; the
+ * right side is an empty balance. Both grow equally from a 0 basis, so the
+ * switcher is centred when there's room — but they keep their automatic
+ * min-content floor (NO `min-width: 0`), so the left cluster never shrinks under
+ * Run/Reset: as the window narrows the switcher is pushed right instead of
+ * overlapping, always keeping the toolbar `gap` as a margin. */
+.toolbar__side {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex: 1 1 0;
+}
+
+.toolbar__side--end {
+  /* Empty balance — nothing to render, just claims the mirror-image space. */
+  pointer-events: none;
+}
+
 /* Buttons — big, easy to click, and pressable like 8-bit hardware. */
 .btn {
   display: inline-flex;
@@ -2236,6 +2255,50 @@ body {
   min-width: 0;
 }
 
+/* Build (#…): a NON-RRP solo layout — the URDF/3-D editor fills the area, with an
+   optional lesson panel (tutorial/help) on the left. Sits where the panel group
+   would, filling the space between the activity bar and (absent) dock. */
+.shell__main .shell__solo {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  min-height: 0;
+  height: 100%;
+}
+.shell__solo-lesson {
+  flex: 0 0 auto;
+  width: 320px;
+  max-width: 42%;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  border-right: var(--border-w) solid var(--border);
+  overflow: hidden;
+}
+.shell__solo-lesson > .region {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+.shell__solo > .shell__robot-main {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+/* Electronics: the Board View fills the solo area (its library panel is part of
+   BoardPane). */
+.shell__solo > .shell__solo-board {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  overflow: hidden;
+}
+.shell__solo-board > * {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+}
+
 /* The instrument dock — a fixed-width region to the right of the panel group
    (NOT a resizable panel), so its show/hide is independent of the chat panel.
    It fits a 404px instrument window; capped on narrow windows. */
@@ -2255,10 +2318,12 @@ body {
 .shell__main .shell__dock--mini {
   flex-direction: column;
 }
-/* Mini viewer slot (#595): mirrors the robot 3-D slot's sizing. */
+/* Mini viewer slot (#595): sizes to the MiniViewer's own content (the mini-board
+   island / the fixed-height 3-D box), so the instrument dock below sits FLUSH —
+   no parchment gap between the viewer and the dock. */
 .shell__miniviewer {
-  flex: 0 0 42%;
-  min-height: 160px;
+  flex: 0 0 auto;
+  min-height: 0;
   position: relative;
   border-bottom: var(--border-w) solid var(--border);
   overflow: hidden;
@@ -2285,6 +2350,15 @@ body {
 /* The instrument dock takes the remaining height + scrolls. */
 .shell__dock--robot .instr-dock {
   min-height: 0;
+}
+/* Build (#…): the URDF/3-D pose editor fills the WHOLE centre column (full-screen,
+   no code, no board). The absolutely-positioned `.robotdock` fills this relative
+   box, and `--full` renders the non-compact pose tool inside it. */
+.shell__robot-main {
+  position: relative;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
 }
 /* The docked mini-viewer fills its slot; a top action row creates a new robot
    or pops the viewer out full-screen (#320 / new-URDF). */

--- a/src/renderer/src/store/layout.ts
+++ b/src/renderer/src/store/layout.ts
@@ -60,6 +60,11 @@ export interface WorkspaceLayout {
   /** Active left-sidebar view (activity bar). */
   activityView: ActivityView
   filesCollapsed: boolean
+  /** The centre column (code editor + console). Collapsed to 0 in Electronics,
+   *  where the Board View takes over the whole main area (#…). The editor stays
+   *  MOUNTED behind the 0-width panel, so switching Code↔Electronics never
+   *  remounts Monaco. */
+  centreCollapsed: boolean
   shellCollapsed: boolean
   rightCollapsed: boolean
   /** The fixed-width instrument dock (not a Panel — a plain show/hide region). */
@@ -74,9 +79,13 @@ export interface WorkspaceLayout {
   vertical: [number, number]
 }
 
-/** The persisted envelope. Bump `version` on breaking shape changes. */
+/** The persisted envelope. Bump `version` on breaking shape changes.
+ *  v2 (#…): Electronics + Build were redesigned — Electronics hides code+console
+ *  so the Board View fills the area; Build is the full-screen URDF editor with no
+ *  code/board/instrument dock. A stored v1 envelope keeps the user's Code layout
+ *  but resets those two workspaces to the new presets ({@link loadLayoutState}). */
 export interface LayoutState {
-  version: 1
+  version: 2
   active: WorkspaceId
   workspaces: Record<WorkspaceId, WorkspaceLayout>
 }
@@ -90,40 +99,43 @@ export const WORKSPACE_PRESETS: Record<WorkspaceId, WorkspaceLayout> = {
   code: {
     activityView: 'files',
     filesCollapsed: false,
+    centreCollapsed: false,
     shellCollapsed: false,
     rightCollapsed: true,
     dockOpen: false,
     boardPaneOpen: false,
     horizontal: [18, 82, 0, 0],
-    vertical: [70, 30]
+    // Console gets a roomy default share so the REPL is usable at a glance (#…) —
+    // 30% was too short to show the prompt + a few lines of output.
+    vertical: [60, 40]
   },
-  // Board-first (the education tri-split): CODE on the left, the EMBEDDED
-  // Board View (breadboard/schematic/node graph) on the right, and the
-  // instrument dock at the far right — code, wiring and live instruments all
-  // visible at once. Console stays under the code.
+  // Electronics: the Board View fills the whole main area — CODE AND CONSOLE ARE
+  // HIDDEN (the centre column collapses to 0, editor still mounted behind it), so
+  // wiring is the sole focus. The instrument dock stays closed (reopenable).
   board: {
     activityView: 'files',
     filesCollapsed: true,
+    centreCollapsed: true,
     shellCollapsed: false,
     rightCollapsed: true,
-    // Instruments HIDDEN by default in Board mode — the board is the star, so it
-    // gets the room (Data Lab opens the dock, Code keeps it closed).
     dockOpen: false,
     boardPaneOpen: true,
-    horizontal: [0, 42, 58, 0],
+    horizontal: [0, 0, 100, 0],
     vertical: [65, 35]
   },
-  // Robot (#320): the robotics cockpit — files collapsed, CODE ~⅓ on the left,
-  // the Board View (breadboard) in the middle, and the dock on the right (which
-  // in this mode carries a mini 3-D Robot panel above the instruments).
+  // Build (#320): the URDF/3-D editor FULL SCREEN — no code, no board view. The
+  // centre column hosts the full-screen Robot pose tool (files collapsed, board
+  // pane closed, dock closed & reopenable for instruments). The 3-D IS the main
+  // area now, so the old mini-3-D dock panel is gone.
   robot: {
     activityView: 'files',
     filesCollapsed: true,
+    centreCollapsed: false,
     shellCollapsed: false,
     rightCollapsed: true,
-    dockOpen: true,
-    boardPaneOpen: true,
-    horizontal: [0, 34, 66, 0],
+    dockOpen: false,
+    boardPaneOpen: false,
+    horizontal: [0, 100, 0, 0],
     vertical: [65, 35]
   }
 }
@@ -146,9 +158,16 @@ const VIEWS: ActivityView[] = [
   'packages',
   'plugins',
   'inspect',
+  'learn',
   'help',
   'report-bug'
 ]
+
+/** Sidebar views that are a guided lesson (the Learn tutorials + the Help
+ *  library). When one of these is OPEN, it STAYS open across workspace switches
+ *  so the user can follow the lesson while changing modes — even into Build,
+ *  which otherwise hides the sidebar (#…). */
+const STICKY_LESSON_VIEWS: ReadonlySet<ActivityView> = new Set(['learn', 'help'])
 
 /** Validate one workspace's shape, falling back to `preset` field-by-field. */
 function sanitiseWorkspace(raw: unknown, preset: WorkspaceLayout): WorkspaceLayout {
@@ -158,6 +177,8 @@ function sanitiseWorkspace(raw: unknown, preset: WorkspaceLayout): WorkspaceLayo
       ? (r.activityView as ActivityView)
       : preset.activityView,
     filesCollapsed: typeof r.filesCollapsed === 'boolean' ? r.filesCollapsed : preset.filesCollapsed,
+    centreCollapsed:
+      typeof r.centreCollapsed === 'boolean' ? r.centreCollapsed : preset.centreCollapsed,
     shellCollapsed: typeof r.shellCollapsed === 'boolean' ? r.shellCollapsed : preset.shellCollapsed,
     rightCollapsed: typeof r.rightCollapsed === 'boolean' ? r.rightCollapsed : preset.rightCollapsed,
     dockOpen: typeof r.dockOpen === 'boolean' ? r.dockOpen : preset.dockOpen,
@@ -227,7 +248,7 @@ export function defaultLayoutState(): LayoutState {
       vertical: [...WORKSPACE_PRESETS[id].vertical]
     }
   }
-  return { version: 1, active: 'code', workspaces }
+  return { version: 2, active: 'code', workspaces }
 }
 
 /** Storage surface the loader reads (injectable for tests). */
@@ -274,7 +295,8 @@ export function loadLayoutState(storage: StorageLike): LayoutState {
     const raw = storage.getItem(LAYOUT_STORAGE_KEY)
     if (raw) {
       const parsed = JSON.parse(raw) as Partial<LayoutState>
-      if (parsed && parsed.version === 1 && parsed.workspaces) {
+      const ver = (parsed as { version?: number } | null)?.version
+      if (parsed && (ver === 1 || ver === 2) && parsed.workspaces) {
         const state = defaultLayoutState()
         // Any retired active workspace (`lab`/`data`/`datalab` — Data Lab was
         // never surfaced and is retired in Soft Shell, #581) coerces to `code`
@@ -283,8 +305,23 @@ export function loadLayoutState(storage: StorageLike): LayoutState {
         const saved = parsed.workspaces as Record<string, unknown>
         const activeRaw = parsed.active as WorkspaceId
         state.active = WORKSPACE_IDS.includes(activeRaw) ? activeRaw : 'code'
+        // v1 → v2: Electronics (`board`) + Build (`robot`) were redesigned, so a v1
+        // envelope's saved geometry for them no longer makes sense (old Build kept
+        // the code + board panes; new Build is a full-screen URDF editor). Reset
+        // those two to the new presets; the user's Code layout still carries over.
+        const resetRedesigned = ver === 1
         for (const id of WORKSPACE_IDS) {
+          if (resetRedesigned && (id === 'board' || id === 'robot')) continue // keep preset
           state.workspaces[id] = sanitiseWorkspace(saved[id], WORKSPACE_PRESETS[id])
+        }
+        // The Code console's default share grew (30% → 40%) so the REPL is usable
+        // by default. A v1 user still on the exact OLD default gets the new one;
+        // a customised editor/console split is kept as-is.
+        if (resetRedesigned) {
+          const c = state.workspaces.code
+          if (c.vertical[0] === 70 && c.vertical[1] === 30) {
+            c.vertical = [...WORKSPACE_PRESETS.code.vertical] as [number, number]
+          }
         }
         return state
       }
@@ -342,7 +379,7 @@ export interface LayoutStore {
   /** Restore the ACTIVE workspace to its factory preset. */
   resetActive: () => void
   setActivityView: (view: ActivityView) => void
-  setCollapsed: (panel: 'files' | 'shell' | 'right', collapsed: boolean) => void
+  setCollapsed: (panel: 'files' | 'centre' | 'shell' | 'right', collapsed: boolean) => void
   setDockOpen: (open: boolean) => void
   /** Enter/leave transient editor-focus mode. */
   setFocus: (focus: boolean) => void
@@ -440,6 +477,18 @@ export function LayoutProvider({
         })
         return
       }
+      // Sticky lesson: if the OUTGOING workspace has a tutorial / help lesson
+      // open, carry it into the target so the user keeps following it across the
+      // switch (Build otherwise hides the sidebar). A collapsed lesson, or any
+      // non-lesson view, is left alone — so Build keeps its files-hidden default.
+      const cur = s.workspaces[s.active]
+      if (STICKY_LESSON_VIEWS.has(cur.activityView) && !cur.filesCollapsed) {
+        s.workspaces[id] = {
+          ...s.workspaces[id],
+          activityView: cur.activityView,
+          filesCollapsed: false
+        }
+      }
       s.active = id
       setActive(id)
       setWorkspace(s.workspaces[id])
@@ -468,13 +517,15 @@ export function LayoutProvider({
     [patchActive]
   )
   const setCollapsed = useCallback(
-    (panel: 'files' | 'shell' | 'right', collapsed: boolean): void =>
+    (panel: 'files' | 'centre' | 'shell' | 'right', collapsed: boolean): void =>
       patchActive(
         panel === 'files'
           ? { filesCollapsed: collapsed }
-          : panel === 'shell'
-            ? { shellCollapsed: collapsed }
-            : { rightCollapsed: collapsed }
+          : panel === 'centre'
+            ? { centreCollapsed: collapsed }
+            : panel === 'shell'
+              ? { shellCollapsed: collapsed }
+              : { rightCollapsed: collapsed }
       ),
     [patchActive]
   )

--- a/src/renderer/src/store/layout.ts
+++ b/src/renderer/src/store/layout.ts
@@ -325,6 +325,7 @@ export function loadLayoutState(storage: StorageLike): LayoutState {
           c.horizontal = [...WORKSPACE_PRESETS.code.horizontal] as [number, number, number, number]
           c.vertical = [...WORKSPACE_PRESETS.code.vertical] as [number, number]
         }
+        ensureUsableConsole(state)
         return state
       }
     }
@@ -358,7 +359,19 @@ export function loadLayoutState(storage: StorageLike): LayoutState {
   } catch {
     // any migration hiccup → plain defaults
   }
+  ensureUsableConsole(state)
   return state
+}
+
+/**
+ * Guarantee a usable Code console height on EVERY load: a persisted split whose
+ * console share is too short to show the REPL (any version) is bumped to the
+ * preset, so the console is always recognisable — a hard floor over the runtime
+ * `minSize`, which can't retro-fix an already-stored tiny value (#…).
+ */
+function ensureUsableConsole(state: LayoutState): void {
+  const c = state.workspaces.code
+  if (c.vertical[1] < 30) c.vertical = [...WORKSPACE_PRESETS.code.vertical] as [number, number]
 }
 
 // ---------------------------------------------------------------------------

--- a/src/renderer/src/store/layout.ts
+++ b/src/renderer/src/store/layout.ts
@@ -85,7 +85,7 @@ export interface WorkspaceLayout {
  *  code/board/instrument dock. A stored v1 envelope keeps the user's Code layout
  *  but resets those two workspaces to the new presets ({@link loadLayoutState}). */
 export interface LayoutState {
-  version: 2
+  version: 3
   active: WorkspaceId
   workspaces: Record<WorkspaceId, WorkspaceLayout>
 }
@@ -104,10 +104,11 @@ export const WORKSPACE_PRESETS: Record<WorkspaceId, WorkspaceLayout> = {
     rightCollapsed: true,
     dockOpen: false,
     boardPaneOpen: false,
-    horizontal: [18, 82, 0, 0],
-    // Console gets a roomy default share so the REPL is usable at a glance (#…) —
-    // 30% was too short to show the prompt + a few lines of output.
-    vertical: [60, 40]
+    // Files ~20% (≈ the design's 272px) — not the old 30% clamp. Console gets a
+    // roomy ~45% so a couple of REPL lines are clearly visible by default, so the
+    // user recognises the console for what it is (#…).
+    horizontal: [20, 80, 0, 0],
+    vertical: [55, 45]
   },
   // Electronics: the Board View fills the whole main area — CODE AND CONSOLE ARE
   // HIDDEN (the centre column collapses to 0, editor still mounted behind it), so
@@ -248,7 +249,7 @@ export function defaultLayoutState(): LayoutState {
       vertical: [...WORKSPACE_PRESETS[id].vertical]
     }
   }
-  return { version: 2, active: 'code', workspaces }
+  return { version: 3, active: 'code', workspaces }
 }
 
 /** Storage surface the loader reads (injectable for tests). */
@@ -296,7 +297,7 @@ export function loadLayoutState(storage: StorageLike): LayoutState {
     if (raw) {
       const parsed = JSON.parse(raw) as Partial<LayoutState>
       const ver = (parsed as { version?: number } | null)?.version
-      if (parsed && (ver === 1 || ver === 2) && parsed.workspaces) {
+      if (parsed && (ver === 1 || ver === 2 || ver === 3) && parsed.workspaces) {
         const state = defaultLayoutState()
         // Any retired active workspace (`lab`/`data`/`datalab` — Data Lab was
         // never surfaced and is retired in Soft Shell, #581) coerces to `code`
@@ -310,18 +311,19 @@ export function loadLayoutState(storage: StorageLike): LayoutState {
         // the code + board panes; new Build is a full-screen URDF editor). Reset
         // those two to the new presets; the user's Code layout still carries over.
         const resetRedesigned = ver === 1
+        // v2 → v3: the Code proportions were corrected — files were clamped too wide
+        // (~30%) and the console too short. A pre-v3 envelope resets the Code
+        // workspace's sizes to the new preset (files ~20%, console ~45%) so the fix
+        // actually reaches existing users; collapse flags + the active view carry over.
+        const resetCodeSizes = ver === 1 || ver === 2
         for (const id of WORKSPACE_IDS) {
           if (resetRedesigned && (id === 'board' || id === 'robot')) continue // keep preset
           state.workspaces[id] = sanitiseWorkspace(saved[id], WORKSPACE_PRESETS[id])
         }
-        // The Code console's default share grew (30% → 40%) so the REPL is usable
-        // by default. A v1 user still on the exact OLD default gets the new one;
-        // a customised editor/console split is kept as-is.
-        if (resetRedesigned) {
+        if (resetCodeSizes) {
           const c = state.workspaces.code
-          if (c.vertical[0] === 70 && c.vertical[1] === 30) {
-            c.vertical = [...WORKSPACE_PRESETS.code.vertical] as [number, number]
-          }
+          c.horizontal = [...WORKSPACE_PRESETS.code.horizontal] as [number, number, number, number]
+          c.vertical = [...WORKSPACE_PRESETS.code.vertical] as [number, number]
         }
         return state
       }

--- a/test/layoutStore.test.ts
+++ b/test/layoutStore.test.ts
@@ -145,47 +145,56 @@ describe('horizontal slot mapping — elided board/chat panels (#528)', () => {
 describe('loadLayoutState (corruption-safe, versioned)', () => {
   it('returns factory defaults with no stored state', () => {
     const s = loadLayoutState(storage())
-    expect(s.version).toBe(2)
+    expect(s.version).toBe(3)
     expect(s.active).toBe('code')
   })
 
-  it('migrates a v1 envelope: keeps Code, resets Electronics + Build to the new presets (#…)', () => {
-    // A pre-redesign v1 envelope where the user customised Code AND had the old
-    // Build layout (board pane open, dock open). Code carries over; Build +
-    // Electronics reset to the new full-screen / board-only presets.
+  it('migrates a v1 envelope: resets Electronics + Build + the Code proportions (#…)', () => {
+    // A pre-redesign v1 envelope where the user had the old Build layout (board
+    // pane open, dock open) and a stale Code split. Build + Electronics reset to
+    // the new full-screen / board-only presets; the Code sizes reset to the
+    // corrected proportions (files ~20%, console ~45%); the active view carries.
     const oldRobot = { ...WORKSPACE_PRESETS.robot, boardPaneOpen: true, dockOpen: true, centreCollapsed: false, horizontal: [0, 34, 66, 0] }
     const oldBoard = { ...WORKSPACE_PRESETS.board, centreCollapsed: false, horizontal: [0, 42, 58, 0] }
     const v1 = {
       version: 1,
       active: 'robot',
       workspaces: {
-        code: { ...WORKSPACE_PRESETS.code, horizontal: [22, 78, 0, 0] as [number, number, number, number] },
+        code: { ...WORKSPACE_PRESETS.code, activityView: 'help', horizontal: [30, 70, 0, 0] as [number, number, number, number], vertical: [70, 30] as [number, number] },
         board: oldBoard,
         robot: oldRobot
       }
     }
     const s = loadLayoutState(storage({ [LAYOUT_STORAGE_KEY]: JSON.stringify(v1) }))
-    expect(s.version).toBe(2)
+    expect(s.version).toBe(3)
     expect(s.active).toBe('robot')
-    // Code preserved.
-    expect(s.workspaces.code.horizontal).toEqual([22, 78, 0, 0])
+    // Code sizes reset to the corrected preset; the active view carries over.
+    expect(s.workspaces.code.horizontal).toEqual(WORKSPACE_PRESETS.code.horizontal)
+    expect(s.workspaces.code.vertical).toEqual(WORKSPACE_PRESETS.code.vertical)
+    expect(s.workspaces.code.activityView).toBe('help')
     // Build + Electronics reset — no board/dock in Build, code hidden in Electronics.
     expect(s.workspaces.robot).toEqual(WORKSPACE_PRESETS.robot)
     expect(s.workspaces.board).toEqual(WORKSPACE_PRESETS.board)
   })
 
-  it('v1 migration: a Code console still on the old 30% default grows to 40%; a custom split is kept', () => {
-    const mk = (vertical: [number, number]) => ({
-      version: 1,
+  it('v2 → v3 migration: the Code files width + console height reset to the corrected preset', () => {
+    // A v2 envelope with the old too-wide files (~30%) / too-short console (~30%).
+    const v2 = {
+      version: 2,
       active: 'code',
-      workspaces: { code: { ...WORKSPACE_PRESETS.code, vertical } }
-    })
-    // On the old default → bumped to the new preset.
-    const bumped = loadLayoutState(storage({ [LAYOUT_STORAGE_KEY]: JSON.stringify(mk([70, 30])) }))
-    expect(bumped.workspaces.code.vertical).toEqual(WORKSPACE_PRESETS.code.vertical)
-    expect(WORKSPACE_PRESETS.code.vertical).toEqual([60, 40])
-    // A customised split is preserved.
-    const kept = loadLayoutState(storage({ [LAYOUT_STORAGE_KEY]: JSON.stringify(mk([50, 50])) }))
+      workspaces: {
+        code: { ...WORKSPACE_PRESETS.code, horizontal: [30, 70, 0, 0], vertical: [70, 30] }
+      }
+    }
+    const s = loadLayoutState(storage({ [LAYOUT_STORAGE_KEY]: JSON.stringify(v2) }))
+    expect(s.version).toBe(3)
+    expect(s.workspaces.code.horizontal).toEqual(WORKSPACE_PRESETS.code.horizontal)
+    expect(s.workspaces.code.vertical).toEqual(WORKSPACE_PRESETS.code.vertical)
+    expect(WORKSPACE_PRESETS.code.horizontal).toEqual([20, 80, 0, 0])
+    expect(WORKSPACE_PRESETS.code.vertical).toEqual([55, 45])
+    // A v3 envelope is left as-is (no further reset).
+    const v3 = { version: 3, active: 'code', workspaces: { code: { ...WORKSPACE_PRESETS.code, vertical: [50, 50] } } }
+    const kept = loadLayoutState(storage({ [LAYOUT_STORAGE_KEY]: JSON.stringify(v3) }))
     expect(kept.workspaces.code.vertical).toEqual([50, 50])
   })
 

--- a/test/layoutStore.test.ts
+++ b/test/layoutStore.test.ts
@@ -27,15 +27,29 @@ describe('workspace presets (epic #259; +Robot mode #320)', () => {
     }
   })
 
-  it("Robot mode: files collapsed, code ~1/3, board middle, dock open (#320)", () => {
+  it('Build mode: URDF/3-D editor full screen — no code, no board, dock closed (#…)', () => {
     const r = WORKSPACE_PRESETS.robot
     expect(r.filesCollapsed).toBe(true)
-    expect(r.boardPaneOpen).toBe(true)
-    expect(r.dockOpen).toBe(true)
-    // code (centre) is roughly a third and the board (slot 2) gets the rest.
-    expect(r.horizontal[1]).toBeGreaterThan(25)
-    expect(r.horizontal[1]).toBeLessThan(45)
-    expect(r.horizontal[2]).toBeGreaterThan(r.horizontal[1])
+    // No board view and no reopened instrument dock — the 3-D IS the main area.
+    expect(r.boardPaneOpen).toBe(false)
+    expect(r.dockOpen).toBe(false)
+    // The centre column (now the full-screen robot editor) fills the width; the
+    // board slot is empty.
+    expect(r.horizontal[1]).toBe(100)
+    expect(r.horizontal[2]).toBe(0)
+    // The centre isn't collapsed (it holds the robot editor); only Electronics
+    // collapses the centre to hand the whole area to the Board View.
+    expect(r.centreCollapsed).toBe(false)
+  })
+
+  it('Electronics mode: code + console hidden, Board View fills the main area (#…)', () => {
+    const b = WORKSPACE_PRESETS.board
+    expect(b.filesCollapsed).toBe(true)
+    expect(b.centreCollapsed).toBe(true)
+    expect(b.boardPaneOpen).toBe(true)
+    // Centre collapsed to 0, board takes the whole width.
+    expect(b.horizontal[1]).toBe(0)
+    expect(b.horizontal[2]).toBe(100)
   })
 
   it('a pre-Robot saved envelope gains the robot preset (migration)', () => {
@@ -131,9 +145,48 @@ describe('horizontal slot mapping — elided board/chat panels (#528)', () => {
 describe('loadLayoutState (corruption-safe, versioned)', () => {
   it('returns factory defaults with no stored state', () => {
     const s = loadLayoutState(storage())
-    expect(s.version).toBe(1)
+    expect(s.version).toBe(2)
     expect(s.active).toBe('code')
-    expect(s.workspaces.datalab).toEqual(WORKSPACE_PRESETS.datalab)
+  })
+
+  it('migrates a v1 envelope: keeps Code, resets Electronics + Build to the new presets (#…)', () => {
+    // A pre-redesign v1 envelope where the user customised Code AND had the old
+    // Build layout (board pane open, dock open). Code carries over; Build +
+    // Electronics reset to the new full-screen / board-only presets.
+    const oldRobot = { ...WORKSPACE_PRESETS.robot, boardPaneOpen: true, dockOpen: true, centreCollapsed: false, horizontal: [0, 34, 66, 0] }
+    const oldBoard = { ...WORKSPACE_PRESETS.board, centreCollapsed: false, horizontal: [0, 42, 58, 0] }
+    const v1 = {
+      version: 1,
+      active: 'robot',
+      workspaces: {
+        code: { ...WORKSPACE_PRESETS.code, horizontal: [22, 78, 0, 0] as [number, number, number, number] },
+        board: oldBoard,
+        robot: oldRobot
+      }
+    }
+    const s = loadLayoutState(storage({ [LAYOUT_STORAGE_KEY]: JSON.stringify(v1) }))
+    expect(s.version).toBe(2)
+    expect(s.active).toBe('robot')
+    // Code preserved.
+    expect(s.workspaces.code.horizontal).toEqual([22, 78, 0, 0])
+    // Build + Electronics reset — no board/dock in Build, code hidden in Electronics.
+    expect(s.workspaces.robot).toEqual(WORKSPACE_PRESETS.robot)
+    expect(s.workspaces.board).toEqual(WORKSPACE_PRESETS.board)
+  })
+
+  it('v1 migration: a Code console still on the old 30% default grows to 40%; a custom split is kept', () => {
+    const mk = (vertical: [number, number]) => ({
+      version: 1,
+      active: 'code',
+      workspaces: { code: { ...WORKSPACE_PRESETS.code, vertical } }
+    })
+    // On the old default → bumped to the new preset.
+    const bumped = loadLayoutState(storage({ [LAYOUT_STORAGE_KEY]: JSON.stringify(mk([70, 30])) }))
+    expect(bumped.workspaces.code.vertical).toEqual(WORKSPACE_PRESETS.code.vertical)
+    expect(WORKSPACE_PRESETS.code.vertical).toEqual([60, 40])
+    // A customised split is preserved.
+    const kept = loadLayoutState(storage({ [LAYOUT_STORAGE_KEY]: JSON.stringify(mk([50, 50])) }))
+    expect(kept.workspaces.code.vertical).toEqual([50, 50])
   })
 
   it('survives corrupt JSON and wrong shapes', () => {


### PR DESCRIPTION
Reshapes the three workspaces to match the **Soft Shell** design handoff so each shows only what it's for, plus a batch of follow-up fixes from hands-on review.

## Workspaces
- **Code** — files + editor + console; the mini-viewer / instrument dock lives here (Code-only). File panel opens ~272px (was clamped ~30% too wide); the console opens ~45% so the REPL is clearly visible.
- **Electronics** — the Board View fills the whole area in a dedicated non-RRP layout; no code editor, console, or instrument dock. The code panels are structurally absent, so no stale/persisted layout can resurface them.
- **Build** — the URDF / 3-D pose editor full-screen, likewise dedicated; no code, no board, no dock. A tutorial/help lesson carried from another workspace stays open beside it.

## Toolbar & chrome
- Workspace switcher **centred** and more prominent (keeps a margin from Run/Reset at any width).
- Removed the **reset-layout** and **pop-out Board View** toolbar buttons.
- Mini-viewer's Board/3D toggle centred with the instrument dock flush beneath.

## Board selection sync
- One board across the mini-board, the Board View and the Code workspace — `robot.yml`'s `board` is the shared source of truth; picking a board anywhere updates everywhere.

## Mini-viewer pop-outs
- Mini-board → **Electronics**, mini-3-D → **Build** (in-app, no standalone window).

## Fixes
- **Chat** toggle restored in the console header (the pane's opener went missing when the global toolbar toggles were retired in #592).
- No demo-arm flash when entering the 3-D view (brief loading → real model).
- The Build toolbar stays available when the URDF hierarchy is hidden.

## Store / migration
- Adds `centreCollapsed`; new Electronics/Build presets; sticky lesson carry-over; `learn` added to persisted views.
- Layout envelope bumped to **v3**: existing users keep their Code activity view / collapse flags but Electronics + Build reset to the new presets and the Code proportions reset to the corrected file-width / console-height. Migration is unit-tested and verified against seeded stale states.

## Verification
`typecheck`, `lint`, **2048 tests**, and `build` all green. UI changes checked headlessly (both themes where relevant): workspace layouts, switcher centring + no-overlap, Electronics/Build structural correctness (incl. stale-state migration), mini-viewer flush + centred toggle + pop-outs, board-selection sync (both directions), file width + console height.

> Note: the desktop-only **chat toggle** and the **cross-window** board sync (separate Board View window) can't be exercised in the headless web harness — logic is in place; worth a quick check in the packaged app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)