### PR TITLE
feat: publish a project to GitHub from the Source Control panel (#795)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Publish a project to GitHub without leaving Snakie.** (#795) A repository
+  you created locally had nowhere to go: the Source Control panel offered
+  **Push** and **Pull**, both of which need a remote, and setting one up meant
+  a terminal, `gh repo create` or the GitHub website plus a `git remote add`
+  typed by hand. Those two buttons were dead controls in exactly the state
+  where a useful one belongs — so on a repository with no remote they are now
+  replaced by **Publish to GitHub**.
+
+  It opens a dialog: the repository name (pre-filled from your folder, and
+  sanitised — "Line Follower (v2)" becomes `Line-Follower-v2`, because GitHub
+  will not take the first), an optional description, and who can see it.
+  Publishing creates the repository, adds it as `origin` and pushes your
+  current branch in one step, then the panel says what it did — the full
+  `owner/name`, the visibility, and the branch it pushed.
+
+  **It defaults to private, and that is a safety decision rather than a
+  preference.** The MicroPython convention for Wi-Fi credentials is a plain
+  `secrets.py` sitting next to `main.py`, and a public repository is scraped,
+  forked and cached within minutes — "delete the repo" does not un-publish a
+  password. Choosing public costs one extra click; getting it wrong by default
+  would cost some people their network. For the same reason, choosing public
+  when the repository actually *tracks* a credentials-shaped file — `secrets.py`,
+  `.env`, a `.pem` — names those files before you commit to it. It warns rather
+  than blocks (your `.pem` may well be a public certificate), and it only counts
+  files git is already tracking, because an untracked or ignored one is never
+  pushed and warning about it would just teach you to click through.
+
+  **Snakie never holds a GitHub credential.** Publishing runs through the
+  GitHub CLI, which already keeps your token in the OS keychain and already
+  handles two-factor — the alternative was a personal access token typed into
+  a Snakie field and stored by Snakie, which is a thing that can leak. So the
+  dialog checks up front, before showing you a form: no `gh` installed, not
+  signed in, no commits yet, or a remote already configured each appear as a
+  sentence with the next step in it, rather than as an error after you have
+  typed a description and pressed the button. Sign-in itself stays in your
+  terminal (`gh auth login`) on purpose, so your credentials only ever go to
+  GitHub.
+
+  The repository name is validated as you type against the same rule the main
+  process guards with, so the dialog cannot accept something GitHub will
+  reject — and every value reaches `gh` as its own argument rather than as part
+  of a command line, which is what makes a repository named `foo; rm -rf ~`
+  merely an invalid name. Desktop only: the web app has no local git and no
+  `gh` to run.
 - **Right-click your code and Snakie offers to tidy it — and explains why.**
   Select some Python, right-click **Refactor…** (or <kbd>Ctrl/Cmd</kbd>+<kbd>⇧</kbd>+<kbd>R</kbd>),
   and you get concrete, safe rewrites: *Convert to guard clause*, *Merge nested

--- a/src/main/git/GitService.ts
+++ b/src/main/git/GitService.ts
@@ -8,12 +8,24 @@ import {
   stageSummary,
   type GitStageScope
 } from '../../shared/git-stage'
+import {
+  publishArgs,
+  publishSummary,
+  secretRisks,
+  suggestRepoName,
+  validateRepoName,
+  type GitVisibility
+} from '../../shared/git-publish'
+import { ghAccount, ghVersion, publishTimeout, runGh } from './gh'
 import { SNAKIE_GITIGNORE, gitFailureText, initSummary } from './init-support'
 import type {
   GitBranchList,
   GitDiff,
   GitFileStatus,
   GitInitResult,
+  GitPublishOptions,
+  GitPublishPreflight,
+  GitPublishResult,
   GitRemoteResult,
   GitStageResult,
   GitStatus
@@ -140,7 +152,8 @@ export class GitService {
       staged: [],
       changed: [],
       untracked: [],
-      hasCommits: false
+      hasCommits: false,
+      remotes: []
     }
     if (!this.git) return empty
 
@@ -201,7 +214,26 @@ export class GitService {
       staged,
       changed,
       untracked,
-      hasCommits: await this.hasCommits()
+      hasCommits: await this.hasCommits(),
+      remotes: await this.remotes()
+    }
+  }
+
+  /**
+   * Names of the configured remotes, or `[]` when there are none.
+   *
+   * Never throws: a repo with no remotes is the normal state this feature
+   * exists for (#795), not a failure, and a status refresh that rejected
+   * because of it would break the whole panel over a missing `origin`.
+   */
+  private async remotes(): Promise<string[]> {
+    const git = this.git
+    if (!git) return []
+    try {
+      const list = await git.getRemotes(false)
+      return list.map((r) => r.name).filter(Boolean)
+    } catch {
+      return []
     }
   }
 
@@ -288,6 +320,223 @@ export class GitService {
       untrackedCount,
       warning,
       summary: initSummary({ branch, wroteGitignore, untrackedCount })
+    }
+  }
+
+  /**
+   * Everything the publish dialog needs to know before it opens (#795).
+   *
+   * Answers the four questions that decide whether a publish can happen at all
+   * — is `gh` installed, is it signed in, is there anything to push, and does
+   * this repo already have a remote — plus the two that shape what the dialog
+   * shows: a sanitised starting name, and which tracked files would be a bad
+   * thing to make public.
+   *
+   * Never throws for any of those states. They are all things the dialog
+   * RENDERS: a missing `gh` should read as a sentence with an install link, not
+   * as a red error bar under a form the user cannot use anyway.
+   */
+  async publishPreflight(): Promise<GitPublishPreflight> {
+    const blockers: string[] = []
+
+    const version = await ghVersion()
+    const ghInstalled = version !== undefined
+    if (!ghInstalled) {
+      blockers.push(
+        'The GitHub CLI (gh) is not installed on this computer, or is not on its PATH. ' +
+          'Snakie publishes through gh so it never has to hold your GitHub credentials — ' +
+          'install it from https://cli.github.com, then restart Snakie.'
+      )
+    }
+
+    // Only worth asking when there is a binary to ask.
+    let authenticated = false
+    let account: string | undefined
+    if (ghInstalled) {
+      try {
+        account = await ghAccount()
+        authenticated = true
+      } catch {
+        authenticated = false
+        blockers.push(
+          'The GitHub CLI is not signed in. Open a terminal, run `gh auth login`, then try ' +
+            'again. Snakie cannot run that sign-in for you — it is interactive on purpose, ' +
+            'so your credentials only ever go to GitHub.'
+        )
+      }
+    }
+
+    const current = await this.status()
+    if (!current.isRepo) {
+      blockers.push('This folder is not a Git repository yet. Initialise one first.')
+    }
+
+    // Publishing an unborn HEAD would create an empty repository on GitHub and
+    // push nothing — the user would be left with a repo that does not contain
+    // their project and no clue why.
+    if (current.isRepo && !current.hasCommits) {
+      blockers.push(
+        'There are no commits yet, so there would be nothing to publish. ' +
+          'Stage your files and make a first commit, then publish.'
+      )
+    }
+
+    const existingRemote = current.remotes[0]
+    if (existingRemote) {
+      blockers.push(
+        `This repository already has a remote ("${existingRemote}"), so it is already published ` +
+          'somewhere. Use Push to send your commits there.'
+      )
+    }
+
+    const root = current.root ?? this.dir ?? ''
+    const folderName = root.split(/[\\/]/).filter(Boolean).pop() ?? ''
+
+    return {
+      ghInstalled,
+      ghVersion: version,
+      authenticated,
+      account,
+      suggestedName: suggestRepoName(folderName),
+      hasCommits: current.hasCommits,
+      existingRemote,
+      riskyPaths: current.isRepo ? secretRisks(await this.trackedPaths()) : [],
+      blockers
+    }
+  }
+
+  /**
+   * The repo-relative paths git is TRACKING.
+   *
+   * Tracking is the right question, not "what is in the folder": an untracked
+   * or ignored `secrets.py` is never pushed, so warning about it would be a
+   * false alarm — and false alarms are how a warning gets clicked through.
+   */
+  private async trackedPaths(): Promise<string[]> {
+    const git = this.git
+    if (!git) return []
+    try {
+      const out = await git.raw(['ls-files'])
+      return out.split(/\r?\n/).map((line) => line.trim()).filter(Boolean)
+    } catch {
+      return []
+    }
+  }
+
+  /**
+   * Create a GitHub repository from the open folder and push to it (#795).
+   *
+   * The whole operation is `gh repo create --source … --push`, which creates
+   * the remote repository, adds it as a git remote and pushes the current
+   * branch in one step. Doing it as one `gh` call rather than three of our own
+   * is deliberate: any split leaves failure states that are genuinely hard for
+   * a user to unpick (a repository created on GitHub but no remote locally, or
+   * a remote pointing at a repository that was never created).
+   *
+   * Everything is re-checked here rather than trusted from the dialog's
+   * preflight. The two are separated by however long the user spent typing, and
+   * in that window they could have committed, added a remote, or opened a
+   * different folder — and unlike a stale button, a stale publish creates a
+   * real repository on a real account.
+   */
+  async publish(options: GitPublishOptions): Promise<GitPublishResult> {
+    const visibility: GitVisibility = options.visibility === 'public' ? 'public' : 'private'
+
+    const check = validateRepoName(options.name)
+    if (!check.ok) throw new Error(check.error ?? 'That repository name is not valid.')
+
+    const current = await this.status()
+    if (!current.isRepo || !current.root) {
+      throw new Error('This folder is not a Git repository, so there is nothing to publish.')
+    }
+    if (!current.hasCommits) {
+      throw new Error(
+        'There are no commits yet, so there would be nothing to publish. Make a first commit, then publish.'
+      )
+    }
+    const existing = current.remotes[0]
+    if (existing) {
+      throw new Error(
+        `This repository already has a remote ("${existing}"), so it is already published somewhere. ` +
+          'Use Push to send your commits there.'
+      )
+    }
+
+    const root = current.root
+    const branch = current.branch
+
+    await runGh(
+      publishArgs({
+        name: options.name.trim(),
+        description: options.description,
+        visibility,
+        source: root
+      }),
+      { cwd: root, timeout: publishTimeout }
+    )
+
+    // What gh actually created — asked for rather than assumed, because the
+    // owner half of `fullName` is resolved by gh (the authenticated user, when
+    // the name was typed bare) and the visibility is worth reading back from
+    // GitHub rather than echoing the flag we sent.
+    let fullName = options.name.trim()
+    let url = ''
+    let confirmedVisibility = visibility
+    let warning: string | undefined
+    try {
+      const { stdout } = await runGh([
+        'repo',
+        'view',
+        '--json',
+        'nameWithOwner,url,visibility'
+      ], { cwd: root })
+      const meta = JSON.parse(stdout) as {
+        nameWithOwner?: string
+        url?: string
+        visibility?: string
+      }
+      if (meta.nameWithOwner) fullName = meta.nameWithOwner
+      if (meta.url) url = meta.url
+      if (meta.visibility) {
+        confirmedVisibility = meta.visibility.toLowerCase() === 'public' ? 'public' : 'private'
+      }
+    } catch {
+      // The repository exists and the push succeeded — this call is only for a
+      // tidier report, so failing it must not turn a success into an error.
+      warning = 'The repository was published, but Snakie could not read back its details from GitHub.'
+    }
+
+    // gh's `--push` sets the upstream itself, but say so out loud rather than
+    // assume: without tracking, the panel's ahead/behind counts stay blank and
+    // Push would fail with "no upstream" on the very next commit.
+    const after = await this.status()
+    const remote = after.remotes[0] ?? 'origin'
+    if (!after.tracking && branch) {
+      try {
+        await this.require().raw(['branch', `--set-upstream-to=${remote}/${branch}`, branch])
+      } catch {
+        warning =
+          warning ??
+          `Published, but ${branch} is not tracking ${remote}/${branch} yet — the first Push may ask you to set an upstream.`
+      }
+    }
+
+    if (confirmedVisibility !== visibility) {
+      // Almost always an organisation policy forcing private. The user asked
+      // for one thing and got another; that is not a detail to swallow.
+      warning =
+        `You asked for a ${visibility} repository, but GitHub created a ${confirmedVisibility} one ` +
+        '(an organisation policy usually causes this).'
+    }
+
+    return {
+      fullName,
+      url: url || `https://github.com/${fullName}`,
+      visibility: confirmedVisibility,
+      branch,
+      remote,
+      warning,
+      summary: publishSummary({ fullName, visibility: confirmedVisibility, branch, remote })
     }
   }
 

