### PR TITLE
fix: a driver install clears the board's stale import cache (#784)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **Installing a driver no longer leaves the board using its old, broken copy.**
+  (#784) If you tried an import, it failed, you installed the driver, and tried
+  again — the natural order of events — the import kept failing. The files on
+  disk were byte-for-byte correct and exported the missing symbol, but the first
+  failed import had left a half-built module in the board's `sys.modules`, and
+  every retry got that cache back instead of re-reading the disk. The error
+  named a real symbol in a real file that really contained it, so every instinct
+  was to suspect the installer, the package or the URL. Only a board reset
+  cleared it.
+
+  A successful install now drops that module — and its submodules — from the
+  board's import cache, so the next `import` reads the files that were just
+  written.
+
+  It is a **targeted purge rather than a soft reset**, which is the difference
+  between fixing this and charging for it: a reset would throw away the whole
+  REPL session, every variable you were mid-experiment with, to solve a problem
+  you did not know you had. And it is not silent — when a cached copy really was
+  found, the install row says so, and says plainly what a purge cannot undo
+  (a name you already imported *from* the stale module keeps pointing at it
+  until the board resets). On a board that had never imported the module,
+  nothing is said, because there is nothing to report.
+
 ### Added
 - **Publish a project to GitHub without leaving Snakie.** (#795) A repository
   you created locally had nowhere to go: the Source Control panel offered

--- a/src/renderer/src/components/DriverInstallBanner.css
+++ b/src/renderer/src/components/DriverInstallBanner.css
@@ -94,3 +94,21 @@
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
+
+/* The "the board was holding a stale copy, so it was cleared" note (#784).
+   Shown on a row that SUCCEEDED, so it must not read as an error: muted body
+   text with an accent rule down its left edge, rather than the error red.
+
+   Themed tokens throughout — this panel's older `--row-error` is a hardcoded
+   dark-only colour, and repeating that here would make the note unreadable on
+   the skeuomorph parchment skin. */
+.drvbanner__row-note {
+  width: 100%;
+  margin-top: 4px;
+  padding: 4px 0 4px 8px;
+  margin-left: 16px;
+  border-left: 2px solid var(--accent);
+  color: var(--text-muted);
+  font-size: 0.92em;
+  line-height: 1.45;
+}

--- a/src/renderer/src/components/DriverInstallBanner.tsx
+++ b/src/renderer/src/components/DriverInstallBanner.tsx
@@ -48,6 +48,11 @@ type DriverState = 'pending' | 'installing' | 'ok' | 'error'
 interface DriverStatus {
   state: DriverState
   message?: string
+  /** Said on SUCCESS when the board was still holding a stale copy of this
+   *  module and Snakie dropped it (#784). Kept separate from `message`, which
+   *  is a failure reason — this row succeeded, and the note explains something
+   *  that happened along the way rather than something that went wrong. */
+  note?: string
 }
 
 export interface DriverInstallBannerProps {
@@ -200,7 +205,7 @@ export function DriverInstallBanner({ needs }: DriverInstallBannerProps): JSX.El
     // The mip/copy sequence lives in the shared installer (also used by the main
     // editor's missing-library banner, #166) — this wrapper just maps to status.
     const res = await installPartDriver(need.libraryId, need.partId, d)
-    setStatus(id, { state: res.ok ? 'ok' : 'error', message: res.message })
+    setStatus(id, { state: res.ok ? 'ok' : 'error', message: res.message, note: res.note })
   }
 
   const installAll = async (): Promise<void> => {
@@ -296,6 +301,14 @@ export function DriverInstallBanner({ needs }: DriverInstallBannerProps): JSX.El
                 )}
                 {st === 'error' && statuses[id]?.message && (
                   <span className="drvbanner__row-error">{statuses[id]?.message}</span>
+                )}
+                {/* A successful install that ALSO had to clear the board's
+                    cached copy (#784). Without this the banner reports plain
+                    success while something the user never asked about was
+                    changed on their board — and the import that sent them here
+                    would still have been failing for a reason nothing named. */}
+                {st === 'ok' && statuses[id]?.note && (
+                  <span className="drvbanner__row-note">{statuses[id]?.note}</span>
                 )}
               </li>
             )

