### PR TITLE
feat: file I/O against a board whose filesystem is read-only to itself (#754)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Files, drivers and libraries can be written to a CircuitPython board.**
+  (#754, epic #209) CircuitPython's filesystem is read-only *to the board* while
+  its CIRCUITPY drive is mounted, so every file operation Snakie has — the Files
+  panel, driver installs, the instrument library, the Modules manager — used to
+  fail with a bare `OSError: 30`. Those operations now go to the drive instead.
+  Reads go there too, so listing a folder no longer has to interrupt a running
+  `code.py` to do it, and a file copy replaces the hex-over-serial transfer.
+  Writes are flushed before returning, so CircuitPython's auto-reload can't catch
+  a half-written file. A board that has taken its filesystem back with
+  `storage.remount` still works exactly as before, over the REPL — and if a write
+  does hit the read-only filesystem, the error now explains it instead of naming
+  an errno. The flash gauge measures the drive, which is the number that answers
+  "will this fit".
 - **Snakie finds a CircuitPython board's drive, and says what the board is before
   you connect.** (#753, epic #209) A board running CircuitPython mounts a
   **CIRCUITPY** volume, and its `boot_out.txt` names the version and the

--- a/src/main/device/MicroPythonDevice.ts
+++ b/src/main/device/MicroPythonDevice.ts
@@ -1,4 +1,6 @@
 import { EventEmitter } from 'events'
+import { stat } from 'fs/promises'
+import { join } from 'path'
 import { SerialPort } from 'serialport'
 import { buildControlLine } from '../../shared/control'
 import {
@@ -7,6 +9,19 @@ import {
   runtimeGreeting,
   type RuntimeInfo
 } from '../../shared/dialect'
+import { findCircuitPyDrives, pairDriveToPort } from './circuitpy'
+import {
+  driveListDir,
+  driveMkdir,
+  driveReadFileBytes,
+  driveReadFileLine,
+  driveRemove,
+  driveRename,
+  driveStat,
+  driveUsage,
+  driveWriteFile,
+  readOnlyFsError
+} from './circuitpy-fs'
 import type {
   ConnectOptions,
   ConnectionState,
@@ -72,6 +87,12 @@ export class MicroPythonDevice extends EventEmitter implements SnakieDevice {
    *  reads this instead of assuming MicroPython. Cleared on disconnect so the
    *  next board can't inherit the last one's runtime. */
   private runtime: RuntimeInfo | null = null
+
+  /** The CIRCUITPY drive this board's files live on (#754), resolved once the
+   *  runtime probe says it is CircuitPython. Null means "use the REPL", which is
+   *  right for MicroPython AND for a CircuitPython board that has handed its
+   *  filesystem to itself with `storage.remount`. */
+  private mount: string | null = null
 
   /**
    * Buffer of bytes received from the device. When a command is awaiting a
@@ -225,6 +246,10 @@ export class MicroPythonDevice extends EventEmitter implements SnakieDevice {
       const info = parseRuntimeProbe(await this.eval(RUNTIME_PROBE_PY))
       if (!info || !this.isConnected()) return
       this.runtime = info
+      // Now that we know it is CircuitPython, find the drive its files live on
+      // (#754). Best-effort: no drive just means the REPL path, which is what a
+      // `storage.remount` board wants anyway.
+      if (info.dialect === 'circuitpython') await this.resolveMount()
       // The `connected` status went out before the probe answered, so publish a
       // second one now that the runtime is known.
       this.emit('status', this.getStatus())
@@ -254,7 +279,10 @@ export class MicroPythonDevice extends EventEmitter implements SnakieDevice {
     // A new connection knows nothing about the board yet, and the PREVIOUS
     // board's runtime must not leak into it — unplugging a Pico and plugging in
     // a Feather would otherwise leave the status bar naming the wrong Python.
-    if (state !== 'connected') this.runtime = null
+    if (state !== 'connected') {
+      this.runtime = null
+      this.mount = null
+    }
     const status: DeviceStatus = {
       state,
       path: this.currentPath,
@@ -657,7 +685,70 @@ export class MicroPythonDevice extends EventEmitter implements SnakieDevice {
   }
 
   // ---------------------------------------------------------------------------
-  // Filesystem helpers (built on top of exec/eval)
+  // Where this board's files live (#754)
+  // ---------------------------------------------------------------------------
+
+  /** Find the CIRCUITPY drive belonging to THIS port and remember it. Silent on
+   *  failure — every caller treats "no mount" as "use the REPL". */
+  private async resolveMount(): Promise<void> {
+    this.mount = null
+    try {
+      const drives = await findCircuitPyDrives()
+      if (drives.length === 0) return
+      const ports = await MicroPythonDevice.listPorts()
+      // Normally the connected port is in the list, carrying the USB serial
+      // number that identifies the board. Where enumeration reports nothing
+      // useful — no permissions, no udev metadata — fall back to the bare path:
+      // it can't match by id, but one drive and no other board still can, and
+      // any other enumerated port correctly makes it ambiguous.
+      const self = ports.find((p) => p.path === this.currentPath) ?? { path: this.currentPath ?? '' }
+      const paired = pairDriveToPort(drives, self, ports)
+      // An ambiguous pairing deliberately yields nothing: writing to the wrong
+      // board's drive is worse than falling back to the REPL (#753).
+      this.mount = paired.drive?.mountPath ?? null
+    } catch {
+      // Detection is an optimisation over the REPL, never a prerequisite.
+    }
+  }
+
+  /**
+   * The drive to use for filesystem operations right now, or null for the REPL.
+   *
+   * Re-checked rather than trusted: a CIRCUITPY drive ejects when the board soft
+   * reboots and returns a moment later at the same path, so a remembered mount
+   * can be a path that does not currently exist. One `stat` of the marker file
+   * is cheap; a re-resolve only happens when it has genuinely gone.
+   */
+  private async driveMount(): Promise<string | null> {
+    if (!this.mount) return null
+    try {
+      await stat(join(this.mount, 'boot_out.txt'))
+      return this.mount
+    } catch {
+      await this.resolveMount()
+      return this.mount
+    }
+  }
+
+  /**
+   * Run a filesystem WRITE over the REPL, turning a read-only-filesystem
+   * failure into something a user can act on.
+   *
+   * This is the path a CircuitPython board takes when no drive was found — and
+   * the one it takes when the runtime probe couldn't identify it at all, which
+   * is exactly when a bare `OSError: 30` would be most baffling. Every other
+   * error passes through untouched.
+   */
+  private async replWrite<T>(run: () => Promise<T>): Promise<T> {
+    try {
+      return await run()
+    } catch (err) {
+      throw readOnlyFsError(err)
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Filesystem helpers (over the drive when there is one, else the REPL)
   // ---------------------------------------------------------------------------
 
   /**
@@ -666,6 +757,8 @@ export class MicroPythonDevice extends EventEmitter implements SnakieDevice {
    * compact, machine-parseable line per entry.
    */
   async listDir(path = '/'): Promise<DirEntry[]> {
+    const mount = await this.driveMount()
+    if (mount) return driveListDir(mount, path)
     const code = [
       'import os, json',
       `def _ls(p):`,
@@ -697,6 +790,8 @@ export class MicroPythonDevice extends EventEmitter implements SnakieDevice {
 
   /** Read a file from the device and return its raw bytes. */
   async readFileBytes(path: string): Promise<Buffer> {
+    const mount = await this.driveMount()
+    if (mount) return driveReadFileBytes(mount, path)
     // `ubinascii` is exposed as `binascii` on some ports; import defensively.
     const code = [
       'import sys',
@@ -724,6 +819,8 @@ export class MicroPythonDevice extends EventEmitter implements SnakieDevice {
    * header was reordered.
    */
   async readFileLine(path: string, prefix: string): Promise<string> {
+    const mount = await this.driveMount()
+    if (mount) return driveReadFileLine(mount, path, prefix)
     const code = [
       `_l = ''`,
       `try:`,
@@ -746,6 +843,8 @@ export class MicroPythonDevice extends EventEmitter implements SnakieDevice {
    * text-oriented REPL transport.
    */
   async writeFile(path: string, contents: string | Buffer, chunkSize = 256): Promise<void> {
+    const mount = await this.driveMount()
+    if (mount) return driveWriteFile(mount, path, contents)
     const data = Buffer.isBuffer(contents) ? contents : Buffer.from(contents, 'utf8')
     // Open the file once, then stream hex chunks via repeated exec calls so we
     // never put a multi-megabyte literal on a single line.
@@ -754,12 +853,12 @@ export class MicroPythonDevice extends EventEmitter implements SnakieDevice {
       'try:\n import ubinascii\nexcept ImportError:\n import binascii as ubinascii',
       `_f=open(${pyStr(path)},'wb')`
     ].join('\n')
-    await this.eval(open)
+    await this.replWrite(() => this.eval(open))
     try {
       for (let i = 0; i < data.length; i += chunkSize) {
         const slice = data.subarray(i, i + chunkSize)
         const hex = slice.toString('hex')
-        await this.eval(`_f.write(ubinascii.unhexlify(${pyStr(hex)}))`)
+        await this.replWrite(() => this.eval(`_f.write(ubinascii.unhexlify(${pyStr(hex)}))`))
       }
     } finally {
       await this.eval('_f.close()').catch(() => undefined)
@@ -770,38 +869,48 @@ export class MicroPythonDevice extends EventEmitter implements SnakieDevice {
    *  (and `os.rmdir()` only empty ones), so walk depth-first with an explicit
    *  stack: children first, then the emptied folder (#219). */
   async remove(path: string): Promise<void> {
-    await this.eval(
-      [
-        'import os',
-        `_s = [${pyStr(path)}]`,
-        'while _s:',
-        '    _p = _s[-1]',
-        '    if (os.stat(_p)[0] & 0x4000) != 0:',
-        '        _c = os.listdir(_p)',
-        '        if _c:',
-        "            _s.extend([_p + '/' + _x for _x in _c])",
-        '        else:',
-        '            os.rmdir(_p)',
-        '            _s.pop()',
-        '    else:',
-        '        os.remove(_p)',
-        '        _s.pop()'
-      ].join('\n')
+    const mount = await this.driveMount()
+    if (mount) return driveRemove(mount, path)
+    await this.replWrite(() =>
+      this.eval(
+        [
+          'import os',
+          `_s = [${pyStr(path)}]`,
+          'while _s:',
+          '    _p = _s[-1]',
+          '    if (os.stat(_p)[0] & 0x4000) != 0:',
+          '        _c = os.listdir(_p)',
+          '        if _c:',
+          "            _s.extend([_p + '/' + _x for _x in _c])",
+          '        else:',
+          '            os.rmdir(_p)',
+          '            _s.pop()',
+          '    else:',
+          '        os.remove(_p)',
+          '        _s.pop()'
+        ].join('\n')
+      )
     )
   }
 
   /** Create a directory. */
   async mkdir(path: string): Promise<void> {
-    await this.eval(`import os\nos.mkdir(${pyStr(path)})`)
+    const mount = await this.driveMount()
+    if (mount) return driveMkdir(mount, path)
+    await this.replWrite(() => this.eval(`import os\nos.mkdir(${pyStr(path)})`))
   }
 
   /** Rename / move a path. */
   async rename(from: string, to: string): Promise<void> {
-    await this.eval(`import os\nos.rename(${pyStr(from)}, ${pyStr(to)})`)
+    const mount = await this.driveMount()
+    if (mount) return driveRename(mount, from, to)
+    await this.replWrite(() => this.eval(`import os\nos.rename(${pyStr(from)}, ${pyStr(to)})`))
   }
 
   /** Stat a path, returning type, size and mtime when available. */
   async stat(path: string): Promise<StatResult> {
+    const mount = await this.driveMount()
+    if (mount) return driveStat(mount, path)
     const code = [
       'import os, json',
       `st=os.stat(${pyStr(path)})`,
@@ -812,6 +921,20 @@ export class MicroPythonDevice extends EventEmitter implements SnakieDevice {
     const raw = (await this.eval(code)).trim()
     const [isDir, size, mtime] = JSON.parse(raw) as [boolean, number, number | null]
     return { isDir, size, mtime: mtime ?? undefined }
+  }
+
+  /**
+   * Free/total bytes for the flash gauge (#211), when this board's files live on
+   * a drive (#754).
+   *
+   * Null means "ask the board", which is what every MicroPython board wants. For
+   * a mounted CircuitPython board the HOST has the honest number: `os.statvfs`
+   * there describes a filesystem the board cannot write to, while the gauge is
+   * answering "how much room is left for what I am about to copy".
+   */
+  async driveUsage(): Promise<{ total: number; free: number; used: number } | null> {
+    const mount = await this.driveMount()
+    return mount ? driveUsage(mount) : null
   }
 
   /** Tear down resources (called on app quit). */

--- a/src/main/device/circuitpy-fs.ts
+++ b/src/main/device/circuitpy-fs.ts
@@ -1,0 +1,220 @@
+/**
+ * FILE I/O ON A CIRCUITPYTHON BOARD (#754, epic #209).
+ * =============================================================================
+ *
+ * Every file operation in Snakie goes over the REPL: `writeFile` opens the path
+ * with `open(path,'wb')` and streams hex chunks through `ubinascii.unhexlify`.
+ * That is the only way to reach a MicroPython board, and it is the wrong way to
+ * reach a CircuitPython one.
+ *
+ * **CircuitPython's filesystem is read-only to the board while the host has
+ * CIRCUITPY mounted**, which is the default. So the REPL write raises
+ * `OSError: 30`, and every feature built on it — the Files panel, driver
+ * installs, the instrument library, the Modules manager — fails.
+ *
+ * The drive is the answer, and it is a better answer than a workaround:
+ *
+ *  - **It works.** The host mounts CIRCUITPY writable; that IS the supported
+ *    way to put files on a CircuitPython board.
+ *  - **It doesn't stop the program.** Entering the raw REPL sends Ctrl-C, which
+ *    interrupts whatever `code.py` is doing. Listing a directory should not
+ *    stop the user's robot. So READS go to the drive too, not just writes —
+ *    the reason the scope left that choice open.
+ *  - **It is enormously faster.** The REPL path hex-encodes every byte and
+ *    round-trips per 256-byte chunk; the drive is a file copy.
+ *
+ * When there is NO drive, the REPL path is still correct and is left alone: a
+ * user who puts `storage.remount("/", readonly=False)` in `boot.py` hands the
+ * filesystem to the board and hides it from the host, and for them the REPL
+ * write genuinely works. That is why nothing here refuses up front — it routes
+ * when a drive is there, and {@link readOnlyFsError} explains the failure when
+ * one is needed and missing.
+ */
+import { promises as fs } from 'fs'
+import { dirname, isAbsolute, join, normalize, relative } from 'path'
+import type { DirEntry, StatResult } from './types'
+
+/**
+ * Shown when a write fails because the board's filesystem is read-only to
+ * itself — the CircuitPython default, whenever a host has the drive mounted.
+ *
+ * In the house style of `RAW_REPL_NO_RESPONSE`: name what happened, then the
+ * ways out in likelihood order. The first is the one that applies to somebody
+ * whose drive simply wasn't found; the second is for a board deliberately set
+ * up the other way round.
+ */
+export const CIRCUITPY_READ_ONLY =
+  "The board's filesystem is read-only to CircuitPython while its CIRCUITPY drive is mounted on this computer, so Snakie couldn't write the file. Snakie normally writes to that drive instead — check it is mounted and not ejected, then reconnect. (If you have made the board's filesystem writable with `storage.remount` in boot.py, the drive is hidden from this computer on purpose and this error means the remount did not take effect.)"
+
+/** Does a device error say the filesystem was read-only? */
+export function isReadOnlyFsError(raw: string): boolean {
+  // Errno 30 is EROFS. MicroPython/CircuitPython render it variously — with the
+  // name, with the number, or (on a minimal build) with neither, so match any.
+  return /OSError:\s*(?:\[Errno\s*)?30\b|EROFS|read[- ]only\s+filesystem/i.test(raw)
+}
+
+/**
+ * Rewrite a read-only filesystem failure into something a user can act on,
+ * leaving every other error alone. The same shape as the `OSError: 28` → "the
+ * board is full" translation in `driver-install.ts`.
+ */
+export function readOnlyFsError(err: unknown): unknown {
+  const message = err instanceof Error ? err.message : String(err)
+  return isReadOnlyFsError(message) ? new Error(CIRCUITPY_READ_ONLY) : err
+}
+
+/**
+ * Map a DEVICE path (`/lib/foo.py`, always POSIX-ish, always rooted at the
+ * board) onto the mounted drive.
+ *
+ * Throws rather than clamping when the result would escape the mount. Device
+ * paths are not all typed by the user — a part's driver declares its own
+ * `target` (#184) — so `../../` in one must not be able to write outside the
+ * board's filesystem and onto the user's computer.
+ */
+export function resolveOnDrive(mount: string, devicePath: string): string {
+  const cleaned = devicePath.replace(/^[/\\]+/, '')
+  const full = normalize(join(mount, cleaned))
+  const rel = relative(mount, full)
+  if (rel.startsWith('..') || isAbsolute(rel)) {
+    throw new Error(`Refusing to use a path outside the board's drive: ${devicePath}`)
+  }
+  return full
+}
+
+/** List a directory on the drive, matching the REPL `listDir` shape. */
+export async function driveListDir(mount: string, devicePath = '/'): Promise<DirEntry[]> {
+  const dir = resolveOnDrive(mount, devicePath)
+  const entries = await fs.readdir(dir, { withFileTypes: true })
+  const out: DirEntry[] = []
+  for (const e of entries) {
+    // CircuitPython does not show these to the board, and they are noise in a
+    // file tree: the FAT volume carries macOS/Windows indexing droppings.
+    if (isHostDropping(e.name)) continue
+    const isDir = e.isDirectory()
+    let size = 0
+    if (!isDir) {
+      try {
+        size = (await fs.stat(join(dir, e.name))).size
+      } catch {
+        size = 0 // a file that vanished between readdir and stat
+      }
+    }
+    out.push({ name: e.name, isDir, size })
+  }
+  return out
+}
+
+/**
+ * Files the HOST puts on the drive that the board itself never sees. Hiding
+ * them keeps the Files panel showing the board's contents rather than macOS's
+ * and Windows's bookkeeping.
+ */
+function isHostDropping(name: string): boolean {
+  return (
+    name === '.metadata_never_index' ||
+    name === '.Trashes' ||
+    name === '.fseventsd' ||
+    name === 'System Volume Information' ||
+    name.startsWith('._')
+  )
+}
+
+/** Read a file from the drive as bytes. */
+export async function driveReadFileBytes(mount: string, devicePath: string): Promise<Buffer> {
+  return fs.readFile(resolveOnDrive(mount, devicePath))
+}
+
+/** The first line of a file starting with `prefix` — the drive twin of the
+ *  on-board search in `readFileLine` (#700). No wire, so no need to be clever. */
+export async function driveReadFileLine(
+  mount: string,
+  devicePath: string,
+  prefix: string
+): Promise<string> {
+  let text: string
+  try {
+    text = await fs.readFile(resolveOnDrive(mount, devicePath), 'utf8')
+  } catch {
+    return '' // matches the REPL version, which swallows OSError
+  }
+  return text.split(/\r?\n/).find((l) => l.startsWith(prefix))?.trim() ?? ''
+}
+
+/**
+ * Write a file to the drive, creating parent folders, and **flush it to the
+ * device before returning**.
+ *
+ * The flush is load-bearing rather than cautious. CircuitPython watches the
+ * filesystem and re-runs `code.py` the moment it changes, so a buffered write
+ * can be picked up half-written — the board restarts into a syntax error from a
+ * file that is fine on disk a millisecond later. `fsync` before close means the
+ * board never sees a partial file.
+ */
+export async function driveWriteFile(
+  mount: string,
+  devicePath: string,
+  contents: string | Buffer
+): Promise<void> {
+  const full = resolveOnDrive(mount, devicePath)
+  const data = Buffer.isBuffer(contents) ? contents : Buffer.from(contents, 'utf8')
+  // `dirname`, not a separator search: on Windows the mount IS a drive root
+  // (`E:\\`), and slicing at the last separator would yield `E:` — a different
+  // path entirely. `recursive` makes the already-exists case a no-op.
+  await fs.mkdir(dirname(full), { recursive: true })
+  const handle = await fs.open(full, 'w')
+  try {
+    await handle.write(data)
+    await handle.sync()
+  } finally {
+    await handle.close()
+  }
+}
+
+/** Remove a file or a directory tree from the drive. */
+export async function driveRemove(mount: string, devicePath: string): Promise<void> {
+  await fs.rm(resolveOnDrive(mount, devicePath), { recursive: true, force: true })
+}
+
+/** Create a directory on the drive. */
+export async function driveMkdir(mount: string, devicePath: string): Promise<void> {
+  await fs.mkdir(resolveOnDrive(mount, devicePath))
+}
+
+/** Rename / move a path on the drive. */
+export async function driveRename(mount: string, from: string, to: string): Promise<void> {
+  await fs.rename(resolveOnDrive(mount, from), resolveOnDrive(mount, to))
+}
+
+/** Stat a path on the drive, matching the REPL `stat` shape. */
+export async function driveStat(mount: string, devicePath: string): Promise<StatResult> {
+  const st = await fs.stat(resolveOnDrive(mount, devicePath))
+  return {
+    isDir: st.isDirectory(),
+    size: st.size,
+    // Seconds since the epoch, as the board reports it — not milliseconds.
+    mtime: Math.floor(st.mtimeMs / 1000)
+  }
+}
+
+/**
+ * Free/total bytes of the mounted drive, for the flash gauge (#211).
+ *
+ * Asked of the HOST rather than the board: `os.statvfs` on a CircuitPython board
+ * reports a filesystem the board cannot write to, and the number a user wants
+ * is how much room is left for the files Snakie is about to put there.
+ */
+export async function driveUsage(
+  mount: string
+): Promise<{ total: number; free: number; used: number } | null> {
+  try {
+    const st = await fs.statfs(mount)
+    const total = Number(st.blocks) * Number(st.bsize)
+    const free = Number(st.bavail) * Number(st.bsize)
+    if (!Number.isFinite(total) || total <= 0) return null
+    const clamped = Math.max(0, Math.min(free, total))
+    return { total, free: clamped, used: total - clamped }
+  } catch {
+    return null // statfs is unavailable on some platforms/older Node
+  }
+}

--- a/src/main/device/ipc.ts
+++ b/src/main/device/ipc.ts
@@ -164,6 +164,13 @@ export function registerDeviceIpc(getWebContents: () => WebContents | undefined)
   // can't stat (or a non-numeric reply) yields `null` so the gauge just hides.
   ipcMain.handle('device:df', () =>
     wrap<{ total: number; free: number; used: number } | null>(async () => {
+      // A CircuitPython board whose files live on a mounted drive (#754) is
+      // measured on the host instead — see `MicroPythonDevice.driveUsage`.
+      const dev = getActive()
+      if (dev === realDev) {
+        const fromDrive = await realDev.driveUsage()
+        if (fromDrive) return fromDrive
+      }
       const code = [
         'import os',
         'try:',

--- a/test/circuitpyFs.test.ts
+++ b/test/circuitpyFs.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtemp, mkdir, readFile, rm, writeFile, stat } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  CIRCUITPY_READ_ONLY,
+  driveListDir,
+  driveMkdir,
+  driveReadFileBytes,
+  driveReadFileLine,
+  driveRemove,
+  driveRename,
+  driveStat,
+  driveUsage,
+  driveWriteFile,
+  isReadOnlyFsError,
+  readOnlyFsError,
+  resolveOnDrive
+} from '../src/main/device/circuitpy-fs'
+
+/**
+ * FILE I/O AGAINST A MOUNTED CIRCUITPY DRIVE (#754, epic #209).
+ *
+ * Everything here runs against a real temp directory standing in for the drive,
+ * because the operations ARE filesystem operations — mocking `fs` would only
+ * test that the mocks were called. The two properties that matter beyond "it
+ * works": a device path can never escape the mount, and the shapes match what
+ * the REPL implementations return, since callers must not be able to tell which
+ * path served them.
+ */
+
+let mount: string
+
+beforeEach(async () => {
+  mount = await mkdtemp(join(tmpdir(), 'snakie-cpfs-'))
+  await mkdir(join(mount, 'lib'))
+  await writeFile(join(mount, 'code.py'), 'print("hello")\n')
+  await writeFile(join(mount, 'lib', 'bme280.py'), '__version__ = "1.2.0"\nclass BME280: pass\n')
+})
+
+afterEach(async () => {
+  await rm(mount, { recursive: true, force: true })
+})
+
+describe('resolveOnDrive', () => {
+  it('maps a rooted device path onto the mount', () => {
+    expect(resolveOnDrive('/mnt/CIRCUITPY', '/lib/foo.py')).toBe('/mnt/CIRCUITPY/lib/foo.py')
+    expect(resolveOnDrive('/mnt/CIRCUITPY', 'lib/foo.py')).toBe('/mnt/CIRCUITPY/lib/foo.py')
+    expect(resolveOnDrive('/mnt/CIRCUITPY', '/')).toBe('/mnt/CIRCUITPY')
+  })
+
+  it('REFUSES to escape the mount — a part declares its own driver target, not just the user', () => {
+    for (const evil of ['../secrets', '/../secrets', 'lib/../../etc/passwd', '/lib/../../..']) {
+      expect(() => resolveOnDrive('/mnt/CIRCUITPY', evil)).toThrow(/outside the board/i)
+    }
+  })
+
+  it('allows a `..` that stays inside', () => {
+    expect(resolveOnDrive('/mnt/CIRCUITPY', '/lib/../code.py')).toBe('/mnt/CIRCUITPY/code.py')
+  })
+})
+
+describe('reads', () => {
+  it('lists a directory in the same shape the REPL listDir returns', async () => {
+    const entries = await driveListDir(mount, '/')
+    expect(entries).toContainEqual({ name: 'code.py', isDir: false, size: 15 })
+    expect(entries).toContainEqual({ name: 'lib', isDir: true, size: 0 })
+  })
+
+  it('hides the host bookkeeping the BOARD never sees', async () => {
+    await writeFile(join(mount, '.metadata_never_index'), '')
+    await writeFile(join(mount, '._code.py'), '')
+    await mkdir(join(mount, '.fseventsd'))
+    const names = (await driveListDir(mount, '/')).map((e) => e.name)
+    expect(names.sort()).toEqual(['code.py', 'lib'])
+  })
+
+  it('reads bytes', async () => {
+    expect((await driveReadFileBytes(mount, '/code.py')).toString()).toBe('print("hello")\n')
+  })
+
+  it('finds a prefixed line — the drive twin of the on-board search (#700)', async () => {
+    expect(await driveReadFileLine(mount, '/lib/bme280.py', '__version__')).toBe('__version__ = "1.2.0"')
+  })
+
+  it('returns empty for a missing file, matching the REPL version that swallows OSError', async () => {
+    expect(await driveReadFileLine(mount, '/lib/nope.py', '__version__')).toBe('')
+  })
+
+  it('stats in seconds, not milliseconds — the board reports seconds', async () => {
+    const st = await driveStat(mount, '/code.py')
+    expect(st.isDir).toBe(false)
+    expect(st.size).toBe(15)
+    const onDisk = await stat(join(mount, 'code.py'))
+    expect(st.mtime).toBe(Math.floor(onDisk.mtimeMs / 1000))
+  })
+})
+
+describe('writes', () => {
+  it('writes a file', async () => {
+    await driveWriteFile(mount, '/lib/new.py', 'x = 1\n')
+    expect(await readFile(join(mount, 'lib', 'new.py'), 'utf8')).toBe('x = 1\n')
+  })
+
+  it('creates missing parent folders — a driver target names a folder that may not exist', async () => {
+    await driveWriteFile(mount, '/lib/vendor/deep/thing.py', 'ok')
+    expect(await readFile(join(mount, 'lib', 'vendor', 'deep', 'thing.py'), 'utf8')).toBe('ok')
+  })
+
+  it('writes to the drive ROOT, where the parent is the mount itself', async () => {
+    // The Windows shape: the mount is a drive root, so deriving the parent by
+    // slicing at the last separator would produce `E:` rather than `E:\`.
+    await driveWriteFile(mount, '/main.py', 'root file')
+    expect(await readFile(join(mount, 'main.py'), 'utf8')).toBe('root file')
+  })
+
+  it('overwrites rather than appending', async () => {
+    await driveWriteFile(mount, '/code.py', 'first')
+    await driveWriteFile(mount, '/code.py', 'second')
+    expect(await readFile(join(mount, 'code.py'), 'utf8')).toBe('second')
+  })
+
+  it('writes binary content intact', async () => {
+    const bytes = Buffer.from([0x00, 0xff, 0x0d, 0x0a, 0x1a])
+    await driveWriteFile(mount, '/blob.bin', bytes)
+    expect(await readFile(join(mount, 'blob.bin'))).toEqual(bytes)
+  })
+
+  it('will not write outside the mount', async () => {
+    await expect(driveWriteFile(mount, '../escaped.py', 'x')).rejects.toThrow(/outside the board/i)
+  })
+
+  it('makes and renames directories', async () => {
+    await driveMkdir(mount, '/data')
+    expect((await driveStat(mount, '/data')).isDir).toBe(true)
+    await driveRename(mount, '/data', '/logs')
+    expect((await driveStat(mount, '/logs')).isDir).toBe(true)
+  })
+
+  it('removes a whole tree, as the REPL version does (#219)', async () => {
+    await driveWriteFile(mount, '/lib/pkg/a.py', 'a')
+    await driveWriteFile(mount, '/lib/pkg/sub/b.py', 'b')
+    await driveRemove(mount, '/lib/pkg')
+    expect((await driveListDir(mount, '/lib')).map((e) => e.name)).toEqual(['bme280.py'])
+  })
+
+  it('removing something absent is not an error, matching `force`', async () => {
+    await expect(driveRemove(mount, '/not/here')).resolves.toBeUndefined()
+  })
+})
+
+describe('driveUsage', () => {
+  it('measures the host filesystem the drive is on', async () => {
+    const usage = await driveUsage(mount)
+    expect(usage).not.toBeNull()
+    expect(usage!.total).toBeGreaterThan(0)
+    expect(usage!.used + usage!.free).toBe(usage!.total)
+    expect(usage!.free).toBeLessThanOrEqual(usage!.total)
+  })
+
+  it('is null rather than throwing for a path that is gone', async () => {
+    expect(await driveUsage(join(mount, 'nope'))).toBeNull()
+  })
+})
+
+describe('read-only filesystem errors', () => {
+  it('recognises how the runtimes actually render errno 30', () => {
+    for (const raw of [
+      'OSError: 30',
+      'OSError: [Errno 30] Read-only filesystem',
+      "OSError: [Errno 30] EROFS",
+      'Traceback (most recent call last):\n  File "<stdin>", line 1\nOSError: 30'
+    ]) {
+      expect(isReadOnlyFsError(raw)).toBe(true)
+    }
+  })
+
+  it('does not mistake other errors for it', () => {
+    for (const raw of ['OSError: 28', 'OSError: 2', 'OSError: 300', 'ValueError: 30']) {
+      expect(isReadOnlyFsError(raw)).toBe(false)
+    }
+  })
+
+  it('rewrites it into something a user can act on, and leaves everything else alone', () => {
+    const rewritten = readOnlyFsError(new Error('OSError: [Errno 30] Read-only filesystem'))
+    expect((rewritten as Error).message).toBe(CIRCUITPY_READ_ONLY)
+    expect(CIRCUITPY_READ_ONLY).toMatch(/CIRCUITPY drive/)
+    // It names the deliberate case too, so a `storage.remount` user isn't sent
+    // hunting for a drive they hid on purpose.
+    expect(CIRCUITPY_READ_ONLY).toMatch(/storage\.remount/)
+
+    const other = new Error('OSError: 28')
+    expect(readOnlyFsError(other)).toBe(other)
+  })
+})

--- a/test/circuitpyFsRouting.test.ts
+++ b/test/circuitpyFsRouting.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { MicroPythonDevice } from '../src/main/device/MicroPythonDevice'
+
+/**
+ * ROUTING: does a CircuitPython board's file I/O actually reach its drive (#754)?
+ *
+ * `circuitpyFs.test.ts` proves the drive operations work; this proves
+ * `MicroPythonDevice` USES them — that every filesystem method checks for a
+ * mount, and that none was missed. A missed one is not a visible bug, it is a
+ * silent `OSError: 30` in whichever feature happens to call it.
+ *
+ * The device is driven with no serial port at all. Reaching into `mount` is
+ * deliberate: it is the one piece of state `connect()` would set from real
+ * hardware, and faking a board over a mock serial port would test the raw-REPL
+ * protocol (which `rawRepl.test.ts` already covers) rather than the routing.
+ * Every REPL path throws "Not connected" here, which is exactly what makes the
+ * assertions meaningful — a method that failed to route would throw.
+ */
+
+/** The private field `connect()` sets once the runtime probe says CircuitPython. */
+type WithMount = { mount: string | null }
+
+let mount: string
+let device: MicroPythonDevice
+
+beforeEach(async () => {
+  mount = await mkdtemp(join(tmpdir(), 'snakie-route-'))
+  await writeFile(join(mount, 'boot_out.txt'), 'Adafruit CircuitPython 10.2.1 on 2026-08-18; Feather\n')
+  await mkdir(join(mount, 'lib'))
+  await writeFile(join(mount, 'code.py'), 'print("hi")\n')
+  device = new MicroPythonDevice()
+  ;(device as unknown as WithMount).mount = mount
+})
+
+afterEach(async () => {
+  await device.dispose()
+  await rm(mount, { recursive: true, force: true })
+})
+
+describe('with a CIRCUITPY drive, every filesystem method uses it', () => {
+  it('listDir', async () => {
+    const names = (await device.listDir('/')).map((e) => e.name).sort()
+    expect(names).toEqual(['boot_out.txt', 'code.py', 'lib'])
+  })
+
+  it('readFile', async () => {
+    expect(await device.readFile('/code.py')).toBe('print("hi")\n')
+  })
+
+  it('readFileBytes', async () => {
+    expect((await device.readFileBytes('/code.py')).toString()).toBe('print("hi")\n')
+  })
+
+  it('readFileLine', async () => {
+    await writeFile(join(mount, 'lib', 'drv.py'), 'x = 1\n__version__ = "2.0.0"\n')
+    expect(await device.readFileLine('/lib/drv.py', '__version__')).toBe('__version__ = "2.0.0"')
+  })
+
+  it('writeFile', async () => {
+    await device.writeFile('/lib/new.py', 'y = 2\n')
+    expect(await readFile(join(mount, 'lib', 'new.py'), 'utf8')).toBe('y = 2\n')
+  })
+
+  it('writeFile with binary content', async () => {
+    const bytes = Buffer.from([0, 255, 10, 13])
+    await device.writeFile('/blob.bin', bytes)
+    expect(await readFile(join(mount, 'blob.bin'))).toEqual(bytes)
+  })
+
+  it('mkdir', async () => {
+    await device.mkdir('/data')
+    expect((await device.stat('/data')).isDir).toBe(true)
+  })
+
+  it('rename', async () => {
+    await device.rename('/code.py', '/main.py')
+    expect(await device.readFile('/main.py')).toBe('print("hi")\n')
+  })
+
+  it('remove', async () => {
+    await device.remove('/code.py')
+    expect((await device.listDir('/')).map((e) => e.name)).not.toContain('code.py')
+  })
+
+  it('stat', async () => {
+    const st = await device.stat('/code.py')
+    expect(st).toMatchObject({ isDir: false, size: 'print("hi")\n'.length })
+  })
+
+  it('driveUsage, for the flash gauge (#211)', async () => {
+    const usage = await device.driveUsage()
+    expect(usage?.total).toBeGreaterThan(0)
+  })
+})
+
+describe('without a drive, everything falls back to the REPL', () => {
+  beforeEach(() => {
+    ;(device as unknown as WithMount).mount = null
+  })
+
+  it('does not silently succeed — a MicroPython board must still go over the wire', async () => {
+    // "Not connected" IS the pass: it proves the call reached the REPL path
+    // rather than being served by a stale mount.
+    await expect(device.readFile('/code.py')).rejects.toThrow(/not connected/i)
+    await expect(device.writeFile('/code.py', 'x')).rejects.toThrow(/not connected/i)
+    await expect(device.listDir('/')).rejects.toThrow(/not connected/i)
+  })
+
+  it('reports no drive usage, so the gauge asks the board instead', async () => {
+    expect(await device.driveUsage()).toBeNull()
+  })
+})
+
+describe('a drive that ejected', () => {
+  it('is not trusted — a soft reboot unmounts it, and the path stops existing', async () => {
+    // The board rebooted and the OS tore the mount down.
+    await rm(mount, { recursive: true, force: true })
+    // Re-resolution finds nothing (no real board is plugged in), so the call
+    // falls back to the REPL rather than throwing ENOENT from a dead path.
+    await expect(device.readFile('/code.py')).rejects.toThrow(/not connected/i)
+    expect((device as unknown as WithMount).mount).toBeNull()
+  })
+
+  it('keeps using a drive that is still there', async () => {
+    expect(await device.readFile('/code.py')).toBe('print("hi")\n')
+    expect((device as unknown as WithMount).mount).toBe(mount)
+  })
+})
+
+describe('path safety', () => {
+  it('refuses a device path that would escape onto the user\'s computer', async () => {
+    await expect(device.writeFile('../../evil.py', 'x')).rejects.toThrow(/outside the board/i)
+    await expect(device.readFile('/lib/../../../etc/passwd')).rejects.toThrow(/outside the board/i)
+  })
+})


### PR DESCRIPTION
Closes #754.

> **Stacked on #766** (which is itself stacked on #765). Base is set to `feat/circuitpy-drive-detect`, so this diff shows only #754. Merge the stack bottom-up and the bases retarget automatically.

## The problem

CircuitPython's filesystem is read-only **to the board** while the host has CIRCUITPY mounted — the default. Every file operation in Snakie goes over the REPL (`open(path,'wb')` + hex chunks through `unhexlify`), so on a CircuitPython board *all of them* raise `OSError: 30`: the Files panel, driver installs, the instrument library, the Modules manager.

## The fix

They go to the drive. **Reads too, not just writes** — the scope left that choice open, and there are two reasons to route them:

- Entering the raw REPL sends Ctrl-C. Listing a directory should not stop the user's `code.py`.
- It's a file copy rather than a hex-encoded 256-byte round trip per chunk.

Routing sits behind the existing device file API, so **no caller branches** — every writer in the app already goes through `device.writeFile`, and one branch in each `MicroPythonDevice` filesystem method covers them all.

## Three decisions worth flagging

**Nothing refuses up front when there's no drive.** A user who puts `storage.remount("/", readonly=False)` in `boot.py` hands the filesystem to the board and hides the drive from the host — and for them the REPL write *genuinely works*. So no drive means the REPL, exactly as before. A read-only failure that does surface (most likely when the runtime probe couldn't identify the board at all) gets rewritten into an explanation naming both cases, the way `driver-install.ts` already rewrites `OSError: 28` into "the board is full". That satisfies the scope's "actionable message, not a bare `OSError: 30`" better than a pre-emptive refusal would, because it doesn't break the remount setup.

**Writes `fsync` before returning.** Load-bearing rather than cautious: CircuitPython re-runs `code.py` the moment a file changes, so a buffered write can be picked up half-written — the board restarts into a syntax error from a file that is fine on disk a millisecond later.

**A mount is re-checked, not trusted.** One `stat` of `boot_out.txt` per operation. A soft reboot unmounts the drive and it returns a moment later, so a remembered path can be a path that doesn't currently exist; if it's gone, it re-resolves once and otherwise falls back to the REPL rather than throwing ENOENT from a dead path.

Device paths are resolved against the mount and **refused if they escape it**. A part declares its own driver `target` (#184), so `../..` in one must not be able to write onto the user's computer.

The flash gauge (#211) measures the drive on a mounted board — `os.statvfs` there describes a filesystem the board can't write to, while the question the gauge answers is how much room is left for what Snakie is about to copy.

## Verification

- `lint`, `typecheck`, `build`, `build:web` green. Full suite 3409 pass; the one failure is the known #737 flake.
- **39 new tests.** The drive operations run against a real temp directory (mocking `fs` would only test that the mocks were called), covering binary content, tree removal, parent creation, host-dropping files that the board never sees, and the path-escape refusals.
- **A routing test drives `MicroPythonDevice` with no serial port at all**, asserting every filesystem method reaches the drive. A method that failed to route would throw "Not connected" — which is what makes the assertions meaningful, and is exactly how a missed method would show up in production: a silent `OSError: 30` in whichever feature happened to call it. It also covers the ejected-drive re-resolve.
- **End-to-end on this machine** through the real production chain — real volume scan, real pairing, real routing — round-tripping read / write / `readFileLine` / `listDir` / usage against a drive under an actual search root. Fixture removed afterwards.

I also found and fixed a Windows bug while writing it: the parent directory was derived by slicing at the last separator, which turns `E:\code.py` into `E:` — a different path. It uses `dirname` now, with a test for the drive-root case.

## Not verified

**Against real hardware.** In particular the literal text CircuitPython prints for a read-only write is matched by pattern (errno 30, `EROFS`, or the words) rather than against a captured string — #751 exists to capture that, and it needs a board. If it turns out to print something else entirely, `isReadOnlyFsError` is the one place to update.

Whether `os.statvfs` on a mounted CircuitPython board is trustworthy is also still unknown; I sidestepped it by measuring the host, which is correct regardless of the answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)