### PR TITLE
feat: bundled Pico Carrier Base (#166)

### DIFF
--- a/examples/parts/snakie-standard/library.yml
+++ b/examples/parts/snakie-standard/library.yml
@@ -3,4 +3,4 @@ name: Standard Parts
 description: The canonical Snakie parts — microcontrollers, sensors, ICs, power and more — kept up to date from github.com/kevinmcaleer/snakie-parts.
 author: Snakie
 homepage: https://github.com/kevinmcaleer/snakie-parts
-version: 1.3.0
+version: 1.4.0

--- a/examples/parts/snakie-standard/pico-carrier-base/parts.yml
+++ b/examples/parts/snakie-standard/pico-carrier-base/parts.yml
@@ -1,0 +1,687 @@
+id: pico-carrier-base
+name: Pico Carrier Base
+description: A generic carrier a Raspberry Pi Pico plugs into — its 40-pin socket is broken out as a footprint you can wire to.
+family: Microcontroller
+pcbColor: "#0f5a2e"
+dimensions:
+  width: 55
+  height: 80
+shape:
+  kind: rect
+  cornerRadius: 0.04
+headers:
+  - edge: left
+    pins:
+      - name: GP0
+        type: io
+        locked: true
+        number: 1
+        gpio: 0
+        capabilities:
+          - digital
+          - pwm
+          - spi
+          - i2c
+        signals:
+          i2c: SDA
+          spi: RX
+          pwm: A
+        buses:
+          i2c: 0
+          spi: 0
+        shape: round
+        x: 0.34715705455433243
+        y: 0.22107806816101078
+        derived: mount-1
+      - name: GP1
+        type: io
+        locked: true
+        number: 2
+        gpio: 1
+        capabilities:
+          - digital
+          - pwm
+          - spi
+          - i2c
+        signals:
+          i2c: SCL
+          spi: CSn
+          pwm: B
+        buses:
+          i2c: 0
+          spi: 0
+        shape: round
+        x: 0.34715705455433243
+        y: 0.25053056816101077
+        derived: mount-1
+      - name: GND
+        type: gnd
+        locked: true
+        number: 3
+        shape: round
+        x: 0.34715705455433243
+        y: 0.27998306816101076
+        derived: mount-1
+      - name: GP2
+        type: io
+        locked: true
+        number: 4
+        gpio: 2
+        capabilities:
+          - digital
+          - pwm
+          - spi
+          - i2c
+        signals:
+          i2c: SDA
+          spi: SCK
+          pwm: A
+        buses:
+          i2c: 1
+          spi: 0
+        shape: round
+        x: 0.34715705455433243
+        y: 0.30943556816101075
+        derived: mount-1
+      - name: GP3
+        type: io
+        locked: true
+        number: 5
+        gpio: 3
+        capabilities:
+          - digital
+          - pwm
+          - spi
+          - i2c
+        signals:
+          i2c: SCL
+          spi: TX
+          pwm: B
+        buses:
+          i2c: 1
+          spi: 0
+        shape: round
+        x: 0.34715705455433243
+        y: 0.3388880681610108
+        derived: mount-1
+      - name: GP4
+        type: io
+        locked: true
+        number: 6
+        gpio: 4
+        capabilities:
+          - digital
+          - pwm
+          - spi
+          - i2c
+        signals:
+          i2c: SDA
+          spi: RX
+          pwm: A
+        buses:
+          i2c: 0
+          spi: 0
+        shape: round
+        x: 0.34715705455433243
+        y: 0.36840431816101077
+        derived: mount-1
+      - name: GP5
+        type: io
+        locked: true
+        number: 7
+        gpio: 5
+        capabilities:
+          - digital
+          - pwm
+          - spi
+          - i2c
+        signals:
+          i2c: SCL
+          spi: CSn
+          pwm: B
+        buses:
+          i2c: 0
+          spi: 0
+        shape: round
+        x: 0.34715705455433243
+        y: 0.39785681816101076
+        derived: mount-1
+      - name: GND
+        type: gnd
+        locked: true
+        number: 8
+        shape: round
+        x: 0.34715705455433243
+        y: 0.42730931816101075
+        derived: mount-1
+      - name: GP6
+        type: io
+        locked: true
+        number: 9
+        gpio: 6
+        capabilities:
+          - digital
+          - pwm
+          - spi
+          - i2c
+        signals:
+          i2c: SDA
+          spi: SCK
+          pwm: A
+        buses:
+          i2c: 1
+          spi: 0
+        shape: round
+        x: 0.34715705455433243
+        y: 0.45676181816101075
+        derived: mount-1
+      - name: GP7
+        type: io
+        locked: true
+        number: 10
+        gpio: 7
+        capabilities:
+          - digital
+          - pwm
+          - spi
+          - i2c
+        signals:
+          i2c: SCL
+          spi: TX
+          pwm: B
+        buses:
+          i2c: 1
+          spi: 0
+        shape: round
+        x: 0.34715705455433243
+        y: 0.48621431816101074
+        derived: mount-1
+      - name: GP8
+        type: io
+        locked: true
+        number: 11
+        gpio: 8
+        capabilities:
+          - digital
+          - pwm
+          - spi
+          - i2c
+        signals:
+          i2c: SDA
+          spi: RX
+          pwm: A
+        buses:
+          i2c: 0
+          spi: 1
+        shape: round
+        x: 0.34715705455433243
+        y: 0.5156668181610108
+        derived: mount-1
+      - name: GP9
+        type: io
+        locked: true
+        number: 12
+        gpio: 9
+        capabilities:
+          - digital
+          - pwm
+          - spi
+          - i2c
+        signals:
+          i2c: SCL
+          spi: CSn
+          pwm: B
+        buses:
+          i2c: 0
+          spi: 1
+        shape: round
+        x: 0.34715705455433243
+        y: 0.5451193181610107
+        derived: mount-1
+      - name: GND
+        type: gnd
+        locked: true
+        number: 13
+        shape: round
+        x: 0.34715705455433243
+        y: 0.5745718181610107
+        derived: mount-1
+      - name: GP10
+        type: io
+        locked: true
+        number: 14
+        gpio: 10
+        capabilities:
+          - digital
+          - pwm
+          - spi
+          - i2c
+        signals:
+          i2c: SDA
+          spi: SCK
+          pwm: A
+        buses:
+          i2c: 1
+          spi: 1
+        shape: round
+        x: 0.34715705455433243
+        y: 0.6040243181610108
+        derived: mount-1
+      - name: GP11
+        type: io
+        locked: true
+        number: 15
+        gpio: 11
+        capabilities:
+          - digital
+          - pwm
+          - spi
+          - i2c
+        signals:
+          i2c: SCL
+          spi: TX
+          pwm: B
+        buses:
+          i2c: 1
+          spi: 1
+        shape: round
+        x: 0.34715705455433243
+        y: 0.6334768181610108
+        derived: mount-1
+      - name: GP12
+        type: io
+        locked: true
+        number: 16
+        gpio: 12
+        capabilities:
+          - digital
+          - pwm
+          - spi
+          - i2c
+        signals:
+          i2c: SDA
+          spi: RX
+          pwm: A
+        buses:
+          i2c: 0
+          spi: 1
+        shape: round
+        x: 0.34715705455433243
+        y: 0.6629930681610108
+        derived: mount-1
+      - name: GP13
+        type: io
+        locked: true
+        number: 17
+        gpio: 13
+        capabilities:
+          - digital
+          - pwm
+          - spi
+          - i2c
+        signals:
+          i2c: SCL
+          spi: CSn
+          pwm: B
+        buses:
+          i2c: 0
+          spi: 1
+        shape: round
+        x: 0.34715705455433243
+        y: 0.6924455681610108
+        derived: mount-1
+      - name: GND
+        type: gnd
+        locked: true
+        number: 18
+        shape: round
+        x: 0.34715705455433243
+        y: 0.7218980681610108
+        derived: mount-1
+      - name: GP14
+        type: io
+        locked: true
+        number: 19
+        gpio: 14
+        capabilities:
+          - digital
+          - pwm
+          - spi
+          - i2c
+        signals:
+          i2c: SDA
+          spi: SCK
+          pwm: A
+        buses:
+          i2c: 1
+          spi: 1
+        shape: round
+        x: 0.34715705455433243
+        y: 0.7513505681610108
+        derived: mount-1
+      - name: GP15
+        type: io
+        locked: true
+        number: 20
+        gpio: 15
+        capabilities:
+          - digital
+          - pwm
+          - spi
+          - i2c
+        signals:
+          i2c: SCL
+          spi: TX
+          pwm: B
+        buses:
+          i2c: 1
+          spi: 1
+        shape: round
+        x: 0.34715705455433243
+        y: 0.7808030681610106
+        derived: mount-1
+      - name: VBUS
+        type: pwr
+        locked: true
+        number: 40
+        shape: round
+        x: 0.6538935546875
+        y: 0.21903235092163087
+        derived: mount-1
+      - name: VSYS
+        type: pwr
+        locked: true
+        number: 39
+        shape: round
+        x: 0.6538935546875
+        y: 0.24848485092163092
+        derived: mount-1
+      - name: GND
+        type: gnd
+        locked: true
+        number: 38
+        shape: round
+        x: 0.6538935546875
+        y: 0.27793735092163085
+        derived: mount-1
+      - name: 3V3_EN
+        type: other
+        locked: true
+        number: 37
+        shape: round
+        x: 0.6538935546875
+        y: 0.30738985092163085
+        derived: mount-1
+      - name: 3V3
+        type: pwr
+        locked: true
+        number: 36
+        shape: round
+        x: 0.6538935546875
+        y: 0.33684235092163084
+        derived: mount-1
+      - name: ADC_VREF
+        type: other
+        locked: true
+        number: 35
+        shape: round
+        x: 0.6538935546875
+        y: 0.36635860092163086
+        derived: mount-1
+      - name: GP28
+        type: io
+        locked: true
+        number: 34
+        gpio: 28
+        capabilities:
+          - digital
+          - pwm
+          - adc
+          - spi
+          - i2c
+        signals:
+          i2c: SDA
+          spi: RX
+          pwm: A
+        buses:
+          i2c: 0
+          spi: 1
+          adc: 2
+        shape: round
+        x: 0.6538935546875
+        y: 0.39581110092163085
+        derived: mount-1
+      - name: GND
+        type: gnd
+        locked: true
+        number: 33
+        shape: round
+        x: 0.6538935546875
+        y: 0.4252636009216309
+        derived: mount-1
+      - name: GP27
+        type: io
+        locked: true
+        number: 32
+        gpio: 27
+        capabilities:
+          - digital
+          - pwm
+          - adc
+          - spi
+          - i2c
+        signals:
+          i2c: SCL
+          spi: TX
+          pwm: B
+        buses:
+          i2c: 1
+          spi: 1
+          adc: 1
+        shape: round
+        x: 0.6538935546875
+        y: 0.45471610092163084
+        derived: mount-1
+      - name: GP26
+        type: io
+        locked: true
+        number: 31
+        gpio: 26
+        capabilities:
+          - digital
+          - pwm
+          - adc
+          - spi
+          - i2c
+        signals:
+          i2c: SDA
+          spi: SCK
+          pwm: A
+        buses:
+          i2c: 1
+          spi: 1
+          adc: 0
+        shape: round
+        x: 0.6538935546875
+        y: 0.4841686009216309
+        derived: mount-1
+      - name: RUN
+        type: other
+        locked: true
+        number: 30
+        shape: round
+        x: 0.6538935546875
+        y: 0.5136211009216308
+        derived: mount-1
+      - name: GP22
+        type: io
+        locked: true
+        number: 29
+        gpio: 22
+        capabilities:
+          - digital
+          - pwm
+          - spi
+          - i2c
+        signals:
+          i2c: SDA
+          spi: SCK
+          pwm: A
+        buses:
+          i2c: 1
+          spi: 0
+        shape: round
+        x: 0.6538935546875
+        y: 0.5430736009216308
+        derived: mount-1
+      - name: GND
+        type: gnd
+        locked: true
+        number: 28
+        shape: round
+        x: 0.6538935546875
+        y: 0.5725261009216309
+        derived: mount-1
+      - name: GP21
+        type: io
+        locked: true
+        number: 27
+        gpio: 21
+        capabilities:
+          - digital
+          - pwm
+          - spi
+          - i2c
+        signals:
+          i2c: SCL
+          spi: CSn
+          pwm: B
+        buses:
+          i2c: 0
+          spi: 0
+        shape: round
+        x: 0.6538935546875
+        y: 0.6019786009216309
+        derived: mount-1
+      - name: GP20
+        type: io
+        locked: true
+        number: 26
+        gpio: 20
+        capabilities:
+          - digital
+          - pwm
+          - spi
+          - i2c
+        signals:
+          i2c: SDA
+          spi: RX
+          pwm: A
+        buses:
+          i2c: 0
+          spi: 0
+        shape: round
+        x: 0.6538935546875
+        y: 0.6314311009216309
+        derived: mount-1
+      - name: GP19
+        type: io
+        locked: true
+        number: 25
+        gpio: 19
+        capabilities:
+          - digital
+          - pwm
+          - spi
+          - i2c
+        signals:
+          i2c: SCL
+          spi: TX
+          pwm: B
+        buses:
+          i2c: 1
+          spi: 0
+        shape: round
+        x: 0.6538935546875
+        y: 0.6609473509216309
+        derived: mount-1
+      - name: GP18
+        type: io
+        locked: true
+        number: 24
+        gpio: 18
+        capabilities:
+          - digital
+          - pwm
+          - spi
+          - i2c
+        signals:
+          i2c: SDA
+          spi: SCK
+          pwm: A
+        buses:
+          i2c: 1
+          spi: 0
+        shape: round
+        x: 0.6538935546875
+        y: 0.6903998509216309
+        derived: mount-1
+      - name: GND
+        type: gnd
+        locked: true
+        number: 23
+        shape: round
+        x: 0.6538935546875
+        y: 0.7198523509216309
+        derived: mount-1
+      - name: GP17
+        type: io
+        locked: true
+        number: 22
+        gpio: 17
+        capabilities:
+          - digital
+          - pwm
+          - spi
+          - i2c
+        signals:
+          i2c: SCL
+          spi: CSn
+          pwm: B
+        buses:
+          i2c: 0
+          spi: 0
+        shape: round
+        x: 0.6538935546875
+        y: 0.7493048509216309
+        derived: mount-1
+      - name: GP16
+        type: io
+        locked: true
+        number: 21
+        gpio: 16
+        capabilities:
+          - digital
+          - pwm
+          - spi
+          - i2c
+        signals:
+          i2c: SDA
+          spi: RX
+          pwm: A
+        buses:
+          i2c: 0
+          spi: 0
+        shape: round
+        x: 0.6538935546875
+        y: 0.7787573509216308
+        derived: mount-1
+mounts:
+  - id: mount-1
+    footprint: pico
+    ref:
+      lib: snakie-standard
+      part: pico2w
+    label: Raspberry Pi Pico 2 W
+    x: 0.5
+    y: 0.5

--- a/test/footprintSignature.test.ts
+++ b/test/footprintSignature.test.ts
@@ -116,6 +116,14 @@ describe('real bundled boards (#166)', () => {
     const ref = load(mount!.ref!.part)
     expect(signaturesMatch(partSignature(ref), partSignature(load('seeed-xiao-rp2040')))).toBe(true)
   })
+
+  it('the bundled Pico carrier ships an imprinted Pico footprint (docks out of the box)', () => {
+    const carrier = load('pico-carrier-base')
+    const mount = carrier.mounts?.[0]
+    expect(mount?.ref).toEqual({ lib: 'snakie-standard', part: 'pico2w' })
+    const derived = (carrier.headers ?? []).flatMap((h) => h.pins).filter((p) => p.derived === mount?.id)
+    expect(derived.length).toBe(40)
+  })
 })
 
 describe('serialisation of the imprint fields (#166)', () => {


### PR DESCRIPTION
Follow-up to the footprint arc (#166 / #641): the library only had **one** carrier (the XIAO expansion base). This adds a generic **Pico Carrier Base** so a Raspberry Pi Pico docks out of the box too.

- 55×80 mm plain-PCB carrier (no photo) whose **40-pin Pico socket is imprinted as a footprint** (`ref = pico2w`, footprint `pico`), authored with the same imprint engine the Part Editor uses. Any Pico-layout board docks via the ref-based structural match.
- `snakie-standard/library.yml` → **1.4.0** so the seeder picks up the new part.
- Regression test: the bundled carrier has a `pico2w`-ref mount + 40 derived pins. Verified headlessly: a Pico 2 W drags onto it and seats; it renders as a clean PCB rect + the 40-pad socket.

Best-effort per the plan — no board photo and the socket is centred, so it's a **starting point to refine in the Part Editor** (reposition the socket, add real ports/buttons). `pico` (the base part) has no positioned pins so `pico2w` is the ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)