### PR TITLE
fix: an unidentified runtime is not greeted as MicroPython (#770)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **A board Snakie can't identify is no longer greeted as MicroPython.** (#770)
+  A CircuitPython 10.2.1 board was welcomed in the REPL as
+  `MicroPython v10.2.1` — the version was right, so the probe had reached the
+  board; only the runtime was wrong, in the very first line the user reads.
+
+  The cause was a binary in the greeting: `circuitpython ? … : MicroPython`. Any
+  failure to *positively* identify CircuitPython — a probe line that didn't
+  arrive, an `implementation.name` that is neither runtime — silently reported
+  the board as MicroPython. That reintroduced, at the very last step, the
+  "assume MicroPython everywhere" default the dialect module exists to remove.
+  The `v` prefix was the second half of it, since that is MicroPython's own
+  convention and CircuitPython prints its version bare.
+
+  An unidentified runtime now claims **no** runtime name and drops the `v`,
+  while still printing the version, build date and board — those came off the
+  board and are true. It also now matches what the status bar shows for the same
+  information, so the two can no longer disagree about what a board is running.
+
 ### Added
 - **Publish a project to GitHub without leaving Snakie.** (#795) A repository
   you created locally had nowhere to go: the Source Control panel offered

--- a/src/shared/dialect.ts
+++ b/src/shared/dialect.ts
@@ -224,10 +224,26 @@ export function parseBootOutUid(text: string): string | undefined {
  */
 export function runtimeGreeting(info: RuntimeInfo | null): string {
   if (!info || !info.version) return ''
-  const name = info.dialect === 'circuitpython' ? 'Adafruit CircuitPython' : 'MicroPython'
-  const version = info.dialect === 'circuitpython' ? info.version : `v${info.version}`
   const date = info.buildDate ? ` on ${info.buildDate}` : ''
   const machine = info.machine ? `; ${info.machine}` : ''
+  // Three-way, NOT `circuitpython ? … : MicroPython` (#770). That binary made
+  // every unidentified board claim to be MicroPython — a probe line that never
+  // arrived, or an `implementation.name` that is neither runtime, and the very
+  // first thing the user reads is a confident lie about what their board runs.
+  // It reintroduced, at the last step, exactly the "assume MicroPython
+  // everywhere" default this module exists to remove.
+  //
+  // An unknown runtime therefore claims NO runtime name and drops the `v`
+  // prefix (which is MicroPython's own convention, and was the second half of
+  // the wrong wording). It still prints the version, date and machine, because
+  // those came off the board and are true. It also matches what the status bar
+  // shows for the same `RuntimeInfo`, so the two can no longer disagree.
+  if (info.dialect === 'unknown') {
+    return `${DIALECT_LABEL.unknown} ${info.version}${date}${machine}`
+  }
+  const name = info.dialect === 'circuitpython' ? 'Adafruit CircuitPython' : 'MicroPython'
+  // MicroPython prints `v1.28.0`; CircuitPython prints the version bare.
+  const version = info.dialect === 'circuitpython' ? info.version : `v${info.version}`
   return `${name} ${version}${date}${machine}`
 }
 

--- a/test/dialect.test.ts
+++ b/test/dialect.test.ts
@@ -203,6 +203,46 @@ describe('runtimeGreeting', () => {
     expect(runtimeGreeting({ dialect: 'circuitpython' })).toBe('')
     expect(runtimeGreeting(null)).toBe('')
   })
+
+  // #770 — the greeting used to be `circuitpython ? … : MicroPython`, so ANY
+  // board it could not positively identify was announced as MicroPython. The
+  // reported case was a real CircuitPython 10.2.1 board greeted as
+  // "MicroPython v10.2.1": the version was right and the runtime was a lie, in
+  // the first line the user reads.
+  it('never claims MicroPython for a runtime it could not identify (#770)', () => {
+    const greeting = runtimeGreeting({ dialect: 'unknown', version: '10.2.1' })
+    expect(greeting).not.toMatch(/MicroPython/i)
+    expect(greeting).toContain('10.2.1')
+  })
+
+  it('drops the `v` prefix for an unknown runtime — that is MicroPython’s own convention', () => {
+    expect(runtimeGreeting({ dialect: 'unknown', version: '10.2.1' })).not.toContain('v10.2.1')
+  })
+
+  it('still reports what the board DID say — version, date and machine', () => {
+    expect(
+      runtimeGreeting({
+        dialect: 'unknown',
+        version: '10.2.1',
+        buildDate: '2026-08-18',
+        machine: 'Adafruit Feather RP2040 with rp2040'
+      })
+    ).toBe('Unknown runtime 10.2.1 on 2026-08-18; Adafruit Feather RP2040 with rp2040')
+  })
+
+  it('agrees with the status bar, which reads the same RuntimeInfo', () => {
+    // The issue asked whether the two could disagree. They cannot now: both
+    // route an unidentified runtime through DIALECT_LABEL.unknown.
+    const info = { dialect: 'unknown' as const, version: '10.2.1' }
+    expect(runtimeGreeting(info).startsWith(runtimeLabel(info).split(' ')[0])).toBe(true)
+  })
+
+  it('still words each KNOWN runtime exactly as its own banner does', () => {
+    expect(runtimeGreeting({ dialect: 'micropython', version: '1.28.0' })).toBe('MicroPython v1.28.0')
+    expect(runtimeGreeting({ dialect: 'circuitpython', version: '10.2.1' })).toBe(
+      'Adafruit CircuitPython 10.2.1'
+    )
+  })
 })
 
 describe('runtimeLabel', () => {


### PR DESCRIPTION
Closes #770.

## The bug

A CircuitPython 10.2.1 board was welcomed in the REPL as `MicroPython v10.2.1`. The version was right — so the probe had reached the board and read it — and only the dialect was wrong, in the first line the user reads.

## The cause

A binary at the render step:

```ts
const name = info.dialect === 'circuitpython' ? 'Adafruit CircuitPython' : 'MicroPython'
const version = info.dialect === 'circuitpython' ? info.version : `v${info.version}`
```

`Dialect` has **three** values, and both lines collapse `unknown` into MicroPython. Any failure to *positively* identify CircuitPython reported the board as MicroPython — reintroducing the "assume MicroPython everywhere" default this module was written to remove, at the very last step. The `v` prefix was the second half of the same mistake: that's MicroPython's convention, and CircuitPython prints its version bare.

## The fix

An unknown runtime now claims **no** runtime name and drops the `v`, while still printing version, build date and machine — those came off the board and are true.

It routes through `DIALECT_LABEL.unknown`, which is what `runtimeLabel` already used, so **the greeting and the status bar can no longer disagree** about the same `RuntimeInfo` — something the issue explicitly asked to check.

## What I deliberately did NOT change

- **The parse side.** `dialectFromName` already returns `unknown` for a name that is neither runtime, which is correct. `parseRuntimeBanner`'s ternary is safe because its regex only matches the two literal runtime names.
- **The other two sites with the same shape.** The issue says "the places that render it" (plural), so I checked: `bootFileNote` returns `null` unless the dialect is one of the two, and `crossDialectHints` returns early when `otherDialect` gives `null`, which it does for `unknown`. Both are already guarded and don't have this bug. `runtimeGreeting` was the only genuine one.

## Tests

Five added to `test/dialect.test.ts`, including the reported case directly: an `unknown` dialect with version 10.2.1 must not mention MicroPython, must not carry the `v`, must still report what the board said, and must agree with the status bar.

Gates: typecheck, lint, **5701** tests, build — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)