### PR TITLE
feat: a simple flash dialog, with the rest behind a disclosure (#833)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,26 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **The firmware flasher asks for a lot less.** It used to want a board type, a
+  flash offset, an erase decision and a firmware source before it would do
+  anything — every one of which either follows from knowing the board, or should
+  not be a decision at all. Those now sit behind **Advanced options**, closed by
+  default, and open on their own if the board could not be worked out, which is
+  the one time they are the way through rather than clutter.
+
+  **Detect** and **Identify board** are one button. They were two halves of the
+  same question — one scanned USB for a board, the other asked that board what
+  it was — which meant knowing both existed, knowing you wanted both, and
+  pressing them in the right order, since the second only worked once the first
+  had chosen a port. **Detect board** does the lot: finds the board, asks it what
+  it is, selects the matching profile, and sets the offset, the erase default and
+  the recommended firmware build from it.
+
+  The firmware source also defaults to downloading from micropython.org rather
+  than picking a file off disk — the second assumes you have already been
+  somewhere else and come back with the right build.
+
+
 - **Identifying a board now selects it, instead of just describing it.** The
   flash dialog would run its detection, learn that the connected board was an
   ESP32-PICO-V3-02 with PSRAM and 8 MB of flash — and then leave the Board

--- a/src/renderer/src/components/FirmwareFlasher.css
+++ b/src/renderer/src/components/FirmwareFlasher.css
@@ -458,3 +458,46 @@
 .firmware-link:hover {
   text-decoration: none;
 }
+
+/* The one "what have I plugged in" action (#833). Prominent, because pressing it
+   is what makes most of the fields below unnecessary — it is the happy path, not
+   a utility. */
+.firmware-detect {
+  align-self: flex-start;
+  margin-bottom: 0.5rem;
+  font-family: var(--font-ui);
+  font-size: 0.82rem;
+  font-weight: 600;
+  padding: 0.4rem 0.8rem;
+  color: #f4f6f8;
+  background: rgba(255, 255, 255, 0.12);
+  border: var(--border-w) solid var(--accent);
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+
+.firmware-detect:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.firmware-detect:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+/* The advanced disclosure. Quiet — it is a way out, not a destination. */
+.firmware-advanced-toggle {
+  align-self: flex-start;
+  margin: 0.2rem 0;
+  padding: 0.2rem 0;
+  font-family: var(--font-ui);
+  font-size: 0.74rem;
+  color: #c7ccd4;
+  background: none;
+  border: 0;
+  cursor: pointer;
+}
+
+.firmware-advanced-toggle:hover {
+  color: #f4f6f8;
+}

--- a/src/renderer/src/components/FirmwareFlasher.tsx
+++ b/src/renderer/src/components/FirmwareFlasher.tsx
@@ -666,9 +666,21 @@ export function FirmwareFlasher({
     if (!known && !drive) setAdvancedOpen(true)
   }, [refreshDetection, identifyBoard])
 
+  /**
+   * The build worth flashing for this board, from whichever source knows.
+   *
+   * The PROFILE first: `preferredBuild` is authored and checked by a human, and
+   * it is available the moment a board is selected — no interrogation needed.
+   * The board's own report is the fallback, for a board with no profile.
+   *
+   * Reading only the identity was a real gap: the Feather V2 profile has named
+   * ESP32_GENERIC-SPIRAM all along and the dialog ignored it, so unless you had
+   * pressed Detect AND identification had succeeded, the plain build was
+   * downloaded — on a board that needs the SPIRAM one.
+   */
   const suggestedBuild = useMemo(
-    () => (identity ? suggestedBuildFor(identity) : null),
-    [identity]
+    () => profile?.preferredBuild ?? (identity ? suggestedBuildFor(identity) : null),
+    [profile, identity]
   )
 
   /**

--- a/src/renderer/src/components/FirmwareFlasher.tsx
+++ b/src/renderer/src/components/FirmwareFlasher.tsx
@@ -141,6 +141,16 @@ export function FirmwareFlasher({
    *  Null until the user asks; `{}` when the board could not be reached. */
   const [identity, setIdentity] = useState<BoardIdentity | null>(null)
   const [identifying, setIdentifying] = useState(false)
+  /**
+   * Whether the advanced fields are showing (#833). Closed by default.
+   *
+   * Everything behind it is either derived from the board once it is known — the
+   * flash offset, the board type, whether to erase — or a decision nobody should
+   * have to make to put MicroPython on a board they just plugged in. It opens by
+   * ITSELF when the board could not be worked out, because that is exactly when
+   * those fields stop being noise and become the only way through.
+   */
+  const [advancedOpen, setAdvancedOpen] = useState(false)
   /** Profiles that claim the identified chip, when more than one does — a
    *  question for the user rather than a guess we make for them. */
   const [matchedProfiles, setMatchedProfiles] = useState<BoardProfile[]>([])
@@ -202,7 +212,11 @@ export function FirmwareFlasher({
   const runtimeLabel = FIRMWARE_RUNTIME_LABEL[runtime]
 
   // --- Catalog (download-from-micropython.org / circuitpython.org) state (#64) ---
-  const [source, setSource] = useState<Source>('local')
+  // Default to the catalog rather than a local file (#833). Downloading the
+  // official build is what almost everyone wants and needs no prior knowledge;
+  // picking a file off disk assumes you have already been somewhere else and
+  // come back with the right one.
+  const [source, setSource] = useState<Source>('catalog')
   const [catalog, setCatalog] = useState<FirmwareCatalog | null>(null)
   const [catalogLoading, setCatalogLoading] = useState(false)
   const [catalogError, setCatalogError] = useState<string | null>(null)
@@ -259,7 +273,7 @@ export function FirmwareFlasher({
     return () => window.removeEventListener('keydown', onKey)
   }, [flashing, onClose])
 
-  const refreshDetection = useCallback(async (): Promise<void> => {
+  const refreshDetection = useCallback(async (): Promise<BoardCandidate[] | undefined> => {
     try {
       const [found, tool, allPorts] = await Promise.all([
         window.api.firmware.detectBoards(),
@@ -283,8 +297,10 @@ export function FirmwareFlasher({
         // port / mountPath / detectedMicrobit are derived from the selected board
         // by the effect below, so a board switch can't keep a stale target.
       }
+      return found
     } catch {
       // Detection is best-effort; leave manual selection available.
+      return undefined
     }
   }, [])
 
@@ -583,12 +599,15 @@ export function FirmwareFlasher({
    * WROOM` entry carries no variants at all. The board knows, and esptool will
    * ask it.
    */
-  const identifyBoard = useCallback(async (): Promise<void> => {
-    if (!port) return
+  const identifyBoard = useCallback(async (portOverride?: string): Promise<boolean> => {
+    // Detection has only just set state, so a caller that has a port in hand
+    // passes it rather than waiting a render for it.
+    const target = portOverride ?? port
+    if (!target) return false
     setIdentifying(true)
     setMatchedProfiles([])
     try {
-      const id = await window.api.firmware.identifyBoard(port)
+      const id = await window.api.firmware.identifyBoard(target)
       setIdentity(id)
 
       // ACT on what came back, rather than reporting it and leaving the user to
@@ -603,6 +622,7 @@ export function FirmwareFlasher({
       const matches = profilesForChip(id.chip)
       if (matches.length === 1) {
         handleProfileChange(matches[0].id)
+        return true
       } else if (matches.length > 1) {
         // Two boards on the same chip. Picking one would mean guessing at the
         // flash offset, so offer them instead.
@@ -613,12 +633,38 @@ export function FirmwareFlasher({
         // choice — same rule as detection.
         if (!profileRef.current) setSelFamily(id.family)
       }
+      // More than one claimant is still a resolved question — the user just has
+      // to answer it — so it does not count as "could not tell".
+      return matches.length > 1
     } catch {
       setIdentity({})
+      return false
     } finally {
       setIdentifying(false)
     }
   }, [port, families, handleProfileChange])
+
+  /**
+   * ONE action for "what have I plugged in" (#833).
+   *
+   * Detect scanned USB for a board; Identify asked that board what it was. Two
+   * buttons for two halves of one question, which meant knowing that both
+   * existed and that you wanted both — and the second only worked after the
+   * first had set a port. Nobody plugging in a board wants two verbs for that.
+   *
+   * When it cannot work the board out it opens the advanced fields, because at
+   * that point they stop being clutter and become the only way through. When it
+   * can, they stay shut: there is nothing left to decide.
+   */
+  const detectBoard = useCallback(async (): Promise<void> => {
+    const found = await refreshDetection()
+    const serial = (found ?? []).find((c) => c.source === 'serial')
+    const known = serial?.port ? await identifyBoard(serial.port) : false
+    // A UF2 / drive board has no esptool to interrogate, so detection alone
+    // settles it — a mount that was found counts as a success.
+    const drive = (found ?? []).some((c) => c.source !== 'serial')
+    if (!known && !drive) setAdvancedOpen(true)
+  }, [refreshDetection, identifyBoard])
 
   const suggestedBuild = useMemo(
     () => (identity ? suggestedBuildFor(identity) : null),
@@ -986,6 +1032,21 @@ export function FirmwareFlasher({
               offset and the firmware family, and warns if the chosen build is for
               a different chip. Optional — "Other" leaves every field manual. */}
           <div className="firmware-field">
+            {/* The one action for "what have I plugged in" (#833). It scans, then
+                asks whatever it found what it is, and selects the matching
+                board — Detect and Identify were two buttons for two halves of
+                one question. Placed FIRST because it is the step that makes
+                every field below it unnecessary. */}
+            {isElectron() && (
+              <button
+                type="button"
+                className="firmware-detect"
+                onClick={() => void detectBoard()}
+                disabled={flashing || identifying}
+              >
+                {identifying ? 'Asking the board…' : '⟳ Detect board'}
+              </button>
+            )}
             <label className="firmware-field__label" htmlFor="firmware-profile">
               Board
             </label>
@@ -1045,7 +1106,7 @@ export function FirmwareFlasher({
                 the wrong board flashes without error and comes up with the wrong pins.
               </p>
             )}
-            {board !== 'rp2040' && board !== 'microbit' && (
+            {advancedOpen && board !== 'rp2040' && board !== 'microbit' && (
               <label className="firmware-check">
                 <input
                   type="checkbox"
@@ -1061,49 +1122,54 @@ export function FirmwareFlasher({
             )}
           </div>
 
-          <div className="firmware-field">
-            <label className="firmware-field__label" htmlFor="firmware-board">
-              Board type
-            </label>
-            <div className="firmware-field__row">
-              <select
-                id="firmware-board"
-                className="firmware-select"
-                value={board}
-                // In catalog mode the selected Family drives the board (issue
-                // #125), so the dropdown reflects it read-only.
-                disabled={flashing || usingCatalog}
-                onChange={(e) => handleBoardChange(e.target.value as BoardType)}
-              >
-                {(Object.keys(BOARD_LABELS) as BoardType[]).map((b) => (
-                  <option key={b} value={b}>
-                    {BOARD_LABELS[b]}
-                  </option>
-                ))}
-              </select>
-              {isElectron() && (
-                <button
-                  type="button"
-                  className="btn btn--ghost btn--sm"
-                  onClick={() => void refreshDetection()}
-                  disabled={flashing}
-                  title="Re-scan for connected boards"
+          {/* One switch for everything that should not be a decision (#833).
+              It opens by itself when Detect could not work the board out. */}
+          {isElectron() && (
+            <button
+              type="button"
+              className="firmware-advanced-toggle"
+              aria-expanded={advancedOpen}
+              onClick={() => setAdvancedOpen((v) => !v)}
+            >
+              {advancedOpen ? '▾' : '▸'} Advanced options
+            </button>
+          )}
+          {/* Advanced (#833): the board type follows from the board, or from
+              the catalog family. Only worth showing when neither is known. */}
+          {advancedOpen && (
+            <div className="firmware-field">
+              <label className="firmware-field__label" htmlFor="firmware-board">
+                Board type
+              </label>
+              <div className="firmware-field__row">
+                <select
+                  id="firmware-board"
+                  className="firmware-select"
+                  value={board}
+                  // In catalog mode the selected Family drives the board (issue
+                  // #125), so the dropdown reflects it read-only.
+                  disabled={flashing || usingCatalog}
+                  onChange={(e) => handleBoardChange(e.target.value as BoardType)}
                 >
-                  ⟳ Detect
-                </button>
+                  {(Object.keys(BOARD_LABELS) as BoardType[]).map((b) => (
+                    <option key={b} value={b}>
+                      {BOARD_LABELS[b]}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              {usingCatalog && (
+                <p className="firmware-hint">
+                  Board type follows the catalog Family you pick below.
+                </p>
+              )}
+              {candidates.length > 0 && (
+                <p className="firmware-hint">
+                  Detected: {candidates.map((c) => c.label).join('; ')}
+                </p>
               )}
             </div>
-            {usingCatalog && (
-              <p className="firmware-hint">
-                Board type follows the catalog Family you pick below.
-              </p>
-            )}
-            {candidates.length > 0 && (
-              <p className="firmware-hint">
-                Detected: {candidates.map((c) => c.label).join('; ')}
-              </p>
-            )}
-          </div>
+          )}
 
           {isEsp ? (
             <>
@@ -1139,14 +1205,6 @@ export function FirmwareFlasher({
                   {/* Ask the board rather than make the user recall its spec
                       (#829). Read-only — it uploads esptool's stub and reads the
                       flash id; it writes nothing. */}
-                  <button
-                    type="button"
-                    className="firmware-btn firmware-btn--ghost"
-                    disabled={!port || flashing || identifying}
-                    onClick={() => void identifyBoard()}
-                  >
-                    {identifying ? 'Asking the board…' : 'Identify board'}
-                  </button>
                   {identity && (
                     <p className="firmware-hint">
                       {describeIdentity(identity) ? (
@@ -1224,20 +1282,25 @@ export function FirmwareFlasher({
                 </p>
               )}
 
-              <div className="firmware-field">
-                <label className="firmware-field__label" htmlFor="firmware-offset">
-                  Flash offset
-                </label>
-                <input
-                  id="firmware-offset"
-                  className="firmware-input"
-                  type="text"
-                  value={offset}
-                  disabled={flashing}
-                  onChange={(e) => setOffset(e.target.value)}
-                  placeholder="0x0"
-                />
-              </div>
+              {/* Advanced (#833): the offset comes from the chip, and getting
+                  it wrong writes cleanly and leaves the board dead. Not a
+                  number anyone should be typing to flash a board. */}
+              {advancedOpen && (
+                <div className="firmware-field">
+                  <label className="firmware-field__label" htmlFor="firmware-offset">
+                    Flash offset
+                  </label>
+                  <input
+                    id="firmware-offset"
+                    className="firmware-input"
+                    type="text"
+                    value={offset}
+                    disabled={flashing}
+                    onChange={(e) => setOffset(e.target.value)}
+                    placeholder="0x0"
+                  />
+                </div>
+              )}
 
               {isElectron() && esptool && !esptool.available && (
                 <p className="firmware-banner firmware-banner--warn">
@@ -1355,7 +1418,10 @@ export function FirmwareFlasher({
               `window.api.firmware.fetchCatalog`/`downloadAndFlash`, which have
               no browser implementation yet (Web W3, issue #284) — only Local
               file is offered there. */}
-          {isElectron() && (
+          {/* Advanced (#833): the catalog is the default and covers almost
+              everyone. Choosing a local file assumes you have already been
+              somewhere else and come back with the right build. */}
+          {isElectron() && advancedOpen && (
             <div className="firmware-field">
               <span className="firmware-field__label">Firmware source</span>
               <div className="firmware-source-toggle" role="radiogroup" aria-label="Firmware source">

--- a/src/shared/board-profiles.ts
+++ b/src/shared/board-profiles.ts
@@ -243,7 +243,7 @@ export const BOARD_PROFILES: BoardProfile[] = [
     // named here instead — it exists upstream, it is just not offered.
     preferredBuild: {
       name: 'ESP32_GENERIC-SPIRAM',
-      why: 'This board has 2 MB of PSRAM, and only the SPIRAM build can use it. The plain ESP32_GENERIC build runs perfectly well — it simply leaves the PSRAM unavailable. The firmware catalog does not offer the SPIRAM build for this family, so download it and flash it with "Local file".',
+      why: 'This board has 2 MB of PSRAM, and only the SPIRAM build can use it. The firmware catalog does not offer that build for this family, so Snakie fetches it directly.',
       url: 'https://micropython.org/download/ESP32_GENERIC/'
     },
     notes:

--- a/test/flasherSimpleMode.test.ts
+++ b/test/flasherSimpleMode.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * #833 — a simple flash dialog, with the rest behind a disclosure.
+ *
+ * Reported by someone who could not get their own board flashed through the UI:
+ * "If I can't do it via the UI, I doubt users will make the right choices
+ * either." The dialog asked for a board type, a flash offset, an erase decision
+ * and a firmware source before it would do anything — every one of which either
+ * follows from knowing the board or should not be a decision at all.
+ *
+ * Checked at SOURCE level. The dialog is Electron-only, so `isElectron()` is
+ * false under `renderToStaticMarkup` and every branch that matters is skipped —
+ * a render test here would pass while asserting nothing.
+ */
+const SRC = readFileSync(
+  join(__dirname, '..', 'src/renderer/src/components/FirmwareFlasher.tsx'),
+  'utf-8'
+)
+
+describe('the simple path', () => {
+  it('offers ONE action for "what have I plugged in", not two', () => {
+    // Detect scanned USB; Identify asked the board what it was. Two buttons for
+    // two halves of one question, and the second only worked once the first had
+    // set a port.
+    expect(SRC).toContain('Detect board')
+    expect(SRC).not.toContain('Identify board')
+    expect(SRC).not.toContain('⟳ Detect<')
+  })
+
+  it('that action both scans and asks, then decides whether advanced is needed', () => {
+    const fn = /const detectBoard = useCallback\(async[\s\S]*?\}, \[[^\]]*\]\)/.exec(SRC)
+    expect(fn, 'detectBoard not found').toBeTruthy()
+    expect(fn![0]).toContain('refreshDetection')
+    expect(fn![0]).toContain('identifyBoard')
+    expect(fn![0]).toContain('setAdvancedOpen(true)')
+  })
+
+  it('defaults the firmware source to the catalog, not a local file', () => {
+    // Downloading the official build needs no prior knowledge; picking a file
+    // off disk assumes you have already been somewhere else to get it.
+    expect(SRC).toMatch(/useState<Source>\('catalog'\)/)
+  })
+
+  it('starts with the advanced fields closed', () => {
+    expect(SRC).toMatch(/const \[advancedOpen, setAdvancedOpen\] = useState\(false\)/)
+  })
+})
+
+describe('what is behind the disclosure', () => {
+  /** The JSX for a labelled field, with whatever guards precede it. */
+  function contextOf(label: string): string {
+    const i = SRC.indexOf(label)
+    expect(i, `${label} not found`).toBeGreaterThan(-1)
+    return SRC.slice(Math.max(0, i - 700), i)
+  }
+
+  // Anchored on the ELEMENTS, not on prose: the same words appear in the doc
+  // comments above, and matching those would assert nothing about the JSX.
+  it.each([
+    ['Board type', 'htmlFor="firmware-board"'],
+    ['Flash offset', 'htmlFor="firmware-offset"'],
+    ['Erase first', 'checked={eraseFirst}'],
+    ['Firmware source', '>Firmware source<']
+  ])('%s is gated on advancedOpen', (_name, anchor) => {
+    expect(contextOf(anchor)).toContain('advancedOpen')
+  })
+
+  it('leaves the things you DO need in the simple view', () => {
+    // The board, the port and the version are the actual inputs; gating those
+    // would just move the problem behind a disclosure.
+    for (const anchor of ['htmlFor="firmware-port"', 'htmlFor="firmware-profile"']) {
+      expect(contextOf(anchor), `${anchor} is behind advanced`).not.toContain('advancedOpen')
+    }
+  })
+})

--- a/test/preferredBuildWiring.test.ts
+++ b/test/preferredBuildWiring.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { BOARD_PROFILES, profilesForChip } from '../src/shared/board-profiles'
+import { siblingBuildUrl } from '../src/shared/firmware-runtime'
+
+/**
+ * A board profile's `preferredBuild` must reach the download.
+ *
+ * The Adafruit ESP32 Feather V2 profile has named `ESP32_GENERIC-SPIRAM` since
+ * it was written, and the flash dialog ignored it: the recommendation was read
+ * only from the board's own esptool report, so unless you had pressed Detect
+ * AND identification had succeeded, the PLAIN build was downloaded — on a board
+ * that needs the SPIRAM one. Reported as "the recommended download file works
+ * fine — if we suggest this why not just make that download automatically".
+ */
+const UI = readFileSync(
+  join(__dirname, '..', 'src/renderer/src/components/FirmwareFlasher.tsx'),
+  'utf-8'
+)
+
+describe('preferredBuild reaches the flash', () => {
+  it('the dialog reads the profile, not only the board’s self-report', () => {
+    const m = /const suggestedBuild = useMemo\(([\s\S]*?)\)\n/.exec(UI)
+    expect(m, 'suggestedBuild not found').toBeTruthy()
+    expect(m![1], 'the profile’s preferredBuild is ignored').toContain('preferredBuild')
+  })
+
+  it('prefers the profile over the self-report', () => {
+    // The profile is authored and checked by a human, and is available the
+    // moment a board is selected — no interrogation needed.
+    const m = /const suggestedBuild = useMemo\(([\s\S]*?)\)\n/.exec(UI)!
+    const body = m[1]
+    expect(body.indexOf('preferredBuild')).toBeLessThan(body.indexOf('suggestedBuildFor'))
+  })
+})
+
+describe('the Feather V2 end to end', () => {
+  const feather = profilesForChip('ESP32-PICO-V3-02')[0]
+
+  it('names the build that actually boots this board', () => {
+    expect(feather?.preferredBuild?.name).toBe('ESP32_GENERIC-SPIRAM')
+  })
+
+  it('that name derives a real download from the catalog’s URL', () => {
+    const catalog = 'https://micropython.org/resources/firmware/ESP32_GENERIC-20260406-v1.28.0.bin'
+    expect(siblingBuildUrl(catalog, feather!.preferredBuild!.name)).toBe(
+      'https://micropython.org/resources/firmware/ESP32_GENERIC-SPIRAM-20260406-v1.28.0.bin'
+    )
+  })
+
+  it('no longer tells the user to go and fetch it by hand', () => {
+    // The copy predated Snakie being able to download it.
+    expect(feather?.preferredBuild?.why).not.toMatch(/Local file/i)
+  })
+})
+
+describe('every profile that names a build names a usable one', () => {
+  it.each(BOARD_PROFILES.filter((p) => p.preferredBuild).map((p) => [p.id, p] as const))(
+    '%s',
+    (_id, p) => {
+      const name = p.preferredBuild!.name
+      // It has to survive the URL derivation, or the recommendation is a
+      // dead end that cannot be downloaded.
+      const catalog = `https://micropython.org/resources/firmware/${p.chipFamily.toUpperCase()}-20260406-v1.28.0.bin`
+      expect(siblingBuildUrl(catalog, name), `${name} cannot form a URL`).toBeTruthy()
+      expect(p.preferredBuild!.why.length, 'a recommendation needs a reason').toBeGreaterThan(20)
+    }
+  )
+})


### PR DESCRIPTION
Closes #833.

From someone who could not flash their own board through the UI, and named the real problem:

> *"If I can't do it via the UI, I doubt users will make the right choices either."*

## One button, not two

**Detect** scanned USB for a board; **Identify board** asked that board what it was. Two halves of one question — which meant knowing both existed, knowing you wanted both, and pressing them in the right order, since the second only worked once the first had set a port.

**Detect board** now does the lot: scan, ask, select the matching profile, and let the offset, the erase default and the recommended firmware build follow from it.

## Advanced, closed by default

Board type, flash offset, the erase toggle and the firmware source now sit behind a disclosure. Each either follows from knowing the board or should not be a decision:

| field | why it is not a question |
|---|---|
| Flash offset | comes from the chip; a wrong one writes cleanly and leaves the board dead |
| Erase first | on by default — a stale partition table is the common failure (#834) |
| Board type | follows the profile, or the catalog family |
| Firmware source | the catalog covers almost everyone |

**It opens itself when detection cannot work the board out** — a drive board that detection settles alone counts as success; an ESP that could not be identified does not. That is the one moment those fields stop being clutter and become the only way through, which is why they are hidden rather than removed.

The source also defaults to **downloading from micropython.org** rather than picking a file off disk. The second assumes you have already been somewhere else and come back with the right build.

## On the tests

Checked at **source level**, not by rendering. The dialog is Electron-only, so `isElectron()` is false under `renderToStaticMarkup` and every branch that matters is skipped — I confirmed a render test passes while asserting nothing before writing these.

The assertions anchor on the **elements** (`htmlFor="firmware-offset"`, `checked={eraseFirst}`) rather than on prose, because the same words appear in the doc comments above them — the first draft matched a comment and passed for the wrong reason.

Gates: typecheck, lint, **5859 tests**, build — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)