--- a/src/renderer/src/components/driver-install.ts
+++ b/src/renderer/src/components/driver-install.ts
@@ -14,12 +14,47 @@
  */
 import { driverDeviceDirs, driverInstallMethod, driverModuleId } from './part-editor.util'
 import { moduleById } from '../../../shared/modules-catalog'
+import {
+  parsePurgeCount,
+  purgeModuleSnippet,
+  purgeNote,
+  topLevelModuleName
+} from '../../../shared/module-cache'
 import type { DriverFile } from '../../../preload/index.d'
 
 export interface DriverInstallResult {
   ok: boolean
   /** A short failure reason for the banner copy (undefined on success). */
   message?: string
+  /**
+   * Set when the board was still holding a stale copy of the module we just
+   * installed, and we dropped it (#784). The banner shows this so a cache the
+   * user never asked about is not cleared behind their back — and so the one
+   * case that used to cost an hour of debugging now explains itself.
+   */
+  note?: string
+}
+
+/**
+ * Drop the just-installed module from the board's `sys.modules` (#784).
+ *
+ * Runs after a SUCCESSFUL install, and is strictly best-effort: the files are
+ * already written and correct, so nothing here may turn success into failure.
+ * A board that cannot run the snippet simply gets the old behaviour, which is
+ * why every failure path returns `undefined` rather than propagating.
+ */
+async function clearStaleModule(target: string): Promise<string | undefined> {
+  const name = topLevelModuleName(target)
+  if (!name) return undefined
+  try {
+    const out = await window.api.device.exec(purgeModuleSnippet(name))
+    const text = typeof out === 'string' ? out : ((out as { output?: string })?.output ?? '')
+    return purgeNote([name], parsePurgeCount(text))
+  } catch {
+    // No board, a busy REPL, a runtime without `sys.modules` — the install
+    // still stands, and the user is no worse off than before this existed.
+    return undefined
+  }
 }
 
 /** Install ONE driver file onto the connected board. Never throws. */
@@ -39,20 +74,24 @@ export async function installPartDriver(
         return { ok: false, message: `Unknown module "${id}" — it is not in the catalog.` }
       }
       const res = await window.api.modules.install(id)
-      return res.ok
-        ? { ok: true }
-        : { ok: false, message: res.log?.split('\n').filter(Boolean).pop() || `Could not install ${id}.` }
+      if (!res.ok) {
+        return {
+          ok: false,
+          message: res.log?.split('\n').filter(Boolean).pop() || `Could not install ${id}.`
+        }
+      }
+      return { ok: true, note: await clearStaleModule(d.target || id) }
     }
     if (method === 'mip') {
       const target = d.target.trim()
       const res = await window.api.packages.install(d.source, target ? { target } : undefined)
-      return res.ok
-        ? { ok: true }
-        : {
-            ok: false,
-            message:
-              res.log.split('\n').filter(Boolean).pop() || `Could not install ${d.source}.`
-          }
+      if (!res.ok) {
+        return {
+          ok: false,
+          message: res.log.split('\n').filter(Boolean).pop() || `Could not install ${d.source}.`
+        }
+      }
+      return { ok: true, note: await clearStaleModule(target || d.source) }
     }
     // copy: read the file (bundled file or URL, via main) then write to target.
     const read = await window.api.parts.readDriverSource(libraryId, partId, d.source)
@@ -77,7 +116,7 @@ export async function installPartDriver(
       await window.api.device.mkdir(dir).catch(() => undefined)
     }
     await window.api.device.writeFile(d.target.trim(), read.contents)
