### PR TITLE
fix: the console pops out into a real window on the web (#810)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **The console pops out into a real window on the web app too.** (#810) The
+  sibling of #781, and a worse failure than it looked. On app.snakie.org the
+  pop-out control called `console.open`, which outside Electron landed on a stub
+  that did nothing — but the panel had *already* hidden the docked terminal
+  behind a "Console popped out to its own window" placeholder. So the console
+  vanished, no window appeared, **and the Redock button was dead too**: it asks
+  the window to close and then waits for the `console:closed` event to put the
+  console back, and that event could never arrive because its listener was a stub
+  as well. The console stayed gone for the rest of the session.
+
+  It now opens a real, resizable browser window — and a live one. As with an
+  instrument, a pop-up is its own JavaScript world, so a window that built its
+  own backend would be watching a second simulator (and a USB board can only be
+  open in one place at a time). Instead the editor tab lends the pop-out its own
+  device, so the detached console shows the same output *and* types back to the
+  same board. It opens seeded with the scrollback you already had rather than
+  blank, and closing it re-docks exactly as on the desktop.
+
+  Every route back to the dock now reports itself, because that event is the
+  console coming back: closing the window, clicking Redock, the browser blocking
+  the pop-up (the console re-docks and says why), and the window being closed
+  behind the editor's back. A reload is deliberately *not* treated as a close, so
+  refreshing a detached console doesn't re-dock a perfectly good one. If the
+  editor tab it belongs to is gone, the window says so instead of accepting
+  keystrokes that go nowhere.
+
+  Two smaller things came out of the same fix: `console.html` was missing from
+  the web build entirely, and the offline service worker would have answered its
+  navigation with the app shell — opening the whole editor inside a 760px window.
+  And the detached console now uses the Soft Shell fonts the rest of the app
+  does, which #781 had already corrected for instruments.
+
 ### Added
 - **Publish a project to GitHub without leaving Snakie.** (#795) A repository
   you created locally had nowhere to go: the Source Control panel offered

--- a/src/renderer/src/console-window-main.tsx
+++ b/src/renderer/src/console-window-main.tsx
@@ -9,9 +9,14 @@
  * popped-out console is fully interactive. Applies the persisted theme so it
  * matches the app (localStorage is shared per-origin).
  *
- * Note: this window's terminal is a FRESH xterm, so it shows the live stream from
- * pop-out onward rather than the docked console's prior scrollback (which is kept
- * intact in the main window for when you re-dock).
+ * In the WEB build (#810) this same page is a browser popup opened by the editor
+ * tab, and it runs on THAT tab's `window.api` — the same device, the same
+ * stream, one board (see `web/web-console.ts`). If the editor window is gone
+ * there is no board to read or write, so the window says so plainly instead of
+ * sitting on a terminal that silently accepts keystrokes going nowhere.
+ *
+ * Note: this window's terminal is a FRESH xterm seeded with the scrollback handed
+ * over at pop-out, so it redraws prior output and then follows the live stream.
  */
 
 // Install the preload-bridge fallback BEFORE anything renders (mirrors main.tsx).
@@ -19,21 +24,53 @@ import './lib/preloadFallback'
 import { useEffect, useState } from 'react'
 import ReactDOM from 'react-dom/client'
 import { Terminal } from './components/Terminal'
-import '@fontsource/jetbrains-mono'
+import { IS_WEB } from './lib/env'
+// Soft Shell fonts (#574) — the same faces the editor window loads, so a
+// detached console is typeset like its docked twin. (JetBrains Mono was the old
+// direction; #781 corrected the instrument window and this is its sibling.)
+import '@fontsource/ibm-plex-mono/400.css'
+import '@fontsource/ibm-plex-mono/500.css'
+import '@fontsource/ibm-plex-mono/600.css'
 import './index.css'
 
 /** Theme key shared with the editor window's `useTheme`. */
 const THEME_KEY = 'snakie.theme.v2'
 
+/** How often a web popup checks that its editor window is still there. */
+const HOST_CHECK_MS = 2000
+
 function applyTheme(theme: string): void {
   document.documentElement.setAttribute('data-theme', theme)
 }
 
-function ConsoleWindowApp(): JSX.Element {
+/**
+ * The web popup lost (or never had) its editor window. Everything this terminal
+ * shows — and every keystroke it sends — travels through the tab that opened it,
+ * so once that tab is gone the console is a picture. Say that, rather than
+ * accepting input that goes nowhere.
+ */
+function DisconnectedConsole(): JSX.Element {
+  return (
+    <div className="instr-offline" role="alert">
+      <h1 className="instr-offline__title">Console disconnected</h1>
+      <p className="instr-offline__body">
+        This console reads and writes the board through the Snakie window that opened it, and
+        that window is no longer there. In a browser a pop-up cannot reach the simulator or a
+        USB board by itself.
+      </p>
+      <p className="instr-offline__body">
+        Open Snakie again and pop the console out to get a live window back.
+      </p>
+    </div>
+  )
+}
+
+function ConsoleWindowApp({ connected }: { connected: boolean }): JSX.Element {
   // `null` until the prior console content has been fetched; we wait for it so
   // the terminal seeds (redraws the existing scrollback) before mounting and
   // following the live stream — otherwise the popped-out console starts blank.
   const [seed, setSeed] = useState<string | null>(null)
+  const [live, setLive] = useState(connected)
 
   useEffect(() => {
     let initial = 'skeuomorph'
@@ -44,13 +81,39 @@ function ConsoleWindowApp(): JSX.Element {
       // Ignore — fall back to the default.
     }
     applyTheme(initial)
-
-    window.api.console
-      .requestSeed()
-      .then((s) => setSeed(s ?? ''))
-      .catch(() => setSeed(''))
   }, [])
 
+  useEffect(() => {
+    if (!live) return
+    let alive = true
+    window.api.console
+      .requestSeed()
+      .then((s) => {
+        if (alive) setSeed(s ?? '')
+      })
+      .catch(() => {
+        if (alive) setSeed('')
+      })
+    return () => {
+      alive = false
+    }
+  }, [live])
+
+  // A web popup outlives its editor tab, and everything it shows comes from
+  // there — so watch for that tab going away and stop pretending to be live.
+  useEffect(() => {
+    if (!IS_WEB || !live) return
+    let stop: (() => void) | undefined
+    void import('./web/web-console').then(({ consoleHostAlive }) => {
+      const id = window.setInterval(() => {
+        if (!consoleHostAlive()) setLive(false)
+      }, HOST_CHECK_MS)
+      stop = () => window.clearInterval(id)
+    })
+    return () => stop?.()
+  }, [live])
+
+  if (!live) return <DisconnectedConsole />
   if (seed === null) return <div className="console-window" />
   return (
     <div className="console-window">
@@ -59,4 +122,21 @@ function ConsoleWindowApp(): JSX.Element {
   )
 }
 
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(<ConsoleWindowApp />)
+const render = (connected: boolean): void =>
+  ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+    <ConsoleWindowApp connected={connected} />
+  )
+
+// In the WEB build this window is a browser popup with no preload: adopt the
+// editor window's backend before rendering (mirrors instrument-window-main.tsx).
+// Without a reachable editor window there is no device at all, and the app says so.
+if (import.meta.env.VITE_SNAKIE_WEB) {
+  import('./web/install-web-api')
+    .then((m) => render(m.installWebApi('console')))
+    .catch((err) => {
+      console.error('[Snakie] web backend install failed', err)
+      render(false)
+    })
+} else {
+  render(true)
+}

--- a/src/renderer/src/web/install-web-api.ts
+++ b/src/renderer/src/web/install-web-api.ts
@@ -26,17 +26,19 @@ import {
   installWebInstrumentWindow,
   instrumentKeyFromHash
 } from './web-instruments'
+import { installWebConsoleMain, installWebConsoleWindow } from './web-console'
 import { VIRTUAL_PORT_PATH } from '../../../shared/virtual-device'
 
 /** Which renderer entry is installing: the main editor (`main.tsx`), the
- *  popped-out Board View window (`board-main.tsx`), or a popped-out instrument
- *  (`instrument-window-main.tsx`). */
-export type WebWindowKind = 'main' | 'board' | 'instrument'
+ *  popped-out Board View window (`board-main.tsx`), a popped-out instrument
+ *  (`instrument-window-main.tsx`) or the popped-out console
+ *  (`console-window-main.tsx`, #810). */
+export type WebWindowKind = 'main' | 'board' | 'instrument' | 'console'
 
 /**
  * Install the web backends for one renderer entry. Returns whether the entry got
- * a working backend — only an instrument popup can fail (it needs its editor
- * window), and it renders a plain "disconnected" state when it does.
+ * a working backend — only the popup entries can fail (they need their editor
+ * window), and they render a plain "disconnected" state when they do.
  */
 export function installWebApi(kind: WebWindowKind = 'main'): boolean {
   const w = window as typeof window & { api?: Record<string, unknown> }
@@ -46,6 +48,9 @@ export function installWebApi(kind: WebWindowKind = 'main'): boolean {
   // browser contexts anyway). It runs on the EDITOR window's api instead — see
   // web-instruments.ts.
   if (kind === 'instrument') return installWebInstrumentWindow(instrumentKeyFromHash(window.location.hash))
+  // Same for the console popup (#810): it reads and writes the SAME board as the
+  // editor tab, through that tab's api — see web-console.ts.
+  if (kind === 'console') return installWebConsoleWindow()
   // Report the real app version (injected from package.json by vite.web.config) so
   // the status bar shows it — the fallback returns '' (no Electron `app.getVersion`).
   const version = (import.meta.env as unknown as { VITE_SNAKIE_VERSION?: string }).VITE_SNAKIE_VERSION ?? ''
@@ -127,6 +132,8 @@ export function installWebApi(kind: WebWindowKind = 'main'): boolean {
     // window's device (#781). AFTER the board relay, which shares the same
     // `instruments` namespace.
     installWebInstrumentsMain()
+    // And the console does the same (#810) — one window, no key.
+    installWebConsoleMain()
   }
   // eslint-disable-next-line no-console
   console.info(

--- a/src/renderer/src/web/web-console.ts
+++ b/src/renderer/src/web/web-console.ts
@@ -1,0 +1,267 @@
+/**
+ * WEB detached CONSOLE window — issue #810.
+ * =============================================================================
+ *
+ * The sibling of `web-instruments.ts` (#781), and the same bug in the same
+ * shape. On the desktop, popping the console out opens a real OS `BrowserWindow`
+ * (`src/main/consoleWindow.ts`) that the main process relays the device stream
+ * to. In the browser `window.api.console.open` landed on the preload FALLBACK's
+ * stub, so the pop-out button did nothing.
+ *
+ * It was worse than a dead button, because `ShellPanel` sets `poppedOut` BEFORE
+ * it calls `open`: the docked terminal was hidden behind a "Console popped out
+ * to its own window" placeholder, no window appeared, and **Redock was dead
+ * too** — it calls `console.close()` (a `noop` stub) and waits for the
+ * `console:closed` event to clear the flag, but `onClosed` was the `unsub` stub,
+ * so that event could never arrive. The console stayed hidden for the rest of
+ * the session unless the panel happened to remount.
+ *
+ * ── The same bridge, for one window ─────────────────────────────────────────
+ * A popup is a separate JS realm, so it cannot build its own backend: it would
+ * spin up a SECOND MicroPython simulator, and a Web Serial port is exclusively
+ * locked by the context that opened it. So — exactly as for instruments — the
+ * editor tab publishes a bridge on itself and the popup runs on the EDITOR's
+ * `window.api`. `Terminal` reads `device.onData` and writes `device.sendData`,
+ * so a popped-out console is fully interactive against the same board.
+ *
+ *   open(seed)     editor → popup   `window.open('console.html')`
+ *   bridge.api()   popup → editor   the editor's api, subscription-tracked
+ *   bridge.seed()  popup → editor   the scrollback to redraw on mount
+ *   bridge.release popup → editor   the popup is gone → drop subs + re-dock
+ *
+ * The guard ({@link createApiGuard}, reused from `web-instruments.ts` rather
+ * than copied) is the load-bearing part for the same reason it was there: the
+ * device layer broadcasts with a bare `forEach`, so one dead popup callback
+ * would throw mid-broadcast and take the EDITOR's own console with it.
+ *
+ * ── Why this one is simpler ─────────────────────────────────────────────────
+ * There is exactly ONE console, so nothing here is keyed. `consoleWindow.ts`
+ * keeps a single window on the desktop and this mirrors that: opening while
+ * already open focuses the existing window instead of stacking a second.
+ */
+import { createApiGuard, type ApiGuard } from './web-instruments'
+
+type Namespaces = Record<string, unknown>
+
+/** Where the editor tab publishes its bridge so the popup can find it through
+ *  `window.opener` — same-origin, so this is a direct object reference. */
+export const CONSOLE_BRIDGE_PROP = '__snakieConsoleHost'
+
+/** Roughly the desktop console window's proportions (`consoleWindow.ts`) — a
+ *  terminal needs width for 80 columns far more than it needs height. */
+export const CONSOLE_WINDOW_FEATURES = 'popup=yes,width=760,height=440'
+
+/** One window, so one stable name: popping out twice re-adopts the window
+ *  rather than stacking a second one. */
+export const CONSOLE_WINDOW_NAME = 'snakie-console'
+
+/** Said when the browser blocks the popup. The console is re-docked either way,
+ *  so nothing is lost — but silence would look like the old bug. */
+export const CONSOLE_POPUP_BLOCKED_MESSAGE =
+  'Your browser blocked the console pop-up window. The console has been put back in the ' +
+  'panel. Allow pop-ups for this site if you would like it in its own window.'
+
+/** The editor-side bridge a console popup runs against. Every member is defined
+ *  in the EDITOR's realm. */
+export interface ConsoleHostBridge {
+  /** The scrollback to redraw on mount, so the popup does not start blank. */
+  seed: () => string
+  /** The editor's `window.api`, subscription-tracked for this popup. */
+  api: () => Namespaces | null
+  /** The popup is going away — drop its subscriptions and re-dock. */
+  release: () => void
+}
+
+/**
+ * The popup URL. Unlike an instrument this carries no key, but it is still a
+ * REAL page rather than the app shell: `console.html` has to be in the web
+ * build's inputs and on the service worker's `navigateFallbackDenylist`, or the
+ * PWA answers its navigation with `index.html` and opens the whole editor
+ * inside a 760px window (the second half of #781's bug).
+ */
+export function consoleWindowUrl(): string {
+  return 'console.html'
+}
+
+/** How often the editor checks whether the popup was closed behind its back (a
+ *  crash, or a close that never fired `pagehide`). */
+const SWEEP_MS = 1000
+
+/** How long after the popup says goodbye the editor waits before believing it —
+ *  long enough for `window.closed` to have flipped on a real close. */
+const CLOSE_CONFIRM_MS = 150
+
+/**
+ * Install the EDITOR side: `console.open` / `close` / `onClosed` /
+ * `requestSeed` drive a real browser window, and the bridge the popup runs on
+ * is published on this window. Called from `installWebApi`.
+ */
+export function installWebConsoleMain(): void {
+  const w = window as typeof window & { api?: Namespaces; [CONSOLE_BRIDGE_PROP]?: unknown }
+  if (!w.api) return
+
+  let popup: Window | null = null
+  let guard: ApiGuard | null = null
+  /** The scrollback handed over at open time, buffered for the popup to pull on
+   *  mount (the same open-time race `consoleWindow.ts` buffers for). */
+  let seed = ''
+  const closedListeners = new Set<() => void>()
+  let sweeper = 0
+
+  /** Forget the popup: drop the subscriptions it took, then tell the editor to
+   *  re-dock — exactly what the desktop's `closed` handler does. */
+  const forget = (): void => {
+    if (!popup) return
+    popup = null
+    guard?.dispose()
+    guard = null
+    seed = ''
+    if (sweeper) {
+      window.clearInterval(sweeper)
+      sweeper = 0
+    }
+    // This is the event ShellPanel's `redock` waits on. Without it the panel
+    // stays stuck behind its placeholder — the actual #810 symptom.
+    for (const cb of [...closedListeners]) {
+      try {
+        cb()
+      } catch {
+        // One bad listener must not stop the others being told.
+      }
+    }
+  }
+
+  const startSweeper = (): void => {
+    if (sweeper) return
+    sweeper = window.setInterval(() => {
+      if (popup?.closed) forget()
+    }, SWEEP_MS)
+  }
+
+  const bridge: ConsoleHostBridge = {
+    seed: () => seed,
+    api: () => {
+      if (!popup || !w.api) return null
+      // The window (re)started: its previous subscriptions belong to a realm
+      // that is already gone, so they go with it.
+      guard?.dispose()
+      guard = createApiGuard()
+      return guard.view(w.api)
+    },
+    // `pagehide` fires for a RELOAD as well as a close, and confusing the two
+    // would re-dock a perfectly good console. `closed` tells them apart, but
+    // only once the window has actually gone — so look a moment later.
+    release: () => {
+      window.setTimeout(() => {
+        if (popup?.closed) forget()
+      }, CLOSE_CONFIRM_MS)
+    }
+  }
+  w[CONSOLE_BRIDGE_PROP] = bridge
+
+  const consoleNs = (w.api.console ?? {}) as Namespaces
+  Object.assign(consoleNs, {
+    open: async (nextSeed?: string): Promise<void> => {
+      seed = nextSeed ?? ''
+      if (popup && !popup.closed) {
+        popup.focus()
+        return
+      }
+      const opened = window.open(consoleWindowUrl(), CONSOLE_WINDOW_NAME, CONSOLE_WINDOW_FEATURES)
+      if (!opened) {
+        // Blocked. Put the console back in the dock and say why, rather than
+        // leaving the user behind a placeholder with no window and no way back.
+        seed = ''
+        for (const cb of [...closedListeners]) {
+          try {
+            cb()
+          } catch {
+            // As above.
+          }
+        }
+        window.alert(CONSOLE_POPUP_BLOCKED_MESSAGE)
+        return
+      }
+      popup = opened
+      startSweeper()
+    },
+    close: (): void => {
+      const open = popup
+      forget()
+      if (open && !open.closed) open.close()
+    },
+    requestSeed: async (): Promise<string> => seed,
+    onClosed: (cb: () => void): (() => void) => {
+      closedListeners.add(cb)
+      return () => closedListeners.delete(cb)
+    }
+  })
+  w.api.console = consoleNs as unknown as Window['api']['console']
+
+  // Reloading or closing the editor would otherwise leave an orphaned popup
+  // running on a dead realm — the desktop closes its console window on quit.
+  window.addEventListener('pagehide', () => {
+    try {
+      popup?.close()
+    } catch {
+      // Already gone.
+    }
+  })
+}
+
+/**
+ * Install the POPUP side (`console-window-main.tsx`): run on the editor's
+ * `window.api` so this console reads and writes the same board.
+ *
+ * Returns `false` when there is no reachable editor window — the caller renders
+ * the "disconnected" state rather than a terminal that looks live and is not.
+ */
+export function installWebConsoleWindow(): boolean {
+  const w = window as typeof window & { api?: Namespaces }
+  if (!w.api) return false
+
+  let bridge: ConsoleHostBridge | undefined
+  try {
+    const opener = window.opener as (Window & { [CONSOLE_BRIDGE_PROP]?: unknown }) | null
+    if (opener && !opener.closed) {
+      bridge = opener[CONSOLE_BRIDGE_PROP] as ConsoleHostBridge | undefined
+    }
+  } catch {
+    // The opener navigated somewhere we may not touch — treat it as gone.
+  }
+  const hostApi = bridge?.api()
+  if (!bridge || !hostApi) return false
+  const host = bridge
+
+  const consoleNs = {
+    ...((hostApi.console ?? {}) as Namespaces),
+    // A popup IS the console window; it never opens another.
+    open: async (): Promise<void> => undefined,
+    close: (): void => window.close(),
+    // `String(...)` copies the scrollback into THIS realm, so it outlives the
+    // editor window's objects if that window ever goes away mid-session.
+    requestSeed: async (): Promise<string> => String(host.seed() ?? ''),
+    onClosed: (): (() => void) => () => undefined
+  }
+  w.api = { ...hostApi, console: consoleNs } as unknown as typeof w.api
+
+  window.addEventListener('pagehide', () => {
+    try {
+      host.release()
+    } catch {
+      // The editor went first — nothing to release.
+    }
+  })
+  return true
+}
+
+/** Is this popup's editor window still there? The console reads the board
+ *  through that tab, so once it is gone the terminal is a picture. */
+export function consoleHostAlive(): boolean {
+  try {
+    const opener = window.opener as (Window & { [CONSOLE_BRIDGE_PROP]?: unknown }) | null
+    return !!opener && !opener.closed && !!opener[CONSOLE_BRIDGE_PROP]
+  } catch {
+    return false
+  }
+}

--- a/test/webConsoleWindow.test.ts
+++ b/test/webConsoleWindow.test.ts
@@ -1,0 +1,442 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  CONSOLE_BRIDGE_PROP,
+  CONSOLE_WINDOW_NAME,
+  consoleHostAlive,
+  consoleWindowUrl,
+  installWebConsoleMain,
+  installWebConsoleWindow,
+  type ConsoleHostBridge
+} from '../src/renderer/src/web/web-console'
+
+/**
+ * #810 — the console pop-out on the web app.
+ *
+ * The sibling of #781, and a worse failure than it first looked. `ShellPanel`
+ * sets `poppedOut` BEFORE calling `console.open`, so on the web the docked
+ * terminal was hidden behind a placeholder, no window opened, and **Redock was
+ * dead too**: it calls `console.close()` and then waits for the `console:closed`
+ * event to clear the flag, but both were preload-fallback stubs, so that event
+ * could never arrive.
+ *
+ * That makes the `onClosed` event the thing worth testing hardest. Every route
+ * out of a popped-out console — a normal close, a blocked pop-up, a window
+ * closed behind the editor's back, the editor closing it itself — has to fire
+ * it, because that event IS the console coming back. A test that only checked
+ * "a window opened" would have passed against the original bug's worst symptom.
+ *
+ * The vitest environment is `node`, so there is no DOM. These build a fake
+ * `window` and drive the real module against it — the lifecycle logic is the
+ * part that broke, and it is all in this module rather than in the DOM.
+ */
+
+interface FakePopup {
+  closed: boolean
+  close: () => void
+  focus: () => void
+  focusCount: number
+}
+
+interface FakeWindow {
+  api: Record<string, unknown>
+  open: (url?: string, name?: string, features?: string) => FakePopup | null
+  alert: (msg?: string) => void
+  opener: unknown
+  closed: boolean
+  setTimeout: typeof setTimeout
+  setInterval: typeof setInterval
+  clearInterval: typeof clearInterval
+  addEventListener: (type: string, cb: () => void) => void
+  /** Fire a window event, so `pagehide` can be simulated. */
+  fire: (type: string) => void
+  opens: { url?: string; name?: string; features?: string }[]
+  alerts: string[]
+  [key: string]: unknown
+}
+
+function makePopup(): FakePopup {
+  const popup: FakePopup = {
+    closed: false,
+    focusCount: 0,
+    close(): void {
+      popup.closed = true
+    },
+    focus(): void {
+      popup.focusCount += 1
+    }
+  }
+  return popup
+}
+
+/** A window that behaves enough like the real one for this module. */
+function makeWindow(openResult: () => FakePopup | null): FakeWindow {
+  const events = new Map<string, Set<() => void>>()
+  const w: FakeWindow = {
+    // A minimal editor api: the console namespace gets replaced by the
+    // installer, and `device` stands in for everything a popup would borrow.
+    api: { console: {}, device: { onData: () => () => undefined } },
+    opens: [],
+    alerts: [],
+    opener: null,
+    closed: false,
+    open(url, name, features) {
+      w.opens.push({ url, name, features })
+      return openResult()
+    },
+    alert(msg) {
+      w.alerts.push(String(msg ?? ''))
+    },
+    setTimeout: ((fn: () => void, ms?: number) =>
+      globalThis.setTimeout(fn, ms)) as unknown as typeof setTimeout,
+    setInterval: ((fn: () => void, ms?: number) =>
+      globalThis.setInterval(fn, ms)) as unknown as typeof setInterval,
+    clearInterval: ((id: number) => globalThis.clearInterval(id)) as unknown as typeof clearInterval,
+    addEventListener(type, cb) {
+      let set = events.get(type)
+      if (!set) events.set(type, (set = new Set()))
+      set.add(cb)
+    },
+    fire(type) {
+      for (const cb of events.get(type) ?? []) cb()
+    }
+  }
+  return w
+}
+
+/** Install the module against `w`, as the editor tab would. */
+function installAgainst(w: FakeWindow): Record<string, (...args: never[]) => unknown> {
+  ;(globalThis as { window?: unknown }).window = w
+  installWebConsoleMain()
+  return w.api.console as Record<string, (...args: never[]) => unknown>
+}
+
+const originalWindow = (globalThis as { window?: unknown }).window
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  ;(globalThis as { window?: unknown }).window = originalWindow
+})
+
+// ---------------------------------------------------------------------------
+// The popup URL
+// ---------------------------------------------------------------------------
+
+describe('console popup identity', () => {
+  it('opens a REAL page, so the service worker denylist can match it', () => {
+    // The second half of #781's bug: the PWA answered every navigation with
+    // index.html, opening the whole editor inside the popup. `console.html` is
+    // on `navigateFallbackDenylist` in vite.web.config.ts, and this is the URL
+    // that entry has to match.
+    expect(consoleWindowUrl()).toBe('console.html')
+  })
+
+  it('uses one stable window name, so popping out twice re-adopts the window', () => {
+    expect(CONSOLE_WINDOW_NAME).toBe('snakie-console')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The editor side — the lifecycle that was broken
+// ---------------------------------------------------------------------------
+
+describe('installWebConsoleMain — the editor side', () => {
+  it('opens a real browser window at the console page', () => {
+    const w = makeWindow(makePopup)
+    const api = installAgainst(w)
+
+    void api.open('prior output' as never)
+
+    expect(w.opens).toHaveLength(1)
+    expect(w.opens[0].url).toBe('console.html')
+    expect(w.opens[0].name).toBe(CONSOLE_WINDOW_NAME)
+    expect(w.opens[0].features).toContain('popup=yes')
+  })
+
+  it('hands the popup the scrollback it was opened with', async () => {
+    const w = makeWindow(makePopup)
+    const api = installAgainst(w)
+
+    await api.open('>>> print(6*7)\r\n42\r\n' as never)
+
+    await expect(api.requestSeed()).resolves.toBe('>>> print(6*7)\r\n42\r\n')
+  })
+
+  it('treats a missing seed as empty rather than undefined', async () => {
+    const w = makeWindow(makePopup)
+    const api = installAgainst(w)
+    await api.open()
+    await expect(api.requestSeed()).resolves.toBe('')
+  })
+
+  it('focuses the open window instead of stacking a second one', async () => {
+    const popup = makePopup()
+    const w = makeWindow(() => popup)
+    const api = installAgainst(w)
+
+    await api.open('a' as never)
+    await api.open('b' as never)
+
+    expect(w.opens).toHaveLength(1)
+    expect(popup.focusCount).toBe(1)
+    // The refreshed scrollback still takes effect.
+    await expect(api.requestSeed()).resolves.toBe('b')
+  })
+
+  // --- every route back to the dock fires onClosed -------------------------
+
+  it('fires onClosed when the editor closes the window (Redock)', async () => {
+    const popup = makePopup()
+    const w = makeWindow(() => popup)
+    const api = installAgainst(w)
+    let closed = 0
+    api.onClosed((() => (closed += 1)) as never)
+
+    await api.open('x' as never)
+    api.close()
+
+    // THE #810 regression test: without this event ShellPanel's `redock` never
+    // clears `poppedOut`, and the console stays hidden behind its placeholder.
+    expect(closed).toBe(1)
+    expect(popup.closed).toBe(true)
+  })
+
+  it('fires onClosed when the pop-up is BLOCKED, so the console re-docks', async () => {
+    const w = makeWindow(() => null)
+    const api = installAgainst(w)
+    let closed = 0
+    api.onClosed((() => (closed += 1)) as never)
+
+    await api.open('x' as never)
+
+    expect(closed).toBe(1)
+    expect(w.alerts).toHaveLength(1)
+    expect(w.alerts[0]).toMatch(/blocked/i)
+    // Nothing was left buffered for a window that never opened.
+    await expect(api.requestSeed()).resolves.toBe('')
+  })
+
+  it('fires onClosed when the window is closed behind the editor’s back', async () => {
+    const popup = makePopup()
+    const w = makeWindow(() => popup)
+    const api = installAgainst(w)
+    let closed = 0
+    api.onClosed((() => (closed += 1)) as never)
+
+    await api.open('x' as never)
+    // A crash, or a close that never fired `pagehide` — the sweeper is the
+    // backstop, and without it the console would never come back.
+    popup.closed = true
+    vi.advanceTimersByTime(1200)
+
+    expect(closed).toBe(1)
+  })
+
+  it('fires onClosed when the popup says goodbye and has really gone', async () => {
+    const popup = makePopup()
+    const w = makeWindow(() => popup)
+    const api = installAgainst(w)
+    let closed = 0
+    api.onClosed((() => (closed += 1)) as never)
+
+    await api.open('x' as never)
+    const bridge = w[CONSOLE_BRIDGE_PROP] as ConsoleHostBridge
+    popup.closed = true
+    bridge.release()
+    vi.advanceTimersByTime(300)
+
+    expect(closed).toBe(1)
+  })
+
+  it('does NOT re-dock when the popup merely RELOADS', async () => {
+    const popup = makePopup()
+    const w = makeWindow(() => popup)
+    const api = installAgainst(w)
+    let closed = 0
+    api.onClosed((() => (closed += 1)) as never)
+
+    await api.open('x' as never)
+    // `pagehide` fires for a reload too. The window is still open, so this must
+    // not be read as a close — that would re-dock a perfectly good console.
+    const bridge = w[CONSOLE_BRIDGE_PROP] as ConsoleHostBridge
+    bridge.release()
+    vi.advanceTimersByTime(300)
+
+    expect(closed).toBe(0)
+  })
+
+  it('stops listening once an onClosed subscriber unsubscribes', async () => {
+    const popup = makePopup()
+    const w = makeWindow(() => popup)
+    const api = installAgainst(w)
+    let closed = 0
+    const off = api.onClosed((() => (closed += 1)) as never) as unknown as () => void
+
+    off()
+    await api.open('x' as never)
+    api.close()
+
+    expect(closed).toBe(0)
+  })
+
+  it('one throwing listener does not stop the others being told', async () => {
+    const w = makeWindow(makePopup)
+    const api = installAgainst(w)
+    let reached = 0
+    api.onClosed((() => {
+      throw new Error('boom')
+    }) as never)
+    api.onClosed((() => (reached += 1)) as never)
+
+    await api.open('x' as never)
+    expect(() => api.close()).not.toThrow()
+    expect(reached).toBe(1)
+  })
+
+  it('closes an orphaned popup when the editor tab goes away', async () => {
+    const popup = makePopup()
+    const w = makeWindow(() => popup)
+    const api = installAgainst(w)
+
+    await api.open('x' as never)
+    w.fire('pagehide')
+
+    // Otherwise the popup lives on running against a dead realm.
+    expect(popup.closed).toBe(true)
+  })
+
+  it('publishes a bridge the popup can find', async () => {
+    const w = makeWindow(makePopup)
+    const api = installAgainst(w)
+    await api.open('seeded' as never)
+
+    const bridge = w[CONSOLE_BRIDGE_PROP] as ConsoleHostBridge
+    expect(bridge).toBeTruthy()
+    expect(bridge.seed()).toBe('seeded')
+    expect(bridge.api()).toBeTruthy()
+  })
+
+  it('lends the editor’s device through the bridge, not a copy of it', async () => {
+    const w = makeWindow(makePopup)
+    const api = installAgainst(w)
+    await api.open('' as never)
+
+    const bridge = w[CONSOLE_BRIDGE_PROP] as ConsoleHostBridge
+    const lent = bridge.api() as { device: { onData: (cb: () => void) => () => void } }
+    // The popup's terminal reads device.onData and writes device.sendData; both
+    // must resolve to the EDITOR's, so there is exactly one board in play.
+    expect(typeof lent.device.onData).toBe('function')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The popup side
+// ---------------------------------------------------------------------------
+
+describe('installWebConsoleWindow — the popup side', () => {
+  it('reports no backend when there is no opener at all', () => {
+    const w = makeWindow(makePopup)
+    w.opener = null
+    ;(globalThis as { window?: unknown }).window = w
+    expect(installWebConsoleWindow()).toBe(false)
+  })
+
+  it('reports no backend when the opener is gone', () => {
+    const w = makeWindow(makePopup)
+    w.opener = { closed: true, [CONSOLE_BRIDGE_PROP]: {} }
+    ;(globalThis as { window?: unknown }).window = w
+    expect(installWebConsoleWindow()).toBe(false)
+  })
+
+  it('reports no backend for a hand-opened console.html (opener, no bridge)', () => {
+    const w = makeWindow(makePopup)
+    w.opener = { closed: false }
+    ;(globalThis as { window?: unknown }).window = w
+    expect(installWebConsoleWindow()).toBe(false)
+  })
+
+  it('adopts the editor’s api, and copies the seed into its own realm', async () => {
+    const editorApi = { device: { onData: () => () => undefined }, console: {} }
+    const bridge: ConsoleHostBridge = {
+      seed: () => 'prior scrollback',
+      api: () => editorApi,
+      release: () => undefined
+    }
+    const w = makeWindow(makePopup)
+    w.opener = { closed: false, [CONSOLE_BRIDGE_PROP]: bridge }
+    ;(globalThis as { window?: unknown }).window = w
+
+    expect(installWebConsoleWindow()).toBe(true)
+
+    const api = w.api as { device: unknown; console: Record<string, () => unknown> }
+    expect(api.device).toBe(editorApi.device)
+    await expect(api.console.requestSeed()).resolves.toBe('prior scrollback')
+  })
+
+  it('never opens a window of its own, and its close() closes itself', async () => {
+    const bridge: ConsoleHostBridge = {
+      seed: () => '',
+      api: () => ({ device: {} }),
+      release: () => undefined
+    }
+    const w = makeWindow(makePopup)
+    w.opener = { closed: false, [CONSOLE_BRIDGE_PROP]: bridge }
+    let selfClosed = 0
+    w.close = (): void => {
+      selfClosed += 1
+    }
+    ;(globalThis as { window?: unknown }).window = w
+    installWebConsoleWindow()
+
+    const api = w.api as { console: Record<string, () => unknown> }
+    await api.console.open()
+    expect(w.opens).toHaveLength(0)
+
+    api.console.close()
+    expect(selfClosed).toBe(1)
+  })
+
+  it('tells the editor it is going, so the console re-docks', () => {
+    let released = 0
+    const bridge: ConsoleHostBridge = {
+      seed: () => '',
+      api: () => ({ device: {} }),
+      release: () => {
+        released += 1
+      }
+    }
+    const w = makeWindow(makePopup)
+    w.opener = { closed: false, [CONSOLE_BRIDGE_PROP]: bridge }
+    ;(globalThis as { window?: unknown }).window = w
+    installWebConsoleWindow()
+
+    w.fire('pagehide')
+    expect(released).toBe(1)
+  })
+})
+
+describe('consoleHostAlive', () => {
+  it('is false with no opener — the terminal would be a picture', () => {
+    const w = makeWindow(makePopup)
+    w.opener = null
+    ;(globalThis as { window?: unknown }).window = w
+    expect(consoleHostAlive()).toBe(false)
+  })
+
+  it('is false once the editor tab has closed', () => {
+    const w = makeWindow(makePopup)
+    w.opener = { closed: true, [CONSOLE_BRIDGE_PROP]: {} }
+    ;(globalThis as { window?: unknown }).window = w
+    expect(consoleHostAlive()).toBe(false)
+  })
+
+  it('is true while the editor tab is there with its bridge', () => {
+    const w = makeWindow(makePopup)
+    w.opener = { closed: false, [CONSOLE_BRIDGE_PROP]: {} }
+    ;(globalThis as { window?: unknown }).window = w
+    expect(consoleHostAlive()).toBe(true)
+  })
+})

--- a/vite.web.config.ts
+++ b/vite.web.config.ts
@@ -73,12 +73,14 @@ export default defineConfig({
       // browser: the Board View (`window.open('board.html')` + a BroadcastChannel
       // relay — src/renderer/src/web/web-board.ts) and a detached instrument
       // (`instrument.html`, which runs on the editor tab's own device — see
-      // src/renderer/src/web/web-instruments.ts, #781). The remaining Electron
-      // detached windows (find / console) stay in-page panes on the web.
+      // src/renderer/src/web/web-instruments.ts, #781) and the console
+      // (`console.html`, the same bridge for one window — web-console.ts, #810).
+      // Find stays an in-page pane on the web.
       input: {
         index: resolve(__dirname, 'src/renderer/index.html'),
         board: resolve(__dirname, 'src/renderer/board.html'),
-        instrument: resolve(__dirname, 'src/renderer/instrument.html')
+        instrument: resolve(__dirname, 'src/renderer/instrument.html'),
+        console: resolve(__dirname, 'src/renderer/console.html')
       },
       output: {
         manualChunks(id: string) {
@@ -106,11 +108,16 @@ export default defineConfig({
         // classroom app truly works offline after the first visit.
         maximumFileSizeToCacheInBytes: 12 * 1024 * 1024,
         // The app is an SPA, so every navigation falls back to `index.html` —
-        // but the two pop-out windows are REAL pages, and answering their
+        // but the pop-out windows are REAL pages, and answering their
         // navigation with the shell opens the whole editor inside a 460px
-        // instrument window (#781). They are precached in their own right, so
-        // exclude them and let the precache (or the network) serve them.
-        navigateFallbackDenylist: [/^\/board\.html/, /^\/instrument\.html/]
+        // instrument window (#781) or a 760px console (#810). They are precached
+        // in their own right, so exclude them and let the precache (or the
+        // network) serve them.
+        navigateFallbackDenylist: [
+          /^\/board\.html/,
+          /^\/instrument\.html/,
+          /^\/console\.html/
+        ]
       },
       manifest: {
         name: 'Snakie — MicroPython IDE',


### PR DESCRIPTION
Closes #810.

The sibling #781 flagged — and **worse than I described when I filed it.** I wrote there that "Redock still works, so the console is recoverable." It doesn't, and it wasn't.

## The actual bug

`ShellPanel` sets `poppedOut` **before** calling `console.open`, so on the web the docked terminal was already hidden behind its "Console popped out to its own window" placeholder by the time the stub did nothing. Then:

- `redock()` calls `console.close()` → the preload fallback's `noop`
- it waits for `console:closed` to clear the flag → but `onClosed` was the fallback's `unsub`, so the listener was never registered and that event could never arrive

So the console vanished, no window opened, and the button offering to bring it back was itself dead. It stayed hidden for the rest of the session unless the panel happened to remount.

## What that means for the fix

The **closed event** is the load-bearing part here, not the window. That event *is* the console coming back, so every route to the dock has to fire it:

- an explicit `close()`
- Redock
- a blocked pop-up (re-docks and says why)
- a window closed behind the editor's back — the sweeper

And a **reload deliberately does not count**: `pagehide` fires for reloads too, and treating one as a close would re-dock a perfectly good console.

The tests are written around exactly that, because a test asserting only "a window opened" would have passed against this bug's worst symptom.

## Reused, not reinvented

Everything else follows #781. `createApiGuard` is **imported** from `web-instruments.ts` rather than copied — the device layer still broadcasts with a bare `forEach`, so one dead pop-up callback would throw mid-broadcast and take the editor's own console with it.

The popup runs on the **editor's** `window.api`, so `Terminal`'s `device.onData` and `device.sendData` both reach the same board: the detached console is fully interactive, not a mirror. It opens seeded with the scrollback you already had rather than blank.

This one is simpler in one respect — there is exactly one console, so nothing is keyed, matching `consoleWindow.ts`'s single window on the desktop.

## Two things found on the way

Both fixed here, because the fix doesn't work without them:

- **`console.html` wasn't in the web build's inputs at all**, and the service worker's `navigateFallbackDenylist` didn't cover it — its navigation would have been answered with `index.html`, opening the whole editor inside a 760px window. Verified in the built output: `console.html` emitted, precached, and on the denylist.
- `console-window-main.tsx` still imported **JetBrains Mono**, superseded by the Soft Shell fonts. #781 corrected the instrument window; this is its twin.

## Tests

**25 new** in `test/webConsoleWindow.test.ts`. The vitest environment is `node`, so they build a fake `window` and drive the real module against it — the lifecycle is where the bug lived, and it's all in this module rather than in the DOM.

## Gates

`typecheck`, `lint` (one pre-existing warning elsewhere), `test` (**5721** passing), `build` and `build:web` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