--- a/src/main/git/gh.ts
+++ b/src/main/git/gh.ts
@@ -1,0 +1,114 @@
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import { ghFailureText } from '../../shared/git-publish'
+
+const run = promisify(execFile)
+
+/**
+ * A very small wrapper around the GitHub CLI, for "Publish to GitHub" (#795).
+ *
+ * Separate from {@link GitService} because `gh` is a different binary with
+ * different failure modes: `simple-git` speaks to a repository, this speaks to
+ * a network service that can be down, rate-limited, or simply not signed in.
+ *
+ * **`gh` rather than the GitHub API on purpose.** Creating a repository needs a
+ * credential, and the alternatives all end with Snakie holding one: a personal
+ * access token typed into a Snakie field and stored by Snakie, or an OAuth flow
+ * Snakie would have to implement and keep secret. `gh` already holds the user's
+ * token in the OS keychain, already handles refresh and two-factor, and is
+ * already the thing they use from a terminal. Snakie never sees the credential,
+ * and there is nothing here to leak.
+ *
+ * Every call is `execFile` with an ARGV — never a shell string — so a
+ * repository name, description or path containing shell metacharacters is
+ * data, not code.
+ */
+
+/** How long a metadata call may take before we stop waiting. */
+const QUICK_TIMEOUT_MS = 15_000
+
+/**
+ * How long a publish may take. Generous because `--push` uploads the whole
+ * history, and a first push of a repo full of `meshes/` on a slow connection is
+ * legitimately slow — timing that out and leaving a created-but-unpushed repo
+ * behind is a worse failure than waiting.
+ */
+const PUBLISH_TIMEOUT_MS = 300_000
+
+/** Combined output of a `gh` invocation. */
+export interface GhOutput {
+  stdout: string
+  stderr: string
+}
+
+/**
+ * Run `gh` with `args`, rejecting with a readable message on failure.
+ *
+ * `gh` writes most of its progress to stderr even on success, so both streams
+ * come back and the CALLER decides what is interesting. On failure the two are
+ * joined before being handed to {@link ghFailureText}, because the sentence
+ * worth showing ("Name already exists on this account") is usually on stderr
+ * while Node's own `Error.message` only carries the exit code.
+ */
+export async function runGh(
+  args: readonly string[],
+  options: { cwd?: string; timeout?: number } = {}
+): Promise<GhOutput> {
+  try {
+    const { stdout, stderr } = await run('gh', [...args], {
+      cwd: options.cwd,
+      timeout: options.timeout ?? QUICK_TIMEOUT_MS,
+      // gh's own output is small; this only guards against a pathological case.
+      maxBuffer: 4 * 1024 * 1024,
+      windowsHide: true
+    })
+    return { stdout: String(stdout), stderr: String(stderr) }
+  } catch (err) {
+    const detail = err as NodeJS.ErrnoException & { stdout?: string; stderr?: string }
+    const combined = [detail.stderr, detail.stdout, detail.message]
+      .map((part) => (part ?? '').toString().trim())
+      .filter(Boolean)
+      .join('\n')
+    throw new Error(ghFailureText(combined || String(err)))
+  }
+}
+
+/** The timeout a publish should be given. Exported so the service reads one number. */
+export const publishTimeout = PUBLISH_TIMEOUT_MS
+
+/**
+ * The `gh` version string, or undefined when no `gh` is on PATH.
+ *
+ * Never throws: "not installed" is a state the dialog renders, not an error it
+ * reports. `gh --version` prints `gh version 2.89.0 (…)` plus a release URL, so
+ * only the first line is kept.
+ */
+export async function ghVersion(): Promise<string | undefined> {
+  try {
+    const { stdout } = await runGh(['--version'])
+    const first = stdout.split(/\r?\n/)[0]?.trim()
+    return first || undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * The signed-in GitHub login, or undefined when `gh` is not authenticated.
+ *
+ * Read from `gh auth status`, whose exit code is the authority (0 signed in,
+ * non-zero not). The login itself is scraped from the "Logged in to github.com
+ * account <login>" line — best-effort, because the dialog uses it only to SHOW
+ * the user where their repository will land. A version of `gh` that words that
+ * line differently costs a nicety, not the feature: `authenticated` still
+ * follows the exit code.
+ */
+export async function ghAccount(): Promise<string | undefined> {
+  const { stdout, stderr } = await runGh(['auth', 'status'])
+  // The line has lived on both streams across gh versions; search both.
+  const text = `${stdout}\n${stderr}`
+  const match =
+    /Logged in to \S+ (?:as|account) ([A-Za-z0-9-]+)/i.exec(text) ??
+    /account ([A-Za-z0-9-]+)/i.exec(text)
+  return match?.[1]
+}

--- a/src/main/git/ipc.ts
+++ b/src/main/git/ipc.ts
@@ -5,6 +5,9 @@ import type {
   GitBranchList,
   GitDiff,
   GitInitResult,
+  GitPublishOptions,
+  GitPublishPreflight,
+  GitPublishResult,
   GitRemoteResult,
   GitStageResult,
   GitStageScope,
@@ -98,4 +101,20 @@ export function registerGitIpc(): void {
 
   ipcMain.handle('git:push', () => wrap<GitRemoteResult>(() => service.push()))
   ipcMain.handle('git:pull', () => wrap<GitRemoteResult>(() => service.pull()))
+
+  // Everything the publish dialog needs before it opens (#795). Like
+  // `git:status` this does NOT reject for the states it exists to report — a
+  // missing `gh`, a signed-out CLI and a repo with no commits all come back as
+  // `blockers`, because they are things the dialog renders rather than errors.
+  ipcMain.handle('git:publishPreflight', () =>
+    wrap<GitPublishPreflight>(() => service.publishPreflight())
+  )
+
+  // Create the GitHub repository and push to it (#795). This one DOES reject:
+  // it creates a repository on the user's GitHub account, and a button that
+  // appears to do nothing after that is the worst possible outcome — the user
+  // would click it again and hit "name already exists" on their second try.
+  ipcMain.handle('git:publish', (_e, options: GitPublishOptions) =>
+    wrap<GitPublishResult>(() => service.publish(options))
+  )
 }

--- a/src/main/git/types.ts
+++ b/src/main/git/types.ts
@@ -51,6 +51,16 @@ export interface GitStatus {
    * and there is nothing to diff, push or discard against.
    */
   hasCommits: boolean
+  /**
+   * Names of the configured remotes (usually `['origin']`, often empty).
+   *
+   * This is what decides whether the panel offers **Publish to GitHub** (#795):
+   * a repository with no remote at all has nowhere for Push to push, which is
+   * exactly the state that button exists to resolve. Once anything is
+   * configured, the repo already lives somewhere and publishing it again is not
+   * what the user means.
+   */
+  remotes: string[]
   /** Set when the folder is a repo but status could not be read fully. */
   warning?: string
 }
@@ -124,5 +134,74 @@ export interface GitDiff {
 /** Result of a push/pull, surfacing a short human-readable summary. */
 export interface GitRemoteResult {
   /** Short summary suitable for a toast/status line. */
+  summary: string
+}
+
+/**
+ * What Snakie learned BEFORE opening the publish dialog (#795).
+ *
+ * Gathered up front rather than discovered on submit. Publishing is a single
+ * irreversible click, so every reason it might fail — no `gh`, not signed in,
+ * nothing committed yet, already has a remote — should be visible while the
+ * user is still deciding, not after they have typed a description and pressed
+ * the button.
+ */
+export interface GitPublishPreflight {
+  /** True when a `gh` binary answered `gh --version`. */
+  ghInstalled: boolean
+  /** The version string `gh` reported, for the "not installed" help text. */
+  ghVersion?: string
+  /** True when `gh auth status` reports a signed-in host. */
+  authenticated: boolean
+  /** The signed-in GitHub login, so the dialog can show where this will land. */
+  account?: string
+  /** A sanitised starting name, derived from the repository folder. */
+  suggestedName: string
+  /** False for a repo with an unborn HEAD — there would be nothing to push. */
+  hasCommits: boolean
+  /** The first configured remote, when the repo already has one. */
+  existingRemote?: string
+  /** Tracked paths that usually hold secrets, for the public-visibility warning. */
+  riskyPaths: string[]
+  /**
+   * The reasons publishing cannot go ahead right now, as sentences. Empty means
+   * the dialog can offer its Publish button.
+   */
+  blockers: string[]
+}
+
+/** What the publish dialog collected, ready for `gh repo create`. */
+export interface GitPublishOptions {
+  /** `NAME` or `OWNER/NAME`. */
+  name: string
+  /** Optional one-line description. */
+  description?: string
+  /** Who can see the new repository. */
+  visibility: import('../../shared/git-publish').GitVisibility
+}
+
+/**
+ * What a publish actually did (#795).
+ *
+ * Creating a repository on someone else's server, under a name and a visibility
+ * the user chose, is exactly the kind of act that has to report itself in words
+ * rather than by quietly redrawing a panel. The URL is included so the panel can
+ * offer to open what was just created — the fastest way to confirm the
+ * visibility is what was asked for.
+ */
+export interface GitPublishResult {
+  /** `owner/name`, as GitHub created it. */
+  fullName: string
+  /** Browser URL of the new repository. */
+  url: string
+  /** Who can see it. */
+  visibility: import('../../shared/git-publish').GitVisibility
+  /** The branch that was pushed. */
+  branch?: string
+  /** The remote name now pointing at GitHub. */
+  remote: string
+  /** Set when the repo was created but a follow-up step did not fully succeed. */
+  warning?: string
+  /** One-line human-readable report of what happened. */
   summary: string
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -129,7 +129,10 @@ export type {
   GitInitResult,
   GitRemoteResult,
   GitStageResult,
-  GitStageScope
+  GitStageScope,
+  GitPublishOptions,
+  GitPublishPreflight,
+  GitPublishResult
 } from '../main/git/types'
 
 // Re-export the Python plugin-system types (issue #61) so the Plugins panel can

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -66,7 +66,10 @@ import type {
   GitRemoteResult,
   GitStageResult,
   GitStageScope,
-  GitStatus
+  GitStatus,
+  GitPublishOptions,
+  GitPublishPreflight,
+  GitPublishResult
 } from '../main/git/types'
 import type {
   LintResult,
@@ -752,7 +755,25 @@ const git = {
   /** Push the current branch to its upstream. */
   push: (): Promise<GitRemoteResult> => unwrap(ipcRenderer.invoke('git:push')),
   /** Pull from the upstream of the current branch. */
-  pull: (): Promise<GitRemoteResult> => unwrap(ipcRenderer.invoke('git:pull'))
+  pull: (): Promise<GitRemoteResult> => unwrap(ipcRenderer.invoke('git:pull')),
+
+  /**
+   * What the publish dialog needs before it opens (#795): whether `gh` is
+   * installed and signed in, a suggested name, and any tracked files that would
+   * be a bad thing to make public. Resolves even when publishing is impossible —
+   * the reasons come back in `blockers` for the dialog to render.
+   */
+  publishPreflight: (): Promise<GitPublishPreflight> =>
+    unwrap(ipcRenderer.invoke('git:publishPreflight')),
+
+  /**
+   * Create a GitHub repository from the open folder and push to it (#795). Runs
+   * `gh repo create --source … --push`, so Snakie never handles a GitHub
+   * credential itself. Rejects with a readable message when gh is missing,
+   * signed out, or GitHub refuses the name.
+   */
+  publish: (options: GitPublishOptions): Promise<GitPublishResult> =>
+    unwrap(ipcRenderer.invoke('git:publish', options))
 }
 
 /**

--- a/src/renderer/src/components/GitPanel.css
+++ b/src/renderer/src/components/GitPanel.css
@@ -481,3 +481,34 @@
   direction: rtl;
   text-align: left;
 }
+
+/* The toolbar's "Publish to GitHub" button (#795). A text button rather than a
+   glyph, because it takes the place of Push/Pull only on a repository that has
+   never been published — a state the user has no icon vocabulary for yet, and
+   where naming the destination is the whole point. */
+.git__publish-btn {
+  font-family: var(--font-ui);
+  font-size: 0.75rem;
+  font-weight: 600;
+  white-space: nowrap;
+  padding: 0.22rem 0.5rem;
+  color: var(--accent-contrast);
+  background: var(--accent);
+  border: var(--border-w) solid var(--accent);
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+
+.git__publish-btn:hover:not(:disabled) {
+  filter: brightness(1.08);
+}
+
+.git__publish-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.git__publish-btn:focus-visible {
+  outline: var(--border-w) solid var(--accent);
+  outline-offset: 2px;
+}

--- a/src/renderer/src/components/GitPanel.tsx
+++ b/src/renderer/src/components/GitPanel.tsx
@@ -11,8 +11,10 @@ import type {
   GitBranchList,
   GitDiff,
   GitFileStatus,
+  GitPublishOptions,
   GitStatus
 } from '../../../preload/index.d'
+import { GitPublishDialog } from './GitPublishDialog'
 
 /**
  * SOURCE CONTROL TAB (issue #15)
@@ -30,6 +32,11 @@ import type {
  * async action surfaces failures inline rather than throwing. Git itself runs
  * in the main process, so this component is purely a thin view over the IPC
  * bridge.
+ *
+ * A repository with no remote gets **Publish to GitHub** (#795) where Push and
+ * Pull would otherwise sit. That swap is the point: without a remote those two
+ * buttons cannot do anything at all, so the toolbar was offering two dead
+ * controls in exactly the state where one useful one belongs.
  *
  * This panel is desktop-only — `AppShell` never mounts it in the web build,
  * which has no filesystem and no local `git` to run.
@@ -89,6 +96,7 @@ export function GitPanel(): JSX.Element {
   const [notice, setNotice] = useState<string | null>(null)
   const [openDiff, setOpenDiff] = useState<GitDiff | null>(null)
   const [loading, setLoading] = useState(false)
+  const [publishOpen, setPublishOpen] = useState(false)
 
   /** Reload status (and branches) for the open repo. */
   const refresh = useCallback(async (): Promise<void> => {
@@ -230,6 +238,29 @@ export function GitPanel(): JSX.Element {
       } finally {
         setBusy(false)
       }
+    },
+    [refresh]
+  )
+
+  /**
+   * Publish the open repository to GitHub (#795).
+   *
+   * No `window.confirm` in front of it, unlike #783's Initialise button: the
+   * dialog itself IS the confirmation — it names the repository, names the
+   * account it will land under, and makes public a deliberate second choice.
+   * A second "are you sure?" on top of that would be the kind of prompt people
+   * learn to dismiss without reading.
+   *
+   * The dialog stays open on failure so the name and description the user typed
+   * survive to the next attempt; it closes only once the repository exists.
+   */
+  const publish = useCallback(
+    async (options: GitPublishOptions): Promise<void> => {
+      const result = await window.api.git.publish(options)
+      setPublishOpen(false)
+      setError(null)
+      setNotice(result.warning ? `${result.summary} ${result.warning}` : result.summary)
+      await refresh()
     },
     [refresh]
   )
@@ -379,6 +410,9 @@ export function GitPanel(): JSX.Element {
   const changed = status?.changed ?? []
   const untracked = status?.untracked ?? []
   const hasChanges = staged.length + changed.length + untracked.length > 0
+  // No remote at all is the state Publish exists for; anything configured means
+  // the repo already lives somewhere and Push is the right button (#795).
+  const hasRemote = (status?.remotes.length ?? 0) > 0
 
   // How many files each group's bulk-stage button would actually stage. Same
   // helper the main process uses to build the `git add` list (#794), so the
@@ -443,24 +477,40 @@ export function GitPanel(): JSX.Element {
         >
           ⟳
         </button>
-        <button
-          type="button"
-          className="git__icon-btn"
-          title="Pull"
-          disabled={busy}
-          onClick={() => void run(async () => void (await window.api.git.pull()), 'Pulled.')}
-        >
-          ↓
-        </button>
-        <button
-          type="button"
-          className="git__icon-btn"
-          title="Push"
-          disabled={busy}
-          onClick={() => void run(async () => void (await window.api.git.push()), 'Pushed.')}
-        >
-          ↑
-        </button>
+        {/* With no remote, Push and Pull have nowhere to go — offer the one
+            button that fixes that instead of two that cannot work (#795). */}
+        {hasRemote ? (
+          <>
+            <button
+              type="button"
+              className="git__icon-btn"
+              title="Pull"
+              disabled={busy}
+              onClick={() => void run(async () => void (await window.api.git.pull()), 'Pulled.')}
+            >
+              ↓
+            </button>
+            <button
+              type="button"
+              className="git__icon-btn"
+              title="Push"
+              disabled={busy}
+              onClick={() => void run(async () => void (await window.api.git.push()), 'Pushed.')}
+            >
+              ↑
+            </button>
+          </>
+        ) : (
+          <button
+            type="button"
+            className="git__publish-btn"
+            title="Create a repository on GitHub from this folder and push to it"
+            disabled={busy}
+            onClick={() => setPublishOpen(true)}
+          >
+            Publish to GitHub
+          </button>
+        )}
       </div>
 
       {/* Branch switcher */}
@@ -585,6 +635,14 @@ export function GitPanel(): JSX.Element {
           </div>
           <DiffView diff={openDiff.diff} />
         </section>
+      )}
+
+      {publishOpen && (
+        <GitPublishDialog
+          repoPath={status?.root ?? repoPath}
+          onPublish={publish}
+          onCancel={() => setPublishOpen(false)}
+        />
       )}
 
       <div className="git__footer">

--- a/src/renderer/src/components/GitPublishDialog.css
+++ b/src/renderer/src/components/GitPublishDialog.css
@@ -1,0 +1,229 @@
+/*
+ * Styles co-located with GitPublishDialog (issue #795).
+ *
+ * A centred modal over a dimmed backdrop, matching the app chrome through the
+ * shared Soft Shell tokens so it tracks BOTH skins (skeuomorph parchment and
+ * dark) without a hardcoded colour anywhere — the palette here is entirely
+ * var(--…), which is what keeps the warning text readable on parchment.
+ *
+ * Every class carries the `gh-pub` prefix: this stylesheet is global once
+ * imported, and a generic `.warn`/`.actions` here would reach into any other
+ * panel that happened to use the same word.
+ */
+
+.gh-pub__overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+  padding: 1rem;
+}
+
+.gh-pub {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: min(30rem, 100%);
+  max-height: calc(100vh - 2rem);
+  overflow-y: auto;
+  padding: 1.1rem 1.2rem;
+  background: var(--bg-elevated);
+  color: var(--text);
+  border: var(--border-w) solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--pixel-shadow);
+  font-size: 13px;
+}
+
+.gh-pub__title {
+  margin: 0 0 0.25rem;
+  font-family: var(--font-ui);
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.gh-pub__note {
+  margin: 0 0 0.35rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.gh-pub__note code,
+.gh-pub__help code {
+  font-family: var(--font-mono);
+  font-size: 0.92em;
+  color: var(--text);
+}
+
+/* The "this is taking a while" line under a running publish. */
+.gh-pub__note--busy {
+  margin-top: 0.5rem;
+}
+
+.gh-pub__label {
+  font-family: var(--font-ui);
+  font-size: 0.82rem;
+  font-weight: 600;
+  padding: 0;
+}
+
+.gh-pub__optional {
+  font-weight: 400;
+  color: var(--text-muted);
+}
+
+.gh-pub__input {
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  color: var(--text);
+  background: var(--bg-sunken);
+  border: var(--border-w) solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.45rem 0.55rem;
+}
+
+.gh-pub__input:focus-visible {
+  outline: var(--border-w) solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* An invalid name is marked by more than colour — the reason is spelled out in
+   the help line below it, which is what a screen reader reaches via
+   aria-describedby. */
+.gh-pub__input[aria-invalid='true'] {
+  border-color: var(--danger, #c0392b);
+}
+
+.gh-pub__help {
+  margin: 0 0 0.35rem;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  color: var(--text-muted);
+}
+
+.gh-pub__invalid {
+  color: var(--danger, #c0392b);
+}
+
+/* --- Visibility ----------------------------------------------------------- */
+
+.gh-pub__visibility {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin: 0.25rem 0 0.35rem;
+  padding: 0;
+  border: 0;
+}
+
+.gh-pub__radio {
+  display: flex;
+  gap: 0.55rem;
+  align-items: flex-start;
+  padding: 0.45rem 0.55rem;
+  border: var(--border-w) solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-sunken);
+  cursor: pointer;
+  line-height: 1.4;
+}
+
+.gh-pub__radio:hover {
+  border-color: var(--accent);
+}
+
+.gh-pub__radio input {
+  margin-top: 0.15rem;
+  accent-color: var(--accent);
+}
+
+.gh-pub__radio > span {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.gh-pub__radio-note {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+/* --- Messages -------------------------------------------------------------- */
+
+.gh-pub__blockers {
+  margin: 0 0 0.5rem;
+  padding-left: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  line-height: 1.5;
+  color: var(--text);
+}
+
+.gh-pub__warn,
+.gh-pub__error {
+  margin: 0.25rem 0;
+  padding: 0.55rem 0.65rem;
+  border: var(--border-w) solid var(--border);
+  border-radius: var(--radius);
+  line-height: 1.5;
+}
+
+/* The secrets warning uses the accent token rather than a literal gold, so it
+   stays readable on the parchment skin as well as the dark one. */
+.gh-pub__warn {
+  border-color: var(--accent);
+  background: var(--bg-sunken);
+  color: var(--text);
+}
+
+.gh-pub__error {
+  border-color: var(--danger, #c0392b);
+  background: var(--bg-sunken);
+  color: var(--danger, #c0392b);
+}
+
+/* --- Actions --------------------------------------------------------------- */
+
+.gh-pub__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.gh-pub__btn {
+  font-family: var(--font-ui);
+  font-size: 0.85rem;
+  padding: 0.45rem 0.8rem;
+  color: var(--text);
+  background: var(--bg-elevated);
+  border: var(--border-w) solid var(--border);
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+
+.gh-pub__btn:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+
+.gh-pub__btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.gh-pub__btn--primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-contrast, #fff);
+  font-weight: 600;
+}
+
+.gh-pub__btn:focus-visible {
+  outline: var(--border-w) solid var(--accent);
+  outline-offset: 2px;
+}

--- a/src/renderer/src/components/GitPublishDialog.tsx
+++ b/src/renderer/src/components/GitPublishDialog.tsx
@@ -1,0 +1,360 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import './GitPublishDialog.css'
+import { useFocusTrap } from '../hooks/useFocusTrap'
+import {
+  DEFAULT_VISIBILITY,
+  secretWarning,
+  splitOwnerAndName,
+  validateRepoName,
+  type GitVisibility
+} from '../../../shared/git-publish'
+import type { GitPublishOptions, GitPublishPreflight } from '../../../preload/index.d'
+
+/**
+ * PUBLISH TO GITHUB (issue #795)
+ * ==============================
+ *
+ * The dialog behind the Source Control panel's **Publish to GitHub** button:
+ * pick a name, a description and who can see it, and Snakie runs
+ * `gh repo create --source … --push` in the main process.
+ *
+ * Three things shape this component, all of them because publishing is a
+ * single click that cannot really be taken back:
+ *
+ *  1. **Every reason it could fail is shown BEFORE the form.** The preflight
+ *     runs while the dialog opens, so "gh isn't installed" or "you have no
+ *     commits yet" appears instead of the form — not after the user has typed a
+ *     description and pressed a button.
+ *  2. **Private is the default**, and public is a deliberate second click. See
+ *     `DEFAULT_VISIBILITY` for why that is a safety decision and not a
+ *     preference.
+ *  3. **The name is validated as it is typed**, using the same helper the main
+ *     process guards with, so the dialog can never accept something `gh` will
+ *     reject.
+ */
+
+interface GitPublishDialogProps {
+  /** Repository root being published, for the "what am I publishing" line. */
+  repoPath: string
+  /** Called with the collected options when the user confirms. */
+  onPublish: (options: GitPublishOptions) => Promise<void>
+  /** Close without publishing. */
+  onCancel: () => void
+}
+
+export function GitPublishDialog({
+  repoPath,
+  onPublish,
+  onCancel
+}: GitPublishDialogProps): JSX.Element {
+  const [preflight, setPreflight] = useState<GitPublishPreflight | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [visibility, setVisibility] = useState<GitVisibility>(DEFAULT_VISIBILITY)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const nameRef = useRef<HTMLInputElement>(null)
+  const dialogRef = useFocusTrap<HTMLDivElement>(true)
+
+  /** Ask the main process what it knows, and seed the name from the folder. */
+  const load = useCallback(async (): Promise<void> => {
+    setLoading(true)
+    setLoadError(null)
+    try {
+      const result = await window.api.git.publishPreflight()
+      setPreflight(result)
+      // Only seed the name the first time: re-checking after a `gh auth login`
+      // must not throw away a name the user has already typed.
+      setName((current) => current || result.suggestedName)
+    } catch (err) {
+      setLoadError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  // Focus the name field once the form is actually on screen (not while the
+  // preflight is still running, and not when it came back with blockers).
+  const ready = !loading && !loadError && preflight !== null && preflight.blockers.length === 0
+  useEffect(() => {
+    if (ready) {
+      const input = nameRef.current
+      input?.focus()
+      input?.select()
+    }
+  }, [ready])
+
+  const check = useMemo(() => validateRepoName(name), [name])
+  const owner = useMemo(() => splitOwnerAndName(name).owner, [name])
+
+  // The secrets warning is shown ONLY for a public repo: on a private one these
+  // same files are not exposed to anyone, and warning anyway would be the kind
+  // of noise that teaches people to ignore the box.
+  const risk = useMemo(
+    () => (visibility === 'public' ? secretWarning(preflight?.riskyPaths ?? []) : undefined),
+    [visibility, preflight]
+  )
+
+  /** Where this will land, spelled out so the destination is never a surprise. */
+  const destination = useMemo(() => {
+    if (!check.ok) return null
+    const account = owner ?? preflight?.account
+    const { name: bare } = splitOwnerAndName(name)
+    return account ? `${account}/${bare}` : bare
+  }, [check.ok, owner, preflight, name])
+
+  const submit = useCallback(async (): Promise<void> => {
+    if (!check.ok || busy) return
+    setBusy(true)
+    setError(null)
+    try {
+      await onPublish({ name: name.trim(), description: description.trim(), visibility })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+      setBusy(false)
+    }
+  }, [check.ok, busy, name, description, visibility, onPublish])
+
+  const folder = repoPath.split(/[\\/]/).filter(Boolean).pop() ?? repoPath
+
+  return (
+    <div
+      className="gh-pub__overlay"
+      onMouseDown={(e) => {
+        // Backdrop click cancels — but never mid-publish, when the repository
+        // may already exist on GitHub and closing would hide the outcome.
+        if (e.target === e.currentTarget && !busy) onCancel()
+      }}
+    >
+      <div
+        className="gh-pub"
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="gh-pub-title"
+        onKeyDown={(e) => {
+          if (e.key === 'Escape' && !busy) {
+            e.preventDefault()
+            onCancel()
+          }
+        }}
+      >
+        <h2 className="gh-pub__title" id="gh-pub-title">
+          Publish to GitHub
+        </h2>
+
+        {loading && <p className="gh-pub__note">Checking GitHub CLI…</p>}
+
+        {loadError && (
+          <>
+            <p className="gh-pub__error" role="alert">
+              {loadError}
+            </p>
+            <div className="gh-pub__actions">
+              <button type="button" className="gh-pub__btn" onClick={onCancel}>
+                Close
+              </button>
+              <button
+                type="button"
+                className="gh-pub__btn gh-pub__btn--primary"
+                onClick={() => void load()}
+              >
+                Try again
+              </button>
+            </div>
+          </>
+        )}
+
+        {/* Blocked: show WHY instead of a form that cannot be submitted. Each
+            blocker is a sentence with the next action in it, so this state is
+            a set of instructions rather than a dead end. */}
+        {!loading && !loadError && preflight && preflight.blockers.length > 0 && (
+          <>
+            <p className="gh-pub__note">
+              Snakie can&apos;t publish <code>{folder}</code> yet:
+            </p>
+            <ul className="gh-pub__blockers">
+              {preflight.blockers.map((blocker) => (
+                <li key={blocker}>{blocker}</li>
+              ))}
+            </ul>
+            <div className="gh-pub__actions">
+              <button type="button" className="gh-pub__btn" onClick={onCancel}>
+                Close
+              </button>
+              <button
+                type="button"
+                className="gh-pub__btn gh-pub__btn--primary"
+                onClick={() => void load()}
+              >
+                Re-check
+              </button>
+            </div>
+          </>
+        )}
+
+        {ready && preflight && (
+          <>
+            <p className="gh-pub__note">
+              Publishing <code>{folder}</code>
+              {preflight.account && (
+                <>
+                  {' '}
+                  as <strong>{preflight.account}</strong>
+                </>
+              )}
+              . Snakie uses the GitHub CLI, so it never sees your GitHub password or token.
+            </p>
+
+            <label className="gh-pub__label" htmlFor="gh-pub-name">
+              Repository name
+            </label>
+            <input
+              id="gh-pub-name"
+              ref={nameRef}
+              className="gh-pub__input"
+              type="text"
+              value={name}
+              disabled={busy}
+              spellCheck={false}
+              autoComplete="off"
+              placeholder="my-robot"
+              aria-invalid={!check.ok}
+              aria-describedby="gh-pub-name-help"
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && check.ok) {
+                  e.preventDefault()
+                  void submit()
+                }
+              }}
+            />
+            <p className="gh-pub__help" id="gh-pub-name-help">
+              {check.ok ? (
+                destination ? (
+                  <>
+                    Will be created as <code>{destination}</code>. Type{' '}
+                    <code>owner/name</code> to publish under an organisation.
+                  </>
+                ) : (
+                  <>
+                    Type <code>owner/name</code> to publish under an organisation.
+                  </>
+                )
+              ) : (
+                <span className="gh-pub__invalid">{check.error}</span>
+              )}
+            </p>
+
+            <label className="gh-pub__label" htmlFor="gh-pub-desc">
+              Description <span className="gh-pub__optional">(optional)</span>
+            </label>
+            <input
+              id="gh-pub-desc"
+              className="gh-pub__input"
+              type="text"
+              value={description}
+              disabled={busy}
+              placeholder="A line-following robot in MicroPython"
+              onChange={(e) => setDescription(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && check.ok) {
+                  e.preventDefault()
+                  void submit()
+                }
+              }}
+            />
+
+            <fieldset className="gh-pub__visibility" disabled={busy}>
+              <legend className="gh-pub__label">Who can see it</legend>
+              <label className="gh-pub__radio">
+                <input
+                  type="radio"
+                  name="gh-pub-visibility"
+                  value="private"
+                  checked={visibility === 'private'}
+                  onChange={() => setVisibility('private')}
+                />
+                <span>
+                  <strong>Private</strong>
+                  <span className="gh-pub__radio-note">
+                    Only you (and anyone you invite) can see it. You can make it public later.
+                  </span>
+                </span>
+              </label>
+              <label className="gh-pub__radio">
+                <input
+                  type="radio"
+                  name="gh-pub-visibility"
+                  value="public"
+                  checked={visibility === 'public'}
+                  onChange={() => setVisibility('public')}
+                />
+                <span>
+                  <strong>Public</strong>
+                  <span className="gh-pub__radio-note">
+                    Anyone on the internet can see this repository and its whole history.
+                  </span>
+                </span>
+              </label>
+            </fieldset>
+
+            {/* Named files, not a count — "1 risky file" is not something
+                anyone can act on. Deliberately does not block: a .pem may well
+                be a public certificate, and this is the user's project. */}
+            {risk && (
+              <p className="gh-pub__warn" role="alert">
+                {risk}
+              </p>
+            )}
+
+            {error && (
+              <p className="gh-pub__error" role="alert">
+                {error}
+              </p>
+            )}
+
+            <div className="gh-pub__actions">
+              <button
+                type="button"
+                className="gh-pub__btn"
+                disabled={busy}
+                onClick={onCancel}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="gh-pub__btn gh-pub__btn--primary"
+                disabled={busy || !check.ok}
+                title={
+                  check.ok
+                    ? `Create ${destination ?? name} on GitHub and push this branch`
+                    : check.error
+                }
+                onClick={() => void submit()}
+              >
+                {busy ? 'Publishing…' : `Publish ${visibility === 'public' ? 'public' : 'private'} repository`}
+              </button>
+            </div>
+
+            {/* A first push uploads the whole history — on a project full of
+                meshes that is genuinely slow, and silence would read as a hang. */}
+            {busy && (
+              <p className="gh-pub__note gh-pub__note--busy">
+                Creating the repository and pushing your commits. A first push sends the whole
+                history, so this can take a minute on a large project.
+              </p>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/lib/preloadFallback.ts
+++ b/src/renderer/src/lib/preloadFallback.ts
@@ -289,7 +289,8 @@ if (!w.api) {
         behind: 0,
         staged: [],
         changed: [],
-        untracked: []
+        untracked: [],
+        remotes: []
       }),
       stage: P(undefined),
       unstage: P(undefined),
@@ -300,7 +301,19 @@ if (!w.api) {
       listBranches: P({ current: '', branches: [] }),
       checkout: P(undefined),
       push: P({ summary: '' }),
-      pull: P({ summary: '' })
+      pull: P({ summary: '' }),
+      // The web build has no local git and no `gh`, so Publish is never
+      // offered there (#795). The stub still reports WHY rather than resolving
+      // an empty shape, so a stray call reads as a sentence, not as a dialog
+      // that opens on nothing.
+      publishPreflight: P({
+        ghInstalled: false,
+        authenticated: false,
+        suggestedName: '',
+        hasCommits: false,
+        riskyPaths: [],
+        blockers: ['Publishing to GitHub needs the desktop app.']
+      })
     }
   }
 

--- a/src/shared/git-publish.ts
+++ b/src/shared/git-publish.ts
@@ -1,0 +1,329 @@
+/**
+ * Pure helpers behind the Source Control panel's "Publish to GitHub" button (#795).
+ *
+ * Lives in `shared/` for the same reason `git-stage.ts` does: BOTH sides need
+ * the same answers. The renderer validates the name as it is typed and warns
+ * about what a public repo would expose; the main process builds the actual
+ * `gh` argv and guards the call. If those two disagreed, the dialog would
+ * accept a name that `gh` then rejects — or, far worse, promise "private" and
+ * pass a flag that means something else.
+ *
+ * Deliberately free of `child_process`, `fs` and Electron so it is directly
+ * unit-testable (the shape `main/git/init-support.ts` established for #783).
+ */
+
+/**
+ * Who can see the new repository.
+ *
+ * `internal` is deliberately NOT offered: it only exists inside a GitHub
+ * Enterprise organisation, and an option that errors for almost every user of
+ * this app is worse than no option at all.
+ */
+export type GitVisibility = 'private' | 'public'
+
+/**
+ * The default a fresh dialog opens on — **private**.
+ *
+ * This is a safety default, not a neutral one. Snakie's users are people
+ * writing robot code on microcontrollers, and the MicroPython idiom for Wi-Fi
+ * credentials is a plain `secrets.py` sitting next to `main.py`. Publishing is
+ * one click and effectively irreversible — a public commit is scraped, forked
+ * and cached within minutes, so "delete the repo" does not un-publish a
+ * password. Making the user opt IN to public costs one click; making them opt
+ * out costs them their network.
+ */
+export const DEFAULT_VISIBILITY: GitVisibility = 'private'
+
+/** GitHub's own cap on a repository name. */
+export const MAX_REPO_NAME = 100
+
+/** GitHub's cap on an owner (user or organisation) login. */
+export const MAX_OWNER = 39
+
+/** What the user typed, split into its optional owner and its repository name. */
+export interface OwnerAndName {
+  /** The `org/` part, when one was typed. Undefined means "my own account". */
+  owner?: string
+  /** The repository name itself. */
+  name: string
+}
+
+/**
+ * Split `OWNER/NAME` into its parts. A bare name has no owner, which `gh`
+ * reads as "the authenticated user" — the same rule its own CLI documents.
+ */
+export function splitOwnerAndName(input: string): OwnerAndName {
+  const trimmed = input.trim()
+  const slash = trimmed.indexOf('/')
+  if (slash < 0) return { name: trimmed }
+  return { owner: trimmed.slice(0, slash).trim(), name: trimmed.slice(slash + 1).trim() }
+}
+
+/**
+ * Turn a folder name into a plausible repository name.
+ *
+ * GitHub accepts only letters, digits, `.`, `-` and `_`; a folder called
+ * "Line Follower (v2)" is a perfectly ordinary thing to have on disk and a
+ * name GitHub will reject. Rather than fail on submit, offer the sanitised
+ * form up front so the dialog opens on something that already works.
+ *
+ * Case is preserved — GitHub preserves it too, and silently lower-casing
+ * someone's "PicoRover" would be a small unasked-for edit to their project's
+ * identity.
+ */
+export function suggestRepoName(folderName: string): string {
+  const cleaned = (folderName ?? '')
+    .trim()
+    // Every run of unsupported characters becomes ONE hyphen, so "Line
+    // Follower (v2)" reads as "Line-Follower-v2" rather than a hyphen thicket.
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .replace(/-{2,}/g, '-')
+    // Leading/trailing punctuation is legal but looks like a mistake, and a
+    // name of only dots is rejected outright.
+    .replace(/^[-._]+/, '')
+    .replace(/[-._]+$/, '')
+    .slice(0, MAX_REPO_NAME)
+  return cleaned
+}
+
+/** The outcome of checking a typed name, ready to render beside the input. */
+export interface NameCheck {
+  /** True when `gh` would accept this name. */
+  ok: boolean
+  /** Why not, as a sentence — present only when `ok` is false. */
+  error?: string
+}
+
+/**
+ * Validate what the user typed, owner prefix included.
+ *
+ * Checked HERE rather than left to `gh` because a rejection that arrives after
+ * the click has already created nothing, said "HTTP 422", and lost the user's
+ * description is a much worse experience than a line of red under the field.
+ */
+export function validateRepoName(input: string): NameCheck {
+  const raw = (input ?? '').trim()
+  if (!raw) return { ok: false, error: 'Give the repository a name.' }
+
+  const { owner, name } = splitOwnerAndName(raw)
+
+  if (raw.split('/').length > 2) {
+    return {
+      ok: false,
+      error: 'Use either "name" or "owner/name" — a repository name cannot contain a slash.'
+    }
+  }
+
+  if (owner !== undefined) {
+    if (!owner) return { ok: false, error: 'Type an owner before the slash, or drop the slash.' }
+    if (owner.length > MAX_OWNER) {
+      return { ok: false, error: `An owner name can be at most ${MAX_OWNER} characters.` }
+    }
+    if (!/^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$/.test(owner)) {
+      return {
+        ok: false,
+        error: 'An owner is letters, digits and hyphens, and cannot start or end with a hyphen.'
+      }
+    }
+  }
+
+  if (!name) return { ok: false, error: 'Give the repository a name after the slash.' }
+  if (name.length > MAX_REPO_NAME) {
+    return { ok: false, error: `A repository name can be at most ${MAX_REPO_NAME} characters.` }
+  }
+  if (name === '.' || name === '..') {
+    return { ok: false, error: 'GitHub does not allow "." or ".." as a repository name.' }
+  }
+  if (!/^[A-Za-z0-9._-]+$/.test(name)) {
+    return {
+      ok: false,
+      error: 'Use letters, digits, dots, hyphens and underscores only — no spaces.'
+    }
+  }
+  return { ok: true }
+}
+
+/** Everything `gh repo create` needs, already validated. */
+export interface PublishInput {
+  /** `NAME` or `OWNER/NAME`, exactly as the dialog resolved it. */
+  name: string
+  /** Optional one-line description. Empty means "send no description". */
+  description?: string
+  /** Who can see it. */
+  visibility: GitVisibility
+  /** Absolute path of the local repository to publish. */
+  source: string
+  /** Remote name to create. `origin` unless something already owns it. */
+  remote?: string
+}
+
+/**
+ * The exact `gh` argv for a publish — no shell, one array element per argument.
+ *
+ * Built here, and unit-tested, for two reasons. The visibility flag is the
+ * whole promise of the dialog's radio button, so it is worth an assertion that
+ * `private` produces `--private` and nothing else. And keeping this as an argv
+ * (never a command string) is what makes a repository named `foo; rm -rf ~`
+ * merely an invalid name rather than an executed one.
+ */
+export function publishArgs(input: PublishInput): string[] {
+  const args = [
+    'repo',
+    'create',
+    input.name.trim(),
+    '--source',
+    input.source,
+    '--remote',
+    input.remote?.trim() || 'origin',
+    '--push',
+    input.visibility === 'public' ? '--public' : '--private'
+  ]
+  const description = (input.description ?? '').trim()
+  if (description) args.push('--description', description)
+  return args
+}
+
+/**
+ * File names that would be a bad thing to make public, checked against the
+ * files git is ALREADY TRACKING (an untracked file is never pushed).
+ *
+ * The list is short and high-signal on purpose. A scanner that cried wolf over
+ * every `config.py` would train people to click through the warning, which is
+ * the one outcome that makes this worse than having no warning at all.
+ * `secrets.py` leads the list because it is not a guess — it is the documented
+ * MicroPython convention for Wi-Fi credentials, so on this app's projects it is
+ * very often a real password.
+ */
+const RISKY_BASENAMES = new Set([
+  'secrets.py',
+  'secrets.json',
+  'secrets.yml',
+  'secrets.yaml',
+  'credentials.py',
+  'credentials.json',
+  'id_rsa',
+  'id_ecdsa',
+  'id_ed25519',
+  '.netrc',
+  '.npmrc'
+])
+
+/** Extensions that are private keys or key stores almost by definition. */
+const RISKY_EXTENSIONS = ['.pem', '.key', '.p12', '.pfx', '.keystore']
+
+/**
+ * The tracked paths worth a second look before going public.
+ *
+ * Takes repo-relative paths (`git ls-files`) and returns the subset that names
+ * a well-known credential file. Pure string work — it never opens a file, so it
+ * cannot itself become a way to leak one.
+ */
+export function secretRisks(paths: readonly string[]): string[] {
+  const hits: string[] = []
+  for (const path of paths) {
+    if (!path) continue
+    const base = (path.split('/').pop() ?? path).toLowerCase()
+    const risky =
+      RISKY_BASENAMES.has(base) ||
+      base === '.env' ||
+      base.startsWith('.env.') ||
+      RISKY_EXTENSIONS.some((ext) => base.endsWith(ext))
+    if (risky) hits.push(path)
+  }
+  return hits
+}
+
+/** English pluralisation for the small counts this feature deals in. */
+function plural(count: number, one: string, many: string): string {
+  return count === 1 ? one : many
+}
+
+/**
+ * The sentence shown when a public publish would include credential-shaped
+ * files. It names them, because "1 risky file" is not something anyone can act
+ * on, and it stops short of blocking: the user may well have a `.pem` that is a
+ * public certificate, and Snakie does not get to overrule them about their own
+ * files.
+ */
+export function secretWarning(paths: readonly string[]): string | undefined {
+  if (paths.length === 0) return undefined
+  const shown = paths.slice(0, 4).join(', ')
+  const rest = paths.length > 4 ? `, and ${paths.length - 4} more` : ''
+  return (
+    `This repository tracks ${paths.length} ${plural(paths.length, 'file', 'files')} that usually ` +
+    `${plural(paths.length, 'holds', 'hold')} secrets: ${shown}${rest}. ` +
+    'A public repository is scraped and cached within minutes, so anything committed here ' +
+    'should be treated as leaked even if you delete it afterwards. Publish privately, or ' +
+    'remove them from the repository first.'
+  )
+}
+
+/** The shape {@link publishSummary} needs; a subset of `GitPublishResult`. */
+export interface PublishSummaryInput {
+  /** `owner/name` as GitHub created it. */
+  fullName: string
+  visibility: GitVisibility
+  /** Branch that was pushed, when one was. */
+  branch?: string
+  /** Remote name that now points at GitHub. */
+  remote: string
+}
+
+/**
+ * The one-line report shown after a successful publish. It names the repo, says
+ * plainly whether it is public, and names the branch that was pushed — the
+ * three things a user needs to confirm the click did what the dialog promised.
+ */
+export function publishSummary(input: PublishSummaryInput): string {
+  const where = input.visibility === 'public' ? 'public' : 'private'
+  const branch = input.branch ? `, pushed ${input.branch}` : ''
+  return `Published ${input.fullName} as a ${where} repository${branch} (remote "${input.remote}").`
+}
+
+/**
+ * Turn a raw `gh` failure into a sentence the user can act on.
+ *
+ * The two cases that matter both look like a Snakie bug when passed through
+ * raw: a missing binary surfaces as `spawn gh ENOENT`, and an unauthenticated
+ * CLI as a wall of usage text. Everything else is passed through, because a
+ * real GitHub error ("Name already exists on this account") is far more useful
+ * than a paraphrase of it. Mirrors `gitFailureText` in `init-support.ts`.
+ */
+export function ghFailureText(err: unknown): string {
+  const text = (err instanceof Error ? err.message : String(err)).trim()
+
+  const missing =
+    /spawn\s+gh\b.*ENOENT/i.test(text) ||
+    /ENOENT.*\bgh\b/i.test(text) ||
+    /'gh' is not recognized/i.test(text) ||
+    /gh: command not found/i.test(text)
+  if (missing) {
+    return (
+      'The GitHub CLI (gh) is not installed on this computer (or is not on its PATH). ' +
+      'Snakie publishes through gh so it never has to ask for your GitHub password — ' +
+      'install it from https://cli.github.com, then restart Snakie and try again.'
+    )
+  }
+
+  const unauthenticated =
+    /not logged in(to| to)? any GitHub hosts/i.test(text) ||
+    /gh auth login/i.test(text) ||
+    /authentication token not found/i.test(text) ||
+    /requires authentication/i.test(text)
+  if (unauthenticated) {
+    return (
+      'The GitHub CLI is not signed in to GitHub. Open a terminal, run `gh auth login`, ' +
+      'follow the prompts, then come back and try again. (Snakie cannot run that sign-in ' +
+      'for you — it is interactive on purpose, so your credentials only ever go to GitHub.)'
+    )
+  }
+
+  if (/name already exists on this account/i.test(text)) {
+    return (
+      'You already have a repository with that name on GitHub. ' +
+      'Pick a different name, or delete the existing repository first.'
+    )
+  }
+
+  return text
+}

--- a/test/gitPublish.test.ts
+++ b/test/gitPublish.test.ts
@@ -1,0 +1,520 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { GitService } from '../src/main/git/GitService'
+import {
+  DEFAULT_VISIBILITY,
+  ghFailureText,
+  publishArgs,
+  publishSummary,
+  secretRisks,
+  secretWarning,
+  splitOwnerAndName,
+  suggestRepoName,
+  validateRepoName
+} from '../src/shared/git-publish'
+
+/**
+ * #795 — "Publish to GitHub" in the Source Control pane.
+ *
+ * The button creates a repository on someone's real GitHub account and pushes
+ * their code to it, so the promises worth pinning down are the ones that would
+ * be expensive to get wrong:
+ *
+ *  - **The visibility flag means what the radio button said.** `private` must
+ *    produce `--private` and nothing else — an inverted flag here publishes
+ *    someone's Wi-Fi password to the internet.
+ *  - **A name is never interpolated into a shell.** Everything is an argv, so a
+ *    repository called `foo; rm -rf ~` is an invalid name, not a command.
+ *  - **The secrets warning fires on the files that matter and stays quiet
+ *    otherwise** — a warning that cries wolf is one people click through.
+ *  - **Publishing refuses the states that would leave a mess**: no commits (an
+ *    empty repo on GitHub), an existing remote (a second home for the same
+ *    project), an invalid name.
+ *  - The failure modes (no `gh`, signed out, name taken) come back as sentences.
+ *
+ * The repository half runs the REAL {@link GitService} against real temp folders
+ * and the real `git` binary — the same seam `gitInit.test.ts` (#783) and
+ * `gitStageAll.test.ts` (#794) use. Nothing here ever calls `gh`: every test
+ * that would reach the network stops at a guard that fires first, which is
+ * precisely the behaviour being asserted.
+ */
+
+/** True when a real `git` is on PATH; the repo-level suite needs one. */
+function haveGit(): boolean {
+  try {
+    execFileSync('git', ['--version'], { stdio: 'ignore' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Run git in `dir`, returning trimmed stdout. Throws on a non-zero exit. */
+function git(dir: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd: dir,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'ignore']
+  }).trim()
+}
+
+const roots: string[] = []
+
+/** A committed repository, the normal starting point for a publish. */
+function committedRepo(): string {
+  // realpath: macOS temp dirs are symlinks (/var → /private/var) and git always
+  // reports the resolved path, so compare like with like.
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), 'snakie-795-')))
+  roots.push(dir)
+  writeFileSync(join(dir, 'main.py'), 'print("hello")\n')
+  git(dir, ['init'])
+  git(dir, ['config', 'user.email', 'test@example.com'])
+  git(dir, ['config', 'user.name', 'Test'])
+  git(dir, ['add', 'main.py'])
+  git(dir, ['commit', '-m', 'initial'])
+  return dir
+}
+
+afterAll(() => {
+  for (const dir of roots) rmSync(dir, { recursive: true, force: true })
+})
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+describe('suggestRepoName', () => {
+  it('turns an ordinary folder name into one GitHub will accept', () => {
+    expect(suggestRepoName('Line Follower (v2)')).toBe('Line-Follower-v2')
+    expect(suggestRepoName('my robot!!')).toBe('my-robot')
+  })
+
+  it('preserves case, rather than quietly renaming the user’s project', () => {
+    expect(suggestRepoName('PicoRover')).toBe('PicoRover')
+  })
+
+  it('keeps the characters GitHub allows', () => {
+    expect(suggestRepoName('pico-rover_v2.1')).toBe('pico-rover_v2.1')
+  })
+
+  it('trims punctuation that would look like a mistake', () => {
+    expect(suggestRepoName('--rover--')).toBe('rover')
+    expect(suggestRepoName('.hidden')).toBe('hidden')
+  })
+
+  it('collapses a run of bad characters into ONE hyphen', () => {
+    expect(suggestRepoName('a   b')).toBe('a-b')
+    expect(suggestRepoName('a @#$ b')).toBe('a-b')
+  })
+
+  it('survives a folder name with nothing usable in it', () => {
+    expect(suggestRepoName('!!!')).toBe('')
+    expect(suggestRepoName('')).toBe('')
+  })
+
+  it('never exceeds GitHub’s length cap', () => {
+    expect(suggestRepoName('x'.repeat(200))).toHaveLength(100)
+  })
+})
+
+describe('splitOwnerAndName', () => {
+  it('reads a bare name as "my own account"', () => {
+    expect(splitOwnerAndName('rover')).toEqual({ name: 'rover' })
+  })
+
+  it('splits an owner prefix', () => {
+    expect(splitOwnerAndName('kevsrobots/rover')).toEqual({
+      owner: 'kevsrobots',
+      name: 'rover'
+    })
+  })
+})
+
+describe('validateRepoName', () => {
+  it('accepts the names GitHub accepts', () => {
+    for (const name of ['rover', 'pico-rover', 'pico_rover', 'rover.v2', 'org/rover']) {
+      expect(validateRepoName(name).ok, name).toBe(true)
+    }
+  })
+
+  it('rejects an empty name with something the user can act on', () => {
+    const check = validateRepoName('   ')
+    expect(check.ok).toBe(false)
+    expect(check.error).toMatch(/name/i)
+  })
+
+  it('rejects a space, which is the mistake people actually make', () => {
+    const check = validateRepoName('my robot')
+    expect(check.ok).toBe(false)
+    expect(check.error).toMatch(/no spaces/i)
+  })
+
+  it('rejects shell metacharacters as an invalid NAME (they never reach a shell)', () => {
+    expect(validateRepoName('foo; rm -rf ~').ok).toBe(false)
+    expect(validateRepoName('foo$(whoami)').ok).toBe(false)
+    expect(validateRepoName('foo`id`').ok).toBe(false)
+  })
+
+  it('rejects a second slash rather than guessing which half is the owner', () => {
+    const check = validateRepoName('a/b/c')
+    expect(check.ok).toBe(false)
+    expect(check.error).toMatch(/owner\/name/i)
+  })
+
+  it('rejects the names GitHub reserves', () => {
+    expect(validateRepoName('.').ok).toBe(false)
+    expect(validateRepoName('..').ok).toBe(false)
+  })
+
+  it('enforces the length caps', () => {
+    expect(validateRepoName('x'.repeat(100)).ok).toBe(true)
+    expect(validateRepoName('x'.repeat(101)).ok).toBe(false)
+    expect(validateRepoName(`${'o'.repeat(40)}/rover`).ok).toBe(false)
+  })
+
+  it('rejects an owner that starts or ends with a hyphen, as GitHub does', () => {
+    expect(validateRepoName('-org/rover').ok).toBe(false)
+    expect(validateRepoName('org-/rover').ok).toBe(false)
+    expect(validateRepoName('o-rg/rover').ok).toBe(true)
+  })
+
+  it('rejects a bare slash and an empty half', () => {
+    expect(validateRepoName('/rover').ok).toBe(false)
+    expect(validateRepoName('org/').ok).toBe(false)
+  })
+})
+
+describe('publishArgs', () => {
+  const base = { name: 'rover', source: '/tmp/rover', visibility: 'private' as const }
+
+  it('sends --private for a private repository, and never --public', () => {
+    const args = publishArgs(base)
+    expect(args).toContain('--private')
+    expect(args).not.toContain('--public')
+  })
+
+  it('sends --public only when public was actually chosen', () => {
+    const args = publishArgs({ ...base, visibility: 'public' })
+    expect(args).toContain('--public')
+    expect(args).not.toContain('--private')
+  })
+
+  it('defaults to private for anything that is not the literal "public"', () => {
+    // The dialog is typed, but this value crosses IPC — a missing or mangled
+    // field must fail CLOSED, towards the repository nobody can read.
+    const args = publishArgs({ ...base, visibility: 'PUBLIC' as never })
+    expect(args).toContain('--private')
+  })
+
+  it('matches the default the dialog opens on', () => {
+    expect(DEFAULT_VISIBILITY).toBe('private')
+    expect(publishArgs({ ...base, visibility: DEFAULT_VISIBILITY })).toContain('--private')
+  })
+
+  it('publishes from the given source and pushes', () => {
+    const args = publishArgs(base)
+    expect(args.slice(0, 3)).toEqual(['repo', 'create', 'rover'])
+    expect(args[args.indexOf('--source') + 1]).toBe('/tmp/rover')
+    expect(args).toContain('--push')
+    expect(args[args.indexOf('--remote') + 1]).toBe('origin')
+  })
+
+  it('omits --description entirely when there is none, rather than sending ""', () => {
+    expect(publishArgs(base)).not.toContain('--description')
+    expect(publishArgs({ ...base, description: '   ' })).not.toContain('--description')
+  })
+
+  it('passes a description as its OWN argv element, so quoting is impossible', () => {
+    const args = publishArgs({ ...base, description: 'A robot; rm -rf ~' })
+    expect(args[args.indexOf('--description') + 1]).toBe('A robot; rm -rf ~')
+  })
+
+  it('keeps every argument separate, so nothing can be read as a command', () => {
+    const args = publishArgs({
+      ...base,
+      name: 'rover',
+      source: '/tmp/a folder with spaces',
+      description: '$(whoami)'
+    })
+    // No element is a joined command line, and the awkward values survive whole.
+    expect(args).toContain('/tmp/a folder with spaces')
+    expect(args).toContain('$(whoami)')
+    for (const arg of args) expect(arg).not.toMatch(/\s--\w/)
+  })
+})
+
+describe('secretRisks', () => {
+  it('flags the MicroPython credentials file by name', () => {
+    expect(secretRisks(['main.py', 'secrets.py'])).toEqual(['secrets.py'])
+  })
+
+  it('flags it in a subfolder too, and reports the full path', () => {
+    expect(secretRisks(['lib/secrets.py'])).toEqual(['lib/secrets.py'])
+  })
+
+  it('flags dotenv files, including the suffixed variants', () => {
+    expect(secretRisks(['.env', '.env.local', '.environment'])).toEqual(['.env', '.env.local'])
+  })
+
+  it('flags private keys and key stores by extension', () => {
+    expect(secretRisks(['server.pem', 'wifi.key', 'store.p12'])).toHaveLength(3)
+  })
+
+  it('is case-insensitive, because Windows and macOS are', () => {
+    expect(secretRisks(['Secrets.PY'])).toEqual(['Secrets.PY'])
+  })
+
+  it('stays quiet about ordinary project files', () => {
+    expect(
+      secretRisks(['main.py', 'robot.yml', 'arm.urdf', 'meshes/wheel.stl', 'config.py', 'README.md'])
+    ).toEqual([])
+  })
+
+  it('does not flag a file merely because "secret" appears in its name', () => {
+    // Cry-wolf guard: the list is exact basenames, not a substring search.
+    expect(secretRisks(['secret_santa.py', 'no-secrets-here.md'])).toEqual([])
+  })
+})
+
+describe('secretWarning', () => {
+  it('says nothing when there is nothing to say', () => {
+    expect(secretWarning([])).toBeUndefined()
+  })
+
+  it('names the files, because a count is not actionable', () => {
+    const warning = secretWarning(['secrets.py'])
+    expect(warning).toContain('secrets.py')
+  })
+
+  it('explains that deleting afterwards does not un-publish', () => {
+    expect(secretWarning(['secrets.py'])).toMatch(/leaked|cached|scraped/i)
+  })
+
+  it('summarises a long list rather than printing all of it', () => {
+    const warning = secretWarning(['a.pem', 'b.pem', 'c.pem', 'd.pem', 'e.pem', 'f.pem']) ?? ''
+    expect(warning).toContain('and 2 more')
+  })
+})
+
+describe('publishSummary', () => {
+  it('states the visibility in words, so the outcome can be checked', () => {
+    expect(
+      publishSummary({ fullName: 'kev/rover', visibility: 'public', branch: 'main', remote: 'origin' })
+    ).toContain('public')
+    expect(
+      publishSummary({ fullName: 'kev/rover', visibility: 'private', branch: 'main', remote: 'origin' })
+    ).toContain('private')
+  })
+
+  it('names the repository and the branch it pushed', () => {
+    const summary = publishSummary({
+      fullName: 'kev/rover',
+      visibility: 'private',
+      branch: 'main',
+      remote: 'origin'
+    })
+    expect(summary).toContain('kev/rover')
+    expect(summary).toContain('main')
+  })
+})
+
+describe('ghFailureText', () => {
+  it('turns a missing gh binary into an actionable sentence with the install link', () => {
+    const text = ghFailureText(new Error('spawn gh ENOENT'))
+    expect(text).toMatch(/GitHub CLI/i)
+    expect(text).toContain('https://cli.github.com')
+  })
+
+  it('recognises the Windows shell wording for a missing gh', () => {
+    expect(ghFailureText("'gh' is not recognized as an internal or external command")).toMatch(
+      /not installed/i
+    )
+  })
+
+  it('turns a signed-out CLI into the exact command to run', () => {
+    const text = ghFailureText('You are not logged into any GitHub hosts. Run gh auth login')
+    expect(text).toContain('gh auth login')
+  })
+
+  it('explains that Snakie cannot do the sign-in for you', () => {
+    expect(ghFailureText('gh auth login')).toMatch(/interactive/i)
+  })
+
+  it('turns a taken name into advice rather than an HTTP code', () => {
+    const text = ghFailureText('GraphQL: Name already exists on this account (createRepository)')
+    expect(text).toMatch(/already have a repository with that name/i)
+  })
+
+  it('passes a real GitHub message through rather than paraphrasing it', () => {
+    expect(ghFailureText('HTTP 403: Resource not accessible by integration')).toContain('HTTP 403')
+  })
+
+  it('handles a non-Error rejection without losing the text', () => {
+    expect(ghFailureText('something odd happened')).toBe('something odd happened')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// IPC wiring
+// ---------------------------------------------------------------------------
+
+describe('git IPC registration', () => {
+  it('registers a handler for every git channel the preload invokes', async () => {
+    const handlers = new Set<string>()
+    vi.doMock('electron', () => ({
+      ipcMain: {
+        handle: (channel: string) => {
+          handlers.add(channel)
+        }
+      }
+    }))
+
+    const { registerGitIpc } = await import('../src/main/git/ipc')
+    registerGitIpc()
+
+    const preload = readFileSync(join(__dirname, '..', 'src', 'preload', 'index.ts'), 'utf-8')
+    const invoked = [...preload.matchAll(/ipcRenderer\.invoke\(\s*'(git:[^']+)'/g)].map((m) => m[1])
+
+    // Called out by name so a regression reads as "the publish button is dead"
+    // rather than as a count mismatch.
+    expect(invoked).toContain('git:publish')
+    expect(invoked).toContain('git:publishPreflight')
+    expect(handlers).toContain('git:publish')
+    expect(handlers).toContain('git:publishPreflight')
+    for (const channel of invoked) {
+      expect(handlers, `${channel} is invoked by the preload but never registered`).toContain(
+        channel
+      )
+    }
+
+    vi.doUnmock('electron')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Against a real git binary
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!haveGit())('GitService.publish guards, against a real git', () => {
+  let service: GitService
+
+  beforeEach(() => {
+    service = new GitService()
+  })
+
+  it('reports remotes in status, which is what decides the button', async () => {
+    const dir = committedRepo()
+    await service.openRepo(dir)
+    expect((await service.status()).remotes).toEqual([])
+
+    git(dir, ['remote', 'add', 'origin', 'https://example.com/x.git'])
+    expect((await service.status()).remotes).toEqual(['origin'])
+  })
+
+  it('refuses an invalid name before it can reach the network', async () => {
+    const dir = committedRepo()
+    await service.openRepo(dir)
+    await expect(
+      service.publish({ name: 'my robot', visibility: 'private' })
+    ).rejects.toThrow(/no spaces/i)
+  })
+
+  it('refuses to publish a repository that has no commits', async () => {
+    const dir = realpathSync(mkdtempSync(join(tmpdir(), 'snakie-795-empty-')))
+    roots.push(dir)
+    writeFileSync(join(dir, 'main.py'), 'print(1)\n')
+    git(dir, ['init'])
+    await service.openRepo(dir)
+
+    await expect(service.publish({ name: 'rover', visibility: 'private' })).rejects.toThrow(
+      /no commits yet/i
+    )
+  })
+
+  it('refuses to publish a repository that already has a remote, and names it', async () => {
+    const dir = committedRepo()
+    git(dir, ['remote', 'add', 'origin', 'https://example.com/x.git'])
+    await service.openRepo(dir)
+
+    await expect(service.publish({ name: 'rover', visibility: 'private' })).rejects.toThrow(
+      /already has a remote \("origin"\)/i
+    )
+  })
+
+  it('refuses when the folder is not a repository at all', async () => {
+    const dir = realpathSync(mkdtempSync(join(tmpdir(), 'snakie-795-plain-')))
+    roots.push(dir)
+    await service.openRepo(dir)
+
+    await expect(service.publish({ name: 'rover', visibility: 'private' })).rejects.toThrow(
+      /not a Git repository/i
+    )
+  })
+})
+
+describe.skipIf(!haveGit())('GitService.publishPreflight, against a real git', () => {
+  let service: GitService
+
+  beforeEach(() => {
+    service = new GitService()
+  })
+
+  it('suggests a name derived from the repository folder', async () => {
+    const dir = committedRepo()
+    await service.openRepo(dir)
+    const pre = await service.publishPreflight()
+    // The temp folder is `snakie-795-XXXXXX`, already a legal repo name.
+    expect(pre.suggestedName).toMatch(/^snakie-795-/)
+  })
+
+  it('blocks a repository with no commits, in words', async () => {
+    const dir = realpathSync(mkdtempSync(join(tmpdir(), 'snakie-795-pre-empty-')))
+    roots.push(dir)
+    git(dir, ['init'])
+    await service.openRepo(dir)
+
+    const pre = await service.publishPreflight()
+    expect(pre.hasCommits).toBe(false)
+    expect(pre.blockers.join(' ')).toMatch(/no commits yet/i)
+  })
+
+  it('blocks a repository that already has a remote, and names it', async () => {
+    const dir = committedRepo()
+    git(dir, ['remote', 'add', 'origin', 'https://example.com/x.git'])
+    await service.openRepo(dir)
+
+    const pre = await service.publishPreflight()
+    expect(pre.existingRemote).toBe('origin')
+    expect(pre.blockers.join(' ')).toMatch(/already has a remote/i)
+  })
+
+  it('finds tracked secrets, and ignores untracked and ignored ones', async () => {
+    const dir = committedRepo()
+    // Tracked — this one WOULD be pushed.
+    writeFileSync(join(dir, 'secrets.py'), 'WIFI_PASSWORD = "hunter2"\n')
+    git(dir, ['add', 'secrets.py'])
+    git(dir, ['commit', '-m', 'add secrets'])
+    // Untracked, and ignored — neither is ever pushed, so neither should warn.
+    writeFileSync(join(dir, '.env'), 'TOKEN=abc\n')
+    mkdirSync(join(dir, 'lib'), { recursive: true })
+    writeFileSync(join(dir, 'lib', 'credentials.py'), 'X = 1\n')
+    writeFileSync(join(dir, '.gitignore'), 'lib/credentials.py\n')
+
+    await service.openRepo(dir)
+    const pre = await service.publishPreflight()
+
+    expect(pre.riskyPaths).toContain('secrets.py')
+    expect(pre.riskyPaths).not.toContain('.env')
+    expect(pre.riskyPaths).not.toContain('lib/credentials.py')
+  })
+
+  it('reports a clean project as having nothing to warn about', async () => {
+    const dir = committedRepo()
+    await service.openRepo(dir)
+    expect((await service.publishPreflight()).riskyPaths).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #795.

Adds a **Publish to GitHub** button to the Source Control panel: name the repository, describe it, choose who can see it, and Snakie creates it on GitHub and pushes to it.

## Where it appears, and why there

A repository created with **Initialise Repository** (#783) had nowhere to go. The toolbar offered **Push** and **Pull** — both of which need a remote — so on a repo that had never been published it was showing two controls that could not do anything, and the way out was a terminal or the GitHub website plus a `git remote add` typed by hand.

Publish to GitHub takes their place in exactly that state. That swap is what makes it discoverable: the button appears where the dead ones were, and disappears again the moment a remote exists.

## Three decisions worth reviewing

**`gh` rather than the GitHub API.** Creating a repository needs a credential, and every alternative ends with Snakie holding one — a PAT typed into a Snakie field and stored by Snakie, or an OAuth flow Snakie implements and keeps secret. `gh` already keeps the token in the OS keychain, already handles refresh and 2FA, and is already what people use from a terminal. Snakie never sees the credential, so there is nothing here to leak. Sign-in stays interactive in the user's own terminal for the same reason.

**Private is the default — a safety decision, not a preference.** The MicroPython convention for Wi-Fi credentials is a plain `secrets.py` next to `main.py`, and a public repo is scraped, forked and cached within minutes; deleting it does not un-publish a password. Opting in to public costs one click, getting it wrong by default costs somebody their network.

Choosing public when the repo actually **tracks** a credentials-shaped file names those files first. It warns rather than blocks (a `.pem` may well be a public certificate, and it is the user's project), and it counts only tracked files, because an untracked or ignored one is never pushed. The basename list is short and exact for the same reason — a substring search that fired on `secret_santa.py` would train people to click through the box.

**Everything that could fail is checked before the form.** No `gh`, signed out, no commits yet, a remote already configured: each renders as a sentence with the next step in it, rather than arriving as an error after the user has typed a description and pressed the button. The service re-checks all of it at publish time too — the two are separated by however long the user spent typing, and unlike a stale button a stale publish creates a real repository on a real account.

## Implementation notes

- One `gh repo create --source --push` rather than three calls of our own. Any split leaves states that are hard to unpick: a repo on GitHub with no local remote, or a remote pointing at a repo that was never created.
- The result is read back with `repo view` rather than echoed from the flags, so an org policy that forces private when public was asked for is **reported**, not swallowed.
- The name rule lives in `shared/git-publish.ts` and is used by both sides — the dialog validates as you type with the same function the main process guards with, so it cannot accept something `gh` will reject. Same seam as `shared/git-stage.ts` (#794).
- Every value reaches `gh` as its own argv element, never a command string. That is what makes a repository named `foo; rm -rf ~` an invalid name rather than an executed one.
- Desktop only. The web build has no local git and no `gh`; its preload stub says so rather than resolving an empty shape.

## Tests

**57 new tests** in `test/gitPublish.test.ts`. The load-bearing ones:

- `private` produces `--private` and nothing else — an inverted flag here publishes someone's Wi-Fi password.
- An unrecognised visibility crossing IPC fails **closed**, towards private.
- The guards (no commits, existing remote, invalid name) all fire **before** anything can reach the network.
- The secrets check finds a tracked `secrets.py`, ignores untracked and gitignored ones, and stays quiet on ordinary project files.

The repository half runs the real `GitService` against real temp folders and the real `git` binary — the seam #783 and #794 established. Nothing in the suite ever calls `gh`.

Preflight was also verified against a live `gh` 2.89: version detected, account resolved, and this repo correctly blocked for already having `origin`.

## Gates

`lint` (one pre-existing warning in `DriverInstallBanner.tsx`), `typecheck`, `test` (5695 passing), `build` — all green.

No version bump: `package.json` is already `0.46.0`, a minor ahead of `v0.44.0`, and unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
