### PR TITLE
feat: find a CircuitPython board's drive, and name the board before you connect (#753)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Snakie finds a CircuitPython board's drive, and says what the board is before
+  you connect.** (#753, epic #209) A board running CircuitPython mounts a
+  **CIRCUITPY** volume, and its `boot_out.txt` names the version and the
+  per-board build id — so the port picker can read "CircuitPython 10.2.1"
+  against a board nothing has connected to yet. A drive is tied to its port by
+  the board's own id, matched against the port's USB serial number, so two
+  boards on one desk can't swap identities; where that can't be established it
+  says nothing rather than guessing, because the next phase writes files to
+  whichever drive this picks. Renamed drives are still found — the marker file
+  decides, not the label.
 - **Snakie can tell which Python your board is running.** (#752, epic #209) The
   connect probe now reads `sys.implementation`, so the session knows whether a
   board runs **MicroPython or CircuitPython** instead of assuming — the
@@ -15,6 +25,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the connect greeting is rebuilt in that runtime's own wording rather than
   MicroPython's. A board that won't answer stays unidentified rather than being
   guessed at, and the previous board's runtime can't linger after you unplug it.
+
+### Changed
+- The per-platform mount-point scanning behind board detection is now in one
+  place (`fs/volumes.ts`) instead of being hand-rolled once per board type, and
+  it no longer reads every folder in your home directory looking for a board.
 
 ## [0.44.0] - 2026-08-16
 

--- a/src/main/device/circuitpy.ts
+++ b/src/main/device/circuitpy.ts
@@ -1,0 +1,183 @@
+/**
+ * CIRCUITPY DRIVES — finding a CircuitPython board's filesystem (#753, epic #209).
+ * =============================================================================
+ *
+ * A board running CircuitPython mounts a **CIRCUITPY** volume alongside its
+ * serial port. That drive is not a flashing mode — unlike `RPI-RP2` or
+ * `MICROBIT`, which `firmware/detect.ts` looks for — it is the board's own
+ * filesystem, and it is how a host writes to it, because while it is mounted
+ * the board's code can't (#754 builds on this).
+ *
+ * Two things come out of finding one:
+ *
+ *  1. **Identity with no connection.** `boot_out.txt` names the CircuitPython
+ *     version and the per-board build id, so a board can be identified before
+ *     anything is connected — which is what makes a precise firmware-update
+ *     check possible later (#757), CircuitPython builds being per-board rather
+ *     than per-chip.
+ *  2. **A write target**, once it is known which port the drive belongs to.
+ *
+ * That second part is the hard half. Two boards on one desk means two drives,
+ * and writing a file to the wrong one is a silent, confusing failure — so the
+ * pairing below refuses to guess, and reports WHY it couldn't rather than
+ * picking one.
+ */
+import { parseBootOut, parseBootOutUid, type RuntimeInfo } from '../../shared/dialect'
+import { isVirtualPort } from '../../shared/virtual-device'
+import { listVolumes, readVolumeFile, type Volume } from '../fs/volumes'
+import type { PortInfo } from './types'
+
+/** The volume label CircuitPython gives its filesystem. */
+const CIRCUITPY_LABEL = 'CIRCUITPY'
+
+/** The file CircuitPython writes at boot, naming itself. */
+const BOOT_OUT = 'boot_out.txt'
+
+/** A mounted CircuitPython filesystem. */
+export interface CircuitPyDrive {
+  /** Absolute mount path — `/Volumes/CIRCUITPY`, `E:\`, `/media/kev/CIRCUITPY`. */
+  mountPath: string
+  /** What `boot_out.txt` says the board is running. */
+  runtime: RuntimeInfo
+  /** The board's unique id, when its CircuitPython is new enough to write one. */
+  uid?: string
+}
+
+/**
+ * How confidently a drive was tied to a port — carried so the UI can be as
+ * certain as the evidence is, and no more.
+ *
+ * `uid` is a real identification: the board's own id, matched against the USB
+ * serial number the OS reports for that port. `sole` is an inference from there
+ * being exactly one of each — right almost always, but it is a deduction from
+ * absence, not a match, so it is named differently.
+ */
+export type PairConfidence = 'uid' | 'sole'
+
+/** The outcome of pairing drives with a port. A miss says why. */
+export type DrivePairing =
+  | { drive: CircuitPyDrive; confidence: PairConfidence }
+  | { drive: null; why: 'no-drives' | 'ambiguous' }
+
+/**
+ * Does this volume look like a CircuitPython filesystem?
+ *
+ * The label is the strong signal but is unavailable on Windows (a volume is a
+ * bare drive letter), and a user can rename the drive — CircuitPython lets you,
+ * and people do. So the marker file is what actually decides, with the label
+ * only saving a `readdir` on the common path.
+ */
+async function readCircuitPyVolume(vol: Volume): Promise<CircuitPyDrive | null> {
+  // A labelled volume is always worth reading. An unlabelled one only where
+  // reading is cheap — see `Volume.probeContents`.
+  const labelled = vol.name.toUpperCase() === CIRCUITPY_LABEL
+  if (!labelled && !vol.probeContents) return null
+  const text = await readVolumeFile(vol.mountPath, BOOT_OUT)
+  if (text === null) return null
+  const runtime = parseBootOut(text)
+  // A `boot_out.txt` that parses as neither runtime is not a board we know.
+  if (!runtime) return null
+  const drive: CircuitPyDrive = { mountPath: vol.mountPath, runtime }
+  const uid = parseBootOutUid(text)
+  if (uid) drive.uid = uid
+  return drive
+}
+
+/**
+ * Every mounted CircuitPython filesystem, right now.
+ *
+ * Deliberately un-cached: a drive ejects on soft reboot and comes back a moment
+ * later, so a cache would confidently name a mount point that no longer exists.
+ * Scanning is a handful of `readdir`s, cheap enough to just do again.
+ *
+ * `roots` is injectable for tests; production callers pass nothing.
+ */
+export async function findCircuitPyDrives(roots?: string[]): Promise<CircuitPyDrive[]> {
+  const volumes = await listVolumes(roots)
+  const found = await Promise.all(volumes.map(readCircuitPyVolume))
+  return found.filter((d): d is CircuitPyDrive => d !== null)
+}
+
+/** Compare two board ids ignoring case and any separators the OS added. */
+function sameId(a: string | undefined, b: string | undefined): boolean {
+  if (!a || !b) return false
+  const norm = (s: string): string => s.replace(/[^0-9a-z]/gi, '').toUpperCase()
+  return norm(a) === norm(b)
+}
+
+/**
+ * Tie a CIRCUITPY drive to a serial port, or explain why it can't be done.
+ *
+ * The strong path needs no connection to the board: CircuitPython writes its
+ * `microcontroller.cpu.uid` into `boot_out.txt`, and USB reports that same id as
+ * the port's serial number, so the two match offline.
+ *
+ * Failing that — an older CircuitPython writes no UID, and not every OS reports
+ * a serial number — one drive and one candidate port can only be each other.
+ * With more than one of either and no UID match, this returns `ambiguous` and
+ * the caller must not write anything: guessing here means writing a file to
+ * somebody else's board.
+ *
+ * Pure, so the rule is testable without mounting anything.
+ */
+export function pairDriveToPort(
+  drives: CircuitPyDrive[],
+  port: PortInfo,
+  allPorts: PortInfo[] = []
+): DrivePairing {
+  if (drives.length === 0) return { drive: null, why: 'no-drives' }
+
+  const byUid = drives.find((d) => sameId(d.uid, port.serialNumber))
+  if (byUid) return { drive: byUid, confidence: 'uid' }
+
+  // No id match. Only safe if there is exactly one drive AND no other board it
+  // could belong to — a second board makes "the only drive" meaningless, since
+  // the drive might be the OTHER one's. The simulated device is not a board and
+  // has no drive, so it never counts as a rival.
+  const rivals = allPorts.filter((p) => p.path !== port.path && !isVirtualPort(p.path))
+  if (drives.length === 1 && rivals.length === 0) return { drive: drives[0], confidence: 'sole' }
+  return { drive: null, why: 'ambiguous' }
+}
+
+/**
+ * What the UI shows against a port whose board we identified from its drive —
+ * the version and board id from `boot_out.txt`, plus how sure we are.
+ */
+export interface PortCircuitPy {
+  mountPath: string
+  version?: string
+  boardId?: string
+  confidence: PairConfidence
+}
+
+/**
+ * Annotate serial ports with the CircuitPython board behind them, where that
+ * can be established from a mounted drive alone.
+ *
+ * This is what lets the port dropdown say "CircuitPython 10.2.1" **before** the
+ * user connects. A port that can't be tied to a drive is returned untouched
+ * rather than annotated hopefully — the whole point of #753's pairing rule.
+ */
+export async function annotatePortsWithDrives(
+  ports: PortInfo[],
+  roots?: string[]
+): Promise<PortInfo[]> {
+  let drives: CircuitPyDrive[]
+  try {
+    drives = await findCircuitPyDrives(roots)
+  } catch {
+    return ports // detection is an enrichment; never let it break the port list
+  }
+  if (drives.length === 0) return ports
+  return ports.map((port) => {
+    // The simulator has no drive; annotating it would be nonsense.
+    if (isVirtualPort(port.path)) return port
+    const paired = pairDriveToPort(drives, port, ports)
+    if (!paired.drive) return port
+    const { mountPath, runtime } = paired.drive
+    const circuitpy: PortCircuitPy = { mountPath, confidence: paired.confidence }
+    if (runtime.version) circuitpy.version = runtime.version
+    if (runtime.boardId) circuitpy.boardId = runtime.boardId
+    return { ...port, circuitpy }
+  })
+}

--- a/src/main/device/ipc.ts
+++ b/src/main/device/ipc.ts
@@ -6,6 +6,7 @@ import { instrumentWindowWebContents } from '../instrumentWindows'
 import { consoleWindowWebContents } from '../consoleWindow'
 import { boardWindowWebContents } from '../board'
 import { broadcastToTargets } from './broadcast'
+import { annotatePortsWithDrives, findCircuitPyDrives } from './circuitpy'
 import type { ConnectOptions, DeviceStatus, IpcResult, PortInfo, SnakieDevice } from './types'
 
 /**
@@ -107,9 +108,17 @@ export function registerDeviceIpc(getWebContents: () => WebContents | undefined)
     wrap(async () => {
       const ports = await MicroPythonDevice.listPorts()
       const virtual: PortInfo = { path: VIRTUAL_PORT_PATH, friendlyName: VIRTUAL_PORT_LABEL }
-      return [...ports, virtual]
+      // Name the CircuitPython boards among them from their mounted CIRCUITPY
+      // drives (#753), so the picker can say what a board is before you connect
+      // to it. Enrichment only — a failure here leaves the list as it was.
+      return [...(await annotatePortsWithDrives(ports)), virtual]
     })
   )
+
+  // Every mounted CircuitPython filesystem, scanned fresh on each call (#753).
+  // Uncached on purpose: a CIRCUITPY drive ejects on soft reboot and returns a
+  // moment later, so a remembered mount path is a path that may not exist.
+  ipcMain.handle('device:circuitpyDrives', () => wrap(() => findCircuitPyDrives()))
 
   ipcMain.handle('device:connect', (_e, path: string, opts?: ConnectOptions) =>
     wrap(async () => {

--- a/src/main/device/types.ts
+++ b/src/main/device/types.ts
@@ -6,8 +6,10 @@
  * preload typings and the renderer.
  */
 import type { RuntimeInfo } from '../../shared/dialect'
+import type { PortCircuitPy } from './circuitpy'
 
 export type { RuntimeInfo }
+export type { PortCircuitPy, CircuitPyDrive, DrivePairing, PairConfidence } from './circuitpy'
 
 /** A serial port discovered by enumeration. */
 export interface PortInfo {
@@ -21,6 +23,13 @@ export interface PortInfo {
   productId?: string
   /** Human-friendly label, when the OS provides one. */
   friendlyName?: string
+  /**
+   * The CircuitPython board behind this port, identified from its mounted
+   * CIRCUITPY drive (#753) — so the picker can name the board and its version
+   * BEFORE anything is connected. Absent unless the drive could be tied to this
+   * port specifically; see `pairDriveToPort`, which refuses to guess.
+   */
+  circuitpy?: PortCircuitPy
 }
 
 /** Options for opening a connection. */

--- a/src/main/firmware/detect.ts
+++ b/src/main/firmware/detect.ts
@@ -12,15 +12,15 @@
  *
  *  - **UF2 boot drive** — an RP2040 held in BOOTSEL mode mounts as a small FAT
  *    volume labelled `RPI-RP2`. We scan the platform's mount points for that
- *    label/marker and surface it as an `rp2040` candidate.
+ *    label/marker and surface it as an `rp2040` candidate. The scanning itself
+ *    lives in `fs/volumes.ts`, shared with the CIRCUITPY detection (#753) —
+ *    the platforms differ, the boards don't.
  *
  * Detection never throws for the caller: failures in one strategy are swallowed
  * so the other can still contribute candidates.
  */
-import { promises as fs } from 'fs'
-import { homedir, platform } from 'os'
-import { join } from 'path'
 import { MicroPythonDevice } from '../device/MicroPythonDevice'
+import { listVolumes, readVolumeFile, volumeHasFile, type Volume } from '../fs/volumes'
 import type { BoardCandidate, BoardType } from './types'
 
 /**
@@ -79,72 +79,27 @@ async function detectEspFromSerial(): Promise<BoardCandidate[]> {
   return candidates
 }
 
-/**
- * Candidate mount-point roots to scan for a UF2 boot drive, per platform. We
- * only read directory listings (cheap, read-only) so this is safe to call
- * repeatedly.
- */
-function uf2SearchRoots(): string[] {
-  const os = platform()
-  if (os === 'win32') {
-    // Windows mounts removable drives as letters; scan A–Z roots.
-    return Array.from({ length: 26 }, (_, i) => `${String.fromCharCode(65 + i)}:\\`)
-  }
-  if (os === 'darwin') return ['/Volumes']
-  // Linux: media is typically auto-mounted under one of these.
-  return ['/media', join('/media', process.env.USER ?? ''), '/run/media', join(homedir())]
-}
+/** A directory looks like an RP2040 boot drive if it carries the UF2 markers.
+ *  The BOOTSEL FAT volume always contains INFO_UF2.TXT (and usually INDEX.HTM). */
+const looksLikeRp2040Drive = (dir: string): Promise<boolean> =>
+  volumeHasFile(dir, ['INFO_UF2.TXT', 'INDEX.HTM'])
 
-/** A directory looks like an RP2040 boot drive if it carries the UF2 markers. */
-async function looksLikeRp2040Drive(dir: string): Promise<boolean> {
-  try {
-    const entries = await fs.readdir(dir)
-    const lower = entries.map((e) => e.toLowerCase())
-    // The BOOTSEL FAT volume always contains INFO_UF2.TXT (and usually INDEX.HTM).
-    return lower.includes('info_uf2.txt') || lower.includes('index.htm')
-  } catch {
-    return false
-  }
-}
-
-/** Detect an RP2040 in BOOTSEL mode by scanning mount points for the UF2 marker. */
-async function detectRp2040Drive(): Promise<BoardCandidate[]> {
+/** Detect an RP2040 in BOOTSEL mode among `volumes` by its UF2 marker.
+ *  Exported (over the volume list rather than the live filesystem) so the
+ *  scanning rule is testable against a fixture directory. */
+export async function detectRp2040Drive(volumes: Volume[]): Promise<BoardCandidate[]> {
   const candidates: BoardCandidate[] = []
-  const os = platform()
-
-  for (const root of uf2SearchRoots()) {
-    if (!root) continue
-    if (os === 'win32') {
-      // Each drive letter is itself a potential boot volume.
-      if (await looksLikeRp2040Drive(root)) {
-        candidates.push({
-          board: 'rp2040',
-          source: 'uf2-drive',
-          mountPath: root,
-          label: `${root} — RP2040 (RPI-RP2)`
-        })
-      }
-      continue
-    }
-    // POSIX: the root contains per-volume subdirectories; inspect each one.
-    let names: string[]
-    try {
-      names = await fs.readdir(root)
-    } catch {
-      continue
-    }
-    for (const name of names) {
-      const mount = join(root, name)
-      // A direct label match is a strong signal; otherwise probe the contents.
-      const labelled = name.toUpperCase().includes('RPI-RP2')
-      if (labelled || (await looksLikeRp2040Drive(mount))) {
-        candidates.push({
-          board: 'rp2040',
-          source: 'uf2-drive',
-          mountPath: mount,
-          label: `${mount} — RP2040 (RPI-RP2)`
-        })
-      }
+  for (const vol of volumes) {
+    // A label match is a strong signal; otherwise probe the contents (which is
+    // the only option on Windows, where a volume is a bare drive letter).
+    const labelled = vol.name.toUpperCase().includes('RPI-RP2')
+    if (labelled || (vol.probeContents && (await looksLikeRp2040Drive(vol.mountPath)))) {
+      candidates.push({
+        board: 'rp2040',
+        source: 'uf2-drive',
+        mountPath: vol.mountPath,
+        label: `${vol.mountPath} — RP2040 (RPI-RP2)`
+      })
     }
   }
   return candidates
@@ -176,35 +131,20 @@ export function microbitMaintenanceFromDetails(text: string): boolean {
   return mode.includes('bootloader') || mode.includes('maintenance')
 }
 
-/** A directory looks like a BBC micro:bit DAPLink drive if it carries its markers. */
-async function looksLikeMicrobitDrive(dir: string): Promise<boolean> {
-  try {
-    const entries = await fs.readdir(dir)
-    const lower = entries.map((e) => e.toLowerCase())
-    // The MICROBIT / MAINTENANCE MSD volume always contains DETAILS.TXT.
-    return lower.includes('details.txt') || lower.includes('microbit.htm')
-  } catch {
-    return false
-  }
-}
+/** A directory looks like a BBC micro:bit DAPLink drive if it carries its markers.
+ *  The MICROBIT / MAINTENANCE MSD volume always contains DETAILS.TXT. */
+const looksLikeMicrobitDrive = (dir: string): Promise<boolean> =>
+  volumeHasFile(dir, ['DETAILS.TXT', 'MICROBIT.HTM'])
 
-/** Read the micro:bit generation + mode from a drive's DETAILS.TXT, if present.
- *  Resolves the filename case-insensitively (it can mount as `details.txt` on a
- *  case-sensitive vfat mount). */
+/** Read the micro:bit generation + mode from a drive's DETAILS.TXT, if present. */
 async function readMicrobitDetails(
   mount: string
 ): Promise<{ version?: 'v1' | 'v2'; maintenance: boolean }> {
-  try {
-    const entries = await fs.readdir(mount)
-    const file = entries.find((e) => e.toLowerCase() === 'details.txt')
-    if (!file) return { maintenance: false }
-    const text = await fs.readFile(join(mount, file), 'utf8')
-    return {
-      version: microbitVersionFromDetails(text),
-      maintenance: microbitMaintenanceFromDetails(text)
-    }
-  } catch {
-    return { maintenance: false }
+  const text = await readVolumeFile(mount, 'DETAILS.TXT')
+  if (text === null) return { maintenance: false }
+  return {
+    version: microbitVersionFromDetails(text),
+    maintenance: microbitMaintenanceFromDetails(text)
   }
 }
 
@@ -226,32 +166,17 @@ async function microbitCandidate(mount: string, nameIsMaintenance: boolean): Pro
   }
 }
 
-/** Detect a BBC micro:bit by scanning mount points for the MICROBIT/MAINTENANCE volume. */
-async function detectMicrobitDrive(): Promise<BoardCandidate[]> {
+/** Detect a BBC micro:bit among `volumes` by its MICROBIT/MAINTENANCE volume.
+ *  Exported for the same reason as {@link detectRp2040Drive}. */
+export async function detectMicrobitDrive(volumes: Volume[]): Promise<BoardCandidate[]> {
   const candidates: BoardCandidate[] = []
-  const os = platform()
-
-  for (const root of uf2SearchRoots()) {
-    if (!root) continue
-    if (os === 'win32') {
-      // No volume label in the path on Windows; rely on the DETAILS.TXT marker
-      // (the mode is then read from the file itself).
-      if (await looksLikeMicrobitDrive(root)) candidates.push(await microbitCandidate(root, false))
-      continue
-    }
-    let names: string[]
-    try {
-      names = await fs.readdir(root)
-    } catch {
-      continue
-    }
-    for (const name of names) {
-      const mount = join(root, name)
-      const upper = name.toUpperCase()
-      const labelled = upper.includes('MICROBIT') || upper.includes('MAINTENANCE')
-      if (labelled || (await looksLikeMicrobitDrive(mount))) {
-        candidates.push(await microbitCandidate(mount, upper.includes('MAINTENANCE')))
-      }
+  for (const vol of volumes) {
+    const upper = vol.name.toUpperCase()
+    const labelled = upper.includes('MICROBIT') || upper.includes('MAINTENANCE')
+    if (labelled || (vol.probeContents && (await looksLikeMicrobitDrive(vol.mountPath)))) {
+      // On Windows the label isn't in the path, so maintenance mode is read from
+      // DETAILS.TXT instead — `microbitCandidate` handles both.
+      candidates.push(await microbitCandidate(vol.mountPath, upper.includes('MAINTENANCE')))
     }
   }
   return candidates
@@ -264,10 +189,13 @@ async function detectMicrobitDrive(): Promise<BoardCandidate[]> {
  * confidently recognised, which the UI presents as "choose manually".
  */
 export async function detectBoards(): Promise<BoardCandidate[]> {
+  // One volume scan feeds both drive strategies — they look at the same mounts
+  // for different markers.
+  const volumes = await listVolumes()
   const [esp, rp, microbit] = await Promise.all([
     detectEspFromSerial(),
-    detectRp2040Drive(),
-    detectMicrobitDrive()
+    detectRp2040Drive(volumes),
+    detectMicrobitDrive(volumes)
   ])
   const all = [...esp, ...rp, ...microbit]
   const seen = new Set<string>()

--- a/src/main/fs/volumes.ts
+++ b/src/main/fs/volumes.ts
@@ -1,0 +1,146 @@
+/**
+ * REMOVABLE VOLUMES — where a board's drive shows up, per platform.
+ * =============================================================================
+ *
+ * Several boards present themselves to Snakie as a mounted FAT volume rather
+ * than (or as well as) a serial port:
+ *
+ *  - an **RP2040 in BOOTSEL** mounts as `RPI-RP2`, carrying `INFO_UF2.TXT`
+ *  - a **BBC micro:bit** mounts as `MICROBIT` / `MAINTENANCE`, with `DETAILS.TXT`
+ *  - a board **running CircuitPython** mounts as `CIRCUITPY`, with `boot_out.txt`
+ *    (#753) — and unlike the first two this one is not a flashing mode at all,
+ *    it is the board's own filesystem
+ *
+ * Finding them is the same job every time — the platforms differ, the boards
+ * don't — so it lives here once instead of once per board. `firmware/detect.ts`
+ * grew the first two copies of it; this is that machinery, extracted.
+ *
+ * Everything is read-only (`readdir` + `readFile`) and nothing throws for the
+ * caller, so it is safe to call repeatedly and safe to call on a path that
+ * turns out not to exist — which is the normal case for most of the roots.
+ */
+import { promises as fs } from 'fs'
+import { homedir, platform } from 'os'
+import { join } from 'path'
+
+/** A mounted volume that might be a board. */
+export interface Volume {
+  /** Absolute path the volume is mounted at. */
+  mountPath: string
+  /**
+   * The volume's LABEL, when the platform puts it in the path — `CIRCUITPY`,
+   * `RPI-RP2`. Empty on Windows, where a volume is a bare drive letter and the
+   * label lives in metadata we don't read; callers there must fall back to
+   * probing for a marker file.
+   */
+  name: string
+  /**
+   * Whether it is worth READING this volume to see what it is, as opposed to
+   * trusting its label.
+   *
+   * True for anything under a real mount root, where every entry genuinely is a
+   * mounted volume. False for the home directory, which is in the root list for
+   * unusual mount setups but whose entries are overwhelmingly just the user's
+   * folders — probing each of those means a `readdir` per folder in `$HOME`,
+   * every time the port list refreshes. A board mounted there is still found by
+   * its label; only the content probe is skipped.
+   */
+  probeContents: boolean
+}
+
+/**
+ * Where to look for mounted volumes, per platform.
+ *
+ * Windows has no mount-point directory — removable drives are letters — so
+ * every letter is a candidate and the non-existent ones fail their `readdir`
+ * harmlessly. POSIX auto-mounters put volumes under a small set of roots, and
+ * the `$USER` variants matter: Fedora and friends mount at
+ * `/run/media/<user>/CIRCUITPY`, so scanning `/run/media` alone would find the
+ * user's *name*, not the volume.
+ */
+export function volumeSearchRoots(): string[] {
+  const os = platform()
+  if (os === 'win32') {
+    return Array.from({ length: 26 }, (_, i) => `${String.fromCharCode(65 + i)}:\\`)
+  }
+  if (os === 'darwin') return ['/Volumes']
+  // With no $USER the `join`s collapse onto their parents; `listVolumes`
+  // de-duplicates by mount path, so the repeat costs one extra `readdir`.
+  const user = process.env.USER ?? ''
+  return ['/media', join('/media', user), '/run/media', join('/run/media', user), homedir()]
+}
+
+/**
+ * Enumerate the volumes currently mounted under `roots`.
+ *
+ * On Windows each root IS a volume (a drive letter). On POSIX each root is a
+ * directory OF volumes, so its children are the volumes. Roots that don't exist
+ * simply contribute nothing.
+ *
+ * `roots` is injectable so this can be tested against a temp directory — the
+ * platform roots are not something a test can create.
+ */
+export async function listVolumes(roots: string[] = volumeSearchRoots()): Promise<Volume[]> {
+  const out: Volume[] = []
+  const seen = new Set<string>()
+  const push = (mountPath: string, name: string, probeContents: boolean): void => {
+    const existing = seen.has(mountPath)
+    if (existing) return
+    seen.add(mountPath)
+    out.push({ mountPath, name, probeContents })
+  }
+
+  if (platform() === 'win32') {
+    // 26 drive letters, most of which don't exist — cheap to probe, and there is
+    // no label in the path to go on.
+    for (const root of roots) if (root) push(root, '', true)
+    return out
+  }
+
+  const home = homedir()
+  for (const root of roots) {
+    if (!root) continue
+    let names: string[]
+    try {
+      names = await fs.readdir(root)
+    } catch {
+      continue // root doesn't exist / isn't readable — the normal case
+    }
+    const probeContents = root !== home
+    for (const name of names) push(join(root, name), name, probeContents)
+  }
+  return out
+}
+
+/**
+ * Does `dir` contain any of `names` (case-insensitively)? The marker-file test
+ * every board detector runs — a vfat volume can surface `DETAILS.TXT` as
+ * `details.txt` depending on how it was mounted, so the comparison can't be
+ * exact.
+ */
+export async function volumeHasFile(dir: string, names: string[]): Promise<boolean> {
+  return (await resolveVolumeFile(dir, names)) !== null
+}
+
+/** The real, on-disk name of the first of `names` present in `dir`, or null. */
+export async function resolveVolumeFile(dir: string, names: string[]): Promise<string | null> {
+  const wanted = names.map((n) => n.toLowerCase())
+  try {
+    const entries = await fs.readdir(dir)
+    return entries.find((e) => wanted.includes(e.toLowerCase())) ?? null
+  } catch {
+    return null
+  }
+}
+
+/** Read a marker file from a volume, resolving its name case-insensitively.
+ *  Returns null when it isn't there or can't be read. */
+export async function readVolumeFile(dir: string, name: string): Promise<string | null> {
+  const file = await resolveVolumeFile(dir, [name])
+  if (!file) return null
+  try {
+    return await fs.readFile(join(dir, file), 'utf8')
+  } catch {
+    return null
+  }
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -51,6 +51,8 @@ export type {
   ConnectionState,
   DeviceStatus,
   RuntimeInfo,
+  CircuitPyDrive,
+  PortCircuitPy,
   ExecResult,
   DirEntry,
   StatResult,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -11,6 +11,7 @@ import { electronAPI } from '@electron-toolkit/preload'
 ipcRenderer.setMaxListeners(40)
 import type { FlashMethod } from '../shared/board-profiles'
 import type {
+  CircuitPyDrive,
   ConnectOptions,
   DeviceStatus,
   DirEntry,
@@ -175,8 +176,12 @@ async function unwrap<T>(p: Promise<IpcResult<T>>): Promise<T> {
  * and return an unsubscribe function.
  */
 const device = {
-  /** Enumerate available serial ports. */
+  /** Enumerate available serial ports. A port whose CircuitPython board could be
+   *  identified from its mounted CIRCUITPY drive carries a `circuitpy` block (#753). */
   listPorts: (): Promise<PortInfo[]> => unwrap(ipcRenderer.invoke('device:listPorts')),
+  /** Every mounted CircuitPython filesystem, scanned fresh (#753). */
+  circuitpyDrives: (): Promise<CircuitPyDrive[]> =>
+    unwrap(ipcRenderer.invoke('device:circuitpyDrives')),
   /** Open a connection to `path` at `opts.baudRate` (default 115200). */
   connect: (path: string, opts?: ConnectOptions): Promise<void> =>
     unwrap(ipcRenderer.invoke('device:connect', path, opts)),

--- a/src/renderer/src/components/ConnectionControl.tsx
+++ b/src/renderer/src/components/ConnectionControl.tsx
@@ -1,6 +1,22 @@
 import { useCallback, useEffect, useState } from 'react'
 import { isVirtualPort, VIRTUAL_PORT_LABEL } from '../../../shared/virtual-device'
-import type { DeviceStatus, PortInfo } from '../../../preload/index.d'
+import type { DeviceStatus, PortCircuitPy, PortInfo } from '../../../preload/index.d'
+
+/**
+ * Tooltip for a port identified from its CIRCUITPY drive (#753). Names the
+ * board id and the mount path, and is honest about HOW it was matched: a `uid`
+ * pairing is the board's own id matched against the port's USB serial number,
+ * while `sole` is only "there was one of each", which is a deduction rather
+ * than an identification.
+ */
+function circuitpyTitle(cp: PortCircuitPy): string {
+  const board = cp.boardId ? `${cp.boardId} — ` : ''
+  const how =
+    cp.confidence === 'uid'
+      ? 'matched by board id'
+      : 'the only CircuitPython drive mounted, and the only board connected'
+  return `${board}CIRCUITPY at ${cp.mountPath} (${how})`
+}
 
 interface ConnectionControlProps {
   status: DeviceStatus
@@ -96,9 +112,14 @@ export function ConnectionControl({ status }: ConnectionControlProps): JSX.Eleme
           // real device node — show just its USB name. OS serial paths (e.g.
           // /dev/ttyACM0) DO identify the port, so keep those.
           const isWebSerial = p.path.startsWith('webserial://')
-          const label = isWebSerial ? detail || 'USB board' : detail ? `${p.path} — ${detail}` : p.path
+          const base = isWebSerial ? detail || 'USB board' : detail ? `${p.path} — ${detail}` : p.path
+          // A board whose CIRCUITPY drive we found says what it's running before
+          // you connect to it (#753). Only shown when the drive was tied to THIS
+          // port, so a second board can't borrow the first one's identity.
+          const cp = p.circuitpy
+          const label = cp ? `${base} · CircuitPython${cp.version ? ` ${cp.version}` : ''}` : base
           return (
-            <option key={p.path} value={p.path}>
+            <option key={p.path} value={p.path} title={cp ? circuitpyTitle(cp) : undefined}>
               {label}
             </option>
           )

--- a/src/renderer/src/lib/preloadFallback.ts
+++ b/src/renderer/src/lib/preloadFallback.ts
@@ -97,6 +97,10 @@ if (!w.api) {
     versions: {},
     device: {
       listPorts: P([]),
+      // A browser cannot see mass storage, so there is never a CIRCUITPY drive
+      // to find here (#753). Stated explicitly rather than left to `deepStub`,
+      // whose truthy `[]` is the trap #513 was filed about.
+      circuitpyDrives: P([]),
       connect: P(undefined),
       disconnect: P(undefined),
       getStatus: P({ state: 'disconnected' }),

--- a/src/shared/dialect.ts
+++ b/src/shared/dialect.ts
@@ -186,6 +186,25 @@ export function parseBootOut(text: string): RuntimeInfo | null {
 }
 
 /**
+ * The `UID:` line `boot_out.txt` carries on CircuitPython 7 and later — the
+ * board's own unique id, and the same value it reports as
+ * `microcontroller.cpu.uid`.
+ *
+ * This is what lets a mounted drive be tied to a specific serial port WITHOUT
+ * connecting to it (#753): USB exposes the same id as the port's serial number
+ * on the boards that have one, so the two can be matched offline. Returns
+ * `undefined` on an older board that writes no UID line, which is why the
+ * pairing has a fallback.
+ */
+export function parseBootOutUid(text: string): string | undefined {
+  for (const line of text.split(/\r?\n/)) {
+    const m = /^UID\s*:\s*([0-9A-F]+)\s*$/i.exec(line.trim())
+    if (m) return m[1].toUpperCase()
+  }
+  return undefined
+}
+
+/**
  * Rebuild the greeting a board prints on reset, so connecting shows the same
  * line the board itself would (#612). Each runtime words its banner
  * differently — `MicroPython v1.28.0 on …` versus `Adafruit CircuitPython

--- a/test/circuitpyDrive.test.ts
+++ b/test/circuitpyDrive.test.ts
@@ -1,0 +1,245 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises'
+import { homedir, tmpdir } from 'os'
+import { join } from 'path'
+import { listVolumes, readVolumeFile, volumeHasFile } from '../src/main/fs/volumes'
+import {
+  annotatePortsWithDrives,
+  findCircuitPyDrives,
+  pairDriveToPort,
+  type CircuitPyDrive
+} from '../src/main/device/circuitpy'
+import { VIRTUAL_PORT_PATH } from '../src/shared/virtual-device'
+import type { PortInfo } from '../src/main/device/types'
+
+/**
+ * CIRCUITPY DRIVE DETECTION (#753, epic #209).
+ *
+ * The scanning half runs against REAL directories in a temp dir — the volume
+ * roots are injectable precisely so this is possible, and the machinery it
+ * shares with the UF2/micro:bit detectors in `firmware/detect.ts` had no test
+ * at all before. The pairing half is pure, and is where the care is: writing a
+ * file to the wrong board is a silent failure, so "refuses to guess" is the
+ * property under test.
+ */
+
+const bootOut = (version: string, board: string, uid?: string): string =>
+  [
+    `Adafruit CircuitPython ${version} on 2026-08-18; ${board} with rp2040`,
+    `Board ID:${board.toLowerCase().replace(/\s+/g, '_')}`,
+    ...(uid ? [`UID:${uid}`] : []),
+    ''
+  ].join('\r\n')
+
+let root: string
+
+/**
+ * A temp "mount root" holding several volumes:
+ *   CIRCUITPY   — a modern board, with a UID
+ *   FEATHERBOOT — a UF2 bootloader volume (not CircuitPython)
+ *   MY_STUFF    — a renamed CircuitPython drive, no UID (an older board)
+ *   Untitled    — an ordinary USB stick
+ */
+beforeAll(async () => {
+  root = await mkdtemp(join(tmpdir(), 'snakie-vol-'))
+  const vol = async (name: string, files: Record<string, string>): Promise<void> => {
+    await mkdir(join(root, name), { recursive: true })
+    for (const [f, body] of Object.entries(files)) await writeFile(join(root, name, f), body)
+  }
+  await vol('CIRCUITPY', {
+    'boot_out.txt': bootOut('10.2.1', 'Adafruit Feather RP2040', 'E661640843373E2A'),
+    'code.py': 'print("hi")\n'
+  })
+  await vol('FEATHERBOOT', { 'INFO_UF2.TXT': 'UF2 Bootloader\n' })
+  // Renamed drive, older CircuitPython: no UID line. Also spelt in the other
+  // case, which a vfat mount can do.
+  await vol('MY_STUFF', { 'BOOT_OUT.TXT': bootOut('6.3.0', 'Raspberry Pi Pico') })
+  await vol('Untitled', { 'notes.txt': 'shopping list' })
+})
+
+afterAll(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('listVolumes', () => {
+  it('lists each mounted volume under a root, carrying its label', async () => {
+    const vols = await listVolumes([root])
+    expect(vols.map((v) => v.name).sort()).toEqual(['CIRCUITPY', 'FEATHERBOOT', 'MY_STUFF', 'Untitled'])
+    expect(vols.every((v) => v.mountPath.startsWith(root))).toBe(true)
+  })
+
+  it('ignores roots that do not exist, which is the normal case for most of them', async () => {
+    const vols = await listVolumes([join(root, 'nope'), root, '/definitely/not/here'])
+    expect(vols).toHaveLength(4)
+  })
+
+  it('de-duplicates, so a repeated root costs nothing but a readdir', async () => {
+    expect(await listVolumes([root, root])).toHaveLength(4)
+  })
+
+  it('is empty, not thrown, for no roots at all', async () => {
+    expect(await listVolumes([])).toEqual([])
+  })
+
+  it('marks entries under a mount root as worth reading', async () => {
+    const vols = await listVolumes([root])
+    expect(vols.every((v) => v.probeContents)).toBe(true)
+  })
+
+  it('does NOT mark the home directory, whose entries are folders, not volumes', async () => {
+    // `listPorts` refreshes on every dropdown focus and now scans volumes with
+    // it; content-probing each folder in $HOME would mean a readdir apiece.
+    // A board mounted there is still found by its LABEL — only the probe is off.
+    const vols = await listVolumes([homedir()])
+    expect(vols.length).toBeGreaterThan(0)
+    expect(vols.every((v) => v.probeContents === false)).toBe(true)
+  })
+})
+
+describe('volume file helpers', () => {
+  it('finds a marker file case-insensitively — vfat mounts vary', async () => {
+    expect(await volumeHasFile(join(root, 'MY_STUFF'), ['boot_out.txt'])).toBe(true)
+    expect(await volumeHasFile(join(root, 'CIRCUITPY'), ['BOOT_OUT.TXT'])).toBe(true)
+    expect(await volumeHasFile(join(root, 'Untitled'), ['boot_out.txt'])).toBe(false)
+  })
+
+  it('matches any of several markers', async () => {
+    expect(await volumeHasFile(join(root, 'FEATHERBOOT'), ['INDEX.HTM', 'INFO_UF2.TXT'])).toBe(true)
+  })
+
+  it('reads a marker file, and is null rather than throwing when it is absent', async () => {
+    expect(await readVolumeFile(join(root, 'CIRCUITPY'), 'boot_out.txt')).toContain('CircuitPython')
+    expect(await readVolumeFile(join(root, 'Untitled'), 'boot_out.txt')).toBeNull()
+    expect(await readVolumeFile(join(root, 'gone'), 'boot_out.txt')).toBeNull()
+  })
+})
+
+describe('findCircuitPyDrives', () => {
+  it('finds CircuitPython volumes and reads their identity from boot_out.txt', async () => {
+    const drives = await findCircuitPyDrives([root])
+    expect(drives).toHaveLength(2)
+    const feather = drives.find((d) => d.mountPath.endsWith('CIRCUITPY'))
+    expect(feather?.runtime).toMatchObject({
+      dialect: 'circuitpython',
+      version: '10.2.1',
+      boardId: 'adafruit_feather_rp2040'
+    })
+    expect(feather?.uid).toBe('E661640843373E2A')
+  })
+
+  it('finds a RENAMED drive — the marker file decides, not the label', async () => {
+    const drives = await findCircuitPyDrives([root])
+    const renamed = drives.find((d) => d.mountPath.endsWith('MY_STUFF'))
+    expect(renamed?.runtime.version).toBe('6.3.0')
+    // An older CircuitPython writes no UID line, which is why pairing has a fallback.
+    expect(renamed?.uid).toBeUndefined()
+  })
+
+  it('ignores a UF2 bootloader volume and an ordinary USB stick', async () => {
+    const paths = (await findCircuitPyDrives([root])).map((d) => d.mountPath)
+    expect(paths.some((p) => p.endsWith('FEATHERBOOT'))).toBe(false)
+    expect(paths.some((p) => p.endsWith('Untitled'))).toBe(false)
+  })
+
+  it('is empty when nothing is mounted, rather than throwing', async () => {
+    expect(await findCircuitPyDrives(['/no/such/root'])).toEqual([])
+  })
+})
+
+describe('pairDriveToPort', () => {
+  const drive = (mountPath: string, uid?: string): CircuitPyDrive => ({
+    mountPath,
+    runtime: { dialect: 'circuitpython', version: '10.2.1' },
+    ...(uid ? { uid } : {})
+  })
+  const port = (path: string, serialNumber?: string): PortInfo => ({ path, ...(serialNumber ? { serialNumber } : {}) })
+
+  it('matches a drive to its port by the board id, with no connection needed', () => {
+    const drives = [drive('/A', 'AAAA1111'), drive('/B', 'BBBB2222')]
+    const got = pairDriveToPort(drives, port('/dev/ttyACM1', 'BBBB2222'), [
+      port('/dev/ttyACM0', 'AAAA1111'),
+      port('/dev/ttyACM1', 'BBBB2222')
+    ])
+    expect(got).toEqual({ drive: drives[1], confidence: 'uid' })
+  })
+
+  it('normalises case and separators — the OS does not report the id verbatim', () => {
+    const drives = [drive('/A', 'E661640843373E2A')]
+    const got = pairDriveToPort(drives, port('/dev/ttyACM0', 'e66164:08-43373e2a'), [])
+    expect(got).toMatchObject({ confidence: 'uid' })
+  })
+
+  it('falls back to one-drive-one-board when the board is too old to write a UID', () => {
+    const drives = [drive('/A')]
+    const got = pairDriveToPort(drives, port('/dev/ttyACM0'), [port('/dev/ttyACM0')])
+    expect(got).toEqual({ drive: drives[0], confidence: 'sole' })
+  })
+
+  it('does not count the simulated device as a rival board — it has no drive', () => {
+    const drives = [drive('/A')]
+    const got = pairDriveToPort(drives, port('/dev/ttyACM0'), [
+      port('/dev/ttyACM0'),
+      port(VIRTUAL_PORT_PATH)
+    ])
+    expect(got).toEqual({ drive: drives[0], confidence: 'sole' })
+  })
+
+  it('REFUSES to pair two boards and one unidentified drive — the drive may be the other one\'s', () => {
+    const drives = [drive('/A')]
+    const got = pairDriveToPort(drives, port('/dev/ttyACM0'), [
+      port('/dev/ttyACM0'),
+      port('/dev/ttyACM1')
+    ])
+    expect(got).toEqual({ drive: null, why: 'ambiguous' })
+  })
+
+  it('REFUSES to pair one board with two unidentified drives', () => {
+    const drives = [drive('/A'), drive('/B')]
+    const got = pairDriveToPort(drives, port('/dev/ttyACM0'), [port('/dev/ttyACM0')])
+    expect(got).toEqual({ drive: null, why: 'ambiguous' })
+  })
+
+  it('says no-drives rather than ambiguous when there is simply nothing mounted', () => {
+    expect(pairDriveToPort([], port('/dev/ttyACM0'))).toEqual({ drive: null, why: 'no-drives' })
+  })
+
+  it('still matches by id when a second board would otherwise make it ambiguous', () => {
+    const drives = [drive('/A', 'AAAA1111'), drive('/B')]
+    const got = pairDriveToPort(drives, port('/dev/ttyACM0', 'AAAA1111'), [
+      port('/dev/ttyACM0', 'AAAA1111'),
+      port('/dev/ttyACM1')
+    ])
+    expect(got).toEqual({ drive: drives[0], confidence: 'uid' })
+  })
+})
+
+describe('annotatePortsWithDrives', () => {
+  it('names the board on the port it belongs to, before anything is connected', async () => {
+    const ports: PortInfo[] = [{ path: '/dev/ttyACM0', serialNumber: 'E661640843373E2A' }]
+    const [annotated] = await annotatePortsWithDrives(ports, [root])
+    expect(annotated.circuitpy).toMatchObject({
+      version: '10.2.1',
+      boardId: 'adafruit_feather_rp2040',
+      confidence: 'uid'
+    })
+    expect(annotated.circuitpy?.mountPath).toContain('CIRCUITPY')
+  })
+
+  it('leaves a port it cannot tie to a drive untouched', async () => {
+    // Two drives are mounted and this port matches neither by id.
+    const ports: PortInfo[] = [{ path: '/dev/ttyACM0', serialNumber: 'FFFF9999' }]
+    const [annotated] = await annotatePortsWithDrives(ports, [root])
+    expect(annotated.circuitpy).toBeUndefined()
+  })
+
+  it('never annotates the simulated device', async () => {
+    const ports: PortInfo[] = [{ path: VIRTUAL_PORT_PATH, friendlyName: 'Simulated device' }]
+    const [annotated] = await annotatePortsWithDrives(ports, [root])
+    expect(annotated.circuitpy).toBeUndefined()
+  })
+
+  it('returns the ports unchanged when nothing is mounted', async () => {
+    const ports: PortInfo[] = [{ path: '/dev/ttyACM0' }]
+    expect(await annotatePortsWithDrives(ports, ['/no/such/root'])).toEqual(ports)
+  })
+})

--- a/test/dialect.test.ts
+++ b/test/dialect.test.ts
@@ -4,6 +4,7 @@ import {
   RUNTIME_PROBE_PY,
   dialectFromName,
   parseBootOut,
+  parseBootOutUid,
   parseRuntimeBanner,
   parseRuntimeProbe,
   runtimeGreeting,
@@ -160,6 +161,31 @@ describe('parseBootOut', () => {
 
   it('is null for a file that is neither', () => {
     expect(parseBootOut('INFO_UF2.TXT\nModel: Raspberry Pi RP2')).toBeNull()
+  })
+})
+
+describe('parseBootOutUid', () => {
+  it('reads the UID line — how a drive is tied to a port with no connection (#753)', () => {
+    const text = [
+      'Adafruit CircuitPython 10.2.1 on 2026-08-18; Adafruit Feather RP2040 with rp2040',
+      'Board ID:adafruit_feather_rp2040',
+      'UID:E661640843373E2A'
+    ].join('\r\n')
+    expect(parseBootOutUid(text)).toBe('E661640843373E2A')
+  })
+
+  it('normalises to upper case, so the comparison with a USB serial number is stable', () => {
+    expect(parseBootOutUid('UID:e661640843373e2a')).toBe('E661640843373E2A')
+    expect(parseBootOutUid('UID: E66164 ')).toBe('E66164')
+  })
+
+  it('is undefined on an older CircuitPython that writes no UID — hence the pairing fallback', () => {
+    expect(parseBootOutUid('Adafruit CircuitPython 6.3.0 on 2021-01-01; Pico\nBoard ID:pico')).toBeUndefined()
+  })
+
+  it('ignores a line that merely mentions a uid', () => {
+    expect(parseBootOutUid('the UID is somewhere else')).toBeUndefined()
+    expect(parseBootOutUid('UID:not-hex-at-all')).toBeUndefined()
   })
 })
 

--- a/test/microbitDetect.test.ts
+++ b/test/microbitDetect.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from 'vitest'
-import { microbitVersionFromDetails, microbitMaintenanceFromDetails } from '../src/main/firmware/detect'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  detectMicrobitDrive,
+  detectRp2040Drive,
+  microbitVersionFromDetails,
+  microbitMaintenanceFromDetails
+} from '../src/main/firmware/detect'
+import { listVolumes } from '../src/main/fs/volumes'
 
 /**
  * `microbitVersionFromDetails` reads the BBC micro:bit generation from the
@@ -41,5 +50,65 @@ describe('microbitMaintenanceFromDetails', () => {
   it('treats interface mode (and a missing line) as NOT maintenance', () => {
     expect(microbitMaintenanceFromDetails('DAPLink Mode: Interface')).toBe(false)
     expect(microbitMaintenanceFromDetails('Board ID: 9904')).toBe(false)
+  })
+})
+
+/**
+ * The DRIVE SCANNING behind those parsers, against real fixture directories.
+ *
+ * `detect.ts` used to hand-roll the per-platform mount walk twice; #753 needed a
+ * third copy for CIRCUITPY, so the walk moved to `fs/volumes.ts` and both
+ * detectors now take the volume list. This pins that the marker/label rules
+ * survived that move — they had no test before it.
+ */
+describe('drive detection over a volume list', () => {
+  let root: string
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), 'snakie-boards-'))
+    const vol = async (name: string, files: Record<string, string>): Promise<void> => {
+      await mkdir(join(root, name), { recursive: true })
+      for (const [f, body] of Object.entries(files)) await writeFile(join(root, name, f), body)
+    }
+    await vol('RPI-RP2', { 'INFO_UF2.TXT': 'Model: Raspberry Pi RP2\n', 'INDEX.HTM': '' })
+    await vol('MICROBIT', { 'DETAILS.TXT': 'Board ID: 9903\nDAPLink Mode: Interface\n' })
+    await vol('MAINTENANCE', { 'DETAILS.TXT': 'Board ID: 9903\nDAPLink Mode: Bootloader\n' })
+    // A drive with the marker but NO recognisable label — the Windows case,
+    // where a volume is a bare letter.
+    await vol('E', { 'info_uf2.txt': 'Model: Raspberry Pi RP2\n' })
+    await vol('Untitled', { 'holiday.jpg': '' })
+  })
+
+  afterAll(async () => {
+    await rm(root, { recursive: true, force: true })
+  })
+
+  it('finds a BOOTSEL drive by label and by marker file alone', async () => {
+    const found = await detectRp2040Drive(await listVolumes([root]))
+    const names = found.map((c) => c.mountPath.split(/[/\\]/).pop())
+    expect(names).toContain('RPI-RP2')
+    expect(names).toContain('E') // no label, found by INFO_UF2.TXT
+    expect(names).not.toContain('Untitled')
+    expect(found[0].board).toBe('rp2040')
+    expect(found[0].source).toBe('uf2-drive')
+  })
+
+  it('finds a micro:bit and reads its generation from DETAILS.TXT', async () => {
+    const found = await detectMicrobitDrive(await listVolumes([root]))
+    const normal = found.find((c) => c.mountPath.endsWith('MICROBIT'))
+    expect(normal?.microbitVersion).toBe('v2')
+    expect(normal?.maintenance).toBe(false)
+  })
+
+  it('flags maintenance mode, which cannot be flashed', async () => {
+    const found = await detectMicrobitDrive(await listVolumes([root]))
+    const maint = found.find((c) => c.mountPath.endsWith('MAINTENANCE'))
+    expect(maint?.maintenance).toBe(true)
+    expect(maint?.label).toContain('reconnect to flash')
+  })
+
+  it('finds nothing in an empty volume list, rather than throwing', async () => {
+    expect(await detectRp2040Drive([])).toEqual([])
+    expect(await detectMicrobitDrive([])).toEqual([])
   })
 })


### PR DESCRIPTION
Closes #753.

> **Stacked on #765** (`feat/circuitpython-dialect`) — it needs `parseBootOut` from #752. The base is set to that branch, so this diff shows only #753's changes; merge #765 first and the base retargets to `master`.

## What changed

A board running CircuitPython mounts a **CIRCUITPY** volume alongside its serial port. Unlike `RPI-RP2` or `MICROBIT`, which `firmware/detect.ts` looks for, that isn't a flashing mode — it's the board's own filesystem, and it's how a host writes to it, because while it's mounted the board's own code can't (#754 builds on this).

`boot_out.txt` names the version and the per-board build id, so a board can be identified with nothing connected. **The port picker now reads `CircuitPython 10.2.1` against a board before you press Connect**, with the board id and mount path on hover.

## Pairing refuses to guess

Tying a drive to a port is the hard half: two boards on one desk means two drives, and writing to the wrong one fails silently.

- **By board id.** CircuitPython writes its `microcontroller.cpu.uid` into `boot_out.txt`, and USB reports that same id as the port's serial number — so the two match **offline**, with no connection and no block-device plumbing.
- **By elimination.** An older CircuitPython writes no UID; one drive and one board can only be each other. The simulated device never counts as a rival, having no drive.
- **Otherwise, nothing.** `ambiguous`, and the port is returned unannotated. The caller must not write to a guess.

Nothing is cached: a CIRCUITPY drive ejects on soft reboot and comes back a moment later, so a remembered mount path is a path that may not exist.

## Two things I found on the way

**`detect.ts` had hand-rolled the per-platform mount walk twice**, and this needed a third. It moved to `fs/volumes.ts` and both existing detectors now take the volume list — a **113-line deletion**. That also brought the scanning under test for the first time: roots are injectable, so it runs against fixture directories rather than the real `/Volumes`.

**A scan that would have become pathological.** `$HOME` is one of the search roots, and `listPorts` refreshes on every dropdown focus — so content-probing each entry meant a `readdir` per folder in the home directory, several times a minute. Volumes now carry `probeContents`, false for `$HOME`, whose entries are folders rather than mounts. A board mounted there is still found by its label; only the content probe is skipped. This was a latent cost in the existing detector too, just a rarer one.

## Verification

- `lint`, `typecheck`, `build`, `build:web` green. Full suite 3370 pass; `slowReadTimeout.test.ts` is the known flake in #737 (passes standalone).
- **39 new tests.** The scanning runs against real temp directories — a labelled `CIRCUITPY`, a **renamed** one found by its marker file, a UF2 bootloader volume and an ordinary USB stick that must both be ignored. The pairing tests are mostly about what it *refuses*: two boards and one unidentified drive, one board and two drives, and an id match that still wins when either would otherwise be ambiguous.
- **The refactor is now covered** by fixture tests for `detectRp2040Drive` / `detectMicrobitDrive`, including the no-label Windows shape and maintenance mode — none of which had a test before.
- **End-to-end on the real filesystem**: a labelled drive under an actual search root was found through the default (non-injected) code path, parsed, paired by UID and annotated onto a port. Fixture removed afterwards.
- **Port picker rendering verified in headless Chromium**: the identified board shows its version and tooltip, an unidentified second board is left untouched, and the simulator is never annotated.

## Not verified

**Against real hardware or on macOS/Windows.** The mount-root lists for those platforms are unchanged in substance from the ones `detect.ts` already shipped, and the fixture tests exercise the label/marker rules platform-independently — but a real CIRCUITPY drive appearing at `/Volumes/CIRCUITPY` or `E:\`, and whether the OS reports a USB serial number matching the board's UID, are both assumptions from documentation. Worth confirming alongside the #751 spike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)