-    return { ok: true }
+    return { ok: true, note: await clearStaleModule(d.target) }
   } catch (err) {
     const raw = err instanceof Error ? err.message : String(err)
     // The board's MicroPython filesystem is full — OSError 28 (ENOSPC). Small boards

--- a/src/shared/module-cache.ts
+++ b/src/shared/module-cache.ts
@@ -1,0 +1,161 @@
+/**
+ * STALE MODULE CACHE — clearing what the board already imported (#784).
+ * =============================================================================
+ *
+ * Installing a driver for a module the board has **already tried to import**
+ * used to leave the board using the old, broken import. The install succeeded,
+ * the files on disk were correct, and the import kept failing:
+ *
+ *     ImportError: can't import name map_value
+ *       File "/lib/modulino/__init__.py", line 7
+ *
+ * The cause is `sys.modules`. The user's FIRST import failed while the package
+ * was genuinely incomplete (an earlier install had died), MicroPython cached the
+ * half-built module, and every retry afterwards got that cache back instead of
+ * re-reading the disk. A soft reset fixed it instantly, which is what makes the
+ * bug so expensive: the error names a real symbol in a real file that really
+ * contains it, so every instinct is to suspect the installer, the package, the
+ * URL, a version mismatch — anything but a cache.
+ *
+ * And the order of events that gets you there is the NATURAL one: try an import,
+ * see it fail, install the driver, try again.
+ *
+ * ── Why a targeted purge rather than a soft reset ───────────────────────────
+ * A soft reset (Ctrl-D) is the sledgehammer the user reached for by hand, and it
+ * works — but it throws away the whole REPL session: every variable they were
+ * mid-experiment with, and any hardware they had set up. Deleting just the
+ * offending keys from `sys.modules` fixes exactly the same thing and keeps all
+ * of it, because the next `import` then re-reads the file from disk.
+ *
+ * It is not a complete undo, and does not pretend to be: a name already bound
+ * from the stale module (`from modulino import X`) stays bound to the old
+ * object. But that is not the reported flow — the flow is an import that FAILED,
+ * so nothing was bound from it — and the alternative costs the user their whole
+ * session. Where a purge cannot help, a reset is still one click away.
+ *
+ * Dependency-free (the same discipline as `control.ts`, `dialect.ts` and
+ * `device-scratch.ts`) so main, preload and renderer can all import it, and so
+ * the rule is unit-testable without a board.
+ */
+import { scratchBlock, scratchName } from './device-scratch'
+
+/** Extensions a Python module can arrive as on a board. */
+const MODULE_EXTENSIONS = ['.py', '.mpy']
+
+/**
+ * The TOP-LEVEL module name a written file belongs to, or `null` when the path
+ * names no importable module.
+ *
+ * Top-level rather than the full dotted name because that is what has to be
+ * purged: `sys.modules` holds the package AND each submodule, and dropping
+ * `modulino.helpers` while keeping `modulino` leaves the stale package object —
+ * the very thing that produced the reported error — still in place. The caller
+ * pairs this with a prefix sweep, so one name covers the whole package.
+ *
+ *   `/lib/modulino/helpers.py`  → `modulino`
+ *   `/lib/modulino/__init__.py` → `modulino`
+ *   `/lib/ssd1306.py`           → `ssd1306`
+ *   `/lib/`                     → null
+ */
+export function topLevelModuleName(target: string): string | null {
+  if (!target) return null
+  // A board path is always POSIX, but a hand-typed Windows-style separator
+  // should not silently produce a nonsense module name.
+  const parts = target.trim().replace(/\\/g, '/').split('/').filter(Boolean)
+  // `lib` is the library folder, not part of any module's name.
+  if (parts[0] === 'lib') parts.shift()
+  const first = parts[0]
+  if (!first) return null
+  const bare = MODULE_EXTENSIONS.reduce(
+    (name, ext) => (name.toLowerCase().endsWith(ext) ? name.slice(0, -ext.length) : name),
+    first
+  )
+  // `__init__` alone means the path was `/lib/__init__.py` — no package to name.
+  if (!bare || bare === '__init__') return null
+  // Anything that is not a legal identifier cannot be imported, so purging it
+  // would be a no-op at best and a malformed snippet at worst.
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(bare)) return null
+  return bare
+}
+
+/** The distinct top-level module names a set of written paths touches. */
+export function modulesTouched(targets: readonly string[]): string[] {
+  const seen = new Set<string>()
+  for (const t of targets) {
+    const name = topLevelModuleName(t)
+    if (name) seen.add(name)
+  }
+  return [...seen]
+}
+
+/** Marker the purge snippet prints, so its result can be read back. */
+export const PURGE_MARKER = 'SNKPURGED:'
+
+/**
+ * Python that drops `name` and every submodule of it from `sys.modules`, then
+ * prints `SNKPURGED:<count>`.
+ *
+ * Three details that are not incidental:
+ *
+ *  - **The keys are collected before anything is deleted.** Mutating a dict
+ *    while iterating it raises on MicroPython just as it does on CPython.
+ *  - **`name.` prefix, not `startswith(name)`.** `modulino` must not sweep away
+ *    an unrelated `modulinox`.
+ *  - **The whole thing is guarded.** A board with no `sys.modules` to speak of,
+ *    or a frozen module that refuses deletion, must not turn a SUCCESSFUL
+ *    install into a failure — the files are already written and correct. It
+ *    prints a count of 0 and the caller says nothing.
+ */
+export function purgeModuleSnippet(name: string): string {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+    throw new Error(`purgeModuleSnippet: not an importable module name: ${name}`)
+  }
+  const n = scratchName('n')
+  const keys = scratchName('k')
+  const one = scratchName('i')
+  return scratchBlock(
+    [
+      'import sys',
+      `${n} = ${JSON.stringify(name)}`,
+      // Collected first: deleting while iterating raises.
+      `${keys} = [${one} for ${one} in sys.modules if ${one} == ${n} or ${one}.startswith(${n} + ".")]`,
+      `for ${one} in ${keys}:`,
+      `    try: del sys.modules[${one}]`,
+      '    except (KeyError, RuntimeError): pass',
+      `print("${PURGE_MARKER}" + str(len(${keys})))`
+    ],
+    n,
+    keys,
+    one
+  )
+}
+
+/** How many modules a {@link purgeModuleSnippet} run reported dropping. */
+export function parsePurgeCount(stdout: string): number {
+  for (const line of stdout.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (trimmed.startsWith(PURGE_MARKER)) {
+      const n = Number.parseInt(trimmed.slice(PURGE_MARKER.length), 10)
+      if (Number.isFinite(n) && n >= 0) return n
+    }
+  }
+  return 0
+}
+
+/**
+ * The sentence the install banner adds when a purge actually dropped something.
+ *
+ * Only shown when a cached copy really was found, because that is the whole
+ * point: on a board that had never imported the module there is nothing to
+ * report, and saying so every time would be noise that hides the one case that
+ * matters. `undefined` means "say nothing extra".
+ */
+export function purgeNote(names: readonly string[], purged: number): string | undefined {
+  if (purged <= 0 || names.length === 0) return undefined
+  const what = names.length === 1 ? names[0] : names.join(', ')
+  return (
+    `The board had already imported ${what}, so it was still holding the old copy in memory — ` +
+    'cleared, so your next import reads the new files. (Names you already imported from it ' +
+    'keep pointing at the old copy until you reset the board.)'
+  )
+}

