### PR TITLE
feat: Flash fetches the recommended build, instead of naming it (#833)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- **Identifying a board now selects it, instead of just describing it.** The
+  flash dialog would run its detection, learn that the connected board was an
+  ESP32-PICO-V3-02 with PSRAM and 8 MB of flash — and then leave the Board
+  picker sitting on *"Other / set up manually…"*. Everything that follows from
+  knowing the board (the flash offset, whether to erase first, the note that
+  this one needs BOOT held while you tap RESET, which firmware build suits it)
+  was left to be worked out by hand, from a list of fifteen entries.
+
+  **Identify board** now applies what it finds: one click and the right profile
+  is selected, with the dialog saying so rather than moving the settings
+  silently underneath you. Where a chip is used by more than one board it offers
+  the choice instead of guessing — two boards on the same chip can want
+  different flash offsets, and the wrong one writes cleanly and leaves the board
+  dead.
+
+
 ### Fixed
 - **The firmware flasher's text is readable on the light theme again.** The
   dialog is deliberately dark whichever theme you are using, but several bits of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Snakie fetches the recommended firmware build itself.** Identifying a board
+  could tell you it had PSRAM and that `ESP32_GENERIC-SPIRAM` was the build that
+  uses it — and then leave you to open a browser, find that file, download it,
+  and come back through a file picker. For a file whose address Snakie could
+  already work out.
+
+  When a recommended build exists, it is now offered as a tickbox (on by
+  default) and **Flash downloads it for you**, exactly as it does for a catalog
+  build. The build's address is derived from the release already selected, so it
+  is always the same version — and it is *confirmed to exist* before being
+  offered, because a composed URL is a guess about a naming convention and a 404
+  handed to the flasher would be worse than the manual download it replaces.
+
+  This matters because the firmware catalog cannot offer these builds at all:
+  its `ESP32 / WROOM` entry carries no variants, so the PSRAM build has been
+  unreachable from the dropdowns despite being published alongside the one that
+  is offered.
+
+
 - **An Autoscroll toggle on the firmware flasher's output.** The log followed
   the newest line and nothing else, so scrolling back to read while a flash was
   still running was impossible — every new line yanked you to the bottom again.

--- a/src/main/firmware/download.ts
+++ b/src/main/firmware/download.ts
@@ -156,3 +156,23 @@ export async function downloadAndFlash(
     await unlink(tempPath).catch(reporter('firmware: cleanup temp file'))
   }
 }
+
+/**
+ * Does `url` actually resolve to a file? Used before offering a build whose
+ * address was DERIVED rather than read from a catalog (#833).
+ *
+ * A composed URL is a guess about a naming convention. Handing a 404 to the
+ * flasher would be worse than the manual download it replaces, so the guess is
+ * checked before it is offered. HEAD, so nothing is transferred.
+ *
+ * Never throws: offline, blocked, or a slow server all mean "cannot offer it",
+ * which is the same as "not there" from the caller's point of view.
+ */
+export async function firmwareUrlExists(url: string): Promise<boolean> {
+  try {
+    const res = await fetch(url, { method: 'HEAD' })
+    return res.ok
+  } catch {
+    return false
+  }
+}

--- a/src/main/firmware/ipc.ts
+++ b/src/main/firmware/ipc.ts
@@ -14,7 +14,7 @@ import type { BoardIdentity } from '../../shared/esptool-identify'
 import { detectBoards } from './detect'
 import { detectEsptool, flash, identifyBoard } from './flasher'
 import { fetchFirmwareCatalog } from './catalog'
