### PR TITLE
fix: typecheck test/, re-arming the part field-contract guard (#793)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **`test/` is type-checked, so the part field guard actually guards.** (#793)
+  `test/partFieldContract.test.ts` exists to make a forgotten `PartDefinition`
+  field a *compile error* — its `Required<PartDefinition>` fixture is a
+  deliberate tripwire, because this repo has repeatedly shipped fields that were
+  then silently dropped on save. It could not do that: `tsconfig.node.json`
+  covers main/preload/shared, `tsconfig.web.json` covers the renderer, and
+  **neither included `test/`**. Vitest transforms with esbuild, which strips
+  types without checking them, so `npm test` did not catch it either. A
+  deliberate type error in a test file passed all four gates clean.
+
+  The guard had been working by convention — every recent author dutifully
+  updated the fixture — but it was trusted, not enforced, and the next person
+  who did not know the convention would have got no error at all.
+
+  A `tsconfig.test.json` now covers `test/` and runs as part of
+  `npm run typecheck`. Turning it on surfaced **48 real errors across 15 test
+  files**, every one of them a fixture that had drifted from the type it claims
+  to be — a `FakeRuntime` missing the `runStream` the interface gained in #612,
+  `PartCatalog` tests passing an `onAdd` prop that had been renamed to
+  `onAddMany`, `syncPlan` reading a `partId` off a union arm that has none,
+  `BoardDefinition` fixtures without `pcbColor`, a schematic fixture using a
+  `name` field `SchematicPin` never had, and a duplicated import line. All
+  fixed. Adding a field to `PartDefinition` now fails `npm run typecheck` at the
+  one place that makes you decide what that field does.
+
+
 ### Added
 - **Publish a project to GitHub without leaving Snakie.** (#795) A repository
   you created locally had nowhere to go: the Source Control panel offered

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start": "electron-vite preview",
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json --composite false",
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json --composite false",
-    "typecheck": "npm run typecheck:node && npm run typecheck:web",
+    "typecheck": "npm run typecheck:node && npm run typecheck:web && npm run typecheck:test",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "eslint . --ext .ts,.tsx,.cjs",
@@ -28,7 +28,8 @@
     "dist": "electron-vite build && electron-builder",
     "dist:win": "electron-vite build && electron-builder --win",
     "dist:mac": "electron-vite build && electron-builder --mac",
-    "dist:linux": "electron-vite build && electron-builder --linux"
+    "dist:linux": "electron-vite build && electron-builder --linux",
+    "typecheck:test": "tsc --noEmit -p tsconfig.test.json --composite false"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.100.1",

--- a/src/renderer/src/components/part-editor.util.ts
+++ b/src/renderer/src/components/part-editor.util.ts
@@ -69,6 +69,11 @@ import { coerceMeshRotation } from '../../../shared/mesh-rotation'
 import { coerceMeshOffset } from '../../../shared/mesh-offset'
 import { flattenPartPins } from '../../../shared/netlist'
 
+
+/** Re-exported because this module's driver helpers take and return it — the
+ *  Part Editor and its tests should not have to reach past this file for it. */
+export type { DriverFile }
+
 /** The pin types the editor offers, in UI order. */
 export const PIN_TYPES: PartPinType[] = ['io', 'pwr', 'gnd', 'other']
 

--- a/test/boardLayout.test.ts
+++ b/test/boardLayout.test.ts
@@ -454,6 +454,7 @@ describe('authoredPads', () => {
     const def: BoardDefinition = {
       id: 'authored',
       name: 'Authored',
+      pcbColor: '#0f5a2e',
       mcu: 'X',
       aspect: 1,
       headers: [
@@ -471,6 +472,7 @@ describe('authoredPads', () => {
     const def: BoardDefinition = {
       id: 'builtin',
       name: 'Builtin',
+      pcbColor: '#0f5a2e',
       mcu: 'X',
       aspect: 1,
       headers: [{ edge: 'left', pins: [{ gpio: 0, label: 'GP0' }, { gpio: 1, label: 'GP1' }] }]
@@ -482,6 +484,7 @@ describe('authoredPads', () => {
     const def: BoardDefinition = {
       id: 'mixed',
       name: 'Mixed',
+      pcbColor: '#0f5a2e',
       mcu: 'X',
       aspect: 1,
       headers: [

--- a/test/boardValues.test.ts
+++ b/test/boardValues.test.ts
@@ -9,7 +9,15 @@ import {
 } from '../src/renderer/src/components/board-values'
 import type { UsedPins } from '../src/renderer/src/components/parse-pins'
 
-function conn(partial: Partial<UsedPins> & Pick<UsedPins, 'type'>): UsedPins {
+// `UsedPins` has a field literally named `constructor`, so `Partial<UsedPins>`
+// declares `constructor?: string` — which every object literal already inherits
+// from `Object.prototype` as a `Function`. TypeScript reports that clash on the
+// CALLER, not here, so `conn({ type: 'output' })` failed with a baffling
+// "Types of property 'constructor' are incompatible". The default below is the
+// only `constructor` anyone wants, so exclude it from what callers may pass.
+function conn(
+  partial: Omit<Partial<UsedPins>, 'constructor'> & Pick<UsedPins, 'type'>
+): UsedPins {
   return {
     pins: ['0'],
     variable: 'x',

--- a/test/deviceTreeModel.test.ts
+++ b/test/deviceTreeModel.test.ts
@@ -10,8 +10,8 @@ import {
 } from '../src/renderer/src/components/device-tree-model'
 import type { DirEntry } from '../src/preload/index.d'
 
-const d = (name: string): DirEntry => ({ name, isDir: true })
-const f = (name: string): DirEntry => ({ name, isDir: false })
+const d = (name: string): DirEntry => ({ name, isDir: true, size: 0 })
+const f = (name: string, size = 0): DirEntry => ({ name, isDir: false, size })
 
 const dirs = new Map<string, DirEntry[]>([
   ['/', [d('lib'), f('main.py'), f('boot.py')]],

--- a/test/footprintSignature.test.ts
+++ b/test/footprintSignature.test.ts
@@ -10,7 +10,6 @@ import {
   type SigPin
 } from '../src/shared/footprint-signature'
 import { partFromYaml, partToYaml } from '../src/shared/part-yaml'
-import type { PartDefinition, PartPin } from '../src/shared/part'
 
 const pins = (...ps: SigPin[]): SigPin[] => ps
 

--- a/test/microbitDetect.test.ts
+++ b/test/microbitDetect.test.ts
@@ -121,7 +121,7 @@ describe('drive detection over a volume list', () => {
 
   it('finds a BOOTSEL drive by label and by marker file alone', async () => {
     const found = await detectRp2040Drive(await listVolumes([root]))
-    const names = found.map((c) => c.mountPath.split(/[/\\]/).pop())
+    const names = found.map((c) => c.mountPath?.split(/[/\\]/).pop())
     expect(names).toContain('RPI-RP2')
     expect(names).toContain('E') // no label, found by INFO_UF2.TXT
     expect(names).not.toContain('Untitled')
@@ -131,7 +131,7 @@ describe('drive detection over a volume list', () => {
 
   it('finds a vendor-named UF2 bootloader and names it from its OWN info file', async () => {
     const found = await detectRp2040Drive(await listVolumes([root]))
-    const feather = found.find((c) => c.mountPath.endsWith('FEATHERBOOT'))
+    const feather = found.find((c) => c.mountPath?.endsWith('FEATHERBOOT'))
     // Found at all — there is no RPI-RP2 label on it (#756).
     expect(feather).toBeDefined()
     // Named honestly, not as an RP2040.
@@ -139,20 +139,20 @@ describe('drive detection over a volume list', () => {
     expect(feather?.label).toContain('FEATHERBOOT')
     expect(feather?.label).not.toContain('RP2040')
     // …while an actual RP2040 keeps its familiar wording.
-    const pico = found.find((c) => c.mountPath.endsWith('RPI-RP2'))
+    const pico = found.find((c) => c.mountPath?.endsWith('RPI-RP2'))
     expect(pico?.label).toContain('RP2040 (RPI-RP2)')
   })
 
   it('finds a micro:bit and reads its generation from DETAILS.TXT', async () => {
     const found = await detectMicrobitDrive(await listVolumes([root]))
-    const normal = found.find((c) => c.mountPath.endsWith('MICROBIT'))
+    const normal = found.find((c) => c.mountPath?.endsWith('MICROBIT'))
     expect(normal?.microbitVersion).toBe('v2')
     expect(normal?.maintenance).toBe(false)
   })
 
   it('flags maintenance mode, which cannot be flashed', async () => {
     const found = await detectMicrobitDrive(await listVolumes([root]))
-    const maint = found.find((c) => c.mountPath.endsWith('MAINTENANCE'))
+    const maint = found.find((c) => c.mountPath?.endsWith('MAINTENANCE'))
     expect(maint?.maintenance).toBe(true)
     expect(maint?.label).toContain('reconnect to flash')
   })

--- a/test/partCatalog.test.tsx
+++ b/test/partCatalog.test.tsx
@@ -82,7 +82,7 @@ describe('hover flip (#636)', () => {
   ]
 
   it('shows the FRONT face at rest', () => {
-    const out = html(<PartCatalog libraries={withRear} onClose={() => {}} onAdd={() => {}} />)
+    const out = html(<PartCatalog libraries={withRear} onClose={() => {}} onAddMany={() => {}} />)
     expect(out).toContain('base64,FRONT')
     expect(out, 'the back is only revealed on hover').not.toContain('base64,BACK')
   })
@@ -92,7 +92,7 @@ describe('hover flip (#636)', () => {
     // shouting a fact the picture already shows the moment you hover. What it
     // guarded — that only a part with a rear PHOTO gets the flip at all — is
     // still covered by `partHasRearImage` below and by the hover wiring above.
-    const out = html(<PartCatalog libraries={withRear} onClose={() => {}} onAdd={() => {}} />)
+    const out = html(<PartCatalog libraries={withRear} onClose={() => {}} onAddMany={() => {}} />)
     expect(out).not.toContain('pcat__card-face')
     expect(out).not.toMatch(/>FRONT</)
   })

--- a/test/partDetails.test.ts
+++ b/test/partDetails.test.ts
@@ -104,7 +104,7 @@ describe('partSpecRows', () => {
   it('spells the package code out, and passes an unknown one through untouched', () => {
     expect(partSpecRows(part({ package: 'SMD' }))[0].value).toBe('Surface-mount (SMD)')
     expect(partSpecRows(part({ package: 'THT' }))[0].value).toBe('Through-hole (THT)')
-    expect(partSpecRows(part({ package: 'QFN' } as Partial<PartDefinition>))[0].value).toBe('QFN')
+    expect(partSpecRows(part({ package: 'QFN' } as unknown as Partial<PartDefinition>))[0].value).toBe('QFN')
   })
 
   it("appends the author's own key/values as further spec rows", () => {

--- a/test/partRotate.test.ts
+++ b/test/partRotate.test.ts
@@ -204,7 +204,7 @@ describe('rotatePart', () => {
   })
 
   it('leaves the schematic symbol alone', () => {
-    const schematic = { aspect: 2, pins: [{ name: 'A', side: 'left' as const }] }
+    const schematic = { aspect: 2, pins: [{ pin: 'A', side: 'left' as const, order: 0 }] }
     expect(rotatePart(base({ schematic }), 'cw').schematic).toEqual(schematic)
   })
 
@@ -267,7 +267,7 @@ describe('rotatePart', () => {
         { kind: 'rect', x: 0.2, y: 0.3, w: 0.1, h: 0.25, side: 'rear' }
       ],
       labels: [{ text: 'X', x: 0.5, y: 0.1 }],
-      onboardLeds: [{ x: 0.7, y: 0.7 }],
+      onboardLeds: [{ kind: 'single', x: 0.7, y: 0.7 }],
       polygon: [
         { x: 0, y: 0 },
         { x: 1, y: 0 },

--- a/test/partYaml.test.ts
+++ b/test/partYaml.test.ts
@@ -1258,6 +1258,7 @@ describe('suggested modules round-trip (#638)', () => {
     const part: PartDefinition = {
       id: 'base',
       name: 'Carrier',
+      headers: [],
       suggests: [
         { module: 'ssd1306', unlocks: 'the 0.96" OLED' },
         { module: 'pcf8563' }

--- a/test/robotControls.test.ts
+++ b/test/robotControls.test.ts
@@ -47,7 +47,7 @@ describe('sampleControl — puppet pose blend (#416)', () => {
     expect(sampleControl(ctl(['center']), poses, 0.7)).toEqual({ yaw: 0, tilt: 0 })
     // an unknown pose resolves to {}, so the blend holds the known neighbour's joints
     expect(sampleControl(ctl(['ghost', 'center']), poses, 0)).toEqual({ yaw: 0, tilt: 0 })
-    expect(sampleControl({ id: 'x', name: 'x', poses: [] }, poses, 0.5)).toEqual({})
+    expect(sampleControl(ctl([]), poses, 0.5)).toEqual({})
   })
 })
 

--- a/test/robotIkPlanar.test.ts
+++ b/test/robotIkPlanar.test.ts
@@ -111,7 +111,7 @@ describe('reachable-workspace sampling', () => {
     }
     // A pinned base joint collapses the reachable spread in X.
     const pinned = sampleWorkspace({ boneLengths: [1, 1], limits: [[0, 0.001], null] }, 400)
-    const spread = (pts: [number, number][]): number =>
+    const spread = (pts: readonly (readonly [number, number])[]): number =>
       Math.max(...pts.map((p) => p[0])) - Math.min(...pts.map((p) => p[0]))
     expect(spread(pinned.points)).toBeLessThan(spread(full.points))
   })

--- a/test/simulatedDevice.test.ts
+++ b/test/simulatedDevice.test.ts
@@ -31,6 +31,13 @@ class FakeRuntime implements ReplRuntime {
     this.capturedCalls.push(code)
     return this.nextCaptured
   }
+  /** Programs run with their output STREAMING to the console (#612). Recorded
+   *  rather than echoed, so a test can assert WHICH path a run took — the
+   *  interactive REPL (`feed`) or a direct program run. */
+  streamedCalls: string[] = []
+  async runStream(code: string): Promise<void> {
+    this.streamedCalls.push(code)
+  }
   interrupts = 0
   async interrupt(): Promise<void> {
     this.interrupts += 1

--- a/test/simulation.test.ts
+++ b/test/simulation.test.ts
@@ -62,7 +62,15 @@ describe('simulatedTelemetryFrame', () => {
 })
 
 describe('simulateProbeResponse', () => {
-  function conn(partial: Partial<UsedPins> & Pick<UsedPins, 'type'>): UsedPins {
+  // `UsedPins` has a field literally named `constructor`, so `Partial<UsedPins>`
+// declares `constructor?: string` — which every object literal already inherits
+// from `Object.prototype` as a `Function`. TypeScript reports that clash on the
+// CALLER, not here, so `conn({ type: 'output' })` failed with a baffling
+// "Types of property 'constructor' are incompatible". The default below is the
+// only `constructor` anyone wants, so exclude it from what callers may pass.
+function conn(
+  partial: Omit<Partial<UsedPins>, 'constructor'> & Pick<UsedPins, 'type'>
+): UsedPins {
     return {
       pins: ['0'],
       variable: 'x',

--- a/test/syncPlan.test.ts
+++ b/test/syncPlan.test.ts
@@ -115,7 +115,9 @@ describe('computeSyncPlan', () => {
       urdfWithSg90(),
       libs
     )
-    expect(plan.filter((i) => i.partId === 'board' || i.kind === 'missing-body')).toEqual([])
+    expect(
+      plan.filter((i) => ('partId' in i && i.partId === 'board') || i.kind === 'missing-body')
+    ).toEqual([])
   })
 
   it('a box body whose part now ships a mesh is placeholder-upgradable', () => {

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,29 @@
+{
+  // Type-checking for `test/` — issue #793.
+  //
+  // Neither `tsconfig.node.json` (main/preload/shared) nor `tsconfig.web.json`
+  // (renderer) covered `test/`, and vitest transforms with esbuild, which strips
+  // types without checking them. So nothing in the four gates typechecked a test
+  // file, and `test/partFieldContract.test.ts` — whose whole job is to make a
+  // forgotten `PartDefinition` field a COMPILE error — could not do it.
+  //
+  // Tests reach into every layer: main-process services, shared helpers, and
+  // React components rendered to static markup. So this config is deliberately
+  // the UNION — DOM plus node types, and the renderer's JSX settings — rather
+  // than an extension of either side, which would leave half the suite unable
+  // to resolve its imports.
+  "extends": "@electron-toolkit/tsconfig/tsconfig.web.json",
+  "include": ["test/**/*"],
+  "compilerOptions": {
+    "composite": true,
+    "jsx": "react-jsx",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    // `vite/client` for the `import.meta.glob` / `import.meta.env` the renderer
+    // modules under test use; without it every such call reads as an error here.
+    "types": ["node", "vitest/globals", "vite/client"],
+    "baseUrl": ".",
+    "paths": {
+      "@renderer/*": ["src/renderer/src/*"]
+    }
+  }
+}


### PR DESCRIPTION
Closes #793.

## Verified, before and after

Using the issue's own reproduction:

```
$ printf 'export const x: number = "not a number"\n' > test/_tc_probe.ts
$ npm run typecheck
```

**Before:** clean. **After:** `test/_tc_probe.ts(1,14): error TS2322: Type 'string' is not assignable to type 'number'.`

## The fix

A new `tsconfig.test.json` covers `test/`, wired into `npm run typecheck` as a third project.

It's deliberately the **union** of the other two — DOM plus node types, the renderer's JSX settings, and `vite/client` for the `import.meta.glob` / `import.meta.env` that renderer modules under test use — rather than an extension of either. Tests reach into main-process services, shared helpers and React components alike, so either side alone leaves half the suite unable to resolve its imports.

## What it caught

**48 errors across 15 files**, and not one was noise. Every one was a fixture that had drifted from the type it claims to be — which is exactly the failure this issue is about:

| | |
|---|---|
| `FakeRuntime` | never gained the `runStream` that `ReplRuntime` got in #612 — the fake had silently diverged from the interface it *implements* |
| `PartCatalog` tests | two calls still passed an `onAdd` prop after the rename to `onAddMany`; the other three in the same file had been updated |
| `syncPlan` | read `.partId` off a `SyncItem` union arm that doesn't have one |
| `BoardDefinition` fixtures | predated a required `pcbColor` |
| `DirEntry` fixtures | predated a required `size` |
| schematic fixture | used a `name` field `SchematicPin` has never had |
| `footprintSignature` | imported the same two types twice, on two different lines |

The `constructor` cluster deserves its own note. `UsedPins` has a field literally named `constructor`, so `Partial<UsedPins>` declares `constructor?: string` — which every object literal already inherits from `Object.prototype` as a `Function`. TypeScript reports that clash on the **caller**, so a test helper's call sites failed with a baffling *"Types of property 'constructor' are incompatible"*. The helper's own default is the only `constructor` anyone wants, so it's now excluded from the parameter type, with a comment explaining why.

## The guard is armed — proven, not assumed

Adding a probe field to `PartDefinition`:

```
test/partFieldContract.test.ts(47,7): error TS2741: Property 'probeField793' is
missing in type '{ ... }' but required in type 'Required<PartDefinition>'.
```

It names the field and points at the one place that makes you decide what it does. That's what the file always claimed to do, and now actually does.

## Gates

`typecheck` (now three projects), `lint` (one pre-existing warning elsewhere), `test` (5696 passing), `build` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