--- a/test/moduleCache.test.ts
+++ b/test/moduleCache.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from 'vitest'
+import {
+  PURGE_MARKER,
+  modulesTouched,
+  parsePurgeCount,
+  purgeModuleSnippet,
+  purgeNote,
+  topLevelModuleName
+} from '../src/shared/module-cache'
+import { isScratchName } from '../src/shared/device-scratch'
+import { SimulatedDevice } from '../src/main/device/SimulatedDevice'
+
+/**
+ * #784 — a driver install left the board using its cached, broken import.
+ *
+ * The reported session cost about a dozen exchanges to diagnose, because every
+ * check said the install was fine: the file on disk was byte-for-byte correct
+ * and exported the missing symbol, yet the import kept failing. MicroPython had
+ * cached the half-built module from an EARLIER, failed install, and every retry
+ * got that cache back instead of re-reading the disk.
+ *
+ * So the test that matters is not "does the snippet parse" — it is "does the
+ * documented symptom actually reproduce, and does the fix actually clear it".
+ * The suite below does both against the REAL MicroPython interpreter, which is
+ * the only thing that can answer either question.
+ */
+
+describe('topLevelModuleName', () => {
+  it('names the PACKAGE for a file inside one, not the file', () => {
+    // The whole point: dropping `modulino.helpers` while keeping `modulino`
+    // leaves the stale package object that produced the reported error.
+    expect(topLevelModuleName('/lib/modulino/helpers.py')).toBe('modulino')
+    expect(topLevelModuleName('/lib/modulino/__init__.py')).toBe('modulino')
+    expect(topLevelModuleName('/lib/foo/bar/baz.py')).toBe('foo')
+  })
+
+  it('names a single-file module', () => {
+    expect(topLevelModuleName('/lib/ssd1306.py')).toBe('ssd1306')
+    expect(topLevelModuleName('ssd1306.py')).toBe('ssd1306')
+  })
+
+  it('treats a precompiled .mpy the same as its source', () => {
+    expect(topLevelModuleName('/lib/ssd1306.mpy')).toBe('ssd1306')
+  })
+
+  it('does not treat the lib folder as part of the name', () => {
+    expect(topLevelModuleName('/lib/x.py')).toBe('x')
+    expect(topLevelModuleName('lib/x.py')).toBe('x')
+  })
+
+  it('returns null where there is no module to name', () => {
+    expect(topLevelModuleName('')).toBeNull()
+    expect(topLevelModuleName('/lib/')).toBeNull()
+    expect(topLevelModuleName('/lib/__init__.py')).toBeNull()
+  })
+
+  it('refuses a name that could not be imported anyway', () => {
+    // A malformed name must not be interpolated into a snippet.
+    expect(topLevelModuleName('/lib/2bad.py')).toBeNull()
+    expect(topLevelModuleName('/lib/with-dash.py')).toBeNull()
+    expect(topLevelModuleName('/lib/has space.py')).toBeNull()
+  })
+})
+
+describe('modulesTouched', () => {
+  it('collapses a package written as many files to ONE name', () => {
+    expect(
+      modulesTouched(['/lib/modulino/__init__.py', '/lib/modulino/helpers.py', '/lib/ssd1306.py'])
+    ).toEqual(['modulino', 'ssd1306'])
+  })
+
+  it('ignores paths that name no module', () => {
+    expect(modulesTouched(['/lib/', '/lib/2bad.py'])).toEqual([])
+  })
+})
+
+describe('purgeModuleSnippet', () => {
+  it('refuses a name that is not importable, rather than emitting bad Python', () => {
+    expect(() => purgeModuleSnippet('with-dash')).toThrow(/importable/i)
+    expect(() => purgeModuleSnippet('2bad')).toThrow(/importable/i)
+  })
+
+  it('uses only scratch-prefixed globals, so nothing of ours is left on the board', () => {
+    const code = purgeModuleSnippet('modulino')
+    // Every assignment target in the snippet must be one the inspector hides.
+    for (const m of code.matchAll(/^(\w+) = /gm)) {
+      expect(isScratchName(m[1]), `${m[1]} is not a scratch name`).toBe(true)
+    }
+  })
+
+  it('matches submodules by a DOTTED prefix, so a similar name is not swept up', () => {
+    // `modulino` must not take `modulinox` with it.
+    expect(purgeModuleSnippet('modulino')).toContain('+ "."')
+  })
+})
+
+describe('parsePurgeCount', () => {
+  it('reads the count the snippet printed', () => {
+    expect(parsePurgeCount(`${PURGE_MARKER}3`)).toBe(3)
+    expect(parsePurgeCount(`noise\r\n${PURGE_MARKER}0\r\nmore`)).toBe(0)
+  })
+
+  it('reads zero from output that never reported, rather than guessing', () => {
+    expect(parsePurgeCount('')).toBe(0)
+    expect(parsePurgeCount('OSError: 30')).toBe(0)
+  })
+})
+
+describe('purgeNote', () => {
+  it('says nothing when nothing was cached — the common case', () => {
+    // Reporting every install would be noise that hides the one that matters.
+    expect(purgeNote(['modulino'], 0)).toBeUndefined()
+    expect(purgeNote([], 2)).toBeUndefined()
+  })
+
+  it('names the module, and is honest about what a purge cannot undo', () => {
+    const note = purgeNote(['modulino'], 2) ?? ''
+    expect(note).toContain('modulino')
+    // A name already bound from the stale module keeps pointing at it; claiming
+    // otherwise would set up the next confusing session.
+    expect(note).toMatch(/already imported from it|reset the board/i)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Against the real MicroPython interpreter
+// ---------------------------------------------------------------------------
+
+describe('the stale import cache, on a real interpreter (#784)', () => {
+  /** Every global the board holds, as the inspector's snippet would see it. */
+  async function globalsOn(dev: SimulatedDevice): Promise<string[]> {
+    const { stdout } = await dev.exec(
+      "print('NAMES', ' '.join(k for k in list(globals().keys()) if not k.startswith('__')))"
+    )
+    const line = stdout.split(/\r?\n/).find((l) => l.startsWith('NAMES'))
+    return (line ?? '').slice('NAMES'.length).trim().split(/\s+/).filter((n) => n.length > 0)
+  }
+
+  it('reproduces the bug, and the purge fixes it — without losing REPL state', async () => {
+    const dev = new SimulatedDevice()
+    await dev.connect()
+    try {
+      await dev.exec('import sys\nsys.path.insert(0, "/lib")')
+      // The user's own session state, which a soft reset would destroy and this
+      // fix must preserve — that is the whole reason for a targeted purge.
+      await dev.exec("SPRITE = b'\\x01\\x02'\nmatrix = [1, 2, 3]")
+
+      // 1. The BROKEN install: the package exists but lacks the symbol.
+      await dev.mkdir('/lib/modulino').catch(() => undefined)
+      await dev.writeFile('/lib/modulino/__init__.py', 'VALUE = 1\n')
+
+      // 2. The user imports it. This is what poisons sys.modules.
+      await dev.exec('import modulino')
+
+      // 3. The install is repaired on disk — byte-for-byte correct.
+      await dev.writeFile('/lib/modulino/__init__.py', 'VALUE = 1\ndef map_value():\n    return 42\n')
+
+      // 4. The reported symptom: a fresh import STILL serves the cached copy.
+      const stale = await dev.exec(
+        'import modulino\nprint("HAS", hasattr(modulino, "map_value"))'
+      )
+      expect(stale.stdout, 'the stale cache should still be serving the old module').toContain(
+        'HAS False'
+      )
+
+      // 5. The fix.
+      const purge = await dev.exec(purgeModuleSnippet('modulino'))
+      expect(parsePurgeCount(purge.stdout)).toBeGreaterThan(0)
+
+      // 6. The next import reads the disk.
+      const fresh = await dev.exec(
+        'import modulino\nprint("HAS", hasattr(modulino, "map_value"))\nprint("VAL", modulino.map_value())'
+      )
+      expect(fresh.stdout).toContain('HAS True')
+      expect(fresh.stdout).toContain('VAL 42')
+
+      // 7. And the user still has their session — the point of not soft-resetting.
+      const names = await globalsOn(dev)
+      expect(names).toContain('SPRITE')
+      expect(names).toContain('matrix')
+      // 8. ...and none of Snakie's own names were left behind (#798's rule).
+      expect(names.filter((n) => isScratchName(n))).toEqual([])
+    } finally {
+      await dev.dispose()
+    }
+  }, 30_000)
+
+  it('does not sweep away a module with a similar name', async () => {
+    const dev = new SimulatedDevice()
+    await dev.connect()
+    try {
+      await dev.exec('import sys\nsys.path.insert(0, "/lib")')
+      await dev.writeFile('/lib/modx.py', 'A = 1\n')
+      await dev.writeFile('/lib/modxtra.py', 'B = 2\n')
+      await dev.exec('import modx\nimport modxtra')
+
+      await dev.exec(purgeModuleSnippet('modx'))
+
+      const { stdout } = await dev.exec(
+        'import sys\nprint("MODX", "modx" in sys.modules)\nprint("EXTRA", "modxtra" in sys.modules)'
+      )
+      expect(stdout).toContain('MODX False')
+      // The prefix match is dotted, so the unrelated neighbour survives.
+      expect(stdout).toContain('EXTRA True')
+    } finally {
+      await dev.dispose()
+    }
+  }, 30_000)
+
+  it('is harmless on a module the board never imported', async () => {
+    const dev = new SimulatedDevice()
+    await dev.connect()
+    try {
+      const { stdout } = await dev.exec(purgeModuleSnippet('never_imported_here'))
+      expect(parsePurgeCount(stdout)).toBe(0)
+      // A no-op purge must not look like a failure to the installer.
+      expect(stdout).not.toMatch(/Traceback|Error/i)
+    } finally {
+      await dev.dispose()
+    }
+  }, 30_000)
+})


### PR DESCRIPTION
Closes #784.

## Reproduced, not assumed

The diagnosis in the issue was exactly right, and the test proves it against the **real MicroPython interpreter**:

```
write a broken /lib/modulino/__init__.py
import modulino                            <- poisons sys.modules
write the CORRECT file
import modulino  ->  HAS map_value: False  <- the reported symptom
```

The first import failed while the package was genuinely incomplete, MicroPython cached the half-built module, and every retry got the cache instead of the disk.

What makes it expensive is that **the error accuses the wrong thing** — it names a real symbol, in a real file, that really contains it. So every instinct is to suspect the installer, the package, the URL, a version mismatch. And the order of events that gets you there is the *natural* one: try an import, watch it fail, install the driver, try again.

After the fix, the same test: `HAS map_value: True`, and `map_value()` returns `42`.

## A targeted purge, not a soft reset

Ctrl-D is what the user reached for by hand, and it works — but it discards the whole REPL session, every variable they were mid-experiment with, to solve a problem they did not know they had. Deleting the offending `sys.modules` keys fixes the same thing and keeps all of it. The test asserts the user's `SPRITE` and `matrix` survive.

It is **not a complete undo, and the note says so** rather than overclaiming: a name already bound from the stale module (`from modulino import X`) keeps pointing at the old object. That is not the reported flow — an import that *failed* binds nothing — and where a purge cannot help, a reset is still one click away.

## Not silent

Per the issue's closing line: the banner must not report plain success while the board serves a broken cached copy. A row that really found a cached copy says so. A board that never imported the module says **nothing** — reporting every install would be noise that hides the one case that matters.

## Details that are not incidental

All covered by tests:

- **The purge targets the top-level package.** Dropping `modulino.helpers` while keeping `modulino` leaves the stale package object — the very thing that produced the error.
- **Submodules match on a dotted prefix**, so `modulino` cannot sweep away `modulinox` (asserted on the real interpreter).
- **Keys are collected before deletion** — mutating a dict while iterating raises.
- **Strictly best-effort.** The files are already written and correct, so nothing here may turn a successful install into a failure.
- **Only scratch-prefixed globals** (#798), so none of Snakie's names are left in the user's namespace — asserted both structurally and on the board.

The banner's note uses themed tokens rather than this panel's older hardcoded `row-error` colour, which is dark-only and would be unreadable on the skeuomorph skin.

## Tests

**18 new** in `test/moduleCache.test.ts` — pure helpers plus three real-interpreter cases (reproduce-and-fix, the similar-name guard, and the harmless no-op).

Gates: typecheck, lint (one pre-existing warning elsewhere), test (**5714** passing), build — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)