### PR TITLE
feat: footprint authoring + structural board docking (#166)

### DIFF
--- a/examples/parts/snakie-standard/library.yml
+++ b/examples/parts/snakie-standard/library.yml
@@ -3,4 +3,4 @@ name: Standard Parts
 description: The canonical Snakie parts — microcontrollers, sensors, ICs, power and more — kept up to date from github.com/kevinmcaleer/snakie-parts.
 author: Snakie
 homepage: https://github.com/kevinmcaleer/snakie-parts
-version: 1.2.0
+version: 1.3.0

--- a/examples/parts/snakie-standard/seeed-xiao-expansion-base/parts.yml
+++ b/examples/parts/snakie-standard/seeed-xiao-expansion-base/parts.yml
@@ -19,7 +19,7 @@ properties:
   rtc: PCF8563, I²C 0x51, CR1220 backup
   grove: 2x I²C, 1x UART, 1x analog/digital
   storage: microSD (SPI, CS on D2)
-version: 0.1.4
+version: 0.1.7
 pcbColor: "#1b4d3e"
 aspect: 1.365
 dimensions:
@@ -31,92 +31,9 @@ shape:
 headers:
   - edge: left
     pins:
-      - name: D0
-        type: io
-        number: 1
-        capabilities:
-          - digital
-          - adc
-        shape: header
-        rotation: 90
-        x: 0.05967278641824442
-        y: 0.6452254431460087
-        group: grp-4o23l7d
-      - name: D1
-        type: io
-        number: 2
-        capabilities:
-          - digital
-          - adc
-        shape: header
-        rotation: 90
-        x: 0.10363830365962362
-        y: 0.6452254431460087
-        group: grp-4o23l7d
-      - name: D2
-        type: io
-        number: 3
-        capabilities:
-          - digital
-          - adc
-        shape: header
-        rotation: 90
-        x: 0.14760382090100282
-        y: 0.6452254431460087
-        group: grp-4o23l7d
-      - name: D3
-        type: io
-        number: 4
-        capabilities:
-          - digital
-          - pwm
-          - adc
-        shape: header
-        rotation: 90
-        x: 0.19083657952169247
-        y: 0.6452254431460087
-        group: grp-4o23l7d
-      - name: D4
-        type: io
-        number: 5
-        capabilities:
-          - digital
-          - i2c
-        signals:
-          i2c: SDA
-        shape: header
-        rotation: 90
-        x: 0.2348020967630719
-        y: 0.6452254431460087
-        group: grp-4o23l7d
-      - name: D5
-        type: io
-        number: 6
-        capabilities:
-          - digital
-          - i2c
-        signals:
-          i2c: SCL
-        shape: header
-        rotation: 90
-        x: 0.2787676140044511
-        y: 0.6452254431460087
-        group: grp-4o23l7d
-      - name: D6
-        type: io
-        number: 7
-        capabilities:
-          - digital
-          - uart
-        signals:
-          uart: TX
-        shape: header
-        rotation: 90
-        x: 0.32200037262514103
-        y: 0.6452254431460087
-        group: grp-4o23l7d
       - name: TX6
         type: io
+        group: grp-0f21cxf
         gpio: 6
         capabilities:
           - digital
@@ -126,21 +43,21 @@ headers:
         rotation: 0
         x: 0.9369244384765626
         y: 0.4482262103510838
-        group: grp-0f21cxf
       - name: 5v
         type: pwr
+        group: grp-0f21cxf
         rotation: 0
         x: 0.9369244384765626
         y: 0.49764884320427394
-        group: grp-0f21cxf
       - name: GND
         type: gnd
+        group: grp-0f21cxf
         rotation: 180
         x: 0.89090584941294
         y: 0.5543363216624541
-        group: grp-0f21cxf
       - name: RX07
         type: io
+        group: grp-0f21cxf
         gpio: 7
         capabilities:
           - digital
@@ -150,112 +67,253 @@ headers:
         rotation: 0
         x: 0.9369244384765626
         y: 0.3886679825128293
-        group: grp-0f21cxf
       - name: 3v3
         type: pwr
+        group: grp-0f21cxf
         rotation: 180
         x: 0.89090584941294
         y: 0.49764884320427394
-        group: grp-0f21cxf
       - name: GND
         type: gnd
+        group: grp-0f21cxf
         rotation: 0
         x: 0.9369244384765626
         y: 0.5543363216624541
-        group: grp-0f21cxf
       - name: SWDIO
         type: other
+        group: grp-0f21cxf
         rotation: 180
         x: 0.89090584941294
         y: 0.4482262103510838
-        group: grp-0f21cxf
       - name: SWCLK
         type: other
+        group: grp-0f21cxf
         rotation: 180
         x: 0.89090584941294
         y: 0.3886679825128293
-        group: grp-0f21cxf
-  - edge: right
+  - edge: left
     pins:
-      - name: 5V
-        type: pwr
-        number: 8
-        shape: header
-        rotation: 270
-        x: 0.05967278641824442
-        y: 0.306660160900298
-        group: grp-qimzm0l
-      - name: GND
-        type: gnd
-        number: 9
-        shape: header
-        rotation: 270
-        x: 0.10363830365962362
-        y: 0.306660160900298
-        group: grp-qimzm0l
-      - name: 3V3
-        type: pwr
-        number: 10
-        shape: header
-        rotation: 270
-        x: 0.14760382090100282
-        y: 0.306660160900298
-        group: grp-qimzm0l
-      - name: D10
+      - name: D0
         type: io
-        number: 11
+        locked: true
+        number: 1
+        gpio: 26
         capabilities:
           - digital
+          - pwm
+          - adc
+        signals:
+          pwm: A
+        buses:
+          adc: 0
+        shape: round
+        x: 0.07149010029018933
+        y: 0.634778167372771
+        derived: mount-1
+      - name: D1
+        type: io
+        locked: true
+        number: 2
+        gpio: 27
+        capabilities:
+          - digital
+          - pwm
+          - adc
+        signals:
+          pwm: B
+        buses:
+          adc: 1
+        shape: round
+        x: 0.11218116354861002
+        y: 0.634778167372771
+        derived: mount-1
+      - name: D2
+        type: io
+        locked: true
+        number: 3
+        gpio: 28
+        capabilities:
+          - digital
+          - pwm
+          - adc
+        signals:
+          pwm: A
+        buses:
+          adc: 2
+        shape: round
+        x: 0.15182057718646383
+        y: 0.634778167372771
+        derived: mount-1
+      - name: D3
+        type: io
+        locked: true
+        number: 4
+        gpio: 29
+        capabilities:
+          - digital
+          - pwm
+          - adc
+        signals:
+          pwm: B
+        buses:
+          adc: 3
+        shape: round
+        x: 0.191086080209004
+        y: 0.634778167372771
+        derived: mount-1
+      - name: D4
+        type: io
+        locked: true
+        number: 5
+        gpio: 6
+        capabilities:
+          - digital
+          - pwm
+          - i2c
+        signals:
+          i2c: SDA
+          pwm: A
+        buses:
+          i2c: 1
+        shape: round
+        x: 0.23008041628887813
+        y: 0.634778167372771
+        derived: mount-1
+      - name: D5
+        type: io
+        locked: true
+        number: 6
+        gpio: 7
+        capabilities:
+          - digital
+          - pwm
+          - i2c
+        signals:
+          i2c: SCL
+          pwm: B
+        buses:
+          i2c: 1
+        shape: round
+        x: 0.270300359222864
+        y: 0.634778167372771
+        derived: mount-1
+      - name: D6
+        type: io
+        locked: true
+        number: 7
+        gpio: 0
+        capabilities:
+          - digital
+          - pwm
+          - uart
+        signals:
+          uart: TX
+          pwm: A
+        buses:
+          uart: 0
+        shape: round
+        x: 0.30790395740007936
+        y: 0.6347781673727708
+        derived: mount-1
+      - name: 5V
+        type: pwr
+        locked: true
+        number: 8
+        shape: round
+        x: 0.07167496763838632
+        y: 0.3114766864993727
+        derived: mount-1
+      - name: GND
+        type: gnd
+        locked: true
+        number: 9
+        shape: round
+        x: 0.11218116354861002
+        y: 0.3114766864993727
+        derived: mount-1
+      - name: 3V3
+        type: pwr
+        locked: true
+        number: 10
+        shape: round
+        x: 0.15182057718646372
+        y: 0.3114766864993727
+        derived: mount-1
+      - name: D10
+        type: io
+        locked: true
+        number: 11
+        gpio: 3
+        capabilities:
+          - digital
+          - pwm
           - spi
         signals:
           spi: TX
-        shape: header
-        rotation: 270
-        x: 0.19083657952169247
-        y: 0.306660160900298
-        group: grp-qimzm0l
+          pwm: B
+        buses:
+          spi: 0
+        shape: round
+        x: 0.19108608020900394
+        y: 0.3114766864993727
+        derived: mount-1
       - name: D9
         type: io
+        locked: true
         number: 12
+        gpio: 4
         capabilities:
           - digital
           - pwm
           - spi
         signals:
           spi: RX
-        shape: header
-        rotation: 270
-        x: 0.2348020967630719
-        y: 0.306660160900298
-        group: grp-qimzm0l
+          pwm: A
+        buses:
+          spi: 0
+        shape: round
+        x: 0.23008041628887813
+        y: 0.3114766864993727
+        derived: mount-1
       - name: D8
         type: io
+        locked: true
         number: 13
+        gpio: 2
         capabilities:
           - digital
           - pwm
           - spi
         signals:
           spi: SCK
-        shape: header
-        rotation: 270
-        x: 0.2787676140044511
-        y: 0.306660160900298
-        group: grp-qimzm0l
+          pwm: A
+        buses:
+          spi: 0
+        shape: round
+        x: 0.270300359222864
+        y: 0.3114766864993727
+        derived: mount-1
       - name: D7
         type: io
+        locked: true
         number: 14
+        gpio: 1
         capabilities:
           - digital
           - pwm
+          - spi
           - uart
         signals:
+          spi: CSn
           uart: RX
-        shape: header
-        rotation: 270
-        x: 0.32200037262514103
-        y: 0.306660160900298
-        group: grp-qimzm0l
+          pwm: B
+        buses:
+          spi: 0
+          uart: 0
+        shape: round
+        x: 0.30790395740007936
+        y: 0.31147668649937255
+        derived: mount-1
 mountingHoles:
   - x: 0.06976427714029948
     y: 0.10291208304610905
@@ -270,18 +328,18 @@ mountingHoles:
     y: 0.9031413023705576
     diameter: 1.5
 groups:
-  - id: grp-4o23l7d
-    name: bottom row
-  - id: grp-qimzm0l
-    name: top row
   - id: grp-0f21cxf
     name: Edge connector
 mounts:
-  - id: xiao
+  - id: mount-1
     footprint: xiao
-    label: XIAO
-    x: 0.7
-    y: 0.35
+    ref:
+      lib: snakie-standard
+      part: seeed-xiao-rp2350
+    label: Seeed Studio XIAO RP2350
+    x: 0.17445560075618602
+    y: 0.4780852094570392
+    rotation: 270
 image: image.png
 imageLayer:
   x: -0.00024080912272135546

--- a/src/renderer/src/components/FootprintField.tsx
+++ b/src/renderer/src/components/FootprintField.tsx
@@ -1,0 +1,64 @@
+/**
+ * FootprintField (#166) — a footprint picker for the Part Editor. A footprint is
+ * the named compatibility tag that lets a board seat into a carrier (a board's
+ * `footprint` must equal a mount's `footprint`); it's free text on disk, so this
+ * control offers the known footprints as autocomplete to stop typos while still
+ * allowing a brand-new one to be typed. Backed by {@link collectFootprints}.
+ *
+ * Uses the same native `<input list>` + `<datalist>` combobox pattern as the
+ * Part Editor's "Family" field, so it matches the house style with no bespoke
+ * dropdown. The typed value is slugified on commit so `XIAO` / `xiao ` converge.
+ */
+
+import type { JSX } from 'react'
+import { slugifyFootprint, type FootprintInfo } from '../../../shared/footprints'
+
+let uid = 0
+
+export function FootprintField({
+  value,
+  onChange,
+  footprints,
+  label = 'Footprint',
+  placeholder = 'e.g. xiao',
+  hint
+}: {
+  value: string | undefined
+  /** Called with the committed slug, or undefined when cleared. */
+  onChange: (footprint: string | undefined) => void
+  footprints: FootprintInfo[]
+  label?: string
+  placeholder?: string
+  /** Optional helper line under the field. */
+  hint?: string
+}): JSX.Element {
+  // A stable, unique datalist id so multiple fields on one screen don't collide.
+  const listId = `pe-footprints-${(uid = (uid + 1) % 1e6)}`
+  return (
+    <label className="pe__field pe__field--footprint">
+      <span>{label}</span>
+      <input
+        type="text"
+        list={listId}
+        value={value ?? ''}
+        // Keep the raw text while typing (so a space isn't eaten mid-word); the
+        // value is normalised to its slug when the field is committed.
+        onChange={(e) => onChange(e.target.value || undefined)}
+        onBlur={(e) => onChange(slugifyFootprint(e.target.value) || undefined)}
+        placeholder={placeholder}
+        spellCheck={false}
+        autoCapitalize="none"
+        autoCorrect="off"
+      />
+      <datalist id={listId}>
+        {footprints.map((f) => (
+          <option key={f.id} value={f.id}>
+            {f.label}
+            {f.count ? ` — ${f.count} in use` : f.common ? ' — standard' : ''}
+          </option>
+        ))}
+      </datalist>
+      {hint && <small className="pe__hint">{hint}</small>}
+    </label>
+  )
+}

--- a/src/renderer/src/components/PartCanvas.css
+++ b/src/renderer/src/components/PartCanvas.css
@@ -246,6 +246,21 @@
   z-index: 6;
 }
 
+.pcv__ctb-input {
+  width: 8.5rem;
+  height: 1.6rem;
+  padding: 0 0.4rem;
+  color: #eceef1;
+  background: #26282d;
+  border: 1px solid #3a3d44;
+  border-radius: 6px;
+  font-size: 0.78rem;
+}
+.pcv__ctb-input:focus {
+  outline: none;
+  border-color: #565b63;
+}
+
 .pcv__ctb-btn {
   display: inline-flex;
   align-items: center;

--- a/src/renderer/src/components/PartCanvas.tsx
+++ b/src/renderer/src/components/PartCanvas.tsx
@@ -3031,30 +3031,62 @@ export function PartCanvas({
               </text>
               {/* Hover / select the footprint → reveal its pin names, so the board's
                   orientation (which pad is D0 / 5V / GND…) is legible. Labels sit just
-                  outside the block: left-side pads to the left, right-side to the right. */}
+                  outside the block, following its layout: pins in vertical COLUMNS get
+                  labels left/right; pins in horizontal ROWS get them above/below — so a
+                  rotated footprint keeps its labels off the pads, not on top of them. */}
               {(hoverMount === m.id || sel) &&
-                (part.headers ?? [])
-                  .flatMap((h) => h.pins)
-                  .filter((pp) => pp.derived === m.id && pp.x !== undefined && pp.y !== undefined)
-                  .map((pp, pi) => {
-                    const onLeft = px(pp.x!) <= px(m.x)
+                (() => {
+                  const dp = (part.headers ?? [])
+                    .flatMap((h) => h.pins)
+                    .filter((pp) => pp.derived === m.id && pp.x !== undefined && pp.y !== undefined)
+                  // Distinct grid levels per axis IN PIXELS (aspect-correct, so it
+                  // matches what's on screen): more columns than rows ⇒ the block reads
+                  // as horizontal rows. 6px separates adjacent pads without splitting one.
+                  const levels = (vals: number[]): number => {
+                    let n = 0
+                    let prev = -Infinity
+                    for (const v of [...vals].sort((a, b) => a - b)) {
+                      if (v - prev > 6) n++
+                      prev = v
+                    }
+                    return n
+                  }
+                  const horizontal = levels(dp.map((pp) => px(pp.x!))) > levels(dp.map((pp) => py(pp.y!)))
+                  const cxp = px(m.x)
+                  const cyp = py(m.y)
+                  return dp.map((pp, pi) => {
+                    const gx = px(pp.x!)
+                    const gy = py(pp.y!)
+                    const common = {
+                      fontSize: 9,
+                      fontWeight: 700,
+                      fill: '#0b3a22',
+                      stroke: '#ffffff',
+                      strokeWidth: 2.4,
+                      style: { paintOrder: 'stroke' as const }
+                    }
+                    if (horizontal) {
+                      const above = gy <= cyp
+                      return (
+                        <text key={`ml${i}-${pi}`} {...common} x={gx} y={gy + (above ? -7 : 14)} textAnchor="middle">
+                          {pp.name}
+                        </text>
+                      )
+                    }
+                    const onLeft = gx <= cxp
                     return (
                       <text
                         key={`ml${i}-${pi}`}
-                        x={px(pp.x!) + (onLeft ? -7 : 7)}
-                        y={py(pp.y!) + 3}
+                        {...common}
+                        x={gx + (onLeft ? -7 : 7)}
+                        y={gy + 3}
                         textAnchor={onLeft ? 'end' : 'start'}
-                        fontSize={9}
-                        fontWeight={700}
-                        fill="#0b3a22"
-                        stroke="#ffffff"
-                        strokeWidth={2.4}
-                        style={{ paintOrder: 'stroke' }}
                       >
                         {pp.name}
                       </text>
                     )
-                  })}
+                  })
+                })()}
             </g>
           )
         })}

