### PR TITLE
feat: identifying a board selects it, rather than just describing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- **Identifying a board now selects it, instead of just describing it.** The
+  flash dialog would run its detection, learn that the connected board was an
+  ESP32-PICO-V3-02 with PSRAM and 8 MB of flash — and then leave the Board
+  picker sitting on *"Other / set up manually…"*. Everything that follows from
+  knowing the board (the flash offset, whether to erase first, the note that
+  this one needs BOOT held while you tap RESET, which firmware build suits it)
+  was left to be worked out by hand, from a list of fifteen entries.
+
+  **Identify board** now applies what it finds: one click and the right profile
+  is selected, with the dialog saying so rather than moving the settings
+  silently underneath you. Where a chip is used by more than one board it offers
+  the choice instead of guessing — two boards on the same chip can want
+  different flash offsets, and the wrong one writes cleanly and leaves the board
+  dead.
+
+
 ### Fixed
 - **The firmware flasher's text is readable on the light theme again.** The
   dialog is deliberately dark whichever theme you are using, but several bits of

--- a/src/renderer/src/components/FirmwareFlasher.css
+++ b/src/renderer/src/components/FirmwareFlasher.css
@@ -441,3 +441,20 @@
   accent-color: var(--accent);
   cursor: pointer;
 }
+
+/* An inline choice inside a hint line — used when the identified chip is claimed
+   by more than one board, so the dialog asks rather than guesses. Styled as a
+   link, not a button: it sits mid-sentence. */
+.firmware-link {
+  padding: 0;
+  border: 0;
+  background: none;
+  font: inherit;
+  color: var(--accent);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.firmware-link:hover {
+  text-decoration: none;
+}

--- a/src/renderer/src/components/FirmwareFlasher.tsx
+++ b/src/renderer/src/components/FirmwareFlasher.tsx
@@ -11,6 +11,8 @@ import type {
 } from '../../../preload/index.d'
 import {
   BOARD_PROFILES,
+  profilesForChip,
+  type BoardProfile,
   boardProfile,
   firmwareFileIssue,
   firmwareMismatch,
@@ -138,6 +140,9 @@ export function FirmwareFlasher({
    *  Null until the user asks; `{}` when the board could not be reached. */
   const [identity, setIdentity] = useState<BoardIdentity | null>(null)
   const [identifying, setIdentifying] = useState(false)
+  /** Profiles that claim the identified chip, when more than one does — a
+   *  question for the user rather than a guess we make for them. */
+  const [matchedProfiles, setMatchedProfiles] = useState<BoardProfile[]>([])
   const [board, setBoard] = useState<BoardType>('esp32')
   /** The chosen board profile (#682) — drives the mechanics below it. */
   const [profileId, setProfileId] = useState<string>('')
@@ -574,20 +579,39 @@ export function FirmwareFlasher({
   const identifyBoard = useCallback(async (): Promise<void> => {
     if (!port) return
     setIdentifying(true)
+    setMatchedProfiles([])
     try {
       const id = await window.api.firmware.identifyBoard(port)
       setIdentity(id)
-      // Pre-select the family it reported, so the catalog opens on builds that
-      // fit. Never overrides an explicit board choice — same rule as detection.
-      if (id.family && !profileRef.current && families.some((f) => f.family === id.family)) {
-        setSelFamily(id.family)
+
+      // ACT on what came back, rather than reporting it and leaving the user to
+      // find the right entry in a list of fifteen.
+      //
+      // This is the gap the reporter hit: the dialog ran detection AND
+      // identification, learned the board was an ESP32-PICO-V3-02 with PSRAM,
+      // and still sat on "Other / set up manually" — so the flash offset, the
+      // erase default and the BOOT/RESET note all had to be got right by hand.
+      // Identify is an explicit "tell me what this is", so applying the answer
+      // is what was asked for.
+      const matches = profilesForChip(id.chip)
+      if (matches.length === 1) {
+        handleProfileChange(matches[0].id)
+      } else if (matches.length > 1) {
+        // Two boards on the same chip. Picking one would mean guessing at the
+        // flash offset, so offer them instead.
+        setMatchedProfiles(matches)
+      } else if (id.family && families.some((f) => f.family === id.family)) {
+        // No board recognised, but the CHIP FAMILY is still worth acting on:
+        // it opens the catalog on builds that fit. Never over an explicit
+        // choice — same rule as detection.
+        if (!profileRef.current) setSelFamily(id.family)
       }
     } catch {
       setIdentity({})
     } finally {
       setIdentifying(false)
     }
-  }, [port, families])
+  }, [port, families, handleProfileChange])
 
   const suggestedBuild = useMemo(
     () => (identity ? suggestedBuildFor(identity) : null),
@@ -1071,10 +1095,19 @@ export function FirmwareFlasher({
                       {describeIdentity(identity) ? (
                         <>
                           Found <strong>{describeIdentity(identity)}</strong>
-                          {suggestedBuild && (
+                          {/* Say that the Board picker was CHANGED. Selecting it
+                              silently would leave the user wondering why the
+                              offset and the erase box moved on their own. */}
+                          {profile && identity.chip && profilesForChip(identity.chip).length === 1 && (
                             <>
                               {' — '}
-                              use the <strong>{suggestedBuild.name}</strong> build. {suggestedBuild.why}
+                              selected <strong>{profile.label}</strong> for you.
+                            </>
+                          )}
+                          {suggestedBuild && (
+                            <>
+                              {' '}
+                              Use the <strong>{suggestedBuild.name}</strong> build. {suggestedBuild.why}
                             </>
                           )}
                         </>
@@ -1084,6 +1117,28 @@ export function FirmwareFlasher({
                           download mode, then try again.
                         </>
                       )}
+                    </p>
+                  )}
+                  {/* More than one board uses this chip, so picking one would be
+                      a guess about the flash offset. Ask instead. */}
+                  {matchedProfiles.length > 1 && (
+                    <p className="firmware-hint">
+                      That chip is used by {matchedProfiles.length} boards — pick yours:{' '}
+                      {matchedProfiles.map((m, i) => (
+                        <span key={m.id}>
+                          {i > 0 && ', '}
+                          <button
+                            type="button"
+                            className="firmware-link"
+                            onClick={() => {
+                              handleProfileChange(m.id)
+                              setMatchedProfiles([])
+                            }}
+                          >
+                            {m.label}
+                          </button>
+                        </span>
+                      ))}
                     </p>
                   )}
                 </div>

--- a/src/shared/board-profiles.ts
+++ b/src/shared/board-profiles.ts
@@ -65,6 +65,20 @@ export interface BoardProfile {
   /** Anything the user genuinely needs to know, shown next to the picker. */
   notes?: string
   /**
+   * The chip name(s) `esptool flash-id` prints for this board, so identifying a
+   * connected board can select its profile instead of leaving the user to find
+   * it in a list of fifteen.
+   *
+   * Matched case-insensitively against `Chip type:`. Absent means "cannot be
+   * recognised from the chip alone", which is the honest default — most ESP32
+   * boards report the same generic part and nothing distinguishes them.
+   *
+   * A chip that several profiles claim is NOT resolved by picking the first:
+   * {@link profilesForChip} returns them all and the caller offers a choice,
+   * because silently selecting the wrong board sets the wrong flash offset.
+   */
+  matchChip?: readonly string[]
+  /**
    * Erase the whole flash before writing — **on by default for every esptool
    * board**; set this to `false` only to opt a board OUT.
    *
@@ -207,6 +221,10 @@ export const BOARD_PROFILES: BoardProfile[] = [
     method: 'esptool',
     // The original ESP32 — the one chip whose offset is not 0x0.
     offset: '0x1000',
+    // What esptool prints for this board. The PICO-V3-02 packages its flash and
+    // PSRAM on-die, which is distinctive enough to name — and no other profile
+    // here claims it, so identifying the board resolves to exactly this one.
+    matchChip: ['ESP32-PICO-V3-02'],
     circuitPythonBoardId: 'adafruit_feather_esp32_v2',
     // A CH9102F bridge, not native USB: the port stays put across a flash, so
     // no replug is needed the way it is on an S3.
@@ -337,4 +355,21 @@ export function firmwareFileIssue(method: FlashMethod, path: string): string | n
 /** The flash method implied by a coarse board type, for callers without a profile. */
 export function methodForBoardType(board: 'esp32' | 'esp8266' | 'rp2040' | 'microbit'): FlashMethod {
   return board === 'rp2040' ? 'uf2' : board === 'microbit' ? 'daplink' : 'esptool'
+}
+
+/**
+ * The profiles that claim a chip, as `esptool flash-id` reported it.
+ *
+ * Returns ALL of them, never a best guess. One match is something the dialog can
+ * act on; several is a question it has to ask, because choosing wrongly between
+ * two boards on the same chip can mean the wrong flash offset — which writes
+ * cleanly and leaves the board dead. Zero is the normal case: most ESP32 boards
+ * report a generic part that says nothing about which board it is on.
+ */
+export function profilesForChip(chip: string | undefined): BoardProfile[] {
+  const c = (chip ?? '').trim().toUpperCase()
+  if (!c) return []
+  return BOARD_PROFILES.filter((p) =>
+    (p.matchChip ?? []).some((m) => m.trim().toUpperCase() === c)
+  )
 }

--- a/test/profileFromChip.test.ts
+++ b/test/profileFromChip.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { BOARD_PROFILES, profilesForChip } from '../src/shared/board-profiles'
+import { parseEsptoolIdentity } from '../src/shared/esptool-identify'
+
+/**
+ * Identifying a board should SELECT it, not just describe it.
+ *
+ * The reported gap: the flash dialog ran detection and identification, learned
+ * the board was an ESP32-PICO-V3-02 with PSRAM and 8 MB of flash, and still sat
+ * on "Other / set up manually" — leaving the flash offset, the erase default and
+ * the BOOT/RESET note to be got right by hand, from a list of fifteen entries.
+ * The user's own summary: "If I can't do it via the UI, I doubt users will make
+ * the right choices either."
+ */
+const FEATHER_V2 = `Chip type:          ESP32-PICO-V3-02 (revision v3.0)
+Features:           Wi-Fi, BT, Dual Core + LP Core, 240MHz, Embedded Flash, Embedded PSRAM
+Detected flash size: 8MB`
+
+describe('profilesForChip', () => {
+  it('resolves the reported board from what esptool printed', () => {
+    const id = parseEsptoolIdentity(FEATHER_V2)
+    const hits = profilesForChip(id.chip)
+    expect(hits).toHaveLength(1)
+    expect(hits[0].id).toBe('adafruit-feather-esp32-v2')
+  })
+
+  it('carries the settings that were being got right by hand', () => {
+    const p = profilesForChip('ESP32-PICO-V3-02')[0]
+    expect(p.offset).toBe('0x1000')
+    expect(p.eraseByDefault).not.toBe(false)
+    expect(p.notes).toMatch(/BOOT/)
+  })
+
+  it('is case- and whitespace-insensitive, since the banner varies', () => {
+    for (const c of ['esp32-pico-v3-02', '  ESP32-PICO-V3-02  ', 'Esp32-Pico-V3-02']) {
+      expect(profilesForChip(c), c).toHaveLength(1)
+    }
+  })
+
+  it('says nothing for a chip no profile claims', () => {
+    // The normal case: most ESP32 boards report a generic part that says
+    // nothing about WHICH board it is, and inventing a match there would set
+    // the wrong offset on a board that flashes cleanly and then does not boot.
+    expect(profilesForChip('ESP32-D0WD-V3')).toEqual([])
+    expect(profilesForChip('ESP32-S3')).toEqual([])
+  })
+
+  it('handles nothing at all without throwing', () => {
+    expect(profilesForChip(undefined)).toEqual([])
+    expect(profilesForChip('')).toEqual([])
+    expect(profilesForChip('   ')).toEqual([])
+  })
+
+  it('returns EVERY claimant, so an ambiguous chip is a question not a guess', () => {
+    // Two boards on one chip must not be resolved by taking the first: they can
+    // differ in flash offset, and picking wrongly writes cleanly and leaves the
+    // board dead. The UI offers the list instead.
+    const claimed = BOARD_PROFILES.flatMap((p) => p.matchChip ?? [])
+    const dupes = claimed.filter((c, i) => claimed.indexOf(c) !== i)
+    for (const c of dupes) {
+      expect(profilesForChip(c).length).toBeGreaterThan(1)
+    }
+  })
+
+  it('every declared matchChip actually resolves to its own profile', () => {
+    // Guards a typo in the table: a chip string that matches nothing is dead
+    // weight that looks like it works.
+    for (const p of BOARD_PROFILES) {
+      for (const c of p.matchChip ?? []) {
+        expect(profilesForChip(c).map((x) => x.id), `${p.id} claims ${c}`).toContain(p.id)
+      }
+    }
+  })
+})


### PR DESCRIPTION
Reported by someone who could not get their own board flashed through the UI, and who put the real point better than I would have:

> *"If I can't do it via the UI, I doubt users will make the right choices either."*

## The gap

The dialog **already knew**. It ran detection *and* identification, learned the board was an `ESP32-PICO-V3-02` with PSRAM and 8 MB of flash, printed that on screen — and left the Board picker on **"Other / set up manually…"**, which is the first entry and therefore the default.

Everything that follows from knowing the board was then manual: the flash offset, the erase-first default, the note that this board will not enter download mode by itself, and which firmware build suits it. Fifteen entries to find the right one in, having *just been told what the board is*.

## The change

Profiles gain an optional `matchChip` — the chip name(s) esptool prints for them. **Identify board** now applies the answer.

**Two things it deliberately does not do:**

- **It does not guess between claimants.** `profilesForChip` returns *every* profile claiming a chip, and the dialog offers the list when there is more than one — two boards on one chip can want different flash offsets, and the wrong one writes cleanly and leaves the board dead.
- **It does not match on family.** Most ESP32 boards report a generic part that says nothing about *which* board it is, so `matchChip` is absent by default and the answer is an honest "could not tell" rather than a plausible wrong one. Where the family is known but the board is not, it still pre-selects the catalog family, as before.

And it **says** it selected something — moving the offset and the erase checkbox underneath the user without a word would be its own bug.

## Verified end to end, on the reported hardware

```
identity : ESP32-PICO-V3-02 · 8MB flash · PSRAM
profile  : Adafruit ESP32 Feather V2   ← selected automatically
  offset : 0x1000 | erase: true
  note   : Hold BOOT, tap RESET, then release BOOT …
build    : ESP32_GENERIC-SPIRAM
```

7 new tests, including a guard that every declared `matchChip` actually resolves to its own profile — a typo there is dead weight that looks like it works.

Gates: typecheck, lint, **5839 tests**, build — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)