### PR TITLE
fix: the esptool offset follows the runtime, not just the chip (#823)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Fixed
+- **CircuitPython on an original ESP32 or S2 is flashed to the right address.**
+  (#823) The esptool write offset was chosen from the chip alone, but on those
+  two chips it also depends on which runtime you are flashing: MicroPython
+  expects a second-stage bootloader already at `0x1000` and is written there,
+  while CircuitPython ships a *combined* image whose own bootloader sits at `0`.
+  Picking a CircuitPython build wrote it 4 KB too high.
+
+  Nothing reported an error — the flash completed, said so, and the board simply
+  never came back, which is close to the worst way for this to go wrong. The
+  offset now follows the runtime as well as the chip. The ESP32-S3 and the
+  RISC-V parts are `0x0` for both runtimes, which is why only these two chips
+  were ever affected.
+
+- **The Adafruit ESP32 Feather V2 erases before it flashes.** It ships with
+  factory firmware, and a plain write leaves the old partition table behind — the
+  board then boot-loops on `Image hash failed` / `No bootable app partitions`,
+  which reads exactly like a failed flash even though the flash succeeded.
+
+
+### Fixed
 - **A board with an unfamiliar USB-serial chip can be flashed again.** (#821)
   An Adafruit ESP32 Feather V2 never appeared in the flasher's **Serial port**
   dropdown, so there was nothing to select and no way to go on — even though the

--- a/src/shared/board-profiles.ts
+++ b/src/shared/board-profiles.ts
@@ -199,8 +199,16 @@ export const BOARD_PROFILES: BoardProfile[] = [
     // A CH9102F bridge, not native USB: the port stays put across a flash, so
     // no replug is needed the way it is on an S3.
     nativeUsb: false,
+    // This board ships with Adafruit's factory firmware on an 8 MB part, and a
+    // plain `write_flash` leaves whatever that left behind. The reported symptom
+    // was the exact one this flag exists for: the flash reports success and the
+    // board then boot-loops with
+    //   `esp_image: Image hash failed - image is corrupt`
+    //   `boot: No bootable app partitions in the partition table`
+    // which reads as a failed flash even though esptool exited 0.
+    eraseByDefault: true,
     notes:
-      'Hold BOOT, tap RESET, then release BOOT to enter download mode — this board does not auto-reset into the bootloader.'
+      'Hold BOOT, tap RESET, then release BOOT to enter download mode — this board does not auto-reset into the bootloader. It also ships with factory firmware, so Snakie erases the flash first by default; without that the board can boot-loop on a leftover partition table.'
   },
   {
     id: 'esp32-s3-generic',

--- a/src/shared/firmware-runtime.ts
+++ b/src/shared/firmware-runtime.ts
@@ -216,11 +216,41 @@ export function flashTargetForDownload(
     // An esptool write needs an ESP offset. A `.bin` under a non-ESP family is
     // not something we know how to place, so fall back to the family's own
     // answer rather than inventing an address.
-    return byFamily.board === 'esp32' || byFamily.board === 'esp8266'
-      ? byFamily
-      : { board: 'esp32', offset: ESP_BOOTLOADER_OFFSET[family.trim().toLowerCase()] ?? '0x0' }
+    const target =
+      byFamily.board === 'esp32' || byFamily.board === 'esp8266'
+        ? byFamily
+        : { board: 'esp32' as const, offset: ESP_BOOTLOADER_OFFSET[family.trim().toLowerCase()] ?? '0x0' }
+    // On the original ESP32 and the S2 the offset depends on the RUNTIME as well
+    // as the chip (#823). MicroPython ships the application expecting a
+    // second-stage bootloader already at 0x1000 and is written there;
+    // CircuitPython ships a COMBINED image whose own bootloader sits at 0, and
+    // Adafruit's instructions are `write_flash -z 0x0` for the original ESP32
+    // and the S2/S3 alike. Writing a CircuitPython image at 0x1000 flashes
+    // cleanly and leaves the board dead.
+    //
+    // The S3 and the RISC-V parts are 0x0 for both runtimes, which is why this
+    // only ever bit the two chips whose runtimes disagree.
+    if (target.board === 'esp32' && isCircuitPythonDownload(url)) {
+      return { board: 'esp32', offset: '0x0' }
+    }
+    return target
   }
   return byFamily
+}
+
+/**
+ * Is this download a CircuitPython build?
+ *
+ * Decided from the host, which is unambiguous — `downloads.circuitpython.org` is
+ * where every published CircuitPython binary lives, and a MicroPython catalog
+ * never yields one. Deliberately NOT a guess from the filename: a mirror or a
+ * hand-picked local file is not something we can identify, and treating an
+ * unknown as CircuitPython would move a MicroPython write to the wrong address —
+ * the very failure this exists to prevent. Unknown therefore stays MicroPython,
+ * which is both the default and the safer assumption for the catalog.
+ */
+export function isCircuitPythonDownload(url: string): boolean {
+  return boardIdFromDownloadUrl(url) !== null
 }
 
 /**

--- a/test/boardProfiles.test.ts
+++ b/test/boardProfiles.test.ts
@@ -243,4 +243,11 @@ describe('Adafruit ESP32 Feather V2 (#821)', () => {
     expect(feather?.notes).toMatch(/BOOT/)
     expect(feather?.notes).toMatch(/RESET/i)
   })
+
+  it('erases first — it ships with factory firmware (#823 follow-up)', () => {
+    // Reported symptom without this: the flash reports success and the board
+    // boot-loops on "Image hash failed" / "No bootable app partitions", because
+    // a plain write_flash leaves the factory partition table behind.
+    expect(feather?.eraseByDefault).toBe(true)
+  })
 })

--- a/test/flashOffsetRuntime.test.ts
+++ b/test/flashOffsetRuntime.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import {
+  flashTargetForDownload,
+  flashTargetForFamily,
+  isCircuitPythonDownload
+} from '../src/shared/firmware-runtime'
+
+/**
+ * #823 — the esptool `write_flash` offset depends on the RUNTIME, not just the
+ * chip, and only on two chips.
+ *
+ *   MicroPython, esp32   -> 0x1000   (micropython.org: `write_flash 0x1000 …`)
+ *   CircuitPython, esp32 -> 0x0      (Adafruit: `write_flash -z 0x0 firmware.bin`)
+ *
+ * MicroPython ships the application expecting a second-stage bootloader already
+ * at 0x1000. CircuitPython ships a COMBINED image whose own bootloader is at 0.
+ * The S3 and every RISC-V part are 0x0 for both, which is exactly why this went
+ * unnoticed — it bites only the two chips whose runtimes disagree.
+ *
+ * The consequence of getting it wrong is the one `flashTargetForFamily`'s own
+ * comment names: it "flashes cleanly and leaves the board dead". There is no
+ * error to go on, so these are worth pinning per combination.
+ */
+const MP = (family: string) =>
+  `https://micropython.org/resources/firmware/${family.toUpperCase()}_GENERIC-20250101-v1.25.0.bin`
+const CP = (boardId: string) =>
+  `https://downloads.circuitpython.org/bin/${boardId}/en_GB/adafruit-circuitpython-${boardId}-en_GB-10.2.1.bin`
+
+describe('the chip × runtime offset matrix', () => {
+  it.each([
+    // family,    runtime,          url,                                      offset
+    ['esp32',   'MicroPython',   MP('esp32'),                              '0x1000'],
+    ['esp32',   'CircuitPython', CP('adafruit_feather_esp32_v2'),          '0x0'],
+    ['esp32s2', 'MicroPython',   MP('esp32s2'),                            '0x1000'],
+    ['esp32s2', 'CircuitPython', CP('adafruit_metro_esp32s2'),             '0x0'],
+    // The chips where the two runtimes already agree.
+    ['esp32s3', 'MicroPython',   MP('esp32s3'),                            '0x0'],
+    ['esp32s3', 'CircuitPython', CP('adafruit_feather_esp32s3'),           '0x0'],
+    ['esp32c3', 'MicroPython',   MP('esp32c3'),                            '0x0'],
+    ['esp32c3', 'CircuitPython', CP('adafruit_qtpy_esp32c3'),              '0x0']
+  ])('%s + %s -> %s', (family, _runtime, url, offset) => {
+    const t = flashTargetForDownload(family, url)
+    expect(t.board).toBe('esp32')
+    expect(t.offset).toBe(offset)
+  })
+
+  it('is the ONLY thing that changed — esp8266 and the drive-copy families are untouched', () => {
+    expect(flashTargetForDownload('esp8266', MP('esp8266')).offset).toBe('0x0')
+    expect(flashTargetForDownload('rp2', 'https://x/y.uf2').board).toBe('rp2040')
+    expect(flashTargetForDownload('nrf52', 'https://x/y.hex').board).toBe('microbit')
+  })
+
+  it('leaves a CircuitPython .uf2 as a drive copy, not an esptool write', () => {
+    // A CircuitPython S3 board publishes BOTH a .uf2 and a .bin; the extension
+    // decides the mechanism, and the runtime rule must not override that.
+    const t = flashTargetForDownload('esp32s3', CP('adafruit_feather_esp32s3').replace('.bin', '.uf2'))
+    expect(t.board).toBe('rp2040')
+    expect(t.offset).toBeUndefined()
+  })
+})
+
+describe('isCircuitPythonDownload', () => {
+  it('recognises a published CircuitPython binary by host', () => {
+    expect(isCircuitPythonDownload(CP('adafruit_feather_esp32_v2'))).toBe(true)
+  })
+
+  it('does NOT claim a MicroPython build', () => {
+    expect(isCircuitPythonDownload(MP('esp32'))).toBe(false)
+  })
+
+  it('treats anything it cannot identify as NOT CircuitPython', () => {
+    // Unknown must fall back to MicroPython's 0x1000, not CircuitPython's 0x0:
+    // moving a MicroPython write to 0x0 is the very failure this prevents, so
+    // the uncertain case has to fail towards the default runtime.
+    for (const u of ['', 'https://example.com/mirror/firmware.bin', '/local/firmware.bin']) {
+      expect(isCircuitPythonDownload(u), u || '(empty)').toBe(false)
+    }
+    expect(flashTargetForDownload('esp32', 'https://example.com/mirror/fw.bin').offset).toBe('0x1000')
+  })
+})
+
+describe('flashTargetForFamily is unchanged', () => {
+  it('still answers per-chip for callers with no URL in hand', () => {
+    // It cannot know the runtime, so it keeps the MicroPython default.
+    expect(flashTargetForFamily('esp32').offset).toBe('0x1000')
+    expect(flashTargetForFamily('esp32s2').offset).toBe('0x1000')
+    expect(flashTargetForFamily('esp32s3').offset).toBe('0x0')
+  })
+})


### PR DESCRIPTION
Closes #823.

## The bug

On the original ESP32 and the S2, the `write_flash` offset depends on **which runtime** is being flashed — and Snakie chose it from the chip family alone.

| Runtime | Chip | Offset | Source |
|---|---|---|---|
| MicroPython | esp32 | `0x1000` | [micropython.org](https://micropython.org/download/ESP32_GENERIC/) |
| CircuitPython | esp32 | `0x0` | [Adafruit](https://learn.adafruit.com/circuitpython-with-esp32-quick-start/command-line-esptool) |

MicroPython ships the application expecting a second-stage bootloader already at `0x1000`. CircuitPython ships a **combined** image whose own bootloader is at 0, and Adafruit gives that same `0x0` command for the original ESP32 and the S2/S3 alike. So picking a CircuitPython build wrote it 4 KB too high.

**Nothing reported an error.** esptool exits 0, the flasher says "Flash complete", and the board never comes back — the exact failure `flashTargetForFamily`'s own comment warns about:

> *"Getting it wrong flashes cleanly and leaves the board dead"*

The S3 and every RISC-V part are `0x0` for both runtimes, which is why this only ever bit the two chips whose runtimes disagree — and why it went unnoticed.

## The fix

The signal was already in hand. `flashTargetForDownload` receives the URL, and a published CircuitPython binary is unambiguous from its host (`downloads.circuitpython.org`), which `boardIdFromDownloadUrl` already parses. No new plumbing.

**Deliberately not guessed from the filename.** A mirror, or a hand-picked local file, isn't something we can identify — and treating an unknown as CircuitPython would move a *MicroPython* write to `0x0`, the same failure in the other direction. Unknown therefore stays MicroPython, which is both the default and the safer assumption. `flashTargetForFamily` is unchanged for callers with no URL in hand, since it cannot know the runtime.

**14 tests** over the full chip × runtime matrix — including the pairs that already agreed, because both halves are one-line values that look plausible when wrong. Plus a guard that a CircuitPython `.uf2` stays a drive copy: an S3 board publishes both, and the extension must still decide the mechanism.

## Also, from the same report

The **Adafruit ESP32 Feather V2** now sets `eraseByDefault`. It ships with factory firmware on an 8 MB part, and a plain `write_flash` leaves that partition table behind — the board then boot-loops with:

```
E esp_image: Image hash failed - image is corrupt
E boot: Factory app partition is not bootable
E boot: No bootable app partitions in the partition table
```

That is precisely the symptom the flag exists for, and I should have set it when adding the profile in #822.

Gates: typecheck, lint, **5807 tests**, build — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)