--- a/src/renderer/src/components/PartCanvas.tsx
+++ b/src/renderer/src/components/PartCanvas.tsx
@@ -422,6 +422,9 @@ export function PartCanvas({
   const [textMenuOpen, setTextMenuOpen] = useState(false)
   // The selected mounting hole's size (diameter) dropdown.
   const [holeMenuOpen, setHoleMenuOpen] = useState(false)
+  // Which footprint block the pointer is hovering (#166) — reveals its pin labels so
+  // the user can read the board's orientation (which pad is D0 / 5V / GND…).
+  const [hoverMount, setHoverMount] = useState<string | null>(null)
   // Per-type "style clipboard" (copy style / paste style). State (not a ref) so a
   // copy re-renders the toolbars and enables their "Paste style" button. Persists
   // across selections + part switches within a session.
@@ -2348,7 +2351,22 @@ export function PartCanvas({
 
   const onPointerMove = (e: ReactPointerEvent<SVGSVGElement>): void => {
     const d = dragRef.current
-    if (!d || !interactive) return
+    if (!d || !interactive) {
+      // No drag → track which footprint block the pointer is over, to show its labels.
+      if (interactive && mounts.length && visible.mounts) {
+        const { nx, ny } = toNorm(e)
+        let hit: string | null = null
+        for (let i = mounts.length - 1; i >= 0; i--) {
+          const bb = mountBoxN(mounts[i].id)
+          if (bb && nx >= bb.x0 && nx <= bb.x1 && ny >= bb.y0 && ny <= bb.y1) {
+            hit = mounts[i].id
+            break
+          }
+        }
+        if (hit !== hoverMount) setHoverMount(hit)
+      } else if (hoverMount) setHoverMount(null)
+      return
+    }
     if (d.kind === 'pan') {
       const s = viewBoxScale()
       setView((v) => ({ ...v, tx: (d.panTX ?? 0) + (e.clientX - (d.panX ?? 0)) / s, ty: (d.panTY ?? 0) + (e.clientY - (d.panY ?? 0)) / s }))
@@ -2909,6 +2927,7 @@ export function PartCanvas({
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}
       onPointerCancel={onPointerUp}
+      onPointerLeave={() => hoverMount && setHoverMount(null)}
       onDoubleClick={onDoubleClick}
       onWheel={onWheel}
     >
@@ -3010,6 +3029,32 @@ export function PartCanvas({
               >
                 {m.label || m.footprint || m.id}
               </text>
+              {/* Hover / select the footprint → reveal its pin names, so the board's
+                  orientation (which pad is D0 / 5V / GND…) is legible. Labels sit just
+                  outside the block: left-side pads to the left, right-side to the right. */}
+              {(hoverMount === m.id || sel) &&
+                (part.headers ?? [])
+                  .flatMap((h) => h.pins)
+                  .filter((pp) => pp.derived === m.id && pp.x !== undefined && pp.y !== undefined)
+                  .map((pp, pi) => {
+                    const onLeft = px(pp.x!) <= px(m.x)
+                    return (
+                      <text
+                        key={`ml${i}-${pi}`}
+                        x={px(pp.x!) + (onLeft ? -7 : 7)}
+                        y={py(pp.y!) + 3}
+                        textAnchor={onLeft ? 'end' : 'start'}
+                        fontSize={9}
+                        fontWeight={700}
+                        fill="#0b3a22"
+                        stroke="#ffffff"
+                        strokeWidth={2.4}
+                        style={{ paintOrder: 'stroke' }}
+                      >
+                        {pp.name}
+                      </text>
+                    )
+                  })}
             </g>
           )
         })}

--- a/src/renderer/src/components/PartCanvas.tsx
+++ b/src/renderer/src/components/PartCanvas.tsx
@@ -99,6 +99,7 @@ export type CanvasTool =
   | 'pin'
   | 'servo-header'
   | 'hole'
+  | 'mount'
   | 'button'
   | 'text'
   | 'rect'
@@ -129,6 +130,7 @@ export const DEFAULT_LOCKS: LayerLocks = { pcb: false, image: false, holes: fals
 export type CanvasSelection =
   | { type: 'pin'; hi: number; pi: number }
   | { type: 'hole'; index: number }
+  | { type: 'mount'; index: number }
   | { type: 'button'; index: number }
   | { type: 'led'; index: number }
   | { type: 'connector'; index: number }
@@ -421,6 +423,7 @@ export function PartCanvas({
   const box = fitBox(boardAspect(part))
   const pins = resolvedPins(part)
   const holes = part.mountingHoles ?? []
+  const mounts = part.mounts ?? []
   const buttons = part.buttons ?? []
   const onboardLeds = part.onboardLeds ?? []
   const connectors = part.connectors ?? []
@@ -592,6 +595,12 @@ export function PartCanvas({
     // The reverse invariant: a hole can't be dragged onto a pin.
     if (onPin(sx, sy, holeR(holes[index]?.diameter ?? 2.5))) return
     commit({ ...part, mountingHoles: holes.map((h, i) => (i === index ? { ...h, x: sx, y: sy } : h)) })
+  }
+  /** Move a carrier mount (#166) — a seating socket, may sit anywhere on the board. */
+  const moveMountTo = (index: number, nx: number, ny: number, presnapped = false): void => {
+    const sx = presnapped ? nx : snapX(nx)
+    const sy = presnapped ? ny : snapY(ny)
+    commit({ ...part, mounts: mounts.map((m, i) => (i === index ? { ...m, x: sx, y: sy } : m)) })
   }
   /** Move an on-board button (#130) — buttons may sit anywhere, incl. over pins. */
   const moveButtonTo = (index: number, nx: number, ny: number, presnapped = false): void => {
@@ -1838,6 +1847,19 @@ export function PartCanvas({
     onSelect?.({ type: 'hole', index: next.length - 1 })
   }
 
+  /** Add a carrier mount (#166) at the clicked point — a socket a board seats in.
+   *  The footprint it accepts starts blank; the inspector's picker sets it. */
+  const addMount = (nx: number, ny: number): void => {
+    const used = new Set(mounts.map((m) => m.id))
+    let n = mounts.length + 1
+    let id = `mount-${n}`
+    while (used.has(id)) id = `mount-${++n}`
+    const next = [...mounts, { id, footprint: '', x: snapX(nx), y: snapY(ny), label: `M${n}` }]
+    commit({ ...part, mounts: next })
+    onSelect?.({ type: 'mount', index: next.length - 1 })
+    onNotify?.('Pick a footprint for this mount so a board can seat in it.')
+  }
+
   /** Add an on-board push-button at the clicked point (#130). */
   const addButton = (nx: number, ny: number): void => {
     const next = [...buttons, { label: 'BTN', x: snapX(nx), y: snapY(ny) }]
@@ -2005,6 +2027,9 @@ export function PartCanvas({
     if (visible.holes && !locked.holes)
       for (let i = holes.length - 1; i >= 0; i--)
         if (pickable(holes[i]) && dist(nx, ny, holes[i].x, holes[i].y) < HIT) return { type: 'hole', index: i }
+    // Carrier mounts (#166) — a bigger grab radius since the socket marker is large.
+    for (let i = mounts.length - 1; i >= 0; i--)
+      if (dist(nx, ny, mounts[i].x, mounts[i].y) < HIT * 1.6) return { type: 'mount', index: i }
     if (visible.image && !locked.image && part.imageData && nx >= layer.x && nx <= layer.x + layer.w && ny >= layer.y && ny <= layer.y + layer.h)
       return { type: 'image' }
     return null
@@ -2042,6 +2067,7 @@ export function PartCanvas({
       return
     }
     if (tool === 'hole') return locked.holes ? undefined : addHole(nx, ny)
+    if (tool === 'mount') return addMount(nx, ny)
     if (tool === 'button') return locked.components ? undefined : addButton(nx, ny)
     if (tool === 'rect') return locked.components ? undefined : addShape('rect', nx, ny)
     if (tool === 'circle') return locked.components ? undefined : addShape('circle', nx, ny)
@@ -2254,6 +2280,9 @@ export function PartCanvas({
     } else if (hit.type === 'hole') {
       ox = holes[hit.index]?.x ?? nx
       oy = holes[hit.index]?.y ?? ny
+    } else if (hit.type === 'mount') {
+      ox = mounts[hit.index]?.x ?? nx
+      oy = mounts[hit.index]?.y ?? ny
     } else if (hit.type === 'button') {
       ox = buttons[hit.index]?.x ?? nx
       oy = buttons[hit.index]?.y ?? ny
@@ -2466,6 +2495,7 @@ export function PartCanvas({
         if (s.type === 'pin' && d.groupOffsets) moveGroupTo(d.groupOffsets, lx, ly)
         else if (s.type === 'pin') movePinTo(s.hi, s.pi, lx, ly, undefined, true)
         else if (s.type === 'hole') moveHoleTo(s.index, lx, ly, true)
+        else if (s.type === 'mount') moveMountTo(s.index, lx, ly, true)
         else if (s.type === 'button') moveButtonTo(s.index, lx, ly, true)
         else if (s.type === 'led') moveLedTo(s.index, lx, ly)
         else if (s.type === 'connector') moveConnectorTo(s.index, lx, ly)
@@ -2495,6 +2525,8 @@ export function PartCanvas({
         const a = alignDrag(x, y, 'hole', { index: d.sel.index }, noSnap)
         setGuides(a.gx !== undefined || a.gy !== undefined ? { x: a.gx, y: a.gy } : null)
         moveHoleTo(d.sel.index, a.x, a.y, true)
+      } else if (d.sel.type === 'mount') {
+        moveMountTo(d.sel.index, x, y, noSnap)
       } else if (d.sel.type === 'button') {
         const a = alignDrag(x, y, 'button', { index: d.sel.index }, noSnap)
         setGuides(a.gx !== undefined || a.gy !== undefined ? { x: a.gx, y: a.gy } : null)
@@ -2902,6 +2934,47 @@ export function PartCanvas({
               <circle key={`h${i}`} cx={px(h.x)} cy={py(h.y)} r={holeR(h.diameter)} fill="none" stroke="#fff" strokeWidth={3} />
             ) : null
           )}
+
+        {/* Carrier mounts (#166): a socket a board plugs into, drawn as a dashed
+            green square with its label/footprint. Selected → solid, tinted fill. */}
+        {mounts.map((m, i) => {
+          const cx = px(m.x)
+          const cy = py(m.y)
+          const half = Math.max(16, Math.min(box.w, box.h) * 0.16)
+          const sel = isSel({ type: 'mount', index: i })
+          return (
+            <g key={`mnt${i}`} style={{ pointerEvents: 'none' }}>
+              <rect
+                x={cx - half}
+                y={cy - half}
+                width={half * 2}
+                height={half * 2}
+                rx={half * 0.18}
+                fill={sel ? '#3ec46d' : 'none'}
+                fillOpacity={sel ? 0.16 : 0}
+                stroke="#3ec46d"
+                strokeWidth={sel ? 3 : 1.75}
+                strokeDasharray={sel ? undefined : '7 5'}
+                opacity={sel ? 0.98 : 0.6}
+              />
+              <line x1={cx - half * 0.4} y1={cy} x2={cx + half * 0.4} y2={cy} stroke="#3ec46d" strokeWidth={1.5} opacity={0.7} />
+              <line x1={cx} y1={cy - half * 0.4} x2={cx} y2={cy + half * 0.4} stroke="#3ec46d" strokeWidth={1.5} opacity={0.7} />
+              <text
+                x={cx}
+                y={cy - half - 6}
+                textAnchor="middle"
+                fontSize={12}
+                fontWeight={700}
+                fill="#146c3f"
+                stroke="#ffffff"
+                strokeWidth={3.5}
+                style={{ paintOrder: 'stroke' }}
+              >
+                {m.label || m.footprint || m.id}
+              </text>
+            </g>
+          )
+        })}
 
         {/* Layer 3: pins (square / round / castellated / header) */}
         {visible.pins &&

--- a/src/renderer/src/components/PartCanvas.tsx
+++ b/src/renderer/src/components/PartCanvas.tsx
@@ -117,15 +117,31 @@ export interface LayerVisibility {
   holes: boolean
   pins: boolean
   components: boolean
+  /** Carrier footprint blocks (#166). */
+  mounts: boolean
 }
 
-export const DEFAULT_LAYERS: LayerVisibility = { pcb: true, image: true, holes: true, pins: true, components: true }
+export const DEFAULT_LAYERS: LayerVisibility = {
+  pcb: true,
+  image: true,
+  holes: true,
+  pins: true,
+  components: true,
+  mounts: true
+}
 
 /** Per-layer edit lock (same keys as {@link LayerVisibility}). A locked layer is
  *  still drawn, but its items can't be selected, moved, resized, or created — so
  *  you can't accidentally nudge the background PCB while wiring pins. */
 export type LayerLocks = LayerVisibility
-export const DEFAULT_LOCKS: LayerLocks = { pcb: false, image: false, holes: false, pins: false, components: false }
+export const DEFAULT_LOCKS: LayerLocks = {
+  pcb: false,
+  image: false,
+  holes: false,
+  pins: false,
+  components: false,
+  mounts: false
+}
 
 /** What is currently selected (drives the editor's contextual inspector). */
 export type CanvasSelection =
@@ -2036,6 +2052,7 @@ export function PartCanvas({
         if (pickable(holes[i]) && dist(nx, ny, holes[i].x, holes[i].y) < HIT) return { type: 'hole', index: i }
     // Carrier mounts (#166) — grab anywhere inside the footprint block (its pins are
     // locked, so they fall through to here), else a radius around a pin-less mount.
+    if (visible.mounts && !locked.mounts)
     for (let i = mounts.length - 1; i >= 0; i--) {
       const bb = mountBoxN(mounts[i].id)
       if (bb) {
@@ -2951,7 +2968,8 @@ export function PartCanvas({
         {/* Carrier mounts (#166): the footprint BLOCK — a dashed-green outline around
             its imprinted pins (which draw as normal locked pins below) + its label.
             Selected → solid, tinted fill. A pin-less mount falls back to a marker. */}
-        {mounts.map((m, i) => {
+        {visible.mounts &&
+          mounts.map((m, i) => {
           const bb = mountBoxN(m.id)
           const sel = isSel({ type: 'mount', index: i })
           const x0 = bb ? px(bb.x0) : px(m.x) - 20

--- a/src/renderer/src/components/PartCanvas.tsx
+++ b/src/renderer/src/components/PartCanvas.tsx
@@ -36,6 +36,7 @@ import {
   type StyleTarget
 } from './part-editor.util'
 import { itemHidden, itemLocked } from '../../../shared/part'
+import { translateMount } from '../../../shared/footprint-imprint'
 import type {
   ComponentShape,
   ComponentShapeKind,
@@ -596,11 +597,30 @@ export function PartCanvas({
     if (onPin(sx, sy, holeR(holes[index]?.diameter ?? 2.5))) return
     commit({ ...part, mountingHoles: holes.map((h, i) => (i === index ? { ...h, x: sx, y: sy } : h)) })
   }
-  /** Move a carrier mount (#166) — a seating socket, may sit anywhere on the board. */
+  /** A mount's footprint-block box in NORMALISED coords — the bounding box of its
+   *  imprinted (derived) pins, padded. Null when it has no imprinted pins yet. */
+  const mountBoxN = (mountId: string): { x0: number; y0: number; x1: number; y1: number } | null => {
+    const xs: number[] = []
+    const ys: number[] = []
+    for (const h of part.headers ?? [])
+      for (const p of h.pins)
+        if (p.derived === mountId && p.x !== undefined && p.y !== undefined) {
+          xs.push(p.x)
+          ys.push(p.y)
+        }
+    if (!xs.length) return null
+    const pad = 0.025
+    return { x0: Math.min(...xs) - pad, y0: Math.min(...ys) - pad, x1: Math.max(...xs) + pad, y1: Math.max(...ys) + pad }
+  }
+
+  /** Move a carrier mount (#166) — its footprint block + all its imprinted pins
+   *  shift rigidly, so dragging the block keeps the pins under it. */
   const moveMountTo = (index: number, nx: number, ny: number, presnapped = false): void => {
+    const m = mounts[index]
+    if (!m) return
     const sx = presnapped ? nx : snapX(nx)
     const sy = presnapped ? ny : snapY(ny)
-    commit({ ...part, mounts: mounts.map((m, i) => (i === index ? { ...m, x: sx, y: sy } : m)) })
+    commit(translateMount(part, m.id, sx - m.x, sy - m.y))
   }
   /** Move an on-board button (#130) — buttons may sit anywhere, incl. over pins. */
   const moveButtonTo = (index: number, nx: number, ny: number, presnapped = false): void => {
@@ -1847,19 +1867,6 @@ export function PartCanvas({
     onSelect?.({ type: 'hole', index: next.length - 1 })
   }
 
-  /** Add a carrier mount (#166) at the clicked point — a socket a board seats in.
-   *  The footprint it accepts starts blank; the inspector's picker sets it. */
-  const addMount = (nx: number, ny: number): void => {
-    const used = new Set(mounts.map((m) => m.id))
-    let n = mounts.length + 1
-    let id = `mount-${n}`
-    while (used.has(id)) id = `mount-${++n}`
-    const next = [...mounts, { id, footprint: '', x: snapX(nx), y: snapY(ny), label: `M${n}` }]
-    commit({ ...part, mounts: next })
-    onSelect?.({ type: 'mount', index: next.length - 1 })
-    onNotify?.('Pick a footprint for this mount so a board can seat in it.')
-  }
-
   /** Add an on-board push-button at the clicked point (#130). */
   const addButton = (nx: number, ny: number): void => {
     const next = [...buttons, { label: 'BTN', x: snapX(nx), y: snapY(ny) }]
@@ -2027,9 +2034,16 @@ export function PartCanvas({
     if (visible.holes && !locked.holes)
       for (let i = holes.length - 1; i >= 0; i--)
         if (pickable(holes[i]) && dist(nx, ny, holes[i].x, holes[i].y) < HIT) return { type: 'hole', index: i }
-    // Carrier mounts (#166) — a bigger grab radius since the socket marker is large.
-    for (let i = mounts.length - 1; i >= 0; i--)
-      if (dist(nx, ny, mounts[i].x, mounts[i].y) < HIT * 1.6) return { type: 'mount', index: i }
+    // Carrier mounts (#166) — grab anywhere inside the footprint block (its pins are
+    // locked, so they fall through to here), else a radius around a pin-less mount.
+    for (let i = mounts.length - 1; i >= 0; i--) {
+      const bb = mountBoxN(mounts[i].id)
+      if (bb) {
+        if (nx >= bb.x0 && nx <= bb.x1 && ny >= bb.y0 && ny <= bb.y1) return { type: 'mount', index: i }
+      } else if (dist(nx, ny, mounts[i].x, mounts[i].y) < HIT * 1.6) {
+        return { type: 'mount', index: i }
+      }
+    }
     if (visible.image && !locked.image && part.imageData && nx >= layer.x && nx <= layer.x + layer.w && ny >= layer.y && ny <= layer.y + layer.h)
       return { type: 'image' }
     return null
@@ -2067,7 +2081,6 @@ export function PartCanvas({
       return
     }
     if (tool === 'hole') return locked.holes ? undefined : addHole(nx, ny)
-    if (tool === 'mount') return addMount(nx, ny)
     if (tool === 'button') return locked.components ? undefined : addButton(nx, ny)
     if (tool === 'rect') return locked.components ? undefined : addShape('rect', nx, ny)
     if (tool === 'circle') return locked.components ? undefined : addShape('circle', nx, ny)
@@ -2935,33 +2948,34 @@ export function PartCanvas({
             ) : null
           )}
 
-        {/* Carrier mounts (#166): a socket a board plugs into, drawn as a dashed
-            green square with its label/footprint. Selected → solid, tinted fill. */}
+        {/* Carrier mounts (#166): the footprint BLOCK — a dashed-green outline around
+            its imprinted pins (which draw as normal locked pins below) + its label.
+            Selected → solid, tinted fill. A pin-less mount falls back to a marker. */}
         {mounts.map((m, i) => {
-          const cx = px(m.x)
-          const cy = py(m.y)
-          const half = Math.max(16, Math.min(box.w, box.h) * 0.16)
+          const bb = mountBoxN(m.id)
           const sel = isSel({ type: 'mount', index: i })
+          const x0 = bb ? px(bb.x0) : px(m.x) - 20
+          const y0 = bb ? py(bb.y0) : py(m.y) - 20
+          const x1 = bb ? px(bb.x1) : px(m.x) + 20
+          const y1 = bb ? py(bb.y1) : py(m.y) + 20
           return (
             <g key={`mnt${i}`} style={{ pointerEvents: 'none' }}>
               <rect
-                x={cx - half}
-                y={cy - half}
-                width={half * 2}
-                height={half * 2}
-                rx={half * 0.18}
+                x={x0}
+                y={y0}
+                width={x1 - x0}
+                height={y1 - y0}
+                rx={8}
                 fill={sel ? '#3ec46d' : 'none'}
-                fillOpacity={sel ? 0.16 : 0}
+                fillOpacity={sel ? 0.1 : 0}
                 stroke="#3ec46d"
-                strokeWidth={sel ? 3 : 1.75}
+                strokeWidth={sel ? 2.5 : 1.5}
                 strokeDasharray={sel ? undefined : '7 5'}
-                opacity={sel ? 0.98 : 0.6}
+                opacity={sel ? 0.95 : 0.6}
               />
-              <line x1={cx - half * 0.4} y1={cy} x2={cx + half * 0.4} y2={cy} stroke="#3ec46d" strokeWidth={1.5} opacity={0.7} />
-              <line x1={cx} y1={cy - half * 0.4} x2={cx} y2={cy + half * 0.4} stroke="#3ec46d" strokeWidth={1.5} opacity={0.7} />
               <text
-                x={cx}
-                y={cy - half - 6}
+                x={(x0 + x1) / 2}
+                y={y0 - 6}
                 textAnchor="middle"
                 fontSize={12}
                 fontWeight={700}

--- a/src/renderer/src/components/PartCanvas.tsx
+++ b/src/renderer/src/components/PartCanvas.tsx
@@ -36,7 +36,7 @@ import {
   type StyleTarget
 } from './part-editor.util'
 import { itemHidden, itemLocked } from '../../../shared/part'
-import { translateMount } from '../../../shared/footprint-imprint'
+import { translateMount, rotateMount, removeMountImprint } from '../../../shared/footprint-imprint'
 import type {
   ComponentShape,
   ComponentShapeKind,
@@ -1797,6 +1797,12 @@ export function PartCanvas({
       if (!c) return null
       const { h } = connectorSize(c, connPxPerMm)
       return { nx: c.x, ny: c.y - h / 2 / box.h }
+    }
+    if (sel?.type === 'mount') {
+      const m = mounts[sel.index]
+      if (!m) return null
+      const bb = mountBoxN(m.id)
+      return bb ? { nx: (bb.x0 + bb.x1) / 2, ny: bb.y0 } : { nx: m.x, ny: m.y }
     }
     return null
   }
@@ -4033,6 +4039,54 @@ export function PartCanvas({
                 {rotateIcon}
               </button>
               <button type="button" className="pcv__ctb-btn pcv__ctb-btn--danger" title="Delete" aria-label="Delete connector" onClick={() => deleteComponent(sel)}>
+                {delIcon}
+              </button>
+            </div>
+          )
+        })()}
+      {/* Footprint toolbar — rename + rotate + delete for a selected carrier mount (#166). */}
+      {interactive &&
+        !locked.mounts &&
+        alignCount === 0 &&
+        selection?.type === 'mount' &&
+        (() => {
+          const sel = selection
+          const m = mounts[sel.index]
+          if (!m) return null
+          const anchor = componentAnchorPx(sel)
+          const style = anchor
+            ? { left: `${anchor.left}px`, top: `${anchor.top}px`, transform: 'translate(-50%, calc(-100% - 14px))' }
+            : undefined
+          return (
+            <div className="pcv__ctb" role="toolbar" aria-label="Edit footprint" style={style}>
+              <input
+                className="pcv__ctb-input"
+                type="text"
+                value={m.label ?? ''}
+                placeholder="Label"
+                aria-label="Footprint label"
+                onChange={(e) =>
+                  commit({
+                    ...part,
+                    mounts: mounts.map((mm, i) =>
+                      i === sel.index ? { ...mm, label: e.target.value || undefined } : mm
+                    )
+                  })
+                }
+              />
+              <button type="button" className="pcv__ctb-btn" title="Rotate 90°" aria-label="Rotate footprint 90 degrees" onClick={() => commit(rotateMount(part, m.id, 90))}>
+                {rotateIcon}
+              </button>
+              <button
+                type="button"
+                className="pcv__ctb-btn pcv__ctb-btn--danger"
+                title="Delete"
+                aria-label="Delete footprint"
+                onClick={() => {
+                  commit(removeMountImprint(part, m.id))
+                  onSelect?.(null)
+                }}
+              >
                 {delIcon}
               </button>
             </div>

--- a/src/renderer/src/components/PartEditor.css
+++ b/src/renderer/src/components/PartEditor.css
@@ -268,9 +268,45 @@
   color: var(--text);
   cursor: pointer;
 }
-.pe__mounts-add:hover {
+.pe__mounts-add:hover:not(:disabled) {
   border-color: var(--accent, #3ec46d);
   color: var(--accent, #3ec46d);
+}
+.pe__mounts-add:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+/* The reference-board dropdown — fixed so the inspector's overflow can't crop it,
+   and scrollable when the list is long (#166). */
+.pe__mounts-menu {
+  position: fixed;
+  z-index: 1000;
+  margin: 0;
+  padding: 4px;
+  list-style: none;
+  max-height: min(50vh, 320px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  background: var(--panel, var(--card, #fff));
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.28);
+}
+.pe__mounts-menu-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 0.35rem 0.55rem;
+  border: 0;
+  border-radius: 5px;
+  background: none;
+  color: var(--text);
+  font-size: 0.8rem;
+  white-space: nowrap;
+  cursor: pointer;
+}
+.pe__mounts-menu-item:hover {
+  background: color-mix(in srgb, var(--accent, #3ec46d) 16%, transparent);
 }
 .pe__mounts-list {
   list-style: none;

--- a/src/renderer/src/components/PartEditor.css
+++ b/src/renderer/src/components/PartEditor.css
@@ -303,6 +303,8 @@
   color: var(--text);
   font-size: 0.8rem;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   cursor: pointer;
 }
 .pe__mounts-menu-item:hover {

--- a/src/renderer/src/components/PartEditor.css
+++ b/src/renderer/src/components/PartEditor.css
@@ -244,6 +244,95 @@
   border-radius: 3px;
 }
 
+/* --- Carrier mounts list (#166) --- */
+.pe__mounts {
+  margin-top: 0.6rem;
+}
+.pe__mounts-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.pe__mounts-add {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.1rem 0.45rem;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--bg-sunken);
+  color: var(--text);
+  cursor: pointer;
+}
+.pe__mounts-add:hover {
+  border-color: var(--accent, #3ec46d);
+  color: var(--accent, #3ec46d);
+}
+.pe__mounts-list {
+  list-style: none;
+  margin: 0.35rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.pe__mounts-list li {
+  display: flex;
+  align-items: stretch;
+  gap: 0.25rem;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  overflow: hidden;
+  background: var(--bg-sunken);
+}
+.pe__mounts-list li.is-sel {
+  border-color: var(--accent, #3ec46d);
+  box-shadow: 0 0 0 1px var(--accent, #3ec46d) inset;
+}
+.pe__mounts-row {
+  flex: 1;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.3rem 0.5rem;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  color: var(--text);
+  text-align: left;
+}
+.pe__mounts-name {
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+.pe__mounts-fp {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--accent, #3ec46d);
+}
+.pe__mounts-fp.is-empty {
+  color: var(--danger, #c0392b);
+  font-style: italic;
+}
+.pe__mounts-remove {
+  border: 0;
+  border-left: 1px solid var(--border);
+  background: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 0 0.5rem;
+  font-size: 0.8rem;
+}
+.pe__mounts-remove:hover {
+  color: var(--danger, #c0392b);
+  background: color-mix(in srgb, var(--danger, #c0392b) 12%, transparent);
+}
+
 /* --- Fields --- */
 .pe__field {
   display: flex;

--- a/src/renderer/src/components/PartEditor.tsx
+++ b/src/renderer/src/components/PartEditor.tsx
@@ -5,6 +5,12 @@ import { SwatchPicker } from './SwatchPicker'
 import { FootprintField } from './FootprintField'
 import { collectFootprints, type FootprintInfo } from '../../../shared/footprints'
 import {
+  applyImprint,
+  removeMountImprint,
+  translateMount,
+  type MountPlacement
+} from '../../../shared/footprint-imprint'
+import {
   PartCanvas,
   DEFAULT_LAYERS,
   DEFAULT_LOCKS,
@@ -69,6 +75,7 @@ import type {
   PartItemFlags,
   PartDefinition,
   PartElectrical,
+  PartLibraryWithParts,
   PartMount,
   PartHeader,
   PartLabel,
@@ -853,21 +860,74 @@ export function PartEditor({
     setPropRows(Object.entries(part.properties ?? {}))
   }, [part])
 
-  // Known footprints across the installed libraries (#166) — the vocabulary the
-  // Footprint + mount pickers offer, so seating tags stay consistent instead of
-  // being retyped (and mis-typed) per board. Loaded once; the curated standards
-  // are always present even if listing fails.
-  const [footprints, setFootprints] = useState<FootprintInfo[]>(() => collectFootprints([]))
+  // The installed libraries WITH parts (#166) — the vocabulary the Footprint field
+  // offers and the reference boards a carrier mount imprints its pins from.
+  const [partLibs, setPartLibs] = useState<PartLibraryWithParts[]>([])
   useEffect(() => {
     let live = true
     window.api.parts
       .listLibraries()
-      .then((libs) => live && setFootprints(collectFootprints(libs)))
+      .then((libs) => live && setPartLibs(libs))
       .catch(() => undefined)
     return () => {
       live = false
     }
   }, [])
+  const footprints = useMemo(() => collectFootprints(partLibs), [partLibs])
+  /** Boards that can be imprinted as a footprint — those with positioned pins. */
+  const referenceBoards = useMemo<ReferenceBoard[]>(
+    () =>
+      partLibs.flatMap((l) =>
+        l.parts
+          .filter((p) => (p.headers ?? []).some((h) => h.pins.some((pin) => pin.x !== undefined)))
+          .map((p) => ({ lib: l.id, part: p }))
+      ),
+    [partLibs]
+  )
+  const resolveRefPart = (lib: string, partId: string): PartDefinition | null =>
+    partLibs.find((l) => l.id === lib)?.parts.find((p) => p.id === partId) ?? null
+
+  // Footprint imprint operations (#166 phase 2): add stamps a reference board's real
+  // pins into the carrier; rotate/re-sync recompute them; remove strips them.
+  const addFootprint = (lib: string, ref: PartDefinition): void => {
+    const used = new Set((part.mounts ?? []).map((m) => m.id))
+    let n = (part.mounts?.length ?? 0) + 1
+    let id = `mount-${n}`
+    while (used.has(id)) id = `mount-${++n}`
+    const nextIndex = part.mounts?.length ?? 0
+    setPart((d) => applyImprint(d, ref, { lib, part: ref.id ?? '' }, { id, x: 0.5, y: 0.5, label: ref.name }))
+    setSelection({ type: 'mount', index: nextIndex })
+  }
+  const reimprint = (mountId: string, patchPlacement: Partial<MountPlacement>): void =>
+    setPart((d) => {
+      const m = (d.mounts ?? []).find((x) => x.id === mountId)
+      if (!m?.ref) return d
+      const ref = resolveRefPart(m.ref.lib, m.ref.part)
+      if (!ref) return d
+      return applyImprint(d, ref, m.ref, {
+        id: mountId,
+        x: m.x,
+        y: m.y,
+        rotation: m.rotation,
+        label: m.label,
+        footprint: m.footprint,
+        ...patchPlacement
+      })
+    })
+  const removeFootprint = (mountId: string): void => setPart((d) => removeMountImprint(d, mountId))
+  const moveFootprint = (mountId: string, x: number, y: number): void =>
+    setPart((d) => {
+      const m = (d.mounts ?? []).find((mm) => mm.id === mountId)
+      return m ? translateMount(d, mountId, x - m.x, y - m.y) : d
+    })
+  const footprintOps: FootprintOps = {
+    referenceBoards,
+    resolveRefPart,
+    addFootprint,
+    reimprint,
+    removeFootprint,
+    moveFootprint
+  }
 
   // Delete / Backspace removes the selected object; Ctrl/Cmd+Z undoes and
   // Ctrl/Cmd+Shift+Z (or Ctrl+Y) redoes — but never while typing in a field, so
@@ -1067,9 +1127,6 @@ export function PartEditor({
                 <button type="button" className={`pe__iconbtn${tool === 'hole' ? ' is-active' : ''}`} onClick={() => setTool('hole')} title="Add a mounting hole" aria-label="Mounting hole">
                   {ICON.hole}
                 </button>
-                <button type="button" className={`pe__iconbtn${tool === 'mount' ? ' is-active' : ''}`} onClick={() => setTool('mount')} title="Add a carrier mount (a socket a board seats into)" aria-label="Carrier mount">
-                  {ICON.mount}
-                </button>
                 <button type="button" className={`pe__iconbtn${tool === 'button' ? ' is-active' : ''}`} onClick={() => setTool('button')} title="Add a push-button" aria-label="Push-button">
                   {ICON.button}
                 </button>
@@ -1155,6 +1212,7 @@ export function PartEditor({
                 deleteSelection={deleteSelection}
                 footprints={footprints}
                 onSelect={setSelection}
+                footprintOps={footprintOps}
               />
               {/* Board structure (mounting holes + PCB + image) sits BELOW the
                   selected-item details, so pin editing stays near the top. */}
@@ -2040,6 +2098,26 @@ function LayersPanel({
   )
 }
 
+// --- Footprint imprint plumbing (#166 phase 2) ------------------------------
+
+/** A board that can be imprinted as a carrier footprint (it has positioned pins). */
+interface ReferenceBoard {
+  lib: string
+  part: PartDefinition
+}
+
+/** Footprint operations threaded to the mounts UI (add/rotate/re-sync/remove). */
+interface FootprintOps {
+  referenceBoards: ReferenceBoard[]
+  resolveRefPart: (lib: string, part: string) => PartDefinition | null
+  addFootprint: (lib: string, ref: PartDefinition) => void
+  /** Re-imprint a mount with a placement patch (rotation change, or a fresh re-sync). */
+  reimprint: (mountId: string, patch: Partial<MountPlacement>) => void
+  removeFootprint: (mountId: string) => void
+  /** Move a mount + its imprinted pins to an absolute normalised centre. */
+  moveFootprint: (mountId: string, x: number, y: number) => void
+}
+
 // --- Breadboard inspector ---------------------------------------------------
 
 interface InspectorProps {
@@ -2062,43 +2140,53 @@ interface InspectorProps {
   deleteSelection: () => void
   footprints: FootprintInfo[]
   onSelect: (sel: CanvasSelection) => void
+  footprintOps: FootprintOps
 }
 
-/** The carrier-mounts list in the Board section (#166): add/select/remove the
- *  sockets a board seats in. Selecting a row opens it in the Inspector above. */
+/** The carrier-mounts list in the Board section (#166): add a footprint by picking
+ *  a reference board (its real pins get imprinted), select/remove existing ones.
+ *  Selecting a row opens it in the Inspector above. */
 function MountsList({
   part,
-  patch,
   selection,
-  onSelect
+  onSelect,
+  ops
 }: {
   part: PartDefinition
-  patch: (p: Partial<PartDefinition>) => void
   selection: CanvasSelection
   onSelect: (sel: CanvasSelection) => void
+  ops: FootprintOps
 }): JSX.Element {
   const mounts = part.mounts ?? []
-  const addMount = (): void => {
-    const used = new Set(mounts.map((m) => m.id))
-    let n = mounts.length + 1
-    let id = `mount-${n}`
-    while (used.has(id)) id = `mount-${++n}`
-    const next = [...mounts, { id, footprint: '', x: 0.5, y: 0.5, label: `M${n}` }]
-    patch({ mounts: next })
-    onSelect({ type: 'mount', index: next.length - 1 })
+  const onPick = (e: React.ChangeEvent<HTMLSelectElement>): void => {
+    const board = ops.referenceBoards.find((b) => `${b.lib}/${b.part.id}` === e.target.value)
+    if (board) ops.addFootprint(board.lib, board.part)
+    e.target.value = '' // reset so the same board can be added again
   }
   return (
     <div className="pe__mounts">
       <div className="pe__mounts-head">
-        <span>Mounts</span>
-        <button type="button" className="pe__mounts-add" onClick={addMount} title="Add a carrier mount">
-          + Add
-        </button>
+        <span>Footprints (mounts)</span>
+        <select
+          className="pe__mounts-add"
+          value=""
+          onChange={onPick}
+          disabled={!ops.referenceBoards.length}
+          title="Imprint a reference board's pins as a mount"
+          aria-label="Add a footprint from a reference board"
+        >
+          <option value="">+ Add footprint…</option>
+          {ops.referenceBoards.map((b) => (
+            <option key={`${b.lib}/${b.part.id}`} value={`${b.lib}/${b.part.id}`}>
+              {b.part.name || b.part.id}
+            </option>
+          ))}
+        </select>
       </div>
       {mounts.length === 0 ? (
         <p className="pe__hint pe__hint--muted">
-          A carrier (e.g. a XIAO expansion base) has a mount for each board it seats. Add one here or with the
-          mount tool, then set the footprint it accepts.
+          A carrier (e.g. a XIAO expansion base) seats a board at each footprint. Pick a reference board above to
+          stamp its real pins into this part as a movable, locked block.
         </p>
       ) : (
         <ul className="pe__mounts-list">
@@ -2116,9 +2204,9 @@ function MountsList({
               <button
                 type="button"
                 className="pe__mounts-remove"
-                title="Remove mount"
-                aria-label="Remove mount"
-                onClick={() => patch({ mounts: mounts.filter((_, j) => j !== i) })}
+                title="Remove footprint"
+                aria-label="Remove footprint"
+                onClick={() => ops.removeFootprint(m.id)}
               >
                 ✕
               </button>
@@ -2206,7 +2294,7 @@ function Inspector(props: InspectorProps): JSX.Element {
           footprints={props.footprints}
           hint="Boards sharing a footprint plug into the same carriers (e.g. a XIAO base)."
         />
-        <MountsList part={part} patch={patch} selection={props.selection} onSelect={props.onSelect} />
+        <MountsList part={part} selection={props.selection} onSelect={props.onSelect} ops={props.footprintOps} />
       </section>
 
       {/* Electrical behaviour — what the netlist / ERC / DC solver read (#597) */}
@@ -2556,7 +2644,7 @@ function SelectionInspector({
   lockImageAspect,
   onToggleLockAspect,
   deleteSelection,
-  footprints
+  footprintOps
 }: InspectorProps): JSX.Element {
   if (!selection) {
     return (
@@ -2815,9 +2903,14 @@ function SelectionInspector({
   } else if (selection.type === 'mount') {
     const mount = (part.mounts ?? [])[selection.index]
     if (mount) {
-      title = 'Carrier mount'
+      title = 'Footprint mount'
       const upd = (p: Partial<PartMount>): void =>
         patch({ mounts: (part.mounts ?? []).map((m, i) => (i === selection.index ? { ...m, ...p } : m)) })
+      const ref = mount.ref ? footprintOps.resolveRefPart(mount.ref.lib, mount.ref.part) : null
+      const pinCount = (part.headers ?? []).reduce(
+        (n, h) => n + h.pins.filter((p) => p.derived === mount.id).length,
+        0
+      )
       body = (
         <>
           <label className="pe__field">
@@ -2829,24 +2922,38 @@ function SelectionInspector({
               placeholder="e.g. XIAO"
             />
           </label>
-          <FootprintField
-            value={mount.footprint || undefined}
-            onChange={(fp) => upd({ footprint: fp ?? '' })}
-            footprints={footprints}
-            label="Accepts footprint"
-            hint="The board footprint this socket seats — must match the board's Footprint."
-          />
-          {!mount.footprint && (
-            <p className="pe__hint">Pick a footprint so a board can seat here (a mount with none is not saved).</p>
+          <div className="pe__field">
+            <span>Source board</span>
+            <div className="pe__mounts-src">
+              <span className="pe__mounts-srcname">{ref?.name ?? mount.ref?.part ?? '— none —'}</span>
+              {mount.ref && (
+                <button
+                  type="button"
+                  className="pe__mounts-add"
+                  disabled={!ref}
+                  onClick={() => footprintOps.reimprint(mount.id, {})}
+                  title="Re-copy the pins from the source board"
+                >
+                  Re-sync
+                </button>
+              )}
+            </div>
+          </div>
+          {mount.ref && !ref && (
+            <p className="pe__hint">Source board not installed — its pins can’t be re-synced.</p>
           )}
+          <p className="pe__hint">
+            Footprint <code>{mount.footprint || '—'}</code> · {pinCount} pins · read-only (edit the source board to
+            change them).
+          </p>
           <div className="pe__row">
-            {num('x', mount.x, (v) => upd({ x: v }))}
-            {num('y', mount.y, (v) => upd({ y: v }))}
+            {num('x', mount.x, (v) => footprintOps.moveFootprint(mount.id, v, mount.y))}
+            {num('y', mount.y, (v) => footprintOps.moveFootprint(mount.id, mount.x, v))}
             <label className="pe__num">
               <span>Rotation</span>
               <select
                 value={mount.rotation ?? 0}
-                onChange={(e) => upd({ rotation: Number(e.target.value) || undefined })}
+                onChange={(e) => footprintOps.reimprint(mount.id, { rotation: Number(e.target.value) || undefined })}
               >
                 <option value={0}>0°</option>
                 <option value={90}>90°</option>

--- a/src/renderer/src/components/PartEditor.tsx
+++ b/src/renderer/src/components/PartEditor.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type CSSProperties, type JSX } from 'react'
+import { createPortal } from 'react-dom'
 import { useHistory } from './use-history'
 import { PartSchematicView } from './PartSchematicView'
 import { SwatchPicker } from './SwatchPicker'
@@ -2143,6 +2144,109 @@ interface InspectorProps {
   footprintOps: FootprintOps
 }
 
+/** "Add footprint…" dropdown (#166): a scrollable, fixed-positioned menu of
+ *  reference boards. Fixed positioning escapes the inspector's `overflow: auto`
+ *  (a native <select>'s list would be cropped), and it scrolls when the list is
+ *  long. Picking a board imprints its pins. */
+function AddFootprintMenu({
+  boards,
+  onAdd
+}: {
+  boards: ReferenceBoard[]
+  onAdd: (lib: string, ref: PartDefinition) => void
+}): JSX.Element {
+  const [open, setOpen] = useState(false)
+  const [pos, setPos] = useState<{ left: number; top: number; width: number; maxH: number }>({
+    left: 0,
+    top: 0,
+    width: 220,
+    maxH: 320
+  })
+  const btnRef = useRef<HTMLButtonElement>(null)
+  const menuRef = useRef<HTMLUListElement>(null)
+  useEffect(() => {
+    if (!open) return
+    const onDoc = (e: MouseEvent): void => {
+      const t = e.target as Node
+      if (btnRef.current?.contains(t) || menuRef.current?.contains(t)) return
+      setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    const onScroll = (): void => setOpen(false)
+    document.addEventListener('mousedown', onDoc)
+    document.addEventListener('keydown', onKey)
+    window.addEventListener('scroll', onScroll, true)
+    return () => {
+      document.removeEventListener('mousedown', onDoc)
+      document.removeEventListener('keydown', onKey)
+      window.removeEventListener('scroll', onScroll, true)
+    }
+  }, [open])
+  const toggle = (): void => {
+    const r = btnRef.current?.getBoundingClientRect()
+    if (r) {
+      const margin = 8
+      const spaceBelow = window.innerHeight - r.bottom - margin
+      const spaceAbove = r.top - margin
+      // Flip up when there isn't room below and there's more above; size to fit so
+      // it never runs off the viewport (and scrolls within whatever space it gets).
+      const openUp = spaceBelow < 180 && spaceAbove > spaceBelow
+      const maxH = Math.min(320, Math.max(120, openUp ? spaceAbove : spaceBelow))
+      const top = openUp ? r.top - 4 - maxH : r.bottom + 4
+      // Clamp horizontally so a right-aligned trigger doesn't push the menu off-screen.
+      const width = Math.max(r.width, 240)
+      const left = Math.max(margin, Math.min(r.left, window.innerWidth - width - margin))
+      setPos({ left, top: Math.max(margin, top), width, maxH })
+    }
+    setOpen((o) => !o)
+  }
+  return (
+    <>
+      <button
+        ref={btnRef}
+        type="button"
+        className="pe__mounts-add"
+        onClick={toggle}
+        disabled={!boards.length}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        title="Imprint a reference board's pins as a mount"
+      >
+        + Add footprint…
+      </button>
+      {open &&
+        createPortal(
+          <ul
+            ref={menuRef}
+            className="pe__mounts-menu"
+            role="listbox"
+            style={{ left: pos.left, top: pos.top, minWidth: pos.width, maxHeight: pos.maxH }}
+          >
+            {boards.map((b) => (
+              <li key={`${b.lib}/${b.part.id}`}>
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={false}
+                  className="pe__mounts-menu-item"
+                  onClick={() => {
+                    onAdd(b.lib, b.part)
+                    setOpen(false)
+                  }}
+                >
+                  {b.part.name || b.part.id}
+                </button>
+              </li>
+            ))}
+          </ul>,
+          document.body
+        )}
+    </>
+  )
+}
+
 /** The carrier-mounts list in the Board section (#166): add a footprint by picking
  *  a reference board (its real pins get imprinted), select/remove existing ones.
  *  Selecting a row opens it in the Inspector above. */
@@ -2158,30 +2262,11 @@ function MountsList({
   ops: FootprintOps
 }): JSX.Element {
   const mounts = part.mounts ?? []
-  const onPick = (e: React.ChangeEvent<HTMLSelectElement>): void => {
-    const board = ops.referenceBoards.find((b) => `${b.lib}/${b.part.id}` === e.target.value)
-    if (board) ops.addFootprint(board.lib, board.part)
-    e.target.value = '' // reset so the same board can be added again
-  }
   return (
     <div className="pe__mounts">
       <div className="pe__mounts-head">
         <span>Footprints (mounts)</span>
-        <select
-          className="pe__mounts-add"
-          value=""
-          onChange={onPick}
-          disabled={!ops.referenceBoards.length}
-          title="Imprint a reference board's pins as a mount"
-          aria-label="Add a footprint from a reference board"
-        >
-          <option value="">+ Add footprint…</option>
-          {ops.referenceBoards.map((b) => (
-            <option key={`${b.lib}/${b.part.id}`} value={`${b.lib}/${b.part.id}`}>
-              {b.part.name || b.part.id}
-            </option>
-          ))}
-        </select>
+        <AddFootprintMenu boards={ops.referenceBoards} onAdd={ops.addFootprint} />
       </div>
       {mounts.length === 0 ? (
         <p className="pe__hint pe__hint--muted">

--- a/src/renderer/src/components/PartEditor.tsx
+++ b/src/renderer/src/components/PartEditor.tsx
@@ -765,7 +765,8 @@ export function PartEditor({
     } else if (sel.type === 'hole') {
       patch({ mountingHoles: (part.mountingHoles ?? []).filter((_, i) => i !== sel.index) })
     } else if (sel.type === 'mount') {
-      patch({ mounts: (part.mounts ?? []).filter((_, i) => i !== sel.index) })
+      const m = (part.mounts ?? [])[sel.index]
+      if (m) setPart((d) => removeMountImprint(d, m.id))
     } else if (sel.type === 'button') {
       patch({ buttons: (part.buttons ?? []).filter((_, i) => i !== sel.index) })
     } else if (sel.type === 'led') {
@@ -1181,6 +1182,7 @@ export function PartEditor({
                 setTool={setTool}
                 selection={selection}
                 setSelection={selectFromPanel}
+                footprintOps={footprintOps}
                 onSelectGroup={selectGroup}
                 onDeleteSelected={deleteSelection}
                 fileInputRef={fileInputRef}
@@ -1290,6 +1292,8 @@ interface LayersPanelProps {
   /** Which sections to show: 'layers' = Components + Pins; 'board' = Mounting holes
    *  + PCB + Image. Lets the board layers sit BELOW the selection inspector. */
   variant?: 'layers' | 'board'
+  /** Footprint imprint ops — enables the Footprints bucket's "+ Add" picker (#166). */
+  footprintOps?: FootprintOps
 }
 
 /**
@@ -1318,7 +1322,8 @@ function LayersPanel({
   canResetBg,
   bgTol,
   setBgTol,
-  variant = 'layers'
+  variant = 'layers',
+  footprintOps
 }: LayersPanelProps): JSX.Element {
   const [addOpen, setAddOpen] = useState(false)
   const [bgMenuOpen, setBgMenuOpen] = useState(false)
@@ -1657,6 +1662,35 @@ function LayersPanel({
     )
   }
 
+  /** A footprint (carrier mount) row in the hierarchy (#166) — select it to edit
+   *  its source board / placement in the inspector; trash removes it + its pins. */
+  const mountRowHier = (index: number, depth: number): JSX.Element => {
+    const m = (part.mounts ?? [])[index]
+    return (
+      <li
+        key={`mount${index}`}
+        className={`pe__flatrow pe__flatrow--mount${selEq({ type: 'mount', index }) ? ' is-active' : ''}`}
+        style={depth ? { paddingLeft: `${0.4 + depth * 0.7}rem` } : undefined}
+      >
+        <button type="button" className="pe__flatname" onClick={() => setSelection({ type: 'mount', index })}>
+          <span className="pe__item-name">{m?.label || m?.footprint || `Footprint ${index + 1}`}</span>
+        </button>
+        <span className="pe__flathelp">{m?.footprint}</span>
+        {m && footprintOps && (
+          <button
+            type="button"
+            className="pe__trash"
+            onClick={() => footprintOps.removeFootprint(m.id)}
+            title="Remove footprint"
+            aria-label="Remove footprint"
+          >
+            <TrashIcon size={13} />
+          </button>
+        )}
+      </li>
+    )
+  }
+
   /** Whether ANY group exists — drag-reorder of the flat component list is only
    *  offered when there are none, exactly as before the merge (reordering a
    *  subset of the z-stack while groups nest is not well defined). */
@@ -1785,6 +1819,14 @@ function LayersPanel({
               ＋
             </button>
           )}
+          {node.bucket === 'mounts' && footprintOps && (
+            <AddFootprintMenu
+              boards={footprintOps.referenceBoards}
+              onAdd={footprintOps.addFootprint}
+              buttonClassName="pe__chip pe__chip--add"
+              label="＋ Add"
+            />
+          )}
           {isPins && (
             <>
               <button
@@ -1810,8 +1852,10 @@ function LayersPanel({
               ? selection?.type === 'pin'
               : node.bucket === 'holes'
                 ? selection?.type === 'hole'
-                : selection != null &&
-                  ['shape', 'shape-vertex', 'label', 'button', 'led', 'connector'].includes(selection.type)
+                : node.bucket === 'mounts'
+                  ? selection?.type === 'mount'
+                  : selection != null &&
+                    ['shape', 'shape-vertex', 'label', 'button', 'led', 'connector'].includes(selection.type)
           )}
         </div>
         {open && isPins && kids.length > 1 && (() => {
@@ -1878,12 +1922,12 @@ function LayersPanel({
    *  create the first pin or hole. */
   const panelNodes: LayerNode[] = [
     ...layerTree.filter((n) => n.kind === 'group'),
-    ...(['components', 'pins', 'holes'] as const).map(
+    ...(['components', 'pins', 'holes', 'mounts'] as const).map(
       (b): LayerNode =>
         layerTree.find((n) => n.bucket === b) ?? {
           id: `bucket:${b}`,
           kind: 'bucket',
-          label: b === 'components' ? 'Components' : b === 'pins' ? 'Pins' : 'Mounting holes',
+          label: b === 'components' ? 'Components' : b === 'pins' ? 'Pins' : b === 'holes' ? 'Mounting holes' : 'Footprints',
           bucket: b,
           children: [],
           hidden: false,
@@ -1945,6 +1989,7 @@ function LayersPanel({
       return rp ? pinRowHier(rp, depth) : <li key={node.id} />
     }
     if (it.kind === 'hole') return holeRowHier(it.index, depth)
+    if (it.kind === 'mount') return mountRowHier(it.index, depth)
     return itemRowTree({ kind: it.kind, index: it.index, z: 0 }, depth)
   }
 
@@ -2150,10 +2195,14 @@ interface InspectorProps {
  *  long. Picking a board imprints its pins. */
 function AddFootprintMenu({
   boards,
-  onAdd
+  onAdd,
+  buttonClassName = 'pe__mounts-add',
+  label = '+ Add footprint…'
 }: {
   boards: ReferenceBoard[]
   onAdd: (lib: string, ref: PartDefinition) => void
+  buttonClassName?: string
+  label?: string
 }): JSX.Element {
   const [open, setOpen] = useState(false)
   const [pos, setPos] = useState<{ left: number; top: number; width: number; maxH: number }>({
@@ -2207,14 +2256,14 @@ function AddFootprintMenu({
       <button
         ref={btnRef}
         type="button"
-        className="pe__mounts-add"
+        className={buttonClassName}
         onClick={toggle}
         disabled={!boards.length}
         aria-haspopup="listbox"
         aria-expanded={open}
-        title="Imprint a reference board's pins as a mount"
+        title="Imprint a reference board's pins as a footprint mount"
       >
-        + Add footprint…
+        {label}
       </button>
       {open &&
         createPortal(
@@ -2244,62 +2293,6 @@ function AddFootprintMenu({
           document.body
         )}
     </>
-  )
-}
-
-/** The carrier-mounts list in the Board section (#166): add a footprint by picking
- *  a reference board (its real pins get imprinted), select/remove existing ones.
- *  Selecting a row opens it in the Inspector above. */
-function MountsList({
-  part,
-  selection,
-  onSelect,
-  ops
-}: {
-  part: PartDefinition
-  selection: CanvasSelection
-  onSelect: (sel: CanvasSelection) => void
-  ops: FootprintOps
-}): JSX.Element {
-  const mounts = part.mounts ?? []
-  return (
-    <div className="pe__mounts">
-      <div className="pe__mounts-head">
-        <span>Footprints (mounts)</span>
-        <AddFootprintMenu boards={ops.referenceBoards} onAdd={ops.addFootprint} />
-      </div>
-      {mounts.length === 0 ? (
-        <p className="pe__hint pe__hint--muted">
-          A carrier (e.g. a XIAO expansion base) seats a board at each footprint. Pick a reference board above to
-          stamp its real pins into this part as a movable, locked block.
-        </p>
-      ) : (
-        <ul className="pe__mounts-list">
-          {mounts.map((m, i) => (
-            <li
-              key={m.id}
-              className={selection?.type === 'mount' && selection.index === i ? 'is-sel' : undefined}
-            >
-              <button type="button" className="pe__mounts-row" onClick={() => onSelect({ type: 'mount', index: i })}>
-                <span className="pe__mounts-name">{m.label || m.id}</span>
-                <span className={`pe__mounts-fp${m.footprint ? '' : ' is-empty'}`}>
-                  {m.footprint || 'no footprint'}
-                </span>
-              </button>
-              <button
-                type="button"
-                className="pe__mounts-remove"
-                title="Remove footprint"
-                aria-label="Remove footprint"
-                onClick={() => ops.removeFootprint(m.id)}
-              >
-                ✕
-              </button>
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
   )
 }
 
@@ -2379,7 +2372,6 @@ function Inspector(props: InspectorProps): JSX.Element {
           footprints={props.footprints}
           hint="Boards sharing a footprint plug into the same carriers (e.g. a XIAO base)."
         />
-        <MountsList part={part} selection={props.selection} onSelect={props.onSelect} ops={props.footprintOps} />
       </section>
 
       {/* Electrical behaviour — what the netlist / ERC / DC solver read (#597) */}

--- a/src/renderer/src/components/PartEditor.tsx
+++ b/src/renderer/src/components/PartEditor.tsx
@@ -2244,9 +2244,11 @@ function AddFootprintMenu({
       const openUp = spaceBelow < 180 && spaceAbove > spaceBelow
       const maxH = Math.min(320, Math.max(120, openUp ? spaceAbove : spaceBelow))
       const top = openUp ? r.top - 4 - maxH : r.bottom + 4
-      // Clamp horizontally so a right-aligned trigger doesn't push the menu off-screen.
-      const width = Math.max(r.width, 240)
-      const left = Math.max(margin, Math.min(r.left, window.innerWidth - width - margin))
+      // FIXED width so the clamp is exact — a min-width menu grows to its longest
+      // item and then its right edge (and scrollbar) fall off-screen. Long names
+      // ellipsis instead. Right-align to the trigger, then clamp into the viewport.
+      const width = Math.min(280, window.innerWidth - 2 * margin)
+      const left = Math.max(margin, Math.min(r.right - width, window.innerWidth - width - margin))
       setPos({ left, top: Math.max(margin, top), width, maxH })
     }
     setOpen((o) => !o)
@@ -2271,7 +2273,7 @@ function AddFootprintMenu({
             ref={menuRef}
             className="pe__mounts-menu"
             role="listbox"
-            style={{ left: pos.left, top: pos.top, minWidth: pos.width, maxHeight: pos.maxH }}
+            style={{ left: pos.left, top: pos.top, width: pos.width, maxHeight: pos.maxH }}
           >
             {boards.map((b) => (
               <li key={`${b.lib}/${b.part.id}`}>

--- a/src/renderer/src/components/PartEditor.tsx
+++ b/src/renderer/src/components/PartEditor.tsx
@@ -2223,7 +2223,14 @@ function AddFootprintMenu({
     const onKey = (e: KeyboardEvent): void => {
       if (e.key === 'Escape') setOpen(false)
     }
-    const onScroll = (): void => setOpen(false)
+    // Close when something ELSE scrolls (e.g. the inspector panel, which would
+    // detach this fixed menu) — but NOT when the menu scrolls its own list, or
+    // dragging its scrollbar / wheeling it would dismiss it.
+    const onScroll = (e: Event): void => {
+      const t = e.target as Node | null
+      if (t && menuRef.current && (t === menuRef.current || menuRef.current.contains(t))) return
+      setOpen(false)
+    }
     document.addEventListener('mousedown', onDoc)
     document.addEventListener('keydown', onKey)
     window.addEventListener('scroll', onScroll, true)

--- a/src/renderer/src/components/PartEditor.tsx
+++ b/src/renderer/src/components/PartEditor.tsx
@@ -2,6 +2,8 @@ import { useEffect, useMemo, useRef, useState, type CSSProperties, type JSX } fr
 import { useHistory } from './use-history'
 import { PartSchematicView } from './PartSchematicView'
 import { SwatchPicker } from './SwatchPicker'
+import { FootprintField } from './FootprintField'
+import { collectFootprints, type FootprintInfo } from '../../../shared/footprints'
 import {
   PartCanvas,
   DEFAULT_LAYERS,
@@ -67,6 +69,7 @@ import type {
   PartItemFlags,
   PartDefinition,
   PartElectrical,
+  PartMount,
   PartHeader,
   PartLabel,
   PartLibrary,
@@ -286,6 +289,14 @@ const ICON: Record<string, JSX.Element> = {
       <g fill="none" stroke="currentColor" strokeWidth="1.4">
         <rect x="2.5" y="2.5" width="11" height="11" rx="2" />
         <circle cx="8" cy="8" r="3" />
+      </g>
+    </svg>
+  ),
+  mount: (
+    <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true">
+      <g fill="none" stroke="currentColor" strokeWidth="1.3">
+        <rect x="1.8" y="1.8" width="12.4" height="12.4" rx="2" strokeDasharray="2.4 1.8" />
+        <rect x="5" y="5" width="6" height="6" rx="1" />
       </g>
     </svg>
   ),
@@ -745,6 +756,8 @@ export function PartEditor({
       }))
     } else if (sel.type === 'hole') {
       patch({ mountingHoles: (part.mountingHoles ?? []).filter((_, i) => i !== sel.index) })
+    } else if (sel.type === 'mount') {
+      patch({ mounts: (part.mounts ?? []).filter((_, i) => i !== sel.index) })
     } else if (sel.type === 'button') {
       patch({ buttons: (part.buttons ?? []).filter((_, i) => i !== sel.index) })
     } else if (sel.type === 'led') {
@@ -839,6 +852,22 @@ export function PartEditor({
     resyncPropsRef.current = false
     setPropRows(Object.entries(part.properties ?? {}))
   }, [part])
+
+  // Known footprints across the installed libraries (#166) — the vocabulary the
+  // Footprint + mount pickers offer, so seating tags stay consistent instead of
+  // being retyped (and mis-typed) per board. Loaded once; the curated standards
+  // are always present even if listing fails.
+  const [footprints, setFootprints] = useState<FootprintInfo[]>(() => collectFootprints([]))
+  useEffect(() => {
+    let live = true
+    window.api.parts
+      .listLibraries()
+      .then((libs) => live && setFootprints(collectFootprints(libs)))
+      .catch(() => undefined)
+    return () => {
+      live = false
+    }
+  }, [])
 
   // Delete / Backspace removes the selected object; Ctrl/Cmd+Z undoes and
   // Ctrl/Cmd+Shift+Z (or Ctrl+Y) redoes — but never while typing in a field, so
@@ -1038,6 +1067,9 @@ export function PartEditor({
                 <button type="button" className={`pe__iconbtn${tool === 'hole' ? ' is-active' : ''}`} onClick={() => setTool('hole')} title="Add a mounting hole" aria-label="Mounting hole">
                   {ICON.hole}
                 </button>
+                <button type="button" className={`pe__iconbtn${tool === 'mount' ? ' is-active' : ''}`} onClick={() => setTool('mount')} title="Add a carrier mount (a socket a board seats into)" aria-label="Carrier mount">
+                  {ICON.mount}
+                </button>
                 <button type="button" className={`pe__iconbtn${tool === 'button' ? ' is-active' : ''}`} onClick={() => setTool('button')} title="Add a push-button" aria-label="Push-button">
                   {ICON.button}
                 </button>
@@ -1121,6 +1153,8 @@ export function PartEditor({
                 patch={patch}
                 setPart={setPart}
                 deleteSelection={deleteSelection}
+                footprints={footprints}
+                onSelect={setSelection}
               />
               {/* Board structure (mounting holes + PCB + image) sits BELOW the
                   selected-item details, so pin editing stays near the top. */}
@@ -2026,6 +2060,74 @@ interface InspectorProps {
   patch: (p: Partial<PartDefinition>) => void
   setPart: React.Dispatch<React.SetStateAction<PartDefinition>>
   deleteSelection: () => void
+  footprints: FootprintInfo[]
+  onSelect: (sel: CanvasSelection) => void
+}
+
+/** The carrier-mounts list in the Board section (#166): add/select/remove the
+ *  sockets a board seats in. Selecting a row opens it in the Inspector above. */
+function MountsList({
+  part,
+  patch,
+  selection,
+  onSelect
+}: {
+  part: PartDefinition
+  patch: (p: Partial<PartDefinition>) => void
+  selection: CanvasSelection
+  onSelect: (sel: CanvasSelection) => void
+}): JSX.Element {
+  const mounts = part.mounts ?? []
+  const addMount = (): void => {
+    const used = new Set(mounts.map((m) => m.id))
+    let n = mounts.length + 1
+    let id = `mount-${n}`
+    while (used.has(id)) id = `mount-${++n}`
+    const next = [...mounts, { id, footprint: '', x: 0.5, y: 0.5, label: `M${n}` }]
+    patch({ mounts: next })
+    onSelect({ type: 'mount', index: next.length - 1 })
+  }
+  return (
+    <div className="pe__mounts">
+      <div className="pe__mounts-head">
+        <span>Mounts</span>
+        <button type="button" className="pe__mounts-add" onClick={addMount} title="Add a carrier mount">
+          + Add
+        </button>
+      </div>
+      {mounts.length === 0 ? (
+        <p className="pe__hint pe__hint--muted">
+          A carrier (e.g. a XIAO expansion base) has a mount for each board it seats. Add one here or with the
+          mount tool, then set the footprint it accepts.
+        </p>
+      ) : (
+        <ul className="pe__mounts-list">
+          {mounts.map((m, i) => (
+            <li
+              key={m.id}
+              className={selection?.type === 'mount' && selection.index === i ? 'is-sel' : undefined}
+            >
+              <button type="button" className="pe__mounts-row" onClick={() => onSelect({ type: 'mount', index: i })}>
+                <span className="pe__mounts-name">{m.label || m.id}</span>
+                <span className={`pe__mounts-fp${m.footprint ? '' : ' is-empty'}`}>
+                  {m.footprint || 'no footprint'}
+                </span>
+              </button>
+              <button
+                type="button"
+                className="pe__mounts-remove"
+                title="Remove mount"
+                aria-label="Remove mount"
+                onClick={() => patch({ mounts: mounts.filter((_, j) => j !== i) })}
+              >
+                ✕
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
 }
 
 function Inspector(props: InspectorProps): JSX.Element {
@@ -2096,6 +2198,15 @@ function Inspector(props: InspectorProps): JSX.Element {
             ))}
           </select>
         </label>
+        {/* The seating footprint (#166): a board with a footprint plugs into any
+            carrier mount that accepts the same footprint. */}
+        <FootprintField
+          value={part.footprint}
+          onChange={(fp) => patch({ footprint: fp })}
+          footprints={props.footprints}
+          hint="Boards sharing a footprint plug into the same carriers (e.g. a XIAO base)."
+        />
+        <MountsList part={part} patch={patch} selection={props.selection} onSelect={props.onSelect} />
       </section>
 
       {/* Electrical behaviour — what the netlist / ERC / DC solver read (#597) */}
@@ -2444,7 +2555,8 @@ function SelectionInspector({
   setImageLayer,
   lockImageAspect,
   onToggleLockAspect,
-  deleteSelection
+  deleteSelection,
+  footprints
 }: InspectorProps): JSX.Element {
   if (!selection) {
     return (
@@ -2698,6 +2810,52 @@ function SelectionInspector({
           {num('y', hole.y, (v) => upd({ y: v }))}
           {num('⌀mm', hole.diameter, (v) => upd({ diameter: v }), 0.1)}
         </div>
+      )
+    }
+  } else if (selection.type === 'mount') {
+    const mount = (part.mounts ?? [])[selection.index]
+    if (mount) {
+      title = 'Carrier mount'
+      const upd = (p: Partial<PartMount>): void =>
+        patch({ mounts: (part.mounts ?? []).map((m, i) => (i === selection.index ? { ...m, ...p } : m)) })
+      body = (
+        <>
+          <label className="pe__field">
+            <span>Label</span>
+            <input
+              type="text"
+              value={mount.label ?? ''}
+              onChange={(e) => upd({ label: e.target.value || undefined })}
+              placeholder="e.g. XIAO"
+            />
+          </label>
+          <FootprintField
+            value={mount.footprint || undefined}
+            onChange={(fp) => upd({ footprint: fp ?? '' })}
+            footprints={footprints}
+            label="Accepts footprint"
+            hint="The board footprint this socket seats — must match the board's Footprint."
+          />
+          {!mount.footprint && (
+            <p className="pe__hint">Pick a footprint so a board can seat here (a mount with none is not saved).</p>
+          )}
+          <div className="pe__row">
+            {num('x', mount.x, (v) => upd({ x: v }))}
+            {num('y', mount.y, (v) => upd({ y: v }))}
+            <label className="pe__num">
+              <span>Rotation</span>
+              <select
+                value={mount.rotation ?? 0}
+                onChange={(e) => upd({ rotation: Number(e.target.value) || undefined })}
+              >
+                <option value={0}>0°</option>
+                <option value={90}>90°</option>
+                <option value={180}>180°</option>
+                <option value={270}>270°</option>
+              </select>
+            </label>
+          </div>
+        </>
       )
     }
   } else if (selection.type === 'button') {

--- a/src/renderer/src/components/WiringCanvas.tsx
+++ b/src/renderer/src/components/WiringCanvas.tsx
@@ -957,7 +957,18 @@ export function WiringCanvas({ robot, onChange, joints = [], jointLimits = {}, l
   // at its mount on the carrier — so carriers must be laid out FIRST. Keep each
   // part's ORIGINAL index so the default scatter positions don't shift. One level
   // of nesting is all that's supported (a carrier can't itself be seated).
-  const placedBody = new Map<string, { x: number; y: number; w: number; h: number }>()
+  // Each placed carrier records its AABB (x/y/w/h) AND its un-rotated body (bw/bh),
+  // subject origin (px/py) and rotation, so a point given in the carrier's own
+  // un-rotated frame (a mount centre, an imprinted pin) can be transformed through
+  // the carrier's rotation — the footprint then follows the carrier when it turns.
+  type PlacedBody = { x: number; y: number; w: number; h: number; rot: 0 | 90 | 180 | 270; bw: number; bh: number; px: number; py: number }
+  const placedBody = new Map<string, PlacedBody>()
+  /** Canvas position of a normalised point in a carrier's UN-rotated frame. */
+  const carrierPoint = (body: PlacedBody, nx: number, ny: number): { x: number; y: number } => {
+    if (!body.rot) return { x: body.x + nx * body.w, y: body.y + ny * body.h }
+    const r = rotatePoint(nx * body.bw, ny * body.bh, body.bw / 2, body.bh / 2, body.rot)
+    return { x: body.px + r.x, y: body.py + r.y }
+  }
   const orderedParts = robot.parts
     .map((rp, i) => ({ rp, i }))
     .sort((a, b) => (a.rp.mountedOn ? 1 : 0) - (b.rp.mountedOn ? 1 : 0))
@@ -971,7 +982,7 @@ export function WiringCanvas({ robot, onChange, joints = [], jointLimits = {}, l
     if (!carrier || !body) return null
     const mount = resolvePart(carrier.lib, carrier.part)?.mounts?.find((m) => m.id === rp.mount)
     if (!mount) return null
-    return { x: body.x + mount.x * body.w, y: body.y + mount.y * body.h }
+    return carrierPoint(body, mount.x, mount.y)
   }
   orderedParts.forEach(({ rp, i }) => {
     const def = resolvePart(rp.lib, rp.part)
@@ -1024,7 +1035,7 @@ export function WiringCanvas({ robot, onChange, joints = [], jointLimits = {}, l
       const seat = seatCentre(rp)
       const px = seat ? seat.x - (aabb.x + aabb.w / 2) : x
       const py = seat ? seat.y - (aabb.y + aabb.h / 2) : y
-      placedBody.set(rp.id, { x: px + aabb.x, y: py + aabb.y, w: aabb.w, h: aabb.h })
+      placedBody.set(rp.id, { x: px + aabb.x, y: py + aabb.y, w: aabb.w, h: aabb.h, rot, bw, bh, px, py })
       subjects.push({
         key: rp.id,
         kind: 'part',
@@ -1085,7 +1096,9 @@ export function WiringCanvas({ robot, onChange, joints = [], jointLimits = {}, l
       // Rotate the board to match the footprint (#166) so its pads overlay the
       // imprinted pins — a footprint placed at 270° seats the board turned 270°,
       // not sitting square over a rotated socket. Mirrors how a placed part rotates.
-      const R = normRot(mount.rotation)
+      // Add the CARRIER's own rotation so the footprint (and the board) turn WITH the
+      // carrier when it's rotated in the workspace.
+      const R = normRot((mount.rotation ?? 0) + (carrier.rotation ?? 0))
       if (R && bs.box) {
         const bw0 = bs.box.w
         const bh0 = bs.box.h
@@ -1111,10 +1124,10 @@ export function WiringCanvas({ robot, onChange, joints = [], jointLimits = {}, l
       }
       const dx = bs.bodyDX ?? 0
       const dy = bs.bodyDY ?? 0
-      const mx = cbody.x + mount.x * cbody.w
-      const my = cbody.y + mount.y * cbody.h
-      bs.x = mx - (dx + bs.w / 2)
-      bs.y = my - (dy + bs.h / 2)
+      // The mount centre in canvas coords, transformed through the carrier's rotation.
+      const mp = carrierPoint(cbody, mount.x, mount.y)
+      bs.x = mp.x - (dx + bs.w / 2)
+      bs.y = mp.y - (dy + bs.h / 2)
       bs.seated = true
       bs.hit = hitRegion(bs.mode, bs.x + dx, bs.y + dy, bs.w, bs.h)
       const bi = subjects.indexOf(bs)
@@ -1343,8 +1356,9 @@ export function WiringCanvas({ robot, onChange, joints = [], jointLimits = {}, l
         const takenByBoard =
           excludeKey !== 'board' && robot.boardMountedOn === carrier.id && robot.boardMount === m.id
         if (takenByPart || takenByBoard) continue
-        const mx = body.x + m.x * body.w
-        const my = body.y + m.y * body.h
+        const mp = carrierPoint(body, m.x, m.y)
+        const mx = mp.x
+        const my = mp.y
         // Generous radius: you're aiming at a socket, not a pixel.
         if (Math.hypot(cx - mx, cy - my) <= Math.min(body.w, body.h) * 0.55) {
           return { carrier: carrier.id, mount: m.id }
@@ -2588,8 +2602,9 @@ export function WiringCanvas({ robot, onChange, joints = [], jointLimits = {}, l
                           if (!dp.length) {
                             // Legacy pin-less mount → fall back to a socket ring.
                             const r = Math.min(body.w, body.h) * 0.5
-                            const mx = body.x + m.x * body.w
-                            const my = body.y + m.y * body.h
+                            const mp = carrierPoint(body, m.x, m.y)
+                            const mx = mp.x
+                            const my = mp.y
                             return (
                               <g key={`mt${carrier.id}${m.id}`}>
                                 <circle cx={mx} cy={my} r={r} fill={isOver ? '#3ec46d' : 'none'} fillOpacity={isOver ? 0.16 : 0} stroke="#3ec46d" strokeWidth={sw} strokeDasharray={isOver ? undefined : '6 5'} opacity={op} />
@@ -2599,8 +2614,9 @@ export function WiringCanvas({ robot, onChange, joints = [], jointLimits = {}, l
                               </g>
                             )
                           }
-                          const xs = dp.map((pp) => body.x + pp.x! * body.w)
-                          const ys = dp.map((pp) => body.y + pp.y! * body.h)
+                          const pts = dp.map((pp) => carrierPoint(body, pp.x!, pp.y!))
+                          const xs = pts.map((pt) => pt.x)
+                          const ys = pts.map((pt) => pt.y)
                           const pad = 7
                           const x0 = Math.min(...xs) - pad
                           const y0 = Math.min(...ys) - pad
@@ -2609,8 +2625,8 @@ export function WiringCanvas({ robot, onChange, joints = [], jointLimits = {}, l
                           return (
                             <g key={`mt${carrier.id}${m.id}`}>
                               <rect x={x0} y={y0} width={x1 - x0} height={y1 - y0} rx={6} fill={isOver ? '#3ec46d' : 'none'} fillOpacity={isOver ? 0.12 : 0} stroke="#3ec46d" strokeWidth={sw} strokeDasharray={isOver ? undefined : '6 5'} opacity={op} />
-                              {dp.map((pp, pi) => (
-                                <circle key={pi} cx={body.x + pp.x! * body.w} cy={body.y + pp.y! * body.h} r={4} fill={isOver ? '#3ec46d' : 'none'} fillOpacity={isOver ? 0.95 : 0} stroke="#3ec46d" strokeWidth={1.5} opacity={op} />
+                              {pts.map((pt, pi) => (
+                                <circle key={pi} cx={pt.x} cy={pt.y} r={4} fill={isOver ? '#3ec46d' : 'none'} fillOpacity={isOver ? 0.95 : 0} stroke="#3ec46d" strokeWidth={1.5} opacity={op} />
                               ))}
                               <text x={(x0 + x1) / 2} y={y0 - 6} textAnchor="middle" fontSize={11} fontWeight={700} fill="#d8f5e3" stroke="#08301c" strokeWidth={3.5} style={{ paintOrder: 'stroke' }}>
                                 {m.label || m.footprint}

--- a/src/renderer/src/components/WiringCanvas.tsx
+++ b/src/renderer/src/components/WiringCanvas.tsx
@@ -35,6 +35,7 @@ import { McuSymbol, PartSchematicSymbol } from './SchematicSymbols'
 import { routeOrthogonal, toSvgPath, type RBox, type RSide, type RWire } from './ortho-router'
 import { PART_DRAG_MIME, decodePartDrag } from './part-drag'
 import { classifyBusWire } from '../../../shared/bus-wires'
+import { partSignature, mountSignature, signaturesMatch } from '../../../shared/footprint-signature'
 import { voltageColour, formatVoltage } from '../../../shared/circuit-probe'
 import { BoardMeter, type BoardMeterReading } from './BoardMeter'
 import { useFloatPlacement } from './InstrumentWindow'
@@ -1258,24 +1259,41 @@ export function WiringCanvas({ robot, onChange, joints = [], jointLimits = {}, l
   }
 
   /**
-   * A carrier mount the dropped part could seat in (#166): the part must declare
-   * the mount's footprint, and the mount must be free. Returns the carrier + mount
-   * ids, or null when the drop isn't over a compatible empty socket.
+   * Does a carrier mount accept a dragged board (#166)? STRUCTURAL when the mount
+   * has imprinted pins — the board's pin signature must match the socket's (so a
+   * XIAO 2040/2350/compatible all seat) — else a legacy footprint-NAME match for
+   * mounts authored before the imprint tooling. `sig`/`footprint` describe the
+   * dragged board; `cpart` is the resolved carrier part.
    */
-  const mountUnderFp = (
-    footprint: string | undefined,
+  const mountAccepts = (
+    cpart: PartDefinition,
+    m: { id: string; footprint: string },
+    sig: string,
+    footprint: string | undefined
+  ): boolean => {
+    const msig = mountSignature(cpart, m.id)
+    return msig ? sig !== '' && signaturesMatch(msig, sig) : !!footprint && m.footprint === footprint
+  }
+  /**
+   * A free carrier mount the dragged board could seat in: structurally compatible
+   * (or legacy footprint-name compatible), unoccupied, and under the drop point.
+   */
+  const mountUnderFor = (
+    dragged: PartDefinition | null | undefined,
     excludeKey: string,
     cx: number,
     cy: number
   ): { carrier: string; mount: string } | null => {
-    if (!footprint) return null
+    const sig = dragged ? partSignature(dragged) : ''
+    const footprint = dragged?.footprint
+    if (!sig && !footprint) return null
     for (const carrier of robot.parts) {
       if (carrier.id === excludeKey) continue
       const body = placedBody.get(carrier.id)
-      const mounts = resolvePart(carrier.lib, carrier.part)?.mounts
-      if (!body || !mounts?.length) continue
-      for (const m of mounts) {
-        if (m.footprint !== footprint) continue
+      const cpart = resolvePart(carrier.lib, carrier.part)
+      if (!body || !cpart?.mounts?.length) continue
+      for (const m of cpart.mounts) {
+        if (!mountAccepts(cpart, m, sig, footprint)) continue
         // One thing per socket — a mount taken by a placed part OR by the board
         // (which seats here too, #166) isn't a drop target.
         const takenByPart = robot.parts.some(
@@ -1296,7 +1314,7 @@ export function WiringCanvas({ robot, onChange, joints = [], jointLimits = {}, l
   }
   const mountUnder = (key: string, cx: number, cy: number): { carrier: string; mount: string } | null => {
     const rp = robot.parts.find((p) => p.id === key)
-    return mountUnderFp(rp ? resolvePart(rp.lib, rp.part)?.footprint : undefined, key, cx, cy)
+    return mountUnderFor(rp ? resolvePart(rp.lib, rp.part) : undefined, key, cx, cy)
   }
 
   const moveBox = (key: string, x: number, y: number): void => {
@@ -1308,8 +1326,8 @@ export function WiringCanvas({ robot, onChange, joints = [], jointLimits = {}, l
       // on it's drawn at the mount and moves with the carrier. Dropping it elsewhere
       // un-seats it (drag it off the carrier to take it back out).
       const bs = subjByKey.get('board')
-      const seat = mountUnderFp(
-        boardPart?.footprint,
+      const seat = mountUnderFor(
+        boardPart,
         'board',
         x + (bs?.bodyDX ?? 0) + (bs?.w ?? 0) / 2,
         y + (bs?.bodyDY ?? 0) + (bs?.h ?? 0) / 2
@@ -2484,22 +2502,32 @@ export function WiringCanvas({ robot, onChange, joints = [], jointLimits = {}, l
               drag.moved &&
               drag.boxKey &&
               (() => {
-                const dragged = robot.parts.find((p) => p.id === drag.boxKey)
-                const footprint = dragged && resolvePart(dragged.lib, dragged.part)?.footprint
-                if (!footprint) return null
+                // The dragged board — a placed part, OR the MCU itself (#166): both
+                // can plug into a compatible carrier socket.
+                const draggedPart =
+                  drag.boxKey === 'board'
+                    ? boardPart
+                    : (() => {
+                        const dp = robot.parts.find((p) => p.id === drag.boxKey)
+                        return dp ? resolvePart(dp.lib, dp.part) : null
+                      })()
+                const sig = draggedPart ? partSignature(draggedPart) : ''
+                const footprint = draggedPart?.footprint
+                if (!sig && !footprint) return null
                 const s = subjByKey.get(drag.boxKey)
                 const cx = (s?.x ?? 0) + (s?.bodyDX ?? 0) + (s?.w ?? 0) / 2
                 const cy = (s?.y ?? 0) + (s?.bodyDY ?? 0) + (s?.h ?? 0) / 2
-                const target = mountUnder(drag.boxKey, cx, cy)
+                const target = mountUnderFor(draggedPart, drag.boxKey, cx, cy)
                 return (
                   <g style={{ pointerEvents: 'none' }} className="wc__mount-targets">
                     {robot.parts.flatMap((carrier) => {
                       if (carrier.id === drag.boxKey) return []
                       const body = placedBody.get(carrier.id)
-                      const mounts = resolvePart(carrier.lib, carrier.part)?.mounts ?? []
-                      if (!body) return []
+                      const cpart = resolvePart(carrier.lib, carrier.part)
+                      const mounts = cpart?.mounts ?? []
+                      if (!body || !cpart) return []
                       return mounts
-                        .filter((m) => m.footprint === footprint)
+                        .filter((m) => mountAccepts(cpart, m, sig, footprint))
                         .filter(
                           (m) =>
                             !robot.parts.some(

--- a/src/renderer/src/components/WiringCanvas.tsx
+++ b/src/renderer/src/components/WiringCanvas.tsx
@@ -1267,10 +1267,20 @@ export function WiringCanvas({ robot, onChange, joints = [], jointLimits = {}, l
    */
   const mountAccepts = (
     cpart: PartDefinition,
-    m: { id: string; footprint: string },
+    m: { id: string; footprint: string; ref?: { lib: string; part: string } },
     sig: string,
     footprint: string | undefined
   ): boolean => {
+    // Prefer the SOURCE board the footprint was imprinted from (#166): comparing the
+    // dragged board against it is rotation-INDEPENDENT — a footprint imprinted at 90°
+    // still accepts the same (un-rotated) board, because the imprint's rotation is
+    // only how it's drawn, not what fits. (The imprinted pins' own signature IS
+    // orientation-specific, so it would reject a board unless drawn at the same angle.)
+    if (m.ref) {
+      const ref = resolvePart(m.ref.lib, m.ref.part)
+      if (ref) return sig !== '' && signaturesMatch(partSignature(ref), sig)
+    }
+    // No installed source → the imprinted pins' signature, else a legacy name match.
     const msig = mountSignature(cpart, m.id)
     return msig ? sig !== '' && signaturesMatch(msig, sig) : !!footprint && m.footprint === footprint
   }

--- a/src/renderer/src/components/WiringCanvas.tsx
+++ b/src/renderer/src/components/WiringCanvas.tsx
@@ -1082,10 +1082,41 @@ export function WiringCanvas({ robot, onChange, joints = [], jointLimits = {}, l
     const mount =
       carrier && resolvePart(carrier.lib, carrier.part)?.mounts?.find((m) => m.id === robot.boardMount)
     if (bs && cbody && mount) {
-      bs.x = cbody.x + mount.x * cbody.w - bs.w / 2
-      bs.y = cbody.y + mount.y * cbody.h - bs.h / 2
+      // Rotate the board to match the footprint (#166) so its pads overlay the
+      // imprinted pins — a footprint placed at 270° seats the board turned 270°,
+      // not sitting square over a rotated socket. Mirrors how a placed part rotates.
+      const R = normRot(mount.rotation)
+      if (R && bs.box) {
+        const bw0 = bs.box.w
+        const bh0 = bs.box.h
+        const cx = bw0 / 2
+        const cy = bh0 / 2
+        const aabb =
+          R === 90 || R === 270
+            ? { x: cx - bh0 / 2, y: cy - bw0 / 2, w: bh0, h: bw0 }
+            : { x: 0, y: 0, w: bw0, h: bh0 }
+        bs.pins = bs.pins.map((p) => ({
+          ...p,
+          anchors: p.anchors.map((a) => {
+            const r = rotatePoint(a.x, a.y, cx, cy, R)
+            const n = rotateNormal(a.ox, a.oy, R)
+            return { x: r.x, y: r.y, ox: n.ox, oy: n.oy }
+          })
+        }))
+        bs.rotation = R
+        bs.bodyDX = aabb.x
+        bs.bodyDY = aabb.y
+        bs.w = aabb.w
+        bs.h = aabb.h
+      }
+      const dx = bs.bodyDX ?? 0
+      const dy = bs.bodyDY ?? 0
+      const mx = cbody.x + mount.x * cbody.w
+      const my = cbody.y + mount.y * cbody.h
+      bs.x = mx - (dx + bs.w / 2)
+      bs.y = my - (dy + bs.h / 2)
       bs.seated = true
-      bs.hit = hitRegion(bs.mode, bs.x, bs.y, bs.w, bs.h)
+      bs.hit = hitRegion(bs.mode, bs.x + dx, bs.y + dy, bs.w, bs.h)
       const bi = subjects.indexOf(bs)
       subjects.splice(bi, 1)
       const ci = subjects.findIndex((s) => s.key === robot.boardMountedOn)
@@ -2546,31 +2577,42 @@ export function WiringCanvas({ robot, onChange, joints = [], jointLimits = {}, l
                         )
                         .map((m) => {
                           const isOver = target?.carrier === carrier.id && target?.mount === m.id
-                          const r = Math.min(body.w, body.h) * 0.5
+                          const sw = isOver ? 3 : 1.5
+                          const op = isOver ? 0.98 : 0.55
+                          // The footprint's imprinted pins on the carrier body — draw
+                          // the actual OUTLINE + pin dots so the socket reads as the
+                          // real footprint, not an abstract circle.
+                          const dp = (cpart.headers ?? [])
+                            .flatMap((h) => h.pins)
+                            .filter((pp) => pp.derived === m.id && pp.x !== undefined && pp.y !== undefined)
+                          if (!dp.length) {
+                            // Legacy pin-less mount → fall back to a socket ring.
+                            const r = Math.min(body.w, body.h) * 0.5
+                            const mx = body.x + m.x * body.w
+                            const my = body.y + m.y * body.h
+                            return (
+                              <g key={`mt${carrier.id}${m.id}`}>
+                                <circle cx={mx} cy={my} r={r} fill={isOver ? '#3ec46d' : 'none'} fillOpacity={isOver ? 0.16 : 0} stroke="#3ec46d" strokeWidth={sw} strokeDasharray={isOver ? undefined : '6 5'} opacity={op} />
+                                <text x={mx} y={my - r - 6} textAnchor="middle" fontSize={11} fontWeight={700} fill="#d8f5e3" stroke="#08301c" strokeWidth={3.5} style={{ paintOrder: 'stroke' }}>
+                                  {m.label || m.footprint}
+                                </text>
+                              </g>
+                            )
+                          }
+                          const xs = dp.map((pp) => body.x + pp.x! * body.w)
+                          const ys = dp.map((pp) => body.y + pp.y! * body.h)
+                          const pad = 7
+                          const x0 = Math.min(...xs) - pad
+                          const y0 = Math.min(...ys) - pad
+                          const x1 = Math.max(...xs) + pad
+                          const y1 = Math.max(...ys) + pad
                           return (
                             <g key={`mt${carrier.id}${m.id}`}>
-                              <circle
-                                cx={body.x + m.x * body.w}
-                                cy={body.y + m.y * body.h}
-                                r={r}
-                                fill={isOver ? '#3ec46d' : 'none'}
-                                fillOpacity={isOver ? 0.16 : 0}
-                                stroke="#3ec46d"
-                                strokeWidth={isOver ? 3 : 1.5}
-                                strokeDasharray={isOver ? undefined : '6 5'}
-                                opacity={isOver ? 0.95 : 0.5}
-                              />
-                              <text
-                                x={body.x + m.x * body.w}
-                                y={body.y + m.y * body.h - r - 6}
-                                textAnchor="middle"
-                                fontSize={11}
-                                fontWeight={700}
-                                fill="#d8f5e3"
-                                stroke="#08301c"
-                                strokeWidth={3.5}
-                                style={{ paintOrder: 'stroke' }}
-                              >
+                              <rect x={x0} y={y0} width={x1 - x0} height={y1 - y0} rx={6} fill={isOver ? '#3ec46d' : 'none'} fillOpacity={isOver ? 0.12 : 0} stroke="#3ec46d" strokeWidth={sw} strokeDasharray={isOver ? undefined : '6 5'} opacity={op} />
+                              {dp.map((pp, pi) => (
+                                <circle key={pi} cx={body.x + pp.x! * body.w} cy={body.y + pp.y! * body.h} r={4} fill={isOver ? '#3ec46d' : 'none'} fillOpacity={isOver ? 0.95 : 0} stroke="#3ec46d" strokeWidth={1.5} opacity={op} />
+                              ))}
+                              <text x={(x0 + x1) / 2} y={y0 - 6} textAnchor="middle" fontSize={11} fontWeight={700} fill="#d8f5e3" stroke="#08301c" strokeWidth={3.5} style={{ paintOrder: 'stroke' }}>
                                 {m.label || m.footprint}
                               </text>
                             </g>

--- a/src/renderer/src/components/part-editor.util.ts
+++ b/src/renderer/src/components/part-editor.util.ts
@@ -318,6 +318,7 @@ function normalisePin(pin: PartPin): PartPin {
   if (PIN_SHAPES.includes(pin.shape as PartPinShape)) out.shape = pin.shape
   if (pin.labelHidden === true) out.labelHidden = true
   if (typeof pin.group === 'string' && pin.group.trim()) out.group = pin.group.trim()
+  if (typeof pin.derived === 'string' && pin.derived.trim()) out.derived = pin.derived.trim()
   if (typeof pin.rotation === 'number' && Number.isFinite(pin.rotation)) {
     out.rotation = ((Math.round(pin.rotation / 90) * 90) % 360 + 360) % 360
   }
@@ -1142,6 +1143,11 @@ export function normalisePart(part: PartDefinition): PartDefinition {
         const footprint = text(m?.footprint)
         if (!id || !footprint || typeof m.x !== 'number' || typeof m.y !== 'number') return null
         const mount: PartMount = { id, footprint, x: clamp(m.x, 0, 1), y: clamp(m.y, 0, 1) }
+        if (m.ref && typeof m.ref === 'object') {
+          const lib = text(m.ref.lib)
+          const rp = text(m.ref.part)
+          if (lib && rp) mount.ref = { lib, part: rp }
+        }
         const label = text(m.label)
         if (label) mount.label = label
         if (typeof m.rotation === 'number' && Number.isFinite(m.rotation)) {

--- a/src/renderer/src/components/part-editor.util.ts
+++ b/src/renderer/src/components/part-editor.util.ts
@@ -1804,7 +1804,7 @@ export function schematicSymbolLayout(
 // The rule is positional, not clever: grouped ⇒ top level, ungrouped ⇒ bucket.
 
 /** Every kind of thing that can appear as a leaf in the hierarchy. */
-export type HierItemKind = OrderedItemKind | 'pin' | 'hole'
+export type HierItemKind = OrderedItemKind | 'pin' | 'hole' | 'mount'
 
 /** A leaf's identity: its kind plus its index in that kind's array. Pins use the
  *  FLAT index across headers (the same one endpoints and `resolvedPins` use). */
@@ -1813,7 +1813,7 @@ export interface HierItem {
   index: number
 }
 
-export type LayerBucket = 'components' | 'pins' | 'holes'
+export type LayerBucket = 'components' | 'pins' | 'holes' | 'mounts'
 
 export interface LayerNode {
   /** Stable key for React and for remembering which rows are collapsed. */
@@ -1840,7 +1840,8 @@ export interface LayerNode {
 const BUCKET_LABEL: Record<LayerBucket, string> = {
   components: 'Components',
   pins: 'Pins',
-  holes: 'Mounting holes'
+  holes: 'Mounting holes',
+  mounts: 'Footprints'
 }
 
 /** Every leaf in the part, with the flags and label the tree needs. */
@@ -1881,8 +1882,14 @@ function hierLeaves(part: PartDefinition): { node: LayerNode; group?: string }[]
       push('connector', it.index, c?.label || c?.kind?.toUpperCase() || 'Connector', c ?? {})
     }
   }
-  resolvedPins(part).forEach((rp, i) => push('pin', i, rp.pin.name || `Pin ${i + 1}`, rp.pin))
+  // Skip pins imprinted from a footprint (#166) — they belong to their mount, not
+  // the loose Pins bucket, and would otherwise bury it under a carrier's 14+ pads.
+  resolvedPins(part).forEach((rp, i) => {
+    if (rp.pin.derived) return
+    push('pin', i, rp.pin.name || `Pin ${i + 1}`, rp.pin)
+  })
   ;(part.mountingHoles ?? []).forEach((h, i) => push('hole', i, `Hole ${i + 1}`, h))
+  ;(part.mounts ?? []).forEach((m, i) => push('mount', i, m.label || m.footprint || `Footprint ${i + 1}`, {}))
   return out
 }
 
@@ -1935,9 +1942,9 @@ export function partLayerTree(part: PartDefinition): LayerNode[] {
   const roots = groups.filter((g) => !g.parent || !known.has(g.parent))
 
   const bucketOf = (k: HierItemKind): LayerBucket =>
-    k === 'pin' ? 'pins' : k === 'hole' ? 'holes' : 'components'
+    k === 'pin' ? 'pins' : k === 'hole' ? 'holes' : k === 'mount' ? 'mounts' : 'components'
 
-  const buckets: LayerNode[] = (['components', 'pins', 'holes'] as LayerBucket[])
+  const buckets: LayerNode[] = (['components', 'pins', 'holes', 'mounts'] as LayerBucket[])
     .map((b): LayerNode => {
       const kids = leaves
         .filter((l) => !l.group || !known.has(l.group))
@@ -1997,6 +2004,10 @@ export function withItemFlag(
       return { connectors: set(part.connectors, item.index) }
     case 'hole':
       return { mountingHoles: set(part.mountingHoles, item.index) }
+    case 'mount':
+      // Footprint mounts (#166) have no per-item hidden/locked flag — the whole
+      // Footprints layer toggles them — so there's nothing to write.
+      return {}
     case 'pin': {
       const at = pinAt(part, item.index)
       if (!at) return {}

--- a/src/shared/footprint-imprint.ts
+++ b/src/shared/footprint-imprint.ts
@@ -155,6 +155,37 @@ export function removeMountImprint(carrier: PartDefinition, mountId: string): Pa
 }
 
 /**
+ * Rotate a mount's footprint block by `deg` about its centre (#166). Its imprinted
+ * pins spin as a rigid GROUP — every position rotates about the mount centre
+ * (isotropically in mm, so a non-square carrier doesn't shear it), NOT each pin
+ * about its own axis — and the mount's stored rotation advances. Operates on the
+ * existing pins, so it needs no reference board.
+ */
+export function rotateMount(carrier: PartDefinition, mountId: string, deg: number): PartDefinition {
+  const m = (carrier.mounts ?? []).find((x) => x.id === mountId)
+  if (!m) return carrier
+  const cw = carrier.dimensions?.width ?? 0
+  const ch = carrier.dimensions?.height ?? 0
+  const mm = cw > 0 && ch > 0
+  const spin = (x: number, y: number): { x: number; y: number } => {
+    const r = mm ? rotate((x - m.x) * cw, (y - m.y) * ch, deg) : rotate(x - m.x, y - m.y, deg)
+    return mm ? { x: m.x + r.x / cw, y: m.y + r.y / ch } : { x: m.x + r.x, y: m.y + r.y }
+  }
+  const headers = (carrier.headers ?? []).map((h) => ({
+    ...h,
+    pins: h.pins.map((p) => {
+      if (p.derived !== mountId || p.x === undefined || p.y === undefined) return p
+      const s = spin(p.x, p.y)
+      return { ...p, x: clamp01(s.x), y: clamp01(s.y) }
+    })
+  }))
+  const mounts = (carrier.mounts ?? []).map((mm2) =>
+    mm2.id === mountId ? { ...mm2, rotation: ((((mm2.rotation ?? 0) + deg) % 360) + 360) % 360 || undefined } : mm2
+  )
+  return { ...carrier, headers, mounts }
+}
+
+/**
  * Translate a mount and its derived pins by a delta (for a cheap on-canvas DRAG that
  * needs no reference board — the block just shifts rigidly). Positions are clamped.
  */

--- a/src/shared/footprint-imprint.ts
+++ b/src/shared/footprint-imprint.ts
@@ -1,0 +1,174 @@
+/**
+ * Footprint imprinting (#166, phase 2) — stamping a reference board's real pins
+ * into a carrier's mount. Adding a footprint isn't a labelled rectangle: it copies
+ * the reference MCU's actual pads (type + position + name + GPIO) into the carrier
+ * as {@link PartPin.derived} pins — locked, read-only, sized + placed at the mount —
+ * so the carrier gains real, wireable pins for a seated board to bond onto, and the
+ * mount's structural signature (see {@link ./footprint-signature}) comes straight
+ * from them.
+ *
+ * A SNAPSHOT (per the design): the pins are copied at imprint time; {@link PartMount.ref}
+ * records the source so the editor can re-imprint ("re-sync from source"). Pure +
+ * dependency-light so the Part Editor and tests share one imprint definition.
+ */
+
+import type { PartDefinition, PartMount, PartPin } from './part'
+import { slugifyFootprint } from './footprints'
+
+const clamp01 = (v: number): number => Math.max(0, Math.min(1, v))
+
+/** Where the mount sits + how it's turned — the transform an imprint needs. */
+export interface MountPlacement {
+  id: string
+  /** Normalised centre of the footprint block within the carrier. */
+  x: number
+  y: number
+  /** Block rotation in degrees (0/90/180/270). */
+  rotation?: number
+  /** Optional silk label + footprint tag overrides (else derived from the source). */
+  label?: string
+  footprint?: string
+}
+
+/** The footprint block's size as a fraction of the carrier — from real mm
+ *  dimensions when both boards have them (physically to scale), else a default. */
+function blockFraction(
+  ref: PartDefinition,
+  carrier: PartDefinition
+): { fw: number; fh: number; mm: boolean } {
+  const rw = ref.dimensions?.width
+  const rh = ref.dimensions?.height
+  const cw = carrier.dimensions?.width
+  const ch = carrier.dimensions?.height
+  if (rw && rh && cw && ch && cw > 0 && ch > 0) {
+    return { fw: clamp01(rw / cw), fh: clamp01(rh / ch), mm: true }
+  }
+  return { fw: 0.3, fh: 0.3, mm: false }
+}
+
+const rotate = (x: number, y: number, deg: number): { x: number; y: number } => {
+  const r = (deg * Math.PI) / 180
+  const c = Math.cos(r)
+  const s = Math.sin(r)
+  return { x: x * c - y * s, y: x * s + y * c }
+}
+
+/**
+ * The derived pins for one mount: the reference board's positioned pins, scaled to
+ * the reference's real size within the carrier, rotated about the mount centre, and
+ * placed at it. Names / types / GPIO / capabilities are carried through; each pin is
+ * flagged `derived = mount.id` and `locked` so it's read-only in the editor.
+ */
+export function imprintPins(
+  ref: PartDefinition,
+  mount: MountPlacement,
+  carrier: PartDefinition
+): PartPin[] {
+  const { fw, fh, mm } = blockFraction(ref, carrier)
+  const rot = (((mount.rotation ?? 0) % 360) + 360) % 360
+  const cw = carrier.dimensions?.width ?? 1
+  const ch = carrier.dimensions?.height ?? 1
+  const out: PartPin[] = []
+  for (const h of ref.headers ?? []) {
+    for (const p of h.pins ?? []) {
+      if (p.x === undefined || p.y === undefined) continue
+      // Offset from the reference board's centre, in its own normalised frame.
+      const ox = (p.x - 0.5) * fw
+      const oy = (p.y - 0.5) * fh
+      // Rotate isotropically in mm (so a non-square carrier doesn't shear the
+      // block), then convert back to carrier-normalised space.
+      const r = mm && cw > 0 && ch > 0 ? rotate(ox * cw, oy * ch, rot) : rotate(ox, oy, rot)
+      const nx = mm && cw > 0 ? mount.x + r.x / cw : mount.x + r.x
+      const ny = mm && ch > 0 ? mount.y + r.y / ch : mount.y + r.y
+      const np: PartPin = {
+        name: p.name,
+        type: p.type,
+        x: clamp01(nx),
+        y: clamp01(ny),
+        derived: mount.id,
+        // Read-only, and its silk annotation is suppressed — a dense imprinted block
+        // (e.g. a XIAO's 14 pins mid-board) would otherwise draw 14 edge leaders. The
+        // type-coloured pads convey the footprint; names live on for bonding + hover.
+        locked: true,
+        labelHidden: true
+      }
+      if (p.number !== undefined) np.number = p.number
+      if (p.type === 'io' && p.gpio !== undefined) np.gpio = p.gpio
+      if (p.type === 'io' && p.capabilities?.length) np.capabilities = [...p.capabilities]
+      if (p.type === 'io' && p.signals) np.signals = { ...p.signals }
+      if (p.type === 'io' && p.buses) np.buses = { ...p.buses }
+      if (p.shape) np.shape = p.shape
+      if (p.label && p.label !== p.name) np.label = p.label
+      out.push(np)
+    }
+  }
+  return out
+}
+
+/** Strip a mount's derived pins out of a carrier (dropping any header left empty). */
+function stripDerived(carrier: PartDefinition, mountId: string): PartDefinition {
+  const headers = (carrier.headers ?? [])
+    .map((h) => ({ ...h, pins: h.pins.filter((p) => p.derived !== mountId) }))
+    .filter((h) => h.pins.length > 0)
+  return { ...carrier, headers }
+}
+
+/**
+ * Add or refresh a mount's footprint: replace its derived pins with a fresh imprint
+ * (in their own header) and upsert the {@link PartMount} carrying `ref`. Used for the
+ * initial "add footprint", a rotate, and "re-sync from source".
+ */
+export function applyImprint(
+  carrier: PartDefinition,
+  ref: PartDefinition,
+  refId: { lib: string; part: string },
+  mount: MountPlacement
+): PartDefinition {
+  const base = stripDerived(carrier, mount.id)
+  const pins = imprintPins(ref, mount, carrier)
+  // Free-positioned pins (x/y drive placement), so `edge` is only nominal here.
+  const headers = [...(base.headers ?? []), { edge: 'left' as const, pins }]
+  const mounts = [...(base.mounts ?? [])]
+  const footprint =
+    slugifyFootprint(mount.footprint ?? '') ||
+    slugifyFootprint(ref.footprint ?? '') ||
+    slugifyFootprint(ref.name ?? ref.id ?? mount.id)
+  const entry: PartMount = {
+    id: mount.id,
+    footprint,
+    ref: refId,
+    x: clamp01(mount.x),
+    y: clamp01(mount.y)
+  }
+  if (mount.rotation) entry.rotation = mount.rotation
+  if (mount.label) entry.label = mount.label
+  const idx = mounts.findIndex((m) => m.id === mount.id)
+  if (idx >= 0) mounts[idx] = entry
+  else mounts.push(entry)
+  return { ...base, headers, mounts }
+}
+
+/** Remove a mount and its derived pins from a carrier. */
+export function removeMountImprint(carrier: PartDefinition, mountId: string): PartDefinition {
+  const base = stripDerived(carrier, mountId)
+  return { ...base, mounts: (base.mounts ?? []).filter((m) => m.id !== mountId) }
+}
+
+/**
+ * Translate a mount and its derived pins by a delta (for a cheap on-canvas DRAG that
+ * needs no reference board — the block just shifts rigidly). Positions are clamped.
+ */
+export function translateMount(carrier: PartDefinition, mountId: string, dx: number, dy: number): PartDefinition {
+  const headers = (carrier.headers ?? []).map((h) => ({
+    ...h,
+    pins: h.pins.map((p) =>
+      p.derived === mountId && p.x !== undefined && p.y !== undefined
+        ? { ...p, x: clamp01(p.x + dx), y: clamp01(p.y + dy) }
+        : p
+    )
+  }))
+  const mounts = (carrier.mounts ?? []).map((m) =>
+    m.id === mountId ? { ...m, x: clamp01(m.x + dx), y: clamp01(m.y + dy) } : m
+  )
+  return { ...carrier, headers, mounts }
+}

--- a/src/shared/footprint-imprint.ts
+++ b/src/shared/footprint-imprint.ts
@@ -90,14 +90,18 @@ export function imprintPins(
         // (e.g. a XIAO's 14 pins mid-board) would otherwise draw 14 edge leaders. The
         // type-coloured pads convey the footprint; names live on for bonding + hover.
         locked: true,
-        labelHidden: true
+        labelHidden: true,
+        // Always plain ROUND pads. A footprint only needs to show pin positions +
+        // types; carrying the source's castellated/header shape (whose outward
+        // direction is derived from the pin's side) makes the block read as a mess
+        // of pads pointing every which way once it's placed + rotated.
+        shape: 'round'
       }
       if (p.number !== undefined) np.number = p.number
       if (p.type === 'io' && p.gpio !== undefined) np.gpio = p.gpio
       if (p.type === 'io' && p.capabilities?.length) np.capabilities = [...p.capabilities]
       if (p.type === 'io' && p.signals) np.signals = { ...p.signals }
       if (p.type === 'io' && p.buses) np.buses = { ...p.buses }
-      if (p.shape) np.shape = p.shape
       if (p.label && p.label !== p.name) np.label = p.label
       out.push(np)
     }

--- a/src/shared/footprint-signature.ts
+++ b/src/shared/footprint-signature.ts
@@ -1,0 +1,113 @@
+/**
+ * Structural footprint signatures (#166) — the "duck typing" that decides which
+ * boards can dock into a carrier's mount. A footprint's identity is its PIN LAYOUT,
+ * not a name: the ordered set of pins by electrical TYPE and RELATIVE position. Two
+ * boards with the same signature are interchangeable in the same socket (a XIAO
+ * RP2040 and RP2350 share a layout, so they share a signature), regardless of the
+ * `footprint` tag, pin names, GPIO numbers or capabilities — which differ between
+ * otherwise-compatible boards.
+ *
+ * The signature is translation- and scale-invariant, and — deliberately — aspect
+ * invariant: the pin cluster is stretched to a unit square, so two boards with the
+ * SAME pin GRID (same rows/columns of the same types) match even when authored at
+ * different normalised sizes. That's why a XIAO RP2040 and RP2350 — whose pins were
+ * placed against differently-sized board images, so their raw positions differ —
+ * still share a signature. Orientation-specific (a rotated seat is the mount's
+ * rotation, not here). Pure + dependency-free so the renderer (docking), the Part
+ * Editor (imprint/compat) and tests all share one definition of "compatible".
+ */
+
+import type { PartDefinition, PartPinType } from './part'
+
+/** The minimal per-pin input a signature needs: role + normalised position. */
+export interface SigPin {
+  type: PartPinType
+  x: number
+  y: number
+}
+
+/** Gap (in unit-square space) that separates two distinct rows/columns. Larger than
+ *  authoring jitter (~0.01 between independently-drawn versions of a board) and far
+ *  smaller than real pin spacing, so each row/column collapses to one grid level. */
+const LEVEL_GAP = 0.05
+
+/**
+ * Assign each value an integer LEVEL index by 1-D clustering: sort the distinct
+ * values, start a new level when the gap to the previous exceeds {@link LEVEL_GAP}.
+ * This is what makes the signature robust — a row's pins (and the same row on a
+ * differently-authored sibling board) land on one integer level instead of two
+ * float buckets that a fixed grid could split.
+ */
+function levelIndex(values: number[]): (v: number) => number {
+  const uniq = [...new Set(values)].sort((a, b) => a - b)
+  const byVal = new Map<number, number>()
+  let idx = 0
+  let prev: number | null = null
+  for (const v of uniq) {
+    if (prev !== null && v - prev > LEVEL_GAP) idx++
+    byVal.set(v, idx)
+    prev = v
+  }
+  return (v) => byVal.get(v) ?? -1
+}
+
+/**
+ * Canonical structural signature of a pin cluster. Empty string for no pins (never
+ * matches anything). Each axis is stretched to a unit span independently (aspect-
+ * invariant — the same grid at different authored sizes matches), then reduced to
+ * integer row/column LEVELS so authoring jitter can't split a level. Sorted, so pin
+ * order is irrelevant. A single row and a single column stay distinct (one axis
+ * collapses to level 0 while the other spreads).
+ */
+export function pinSignature(pins: SigPin[]): string {
+  const pts = pins.filter((p) => Number.isFinite(p.x) && Number.isFinite(p.y))
+  if (pts.length === 0) return ''
+  const xs = pts.map((p) => p.x)
+  const ys = pts.map((p) => p.y)
+  const minX = Math.min(...xs)
+  const minY = Math.min(...ys)
+  const w = Math.max(...xs) - minX
+  const h = Math.max(...ys) - minY
+  const EPS = 1e-6
+  const nxs = pts.map((p) => (w > EPS ? (p.x - minX) / w : 0))
+  const nys = pts.map((p) => (h > EPS ? (p.y - minY) / h : 0))
+  const col = levelIndex(nxs)
+  const row = levelIndex(nys)
+  const tokens = pts.map((p, i) => `${p.type}@${col(nxs[i])},${row(nys[i])}`).sort()
+  return `${pts.length}|${tokens.join(';')}`
+}
+
+/** A part's own pins (flattened across headers), positioned ones only. */
+export function partSigPins(part: PartDefinition): SigPin[] {
+  const out: SigPin[] = []
+  for (const h of part.headers ?? [])
+    for (const p of h.pins ?? [])
+      if (p.x !== undefined && p.y !== undefined) out.push({ type: p.type, x: p.x, y: p.y })
+  return out
+}
+
+/** Signature of a whole board's pins — its dockable footprint as a SOURCE board. */
+export function partSignature(part: PartDefinition): string {
+  return pinSignature(partSigPins(part))
+}
+
+/** The pins imprinted into a carrier from one mount's footprint (#166) — the
+ *  {@link PartPin.derived} pins tagged with this mount id. */
+export function mountSigPins(carrier: PartDefinition, mountId: string): SigPin[] {
+  const out: SigPin[] = []
+  for (const h of carrier.headers ?? [])
+    for (const p of h.pins ?? [])
+      if (p.derived === mountId && p.x !== undefined && p.y !== undefined)
+        out.push({ type: p.type, x: p.x, y: p.y })
+  return out
+}
+
+/** Signature a carrier MOUNT accepts — from its imprinted pins. */
+export function mountSignature(carrier: PartDefinition, mountId: string): string {
+  return pinSignature(mountSigPins(carrier, mountId))
+}
+
+/** True when two signatures are the same non-empty layout (dock-compatible). */
+export function signaturesMatch(a: string, b: string): boolean {
+  return a !== '' && a === b
+}

--- a/src/shared/footprints.ts
+++ b/src/shared/footprints.ts
@@ -1,0 +1,89 @@
+/**
+ * Header-footprint registry (#166) — the shared vocabulary that makes board
+ * seating reliable. A *footprint* is a named compatibility tag: a board declares
+ * `footprint: xiao`, a carrier declares a mount that ACCEPTS `xiao`, and they seat
+ * when the strings match (see {@link ../renderer/src/components/WiringCanvas}). It's
+ * free text on disk, which invites typos (`XIAO` ≠ `xiao`), so the Part Editor
+ * offers a pick-from-known-list control backed by this registry.
+ *
+ * Pure + dependency-free (renderer and main both import it): the curated set of
+ * well-known standards, plus a collector that harvests every footprint actually in
+ * use across the installed libraries, plus the slugifier that normalises a typed
+ * value so equivalent spellings converge.
+ */
+
+import type { PartLibraryWithParts } from './part'
+
+/** One footprint the picker can offer, with how widely it's used. */
+export interface FootprintInfo {
+  /** The slug written to `parts.yml` (e.g. `xiao`). */
+  id: string
+  /** Human label for the dropdown (falls back to the id when uncurated). */
+  label: string
+  /** How many parts/mounts across the installed libraries reference it. */
+  count: number
+  /** True for a curated well-known standard (shown even at count 0). */
+  common: boolean
+}
+
+/**
+ * Well-known board/module header footprints, offered even before any installed
+ * part uses one — so a new Pico-compatible board can declare the canonical `pico`
+ * shape instead of inventing (and misspelling) a name. Ids are the on-disk slugs.
+ */
+export const COMMON_FOOTPRINTS: { id: string; label: string }[] = [
+  { id: 'xiao', label: 'Seeed XIAO' },
+  { id: 'pico', label: 'Raspberry Pi Pico / Pico 2' },
+  { id: 'feather', label: 'Adafruit Feather' },
+  { id: 'qt-py', label: 'Adafruit QT Py' },
+  { id: 'itsybitsy', label: 'Adafruit ItsyBitsy' },
+  { id: 'nano', label: 'Arduino Nano' },
+  { id: 'nano-esp32', label: 'Arduino Nano ESP32' },
+  { id: 'microbit', label: 'BBC micro:bit edge' },
+  { id: 'esp32-devkit', label: 'ESP32 DevKit' }
+]
+
+/**
+ * Normalise a typed footprint to its on-disk slug: lower-case, keep only
+ * `[a-z0-9-]`, collapse the rest to `-`, trim. So `XIAO`, `xiao ` and `Xiao`
+ * all become `xiao` and seat interchangeably. Mirrors the id sanitiser used for
+ * part folders. Returns `''` for a value that slugs to nothing.
+ */
+export function slugifyFootprint(value: string): string {
+  return String(value ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+/**
+ * Build the footprint option list: the curated standards merged with every
+ * footprint actually referenced by a part (`part.footprint`) or a carrier mount
+ * (`mount.footprint`) across the installed libraries, with usage counts. Sorted
+ * most-used first, then curated standards, then alphabetically — so the shapes a
+ * user's own libraries already use surface at the top.
+ */
+export function collectFootprints(libraries: PartLibraryWithParts[]): FootprintInfo[] {
+  const counts = new Map<string, number>()
+  for (const lib of libraries ?? []) {
+    for (const part of lib.parts ?? []) {
+      const fp = slugifyFootprint(part.footprint ?? '')
+      if (fp) counts.set(fp, (counts.get(fp) ?? 0) + 1)
+      for (const m of part.mounts ?? []) {
+        const mf = slugifyFootprint(m.footprint ?? '')
+        if (mf) counts.set(mf, (counts.get(mf) ?? 0) + 1)
+      }
+    }
+  }
+  const labels = new Map(COMMON_FOOTPRINTS.map((c) => [c.id, c.label]))
+  const common = new Set(COMMON_FOOTPRINTS.map((c) => c.id))
+  const ids = new Set<string>([...common, ...counts.keys()])
+  return [...ids]
+    .map((id) => ({ id, label: labels.get(id) ?? id, count: counts.get(id) ?? 0, common: common.has(id) }))
+    .sort(
+      (a, b) =>
+        b.count - a.count ||
+        Number(b.common) - Number(a.common) ||
+        a.label.localeCompare(b.label)
+    )
+}

--- a/src/shared/netlist.ts
+++ b/src/shared/netlist.ts
@@ -451,6 +451,34 @@ export function buildNetlist(
     })
   }
 
+  // 1c. Board stacking for the MCU ITSELF (#166): the seated microcontroller
+  //     (robot.board, via boardMountedOn/boardMount) bonds to the carrier's
+  //     imprinted footprint pins by name — same as a seated part, but the board's
+  //     endpoints are `board.<label>#<index>`. This is what lets a wire to a carrier
+  //     pad (a Grove port, a header) reach the GPIO on the MCU plugged in above it.
+  if (board && robot.boardMountedOn && robot.boardMount) {
+    const carrierId = robot.boardMountedOn
+    const carrierDef = partDefs.get(carrierId)
+    const mount = carrierDef?.mounts?.find((m) => m.id === robot.boardMount)
+    if (carrierDef && mount) {
+      const carrierEndpoint = new Map<string, string>()
+      flattenPartPins(carrierDef).forEach((pin, i) => {
+        if (pin.name && !carrierEndpoint.has(pin.name)) {
+          carrierEndpoint.set(pin.name, `${carrierId}.${pin.name}#${i}`)
+        }
+      })
+      flattenBoardPads(board).forEach((pad, index) => {
+        if (!pad.label) return
+        const to = carrierEndpoint.get(mount.pinMap?.[pad.label] ?? pad.label)
+        if (!to) return
+        const from = `${BOARD_KEY}.${pad.label}#${index}`
+        if (!register(from) || !register(to)) return
+        uf.union(from, to)
+        edges.push({ id: `mount:board:${pad.label}`, from, to, internal: true })
+      })
+    }
+  }
+
   // 2. Every user-drawn wire joins its two endpoints. Unresolvable endpoints are
   //    surfaced as dangling (the wire is skipped, not silently swallowed).
   for (const conn of robot.connections ?? []) {

--- a/src/shared/part-yaml.ts
+++ b/src/shared/part-yaml.ts
@@ -162,6 +162,8 @@ function coercePin(raw: unknown): PartPin | null {
   const y = num(r.y)
   if (x !== undefined) pin.x = x
   if (y !== undefined) pin.y = y
+  const derived = str(r.derived)
+  if (derived) pin.derived = derived
   readItemFlags(r, pin as unknown as Record<string, unknown>)
   if (r.labelOffset && typeof r.labelOffset === 'object') {
     const lo = r.labelOffset as Record<string, unknown>
@@ -368,6 +370,7 @@ function pinToObj(p: PartPin): Record<string, unknown> {
   if (p.x !== undefined) out.x = p.x
   if (p.y !== undefined) out.y = p.y
   if (p.group) out.group = p.group
+  if (p.derived) out.derived = p.derived
   if (p.labelOffset) out.labelOffset = { x: p.labelOffset.x, y: p.labelOffset.y }
   return out
 }
@@ -423,6 +426,7 @@ export function partToYaml(part: PartDefinition): string {
     mounts: part.mounts?.map((m) => ({
       id: m.id,
       footprint: m.footprint,
+      ref: m.ref ? { lib: m.ref.lib, part: m.ref.part } : undefined,
       label: m.label,
       x: m.x,
       y: m.y,
@@ -705,6 +709,12 @@ export function partFromYaml(text: string): PartDefinition {
         // referenced by a placed part, and one with no footprint accepts nothing.
         if (!id || !footprint || x === undefined || y === undefined) return null
         const mount: PartMount = { id, footprint, x, y }
+        if (r.ref && typeof r.ref === 'object') {
+          const rr = r.ref as Record<string, unknown>
+          const lib = str(rr.lib)
+          const part = str(rr.part)
+          if (lib && part) mount.ref = { lib, part }
+        }
         const label = str(r.label)
         if (label) mount.label = label
         const rot = num(r.rotation)

--- a/src/shared/part.ts
+++ b/src/shared/part.ts
@@ -131,6 +131,12 @@ export interface PartPin {
    *  Signal/V+/GND trio). Pins sharing a `group` move + delete as a unit and collapse
    *  to one row in the pin list. Absent ⇒ a standalone pin. */
   group?: string
+  /** Imprinted from a carrier MOUNT's footprint (#166): the {@link PartMount.id}
+   *  this pin was stamped from. Such pins are the footprint's actual pads (correct
+   *  type + position), copied from a reference board — read-only + moving rigidly
+   *  with their mount block. They give the carrier real, wireable pins to bond a
+   *  seated board onto, instead of an abstract socket. Absent ⇒ an authored pin. */
+  derived?: string
   /**
    * Castellation outward direction in degrees: 0 = right, 90 = down, 180 = left,
    * 270 = up. Absent ⇒ derived from the pin's side (left/right by x). Only affects
@@ -260,8 +266,14 @@ export interface PartConnector {
 export interface PartMount {
   /** Unique id within this part; a placed instance references it as `mount`. */
   id: string
-  /** The footprint family this socket accepts (e.g. `xiao`, `pico`). */
+  /** The footprint family this socket accepts (e.g. `xiao`, `pico`). A label/handle
+   *  only — actual dock compatibility is STRUCTURAL (the imprinted pins' signature),
+   *  so a board whose pins match this mount's can seat even without the same tag. */
   footprint: string
+  /** The reference board this footprint was imprinted from (#166), for the editor's
+   *  "re-sync from source". The imprinted pins live in the carrier's headers, flagged
+   *  {@link PartPin.derived} = this mount's {@link id}. */
+  ref?: { lib: string; part: string }
   /** Normalised 0..1 centre of the SEATED board within this board's outline. */
   x: number
   y: number

--- a/test/footprintImprint.test.ts
+++ b/test/footprintImprint.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { imprintPins, applyImprint, removeMountImprint, translateMount } from '../src/shared/footprint-imprint'
+import { partSignature, mountSignature, signaturesMatch } from '../src/shared/footprint-signature'
+import { partFromYaml } from '../src/shared/part-yaml'
+import type { PartDefinition } from '../src/shared/part'
+
+const load = (id: string): PartDefinition =>
+  partFromYaml(readFileSync(join(__dirname, `../examples/parts/snakie-standard/${id}/parts.yml`), 'utf-8'))
+
+const blankCarrier = (w = 58, h = 42.5): PartDefinition =>
+  ({ parts: [], connections: [], headers: [], dimensions: { width: w, height: h } }) as unknown as PartDefinition
+
+describe('imprintPins (#166 phase 2)', () => {
+  it('copies every positioned reference pin as a derived, locked pin', () => {
+    const xiao = load('seeed-xiao-rp2350')
+    const refCount = (xiao.headers ?? []).flatMap((h) => h.pins).filter((p) => p.x !== undefined).length
+    const pins = imprintPins(xiao, { id: 'm1', x: 0.7, y: 0.35 }, blankCarrier())
+    expect(pins.length).toBe(refCount)
+    expect(pins.every((p) => p.derived === 'm1' && p.locked === true)).toBe(true)
+    // Types + names carried through; positions land inside the board.
+    expect(pins.some((p) => p.type === 'pwr')).toBe(true)
+    expect(pins.some((p) => p.name === 'D0')).toBe(true)
+    expect(pins.every((p) => p.x! >= 0 && p.x! <= 1 && p.y! >= 0 && p.y! <= 1)).toBe(true)
+  })
+
+  it('the imprint shares the reference board’s signature (so a seated board docks)', () => {
+    const xiao = load('seeed-xiao-rp2350')
+    const carrier = applyImprint(blankCarrier(), xiao, { lib: 'snakie-standard', part: 'seeed-xiao-rp2350' }, {
+      id: 'm1',
+      x: 0.7,
+      y: 0.35
+    })
+    expect(signaturesMatch(mountSignature(carrier, 'm1'), partSignature(xiao))).toBe(true)
+    // And a *compatible* board (XIAO 2040) matches the same socket.
+    expect(signaturesMatch(mountSignature(carrier, 'm1'), partSignature(load('seeed-xiao-rp2040')))).toBe(true)
+  })
+
+  it('scales the block to the reference board’s real size within the carrier', () => {
+    const xiao = load('seeed-xiao-rp2350') // 17.8 x 21 mm
+    const pins = imprintPins(xiao, { id: 'm1', x: 0.5, y: 0.5 }, blankCarrier(58, 42.5))
+    const xs = pins.map((p) => p.x!)
+    const ys = pins.map((p) => p.y!)
+    const wSpan = Math.max(...xs) - Math.min(...xs)
+    const hSpan = Math.max(...ys) - Math.min(...ys)
+    // Scaled to the carrier (well under half its size), and taller than wide —
+    // the XIAO is 17.8 × 21 mm on a 58 × 42.5 mm base, so aspect is preserved.
+    expect(wSpan).toBeLessThan(0.5)
+    expect(hSpan).toBeLessThan(0.5)
+    expect(hSpan).toBeGreaterThan(wSpan)
+  })
+})
+
+describe('applyImprint / removeMountImprint / translateMount', () => {
+  const xiao = load('seeed-xiao-rp2350')
+  const refId = { lib: 'snakie-standard', part: 'seeed-xiao-rp2350' }
+
+  it('upserts the mount with its ref and adds the derived pins (idempotent re-apply)', () => {
+    let c = applyImprint(blankCarrier(), xiao, refId, { id: 'm1', x: 0.5, y: 0.5 })
+    const n1 = (c.headers ?? []).flatMap((h) => h.pins).filter((p) => p.derived === 'm1').length
+    expect(c.mounts?.[0]).toMatchObject({ id: 'm1', ref: refId })
+    expect(c.mounts?.[0]?.footprint).toBe('xiao') // from the reference's footprint tag
+    // Re-applying (e.g. re-sync) replaces, doesn't duplicate.
+    c = applyImprint(c, xiao, refId, { id: 'm1', x: 0.5, y: 0.5 })
+    const n2 = (c.headers ?? []).flatMap((h) => h.pins).filter((p) => p.derived === 'm1').length
+    expect(n2).toBe(n1)
+    expect(c.mounts).toHaveLength(1)
+  })
+
+  it('removes the mount and its derived pins', () => {
+    const c = removeMountImprint(applyImprint(blankCarrier(), xiao, refId, { id: 'm1', x: 0.5, y: 0.5 }), 'm1')
+    expect(c.mounts ?? []).toHaveLength(0)
+    expect((c.headers ?? []).flatMap((h) => h.pins).some((p) => p.derived === 'm1')).toBe(false)
+  })
+
+  it('translateMount shifts the mount + its pins rigidly (signature unchanged)', () => {
+    const c0 = applyImprint(blankCarrier(), xiao, refId, { id: 'm1', x: 0.4, y: 0.4 })
+    const c1 = translateMount(c0, 'm1', 0.1, -0.05)
+    expect(c1.mounts?.[0]).toMatchObject({ x: 0.5 })
+    expect(c1.mounts?.[0]?.y).toBeCloseTo(0.35, 5)
+    // A rigid shift can't change the structural signature.
+    expect(mountSignature(c1, 'm1')).toBe(mountSignature(c0, 'm1'))
+  })
+})

--- a/test/footprintImprint.test.ts
+++ b/test/footprintImprint.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'fs'
 import { join } from 'path'
-import { imprintPins, applyImprint, removeMountImprint, translateMount } from '../src/shared/footprint-imprint'
+import { imprintPins, applyImprint, removeMountImprint, translateMount, rotateMount } from '../src/shared/footprint-imprint'
 import { partSignature, mountSignature, signaturesMatch } from '../src/shared/footprint-signature'
 import { partFromYaml } from '../src/shared/part-yaml'
 import type { PartDefinition } from '../src/shared/part'
@@ -72,6 +72,33 @@ describe('applyImprint / removeMountImprint / translateMount', () => {
     const c = removeMountImprint(applyImprint(blankCarrier(), xiao, refId, { id: 'm1', x: 0.5, y: 0.5 }), 'm1')
     expect(c.mounts ?? []).toHaveLength(0)
     expect((c.headers ?? []).flatMap((h) => h.pins).some((p) => p.derived === 'm1')).toBe(false)
+  })
+
+  it('rotateMount spins the block as a GROUP — the row/column grid rotates', () => {
+    const c0 = applyImprint(blankCarrier(58, 42.5), xiao, refId, { id: 'm1', x: 0.5, y: 0.5 })
+    // Count distinct levels (clusters) along an axis — the XIAO is 2 columns × 7 rows.
+    const levels = (vals: number[], gap = 0.03): number => {
+      let n = 0
+      let prev = -Infinity
+      for (const v of [...vals].sort((a, b) => a - b)) {
+        if (v - prev > gap) n++
+        prev = v
+      }
+      return n
+    }
+    const grid = (c: PartDefinition): { cols: number; rows: number } => {
+      const ps = (c.headers ?? []).flatMap((h) => h.pins).filter((p) => p.derived === 'm1')
+      return { cols: levels(ps.map((p) => p.x!)), rows: levels(ps.map((p) => p.y!)) }
+    }
+    expect(grid(c0)).toEqual({ cols: 2, rows: 7 })
+    const c90 = rotateMount(c0, 'm1', 90)
+    // A quarter turn rotates the whole grid: columns and rows swap.
+    expect(grid(c90)).toEqual({ cols: 7, rows: 2 })
+    expect(c90.mounts?.[0]?.rotation).toBe(90)
+    // Four quarter-turns return to the original grid + rotation 0.
+    const c360 = rotateMount(rotateMount(rotateMount(c90, 'm1', 90), 'm1', 90), 'm1', 90)
+    expect(grid(c360)).toEqual({ cols: 2, rows: 7 })
+    expect(c360.mounts?.[0]?.rotation).toBeUndefined()
   })
 
   it('translateMount shifts the mount + its pins rigidly (signature unchanged)', () => {

--- a/test/footprintSignature.test.ts
+++ b/test/footprintSignature.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import {
+  pinSignature,
+  partSignature,
+  mountSignature,
+  signaturesMatch,
+  type SigPin
+} from '../src/shared/footprint-signature'
+import { partFromYaml, partToYaml } from '../src/shared/part-yaml'
+import type { PartDefinition, PartPin } from '../src/shared/part'
+
+const pins = (...ps: SigPin[]): SigPin[] => ps
+
+describe('pinSignature — structural duck-typing (#166)', () => {
+  it('is translation + scale invariant (a board and its shrunk imprint match)', () => {
+    const board = pins(
+      { type: 'pwr', x: 0.1, y: 0.1 },
+      { type: 'gnd', x: 0.1, y: 0.5 },
+      { type: 'io', x: 0.1, y: 0.9 }
+    )
+    // Same layout imprinted into a carrier: translated to (0.6,0.2) and half the size.
+    const imprint = board.map((p) => ({ type: p.type, x: 0.6 + p.x * 0.5, y: 0.2 + p.y * 0.5 }))
+    expect(pinSignature(board)).toBe(pinSignature(imprint))
+    expect(signaturesMatch(pinSignature(board), pinSignature(imprint))).toBe(true)
+  })
+
+  it('ignores pin ORDER (sorted canonical form)', () => {
+    const a = pins({ type: 'pwr', x: 0.1, y: 0.1 }, { type: 'io', x: 0.9, y: 0.9 })
+    const b = pins({ type: 'io', x: 0.9, y: 0.9 }, { type: 'pwr', x: 0.1, y: 0.1 })
+    expect(pinSignature(a)).toBe(pinSignature(b))
+  })
+
+  it('distinguishes different TYPES at the same position', () => {
+    const a = pins({ type: 'io', x: 0.1, y: 0.1 }, { type: 'gnd', x: 0.9, y: 0.9 })
+    const b = pins({ type: 'pwr', x: 0.1, y: 0.1 }, { type: 'gnd', x: 0.9, y: 0.9 })
+    expect(signaturesMatch(pinSignature(a), pinSignature(b))).toBe(false)
+  })
+
+  it('distinguishes different LAYOUTS (a moved pin) and different pin counts', () => {
+    const a = pins({ type: 'io', x: 0.1, y: 0.1 }, { type: 'io', x: 0.1, y: 0.9 })
+    const moved = pins({ type: 'io', x: 0.1, y: 0.1 }, { type: 'io', x: 0.9, y: 0.9 })
+    const fewer = pins({ type: 'io', x: 0.1, y: 0.1 })
+    expect(signaturesMatch(pinSignature(a), pinSignature(moved))).toBe(false)
+    expect(signaturesMatch(pinSignature(a), pinSignature(fewer))).toBe(false)
+  })
+
+  it('an empty cluster never matches (not even another empty one)', () => {
+    expect(pinSignature([])).toBe('')
+    expect(signaturesMatch('', '')).toBe(false)
+  })
+})
+
+const pin = (p: Partial<PartPin> & { name: string; type: PartPin['type'] }): PartPin => p as PartPin
+
+describe('partSignature / mountSignature over a PartDefinition', () => {
+  it('a board and a carrier that imprinted it share a signature', () => {
+    const board: PartDefinition = {
+      parts: [],
+      connections: [],
+      headers: [
+        {
+          pins: [
+            pin({ name: '3V3', type: 'pwr', x: 0.2, y: 0.2 }),
+            pin({ name: 'GND', type: 'gnd', x: 0.2, y: 0.5 }),
+            pin({ name: 'D0', type: 'io', x: 0.2, y: 0.8, gpio: 26 })
+          ]
+        }
+      ]
+    } as unknown as PartDefinition
+    // The carrier holds the same pins imprinted from mount "m1" (shrunk + moved),
+    // plus its own unrelated pin that must NOT count toward the mount's signature.
+    const carrier: PartDefinition = {
+      parts: [],
+      connections: [],
+      headers: [
+        {
+          pins: [
+            pin({ name: 'own', type: 'io', x: 0.05, y: 0.05 }),
+            pin({ name: '3V3', type: 'pwr', x: 0.6, y: 0.3, derived: 'm1' }),
+            pin({ name: 'GND', type: 'gnd', x: 0.6, y: 0.45, derived: 'm1' }),
+            pin({ name: 'D0', type: 'io', x: 0.6, y: 0.6, derived: 'm1' })
+          ]
+        }
+      ]
+    } as unknown as PartDefinition
+    expect(mountSignature(carrier, 'm1')).toBe(partSignature(board))
+    expect(signaturesMatch(mountSignature(carrier, 'm1'), partSignature(board))).toBe(true)
+  })
+})
+
+describe('real bundled boards (#166)', () => {
+  const load = (id: string): PartDefinition =>
+    partFromYaml(readFileSync(join(__dirname, `../examples/parts/snakie-standard/${id}/parts.yml`), 'utf-8'))
+
+  it('the XIAO RP2040 and RP2350 duck-type (same footprint despite different authored positions)', () => {
+    const a = partSignature(load('seeed-xiao-rp2350'))
+    const b = partSignature(load('seeed-xiao-rp2040'))
+    expect(a).not.toBe('')
+    expect(signaturesMatch(a, b)).toBe(true)
+  })
+
+  it('a XIAO does NOT duck-type with an unrelated board', () => {
+    expect(signaturesMatch(partSignature(load('seeed-xiao-rp2350')), partSignature(load('esp32-devkit')))).toBe(false)
+  })
+})
+
+describe('serialisation of the imprint fields (#166)', () => {
+  it('round-trips PartMount.ref and PartPin.derived', () => {
+    const part = partFromYaml(
+      [
+        'id: base',
+        'name: Base',
+        'headers:',
+        '  - pins:',
+        '      - { name: D0, type: io, x: 0.6, y: 0.3, derived: m1, locked: true }',
+        'mounts:',
+        '  - { id: m1, footprint: xiao, ref: { lib: snakie-standard, part: seeed-xiao-rp2350 }, x: 0.7, y: 0.35 }',
+        ''
+      ].join('\n')
+    )
+    expect(part.mounts?.[0]).toMatchObject({ id: 'm1', ref: { lib: 'snakie-standard', part: 'seeed-xiao-rp2350' } })
+    expect(part.headers?.[0]?.pins?.[0]).toMatchObject({ name: 'D0', derived: 'm1' })
+    // Survives a full write→read cycle.
+    const back = partFromYaml(partToYaml(part))
+    expect(back.mounts?.[0]?.ref).toEqual({ lib: 'snakie-standard', part: 'seeed-xiao-rp2350' })
+    expect(back.headers?.[0]?.pins?.[0]?.derived).toBe('m1')
+  })
+})

--- a/test/footprintSignature.test.ts
+++ b/test/footprintSignature.test.ts
@@ -104,6 +104,18 @@ describe('real bundled boards (#166)', () => {
   it('a XIAO does NOT duck-type with an unrelated board', () => {
     expect(signaturesMatch(partSignature(load('seeed-xiao-rp2350')), partSignature(load('esp32-devkit')))).toBe(false)
   })
+
+  it('the bundled expansion base ships an imprinted XIAO footprint (docks out of the box)', () => {
+    const base = load('seeed-xiao-expansion-base')
+    const mount = base.mounts?.[0]
+    expect(mount?.ref).toEqual({ lib: 'snakie-standard', part: 'seeed-xiao-rp2350' })
+    const derived = (base.headers ?? []).flatMap((h) => h.pins).filter((p) => p.derived === mount?.id)
+    expect(derived.length).toBe(14)
+    // Docking compares a dragged board to the mount's REF board — so any XIAO
+    // (RP2040 or RP2350) structurally matches this socket.
+    const ref = load(mount!.ref!.part)
+    expect(signaturesMatch(partSignature(ref), partSignature(load('seeed-xiao-rp2040')))).toBe(true)
+  })
 })
 
 describe('serialisation of the imprint fields (#166)', () => {

--- a/test/footprints.test.ts
+++ b/test/footprints.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { collectFootprints, slugifyFootprint, COMMON_FOOTPRINTS } from '../src/shared/footprints'
+import type { PartLibraryWithParts } from '../src/shared/part'
+
+describe('slugifyFootprint', () => {
+  it('lower-cases, trims and hyphenates so equivalent spellings converge', () => {
+    expect(slugifyFootprint('XIAO')).toBe('xiao')
+    expect(slugifyFootprint('  Xiao ')).toBe('xiao')
+    expect(slugifyFootprint('Nano ESP32')).toBe('nano-esp32')
+    expect(slugifyFootprint('pico__w')).toBe('pico-w')
+  })
+  it('returns empty for a value that slugs to nothing', () => {
+    expect(slugifyFootprint('   ')).toBe('')
+    expect(slugifyFootprint('!!!')).toBe('')
+  })
+})
+
+const lib = (parts: PartLibraryWithParts['parts']): PartLibraryWithParts =>
+  ({ id: 'l', name: 'L', parts }) as PartLibraryWithParts
+
+describe('collectFootprints', () => {
+  it('always offers the curated standards even with no installed parts', () => {
+    const out = collectFootprints([])
+    expect(out.every((f) => f.common)).toBe(true)
+    expect(out.map((f) => f.id).sort()).toEqual(COMMON_FOOTPRINTS.map((c) => c.id).sort())
+    expect(out.every((f) => f.count === 0)).toBe(true)
+  })
+
+  it('counts footprints from both parts and carrier mounts', () => {
+    const libs = [
+      lib([
+        { id: 'a', footprint: 'xiao' } as never,
+        { id: 'b', footprint: 'XIAO' } as never, // slug-collapses onto xiao
+        { id: 'base', mounts: [{ id: 'm', footprint: 'xiao', x: 0.5, y: 0.5 }] } as never
+      ])
+    ]
+    const xiao = collectFootprints(libs).find((f) => f.id === 'xiao')
+    expect(xiao?.count).toBe(3)
+  })
+
+  it('surfaces an uncurated in-use footprint (labelled by its id) and sorts most-used first', () => {
+    const libs = [
+      lib([
+        { id: 'a', footprint: 'my-shield' } as never,
+        { id: 'b', footprint: 'my-shield' } as never
+      ])
+    ]
+    const out = collectFootprints(libs)
+    const custom = out.find((f) => f.id === 'my-shield')
+    expect(custom).toMatchObject({ id: 'my-shield', label: 'my-shield', count: 2, common: false })
+    // A count-2 custom footprint outranks the count-0 curated standards.
+    expect(out[0].id).toBe('my-shield')
+  })
+})

--- a/test/netlist.test.ts
+++ b/test/netlist.test.ts
@@ -259,6 +259,60 @@ describe('connector pins as wire terminals', () => {
   })
 })
 
+describe('buildNetlist — board stacking: the seated MCU (#166)', () => {
+  // A carrier whose imprinted footprint pins mirror the BOARD (GP0/GP1/5V/GND/3V3),
+  // plus its own Grove signal pin. Flattened: 0=GP0 1=GP1 2=5V 3=GND 4=3V3 5=GROVE.
+  const CARRIER: PartDefinition = {
+    id: 'base',
+    name: 'Base',
+    headers: [
+      {
+        edge: 'left',
+        pins: [
+          { name: 'GP0', type: 'io', derived: 'm1' },
+          { name: 'GP1', type: 'io', derived: 'm1' },
+          { name: '5V', type: 'pwr', derived: 'm1' },
+          { name: 'GND', type: 'gnd', derived: 'm1' },
+          { name: '3V3', type: 'pwr', derived: 'm1' },
+          { name: 'GROVE', type: 'io' }
+        ]
+      }
+    ],
+    mounts: [{ id: 'm1', footprint: 'xiao', x: 0.5, y: 0.5 }]
+  } as unknown as PartDefinition
+  const defs = new Map<string, PartDefinition>([['base', CARRIER]])
+  const seated = (connections: RobotConnection[] = []): RobotDefinition => ({
+    parts: [{ id: 'base', lib: 'l', part: 'base' }],
+    connections,
+    boardMountedOn: 'base',
+    boardMount: 'm1'
+  })
+
+  it('bonds the seated MCU pads to the carrier footprint pins of the same name', () => {
+    const nl = buildNetlist(seated(), BOARD, defs)
+    expect(nl.nodeOf[ep('board', 'GP0', 3)]).toBe(nl.nodeOf[ep('base', 'GP0', 0)])
+    expect(nl.nodeOf[ep('board', 'GND', 1)]).toBe(nl.nodeOf[ep('base', 'GND', 3)])
+  })
+
+  it('a wire to a carrier pad reaches the MCU GPIO through the seat', () => {
+    const nl = buildNetlist(seated([wire('w', ep('base', 'GROVE', 5), ep('base', 'GP0', 0))]), BOARD, defs)
+    // GROVE — base.GP0 — board.GP0 are all one node.
+    expect(nl.nodeOf[ep('base', 'GROVE', 5)]).toBe(nl.nodeOf[ep('board', 'GP0', 3)])
+  })
+
+  it('does NOT bond when the board is not seated', () => {
+    const nl = buildNetlist(
+      {
+        parts: [{ id: 'base', lib: 'l', part: 'base' }],
+        connections: [wire('w1', ep('board', 'GP0', 3), ep('base', 'GROVE', 5)), wire('w2', ep('base', 'GP0', 0), ep('base', 'GP1', 1))]
+      },
+      BOARD,
+      defs
+    )
+    expect(nl.nodeOf[ep('board', 'GP0', 3)]).not.toBe(nl.nodeOf[ep('base', 'GP0', 0)])
+  })
+})
+
 describe('remapConnectionsForBoard (MCU swap)', () => {
   // A different board layout: GP0 sits at a NEW index, GP1 is absent, and there is
   // only one GND / 3V3. Flattened: 0=GND 1=3V3 2=GP0 3=5V.


### PR DESCRIPTION
Reopens #640 against `master` (it was auto-closed when its stacked base branch was deleted on merge of #639). Same content — the full #166 footprint arc, now that #639 is merged.

Turns board-into-carrier seating from a footprint-name tag + abstract socket into a real, authorable footprint system: a footprint **is** a reference board's pin layout, boards dock by **structural signature** ("duck typing"), the MCU seats **on** the footprint (rotated to match, even when the carrier is rotated), and it's **electrically bonded** in the netlist.

## Highlights
- **Structural signatures** — footprint identity = pin layout (type + grid position), aspect-invariant + level-clustered so XIAO RP2040 ≡ RP2350, XIAO ≢ ESP32 DevKit.
- **Imprint** — "Add footprint" stamps a reference board's real pins (round pads, correct types/GPIOs) into a carrier as a locked, movable block; hover shows pin names (oriented to the block); mini-toolbar rename/rotate(group)/delete; footprints are a first-class Layers-hierarchy bucket.
- **Docking** — matches the dragged board to the mount's **source board** (rotation-independent), snaps it pin-aligned onto the footprint, rotated to `footprint + carrier` rotation; drop highlight is the footprint outline + pin dots.
- **Bundled base** — the Seeed XIAO expansion base ships with an imprinted footprint, so a XIAO docks out of the box (library.yml → 1.3.0 so the seeder refreshes untouched installs).
- **Electrical bonding** — the seated MCU's pads union with the carrier's same-named footprint pins in the netlist, flowing through ERC / DC solver / live probe.
- **Seeder** — refreshes stale `<userData>/parts` installs so footprint/mount fields land on older copies without clobbering edits.

## Tests / verification
2311 unit tests (signatures, imprint incl. group rotation, seeder policy, netlist bonding). Verified headlessly end-to-end: imprint flow, docking onto rotated footprints and rotated carriers, out-of-the-box bundled base, the scrollable/on-screen Add-footprint menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)