### PR TITLE
fix: the erase checkbox was ignored on the Download & Flash path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Fixed
+- **"Erase the whole flash first" now actually does, when the firmware comes
+  from the catalog.** The checkbox worked when you flashed a file from disk and
+  was silently ignored on **Download & Flash** — which is the default source and
+  the path almost everyone takes. The box could be ticked, the dialog said the
+  flash would be erased, and it was not.
+
+  The cost of that landed somewhere unhelpful: the flash itself succeeded and
+  reported `Hash of data verified`, and then the board sat there boot-looping on
+  a partition table left over from whatever it shipped with. Everything about
+  the flash looked right, because everything about the flash *was* right — the
+  step before it just never happened. Boards arriving with vendor firmware were
+  the ones affected, which is to say new ones out of the box.
+
+  The download path now carries every option the direct one does, and a test
+  holds the two together so they cannot drift apart again.
+
+
+### Fixed
 - **The firmware flasher's text is readable on the light theme again.** The
   dialog is deliberately dark whichever theme you are using, but several bits of
   it took their colour from the theme's own tokens — which on the parchment skin

--- a/src/main/firmware/download.ts
+++ b/src/main/firmware/download.ts
@@ -136,13 +136,19 @@ export async function downloadAndFlash(
   try {
     // `flash` validates the file, dispatches by board (UF2 copy / esptool), and
     // emits the terminal `done`.
+    // Forward EVERY option, not a subset. Listing the fields by hand here is
+    // exactly what dropped `eraseFirst`: the direct path erased, this one
+    // silently did not, and the dialog said the same thing for both.
     return await flash(
       {
         board: opts.board,
         firmwarePath: tempPath,
         mountPath: opts.mountPath,
         port: opts.port,
-        offset: opts.offset
+        offset: opts.offset,
+        eraseFirst: opts.eraseFirst,
+        baud: opts.baud,
+        chip: opts.chip
       },
       emit
     )

--- a/src/main/firmware/types.ts
+++ b/src/main/firmware/types.ts
@@ -206,4 +206,23 @@ export interface DownloadAndFlashOptions {
   port?: string
   /** Flash offset for the esptool `write_flash` (ESP only; per-chip). */
   offset?: string
+  /**
+   * Erase the whole flash before writing (ESP only).
+   *
+   * Its ABSENCE here was a silent bug: the flash dialog's erase checkbox reached
+   * {@link FlashOptions} on the local-file path and was dropped on this one, so
+   * the box could be ticked, the dialog could say it would erase, and the
+   * catalog path — the default source, and the one almost everyone takes —
+   * quietly would not. A board arriving with vendor firmware then boot-looped on
+   * a partition table that had never been cleared, while the log reported
+   * `Hash of data verified.`
+   *
+   * Every option {@link FlashOptions} takes is mirrored here for that reason: a
+   * field on one path and not the other is a lie waiting to happen.
+   */
+  eraseFirst?: boolean
+  /** Recommended baud for the esptool flash (ESP only). */
+  baud?: number
+  /** Chip name for esptool's `--chip` (ESP only), when the board is known. */
+  chip?: string
 }

--- a/src/renderer/src/components/FirmwareFlasher.tsx
+++ b/src/renderer/src/components/FirmwareFlasher.tsx
@@ -745,7 +745,14 @@ export function FirmwareFlasher({
           // ESP: serial port + offset; RP2040 / micro:bit: copy to the drive.
           port: esp ? port : undefined,
           offset: esp ? offset || target.offset : undefined,
-          mountPath: esp ? undefined : mountPath
+          mountPath: esp ? undefined : mountPath,
+          // The SAME esptool options as the local-file branch below. These were
+          // missing, so the erase checkbox did nothing whenever the firmware
+          // came from the catalog — the default source, and the path almost
+          // everyone takes. The box was ticked, the dialog said it would erase,
+          // and the board boot-looped on a partition table never cleared.
+          eraseFirst: esp ? eraseFirst : undefined,
+          chip: esp ? profile?.chipFamily : undefined
         })
       } else {
         await window.api.firmware.flash({

--- a/test/downloadFlashParity.test.ts
+++ b/test/downloadFlashParity.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * #833 — the erase checkbox did nothing on the "Download & Flash" path.
+ *
+ * `DownloadAndFlashOptions` carried a SUBSET of `FlashOptions`, and
+ * `downloadAndFlash` rebuilt the options object field by field. `eraseFirst`
+ * was not among them, so it was silently dropped — on the catalog path, which
+ * is the default source and the one almost everyone uses.
+ *
+ * The dialog said the same thing for both paths. The box was ticked, the board
+ * arrived with vendor firmware, nothing was erased, and it boot-looped on a
+ * leftover partition table with the log cheerfully reporting
+ * `Hash of data verified.`
+ *
+ * Reported by a user who could not flash an Adafruit ESP32 Feather V2 through
+ * the UI while the identical esptool command worked by hand — the difference
+ * being the `--erase-all` the UI never passed.
+ *
+ * These read the SOURCE rather than calling anything, because the bug was a
+ * field that did not exist: it cannot be caught by exercising a type that is
+ * already missing it.
+ */
+const read = (p: string): string => readFileSync(join(__dirname, '..', p), 'utf-8')
+
+/** The optional fields of an interface, as declared. */
+function fieldsOf(src: string, name: string): string[] {
+  const m = new RegExp(`export interface ${name} \\{([\\s\\S]*?)\\n\\}`).exec(src)
+  if (!m) throw new Error(`interface ${name} not found`)
+  return [...m[1].matchAll(/^\s{2}(\w+)\??:/gm)].map((x) => x[1])
+}
+
+describe('the download path carries every option the direct path does', () => {
+  const types = read('src/main/firmware/types.ts')
+
+  it('DownloadAndFlashOptions is not missing esptool knobs FlashOptions has', () => {
+    const flash = fieldsOf(types, 'FlashOptions')
+    const dl = fieldsOf(types, 'DownloadAndFlashOptions')
+    // `firmwarePath` is the one legitimate difference: the download path
+    // produces it rather than receiving it.
+    const missing = flash.filter((f) => f !== 'firmwarePath' && !dl.includes(f))
+    expect(missing, `DownloadAndFlashOptions is missing: ${missing.join(', ')}`).toEqual([])
+  })
+
+  it('carries eraseFirst specifically — the field whose absence was the bug', () => {
+    expect(fieldsOf(types, 'DownloadAndFlashOptions')).toContain('eraseFirst')
+  })
+
+  it('downloadAndFlash actually forwards them to flash()', () => {
+    const dl = read('src/main/firmware/download.ts')
+    const call = /return await flash\(\s*\{([\s\S]*?)\}/.exec(dl)
+    expect(call, 'the flash() call was not found').toBeTruthy()
+    for (const f of ['eraseFirst', 'baud', 'chip', 'offset', 'port', 'mountPath']) {
+      expect(call![1], `flash() call drops ${f}`).toContain(f)
+    }
+  })
+
+  it('the renderer sends them on the catalog branch too', () => {
+    const ui = read('src/renderer/src/components/FirmwareFlasher.tsx')
+    const call = /downloadAndFlash\(\{([\s\S]*?)\}\)/.exec(ui)
+    expect(call, 'the downloadAndFlash call was not found').toBeTruthy()
+    expect(call![1], 'the erase checkbox is not forwarded').toContain('eraseFirst')
+    expect(call![1], 'the chip hint is not forwarded').toContain('chip')
+  })
+})


### PR DESCRIPTION
This is why the Feather V2 would not flash through the UI while the **identical esptool command worked by hand**. The difference was `--erase-all`, which the UI never passed.

## The bug

`DownloadAndFlashOptions` carried a *subset* of `FlashOptions`, and `downloadAndFlash` rebuilt the options object field by field. `eraseFirst` was not among them.

| path | | `eraseFirst` | result |
|---|---|---|---|
| Local file | `firmware.flash` | sent | erases |
| **Download & Flash** | `firmware.downloadAndFlash` | **dropped** | does not |

The dialog showed the same ticked checkbox for both. **Download & Flash is the default source** and the path almost everyone takes.

## Why it was so hard to find

The failure landed in the worst possible place. esptool wrote correctly and reported `Hash of data verified`, so every visible signal said success — and the board then boot-looped on a partition table that had never been cleared.

From the user's side: a perfect flash and a dead board. That sent the diagnosis chasing the flash offset, a download truncation, the baud rate, and finally the hardware — **all of them wrong** — across several days. The one step that did not happen was the one nothing reported.

`chip` and `baud` were dropped by the same subset, so all three are forwarded now, and the type mirrors `FlashOptions` rather than picking fields by hand.

## The test

It reads the **source** rather than exercising a type, because the bug was a field that *did not exist* — it cannot be caught by calling something already missing it. I verified it fails when the forwarding is removed again, so it is a regression test rather than decoration.

## Credit where it is due

Found because **#827's post-flash boot check** reported the boot-loop instead of `Flash complete.` Without that line the user would still be looking at a verified flash and a dead board.

Gates: typecheck, lint, **5821 tests**, build — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)