### PR TITLE
fix: align pico2w pin rows so the whole Pico family shares a footprint (#166)

### DIFF
--- a/examples/parts/snakie-standard/library.yml
+++ b/examples/parts/snakie-standard/library.yml
@@ -3,4 +3,4 @@ name: Standard Parts
 description: The canonical Snakie parts — microcontrollers, sensors, ICs, power and more — kept up to date from github.com/kevinmcaleer/snakie-parts.
 author: Snakie
 homepage: https://github.com/kevinmcaleer/snakie-parts
-version: 1.4.0
+version: 1.5.0

--- a/examples/parts/snakie-standard/pico-carrier-base/parts.yml
+++ b/examples/parts/snakie-standard/pico-carrier-base/parts.yml
@@ -386,7 +386,7 @@ headers:
         number: 40
         shape: round
         x: 0.6538935546875
-        y: 0.21903235092163087
+        y: 0.22107806816101078
         derived: mount-1
       - name: VSYS
         type: pwr
@@ -394,7 +394,7 @@ headers:
         number: 39
         shape: round
         x: 0.6538935546875
-        y: 0.24848485092163092
+        y: 0.25053056816101077
         derived: mount-1
       - name: GND
         type: gnd
@@ -402,7 +402,7 @@ headers:
         number: 38
         shape: round
         x: 0.6538935546875
-        y: 0.27793735092163085
+        y: 0.27998306816101076
         derived: mount-1
       - name: 3V3_EN
         type: other
@@ -410,7 +410,7 @@ headers:
         number: 37
         shape: round
         x: 0.6538935546875
-        y: 0.30738985092163085
+        y: 0.30943556816101075
         derived: mount-1
       - name: 3V3
         type: pwr
@@ -418,7 +418,7 @@ headers:
         number: 36
         shape: round
         x: 0.6538935546875
-        y: 0.33684235092163084
+        y: 0.3388880681610108
         derived: mount-1
       - name: ADC_VREF
         type: other
@@ -426,7 +426,7 @@ headers:
         number: 35
         shape: round
         x: 0.6538935546875
-        y: 0.36635860092163086
+        y: 0.36840431816101077
         derived: mount-1
       - name: GP28
         type: io
@@ -449,7 +449,7 @@ headers:
           adc: 2
         shape: round
         x: 0.6538935546875
-        y: 0.39581110092163085
+        y: 0.39785681816101076
         derived: mount-1
       - name: GND
         type: gnd
@@ -457,7 +457,7 @@ headers:
         number: 33
         shape: round
         x: 0.6538935546875
-        y: 0.4252636009216309
+        y: 0.42730931816101075
         derived: mount-1
       - name: GP27
         type: io
@@ -480,7 +480,7 @@ headers:
           adc: 1
         shape: round
         x: 0.6538935546875
-        y: 0.45471610092163084
+        y: 0.45676181816101075
         derived: mount-1
       - name: GP26
         type: io
@@ -503,7 +503,7 @@ headers:
           adc: 0
         shape: round
         x: 0.6538935546875
-        y: 0.4841686009216309
+        y: 0.48621431816101074
         derived: mount-1
       - name: RUN
         type: other
@@ -511,7 +511,7 @@ headers:
         number: 30
         shape: round
         x: 0.6538935546875
-        y: 0.5136211009216308
+        y: 0.5156668181610108
         derived: mount-1
       - name: GP22
         type: io
@@ -532,7 +532,7 @@ headers:
           spi: 0
         shape: round
         x: 0.6538935546875
-        y: 0.5430736009216308
+        y: 0.5451193181610107
         derived: mount-1
       - name: GND
         type: gnd
@@ -540,7 +540,7 @@ headers:
         number: 28
         shape: round
         x: 0.6538935546875
-        y: 0.5725261009216309
+        y: 0.5745718181610107
         derived: mount-1
       - name: GP21
         type: io
@@ -561,7 +561,7 @@ headers:
           spi: 0
         shape: round
         x: 0.6538935546875
-        y: 0.6019786009216309
+        y: 0.6040243181610108
         derived: mount-1
       - name: GP20
         type: io
@@ -582,7 +582,7 @@ headers:
           spi: 0
         shape: round
         x: 0.6538935546875
-        y: 0.6314311009216309
+        y: 0.6334768181610108
         derived: mount-1
       - name: GP19
         type: io
@@ -603,7 +603,7 @@ headers:
           spi: 0
         shape: round
         x: 0.6538935546875
-        y: 0.6609473509216309
+        y: 0.6629930681610108
         derived: mount-1
       - name: GP18
         type: io
@@ -624,7 +624,7 @@ headers:
           spi: 0
         shape: round
         x: 0.6538935546875
-        y: 0.6903998509216309
+        y: 0.6924455681610108
         derived: mount-1
       - name: GND
         type: gnd
@@ -632,7 +632,7 @@ headers:
         number: 23
         shape: round
         x: 0.6538935546875
-        y: 0.7198523509216309
+        y: 0.7218980681610108
         derived: mount-1
       - name: GP17
         type: io
@@ -653,7 +653,7 @@ headers:
           spi: 0
         shape: round
         x: 0.6538935546875
-        y: 0.7493048509216309
+        y: 0.7513505681610108
         derived: mount-1
       - name: GP16
         type: io
@@ -674,7 +674,7 @@ headers:
           spi: 0
         shape: round
         x: 0.6538935546875
-        y: 0.7787573509216308
+        y: 0.7808030681610106
         derived: mount-1
 mounts:
   - id: mount-1

--- a/examples/parts/snakie-standard/pico2w/parts.yml
+++ b/examples/parts/snakie-standard/pico2w/parts.yml
@@ -11,7 +11,7 @@ package: THT
 pinSpacing: 2.54
 voltage: 1.8–5.5V
 partNumber: SC1634
-version: 1.0.6
+version: 1.0.7
 mcu: RP2350
 pcbColor: "#0f5a2e"
 aspect: 0.3943
@@ -377,42 +377,42 @@ headers:
         shape: castellated
         rotation: 0
         x: 0.9030545479910713
-        y: 0.05926643281824449
+        y: 0.062475401036879596
       - name: VSYS
         type: pwr
         number: 39
         shape: castellated
         rotation: 0
         x: 0.9030545479910713
-        y: 0.1054664328182445
+        y: 0.1086754010368796
       - name: GND
         type: gnd
         number: 38
         shape: castellated
         rotation: 0
         x: 0.9030545479910713
-        y: 0.1516664328182445
+        y: 0.1548754010368796
       - name: 3V3_EN
         type: other
         number: 37
         shape: castellated
         rotation: 0
         x: 0.9030545479910713
-        y: 0.19786643281824448
+        y: 0.2010754010368796
       - name: 3V3
         type: pwr
         number: 36
         shape: castellated
         rotation: 0
         x: 0.9030545479910713
-        y: 0.24406643281824447
+        y: 0.2472754010368796
       - name: ADC_VREF
         type: other
         number: 35
         shape: castellated
         rotation: 0
         x: 0.9030545479910713
-        y: 0.29036643281824454
+        y: 0.2935754010368796
       - name: GP28
         type: io
         number: 34
@@ -434,14 +434,14 @@ headers:
         shape: castellated
         rotation: 0
         x: 0.9030545479910713
-        y: 0.3365664328182445
+        y: 0.3397754010368796
       - name: GND
         type: gnd
         number: 33
         shape: castellated
         rotation: 0
         x: 0.9030545479910713
-        y: 0.3827664328182445
+        y: 0.3859754010368796
       - name: GP27
         type: io
         number: 32
@@ -463,7 +463,7 @@ headers:
         shape: castellated
         rotation: 0
         x: 0.9030545479910713
-        y: 0.4289664328182445
+        y: 0.43217540103687957
       - name: GP26
         type: io
         number: 31
@@ -485,14 +485,14 @@ headers:
         shape: castellated
         rotation: 0
         x: 0.9030545479910713
-        y: 0.4751664328182445
+        y: 0.4783754010368796
       - name: RUN
         type: other
         number: 30
         shape: castellated
         rotation: 0
         x: 0.9030545479910713
-        y: 0.5213664328182445
+        y: 0.5245754010368796
       - name: GP22
         type: io
         number: 29
@@ -512,14 +512,14 @@ headers:
         shape: castellated
         rotation: 0
         x: 0.9030545479910713
-        y: 0.5675664328182445
+        y: 0.5707754010368795
       - name: GND
         type: gnd
         number: 28
         shape: castellated
         rotation: 0
         x: 0.9030545479910713
-        y: 0.6137664328182445
+        y: 0.6169754010368795
       - name: GP21
         type: io
         number: 27
@@ -539,7 +539,7 @@ headers:
         shape: castellated
         rotation: 0
         x: 0.9030545479910713
-        y: 0.6599664328182445
+        y: 0.6631754010368796
       - name: GP20
         type: io
         number: 26
@@ -559,7 +559,7 @@ headers:
         shape: castellated
         rotation: 0
         x: 0.9030545479910713
-        y: 0.7061664328182445
+        y: 0.7093754010368796
       - name: GP19
         type: io
         number: 25
@@ -579,7 +579,7 @@ headers:
         shape: castellated
         rotation: 0
         x: 0.9030545479910713
-        y: 0.7524664328182445
+        y: 0.7556754010368796
       - name: GP18
         type: io
         number: 24
@@ -599,14 +599,14 @@ headers:
         shape: castellated
         rotation: 0
         x: 0.9030545479910713
-        y: 0.7986664328182446
+        y: 0.8018754010368796
       - name: GND
         type: gnd
         number: 23
         shape: castellated
         rotation: 0
         x: 0.9030545479910713
-        y: 0.8448664328182446
+        y: 0.8480754010368796
       - name: GP17
         type: io
         number: 22
@@ -626,7 +626,7 @@ headers:
         shape: castellated
         rotation: 0
         x: 0.9030545479910713
-        y: 0.8910664328182446
+        y: 0.8942754010368796
       - name: GP16
         type: io
         number: 21
@@ -646,7 +646,7 @@ headers:
         shape: castellated
         rotation: 0
         x: 0.9030545479910713
-        y: 0.9372664328182444
+        y: 0.9404754010368794
 ledLabel: LED
 image: image.png
 imageLayer:

--- a/test/footprintSignature.test.ts
+++ b/test/footprintSignature.test.ts
@@ -124,6 +124,16 @@ describe('real bundled boards (#166)', () => {
     const derived = (carrier.headers ?? []).flatMap((h) => h.pins).filter((p) => p.derived === mount?.id)
     expect(derived.length).toBe(40)
   })
+
+  it('the whole Pico family shares one footprint, so any Pico docks the carrier', () => {
+    // pico2w's columns were misaligned (40 distinct y-levels), breaking its
+    // signature vs pico/pico-w; once aligned they all duck-type together.
+    const sig = partSignature(load('pico2w')) // the carrier's mount ref
+    expect(sig).not.toBe('')
+    for (const id of ['pico', 'pico-w', 'pico2w']) {
+      expect(signaturesMatch(sig, partSignature(load(id)))).toBe(true)
+    }
+  })
 })
 
 describe('serialisation of the imprint fields (#166)', () => {


### PR DESCRIPTION
Follow-up to the Pico Carrier Base (#644): a plain `pico` or `pico-w` wouldn't dock into it, only `pico2w`.

## Root cause
`pico2w`'s two pad columns were offset by a **uniform 0.003 in y**, so it had **40 distinct y-levels instead of 20 shared rows**. That collapsed its structural signature (rows clustered wrong), so `pico2w ≢ pico` / `pico-w` (both clean 20-row grids). Docking compares a board to the carrier's `ref` (pico2w), so only a pico2w matched.

(My earlier "the pico part has empty pins" was a **grep false-negative** on inline YAML — `pico` was always fine.)

## Fix
- Snap each right-column pad onto its left-column pair's row. The part round-trips **losslessly** — only the 20 y-values change (image / electrical / pins / everything else untouched).
- Re-imprint the **Pico Carrier Base** from the fixed pico2w.
- Bump pico2w 1.0.6→1.0.7 and `snakie-standard/library.yml` 1.4.0→1.5.0 so the seeder refreshes untouched installs.

## Verified
- `pico ≡ pico-w ≡ pico2w` signatures (regression test).
- Headless end-to-end: **all three Pico variants** now drag onto the carrier and seat (previously only pico2w).
- 2314 tests / typecheck / lint / build:web green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)