-import { downloadAndFlash } from './download'
+import { downloadAndFlash, firmwareUrlExists } from './download'
 import type {
   BoardCandidate,
   DownloadAndFlashOptions,
@@ -34,7 +34,8 @@ export const FIRMWARE_CHANNELS = {
   flash: 'firmware:flash',
   fetchCatalog: 'firmware:fetchCatalog',
   downloadAndFlash: 'firmware:downloadAndFlash',
-  identify: 'firmware:identify'
+  identify: 'firmware:identify',
+  urlExists: 'firmware:urlExists'
 } as const
 
 /**
@@ -74,6 +75,11 @@ export function registerFirmwareIpc(getWindow: () => BrowserWindow | undefined):
   // like "has no PSRAM".
   ipcMain.handle(FIRMWARE_CHANNELS.identify, (_e, port: string) =>
     wrap<BoardIdentity>(() => identifyBoard(port))
+  )
+
+  // Confirm a DERIVED firmware URL resolves before the dialog offers it (#833).
+  ipcMain.handle(FIRMWARE_CHANNELS.urlExists, (_e, url: string) =>
+    wrap<boolean>(() => firmwareUrlExists(url))
   )
 
   ipcMain.handle(FIRMWARE_CHANNELS.pickFile, (_e, method?: FlashMethod) =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -682,6 +682,11 @@ const firmware = {
    */
   identifyBoard: (port: string): Promise<BoardIdentity> =>
     unwrap(ipcRenderer.invoke('firmware:identify', port)),
+
+  /** Does a firmware URL resolve? Used to confirm a DERIVED address before the
+   *  dialog offers it — a composed URL is a guess about a naming convention. */
+  firmwareUrlExists: (url: string): Promise<boolean> =>
+    unwrap(ipcRenderer.invoke('firmware:urlExists', url)),
   /** Show the native firmware file picker, offering only the extension the given
    *  flash method can use (#686). Resolves the path, or null if cancelled. */
   pickFirmwareFile: (method?: FlashMethod): Promise<string | null> =>

--- a/src/renderer/src/components/FirmwareFlasher.css
+++ b/src/renderer/src/components/FirmwareFlasher.css
@@ -441,3 +441,20 @@
   accent-color: var(--accent);
   cursor: pointer;
 }
