### PR TITLE
feat: what Run, Stop and Reset mean on CircuitPython, and which file boots (#755)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Run, Stop and Reset say what they actually do on a CircuitPython board, and
+  the file tree shows which file boots.** (#755, epic #209) Run stays a raw-REPL
+  execution on both runtimes — it will not overwrite your `code.py` — but it now
+  says what that costs: your `code.py` stops, and the board waits at the REPL
+  rather than going back to it. Reset is where the runtimes really differ, and it
+  says so: on CircuitPython a soft reboot runs `code.py` again from the start,
+  rather than just clearing the board. The device file tree marks the file the
+  board runs at boot — and marks one it will **ignore**, because CircuitPython
+  tries `code.py` before `main.py`, so a board carrying both runs only the first
+  and edits to the other appear to do nothing.
 - **Files, drivers and libraries can be written to a CircuitPython board.**
   (#754, epic #209) CircuitPython's filesystem is read-only *to the board* while
   its CIRCUITPY drive is mounted, so every file operation Snakie has — the Files

--- a/src/main/device/circuitpy-fs.ts
+++ b/src/main/device/circuitpy-fs.ts
@@ -150,6 +150,16 @@ export async function driveReadFileLine(
  * can be picked up half-written — the board restarts into a syntax error from a
  * file that is fine on disk a millisecond later. `fsync` before close means the
  * board never sees a partial file.
+ *
+ * **Auto-reload is deliberately NOT suppressed** for a multi-file write (#755).
+ * Suppressing it means setting `supervisor.runtime.autoreload = False` over the
+ * raw REPL, and entering the raw REPL sends Ctrl-C — so the board's program gets
+ * interrupted to spare it from being restarted, which is self-defeating.
+ * CircuitPython already waits for the filesystem to settle before reloading, and
+ * Snakie's multi-file writes are consecutive awaits against a local mount with
+ * sub-millisecond gaps, so a batch lands inside one settle window and costs one
+ * reload rather than one per file. If a real board ever shows otherwise, this is
+ * the decision to revisit — and #751 is where the evidence would come from.
  */
 export async function driveWriteFile(
   mount: string,

--- a/src/renderer/src/components/DeviceFileTree.css
+++ b/src/renderer/src/components/DeviceFileTree.css
@@ -128,6 +128,35 @@
 
 /* --- File management (#219): hover delete, drop targets ------------------- */
 
+/* Boot-file marker (#755): which file the board runs when it starts. Quiet —
+   it is a fact about the file, not a warning — except when a file is SHADOWED
+   by one that comes first in the runtime's search order, where the point is
+   that editing it will appear to do nothing. */
+.tree-row__boot {
+  flex: 0 0 auto;
+  margin-left: auto;
+  padding: 0 0.35rem;
+  font-size: 0.62rem;
+  line-height: 1.1rem;
+  letter-spacing: 0.02em;
+  color: var(--text-muted);
+  background: var(--bg-elevated);
+  border: var(--border-w) solid var(--border);
+  border-radius: var(--radius);
+  white-space: nowrap;
+}
+
+.tree-row__boot--shadowed {
+  color: var(--warn);
+  border-color: var(--warn);
+}
+
+/* The delete button takes the end slot back on hover, so the two never stack. */
+.tree-row:hover .tree-row__boot,
+.tree-row:focus-within .tree-row__boot {
+  display: none;
+}
+
 /* The hover ✕: hidden until the row is hovered/focused; sits at the row end. */
 .tree-row__delete {
   display: none;

--- a/src/renderer/src/components/DeviceFileTree.tsx
+++ b/src/renderer/src/components/DeviceFileTree.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { DirEntry } from '../../../preload/index.d'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
+import { bootFileNote } from './run-controls'
 import { useWorkspace } from '../store/workspace'
 import { useSync } from '../store/sync'
 import { usageLabel, usedPct, type DiskUsage } from './disk-usage'
@@ -149,7 +150,8 @@ function DeviceRow({
   onDragStartRow,
   onDropInto,
   onDragOverRow,
-  onDragLeaveRow
+  onDragLeaveRow,
+  bootNote
 }: {
   row: FlatRow
   expanded: boolean
@@ -164,6 +166,8 @@ function DeviceRow({
   onDropInto: (e: React.DragEvent, dir: string) => void
   onDragOverRow: (e: React.DragEvent, row: FlatRow) => void
   onDragLeaveRow: () => void
+  /** Why this file does (or doesn't) run at boot — null for ordinary files (#755). */
+  bootNote: string | null
 }): JSX.Element {
   const { path, entry, depth } = row
   return (
@@ -195,6 +199,18 @@ function DeviceRow({
         {entry.isDir ? (expanded ? '▼' : '▶') : '▤'}
       </span>
       <span className="tree-row__name">{entry.name}</span>
+      {/* Which file the board runs at boot (#755). CircuitPython tries code.py
+          before main.py, so a board carrying both runs only the first — and
+          editing the other looks like it does nothing. The marker says which
+          is which; the tooltip says why. */}
+      {bootNote && (
+        <span
+          className={`tree-row__boot${bootNote.includes('instead') ? ' tree-row__boot--shadowed' : ''}`}
+          title={bootNote}
+        >
+          {bootNote.includes('instead') ? 'ignored' : 'runs at boot'}
+        </span>
+      )}
       {/* Hover delete (#219): removes this row — or the whole selection when the
           row is part of a multi-selection. */}
       <button
@@ -259,6 +275,9 @@ export function DeviceFileTree(): JSX.Element {
   const selectedPath = primary?.path ?? null
   const selectedIsDir = primary?.isDir ?? false
   const rows = useMemo(() => flattenTree(dirs, expanded), [dirs, expanded])
+  // The ROOT listing decides which file boots (#755) — `code.py` beats `main.py`
+  // only when both sit at the top level.
+  const rootNames = useMemo(() => (dirs.get(ROOT) ?? []).map((e) => e.name), [dirs])
 
   /** Re-list one directory into the flat map (drop it if listing fails). */
   const listInto = useCallback(async (dir: string): Promise<void> => {
@@ -773,6 +792,13 @@ export function DeviceFileTree(): JSX.Element {
           <DeviceRow
             key={row.path}
             row={row}
+            bootNote={
+              // Boot files only count in the ROOT — a `/lib/code.py` is just a
+              // module. `depth === 0` is that test.
+              row.depth === 0 && !row.entry.isDir
+                ? bootFileNote(row.entry.name, rootNames, status.runtime?.dialect)
+                : null
+            }
             expanded={expanded.has(row.path)}
             selected={selection.has(row.path) || selectedPath === row.path}
             dropTarget={dropDir === row.path}

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -5,6 +5,7 @@ import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { useWorkspace } from '../store/workspace'
 import { useConsole } from '../store/console'
 import { isVirtualPort } from '../../../shared/virtual-device'
+import { runTitle, stopTitle } from './run-controls'
 import './RunControls.css'
 import './Toolbar.css'
 
@@ -255,15 +256,12 @@ export function Toolbar(): JSX.Element {
           className="btn btn--primary"
           onClick={() => void handleRun()}
           disabled={!canRun}
-          title={
-            !activeFile
-              ? 'Open a file to run'
-              : connecting
-                ? 'Connecting…'
-                : !connected
-                  ? 'Run on the simulator'
-                  : `Run ${activeFile.name} on the device`
-          }
+          title={runTitle({
+            activeFileName: activeFile?.name,
+            connected,
+            connecting,
+            dialect: status.runtime?.dialect
+          })}
           aria-label="Run active file on device"
         >
           <span className="btn__glyph" aria-hidden="true">
@@ -276,13 +274,7 @@ export function Toolbar(): JSX.Element {
           className="btn btn--danger"
           onClick={handleStop}
           disabled={!connected}
-          title={
-            !connected
-              ? 'Connect to a device to stop'
-              : running
-                ? 'Interrupt the running program (Ctrl-C)'
-                : 'Reset the board (soft reboot)'
-          }
+          title={stopTitle({ connected, running, dialect: status.runtime?.dialect })}
           aria-label={running ? 'Stop / interrupt running program' : 'Reset the board'}
         >
           <span className="btn__glyph" aria-hidden="true">

--- a/src/renderer/src/components/run-controls.ts
+++ b/src/renderer/src/components/run-controls.ts
@@ -1,0 +1,114 @@
+/**
+ * WHAT RUN, STOP AND RESET MEAN ON EACH RUNTIME (#755, epic #209).
+ * =============================================================================
+ *
+ * MicroPython runs what Snakie sends it and nothing else. CircuitPython runs
+ * `code.py` from boot and reloads it whenever a file changes — so the same three
+ * buttons do materially different things, and the difference is invisible
+ * unless the app says so.
+ *
+ * Pure and unit-tested (the `updateButton.ts` pattern): the wording is the whole
+ * deliverable here, so it is worth pinning rather than burying in JSX.
+ *
+ * **Run stays a raw-REPL exec on both runtimes.** The alternative — write the
+ * file to `code.py` and let auto-reload run it — was rejected: it would overwrite
+ * a file the user did not ask us to touch, and it would make Run mean something
+ * different from what it means everywhere else in Snakie. What changes is only
+ * the explanation: on CircuitPython, running takes over from `code.py`, and when
+ * it finishes the board is sitting at the REPL rather than back in `code.py`.
+ */
+import type { Dialect } from '../../../shared/dialect'
+
+/** Everything the Run button's tooltip depends on. */
+export interface RunTitleState {
+  /** Name of the file that would run; absent when no file is open. */
+  activeFileName?: string
+  connected: boolean
+  connecting: boolean
+  /** Which Python the board runs — absent until the connect probe answers. */
+  dialect?: Dialect
+}
+
+/** Everything the Stop/Reset button's tooltip depends on. */
+export interface StopTitleState {
+  connected: boolean
+  /** True while a program Snakie started is still going. */
+  running: boolean
+  dialect?: Dialect
+}
+
+/**
+ * The Run button's tooltip.
+ *
+ * The CircuitPython wording names the consequence a user cannot otherwise
+ * predict: their `code.py` stops, and it does not come back on its own.
+ */
+export function runTitle(s: RunTitleState): string {
+  if (!s.activeFileName) return 'Open a file to run'
+  if (s.connecting) return 'Connecting…'
+  if (!s.connected) return 'Run on the simulator'
+  if (s.dialect === 'circuitpython') {
+    return `Run ${s.activeFileName} on the board. It takes over from code.py, and the board stays at the REPL afterwards rather than going back to it — press Reset to run code.py again.`
+  }
+  return `Run ${s.activeFileName} on the device`
+}
+
+/**
+ * The Stop/Reset button's tooltip.
+ *
+ * Reset is where the runtimes genuinely differ: Ctrl-D soft-reboots both, but on
+ * CircuitPython a soft reboot **re-runs `code.py`**, so the button is not the
+ * "clear the board's state" it is on MicroPython — it starts the user's program.
+ */
+export function stopTitle(s: StopTitleState): string {
+  if (!s.connected) return 'Connect to a device to stop'
+  if (s.running) return 'Interrupt the running program (Ctrl-C)'
+  if (s.dialect === 'circuitpython') {
+    return 'Reset the board (soft reboot) — CircuitPython runs code.py again from the start'
+  }
+  return 'Reset the board (soft reboot)'
+}
+
+/**
+ * The files each runtime looks for at boot, in the order it tries them. The
+ * FIRST one present is the one that runs; the rest are ignored, which is the
+ * trap this exists to surface — a board with both `code.py` and `main.py` runs
+ * only `code.py`, and editing `main.py` then appears to do nothing.
+ *
+ * CircuitPython: `code.txt`, `code.py`, `main.txt`, `main.py`.
+ * MicroPython: `boot.py` runs first and then `main.py`, but `boot.py` is setup
+ * rather than the program, so `main.py` is the one worth pointing at.
+ */
+export const BOOT_FILE_ORDER: Record<'circuitpython' | 'micropython', string[]> = {
+  circuitpython: ['code.txt', 'code.py', 'main.txt', 'main.py'],
+  micropython: ['main.py']
+}
+
+/**
+ * Which file in a device directory listing the board will actually run at boot,
+ * or `null` when none of them is a boot file.
+ *
+ * `names` should be the ROOT listing — the boot files are only boot files there.
+ * Returns the winner of the runtime's own search order, so a board carrying both
+ * `code.py` and `main.py` names `code.py`.
+ */
+export function bootFile(names: string[], dialect?: Dialect): string | null {
+  if (dialect !== 'circuitpython' && dialect !== 'micropython') return null
+  const present = new Set(names)
+  return BOOT_FILE_ORDER[dialect].find((f) => present.has(f)) ?? null
+}
+
+/**
+ * Why a file in the root is, or is not, the one that runs — the tooltip for the
+ * marker in the device file tree. `null` for a file that has nothing to say,
+ * which is most of them.
+ */
+export function bootFileNote(name: string, names: string[], dialect?: Dialect): string | null {
+  if (dialect !== 'circuitpython' && dialect !== 'micropython') return null
+  const order = BOOT_FILE_ORDER[dialect]
+  if (!order.includes(name)) return null
+  const winner = bootFile(names, dialect)
+  const runtime = dialect === 'circuitpython' ? 'CircuitPython' : 'MicroPython'
+  if (name === winner) return `${runtime} runs this file when the board starts`
+  return `${runtime} runs ${winner} instead — it comes first, so this file is ignored`
+}

--- a/test/runControls.test.ts
+++ b/test/runControls.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest'
+import { BOOT_FILE_ORDER, bootFile, bootFileNote, runTitle, stopTitle } from '../src/renderer/src/components/run-controls'
+
+/**
+ * RUN / STOP / RESET SEMANTICS (#755, epic #209).
+ *
+ * The wording IS the deliverable: Run behaves identically on both runtimes (a
+ * raw-REPL exec), and what changes is what that costs the user — on
+ * CircuitPython their `code.py` stops and does not come back. So these tests
+ * are about what the app promises, and about the boot-file rule, which is a
+ * real trap: a board carrying both `code.py` and `main.py` runs only the first.
+ */
+
+describe('runTitle', () => {
+  it('is unchanged for MicroPython — this issue changes explanation, not behaviour', () => {
+    expect(runTitle({ activeFileName: 'blink.py', connected: true, connecting: false, dialect: 'micropython' })).toBe(
+      'Run blink.py on the device'
+    )
+  })
+
+  it('warns a CircuitPython user that running stops code.py and does not resume it', () => {
+    const title = runTitle({
+      activeFileName: 'blink.py',
+      connected: true,
+      connecting: false,
+      dialect: 'circuitpython'
+    })
+    expect(title).toContain('blink.py')
+    expect(title).toContain('code.py')
+    expect(title).toMatch(/Reset/) // names the way back
+  })
+
+  it('says nothing runtime-specific before the connect probe has answered', () => {
+    expect(runTitle({ activeFileName: 'blink.py', connected: true, connecting: false })).toBe(
+      'Run blink.py on the device'
+    )
+  })
+
+  it('keeps the states that come before the runtime matters', () => {
+    expect(runTitle({ connected: true, connecting: false })).toBe('Open a file to run')
+    expect(runTitle({ activeFileName: 'a.py', connected: false, connecting: true })).toBe('Connecting…')
+    expect(runTitle({ activeFileName: 'a.py', connected: false, connecting: false })).toBe('Run on the simulator')
+  })
+
+  it('does not promise CircuitPython behaviour while disconnected', () => {
+    const title = runTitle({
+      activeFileName: 'a.py',
+      connected: false,
+      connecting: false,
+      dialect: 'circuitpython'
+    })
+    expect(title).toBe('Run on the simulator')
+  })
+})
+
+describe('stopTitle', () => {
+  it('is unchanged for MicroPython', () => {
+    expect(stopTitle({ connected: true, running: false, dialect: 'micropython' })).toBe(
+      'Reset the board (soft reboot)'
+    )
+    expect(stopTitle({ connected: true, running: true, dialect: 'micropython' })).toBe(
+      'Interrupt the running program (Ctrl-C)'
+    )
+  })
+
+  it('says that a CircuitPython reset RUNS code.py, rather than just clearing state', () => {
+    const title = stopTitle({ connected: true, running: false, dialect: 'circuitpython' })
+    expect(title).toContain('code.py')
+    expect(title).toMatch(/again/)
+  })
+
+  it('interrupting means the same thing on both, so the wording does not fork', () => {
+    expect(stopTitle({ connected: true, running: true, dialect: 'circuitpython' })).toBe(
+      stopTitle({ connected: true, running: true, dialect: 'micropython' })
+    )
+  })
+
+  it('disconnected wins over everything', () => {
+    expect(stopTitle({ connected: false, running: true, dialect: 'circuitpython' })).toBe(
+      'Connect to a device to stop'
+    )
+  })
+})
+
+describe('bootFile', () => {
+  it('picks code.py on CircuitPython, which is what the board actually runs', () => {
+    expect(bootFile(['code.py', 'lib', 'boot_out.txt'], 'circuitpython')).toBe('code.py')
+  })
+
+  it('resolves the trap: with BOTH code.py and main.py, only code.py runs', () => {
+    expect(bootFile(['main.py', 'code.py'], 'circuitpython')).toBe('code.py')
+  })
+
+  it('follows the whole search order, including the .txt forms', () => {
+    expect(bootFile(['main.py', 'code.txt'], 'circuitpython')).toBe('code.txt')
+    expect(bootFile(['main.py', 'main.txt'], 'circuitpython')).toBe('main.txt')
+    expect(bootFile(['main.py'], 'circuitpython')).toBe('main.py')
+  })
+
+  it('is main.py on MicroPython — and code.py is NOT special there', () => {
+    expect(bootFile(['main.py', 'code.py'], 'micropython')).toBe('main.py')
+    expect(bootFile(['code.py'], 'micropython')).toBeNull()
+  })
+
+  it('is null when the board runs nothing at boot, or when the runtime is unknown', () => {
+    expect(bootFile(['lib', 'notes.txt'], 'circuitpython')).toBeNull()
+    expect(bootFile(['code.py'], undefined)).toBeNull()
+    expect(bootFile(['code.py'], 'unknown')).toBeNull()
+  })
+
+  it('the CircuitPython order is the documented one', () => {
+    expect(BOOT_FILE_ORDER.circuitpython).toEqual(['code.txt', 'code.py', 'main.txt', 'main.py'])
+  })
+})
+
+describe('bootFileNote', () => {
+  it('marks the file that runs', () => {
+    expect(bootFileNote('code.py', ['code.py', 'lib'], 'circuitpython')).toBe(
+      'CircuitPython runs this file when the board starts'
+    )
+  })
+
+  it('explains the SHADOWED file, which is the whole point — editing it does nothing', () => {
+    const note = bootFileNote('main.py', ['code.py', 'main.py'], 'circuitpython')
+    expect(note).toBe('CircuitPython runs code.py instead — it comes first, so this file is ignored')
+  })
+
+  it('says nothing about an ordinary file', () => {
+    expect(bootFileNote('helpers.py', ['code.py', 'helpers.py'], 'circuitpython')).toBeNull()
+    expect(bootFileNote('lib', ['code.py', 'lib'], 'circuitpython')).toBeNull()
+  })
+
+  it('says nothing when the runtime is not known, rather than guessing', () => {
+    expect(bootFileNote('code.py', ['code.py'], undefined)).toBeNull()
+  })
+
+  it('does not call code.py a boot file on MicroPython', () => {
+    expect(bootFileNote('code.py', ['code.py', 'main.py'], 'micropython')).toBeNull()
+    expect(bootFileNote('main.py', ['code.py', 'main.py'], 'micropython')).toBe(
+      'MicroPython runs this file when the board starts'
+    )
+  })
+})


### PR DESCRIPTION
Towards #755 — four of its five bullets. The fifth is left deliberately; see the bottom.

> **Stacked on #767** (→ #766 → #765). Base is `feat/circuitpy-file-io`, so this diff shows only #755.

## Run stays a raw-REPL exec

The issue offered two options. **Rejected:** write the file to `code.py` and let auto-reload run it — it overwrites a file the user didn't ask us to touch, and makes Run mean something different from what it means everywhere else in Snakie.

So behaviour doesn't change; the *explanation* does. On CircuitPython, running takes over from `code.py`, and when it finishes the board is sitting at the REPL rather than back in `code.py` — so the tooltip names Reset as the way to start it again.

## Reset is where they genuinely differ

Ctrl-D soft-reboots both, but on CircuitPython a soft reboot **re-runs `code.py`**. So the button is not the "clear the board's state" it is on MicroPython — it starts the user's program, and now says so. Interrupting means the same thing on both runtimes, so that wording deliberately does not fork.

## There was no "main program" affordance to retarget

Files sync to `/<basename>`, and both `code.py` and `main.py` boot on CircuitPython, so nothing points at the wrong name. The faithful delivery of that bullet is to make the rule **visible**: the device file tree now marks the file the board runs at boot — and marks one it will **ignore**.

That second marker is the point. CircuitPython tries `code.txt`, `code.py`, `main.txt`, `main.py` in order, so a board carrying both `code.py` and `main.py` runs only the first, and edits to the other appear to do nothing. The marker is correct on MicroPython too, where `main.py` is the one that boots.

## Auto-reload: decided NOT to suppress

Suppressing it means setting `supervisor.runtime.autoreload = False` over the raw REPL — and entering the raw REPL sends Ctrl-C. The board's program would be **interrupted in order to spare it from being restarted**, which is self-defeating.

CircuitPython already waits for the filesystem to settle before reloading, and Snakie's multi-file writes are consecutive awaits against a local mount with sub-millisecond gaps, so a batch lands inside one settle window and costs one reload rather than one per file. The reasoning is recorded next to the write it concerns, naming #751 as where contrary evidence would come from.

## Verification

- `lint`, `typecheck`, `build`, `build:web` green. Full suite 3429 pass; the one failure is the known #737 flake.
- **20 new tests** over the pure logic — the wording is the deliverable here, so it is pinned rather than buried in JSX. They cover the boot-file search order (including the `.txt` forms and the both-files-present trap), and that MicroPython's wording is byte-for-byte unchanged.
- **Rendered in headless Chromium under both dialects.** CircuitPython gets the new Run/Reset tooltips and `code.py` "runs at boot" / `main.py` "ignored"; MicroPython gets its original tooltips and `main.py` marked. Screenshot checked for layout — the badge yields its slot to the hover-delete button, so the two never collide.

## Left deliberately

**Reconnecting if the port re-enumerates on soft reboot.** Whether it re-enumerates *at all* is one of the questions #751 exists to answer, and building an auto-reconnect handler before knowing would be guesswork — with a real cost if wrong, since a reconnect loop fighting a deliberate unplug is worse than no handler. #755 should stay open for it; I'll comment there with what remains.

Also unverified for the same reason: that raw-REPL Ctrl-D still merely *executes* on CircuitPython rather than soft-rebooting, which the Run path depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)