### PR TITLE
fix: an unrecognised USB-serial bridge no longer blocks flashing (#821)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **A board with an unfamiliar USB-serial chip can be flashed again.** (#821)
+  An Adafruit ESP32 Feather V2 never appeared in the flasher's **Serial port**
+  dropdown, so there was nothing to select and no way to go on — even though the
+  board enumerated fine and was listed in the Console panel's device dropdown.
+
+  Detection matches a port's USB vendor/product id against a table of known
+  bridge chips, and Adafruit moved this board onto a **CH9102F** once the CP2104
+  went obsolete. The table knew the older CH340 and CH341 and nothing else from
+  that vendor, so the port was silently dropped. The CH9102F and its CH343
+  sibling are now in the table, and the **Adafruit ESP32 Feather V2** has a board
+  profile — so it appears in the Board dropdown too, with the right 0x1000 flash
+  offset and a note that it needs BOOT held while you tap RESET.
+
+  More importantly, **an unrecognised port is now offered rather than hidden**,
+  marked as such, so you can pick it and choose the board type yourself. That
+  table will always trail the market, and until now the cost of it trailing was a
+  board that could not be flashed at all with nothing on screen to say why.
+
+
 ### Added
 - **The RCWL-1601 ultrasonic distance sensor is in the Standard parts library.**
   It is pin- and software-compatible with the HC-SR04 already in the library, so

--- a/src/main/firmware/detect.ts
+++ b/src/main/firmware/detect.ts
@@ -37,14 +37,22 @@ const ESP_USB_BRIDGES: Array<{ vid: string; pid?: string; board: BoardType; chip
   // WCH CH340 / CH341 — common on cheaper ESP8266 (NodeMCU) and some ESP32.
   { vid: '1a86', pid: '7523', board: 'esp8266', chip: 'CH340' },
   { vid: '1a86', pid: '5523', board: 'esp8266', chip: 'CH341' },
+  // WCH CH9102F / CH343 — what current ESP32 boards use now that the CP2104 is
+  // obsolete (Adafruit moved the ESP32 Feather V2 onto the CH9102F, #821). These
+  // are `esp32`, NOT `esp8266` like their older CH340 siblings above: the cheap
+  // NodeMCU association does not hold for these newer parts.
+  { vid: '1a86', pid: '55d4', board: 'esp32', chip: 'CH9102F' },
+  { vid: '1a86', pid: '55d3', board: 'esp32', chip: 'CH343' },
   // FTDI FT232 — older ESP dev boards.
   { vid: '0403', pid: '6001', board: 'esp32', chip: 'FT232R' },
   // Espressif native USB CDC (ESP32-S2/S3/C3 built-in USB JTAG/serial).
   { vid: '303a', board: 'esp32', chip: 'Espressif native USB' }
 ]
 
-/** Match a serial port's VID/PID against the known ESP bridge table. */
-function matchEspBridge(
+/** Match a serial port's VID/PID against the known ESP bridge table.
+ *  Exported so the table itself is testable — a chip missing from it makes a
+ *  board silently unflashable, which is exactly how #821 happened. */
+export function matchEspBridge(
   vendorId?: string,
   productId?: string
 ): { board: BoardType; chip: string } | undefined {

--- a/src/renderer/src/components/FirmwareFlasher.tsx
+++ b/src/renderer/src/components/FirmwareFlasher.tsx
@@ -4,7 +4,8 @@ import type {
   BoardType,
   EsptoolInfo,
   FirmwareCatalog,
-  FlashProgress
+  FlashProgress,
+  PortInfo
 } from '../../../preload/index.d'
 import {
   BOARD_PROFILES,
@@ -128,6 +129,9 @@ export function FirmwareFlasher({
   boardId
 }: FirmwareFlasherProps): JSX.Element {
   const [candidates, setCandidates] = useState<BoardCandidate[]>([])
+  /** Every serial port on the machine, so a board whose USB bridge detection did
+   *  not recognise can still be selected (#821). */
+  const [ports, setPorts] = useState<PortInfo[]>([])
   const [board, setBoard] = useState<BoardType>('esp32')
   /** The chosen board profile (#682) — drives the mechanics below it. */
   const [profileId, setProfileId] = useState<string>('')
@@ -227,12 +231,16 @@ export function FirmwareFlasher({
 
   const refreshDetection = useCallback(async (): Promise<void> => {
     try {
-      const [found, tool] = await Promise.all([
+      const [found, tool, allPorts] = await Promise.all([
         window.api.firmware.detectBoards(),
-        window.api.firmware.checkEsptool()
+        window.api.firmware.checkEsptool(),
+        // Best-effort and independent of detection: a port we cannot identify
+        // still needs offering (#821).
+        window.api.device.listPorts().catch(() => [] as PortInfo[])
       ])
       setCandidates(found)
       setEsptool(tool)
+      setPorts(allPorts)
       // Adopt the first detected candidate as a sensible default — but NEVER
       // over an explicitly chosen board (#684). Detection only knows the coarse
       // BoardType, whose ESP offset is the original ESP32's 0x1000; silently
@@ -533,6 +541,18 @@ export function FirmwareFlasher({
   }, [source, selFamily, selVersionUrl])
 
   const serialCandidates = candidates.filter((c) => c.source === 'serial')
+  // Every OTHER serial port — the ones whose USB bridge we did not recognise.
+  //
+  // Detection keys off a VID/PID table (`ESP_USB_BRIDGES`), and that table is
+  // always going to be behind the market: Adafruit moved the ESP32 Feather V2
+  // onto a CH9102F and the board became unflashable, because an unmatched port
+  // was simply dropped and the dropdown is built from matches alone (#821).
+  //
+  // A board we cannot identify is not the same as a board that is not there.
+  // Offering the port, plainly marked as unrecognised, turns a dead end into a
+  // choice — the user picks the board type themselves, which is exactly what the
+  // manual path below already supports.
+  const unknownPorts = ports.filter((p) => !serialCandidates.some((c) => c.port === p.path))
   // Drive candidates relevant to the selected board (RP2040 vs micro:bit drives).
   const uf2Candidates = candidates.filter((c) => c.source === 'uf2-drive' && c.board === board)
 
@@ -970,9 +990,16 @@ export function FirmwareFlasher({
                         {c.label}
                       </option>
                     ))}
-                    {port && !serialCandidates.some((c) => c.port === port) && (
-                      <option value={port}>{port}</option>
-                    )}
+                    {unknownPorts.map((p) => (
+                      <option key={p.path} value={p.path}>
+                        {p.path} — unrecognised USB device
+                      </option>
+                    ))}
+                    {port &&
+                      !serialCandidates.some((c) => c.port === port) &&
+                      !unknownPorts.some((p) => p.path === port) && (
+                        <option value={port}>{port}</option>
+                      )}
                   </select>
                 </div>
               ) : (

--- a/src/shared/board-profiles.ts
+++ b/src/shared/board-profiles.ts
@@ -187,6 +187,22 @@ export const BOARD_PROFILES: BoardProfile[] = [
     offset: '0x1000'
   },
   {
+    id: 'adafruit-feather-esp32-v2',
+    vendor: 'Adafruit',
+    model: 'ESP32 Feather V2',
+    label: 'Adafruit ESP32 Feather V2 (8 MB flash, 2 MB PSRAM)',
+    chipFamily: 'esp32',
+    method: 'esptool',
+    // The original ESP32 — the one chip whose offset is not 0x0.
+    offset: '0x1000',
+    circuitPythonBoardId: 'adafruit_feather_esp32_v2',
+    // A CH9102F bridge, not native USB: the port stays put across a flash, so
+    // no replug is needed the way it is on an S3.
+    nativeUsb: false,
+    notes:
+      'Hold BOOT, tap RESET, then release BOOT to enter download mode — this board does not auto-reset into the bootloader.'
+  },
+  {
     id: 'esp32-s3-generic',
     vendor: 'Espressif',
     model: 'ESP32-S3 (generic)',

--- a/test/boardProfiles.test.ts
+++ b/test/boardProfiles.test.ts
@@ -212,3 +212,35 @@ describe('firmwareFileIssue (#685)', () => {
     expect(methodForBoardType('microbit')).toBe('daplink')
   })
 })
+
+describe('Adafruit ESP32 Feather V2 (#821)', () => {
+  const feather = BOARD_PROFILES.find((p) => p.id === 'adafruit-feather-esp32-v2')
+
+  it('is offered in the board picker at all — it was absent entirely', () => {
+    expect(feather).toBeDefined()
+  })
+
+  it('flashes at 0x1000, the original ESP32 offset', () => {
+    // The one chip whose offset is not 0x0. Getting this wrong writes the
+    // firmware to the wrong address and the board does not come back.
+    expect(feather?.chipFamily).toBe('esp32')
+    expect(feather?.method).toBe('esptool')
+    expect(feather?.offset).toBe('0x1000')
+  })
+
+  it('is not native USB — it sits behind a CH9102F bridge', () => {
+    // So the port survives the flash and no replug is needed, unlike an S3.
+    expect(feather?.nativeUsb).toBe(false)
+  })
+
+  it('carries the CircuitPython board id that actually exists', () => {
+    // Verified against circuitpython.org rather than guessed: flashing another
+    // board's build leaves a board needing a re-flash before it will talk.
+    expect(feather?.circuitPythonBoardId).toBe('adafruit_feather_esp32_v2')
+  })
+
+  it('says how to enter download mode, which this board will not do by itself', () => {
+    expect(feather?.notes).toMatch(/BOOT/)
+    expect(feather?.notes).toMatch(/RESET/i)
+  })
+})

--- a/test/espBridgeDetect.test.ts
+++ b/test/espBridgeDetect.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { matchEspBridge } from '../src/main/firmware/detect'
+
+/**
+ * #821 — an Adafruit ESP32 Feather V2 could not be flashed.
+ *
+ * The board enumerated perfectly well (it was listed in the Console panel's
+ * device dropdown, and Adafruit's own web flasher saw it), but the flasher's
+ * Serial port dropdown never offered it, because that dropdown was built purely
+ * from VID/PID matches and the board's bridge chip was not in the table:
+ *
+ *     /dev/tty.usbserial-51850332091   vendorId: 1a86   productId: 55d4
+ *
+ * `1a86:55d4` is a WCH CH9102F — what Adafruit moved the Feather V2 onto once
+ * the CP2104 went obsolete, and what a good many current ESP32 boards now use.
+ * The table knew `1a86:7523` (CH340) and `1a86:5523` (CH341) and nothing else
+ * with that vendor id, so the match came back undefined and the port was
+ * dropped.
+ */
+describe('the reported board (#821)', () => {
+  it('matches the CH9102F the Feather V2 actually enumerates as', () => {
+    const m = matchEspBridge('1a86', '55d4')
+    expect(m, 'the exact VID/PID read off the reported board').toBeDefined()
+    expect(m?.chip).toBe('CH9102F')
+  })
+
+  it('calls it an esp32, not an esp8266 like its older CH340 sibling', () => {
+    // Getting this wrong would pre-select the wrong chip and the wrong offset.
+    expect(matchEspBridge('1a86', '55d4')?.board).toBe('esp32')
+  })
+
+  it('handles the uppercase VID/PID some platforms report', () => {
+    expect(matchEspBridge('1A86', '55D4')?.chip).toBe('CH9102F')
+  })
+})
+
+describe('the rest of the bridge table still resolves', () => {
+  it.each([
+    ['10c4', 'ea60', 'CP210x', 'esp32'],
+    ['1a86', '7523', 'CH340', 'esp8266'],
+    ['1a86', '5523', 'CH341', 'esp8266'],
+    ['1a86', '55d3', 'CH343', 'esp32'],
+    ['0403', '6001', 'FT232R', 'esp32']
+  ])('%s:%s is the %s', (vid, pid, chip, board) => {
+    const m = matchEspBridge(vid, pid)
+    expect(m?.chip).toBe(chip)
+    expect(m?.board).toBe(board)
+  })
+
+  it('still matches Espressif native USB on the vendor id alone', () => {
+    // 303a is a vid-only entry, so any product id under it should match.
+    expect(matchEspBridge('303a', '1001')?.chip).toBe('Espressif native USB')
+    expect(matchEspBridge('303a', '4001')?.chip).toBe('Espressif native USB')
+  })
+
+  it('does not invent a match for an unrelated device', () => {
+    // A vid-only fallback must not swallow every WCH part: 1a86 has no
+    // pid-less entry, so an unknown WCH pid stays unknown rather than being
+    // silently mapped to whichever 1a86 row happens to be first.
+    expect(matchEspBridge('1a86', '9999')).toBeUndefined()
+    expect(matchEspBridge('05ac', '8103')).toBeUndefined()   // an Apple device
+    expect(matchEspBridge(undefined, undefined)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Closes #821.

## Diagnosed from the board, not inferred

The Adafruit ESP32 Feather V2 never appeared in the flasher's **Serial port** dropdown. It enumerates perfectly well — which is why it showed in the Console panel's device dropdown, and why Adafruit's own web flasher could see it:

```
/dev/tty.usbserial-51850332091   vendorId: 1a86   productId: 55d4
```

`1a86:55d4` is a **WCH CH9102F** — what Adafruit moved this board onto once the CP2104 went obsolete. `ESP_USB_BRIDGES` knew `1a86:7523` (CH340) and `1a86:5523` (CH341) and nothing else under that vendor id, and `matchEspBridge`'s vid-only fallback only considers entries with **no** `pid` — which neither `1a86` row is. So the match came back `undefined`, `detectEspFromSerial` skipped the port, and no candidate ever existed.

## Three changes, and the third is the one that matters

**1. CH9102F (`55d4`) and CH343 (`55d3`) added to the table** — as `esp32`, not the `esp8266` their older CH340 siblings carry. The cheap-NodeMCU association doesn't hold for these newer parts, and getting it wrong would pre-select the wrong chip *and* the wrong flash offset.

**2. An Adafruit ESP32 Feather V2 profile** — so it's in the Board dropdown, which was the first thing the reporter noticed was missing. esptool at `0x1000` (the original ESP32 being the one chip whose offset isn't `0x0`), not native USB, and a note that it needs BOOT held while RESET is tapped because it won't drop into download mode by itself. The CircuitPython board id was **verified against circuitpython.org**, not guessed — flashing another board's build leaves a board needing a re-flash before it will talk.

**3. Unrecognised ports are now offered, marked as such.** The dropdown was built purely from VID/PID matches, and its one apparent escape hatch —

```tsx
{port && !serialCandidates.some((c) => c.port === port) && (<option value={port}>{port}</option>)}
```

— was **unreachable**, because the dropdown is the only control that sets `port`. So an unknown bridge chip was a hard dead end.

That table is always going to trail the market. The cost of it trailing should be *"pick your board type yourself"*, not *"this board cannot be flashed and nothing tells you why"* — and the manual path underneath already supports exactly that.

## Tests

`matchEspBridge` is now exported so the table is testable at all: a chip missing from it makes a board silently unflashable, which is precisely how this happened.

**25 tests**, including the reported VID/PID directly, the uppercase form some platforms report, and a guard that the vid-only fallback never swallows an unrelated WCH part.

**Verified against the board still plugged into the machine** — it now resolves to `/dev/tty.usbserial-51850332091 — CH9102F (esp32)`.

Gates: typecheck, lint, **5787 tests**, build — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)