### PR TITLE
fix: erase by default, and say whether the board actually booted (#826, #827)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Changed
+- **The flasher can ask the board what it is, and flashes the way Thonny does.**
+  (#829) A new **Identify board** button runs `esptool flash-id` against the
+  selected port and reports what came back — the exact chip, the real flash size,
+  and crucially **whether the board has PSRAM**. MicroPython publishes
+  `ESP32_GENERIC` and `ESP32_GENERIC-SPIRAM` as separate builds and only the
+  second can use the PSRAM, but nothing in the firmware catalog says which one a
+  board wants; the board itself knows. When PSRAM is found, the dialog now names
+  the build to use and why. It reads only — nothing is written — and a board it
+  cannot reach is reported as unreachable rather than as a board without PSRAM.
+
+  The flash itself now matches what Thonny does, which is what people have been
+  successfully flashing these boards with: **one** `write-flash --erase-all`
+  invocation instead of a separate erase pass followed by a separate write. Two
+  invocations meant two connections, and a board that needs BOOT held while RESET
+  is tapped had to be coaxed into download mode twice — with the second attempt
+  landing after the flash had already been erased. The flash mode and size are
+  also pinned to `keep` explicitly rather than left to an esptool default that
+  its own help does not state and that has moved between versions.
+
 - **The flasher erases the whole flash by default, and then tells you whether
   the board actually started.** (#826, #827)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- **The flasher erases the whole flash by default, and then tells you whether
+  the board actually started.** (#826, #827)
+
+  Erasing first used to be opt-in per board, which was the wrong way round: the
+  hazard belongs to whatever was on the flash *before*, which no board profile
+  can know. In practice the flag ended up set only on boards somebody had
+  already been caught by — and not on the generic ESP32 entry, which is exactly
+  what you pick when your own board is not listed and its history is therefore
+  unknown. It is now on for every esptool board, and a profile can opt out.
+  Erasing needlessly costs about seven seconds and a filesystem you are
+  replacing anyway; not erasing can cost you a board that looks bricked.
+
+  And the flasher no longer signs off with `Flash complete.` regardless of what
+  happened next. esptool exits successfully for a flash whose result cannot
+  boot, so that message was a claim about the tool rather than about the board.
+  Snakie now resets the board it just wrote and listens: a MicroPython or
+  CircuitPython banner is reported as *"the board is running …"*, and a board
+  looping on `Image hash failed` or `No bootable app partitions` is said out
+  loud, with the fix that usually works. It stays advisory — a board that says
+  nothing (a native-USB board re-enumerates and is not there to hear) is
+  reported as nothing, and a flash esptool completed is never recast as a
+  failure.
+
+
 ### Fixed
 - **CircuitPython on an original ESP32 or S2 is flashed to the right address.**
   (#823) The esptool write offset was chosen from the chip alone, but on those

--- a/src/main/firmware/flasher.ts
+++ b/src/main/firmware/flasher.ts
@@ -17,6 +17,7 @@
  * easy to reason about in isolation.
  */
 import { spawn } from 'child_process'
+import { classifyBootOutput } from '../../shared/boot-check'
 import { promises as fs, createReadStream, createWriteStream } from 'fs'
 import { basename, join } from 'path'
 import type { EsptoolInfo, FlashOptions, FlashProgress, FlashResult } from './types'
@@ -197,7 +198,90 @@ async function flashEsp(opts: FlashOptions, emit: Emit): Promise<FlashResult> {
     return { ok: false, error: msg }
   }
   emit({ kind: 'log', message: 'Flash complete.' })
+
+  // ...and then ASK THE BOARD (#827). esptool exits 0 for a flash whose result
+  // cannot boot, so `Flash complete` on its own is a claim about the tool, not
+  // about the board. We still own the port; listening costs a few seconds and
+  // turns an evening of detective work into one line.
+  await reportBootOutcome(opts.port, emit)
   return { ok: true }
+}
+
+/** How long to listen for the board's boot output before giving up on it. */
+const BOOT_LISTEN_MS = 4000
+
+/**
+ * Reset the freshly-flashed board and say what it printed.
+ *
+ * STRICTLY ADVISORY. The flash has already succeeded by the time this runs, and
+ * nothing here may change that: every failure path is swallowed, and silence is
+ * reported as silence. A board on native USB re-enumerates after flashing and
+ * will not be on this port at all — that is not an error, it is just nothing to
+ * say.
+ */
+async function reportBootOutcome(port: string, emit: Emit): Promise<void> {
+  let text = ''
+  try {
+    text = await readBootOutput(port)
+  } catch {
+    // No port, still busy, no serialport binding — nothing to report.
+    return
+  }
+  const verdict = classifyBootOutput(text)
+  // Both are `log`, never `error`: the flash genuinely succeeded, and calling a
+  // boot-loop an error would contradict the verified write the user just saw.
+  if (verdict.kind === 'running' || verdict.kind === 'bootloop') {
+    emit({ kind: 'log', message: verdict.message })
+  }
+}
+
+/**
+ * Open `port`, pulse the board's reset line, and collect what it says.
+ *
+ * The reset matters: esptool has already hard-reset the board on its way out,
+ * so by the time the port is reopened the banner has long gone. Toggling RTS
+ * (which drives EN) makes the board boot again with us listening — the same
+ * line esptool itself drives, and 115200 because that is the ESP32 ROM's fixed
+ * boot-log rate whatever the flash baud was.
+ */
+async function readBootOutput(port: string): Promise<string> {
+  const { SerialPort } = await import('serialport')
+  return new Promise<string>((resolve) => {
+    let buf = ''
+    let done = false
+    const sp = new SerialPort({ path: port, baudRate: 115200, autoOpen: false })
+    const finish = (): void => {
+      if (done) return
+      done = true
+      clearTimeout(backstop)
+      try {
+        sp.close(() => undefined)
+      } catch {
+        // Already closed.
+      }
+      resolve(buf)
+    }
+    // A backstop, in case a `set()` callback never fires on some driver.
+    const backstop = setTimeout(finish, BOOT_LISTEN_MS + 1000)
+    sp.on('error', finish)
+    sp.open((err) => {
+      if (err) {
+        finish()
+        return
+      }
+      sp.on('data', (d: Buffer) => {
+        buf += d.toString('latin1')
+      })
+      // EN low, then release: the board reboots with the port already open.
+      sp.set({ dtr: false, rts: true }, () => {
+        setTimeout(() => {
+          sp.set({ dtr: false, rts: false }, () => {
+            setTimeout(finish, BOOT_LISTEN_MS)
+          })
+        }, 150)
+      })
+    })
+  })
 }
 
 /**

--- a/src/main/firmware/flasher.ts
+++ b/src/main/firmware/flasher.ts
@@ -1,3 +1,5 @@
+const execFileAsync = promisify(execFile)
+
 /**
  * Firmware-flashing engine (issue #14).
  *
@@ -16,8 +18,10 @@
  * forwards it to the renderer) so this module has no Electron dependency and is
  * easy to reason about in isolation.
  */
-import { spawn } from 'child_process'
+import { execFile, spawn } from 'child_process'
+import { promisify } from 'util'
 import { classifyBootOutput } from '../../shared/boot-check'
+import { parseEsptoolIdentity, type BoardIdentity } from '../../shared/esptool-identify'
 import { promises as fs, createReadStream, createWriteStream } from 'fs'
 import { basename, join } from 'path'
 import type { EsptoolInfo, FlashOptions, FlashProgress, FlashResult } from './types'
@@ -105,6 +109,19 @@ export function writeFlashCommand(version?: string): string {
   return esptoolCommandStyle(version) === 'hyphen' ? 'write-flash' : 'write_flash'
 }
 
+/**
+ * The `--flash-mode` / `--flash-size` FLAGS, which renamed alongside the
+ * subcommands in v5 (`--flash_mode` → `--flash-mode`).
+ *
+ * Passing the v5 spelling to a v4 esptool is not a deprecation warning, it is an
+ * unrecognised argument and a failed flash — so these follow the same version
+ * rule as the subcommand, rather than being hardcoded to whatever the machine
+ * that wrote this happened to have.
+ */
+export function flashOptionFlag(name: 'flash-mode' | 'flash-size', version?: string): string {
+  return esptoolCommandStyle(version) === 'hyphen' ? `--${name}` : `--${name.replace('-', '_')}`
+}
+
 export async function detectEsptool(): Promise<EsptoolInfo> {
   for (const command of ESPTOOL_COMMANDS) {
     const result = await new Promise<EsptoolInfo | null>((resolve) => {
@@ -166,22 +183,32 @@ async function flashEsp(opts: FlashOptions, emit: Emit): Promise<FlashResult> {
   const base = ['--port', opts.port, '--baud', baud]
   if (opts.chip) base.unshift('--chip', opts.chip)
 
-  // Erase first when asked. A board arriving from vendor/Arduino firmware keeps
-  // its old partition table and NVS through a plain `write_flash`, and plenty of
-  // ESP32 boards then boot-loop: they enumerate for a moment, panic, and drop off
-  // again. That reads exactly like a failed flash, except the flash succeeded.
-  if (opts.eraseFirst) {
-    const eraseArgs = [...base, eraseFlashCommand(tool.version)]
-    emit({ kind: 'log', message: `> ${tool.command} ${eraseArgs.join(' ')}` })
-    const erased = await runStreaming(tool.command, eraseArgs, emit)
-    if (erased.spawnError || erased.code !== 0) {
-      const msg = `Erase failed (exit ${erased.code ?? '?'}). The board may be in the wrong mode — hold BOOT while plugging it in.`
-      emit({ kind: 'error', message: msg })
-      return { ok: false, error: msg }
-    }
-  }
+  // Erase as part of the WRITE, not as a separate pass (#829 parity).
+  //
+  // Snakie used to run `erase-flash` and then `write-flash` as two invocations.
+  // Thonny — which people successfully flash these same boards with — issues
+  // ONE: `write_flash --erase-all …`. That difference is not cosmetic. Two
+  // invocations mean two connections, and a board that needs BOOT held while
+  // RESET is tapped has to be coaxed into download mode TWICE; the second
+  // connect is exactly where it fails, after the flash has already been erased,
+  // which leaves the board emptier than it started.
+  //
+  // `--erase-all` also erases the whole chip (not just the write areas), which
+  // is the behaviour the separate pass was there for in the first place.
+  const flashArgs = [
+    writeFlashCommand(tool.version),
+    // Pinned rather than left to esptool's implicit default, which its own
+    // `--help` does not state and which has moved between versions. `keep`
+    // honours the header the firmware was built with — the same thing Thonny
+    // pins — so an image's declared flash mode and size survive the write.
+    flashOptionFlag('flash-mode', tool.version),
+    'keep',
+    flashOptionFlag('flash-size', tool.version),
+    'keep'
+  ]
+  if (opts.eraseFirst) flashArgs.push('--erase-all')
 
-  const args = [...base, writeFlashCommand(tool.version), offset, opts.firmwarePath]
+  const args = [...base, ...flashArgs, offset, opts.firmwarePath]
 
   emit({ kind: 'log', message: `Using ${tool.command}${tool.version ? ` (${tool.version})` : ''}` })
   emit({ kind: 'log', message: `> ${tool.command} ${args.join(' ')}` })
@@ -378,4 +405,42 @@ export async function flash(opts: FlashOptions, emit: Emit): Promise<FlashResult
     message: result.ok ? 'Done.' : (result.error ?? 'Flashing failed.')
   })
   return result
+}
+
+/**
+ * Ask a connected ESP what it is, before anything is written to it.
+ *
+ * `esptool flash-id` reports the exact part, its features — **including whether
+ * it has PSRAM** — and the real flash size. That is precisely the information
+ * the flash dialog otherwise asks the user to supply from memory, and which for
+ * PSRAM they often have no way to know: MicroPython publishes `ESP32_GENERIC`
+ * and `ESP32_GENERIC-SPIRAM` separately, and nothing in the firmware catalog
+ * says which one a given board wants.
+ *
+ * Read-only. It uploads the stub and reads the flash id; it writes nothing.
+ * Failure is not an error the caller has to handle — an unplugged board, a busy
+ * port or a board not in download mode all come back as an empty identity,
+ * because "we could not ask" and "the board has no PSRAM" must never look alike.
+ */
+export async function identifyBoard(port: string): Promise<BoardIdentity> {
+  const tool = await detectEsptool()
+  if (!tool.available || !tool.command) return {}
+  try {
+    const { stdout } = await execFileAsync(
+      tool.command,
+      ['--port', port, '--baud', '115200', flashIdCommand(tool.version)],
+      { timeout: 30_000, maxBuffer: 2 * 1024 * 1024, windowsHide: true }
+    )
+    return parseEsptoolIdentity(String(stdout))
+  } catch (err) {
+    // esptool exits non-zero when it cannot connect, and still prints the chip
+    // banner in some of those cases — so parse what it managed to say.
+    const out = err as { stdout?: string; stderr?: string }
+    return parseEsptoolIdentity(`${out.stdout ?? ''}\n${out.stderr ?? ''}`)
+  }
+}
+
+/** `flash_id` / `flash-id` for the detected esptool. */
+export function flashIdCommand(version?: string): string {
+  return esptoolCommandStyle(version) === 'hyphen' ? 'flash-id' : 'flash_id'
 }

--- a/src/main/firmware/ipc.ts
+++ b/src/main/firmware/ipc.ts
@@ -10,8 +10,9 @@ import { dialog, ipcMain, BrowserWindow, type WebContents } from 'electron'
 import type { FlashMethod } from '../../shared/board-profiles'
 import type { FirmwareRuntime } from '../../shared/firmware-runtime'
 import type { IpcResult } from '../device/types'
+import type { BoardIdentity } from '../../shared/esptool-identify'
 import { detectBoards } from './detect'
-import { detectEsptool, flash } from './flasher'
+import { detectEsptool, flash, identifyBoard } from './flasher'
 import { fetchFirmwareCatalog } from './catalog'
 import { downloadAndFlash } from './download'
 import type {
@@ -32,7 +33,8 @@ export const FIRMWARE_CHANNELS = {
   pickFile: 'firmware:pickFile',
   flash: 'firmware:flash',
   fetchCatalog: 'firmware:fetchCatalog',
-  downloadAndFlash: 'firmware:downloadAndFlash'
+  downloadAndFlash: 'firmware:downloadAndFlash',
+  identify: 'firmware:identify'
 } as const
 
 /**
@@ -65,6 +67,14 @@ export function registerFirmwareIpc(getWindow: () => BrowserWindow | undefined):
   )
 
   ipcMain.handle(FIRMWARE_CHANNELS.esptool, () => wrap<EsptoolInfo>(() => detectEsptool()))
+
+  // Ask the connected board what it is (chip, PSRAM, flash size) before writing
+  // anything. Read-only, and it resolves with an EMPTY identity rather than
+  // rejecting when the board cannot be reached — "could not ask" must not look
+  // like "has no PSRAM".
+  ipcMain.handle(FIRMWARE_CHANNELS.identify, (_e, port: string) =>
+    wrap<BoardIdentity>(() => identifyBoard(port))
+  )
 
   ipcMain.handle(FIRMWARE_CHANNELS.pickFile, (_e, method?: FlashMethod) =>
     wrap<string | null>(async () => {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -135,6 +135,9 @@ export type {
   GitPublishResult
 } from '../main/git/types'
 
+// Board identity from `esptool flash-id`, for the flash dialog's board probe.
+export type { BoardIdentity } from '../shared/esptool-identify'
+
 // Re-export the Python plugin-system types (issue #61) so the Plugins panel can
 // import them from this single UI-facing module.
 export type {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -11,6 +11,7 @@ import { electronAPI } from '@electron-toolkit/preload'
 ipcRenderer.setMaxListeners(40)
 import type { FlashMethod } from '../shared/board-profiles'
 import type { FirmwareRuntime } from '../shared/firmware-runtime'
+import type { BoardIdentity } from '../shared/esptool-identify'
 import type {
   CircuitPyDrive,
   ConnectOptions,
@@ -673,6 +674,14 @@ const firmware = {
     unwrap(ipcRenderer.invoke('firmware:detect')),
   /** Probe for the external esptool prerequisite (presence + version). */
   checkEsptool: (): Promise<EsptoolInfo> => unwrap(ipcRenderer.invoke('firmware:esptool')),
+
+  /**
+   * Ask the board on `port` what it is — chip, PSRAM, flash size — before
+   * anything is written to it. Resolves with an EMPTY identity when the board
+   * cannot be reached, so "could not ask" never reads as "has no PSRAM".
+   */
+  identifyBoard: (port: string): Promise<BoardIdentity> =>
+    unwrap(ipcRenderer.invoke('firmware:identify', port)),
   /** Show the native firmware file picker, offering only the extension the given
    *  flash method can use (#686). Resolves the path, or null if cancelled. */
   pickFirmwareFile: (method?: FlashMethod): Promise<string | null> =>

--- a/src/renderer/src/components/FirmwareFlasher.css
+++ b/src/renderer/src/components/FirmwareFlasher.css
@@ -379,3 +379,28 @@
   letter-spacing: 0.02em;
   color: rgba(230, 230, 230, 0.65);
 }
+
+/* The "Identify board" action beside the port picker (#829). A quiet, secondary
+   action — it only reads — so it must not compete with Flash. Themed tokens
+   throughout, so it stays readable on the skeuomorph parchment as well as dark. */
+.firmware-btn--ghost {
+  align-self: flex-start;
+  margin-top: 6px;
+  font-family: var(--font-ui);
+  font-size: 0.78rem;
+  padding: 0.28rem 0.6rem;
+  color: var(--text);
+  background: var(--bg-elevated);
+  border: var(--border-w) solid var(--border);
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+
+.firmware-btn--ghost:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+
+.firmware-btn--ghost:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}

--- a/src/renderer/src/components/FirmwareFlasher.tsx
+++ b/src/renderer/src/components/FirmwareFlasher.tsx
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react'
+import { describeIdentity, suggestedBuildFor } from '../../../shared/esptool-identify'
+import type { BoardIdentity } from '../../../shared/esptool-identify'
 import type {
   BoardCandidate,
   BoardType,
@@ -132,6 +134,10 @@ export function FirmwareFlasher({
   /** Every serial port on the machine, so a board whose USB bridge detection did
    *  not recognise can still be selected (#821). */
   const [ports, setPorts] = useState<PortInfo[]>([])
+  /** What the connected board said about itself, once asked (esptool flash-id).
+   *  Null until the user asks; `{}` when the board could not be reached. */
+  const [identity, setIdentity] = useState<BoardIdentity | null>(null)
+  const [identifying, setIdentifying] = useState(false)
   const [board, setBoard] = useState<BoardType>('esp32')
   /** The chosen board profile (#682) — drives the mechanics below it. */
   const [profileId, setProfileId] = useState<string>('')
@@ -545,6 +551,38 @@ export function FirmwareFlasher({
     setBoard(target.board)
     setOffset(target.offset ?? DEFAULT_OFFSET[target.board])
   }, [source, selFamily, selVersionUrl])
+
+  /**
+   * Ask the board what it is, and use the answer (#829).
+   *
+   * The PSRAM bit is the point. MicroPython publishes ESP32_GENERIC and
+   * ESP32_GENERIC-SPIRAM separately and only the second can use the PSRAM, but
+   * the firmware catalog does not say which a board has — Thonny's `ESP32 /
+   * WROOM` entry carries no variants at all. The board knows, and esptool will
+   * ask it.
+   */
+  const identifyBoard = useCallback(async (): Promise<void> => {
+    if (!port) return
+    setIdentifying(true)
+    try {
+      const id = await window.api.firmware.identifyBoard(port)
+      setIdentity(id)
+      // Pre-select the family it reported, so the catalog opens on builds that
+      // fit. Never overrides an explicit board choice — same rule as detection.
+      if (id.family && !profileRef.current && families.some((f) => f.family === id.family)) {
+        setSelFamily(id.family)
+      }
+    } catch {
+      setIdentity({})
+    } finally {
+      setIdentifying(false)
+    }
+  }, [port, families])
+
+  const suggestedBuild = useMemo(
+    () => (identity ? suggestedBuildFor(identity) : null),
+    [identity]
+  )
 
   const serialCandidates = candidates.filter((c) => c.source === 'serial')
   // Every OTHER serial port — the ones whose USB bridge we did not recognise.
@@ -1007,6 +1045,37 @@ export function FirmwareFlasher({
                         <option value={port}>{port}</option>
                       )}
                   </select>
+                  {/* Ask the board rather than make the user recall its spec
+                      (#829). Read-only — it uploads esptool's stub and reads the
+                      flash id; it writes nothing. */}
+                  <button
+                    type="button"
+                    className="firmware-btn firmware-btn--ghost"
+                    disabled={!port || flashing || identifying}
+                    onClick={() => void identifyBoard()}
+                  >
+                    {identifying ? 'Asking the board…' : 'Identify board'}
+                  </button>
+                  {identity && (
+                    <p className="firmware-hint">
+                      {describeIdentity(identity) ? (
+                        <>
+                          Found <strong>{describeIdentity(identity)}</strong>
+                          {suggestedBuild && (
+                            <>
+                              {' — '}
+                              use the <strong>{suggestedBuild.name}</strong> build. {suggestedBuild.why}
+                            </>
+                          )}
+                        </>
+                      ) : (
+                        <>
+                          Could not reach the board. Hold BOOT, tap RESET, release BOOT to put it in
+                          download mode, then try again.
+                        </>
+                      )}
+                    </p>
+                  )}
                 </div>
               ) : (
                 <p className="firmware-hint">

--- a/src/renderer/src/components/FirmwareFlasher.tsx
+++ b/src/renderer/src/components/FirmwareFlasher.tsx
@@ -136,7 +136,9 @@ export function FirmwareFlasher({
   /** The chosen board profile (#682) — drives the mechanics below it. */
   const [profileId, setProfileId] = useState<string>('')
   /** Erase the whole flash before writing (#683). */
-  const [eraseFirst, setEraseFirst] = useState<boolean>(false)
+  // Defaults ON: the dialog opens on an ESP board, and a stale flash is the more
+  // likely hazard than a wasted seven seconds (#826).
+  const [eraseFirst, setEraseFirst] = useState<boolean>(true)
   /** Brief "Copied" confirmation on the copy-log button (#685). */
   const [copied, setCopied] = useState(false)
   /**
@@ -416,7 +418,11 @@ export function FirmwareFlasher({
         p.method === 'uf2' ? 'rp2040' : p.method === 'daplink' ? 'microbit' : p.chipFamily === 'esp8266' ? 'esp8266' : 'esp32'
       setBoard(next)
       setOffset(p.offset ?? DEFAULT_OFFSET[next])
-      setEraseFirst(p.eraseByDefault === true)
+      // Erase-before-write defaults ON for esptool boards; a profile opts OUT
+      // by setting `eraseByDefault: false` (#826). Opting in was the wrong way
+      // round — the stale-flash hazard belongs to whatever was on the board
+      // before, which no profile can know.
+      setEraseFirst(p.method === 'esptool' && p.eraseByDefault !== false)
       // Pre-select the firmware family too, so the catalog opens on builds that
       // fit — a generic build is keyed on the chip, which the profile knows.
       if (families.some((f) => f.family === p.chipFamily)) setSelFamily(p.chipFamily)

--- a/src/shared/board-profiles.ts
+++ b/src/shared/board-profiles.ts
@@ -65,12 +65,24 @@ export interface BoardProfile {
   /** Anything the user genuinely needs to know, shown next to the picker. */
   notes?: string
   /**
-   * Erase the whole flash before writing, by default, for this board.
+   * Erase the whole flash before writing — **on by default for every esptool
+   * board**; set this to `false` only to opt a board OUT.
    *
-   * On when the board commonly arrives running something else: a leftover
-   * partition table or NVS survives a plain `write_flash`, and the board then
-   * boot-loops — enumerating for a second and dropping off — which reads exactly
-   * like a failed flash even though the flash succeeded.
+   * It used to be opt-IN, and that was the wrong way round (#826). A leftover
+   * partition table survives a plain `write_flash`, which only erases the range
+   * it writes, and the board then boot-loops on `Image hash failed` /
+   * `No bootable app partitions` — reading exactly like a failed flash even
+   * though esptool verified every byte it wrote.
+   *
+   * The hazard is not a property of the BOARD, it is a property of what was on
+   * the flash before, which no profile can know. Opt-in meant the flag was set
+   * only on boards somebody had already been bitten by — a list of who had
+   * complained, not of who was affected — and the generic `esp32-devkit` entry,
+   * which is exactly what you pick when your board is not listed and its
+   * provenance is therefore unknown, did not have it.
+   *
+   * Erasing unnecessarily costs about seven seconds and a filesystem the user is
+   * replacing anyway. Not erasing costs a board that looks bricked.
    */
   eraseByDefault?: boolean
   /**
@@ -199,14 +211,23 @@ export const BOARD_PROFILES: BoardProfile[] = [
     // A CH9102F bridge, not native USB: the port stays put across a flash, so
     // no replug is needed the way it is on an S3.
     nativeUsb: false,
-    // This board ships with Adafruit's factory firmware on an 8 MB part, and a
-    // plain `write_flash` leaves whatever that left behind. The reported symptom
-    // was the exact one this flag exists for: the flash reports success and the
-    // board then boot-loops with
-    //   `esp_image: Image hash failed - image is corrupt`
-    //   `boot: No bootable app partitions in the partition table`
-    // which reads as a failed flash even though esptool exited 0.
-    eraseByDefault: true,
+    // Erase-before-write is the default for every esptool board now (#826).
+    //
+    // NOT claimed as proven by this board: it boot-looped on `Image hash failed`
+    // with a hash-verified write of a correct image, booted once after a full
+    // erase, and then reverted to boot-looping with byte-identical flash
+    // content. An image that boots once and then does not, without the flash
+    // changing, is not a flashing problem — see #828. The erase default stands
+    // on the general argument in #826, not on this board.
+    //
+    // The catalog has no SPIRAM build for the plain ESP32 family (Thonny's
+    // `ESP32 / WROOM` entry carries no variants at all), so the PSRAM build is
+    // named here instead — it exists upstream, it is just not offered.
+    preferredBuild: {
+      name: 'ESP32_GENERIC-SPIRAM',
+      why: 'This board has 2 MB of PSRAM, and only the SPIRAM build can use it. The plain ESP32_GENERIC build runs perfectly well — it simply leaves the PSRAM unavailable. The firmware catalog does not offer the SPIRAM build for this family, so download it and flash it with "Local file".',
+      url: 'https://micropython.org/download/ESP32_GENERIC/'
+    },
     notes:
       'Hold BOOT, tap RESET, then release BOOT to enter download mode — this board does not auto-reset into the bootloader. It also ships with factory firmware, so Snakie erases the flash first by default; without that the board can boot-loop on a leftover partition table.'
   },

--- a/src/shared/boot-check.ts
+++ b/src/shared/boot-check.ts
@@ -1,0 +1,97 @@
+/**
+ * WHAT THE BOARD SAID AFTER FLASHING — issue #827.
+ * =============================================================================
+ *
+ * `Flash complete.` was the flasher's last word, and it said that whenever
+ * esptool exited 0 — which esptool does even when the board it just wrote
+ * cannot boot. So the one screen that could have explained the failure instead
+ * asserted success, while the board, one serial read away, repeated:
+ *
+ *     E (658) esp_image: Image hash failed - image is corrupt
+ *     E (659) boot: No bootable app partitions in the partition table
+ *
+ * That is not a hypothetical. It was diagnosed on a real Adafruit ESP32 Feather
+ * V2 only after reading the partition table off the chip and decoding the app
+ * image header by hand — every intermediate signal said the flash was fine,
+ * because it WAS. `Hash of data verified` is true and unhelpful.
+ *
+ * This module is the pure half: given whatever the board printed, say which of
+ * three things happened. The reading itself lives in `main/firmware/flasher.ts`.
+ *
+ * Deliberately advisory. A flash that esptool completed is a flash that
+ * completed; nothing here may turn that into a reported failure. The worst this
+ * can do is stay quiet.
+ */
+
+/** What the board's post-flash output tells us. */
+export type BootVerdict =
+  | { kind: 'running'; runtime: string; message: string }
+  | { kind: 'bootloop'; evidence: string; message: string }
+  | { kind: 'unknown' }
+
+/** Lines that mean the second-stage bootloader rejected the app. */
+const BOOTLOOP_MARKERS = [
+  'esp_image:',
+  'no bootable app partitions',
+  'is not bootable',
+  'invalid segment length',
+  'image hash failed',
+  'checksum failed'
+]
+
+/** The ROM banner that heads each boot attempt on an ESP32. */
+const RESET_MARKER = /rst:0x[0-9a-f]+/gi
+
+/**
+ * Classify what a board printed in the seconds after a flash.
+ *
+ * Order matters: a boot-loop can scroll a runtime banner off the top on a board
+ * that was working before, so the FAILURE markers are checked first. A banner
+ * only counts when nothing is also complaining.
+ */
+export function classifyBootOutput(raw: string): BootVerdict {
+  const text = (raw ?? '').replace(/\r/g, '')
+  if (!text.trim()) return { kind: 'unknown' }
+  const lower = text.toLowerCase()
+
+  const marker = BOOTLOOP_MARKERS.find((m) => lower.includes(m))
+  if (marker) {
+    const evidence =
+      text
+        .split('\n')
+        .map((l) => l.trim())
+        .find((l) => l.toLowerCase().includes(marker)) ?? marker
+    return {
+      kind: 'bootloop',
+      evidence,
+      message:
+        'The firmware was written and verified, but the board is not booting it — it says ' +
+        `"${evidence}". This is almost always a leftover partition table from whatever ` +
+        'was on the board before: erasing the whole flash and flashing again usually fixes it.'
+    }
+  }
+
+  // A board that resets over and over without ever saying anything else is also
+  // looping, just without a diagnosis of its own.
+  const resets = text.match(RESET_MARKER)?.length ?? 0
+  if (resets >= 3) {
+    return {
+      kind: 'bootloop',
+      evidence: `the board reset ${resets} times`,
+      message:
+        'The firmware was written and verified, but the board keeps resetting instead of ' +
+        'starting. Erasing the whole flash and flashing again usually fixes it.'
+    }
+  }
+
+  const banner = /(MicroPython|Adafruit CircuitPython)\s+\S+[^\n]*/i.exec(text)
+  if (banner) {
+    return {
+      kind: 'running',
+      runtime: banner[0].trim(),
+      message: `Flash complete — the board is running ${banner[0].trim()}`
+    }
+  }
+
+  return { kind: 'unknown' }
+}

--- a/src/shared/esptool-identify.ts
+++ b/src/shared/esptool-identify.ts
@@ -1,0 +1,127 @@
+/**
+ * WHAT THE BOARD SAYS ABOUT ITSELF — parsing `esptool flash-id`.
+ * =============================================================================
+ *
+ * esptool can interrogate a connected ESP before anything is written to it, and
+ * it answers the two questions the flash dialog otherwise has to ask the user
+ * to guess at:
+ *
+ *   Chip type:          ESP32-PICO-V3-02 (revision v3.0)
+ *   Features:           Wi-Fi, BT, Dual Core + LP Core, 240MHz, Embedded Flash,
+ *                       Embedded PSRAM, Vref calibration in eFuse, ...
+ *   Crystal frequency:  40MHz
+ *   MAC:                e8:9f:6d:26:93:20
+ *   Detected flash size: 8MB
+ *
+ * **PSRAM is the one that matters most.** MicroPython publishes `ESP32_GENERIC`
+ * and `ESP32_GENERIC-SPIRAM` as separate builds, and only the second can use the
+ * PSRAM — but nothing in the firmware catalog says which your board has, so the
+ * choice has been left to a user who often has no way to know. The board knows,
+ * and will say so if asked.
+ *
+ * Pure text parsing, so it is testable against real esptool output without a
+ * board attached. The running of esptool lives in `main/firmware/detect.ts`.
+ */
+
+/** What a board reported about itself. Every field is optional: esptool's
+ *  wording varies by version and by chip, and a missing field must degrade to
+ *  "unknown" rather than to a wrong guess. */
+export interface BoardIdentity {
+  /** The precise part, e.g. `ESP32-PICO-V3-02`. */
+  chip?: string
+  /** Silicon revision, e.g. `v3.0`. */
+  revision?: string
+  /** Chip family for the firmware catalog, e.g. `esp32`, `esp32s3`. */
+  family?: string
+  /** True when the chip reports PSRAM — the SPIRAM build is then the right one. */
+  psram?: boolean
+  /** Flash size as reported, e.g. `8MB`. */
+  flashSize?: string
+  /** The board's MAC, which is the only unique thing about it. */
+  mac?: string
+  /** Everything on the Features line, for display. */
+  features?: string[]
+}
+
+/**
+ * The catalog `family` for a chip name.
+ *
+ * Ordered longest-first so `ESP32-S3` is not matched by the `ESP32` rule. The
+ * PICO and the WROOM/WROVER modules are all plain `esp32` parts — the module
+ * name says what is around the die, not what the die is.
+ */
+function familyFor(chip: string): string | undefined {
+  const c = chip.toUpperCase()
+  for (const [needle, family] of [
+    ['ESP32-S2', 'esp32s2'],
+    ['ESP32-S3', 'esp32s3'],
+    ['ESP32-C2', 'esp32c2'],
+    ['ESP32-C3', 'esp32c3'],
+    ['ESP32-C6', 'esp32c6'],
+    ['ESP32-H2', 'esp32h2'],
+    ['ESP32-P4', 'esp32p4'],
+    ['ESP8266', 'esp8266'],
+    ['ESP32', 'esp32']
+  ] as const) {
+    if (c.includes(needle)) return family
+  }
+  return undefined
+}
+
+/** Parse the output of `esptool … flash-id`. Never throws; unknown stays unknown. */
+export function parseEsptoolIdentity(stdout: string): BoardIdentity {
+  const text = (stdout ?? '').replace(/\r/g, '')
+  const out: BoardIdentity = {}
+
+  const chip = /^\s*Chip type:\s*(.+?)\s*$/m.exec(text)
+  if (chip) {
+    // `ESP32-PICO-V3-02 (revision v3.0)` → chip + revision.
+    const rev = /^(.*?)\s*\(revision\s*([^)]+)\)\s*$/.exec(chip[1])
+    out.chip = (rev ? rev[1] : chip[1]).trim()
+    if (rev) out.revision = rev[2].trim()
+    out.family = familyFor(out.chip)
+  }
+
+  const feats = /^\s*Features:\s*(.+?)\s*$/m.exec(text)
+  if (feats) {
+    out.features = feats[1].split(',').map((f) => f.trim()).filter(Boolean)
+    // "Embedded PSRAM" on a PICO, "PSRAM" elsewhere — match the word, not a
+    // fixed phrase, since the wording differs by chip and esptool version.
+    out.psram = out.features.some((f) => /\bPSRAM\b/i.test(f))
+  }
+
+  const size = /^\s*Detected flash size:\s*(\S+)\s*$/m.exec(text)
+  if (size) out.flashSize = size[1]
+
+  const mac = /^\s*MAC:\s*([0-9a-f:]{17})\s*$/im.exec(text)
+  if (mac) out.mac = mac[1].toLowerCase()
+
+  return out
+}
+
+/**
+ * The MicroPython build worth preferring for what the board reported, or null
+ * when nothing useful can be said.
+ *
+ * Only the plain `esp32` family gets an opinion here. The S3's PSRAM story is a
+ * three-way choice (plain / SPIRAM / SPIRAM_OCT) that depends on the RAM's bus
+ * width, which `flash-id` does not report — guessing there could send someone to
+ * a build that boots with a PSRAM error, so it says nothing instead.
+ */
+export function suggestedBuildFor(id: BoardIdentity): { name: string; why: string } | null {
+  if (id.family !== 'esp32' || id.psram !== true) return null
+  return {
+    name: 'ESP32_GENERIC-SPIRAM',
+    why: `This board reports PSRAM${id.chip ? ` (${id.chip})` : ''}, and only the SPIRAM build can use it. The plain ESP32_GENERIC build runs fine — it just leaves the PSRAM unavailable.`
+  }
+}
+
+/** A one-line summary for the dialog, e.g. `ESP32-PICO-V3-02 · 8MB flash · PSRAM`. */
+export function describeIdentity(id: BoardIdentity): string {
+  const bits = [
+    id.chip,
+    id.flashSize ? `${id.flashSize} flash` : undefined,
+    id.psram === true ? 'PSRAM' : undefined
+  ].filter(Boolean)
+  return bits.join(' · ')
+}

--- a/test/boardProfiles.test.ts
+++ b/test/boardProfiles.test.ts
@@ -244,10 +244,17 @@ describe('Adafruit ESP32 Feather V2 (#821)', () => {
     expect(feather?.notes).toMatch(/RESET/i)
   })
 
-  it('erases first — it ships with factory firmware (#823 follow-up)', () => {
-    // Reported symptom without this: the flash reports success and the board
-    // boot-loops on "Image hash failed" / "No bootable app partitions", because
-    // a plain write_flash leaves the factory partition table behind.
-    expect(feather?.eraseByDefault).toBe(true)
+  it('does NOT opt out of the erase-first default (#826)', () => {
+    // Erase-before-write is on for every esptool board now, so a profile only
+    // has to avoid setting `eraseByDefault: false`.
+    expect(feather?.eraseByDefault).not.toBe(false)
+  })
+
+  it('names the SPIRAM build, which the catalog does not offer', () => {
+    // Thonny's `ESP32 / WROOM` entry carries no variants at all, so there is no
+    // way to pick the PSRAM build from the catalog even though it exists
+    // upstream. The profile is where that gets said.
+    expect(feather?.preferredBuild?.name).toBe('ESP32_GENERIC-SPIRAM')
+    expect(feather?.preferredBuild?.why).toMatch(/PSRAM/i)
   })
 })

--- a/test/bootCheck.test.ts
+++ b/test/bootCheck.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import { classifyBootOutput } from '../src/shared/boot-check'
+
+/**
+ * #827 — the flasher reported `Flash complete.` while the board boot-looped.
+ *
+ * The samples below are verbatim from the Adafruit ESP32 Feather V2 that
+ * prompted this, captured off the serial port after a flash that esptool had
+ * reported as verified.
+ */
+const BOOTLOOP = `ets Jul 29 2019 12:21:46
+
+rst:0x3 (SW_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
+configsip: 271414342, SPIWP:0xee
+mode:DIO, clock div:2
+load:0x3fff0030,len:4200
+entry 0x400805a8
+E (658) esp_image: Image hash failed - image is corrupt
+E (659) boot: Factory app partition is not bootable
+E (659) boot: No bootable app partitions in the partition table
+ets Jul 29 2019 12:21:46`
+
+const SEGMENT = `entry 0x400805a8
+E (146) esp_image: invalid segment length 0x88125782
+E (146) boot: No bootable app partitions in the partition table`
+
+const RUNNING = `entry 0x400805a8
+MicroPython v1.28.0 on 2026-04-06; Generic ESP32 module with ESP32
+Type "help()" for more information.
+>>> `
+
+describe('a board that will not boot', () => {
+  it('recognises the reported failure and quotes the board’s own words', () => {
+    const v = classifyBootOutput(BOOTLOOP)
+    expect(v.kind).toBe('bootloop')
+    if (v.kind !== 'bootloop') return
+    expect(v.evidence).toContain('Image hash failed')
+    expect(v.message).toMatch(/written and verified/i)
+  })
+
+  it('recognises the other shape the same board produced', () => {
+    // The error varies with what is left on the flash; both mean the same thing.
+    expect(classifyBootOutput(SEGMENT).kind).toBe('bootloop')
+  })
+
+  it('points at the fix that actually worked, rather than at the flash', () => {
+    const v = classifyBootOutput(BOOTLOOP)
+    if (v.kind !== 'bootloop') throw new Error('expected bootloop')
+    expect(v.message).toMatch(/eras/i)
+    // It must NOT claim the write failed — esptool verified every byte.
+    expect(v.message).not.toMatch(/flash failed|write failed/i)
+  })
+
+  it('catches a board that resets repeatedly without explaining itself', () => {
+    const silent = Array(4).fill('rst:0x3 (SW_RESET),boot:0x13\nmode:DIO, clock div:2').join('\n')
+    const v = classifyBootOutput(silent)
+    expect(v.kind).toBe('bootloop')
+  })
+
+  it('does not cry wolf over a single reset — that is just booting', () => {
+    expect(classifyBootOutput('rst:0x1 (POWERON_RESET),boot:0x13\nmode:DIO').kind).toBe('unknown')
+  })
+})
+
+describe('a board that came up', () => {
+  it('names the runtime, which is what the user actually wanted to know', () => {
+    const v = classifyBootOutput(RUNNING)
+    expect(v.kind).toBe('running')
+    if (v.kind !== 'running') return
+    expect(v.runtime).toContain('MicroPython v1.28.0')
+    expect(v.message).toContain('MicroPython v1.28.0')
+  })
+
+  it('recognises CircuitPython too', () => {
+    const v = classifyBootOutput('Adafruit CircuitPython 10.2.1 on 2026-08-18; Feather')
+    expect(v.kind).toBe('running')
+  })
+
+  it('reports a FAILURE when both appear — the banner may be scrollback', () => {
+    // A board that was working before still has its old banner in the buffer;
+    // the complaint is the newer, and truer, signal.
+    expect(classifyBootOutput(RUNNING + '\n' + BOOTLOOP).kind).toBe('bootloop')
+  })
+})
+
+describe('silence', () => {
+  it('says nothing at all rather than guessing', () => {
+    // A native-USB board re-enumerates after flashing and will not be there to
+    // read. No output must never be reported as a failure.
+    for (const s of ['', '   \r\n', '\x00\x00']) {
+      expect(classifyBootOutput(s).kind).toBe('unknown')
+    }
+  })
+
+  it('stays quiet on output it cannot make sense of', () => {
+    expect(classifyBootOutput('\x1b[0m garbled ~~~ noise').kind).toBe('unknown')
+  })
+})

--- a/test/esptoolCommands.test.ts
+++ b/test/esptoolCommands.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   esptoolCommandStyle,
   eraseFlashCommand,
+  flashOptionFlag,
   writeFlashCommand
 } from '../src/main/firmware/flasher'
 
@@ -38,5 +39,25 @@ describe('esptoolCommandStyle (#680)', () => {
     expect(writeFlashCommand('esptool v5.3.0')).toBe('write-flash')
     expect(eraseFlashCommand('esptool.py v4.7.0')).toBe('erase_flash')
     expect(writeFlashCommand('esptool.py v4.7.0')).toBe('write_flash')
+  })
+})
+
+describe('the --flash-mode / --flash-size flags (#829 parity)', () => {
+  it('uses hyphens on v5, matching the subcommand spelling', () => {
+    expect(flashOptionFlag('flash-mode', 'esptool v5.3.0')).toBe('--flash-mode')
+    expect(flashOptionFlag('flash-size', 'esptool v5.3.0')).toBe('--flash-size')
+  })
+
+  it('uses underscores on v4 — there the hyphen form is not a warning but a failure', () => {
+    // An unrecognised argument aborts the flash, unlike the deprecated
+    // subcommand spelling which merely warns.
+    expect(flashOptionFlag('flash-mode', 'esptool.py v4.7.0')).toBe('--flash_mode')
+    expect(flashOptionFlag('flash-size', 'esptool.py v4.7.0')).toBe('--flash_size')
+  })
+
+  it('falls back to underscores when the version cannot be read', () => {
+    // Same rule as the subcommands: the old spelling works everywhere to date.
+    expect(flashOptionFlag('flash-mode', undefined)).toBe('--flash_mode')
+    expect(flashOptionFlag('flash-size', 'unparseable')).toBe('--flash_size')
   })
 })

--- a/test/esptoolIdentify.test.ts
+++ b/test/esptoolIdentify.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest'
+import {
+  describeIdentity,
+  parseEsptoolIdentity,
+  suggestedBuildFor
+} from '../src/shared/esptool-identify'
+
+/**
+ * Interrogating the board before flashing it.
+ *
+ * The sample below is verbatim `esptool v5.3.0 flash-id` output from the
+ * Adafruit ESP32 Feather V2 that prompted this — including the line that
+ * matters most, `Embedded PSRAM`, which is the only reliable way to know that
+ * ESP32_GENERIC-SPIRAM is the build this board wants. Nothing in the firmware
+ * catalog carries that fact.
+ */
+const FEATHER_V2 = `Connected to ESP32 on /dev/tty.usbserial-51850332091:
+Chip type:          ESP32-PICO-V3-02 (revision v3.0)
+Features:           Wi-Fi, BT, Dual Core + LP Core, 240MHz, Embedded Flash, Embedded PSRAM, Vref calibration in eFuse, Coding Scheme None
+Crystal frequency:  40MHz
+MAC:                e8:9f:6d:26:93:20
+
+Flash Memory Information:
+=========================
+Manufacturer: 68
+Device: 4017
+Detected flash size: 8MB
+Flash voltage set by a strapping pin: 3.3V`
+
+const PLAIN_ESP32 = `Chip type:          ESP32-D0WD-V3 (revision v3.1)
+Features:           Wi-Fi, BT, Dual Core, 240MHz, Vref calibration in eFuse, Coding Scheme None
+MAC:                24:6f:28:11:22:33
+Detected flash size: 4MB`
+
+describe('parseEsptoolIdentity', () => {
+  it('reads the real Feather V2 output', () => {
+    const id = parseEsptoolIdentity(FEATHER_V2)
+    expect(id.chip).toBe('ESP32-PICO-V3-02')
+    expect(id.revision).toBe('v3.0')
+    expect(id.family).toBe('esp32')
+    expect(id.flashSize).toBe('8MB')
+    expect(id.mac).toBe('e8:9f:6d:26:93:20')
+    expect(id.psram).toBe(true)
+  })
+
+  it('does not see PSRAM where there is none', () => {
+    const id = parseEsptoolIdentity(PLAIN_ESP32)
+    expect(id.psram).toBe(false)
+    expect(id.chip).toBe('ESP32-D0WD-V3')
+    expect(id.family).toBe('esp32')
+  })
+
+  it('does not let a PICO or WROOM module name change the family', () => {
+    // The module name describes what is around the die, not the die.
+    for (const c of ['ESP32-PICO-V3-02', 'ESP32-D0WDQ6', 'ESP32-WROOM-32E']) {
+      expect(parseEsptoolIdentity(`Chip type: ${c}`).family, c).toBe('esp32')
+    }
+  })
+
+  it('does not let the ESP32 rule swallow the S3 and the RISC-V parts', () => {
+    // Longest-first matching: "ESP32-S3" must not be read as plain "ESP32",
+    // which would pre-select a 0x1000 offset for a chip that needs 0x0.
+    expect(parseEsptoolIdentity('Chip type: ESP32-S3 (QFN56)').family).toBe('esp32s3')
+    expect(parseEsptoolIdentity('Chip type: ESP32-S2').family).toBe('esp32s2')
+    expect(parseEsptoolIdentity('Chip type: ESP32-C3').family).toBe('esp32c3')
+    expect(parseEsptoolIdentity('Chip type: ESP32-C6').family).toBe('esp32c6')
+  })
+
+  it('leaves everything unknown rather than guessing, on output it cannot read', () => {
+    for (const s of ['', 'Connecting....', 'A fatal error occurred: Failed to connect']) {
+      expect(parseEsptoolIdentity(s)).toEqual({})
+    }
+  })
+})
+
+describe('suggestedBuildFor', () => {
+  it('recommends the SPIRAM build for a PSRAM esp32 — the reported case', () => {
+    const s = suggestedBuildFor(parseEsptoolIdentity(FEATHER_V2))
+    expect(s?.name).toBe('ESP32_GENERIC-SPIRAM')
+    expect(s?.why).toMatch(/PSRAM/)
+    // ...and is honest that the plain build still works.
+    expect(s?.why).toMatch(/runs fine|leaves the PSRAM/i)
+  })
+
+  it('says nothing for an esp32 without PSRAM', () => {
+    expect(suggestedBuildFor(parseEsptoolIdentity(PLAIN_ESP32))).toBeNull()
+  })
+
+  it('deliberately says nothing for an S3, even with PSRAM', () => {
+    // The S3 is a three-way choice (plain / SPIRAM / SPIRAM_OCT) that turns on
+    // the RAM's bus width, which flash-id does not report. A wrong guess sends
+    // someone to a build that boots with a PSRAM error.
+    const s3 = parseEsptoolIdentity('Chip type: ESP32-S3\nFeatures: Wi-Fi, BT, PSRAM')
+    expect(s3.psram).toBe(true)
+    expect(suggestedBuildFor(s3)).toBeNull()
+  })
+
+  it('says nothing when the board was never identified', () => {
+    expect(suggestedBuildFor({})).toBeNull()
+  })
+})
+
+describe('describeIdentity', () => {
+  it('summarises what the user would want to see', () => {
+    expect(describeIdentity(parseEsptoolIdentity(FEATHER_V2)))
+      .toBe('ESP32-PICO-V3-02 · 8MB flash · PSRAM')
+  })
+
+  it('omits what it does not know instead of printing blanks', () => {
+    expect(describeIdentity({ chip: 'ESP32' })).toBe('ESP32')
+    expect(describeIdentity({})).toBe('')
+  })
+})


### PR DESCRIPTION
Closes #826. Closes #827.

## #826 — erase-before-write defaults on

It was opt-in per board, which is the wrong granularity. A stale partition table is not a property of the **board**; it is a property of **what was on the flash before**, which no profile can know.

Opt-in meant the flag sat on exactly the boards somebody had already been caught by — a list of who had complained, not of who was affected — and **not** on the generic `esp32-devkit` entry, which is precisely what you pick when your board is unlisted and its provenance is therefore unknown.

Now on for every esptool board; a profile opts out with `eraseByDefault: false`. Erasing needlessly costs ~7 seconds and a filesystem being replaced anyway. Not erasing can cost a board that looks bricked.

## #827 — the flasher asks the board

`Flash complete.` was the last word, and esptool exits 0 for a flash whose result cannot boot — so that line was a claim about the *tool*, not the *board*. Snakie still owns the port at that moment, and the board is one serial read away from saying what actually happened.

It now resets the board and listens:

| heard | reported |
|---|---|
| a MicroPython/CircuitPython banner | *"the board is running MicroPython v1.28.0"* |
| `esp_image:` / `No bootable app partitions` / 3+ resets | the write was verified but the board is not starting — quotes the board's own line, points at erasing |
| silence | nothing |

**Strictly advisory.** Failure to open, to reset, or to hear anything is swallowed — a native-USB board re-enumerates after flashing and is not on that port at all, and no output must never be reported as a failure. Neither verdict is emitted as an `error`, because the flash genuinely succeeded and saying otherwise would contradict the verified write the user just watched.

The classifier is pure and in `shared/`, so the wording is testable without a board. Failure markers are checked **before** the banner: a board that was working keeps its old banner in the buffer, and the complaint is the newer and truer signal. A single `rst:` is booting, not looping.

## Also

The Feather V2 profile now names **`ESP32_GENERIC-SPIRAM`** as its `preferredBuild`. The board has 2 MB of PSRAM and only that build can use it — but Thonny's catalog entry for `ESP32 / WROOM` carries **no variants at all**, so there is no way to select it from the Variant dropdown even though it exists upstream (verified: HTTP 200). Saying so in the profile is exactly what `preferredBuild` is for.

## What this does NOT claim

I previously concluded that a full erase fixed the board that prompted #826. **That was wrong**, and the code comment asserting it has been corrected. That board booted once after an erase and then reverted to boot-looping with **byte-identical** flash content — which is not a flashing problem at all. Recorded separately in #828.

#826 stands on its own argument, not on that board.

Gates: typecheck, lint, **5818 tests**, build — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)