+
+/* An inline choice inside a hint line — used when the identified chip is claimed
+   by more than one board, so the dialog asks rather than guesses. Styled as a
+   link, not a button: it sits mid-sentence. */
+.firmware-link {
+  padding: 0;
+  border: 0;
+  background: none;
+  font: inherit;
+  color: var(--accent);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.firmware-link:hover {
+  text-decoration: none;
+}

--- a/src/renderer/src/components/FirmwareFlasher.tsx
+++ b/src/renderer/src/components/FirmwareFlasher.tsx
@@ -11,6 +11,8 @@ import type {
 } from '../../../preload/index.d'
 import {
   BOARD_PROFILES,
+  profilesForChip,
+  type BoardProfile,
   boardProfile,
   firmwareFileIssue,
   firmwareMismatch,
@@ -138,6 +140,9 @@ export function FirmwareFlasher({
    *  Null until the user asks; `{}` when the board could not be reached. */
   const [identity, setIdentity] = useState<BoardIdentity | null>(null)
   const [identifying, setIdentifying] = useState(false)
+  /** Profiles that claim the identified chip, when more than one does — a
+   *  question for the user rather than a guess we make for them. */
+  const [matchedProfiles, setMatchedProfiles] = useState<BoardProfile[]>([])
   const [board, setBoard] = useState<BoardType>('esp32')
   /** The chosen board profile (#682) — drives the mechanics below it. */
   const [profileId, setProfileId] = useState<string>('')
@@ -574,20 +579,39 @@ export function FirmwareFlasher({
   const identifyBoard = useCallback(async (): Promise<void> => {
     if (!port) return
     setIdentifying(true)
+    setMatchedProfiles([])
     try {
       const id = await window.api.firmware.identifyBoard(port)
       setIdentity(id)
-      // Pre-select the family it reported, so the catalog opens on builds that
-      // fit. Never overrides an explicit board choice — same rule as detection.
-      if (id.family && !profileRef.current && families.some((f) => f.family === id.family)) {
-        setSelFamily(id.family)
+
+      // ACT on what came back, rather than reporting it and leaving the user to
+      // find the right entry in a list of fifteen.
+      //
+      // This is the gap the reporter hit: the dialog ran detection AND
+      // identification, learned the board was an ESP32-PICO-V3-02 with PSRAM,
+      // and still sat on "Other / set up manually" — so the flash offset, the
+      // erase default and the BOOT/RESET note all had to be got right by hand.
+      // Identify is an explicit "tell me what this is", so applying the answer
+      // is what was asked for.
+      const matches = profilesForChip(id.chip)
+      if (matches.length === 1) {
+        handleProfileChange(matches[0].id)
+      } else if (matches.length > 1) {
+        // Two boards on the same chip. Picking one would mean guessing at the
+        // flash offset, so offer them instead.
+        setMatchedProfiles(matches)
+      } else if (id.family && families.some((f) => f.family === id.family)) {
+        // No board recognised, but the CHIP FAMILY is still worth acting on:
+        // it opens the catalog on builds that fit. Never over an explicit
+        // choice — same rule as detection.
+        if (!profileRef.current) setSelFamily(id.family)
       }
     } catch {
       setIdentity({})
     } finally {
       setIdentifying(false)
     }
-  }, [port, families])
+  }, [port, families, handleProfileChange])
 
   const suggestedBuild = useMemo(
     () => (identity ? suggestedBuildFor(identity) : null),
@@ -1071,10 +1095,19 @@ export function FirmwareFlasher({
                       {describeIdentity(identity) ? (
                         <>
                           Found <strong>{describeIdentity(identity)}</strong>
-                          {suggestedBuild && (
+                          {/* Say that the Board picker was CHANGED. Selecting it
+                              silently would leave the user wondering why the
+                              offset and the erase box moved on their own. */}
+                          {profile && identity.chip && profilesForChip(identity.chip).length === 1 && (
                             <>
                               {' — '}
-                              use the <strong>{suggestedBuild.name}</strong> build. {suggestedBuild.why}
+                              selected <strong>{profile.label}</strong> for you.
+                            </>
+                          )}
+                          {suggestedBuild && (
+                            <>
+                              {' '}
+                              Use the <strong>{suggestedBuild.name}</strong> build. {suggestedBuild.why}
                             </>
                           )}
                         </>
@@ -1084,6 +1117,28 @@ export function FirmwareFlasher({
                           download mode, then try again.
                         </>
                       )}
+                    </p>
+                  )}
+                  {/* More than one board uses this chip, so picking one would be
+                      a guess about the flash offset. Ask instead. */}
+                  {matchedProfiles.length > 1 && (
+                    <p className="firmware-hint">
+                      That chip is used by {matchedProfiles.length} boards — pick yours:{' '}
+                      {matchedProfiles.map((m, i) => (
+                        <span key={m.id}>
+                          {i > 0 && ', '}
+                          <button
+                            type="button"
+                            className="firmware-link"
+                            onClick={() => {
+                              handleProfileChange(m.id)
+                              setMatchedProfiles([])
+                            }}
+                          >
+                            {m.label}
+                          </button>
+                        </span>
+                      ))}
                     </p>
                   )}
                 </div>

--- a/src/renderer/src/components/FirmwareFlasher.tsx
+++ b/src/renderer/src/components/FirmwareFlasher.tsx
@@ -25,6 +25,7 @@ import {
   FIRMWARE_RUNTIME_LABEL,
   findBoardBuilds,
   flashTargetForDownload,
+  siblingBuildUrl,
   flashTargetForFamily,
   isVendorUf2Family,
   type FirmwareRuntime
@@ -143,6 +144,12 @@ export function FirmwareFlasher({
   /** Profiles that claim the identified chip, when more than one does — a
    *  question for the user rather than a guess we make for them. */
   const [matchedProfiles, setMatchedProfiles] = useState<BoardProfile[]>([])
+  /** A CONFIRMED URL for the recommended build, when the catalog does not carry
+   *  it but micropython.org publishes it alongside the one that is selected. */
+  const [recommendedUrl, setRecommendedUrl] = useState<string | null>(null)
+  /** Whether to flash that build instead of the catalog's. On by default when
+   *  one is found — it is recommended because it is the better fit. */
+  const [useRecommended, setUseRecommended] = useState(true)
   const [board, setBoard] = useState<BoardType>('esp32')
   /** The chosen board profile (#682) — drives the mechanics below it. */
   const [profileId, setProfileId] = useState<string>('')
@@ -618,6 +625,45 @@ export function FirmwareFlasher({
     [identity]
   )
 
+  /**
+   * Find the recommended build, if micropython.org actually publishes it (#833).
+   *
+   * The catalog cannot offer it — Thonny's `ESP32 / WROOM` entry has no variants
+   * — so the dialog used to name the build and stop there, leaving a browser, a
+   * downloads folder and a file picker between the user and a file whose address
+   * is derivable from the one already selected. Derive it, CONFIRM it resolves,
+   * and then it is just another thing Flash can fetch.
+   */
+  useEffect(() => {
+    const name = suggestedBuild?.name
+    if (!name || !selVersionUrl) {
+      setRecommendedUrl(null)
+      return undefined
+    }
+    const candidate = siblingBuildUrl(selVersionUrl, name)
+    if (!candidate || candidate === selVersionUrl) {
+      setRecommendedUrl(null)
+      return undefined
+    }
+    let alive = true
+    // Composed from a naming convention, so it is a guess until checked. A 404
+    // handed to the flasher would be worse than the manual download it replaces.
+    void window.api.firmware
+      .firmwareUrlExists(candidate)
+      .then((ok) => {
+        if (alive) setRecommendedUrl(ok ? candidate : null)
+      })
+      .catch(() => {
+        if (alive) setRecommendedUrl(null)
+      })
+    return () => {
+      alive = false
+    }
+  }, [suggestedBuild?.name, selVersionUrl])
+
+  /** The URL Flash will actually fetch. */
+  const flashUrl = recommendedUrl && useRecommended ? recommendedUrl : selVersionUrl
+
   const serialCandidates = candidates.filter((c) => c.source === 'serial')
   // Every OTHER serial port — the ones whose USB bridge we did not recognise.
   //
@@ -761,10 +807,10 @@ export function FirmwareFlasher({
         // Derive the flash target from the selected DOWNLOAD (its extension is
         // the mechanism; the family only supplies the ESP offset). The user may
         // have edited the offset, so prefer the field value over the default.
-        const target = flashTargetForDownload(selFamily, selVersionUrl)
+        const target = flashTargetForDownload(selFamily, flashUrl)
         const esp = isEspBoard(target.board)
         await window.api.firmware.downloadAndFlash({
-          url: selVersionUrl,
+          url: flashUrl,
           board: target.board,
           // ESP: serial port + offset; RP2040 / micro:bit: copy to the drive.
           port: esp ? port : undefined,
@@ -810,14 +856,18 @@ export function FirmwareFlasher({
     handleProgress,
     usingCatalog,
     selFamily,
-    selVersionUrl,
+    // Not `selVersionUrl`: the callback reads `flashUrl`, which derives from it
+    // and from the recommended-build choice, so depending on both would be
+    // redundant and depending on the wrong one would flash a stale URL.
     board,
     mountPath,
     firmwarePath,
     port,
-    // Both are read inside; without them the callback flashes with whatever they
-    // were when it was last created — so toggling Erase would not take effect.
+    // All three are read inside; without them the callback flashes with whatever
+    // they were when it was last created — so toggling Erase, or choosing the
+    // recommended build, would not take effect.
     eraseFirst,
+    flashUrl,
     profile?.chipFamily
   ])
 
@@ -1114,7 +1164,7 @@ export function FirmwareFlasher({
                           {suggestedBuild && (
                             <>
                               {' '}
-                              Use the <strong>{suggestedBuild.name}</strong> build. {suggestedBuild.why}
+                              {suggestedBuild.why}
                             </>
                           )}
                         </>
@@ -1128,6 +1178,24 @@ export function FirmwareFlasher({
                   )}
                   {/* More than one board uses this chip, so picking one would be
                       a guess about the flash offset. Ask instead. */}
+                  {/* The recommended build, once confirmed to exist. It is
+                      fetched by Flash like any other download — naming it and
+                      leaving the user to find it was the clunky part (#833). */}
+                  {recommendedUrl && (
+                    <label className="firmware-check">
+                      <input
+                        type="checkbox"
+                        checked={useRecommended}
+                        disabled={flashing}
+                        onChange={(e) => setUseRecommended(e.target.checked)}
+                      />
+                      <span>
+                        Flash the recommended <strong>{suggestedBuild?.name}</strong> build —
+                        Snakie downloads it for you. Untick to use the{' '}
+                        {selVariant || 'catalog'} build shown below instead.
+                      </span>
+                    </label>
+                  )}
                   {matchedProfiles.length > 1 && (
                     <p className="firmware-hint">
                       That chip is used by {matchedProfiles.length} boards — pick yours:{' '}

--- a/src/shared/board-profiles.ts
+++ b/src/shared/board-profiles.ts
@@ -65,6 +65,20 @@ export interface BoardProfile {
   /** Anything the user genuinely needs to know, shown next to the picker. */
   notes?: string
   /**
+   * The chip name(s) `esptool flash-id` prints for this board, so identifying a
+   * connected board can select its profile instead of leaving the user to find
+   * it in a list of fifteen.
+   *
+   * Matched case-insensitively against `Chip type:`. Absent means "cannot be
+   * recognised from the chip alone", which is the honest default — most ESP32
+   * boards report the same generic part and nothing distinguishes them.
+   *
+   * A chip that several profiles claim is NOT resolved by picking the first:
+   * {@link profilesForChip} returns them all and the caller offers a choice,
+   * because silently selecting the wrong board sets the wrong flash offset.
+   */
+  matchChip?: readonly string[]
+  /**
    * Erase the whole flash before writing — **on by default for every esptool
    * board**; set this to `false` only to opt a board OUT.
    *
@@ -207,6 +221,10 @@ export const BOARD_PROFILES: BoardProfile[] = [
     method: 'esptool',
     // The original ESP32 — the one chip whose offset is not 0x0.
     offset: '0x1000',
+    // What esptool prints for this board. The PICO-V3-02 packages its flash and
+    // PSRAM on-die, which is distinctive enough to name — and no other profile
+    // here claims it, so identifying the board resolves to exactly this one.
+    matchChip: ['ESP32-PICO-V3-02'],
     circuitPythonBoardId: 'adafruit_feather_esp32_v2',
     // A CH9102F bridge, not native USB: the port stays put across a flash, so
     // no replug is needed the way it is on an S3.
@@ -337,4 +355,21 @@ export function firmwareFileIssue(method: FlashMethod, path: string): string | n
 /** The flash method implied by a coarse board type, for callers without a profile. */
 export function methodForBoardType(board: 'esp32' | 'esp8266' | 'rp2040' | 'microbit'): FlashMethod {
   return board === 'rp2040' ? 'uf2' : board === 'microbit' ? 'daplink' : 'esptool'
+}
+
+/**
+ * The profiles that claim a chip, as `esptool flash-id` reported it.
+ *
+ * Returns ALL of them, never a best guess. One match is something the dialog can
+ * act on; several is a question it has to ask, because choosing wrongly between
+ * two boards on the same chip can mean the wrong flash offset — which writes
+ * cleanly and leaves the board dead. Zero is the normal case: most ESP32 boards
+ * report a generic part that says nothing about which board it is on.
+ */
+export function profilesForChip(chip: string | undefined): BoardProfile[] {
+  const c = (chip ?? '').trim().toUpperCase()
+  if (!c) return []
+  return BOARD_PROFILES.filter((p) =>
+    (p.matchChip ?? []).some((m) => m.trim().toUpperCase() === c)
+  )
 }

--- a/src/shared/firmware-runtime.ts
+++ b/src/shared/firmware-runtime.ts
@@ -403,3 +403,46 @@ export function newestStableVersion(
   }
   return best
 }
+
+/**
+ * The URL of a DIFFERENT build of the same firmware release — issue #833.
+ *
+ * The firmware catalog cannot offer every build. Thonny's `ESP32 / WROOM` entry
+ * carries no variants at all, so `ESP32_GENERIC-SPIRAM` — the only build that
+ * can use the PSRAM on a board that has it — is unreachable from the dropdowns
+ * even though it is published alongside the one that IS offered. Until now the
+ * dialog could only name it and leave the user to go and fetch it by hand,
+ * which is a browser, a downloads folder and a file picker for something we
+ * already know the address of.
+ *
+ * micropython.org names its builds
+ *   `<BOARD>-<YYYYMMDD>-v<version>.<ext>`
+ * in one flat directory, so the sibling build of the SAME release is the same
+ * URL with the board token swapped.
+ *
+ * Returns `null` for anything that is not that shape — a CircuitPython URL, a
+ * mirror, a hand-typed link. **The caller must still confirm the result
+ * exists**: this composes a plausible address, it does not promise a file is
+ * there, and a 404 handed to the flasher would be a worse outcome than the
+ * manual download it replaces.
+ */
+export function siblingBuildUrl(url: string, buildName: string): string | null {
+  const name = buildName.trim()
+  if (!name || !/^[A-Za-z0-9_]+(?:-[A-Za-z0-9_]+)*$/.test(name)) return null
+  let parsed: URL
+  try {
+    parsed = new URL(url.trim())
+  } catch {
+    return null
+  }
+  // Only micropython.org publishes this naming; do not reshape anyone else's.
+  if (!/(^|\.)micropython\.org$/i.test(parsed.hostname)) return null
+  const file = parsed.pathname.split('/').pop() ?? ''
+  // `<BOARD>-<8 digits>-v<rest>.<ext>` — the date is what makes the board token
+  // unambiguous, since a board name may itself contain hyphens.
+  const m = /^(.+)-(\d{8}-v[^/]+)$/.exec(file)
+  if (!m) return null
+  if (m[1] === name) return url.trim()          // already the build asked for
+  parsed.pathname = parsed.pathname.replace(/[^/]+$/, `${name}-${m[2]}`)
+  return parsed.toString()
+}

--- a/test/profileFromChip.test.ts
+++ b/test/profileFromChip.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { BOARD_PROFILES, profilesForChip } from '../src/shared/board-profiles'
+import { parseEsptoolIdentity } from '../src/shared/esptool-identify'
+
+/**
+ * Identifying a board should SELECT it, not just describe it.
+ *
+ * The reported gap: the flash dialog ran detection and identification, learned
+ * the board was an ESP32-PICO-V3-02 with PSRAM and 8 MB of flash, and still sat
+ * on "Other / set up manually" — leaving the flash offset, the erase default and
+ * the BOOT/RESET note to be got right by hand, from a list of fifteen entries.
+ * The user's own summary: "If I can't do it via the UI, I doubt users will make
+ * the right choices either."
+ */
+const FEATHER_V2 = `Chip type:          ESP32-PICO-V3-02 (revision v3.0)
+Features:           Wi-Fi, BT, Dual Core + LP Core, 240MHz, Embedded Flash, Embedded PSRAM
+Detected flash size: 8MB`
+
+describe('profilesForChip', () => {
+  it('resolves the reported board from what esptool printed', () => {
+    const id = parseEsptoolIdentity(FEATHER_V2)
+    const hits = profilesForChip(id.chip)
+    expect(hits).toHaveLength(1)
+    expect(hits[0].id).toBe('adafruit-feather-esp32-v2')
+  })
+
+  it('carries the settings that were being got right by hand', () => {
+    const p = profilesForChip('ESP32-PICO-V3-02')[0]
+    expect(p.offset).toBe('0x1000')
+    expect(p.eraseByDefault).not.toBe(false)
+    expect(p.notes).toMatch(/BOOT/)
+  })
+
+  it('is case- and whitespace-insensitive, since the banner varies', () => {
+    for (const c of ['esp32-pico-v3-02', '  ESP32-PICO-V3-02  ', 'Esp32-Pico-V3-02']) {
+      expect(profilesForChip(c), c).toHaveLength(1)
+    }
+  })
+
+  it('says nothing for a chip no profile claims', () => {
+    // The normal case: most ESP32 boards report a generic part that says
+    // nothing about WHICH board it is, and inventing a match there would set
+    // the wrong offset on a board that flashes cleanly and then does not boot.
+    expect(profilesForChip('ESP32-D0WD-V3')).toEqual([])
+    expect(profilesForChip('ESP32-S3')).toEqual([])
+  })
+
+  it('handles nothing at all without throwing', () => {
+    expect(profilesForChip(undefined)).toEqual([])
+    expect(profilesForChip('')).toEqual([])
+    expect(profilesForChip('   ')).toEqual([])
+  })
+
+  it('returns EVERY claimant, so an ambiguous chip is a question not a guess', () => {
+    // Two boards on one chip must not be resolved by taking the first: they can
+    // differ in flash offset, and picking wrongly writes cleanly and leaves the
+    // board dead. The UI offers the list instead.
+    const claimed = BOARD_PROFILES.flatMap((p) => p.matchChip ?? [])
+    const dupes = claimed.filter((c, i) => claimed.indexOf(c) !== i)
+    for (const c of dupes) {
+      expect(profilesForChip(c).length).toBeGreaterThan(1)
+    }
+  })
+
+  it('every declared matchChip actually resolves to its own profile', () => {
+    // Guards a typo in the table: a chip string that matches nothing is dead
+    // weight that looks like it works.
+    for (const p of BOARD_PROFILES) {
+      for (const c of p.matchChip ?? []) {
+        expect(profilesForChip(c).map((x) => x.id), `${p.id} claims ${c}`).toContain(p.id)
+      }
+    }
+  })
+})

--- a/test/siblingBuildUrl.test.ts
+++ b/test/siblingBuildUrl.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { siblingBuildUrl } from '../src/shared/firmware-runtime'
+
+/**
+ * #833 — reaching a build the catalog does not offer.
+ *
+ * Identifying a board can tell you it has PSRAM and that ESP32_GENERIC-SPIRAM is
+ * the build that uses it. Thonny's catalog has no variants for that family, so
+ * the dialog could name the build and then leave the user to open a browser,
+ * find it, download it, and come back with a file picker — for a file whose
+ * address is entirely derivable from the one already selected.
+ */
+const MP = 'https://micropython.org/resources/firmware/ESP32_GENERIC-20260406-v1.28.0.bin'
+
+describe('siblingBuildUrl', () => {
+  it('derives the SPIRAM build from the plain one — the reported case', () => {
+    expect(siblingBuildUrl(MP, 'ESP32_GENERIC-SPIRAM')).toBe(
+      'https://micropython.org/resources/firmware/ESP32_GENERIC-SPIRAM-20260406-v1.28.0.bin'
+    )
+  })
+
+  it('keeps the SAME release — it swaps the build, never the version', () => {
+    // Silently moving someone to a different version while they think they are
+    // choosing a variant would be its own bug.
+    const out = siblingBuildUrl(MP, 'ESP32_GENERIC-SPIRAM') ?? ''
+    expect(out).toContain('20260406-v1.28.0')
+  })
+
+  it('is a no-op when the URL is already the build asked for', () => {
+    expect(siblingBuildUrl(MP, 'ESP32_GENERIC')).toBe(MP)
+  })
+
+  it('handles a board name containing hyphens', () => {
+    // The 8-digit date is what makes the board token unambiguous.
+    const u = 'https://micropython.org/resources/firmware/ESP32_GENERIC_S3-SPIRAM_OCT-20260406-v1.28.0.bin'
+    expect(siblingBuildUrl(u, 'ESP32_GENERIC_S3')).toBe(
+      'https://micropython.org/resources/firmware/ESP32_GENERIC_S3-20260406-v1.28.0.bin'
+    )
+  })
+
+  it('refuses to reshape anyone else’s URLs', () => {
+    // CircuitPython names builds completely differently, and a mirror makes no
+    // promise about layout. Guessing there would produce a confident 404.
+    for (const u of [
+      'https://downloads.circuitpython.org/bin/adafruit_feather_esp32_v2/en_GB/adafruit-circuitpython-adafruit_feather_esp32_v2-en_GB-10.2.1.bin',
+      'https://example.com/mirror/ESP32_GENERIC-20260406-v1.28.0.bin',
+      'file:///local/ESP32_GENERIC-20260406-v1.28.0.bin'
+    ]) {
+      expect(siblingBuildUrl(u, 'ESP32_GENERIC-SPIRAM'), u).toBeNull()
+    }
+  })
+
+  it('refuses a URL that is not the documented shape', () => {
+    for (const u of [
+      'https://micropython.org/resources/firmware/firmware.bin',
+      'https://micropython.org/resources/firmware/ESP32_GENERIC-v1.28.0.bin',
+      'not a url',
+      ''
+    ]) {
+      expect(siblingBuildUrl(u, 'ESP32_GENERIC-SPIRAM'), u).toBeNull()
+    }
+  })
+
+  it('refuses a build name that could not be a filename', () => {
+    // The name reaches a URL path; anything odd must not be interpolated.
+    for (const n of ['', '   ', '../../etc/passwd', 'a/b', 'x y']) {
+      expect(siblingBuildUrl(MP, n), n).toBeNull()
+    }
+  })
+})


### PR DESCRIPTION
Reported as clunky, and it was. Identifying a board would tell you it has PSRAM and that `ESP32_GENERIC-SPIRAM` is the build that uses it — then leave you to open a browser, find that file, download it, and come back through a file picker. **For a file whose address Snakie could already work out.**

The catalog cannot help here: Thonny's `ESP32 / WROOM` entry carries **no variants at all**, so the PSRAM build is unreachable from the dropdowns despite being published alongside the one that is offered.

## How

micropython.org names builds `<BOARD>-<YYYYMMDD>-v<version>.<ext>` in one flat directory, so the sibling build of the same release is the same URL with the board token swapped. `siblingBuildUrl` does that swap, and **Flash fetches the result like any other download**.

## Three things it is careful about

- **Same release, different build.** It swaps the board token and never the version — quietly moving someone to a different version while they think they are choosing a variant would be its own bug. The 8-digit date is what makes the token unambiguous, since board names contain hyphens themselves.
- **Confirmed, not assumed.** The composed URL is a guess about a naming convention, so it is HEAD-checked before being offered. A 404 reaching the flasher would be worse than the manual download this replaces.
- **micropython.org only.** CircuitPython names builds completely differently, and a mirror promises nothing about layout — those return `null` rather than a confident 404.

Offered as a **tickbox**, not applied silently: on by default because it is recommended, but the dialog says which build it will write, and unticking falls back to the catalog's.

## Also

Fixes a stale-closure bug that lint caught on the way — the flash callback read the chosen URL without depending on it, so toggling the choice could have flashed the previous one.

## Verified end to end, on the reported hardware

```
board       : ESP32-PICO-V3-02 | PSRAM: true
recommends  : ESP32_GENERIC-SPIRAM
catalog url : ESP32_GENERIC-20260406-v1.28.0.bin
derived url : ESP32_GENERIC-SPIRAM-20260406-v1.28.0.bin
resolves    : true
```

7 new tests, including the refusals — a CircuitPython URL, a mirror, a malformed build name.

Gates: typecheck, lint, **5835 tests**, build — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)