### PR TITLE
feat: the flasher says what it is about to do, in words

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **The flasher says what it is about to do, in words.** Before the esptool
+  command line, the log now states which firmware file is being written, to
+  which port, at which address, and whether the whole flash is being erased
+  first. Three separate bugs in this area produced the identical symptom — a
+  flash that reports success and leaves a board that will not boot — and every
+  one of them came down to one of those facts differing from what the dialog
+  implied. All three were technically visible in the esptool arguments, and all
+  three went unnoticed, because reading an argv by eye is not a reasonable way
+  to answer "did it erase?".
+
+
 - **Snakie fetches the recommended firmware build itself.** Identifying a board
   could tell you it had PSRAM and that `ESP32_GENERIC-SPIRAM` was the build that
   uses it — and then leave you to open a browser, find that file, download it,

--- a/src/main/firmware/flasher.ts
+++ b/src/main/firmware/flasher.ts
@@ -210,6 +210,17 @@ async function flashEsp(opts: FlashOptions, emit: Emit): Promise<FlashResult> {
 
   const args = [...base, ...flashArgs, offset, opts.firmwarePath]
 
+  // Say plainly what is about to happen, before the esptool line that says it
+  // in argv. Three flashes in a row that "succeed" and leave a dead board all
+  // came down to one of these three facts being different from what the dialog
+  // implied — the file, the address, or whether the flash was erased first —
+  // and none of them were legible without reading an argv by eye.
+  emit({
+    kind: 'log',
+    message:
+      `Flashing ${basename(opts.firmwarePath)} to ${opts.port} at ${offset}` +
+      `, ${opts.eraseFirst ? 'ERASING the whole flash first' : 'WITHOUT erasing first'}.`
+  })
   emit({ kind: 'log', message: `Using ${tool.command}${tool.version ? ` (${tool.version})` : ''}` })
   emit({ kind: 'log', message: `> ${tool.command} ${args.join(' ')}` })
 

--- a/test/flashSummaryLine.test.ts
+++ b/test/flashSummaryLine.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * The flasher should say, in words, what it is about to do.
+ *
+ * Three separate bugs in this area (#826, #834, #836) all produced the same
+ * symptom — a flash that reports success and leaves a board that will not boot
+ * — and all three came down to one of three facts differing from what the
+ * dialog implied: WHICH FILE, WHAT ADDRESS, and WHETHER IT ERASED FIRST.
+ *
+ * Every one of those was already knowable from the esptool argv in the log, and
+ * every one went unnoticed for days because reading an argv by eye is not
+ * something a user should have to do to answer "did it erase?".
+ */
+const SRC = readFileSync(join(__dirname, '..', 'src/main/firmware/flasher.ts'), 'utf-8')
+
+describe('the flash summary line', () => {
+  const line = /message:\s*\n?\s*`Flashing \$\{[\s\S]*?\.`\s*\n\s*\}\)/.exec(SRC)?.[0] ?? ''
+
+  it('exists, before the esptool command is run', () => {
+    expect(line, 'no plain-language summary is emitted').toBeTruthy()
+    expect(SRC.indexOf('Flashing ${basename')).toBeLessThan(SRC.indexOf('const { code, spawnError }'))
+  })
+
+  it('names the FILE — which build is being written', () => {
+    // "Download & Flash" of the wrong build looks identical to the right one.
+    expect(line).toContain('basename(opts.firmwarePath)')
+  })
+
+  it('names the ADDRESS — a wrong offset writes cleanly and bricks the board', () => {
+    expect(line).toContain('${offset}')
+  })
+
+  it('says whether it ERASED — the fact that hid #834 for days', () => {
+    expect(line).toContain('opts.eraseFirst')
+    // Both branches spelled out: "not erasing" has to be as visible as erasing,
+    // because its absence is what nobody noticed.
+    expect(line).toMatch(/ERASING/)
+    expect(line).toMatch(/WITHOUT erasing/)
+  })
+})


### PR DESCRIPTION
Before the esptool argv, the log now states **which file**, **which port**, **which address**, and **whether it is erasing first**.

This is not decoration. Three bugs in this area produced the *identical* symptom — a flash that reports success over a board that will not boot — and every one came down to one of exactly those facts differing from what the dialog implied:

| | |
|---|---|
| #826 | erase was opt-in, and the profile people reach for did not opt in |
| #834 | the erase flag was dropped entirely on the Download & Flash path |
| #836 | the profile's recommended build never reached the download |

Every one of them was **already visible** in the esptool arguments in the log. Every one went unnoticed for days — mine included — because answering *"did it erase?"* meant reading an argv by eye and knowing which flag to look for.

Both branches are spelled out — `ERASING the whole flash first` and `WITHOUT erasing first` — because it is the **absence** that nobody notices. A line that only appears when erasing is a line whose absence means nothing to a reader who does not already know it should be there.

Gates: typecheck, lint, **5870 tests**, build — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)