### PR TITLE
fix: keep console mounted across workspace switches; pin Electronics library open

### DIFF
--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -281,8 +281,7 @@ export function AppShell(): JSX.Element {
   // workspace's geometry when it becomes active (nothing remounts — the editor,
   // xterm scrollback and instruments survive every switch).
   const layout = useWorkspaceLayout()
-  const { shellCollapsed, rightCollapsed, activityView, boardPaneOpen, filesCollapsed } =
-    layout.workspace
+  const { shellCollapsed, rightCollapsed, activityView, filesCollapsed } = layout.workspace
   // Build (#…): the centre column hosts the full-screen URDF/3-D editor instead of
   // the code editor + console — no code, no board view.
   const robotMain = layout.active === 'robot'
@@ -306,10 +305,6 @@ export function AppShell(): JSX.Element {
   // Transient editor focus (Robot pop-out): hide the board, instruments + console
   // around the URDF without touching the workspace (#320 follow-up).
   const focus = layout.focus
-  // Build (robot) is the full-screen URDF editor ONLY — it structurally never
-  // shows the board pane, whatever a persisted `boardPaneOpen` says (belt-and-
-  // braces over the v2 layout migration).
-  const boardPaneVisible = boardPaneOpen && !focus && !robotMain
 
   const filesRef = useRef<ImperativePanelHandle>(null)
   const centreRef = useRef<ImperativePanelHandle>(null)
@@ -363,7 +358,10 @@ export function AppShell(): JSX.Element {
     // The horizontal group's setLayout array must match the RENDERED panels: the
     // board slot elides when the pane is closed (or in Build), and the chat slot
     // doesn't exist on web (#528) — a stray extra size makes RRP throw.
-    const boardOn = ws.boardPaneOpen && !focus && !rMain
+    // The board pane no longer lives in the panel group (Electronics renders it in
+    // the solo overlay), so the group is always [files, centre, chat] — board off.
+    void rMain
+    const boardOn = false
     hGroupRef.current?.setLayout(appliedHorizontal(ws.horizontal, boardOn, !IS_WEB))
     vGroupRef.current?.setLayout([...ws.vertical])
     // Then sync each collapsible panel's collapsed state (belt-and-braces over the
@@ -1058,37 +1056,11 @@ export function AppShell(): JSX.Element {
             otherwise there's no sidebar. Keeping these out of the resizable panel
             group makes the code panels structurally absent (no persisted flag can
             resurface them) and avoids RRP collapse races. */}
-        {soloWorkspace ? (
-          <div className="shell__solo">
-            {soloLessonOpen && (
-              <aside className="shell__solo-lesson" aria-label="Lesson">
-                <LeftView view={activityView} helpTarget={helpTarget} />
-              </aside>
-            )}
-            {robotMain ? (
-              <div className="shell__robot-main">
-                <Suspense fallback={<div className="shell__robot3d-loading">Loading 3D…</div>}>
-                  <RobotDockPanel full />
-                </Suspense>
-              </div>
-            ) : (
-              <div className="shell__solo-board">
-                <Suspense
-                  fallback={
-                    <div className="board-pane__loading" role="status">
-                      Loading Board View…
-                    </div>
-                  }
-                >
-                  <BoardPane />
-                </Suspense>
-              </div>
-            )}
-          </div>
-        ) : (
-        /* Sizes are recorded into the ACTIVE workspace via onLayout and applied
-            imperatively on workspace switch (setLayout) — the library's own
-            autoSaveId persistence is replaced by the layout store (#259). */
+        <div className="shell__workarea">
+        {/* Code's panel group is ALWAYS mounted (#…) so the console terminal + editor
+            keep their state across a workspace switch, instead of remounting blank.
+            The solo overlay (below) covers it for Electronics/Build. Sizes are
+            recorded per-workspace via onLayout and applied imperatively on switch. */}
         <PanelGroup
           direction="horizontal"
           ref={hGroupRef}
@@ -1186,28 +1158,8 @@ export function AppShell(): JSX.Element {
             </div>
           </Panel>
 
-          {/* The embedded Board View (the Board workspace's tri-split, #259):
-              code on the left, the board here, the instrument dock at the far
-              right — code, wiring and instruments visible together. */}
-          {boardPaneVisible && (
-            <>
-              <PanelResizeHandle className="resize-handle resize-handle--vertical" />
-              {/* defaultSize = the ACTIVE workspace's board share (not the mount-time
-                  snapshot): the pane mounts when switching into Board, and the deferred
-                  setLayout can lose a race — this keeps the fallback correct too. */}
-              <Panel order={3} minSize={25} defaultSize={layout.workspace.horizontal[2] || 40}>
-                <Suspense
-                  fallback={
-                    <div className="board-pane__loading" role="status">
-                      Loading Board View…
-                    </div>
-                  }
-                >
-                  <BoardPane />
-                </Suspense>
-              </Panel>
-            </>
-          )}
+          {/* (The Board View is NOT a panel here anymore — Electronics renders it in
+              the solo overlay below, so the group stays a stable Code layout.) */}
 
           {/* The Chat right-pane is desktop-only — hidden on the web build. */}
           {!IS_WEB && (
@@ -1229,7 +1181,37 @@ export function AppShell(): JSX.Element {
             </>
           )}
         </PanelGroup>
+        {/* Electronics + Build overlay the Code panel group (which stays mounted
+            underneath). A tutorial/help lesson carried in shows in a left panel. */}
+        {soloWorkspace && (
+          <div className="shell__solo shell__solo--overlay">
+            {soloLessonOpen && (
+              <aside className="shell__solo-lesson" aria-label="Lesson">
+                <LeftView view={activityView} helpTarget={helpTarget} />
+              </aside>
+            )}
+            {robotMain ? (
+              <div className="shell__robot-main">
+                <Suspense fallback={<div className="shell__robot3d-loading">Loading 3D…</div>}>
+                  <RobotDockPanel full />
+                </Suspense>
+              </div>
+            ) : (
+              <div className="shell__solo-board">
+                <Suspense
+                  fallback={
+                    <div className="board-pane__loading" role="status">
+                      Loading Board View…
+                    </div>
+                  }
+                >
+                  <BoardPane />
+                </Suspense>
+              </div>
+            )}
+          </div>
         )}
+        </div>
 
         {/* The INSTRUMENT DOCK lives OUTSIDE the PanelGroup — a fixed-width region
             to the right of the chat. Kept out of the group so toggling it (or the

--- a/src/renderer/src/components/BoardGraph.tsx
+++ b/src/renderer/src/components/BoardGraph.tsx
@@ -362,8 +362,11 @@ export function BoardGraph({
   // library is a pinnable Obsidian-style overlay — closed by default, opened
   // from its edge tab, auto-hiding on focus loss unless PINNED. The floating
   // Board window defaults to open+pinned (the pre-review behaviour).
+  // The parts LIBRARY defaults to open + PINNED in the Electronics workspace too
+  // (#…), consistent with the Browser + Build panels; the user's own pin choice
+  // still persists.
   const [dockPinned, setDockPinnedState] = useState<boolean>(() =>
-    asWindow ? true : loadPin(window.localStorage, PIN_KEYS.library, false)
+    asWindow ? true : loadPin(window.localStorage, PIN_KEYS.library, true)
   )
   const [dockOpen, setDockOpen] = useState<boolean>(() => asWindow || dockPinned)
   const dockRef = useRef<HTMLElement | null>(null)

--- a/src/renderer/src/components/ShellPanel.tsx
+++ b/src/renderer/src/components/ShellPanel.tsx
@@ -202,7 +202,11 @@ export function ShellPanel({ chatOpen = false, onToggleChat, onCollapse }: Shell
           {/* Keep the terminal MOUNTED even when popped out, so its scrollback
               survives; just hide it and show a redock placeholder instead. */}
           <div className={`shell-console${poppedOut ? ' shell-console--popped' : ''}`}>
-            <Terminal ref={terminalRef} />
+            {/* Seed from the always-on console store so the REPL scrollback survives
+                a remount — e.g. leaving and returning to the Code workspace, which
+                unmounts/remounts this panel (#…). The live onData stream continues
+                seamlessly on top of the seed. */}
+            <Terminal ref={terminalRef} seed={getAll()} />
             {!poppedOut && (
               <button
                 type="button"

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -2362,15 +2362,35 @@ body {
   display: none;
 }
 
-/* Build (#…): a NON-RRP solo layout — the URDF/3-D editor fills the area, with an
-   optional lesson panel (tutorial/help) on the left. Sits where the panel group
-   would, filling the space between the activity bar and (absent) dock. */
+/* The work area holds the always-mounted Code panel group and, for Electronics /
+   Build, the solo overlay stacked on top of it (so the console/editor survive a
+   workspace switch instead of remounting). */
+.shell__main .shell__workarea {
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+}
+.shell__main .shell__workarea > .shell__panels {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+/* Electronics/Build (#…): the solo layout — the Board View / URDF editor fills the
+   area, with an optional lesson panel (tutorial/help) on the left. Rendered as an
+   OPAQUE overlay covering the hidden Code panel group. */
 .shell__main .shell__solo {
   flex: 1 1 auto;
   min-width: 0;
   display: flex;
   min-height: 0;
   height: 100%;
+}
+.shell__main .shell__solo--overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  background: var(--shell, var(--bg));
 }
 .shell__solo-lesson {
   flex: 0 0 auto;


### PR DESCRIPTION
## Console blanking on workspace switch (regression)
Switching to Electronics/Build unmounted the entire Code panel group, so returning to Code **remounted a fresh terminal** — losing its scrollback and its `device:data` subscription. The console went blank and showed no REPL output until the user disconnected/reconnected.

Fix: the Code panel group now stays **mounted for every workspace**; Electronics and Build render as an **opaque overlay** on top of it (the board pane moved out of the group). Verified the xterm is the **same instance** across a Code→Electronics→Build→Code round-trip, and the console keeps its content. Also seed the terminal from the always-on console store on mount as belt-and-braces for other remounts.

## Library open+pinned in Electronics
The parts Library now defaults to **open + pinned** in the Electronics workspace, consistent with the Browser + Build panels.

Verified headless (both): terminal stays mounted; Electronics board + Build robot fill the overlay; library dock open+pinned. lint / typecheck / 2048 tests / build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)