### PR TITLE
feat: Snakie knows which Python the board runs (#752)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Snakie can tell which Python your board is running.** (#752, epic #209) The
+  connect probe now reads `sys.implementation`, so the session knows whether a
+  board runs **MicroPython or CircuitPython** instead of assuming — the
+  foundation the rest of the CircuitPython work is built on. The status bar names
+  the runtime and version beside the port, with the board string on hover, and
+  the connect greeting is rebuilt in that runtime's own wording rather than
+  MicroPython's. A board that won't answer stays unidentified rather than being
+  guessed at, and the previous board's runtime can't linger after you unplug it.
+
 ## [0.44.0] - 2026-08-16
 
 ### Added

--- a/src/main/device/MicroPythonDevice.ts
+++ b/src/main/device/MicroPythonDevice.ts
@@ -1,6 +1,12 @@
 import { EventEmitter } from 'events'
 import { SerialPort } from 'serialport'
 import { buildControlLine } from '../../shared/control'
+import {
+  RUNTIME_PROBE_PY,
+  parseRuntimeProbe,
+  runtimeGreeting,
+  type RuntimeInfo
+} from '../../shared/dialect'
 import type {
   ConnectOptions,
   ConnectionState,
@@ -60,6 +66,12 @@ export class MicroPythonDevice extends EventEmitter implements SnakieDevice {
   private state: ConnectionState = 'disconnected'
   private currentPath?: string
   private currentBaud?: number
+
+  /** What the board said it is (#752), probed on connect. Null until the probe
+   *  answers, and stays null for a board that wouldn't say — the rest of the app
+   *  reads this instead of assuming MicroPython. Cleared on disconnect so the
+   *  next board can't inherit the last one's runtime. */
+  private runtime: RuntimeInfo | null = null
 
   /**
    * Buffer of bytes received from the device. When a command is awaiting a
@@ -136,11 +148,13 @@ export class MicroPythonDevice extends EventEmitter implements SnakieDevice {
 
   /** Current connection status snapshot (safe to send over IPC). */
   getStatus(): DeviceStatus {
-    return {
+    const status: DeviceStatus = {
       state: this.state,
       path: this.currentPath,
       baudRate: this.currentBaud
     }
+    if (this.runtime) status.runtime = this.runtime
+    return status
   }
 
   isConnected(): boolean {
@@ -191,19 +205,35 @@ export class MicroPythonDevice extends EventEmitter implements SnakieDevice {
     void this.greet()
   }
 
-  /** Print the board's MicroPython greeting to the terminal on connect, rebuilt
-   *  from `os.uname()` so it matches the real banner (`MicroPython vX on DATE;
-   *  <board>`) — the connect cue the leaked Ctrl-B banner used to provide (#612). */
+  /**
+   * Ask the board what it is, then print its greeting to the terminal — the
+   * connect cue the leaked Ctrl-B banner used to provide (#612).
+   *
+   * One probe serves both jobs (#752). It reads `sys.implementation` for the
+   * DIALECT — MicroPython or CircuitPython, which the rest of the app reads off
+   * the session rather than assuming — and `os.uname()` for the version, build
+   * date and board string that make the greeting read like the board's own.
+   * Because each runtime words its banner differently, the line is rebuilt from
+   * what was probed rather than hard-coded, so a CircuitPython user isn't
+   * greeted with MicroPython's wording.
+   *
+   * Fire-and-forget: a board that answers neither still connects, and simply
+   * shows no banner.
+   */
   private async greet(): Promise<void> {
     try {
-      const line = (
-        await this.eval("import os as _o; print('MicroPython v' + _o.uname().version + '; ' + _o.uname().machine)")
-      ).trim()
-      if (line && this.isConnected()) {
+      const info = parseRuntimeProbe(await this.eval(RUNTIME_PROBE_PY))
+      if (!info || !this.isConnected()) return
+      this.runtime = info
+      // The `connected` status went out before the probe answered, so publish a
+      // second one now that the runtime is known.
+      this.emit('status', this.getStatus())
+      const line = runtimeGreeting(info)
+      if (line) {
         this.emit('data', Buffer.from(`\r\n${line}\r\nType "help()" for more information.\r\n>>> `))
       }
     } catch {
-      // Best-effort — a board that can't answer os.uname() just shows no banner.
+      // Best-effort — a board that can't answer the probe just shows no banner.
     }
   }
 
@@ -221,11 +251,16 @@ export class MicroPythonDevice extends EventEmitter implements SnakieDevice {
 
   private setState(state: ConnectionState, error?: string): void {
     this.state = state
+    // A new connection knows nothing about the board yet, and the PREVIOUS
+    // board's runtime must not leak into it — unplugging a Pico and plugging in
+    // a Feather would otherwise leave the status bar naming the wrong Python.
+    if (state !== 'connected') this.runtime = null
     const status: DeviceStatus = {
       state,
       path: this.currentPath,
       baudRate: this.currentBaud
     }
+    if (this.runtime) status.runtime = this.runtime
     if (error) status.error = error
     this.emit('status', status)
   }

--- a/src/main/device/SimulatedDevice.ts
+++ b/src/main/device/SimulatedDevice.ts
@@ -3,6 +3,7 @@ import { VIRTUAL_PORT_PATH } from '../../shared/virtual-device'
 import { INSTALL_START, INSTALL_ERR } from '../packages/install'
 import { MicroPythonRuntime, type ReplRuntime } from './MicroPythonRuntime'
 import { isProbeCode, simulateProbeResponse, simulatedTelemetryFrame } from '../../shared/simulation'
+import type { RuntimeInfo } from '../../shared/dialect'
 import type {
   ConnectionState,
   DeviceStatus,
@@ -14,6 +15,16 @@ import type {
 
 /** How often the simulated board "prints" a telemetry frame (ms). */
 const TELEMETRY_INTERVAL_MS = 120
+
+/**
+ * What the simulator reports as its runtime (#752). Stated rather than probed:
+ * the interpreter behind it IS MicroPython (the official WASM port), so this is
+ * a fact about the simulator, not a guess about a board. No version — the WASM
+ * build's is the port's, not a board firmware anyone could flash, and offering
+ * it would invite the update check to compare against a firmware catalog.
+ * Whether the simulator should ever offer CircuitPython is #764.
+ */
+const SIM_RUNTIME: RuntimeInfo = { dialect: 'micropython' }
 
 /**
  * SIMULATED MicroPython device (issue #135).
@@ -60,7 +71,15 @@ export class SimulatedDevice extends EventEmitter implements SnakieDevice {
   // ---------------------------------------------------------------------------
 
   getStatus(): DeviceStatus {
-    return { state: this.state, path: VIRTUAL_PORT_PATH, baudRate: 115200 }
+    return this.statusFor(this.state)
+  }
+
+  /** The status payload for a state — one place, so the snapshot and the pushed
+   *  event can never disagree about what the simulator is. */
+  private statusFor(state: ConnectionState): DeviceStatus {
+    const status: DeviceStatus = { state, path: VIRTUAL_PORT_PATH, baudRate: 115200 }
+    if (state === 'connected') status.runtime = SIM_RUNTIME
+    return status
   }
 
   isConnected(): boolean {
@@ -100,7 +119,7 @@ export class SimulatedDevice extends EventEmitter implements SnakieDevice {
 
   private setState(state: ConnectionState): void {
     this.state = state
-    this.emit('status', { state, path: VIRTUAL_PORT_PATH, baudRate: 115200 })
+    this.emit('status', this.statusFor(state))
   }
 
   // ---------------------------------------------------------------------------

--- a/src/main/device/types.ts
+++ b/src/main/device/types.ts
@@ -5,6 +5,9 @@
  * serialize cleanly across the Electron IPC boundary and can be re-used by the
  * preload typings and the renderer.
  */
+import type { RuntimeInfo } from '../../shared/dialect'
+
+export type { RuntimeInfo }
 
 /** A serial port discovered by enumeration. */
 export interface PortInfo {
@@ -37,6 +40,13 @@ export interface DeviceStatus {
   baudRate?: number
   /** Populated when `state === 'error'`. */
   error?: string
+  /**
+   * Which Python the connected board is running (#752). Probed just after
+   * connect, so it is ABSENT on the first `connected` status and arrives in a
+   * second one a moment later — consumers must treat "not yet known" and
+   * "board wouldn't say" alike and not assume MicroPython in either case.
+   */
+  runtime?: RuntimeInfo
 }
 
 /** Result of running code in the raw REPL. */

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -50,6 +50,7 @@ export type {
   ConnectOptions,
   ConnectionState,
   DeviceStatus,
+  RuntimeInfo,
   ExecResult,
   DirEntry,
   StatResult,

--- a/src/renderer/src/components/StatusBar.css
+++ b/src/renderer/src/components/StatusBar.css
@@ -103,6 +103,14 @@
   color: var(--text-muted);
 }
 
+/* Which Python the board runs (#752) — a quiet neighbour to the connection
+ * segment, since it answers "what is this board" rather than "am I connected".
+ * Only rendered once the connect probe has answered. */
+.statusbar__runtime {
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
 /* Instrument live-poll warning — the poll interrupts a running program, so this
  * segment is deliberately loud (warning accent) and carries an inline Stop link.
  * Only rendered while live polling is actually interrupting the board. */

--- a/src/renderer/src/components/StatusBar.tsx
+++ b/src/renderer/src/components/StatusBar.tsx
@@ -22,6 +22,7 @@ import {
   type StatusTip
 } from './status-tips'
 import { isVirtualPort, VIRTUAL_PORT_SHORT } from '../../../shared/virtual-device'
+import { runtimeLabel } from '../../../shared/dialect'
 import type { FirmwareCatalog, UpdateStatus } from '../../../preload/index.d'
 import { BulbIcon } from './ui-icons'
 import './StatusBar.css'
@@ -171,6 +172,11 @@ export function StatusBar({
   }, [refreshGit])
 
   const connected = status.state === 'connected'
+  // Which Python the board is actually running (#752). Absent until the connect
+  // probe answers, and absent for good on a board that wouldn't say — so this
+  // renders nothing rather than guessing MicroPython, which is exactly the
+  // assumption the CircuitPython epic (#209) exists to remove.
+  const runtime = connected ? runtimeLabel(status.runtime ?? null) : ''
   // Offline mode (#135): connected to the built-in simulated device, not real
   // hardware — surfaced with a distinct label + badge so it's never mistaken
   // for a physical board.
@@ -337,6 +343,19 @@ export function StatusBar({
           <span className="statusbar__dot" aria-hidden="true" />
           <span>{connLabel}</span>
         </span>
+
+        {runtime && (
+          <span
+            className="statusbar__item statusbar__runtime"
+            title={
+              status.runtime?.machine
+                ? `${runtime} — ${status.runtime.machine}`
+                : `The board is running ${runtime}`
+            }
+          >
+            {runtime}
+          </span>
+        )}
 
         {showLiveWarning && (
           <span

--- a/src/renderer/src/web/web-device.ts
+++ b/src/renderer/src/web/web-device.ts
@@ -17,6 +17,7 @@
 import { WorkerMicroPythonRuntime } from './worker-runtime'
 import { VIRTUAL_PORT_PATH, VIRTUAL_PORT_LABEL } from '../../../shared/virtual-device'
 import { isProbeCode, simulateProbeResponse, simulatedTelemetryFrame } from '../../../shared/simulation'
+import type { RuntimeInfo } from '../../../shared/dialect'
 
 /** How often the simulated board "prints" a telemetry frame (matches the desktop sim). */
 const TELEMETRY_INTERVAL_MS = 120
@@ -26,7 +27,18 @@ interface DeviceStatus {
   state: ConnState
   path: string
   baudRate: number
+  /** Which Python this backend runs (#752). */
+  runtime?: RuntimeInfo
 }
+
+/**
+ * What the web simulator reports as its runtime (#752). Stated, not probed: the
+ * interpreter behind it IS MicroPython (the official WASM port), so this is a
+ * fact about the simulator rather than a guess about a board — and it matches
+ * the desktop `SimulatedDevice`, which is the same thing in the other shell.
+ * Whether a simulator should ever offer CircuitPython is #764.
+ */
+const SIM_RUNTIME: RuntimeInfo = { dialect: 'micropython' }
 
 const enc = new TextEncoder()
 
@@ -81,7 +93,11 @@ export function createWebDeviceApi(): Record<string, unknown> {
       telemetry = null
     }
   }
-  const status = (): DeviceStatus => ({ state, path: VIRTUAL_PORT_PATH, baudRate: 115200 })
+  const status = (): DeviceStatus => {
+    const st: DeviceStatus = { state, path: VIRTUAL_PORT_PATH, baudRate: 115200 }
+    if (state === 'connected') st.runtime = SIM_RUNTIME
+    return st
+  }
   const setState = (s: ConnState): void => {
     state = s
     const st = status()

--- a/src/renderer/src/web/web-serial.ts
+++ b/src/renderer/src/web/web-serial.ts
@@ -13,6 +13,12 @@
  * {@link ./web-device-router} multiplexes this with the sim backend.
  */
 import { RawReplClient, type SerialTransport } from '../../../shared/raw-repl'
+import {
+  RUNTIME_PROBE_PY,
+  parseRuntimeProbe,
+  runtimeGreeting,
+  type RuntimeInfo
+} from '../../../shared/dialect'
 import { SERIAL_USB_FILTERS, describeUsb } from '../../../shared/serial-filters'
 
 /** Structural Web Serial types (not in every TS DOM lib). */
@@ -106,6 +112,8 @@ interface DeviceStatus {
   state: 'disconnected' | 'connecting' | 'connected'
   path: string
   baudRate: number
+  /** Which Python the board runs (#752) — absent until the connect probe answers. */
+  runtime?: RuntimeInfo
 }
 
 /** Path scheme for Web Serial ports in the port dropdown. */
@@ -127,6 +135,8 @@ export function createWebSerialBackend(): Record<string, unknown> {
   let transport: WebSerialTransport | null = null
   let client: RawReplClient | null = null
   let activePort: WebSerialPort | null = null
+  /** What the board said it is (#752) — probed on connect, cleared on disconnect. */
+  let runtimeInfo: RuntimeInfo | null = null
   // Synthetic path → granted port, so the dropdown can re-select one.
   const known = new Map<string, WebSerialPort>()
 
@@ -134,8 +144,15 @@ export function createWebSerialBackend(): Record<string, unknown> {
   const setState = (s: DeviceStatus['state'], p = path): void => {
     state = s
     path = p
+    // A new connection knows nothing about the board yet, and the previous
+    // board's runtime must not leak into it.
+    if (s !== 'connected') runtimeInfo = null
+    statusSubs.forEach((cb) => cb(snapshot()))
+  }
+  const snapshot = (): DeviceStatus => {
     const st: DeviceStatus = { state, path, baudRate: 115200 }
-    statusSubs.forEach((cb) => cb(st))
+    if (runtimeInfo) st.runtime = runtimeInfo
+    return st
   }
   const need = (): RawReplClient => {
     if (!client) throw new Error('No board connected')
@@ -169,15 +186,22 @@ export function createWebSerialBackend(): Record<string, unknown> {
     await transport.open(115200)
     client = new RawReplClient(transport, emitData)
     setState('connected', p)
-    // Greet: print the board's MicroPython banner so a successful connection is
-    // visible (#612) — reconstructed from os.uname() like the desktop device (the
-    // old cue was the raw-REPL probe's Ctrl-B banner leaking, now suppressed).
-    // Fire-and-forget so it never delays or fails the connection.
+    // Greet + identify: one probe reads the DIALECT off `sys.implementation` and
+    // the version/board off `os.uname()`, then rebuilds the board's own banner —
+    // the connect cue the leaked Ctrl-B banner used to provide (#612), and the
+    // runtime the rest of the app reads instead of assuming MicroPython (#752).
+    // Kept in step with `MicroPythonDevice.greet()`, deliberately. Fire-and-forget
+    // so it never delays or fails the connection.
     void client
-      .eval("import os as _o; print('MicroPython v' + _o.uname().version + '; ' + _o.uname().machine)")
-      .then((line) => {
-        const t = line.trim()
-        if (t) emitData(enc.encode(`\r\n${t}\r\nType "help()" for more information.\r\n>>> `))
+      .eval(RUNTIME_PROBE_PY)
+      .then((out) => {
+        const info = parseRuntimeProbe(out)
+        if (!info) return
+        runtimeInfo = info
+        // The `connected` status went out before the probe answered.
+        statusSubs.forEach((cb) => cb(snapshot()))
+        const line = runtimeGreeting(info)
+        if (line) emitData(enc.encode(`\r\n${line}\r\nType "help()" for more information.\r\n>>> `))
       })
       .catch(() => undefined)
   }
@@ -221,7 +245,7 @@ export function createWebSerialBackend(): Record<string, unknown> {
       if (state !== 'disconnected') setState('disconnected', '')
     },
 
-    getStatus: async (): Promise<DeviceStatus> => ({ state, path, baudRate: 115200 }),
+    getStatus: async (): Promise<DeviceStatus> => snapshot(),
 
     exec: async (code: string) => need().exec(code),
     eval: async (code: string) => need().eval(code),

--- a/src/shared/dialect.ts
+++ b/src/shared/dialect.ts
@@ -1,0 +1,211 @@
+/**
+ * RUNTIME DIALECT — which Python is actually on the board (#752, epic #209).
+ * =============================================================================
+ *
+ * Snakie was built assuming MicroPython everywhere: the connect banner is
+ * rebuilt from `os.uname()`, the status bar says "MicroPython", the flash button
+ * offers MicroPython firmware. CircuitPython speaks the same raw-REPL protocol
+ * but differs in ways that reach almost every layer — a read-only filesystem, a
+ * `code.py` that auto-runs, a different package mechanism, and `board` +
+ * `digitalio` instead of `machine`.
+ *
+ * Rather than have each of those layers sniff for itself, the device session
+ * carries ONE {@link RuntimeInfo}, probed on connect, and everything else reads
+ * it. This module is the pure half of that: the probe snippet, the parsers, and
+ * the labels. Dependency-free (the same discipline as `control.ts`) so main,
+ * preload and renderer can all import it, and so the parsing is unit-testable
+ * without a board.
+ *
+ * There are three places a runtime identifies itself, in descending order of
+ * how much we trust them:
+ *
+ *  1. **`sys.implementation`** — the machine-readable answer, and the only one
+ *     guaranteed to exist. `.name` is `'micropython'` / `'circuitpython'`.
+ *  2. **`os.uname()`** — carries the build date and the board string that make
+ *     the banner read like the board's own. Deprecated on CircuitPython, so it
+ *     is asked for but never required.
+ *  3. **`boot_out.txt`** — written to the CIRCUITPY drive at boot. Names the
+ *     version AND the Board ID with no serial connection at all, which is what
+ *     makes drive-only identification possible (#753).
+ */
+
+/** Which Python implementation a connected board is running. */
+export type Dialect = 'micropython' | 'circuitpython' | 'unknown'
+
+/** What a board told us about itself. Every field but `dialect` is best-effort. */
+export interface RuntimeInfo {
+  dialect: Dialect
+  /** Dotted version, no leading `v` and no build date — `'1.28.0'`, `'10.2.1'`. */
+  version?: string
+  /** The board string, as the runtime names it (`'Raspberry Pi Pico with RP2040'`). */
+  machine?: string
+  /** CircuitPython's per-board build id from `boot_out.txt` (`'adafruit_feather_rp2040'`). */
+  boardId?: string
+  /** The build date the runtime reports (`'2026-08-18'`), when it gives one. */
+  buildDate?: string
+}
+
+/** How each dialect is named in the UI. */
+export const DIALECT_LABEL: Record<Dialect, string> = {
+  micropython: 'MicroPython',
+  circuitpython: 'CircuitPython',
+  unknown: 'Unknown runtime'
+}
+
+/**
+ * The line prefixes the probe prints. Distinct sentinels rather than one packed
+ * line because {@link RuntimeInfo.machine} contains spaces ("Raspberry Pi Pico
+ * with RP2040") and would need quoting otherwise.
+ */
+const P_NAME = 'SNKIMPL '
+const P_VERSION = 'SNKVER '
+const P_MACHINE = 'SNKMACH '
+
+/**
+ * Ask the board what it is. Run through the raw REPL on connect; parse the
+ * stdout with {@link parseRuntimeProbe}.
+ *
+ * `sys.implementation` is the load-bearing part and is asked for first, so a
+ * board whose `os` module is unusual still yields a dialect. `os.uname()` only
+ * enriches: on MicroPython its `.version` is `'1.28.0 on 2026-01-01'` (the
+ * banner tail), which is where the build date comes from. Everything is wrapped
+ * so a missing attribute degrades to an empty line rather than a traceback.
+ */
+export const RUNTIME_PROBE_PY = [
+  'import sys as _s',
+  "_n=getattr(_s.implementation,'name','')",
+  "_v='.'.join(str(x) for x in getattr(_s.implementation,'version',()))",
+  "_m=''",
+  'try:',
+  ' import os as _o',
+  ' _u=_o.uname()',
+  " _v=getattr(_u,'version','') or _v",
+  " _m=getattr(_u,'machine','')",
+  'except Exception:',
+  " _m=getattr(_s.implementation,'_machine','')",
+  `print(${JSON.stringify(P_NAME)}+_n)`,
+  `print(${JSON.stringify(P_VERSION)}+_v)`,
+  `print(${JSON.stringify(P_MACHINE)}+_m)`
+].join('\n')
+
+/** `'circuitpython'` / `'MicroPython'` / anything → a {@link Dialect}. */
+export function dialectFromName(name: string): Dialect {
+  const n = name.trim().toLowerCase()
+  if (n === 'circuitpython') return 'circuitpython'
+  if (n === 'micropython') return 'micropython'
+  return 'unknown'
+}
+
+/**
+ * Split a version string that may carry a build date, as `os.uname().version`
+ * does on both runtimes: `'1.28.0 on 2026-01-01'` → `{ version: '1.28.0',
+ * buildDate: '2026-01-01' }`. A leading `v` is dropped so versions compare
+ * cleanly with `isNewerVersion`.
+ */
+function splitVersion(raw: string): { version?: string; buildDate?: string } {
+  const trimmed = raw.trim().replace(/^v/i, '')
+  if (!trimmed) return {}
+  const m = /^(\S+)\s+on\s+(\S+)/.exec(trimmed)
+  if (m) return { version: m[1], buildDate: m[2] }
+  return { version: trimmed.split(/\s+/)[0] }
+}
+
+/** Drop empty fields so a `RuntimeInfo` never carries `undefined`-ish blanks. */
+function compact(info: RuntimeInfo): RuntimeInfo {
+  const out: RuntimeInfo = { dialect: info.dialect }
+  if (info.version) out.version = info.version
+  if (info.machine) out.machine = info.machine
+  if (info.boardId) out.boardId = info.boardId
+  if (info.buildDate) out.buildDate = info.buildDate
+  return out
+}
+
+/**
+ * Parse the stdout of {@link RUNTIME_PROBE_PY}. Returns `null` when the output
+ * carries no name line at all — an old or unusual board that answered nothing
+ * useful, which the caller treats as "keep the previous behaviour" rather than
+ * as an error.
+ */
+export function parseRuntimeProbe(stdout: string): RuntimeInfo | null {
+  let name: string | null = null
+  let version = ''
+  let machine = ''
+  for (const line of stdout.split(/\r?\n/)) {
+    if (line.startsWith(P_NAME)) name = line.slice(P_NAME.length).trim()
+    else if (line.startsWith(P_VERSION)) version = line.slice(P_VERSION.length).trim()
+    else if (line.startsWith(P_MACHINE)) machine = line.slice(P_MACHINE.length).trim()
+  }
+  if (name === null) return null
+  return compact({ dialect: dialectFromName(name), machine, ...splitVersion(version) })
+}
+
+/**
+ * Parse a runtime's own boot banner — the line a board prints on reset, and the
+ * line `boot_out.txt` opens with:
+ *
+ *   `MicroPython v1.28.0 on 2026-01-01; Raspberry Pi Pico with RP2040`
+ *   `Adafruit CircuitPython 10.2.1 on 2026-08-18; Adafruit Feather RP2040 with rp2040`
+ *
+ * Returns `null` for a line that names neither runtime, so a caller can scan a
+ * console buffer with it.
+ */
+export function parseRuntimeBanner(line: string): RuntimeInfo | null {
+  const m = /(Adafruit\s+CircuitPython|MicroPython)\s+(\S+)(?:\s+on\s+(\S+?))?\s*(?:;\s*(.*))?$/i.exec(
+    line.trim()
+  )
+  if (!m) return null
+  const dialect: Dialect = /circuitpython/i.test(m[1]) ? 'circuitpython' : 'micropython'
+  return compact({
+    dialect,
+    version: m[2].replace(/^v/i, '').replace(/;$/, ''),
+    buildDate: m[3]?.replace(/;$/, ''),
+    machine: m[4]?.trim()
+  })
+}
+
+/**
+ * Parse a CIRCUITPY drive's `boot_out.txt` (#753 reads this without connecting):
+ *
+ *   Adafruit CircuitPython 10.2.1 on 2026-08-18; Adafruit Feather RP2040 with rp2040
+ *   Board ID:adafruit_feather_rp2040
+ *   UID:E661640843373E2A
+ *
+ * The Board ID is what makes a firmware-update check precise (#757), because
+ * CircuitPython builds are per-board rather than per-chip.
+ */
+export function parseBootOut(text: string): RuntimeInfo | null {
+  let info: RuntimeInfo | null = null
+  let boardId = ''
+  for (const line of text.split(/\r?\n/)) {
+    if (!info) info = parseRuntimeBanner(line)
+    const m = /^Board\s*ID\s*:\s*(\S+)/i.exec(line.trim())
+    if (m) boardId = m[1]
+  }
+  if (!info) return boardId ? compact({ dialect: 'circuitpython', boardId }) : null
+  return compact({ ...info, boardId })
+}
+
+/**
+ * Rebuild the greeting a board prints on reset, so connecting shows the same
+ * line the board itself would (#612). Each runtime words its banner
+ * differently — `MicroPython v1.28.0 on …` versus `Adafruit CircuitPython
+ * 10.2.1 on …` — and showing a CircuitPython user the MicroPython wording would
+ * be a small lie in the first thing they read.
+ *
+ * Returns `''` when there is nothing worth printing.
+ */
+export function runtimeGreeting(info: RuntimeInfo | null): string {
+  if (!info || !info.version) return ''
+  const name = info.dialect === 'circuitpython' ? 'Adafruit CircuitPython' : 'MicroPython'
+  const version = info.dialect === 'circuitpython' ? info.version : `v${info.version}`
+  const date = info.buildDate ? ` on ${info.buildDate}` : ''
+  const machine = info.machine ? `; ${info.machine}` : ''
+  return `${name} ${version}${date}${machine}`
+}
+
+/** Short runtime + version for the status bar — `'CircuitPython 10.2.1'`. */
+export function runtimeLabel(info: RuntimeInfo | null): string {
+  if (!info) return ''
+  const label = DIALECT_LABEL[info.dialect]
+  return info.version ? `${label} ${info.version}` : label
+}

--- a/test/dialect.test.ts
+++ b/test/dialect.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DIALECT_LABEL,
+  RUNTIME_PROBE_PY,
+  dialectFromName,
+  parseBootOut,
+  parseRuntimeBanner,
+  parseRuntimeProbe,
+  runtimeGreeting,
+  runtimeLabel
+} from '../src/shared/dialect'
+
+/**
+ * RUNTIME DIALECT parsing (#752, epic #209).
+ *
+ * The device session carries one answer to "which Python is this board
+ * running", and every CircuitPython phase after this one reads it rather than
+ * sniffing for itself — so the parsing is the load-bearing part, and it has to
+ * hold for real strings from BOTH runtimes. The samples below are the actual
+ * shapes: MicroPython puts a `v` on its version and CircuitPython doesn't,
+ * both pack a build date into `os.uname().version`, and the board string has
+ * spaces in it (which is why the probe prints three lines instead of one).
+ */
+
+// Real probe output, as `RUNTIME_PROBE_PY` prints it.
+const MP_PROBE = ['SNKIMPL micropython', 'SNKVER 1.28.0 on 2026-01-01', 'SNKMACH Raspberry Pi Pico with RP2040'].join('\n')
+const CP_PROBE = [
+  'SNKIMPL circuitpython',
+  'SNKVER 10.2.1 on 2026-08-18',
+  'SNKMACH Adafruit Feather RP2040 with rp2040'
+].join('\n')
+
+const MP_BANNER = 'MicroPython v1.28.0 on 2026-01-01; Raspberry Pi Pico with RP2040'
+const CP_BANNER = 'Adafruit CircuitPython 10.2.1 on 2026-08-18; Adafruit Feather RP2040 with rp2040'
+
+describe('dialectFromName', () => {
+  it('maps sys.implementation.name for both runtimes, case-insensitively', () => {
+    expect(dialectFromName('micropython')).toBe('micropython')
+    expect(dialectFromName('circuitpython')).toBe('circuitpython')
+    expect(dialectFromName('CircuitPython')).toBe('circuitpython')
+    expect(dialectFromName(' micropython\n')).toBe('micropython')
+  })
+
+  it('is unknown rather than wrong for anything else', () => {
+    expect(dialectFromName('cpython')).toBe('unknown')
+    expect(dialectFromName('')).toBe('unknown')
+  })
+})
+
+describe('parseRuntimeProbe', () => {
+  it('reads MicroPython, splitting the build date off the version', () => {
+    expect(parseRuntimeProbe(MP_PROBE)).toEqual({
+      dialect: 'micropython',
+      version: '1.28.0',
+      buildDate: '2026-01-01',
+      machine: 'Raspberry Pi Pico with RP2040'
+    })
+  })
+
+  it('reads CircuitPython', () => {
+    expect(parseRuntimeProbe(CP_PROBE)).toEqual({
+      dialect: 'circuitpython',
+      version: '10.2.1',
+      buildDate: '2026-08-18',
+      machine: 'Adafruit Feather RP2040 with rp2040'
+    })
+  })
+
+  it('keeps the machine string whole — it has spaces, so the probe cannot pack one line', () => {
+    expect(parseRuntimeProbe(MP_PROBE)?.machine).toBe('Raspberry Pi Pico with RP2040')
+  })
+
+  it('tolerates CRLF and unrelated lines in the captured stdout', () => {
+    const noisy = `some earlier output\r\n${CP_PROBE.replace(/\n/g, '\r\n')}\r\n`
+    expect(parseRuntimeProbe(noisy)?.dialect).toBe('circuitpython')
+  })
+
+  it('degrades to a dialect alone when os.uname() is unavailable', () => {
+    // The probe's `except` path: name + a version from sys.implementation, no machine.
+    expect(parseRuntimeProbe('SNKIMPL circuitpython\nSNKVER 10.2.1\nSNKMACH ')).toEqual({
+      dialect: 'circuitpython',
+      version: '10.2.1'
+    })
+  })
+
+  it('is null — not a guess — when the board answered nothing identifiable', () => {
+    expect(parseRuntimeProbe('')).toBeNull()
+    expect(parseRuntimeProbe('Traceback (most recent call last):\n  AttributeError')).toBeNull()
+  })
+
+  it('reports an unrecognised implementation as unknown rather than assuming MicroPython', () => {
+    expect(parseRuntimeProbe('SNKIMPL pycopy\nSNKVER 3.0.0\nSNKMACH thing')?.dialect).toBe('unknown')
+  })
+})
+
+describe('parseRuntimeBanner', () => {
+  it('parses a MicroPython banner, dropping the leading v', () => {
+    expect(parseRuntimeBanner(MP_BANNER)).toEqual({
+      dialect: 'micropython',
+      version: '1.28.0',
+      buildDate: '2026-01-01',
+      machine: 'Raspberry Pi Pico with RP2040'
+    })
+  })
+
+  it('parses a CircuitPython banner, which carries the Adafruit prefix and no v', () => {
+    expect(parseRuntimeBanner(CP_BANNER)).toEqual({
+      dialect: 'circuitpython',
+      version: '10.2.1',
+      buildDate: '2026-08-18',
+      machine: 'Adafruit Feather RP2040 with rp2040'
+    })
+  })
+
+  it('handles a banner with no build date without swallowing the board string', () => {
+    expect(parseRuntimeBanner('MicroPython v1.20.0; Some Board')).toEqual({
+      dialect: 'micropython',
+      version: '1.20.0',
+      machine: 'Some Board'
+    })
+  })
+
+  it('handles a banner with neither date nor board', () => {
+    expect(parseRuntimeBanner('MicroPython v1.20.0')).toEqual({
+      dialect: 'micropython',
+      version: '1.20.0'
+    })
+  })
+
+  it('is null for a line that names no runtime, so a console buffer can be scanned with it', () => {
+    expect(parseRuntimeBanner('>>> print("hello")')).toBeNull()
+    expect(parseRuntimeBanner('')).toBeNull()
+  })
+})
+
+describe('parseBootOut', () => {
+  const BOOT_OUT = [
+    'Adafruit CircuitPython 10.2.1 on 2026-08-18; Adafruit Feather RP2040 with rp2040',
+    'Board ID:adafruit_feather_rp2040',
+    'UID:E661640843373E2A',
+    ''
+  ].join('\r\n')
+
+  it('reads the version and the per-board id with no serial connection', () => {
+    expect(parseBootOut(BOOT_OUT)).toEqual({
+      dialect: 'circuitpython',
+      version: '10.2.1',
+      buildDate: '2026-08-18',
+      machine: 'Adafruit Feather RP2040 with rp2040',
+      boardId: 'adafruit_feather_rp2040'
+    })
+  })
+
+  it('still identifies the runtime from a Board ID alone — the drive is CIRCUITPY either way', () => {
+    expect(parseBootOut('Board ID:raspberry_pi_pico')).toEqual({
+      dialect: 'circuitpython',
+      boardId: 'raspberry_pi_pico'
+    })
+  })
+
+  it('is null for a file that is neither', () => {
+    expect(parseBootOut('INFO_UF2.TXT\nModel: Raspberry Pi RP2')).toBeNull()
+  })
+})
+
+describe('runtimeGreeting', () => {
+  it('rebuilds each runtime in its OWN wording, round-tripping its banner', () => {
+    expect(runtimeGreeting(parseRuntimeProbe(MP_PROBE))).toBe(MP_BANNER)
+    expect(runtimeGreeting(parseRuntimeProbe(CP_PROBE))).toBe(CP_BANNER)
+  })
+
+  it('omits the parts the board did not report', () => {
+    expect(runtimeGreeting({ dialect: 'micropython', version: '1.28.0' })).toBe('MicroPython v1.28.0')
+  })
+
+  it('prints nothing rather than a bare runtime name when there is no version', () => {
+    expect(runtimeGreeting({ dialect: 'circuitpython' })).toBe('')
+    expect(runtimeGreeting(null)).toBe('')
+  })
+})
+
+describe('runtimeLabel', () => {
+  it('is the short status-bar form', () => {
+    expect(runtimeLabel({ dialect: 'circuitpython', version: '10.2.1' })).toBe('CircuitPython 10.2.1')
+    expect(runtimeLabel({ dialect: 'micropython', version: '1.28.0' })).toBe('MicroPython 1.28.0')
+  })
+
+  it('falls back to the runtime name alone, and to nothing when unknown', () => {
+    expect(runtimeLabel({ dialect: 'micropython' })).toBe('MicroPython')
+    expect(runtimeLabel(null)).toBe('')
+    expect(DIALECT_LABEL.unknown).toBe('Unknown runtime')
+  })
+})
+
+describe('RUNTIME_PROBE_PY', () => {
+  it('asks sys.implementation FIRST, so a board with an odd os module still yields a dialect', () => {
+    const impl = RUNTIME_PROBE_PY.indexOf('.implementation')
+    const uname = RUNTIME_PROBE_PY.indexOf('uname')
+    expect(impl).toBeGreaterThanOrEqual(0)
+    expect(impl).toBeLessThan(uname)
+  })
+
+  it('guards the os.uname() enrichment, so a missing attribute degrades instead of raising', () => {
+    expect(RUNTIME_PROBE_PY).toContain('except Exception:')
+  })
+
+  it('prints the three sentinels the parser reads', () => {
+    for (const p of ['SNKIMPL ', 'SNKVER ', 'SNKMACH ']) expect(RUNTIME_PROBE_PY).toContain(p)
+  })
+})

--- a/test/rawRepl.test.ts
+++ b/test/rawRepl.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { RawReplClient, pyStr, type SerialTransport } from '../src/shared/raw-repl'
+import { RUNTIME_PROBE_PY, parseRuntimeProbe, runtimeGreeting } from '../src/shared/dialect'
 
 /**
  * The transport-agnostic raw-REPL client (#465) against a MOCK board — proves the
@@ -16,6 +17,8 @@ class MockBoard implements SerialTransport {
   private raw = false
   /** stdout the next exec should return (default: empty). */
   nextStdout = ''
+  /** How many blocks the board has been asked to execute (Ctrl-D in raw mode). */
+  execCount = 0
   nextStderr = ''
   /** Deliver the Ctrl-B banner asynchronously (like real serial latency) rather
    *  than synchronously inside write() — proves the suppression handles timing. */
@@ -45,6 +48,7 @@ class MockBoard implements SerialTransport {
         else this.emit(banner)
       } else if (ch === '\x04' && this.raw) {
         // Ctrl-D in raw mode → execute the buffered code, frame the response.
+        this.execCount++
         this.buf = ''
         this.emit('OK' + this.nextStdout + '\x04' + this.nextStderr + '\x04>')
       } else if (ch !== '\x03') {
@@ -164,5 +168,54 @@ describe('RawReplClient', () => {
     expect(s.console).not.toContain('boom\n===') // not the echoed source
     expect(s.console).not.toContain('OK')
     expect(s.console).not.toContain('\x04')
+  })
+})
+
+/**
+ * The CONNECT PROBE (#752, epic #209) end to end: the Python we actually send,
+ * over the real raw-REPL framing, through the parser, back out as the greeting
+ * the terminal prints. Both desktop and web run this same chain, so a sentinel
+ * changed on one side of it and not the other fails here.
+ */
+describe('runtime probe over the raw REPL', () => {
+  const probeReply = (name: string, version: string, machine: string): string =>
+    `SNKIMPL ${name}\nSNKVER ${version}\nSNKMACH ${machine}\n`
+
+  it('identifies a MicroPython board and rebuilds its own banner', async () => {
+    const { board, client } = setup()
+    board.nextStdout = probeReply('micropython', '1.28.0 on 2026-01-01', 'Raspberry Pi Pico with RP2040')
+    const info = parseRuntimeProbe(await client.eval(RUNTIME_PROBE_PY))
+    expect(info?.dialect).toBe('micropython')
+    expect(runtimeGreeting(info)).toBe('MicroPython v1.28.0 on 2026-01-01; Raspberry Pi Pico with RP2040')
+  })
+
+  it('identifies a CircuitPython board and greets it in ITS wording, not MicroPython\'s', async () => {
+    const { board, client } = setup()
+    board.nextStdout = probeReply(
+      'circuitpython',
+      '10.2.1 on 2026-08-18',
+      'Adafruit Feather RP2040 with rp2040'
+    )
+    const info = parseRuntimeProbe(await client.eval(RUNTIME_PROBE_PY))
+    expect(info?.dialect).toBe('circuitpython')
+    const greeting = runtimeGreeting(info)
+    expect(greeting).toBe('Adafruit CircuitPython 10.2.1 on 2026-08-18; Adafruit Feather RP2040 with rp2040')
+    expect(greeting).not.toContain('MicroPython')
+  })
+
+  it('leaves a board that answers nothing unidentified, rather than assuming MicroPython', async () => {
+    const { board, client } = setup()
+    board.nextStdout = ''
+    const info = parseRuntimeProbe(await client.eval(RUNTIME_PROBE_PY))
+    expect(info).toBeNull()
+    expect(runtimeGreeting(info)).toBe('')
+  })
+
+  it('sends the probe as ONE exec — the connect path must not cost several round trips', async () => {
+    const { board, client } = setup()
+    board.nextStdout = probeReply('micropython', '1.28.0', 'Board')
+    const before = board.execCount
+    await client.eval(RUNTIME_PROBE_PY)
+    expect(board.execCount - before).toBe(1)
   })
 })

--- a/test/simulatedDevice.test.ts
+++ b/test/simulatedDevice.test.ts
@@ -63,6 +63,25 @@ describe('SimulatedDevice lifecycle', () => {
     expect(dev.isConnected()).toBe(false)
   })
 
+  it('reports its runtime only while connected — the simulator IS MicroPython (#752)', async () => {
+    const dev = new SimulatedDevice(new FakeRuntime())
+    // Disconnected: nothing to report. A stale runtime here would let the status
+    // bar name a Python for a board that isn't there.
+    expect(dev.getStatus().runtime).toBeUndefined()
+
+    const pushed: (string | undefined)[] = []
+    dev.on('status', (st) => pushed.push(st.runtime?.dialect))
+    await dev.connect()
+
+    expect(dev.getStatus().runtime).toEqual({ dialect: 'micropython' })
+    // The pushed event and the snapshot agree, for every state.
+    expect(pushed).toEqual([undefined, 'micropython'])
+
+    await dev.disconnect()
+    expect(dev.getStatus().runtime).toBeUndefined()
+    await dev.dispose()
+  })
+
   it('emits connecting → connected status and boots the REPL on connect', async () => {
     const dev = new SimulatedDevice(new FakeRuntime())
     const states: string[] = []


### PR DESCRIPTION
Closes #752. The keystone of the CircuitPython epic (#209) — everything else in that epic reads this instead of sniffing for itself.

## What changed

`src/shared/dialect.ts` is the new pure core: the probe snippet, the parsers, the labels. Dependency-free, so main, preload and renderer all import it and the parsing is testable without a board.

The device session now carries a `RuntimeInfo` on `DeviceStatus`, probed on connect:

- **`sys.implementation` first** — it carries the answer that matters, so a board with an unusual `os` module still yields a dialect. `os.uname()` only enriches, with the build date and board string.
- **One exec**, guarded, so a missing attribute degrades to a blank line rather than a traceback.
- **A board that answers nothing stays unidentified** rather than being assumed MicroPython — the exact assumption #209 exists to remove.

The connect greeting is now rebuilt from what was probed rather than hard-coded, because the two runtimes word their banners differently:

```
MicroPython v1.28.0 on 2026-01-01; Raspberry Pi Pico with RP2040
Adafruit CircuitPython 10.2.1 on 2026-08-18; Adafruit Feather RP2040 with rp2040
```

Greeting a CircuitPython user in MicroPython's wording would be a small lie in the first line they read.

`setState` clears the runtime on anything but `connected`, so unplugging a Pico and plugging in a Feather can't leave the status bar naming the previous board's Python. The probe answers *after* the `connected` status has gone out, so a second status follows — consumers must treat "not known yet" and "wouldn't say" alike, which is documented on the field.

Both real-board paths — the desktop serial device and the web's Web Serial backend — run the same probe, replacing the duplicated `os.uname()` greet in each. Both simulators *state* `micropython` rather than probing: the interpreter behind them **is** MicroPython, so it's a fact about the simulator, not a guess about a board.

`parseBootOut` lands here unused: #753 reads it off a CIRCUITPY drive to identify a board with no serial connection at all, and #757 needs its Board ID to match a per-board firmware build.

## Verification

- `lint`, `typecheck`, `build`, `build:web` green.
- **30 new tests.** `test/dialect.test.ts` (25) covers the parsers against real strings from both runtimes — including the banner with no build date, which naively swallows the board string. `test/rawRepl.test.ts` (+4) runs the probe end-to-end through the real raw-REPL framing against the mock board, asserting the greeting round-trips and costs exactly one exec. `test/simulatedDevice.test.ts` (+1) pins that the simulator reports its runtime only while connected.
- Full suite: 3337 pass. `slowReadTimeout.test.ts` fails under full-suite load and passes standalone — that is the known flake in #737, not this change.
- **Rendering verified in headless Chromium** against the web build: the runtime segment appears next to the connection item when connected, carries the board string in its tooltip, and disappears on disconnect rather than going stale. The CircuitPython case was exercised by injecting a CircuitPython status at the API boundary — it renders `CircuitPython 10.2.1` with no "MicroPython" anywhere in the status bar.

## Not verified

**Against real hardware.** No board on this box, and the probe's behaviour on a real CircuitPython board is exactly what #751 (the spike) exists to measure. The probe is written defensively for that reason — every part of it degrades rather than throwing — but the literal `sys.implementation` shape on CircuitPython is assumed from its docs, not observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)