### PR TITLE
fix(firmware): catch a corrupt download before it reaches the flash (#840)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   already gone. ESP images carry a SHA-256 of themselves; Snakie now runs that
   same check on the host, before the erase, and refuses a damaged file without
   touching the board. Confirmed against the real firmware: a copy with one bit
-  flipped and an unchanged length is caught.
+  flipped and an unchanged length is caught. A damaged download is retried once
+  before anything is written, since this kind of corruption is usually
+  transient; if the second copy is damaged too, the two attempts are themselves
+  the diagnosis — identical hashes mean the bad bytes are being served, and
+  differing hashes mean they are being mangled in transit.
 - **`Image hash failed` no longer sends you round the erase-and-retry loop.**
   The advice was "leftover partition table, erase and flash again" for every
   bootloader complaint. That is right for a stale slot and misleading otherwise,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A corrupt firmware download no longer flashes and verifies cleanly, then
+  refuses to boot** (#840). esptool's `Hash of data verified` is a weaker claim
+  than it reads as: it proves the flash matches *the file it was handed*, and
+  says nothing about whether that file is the firmware the vendor built. A
+  download arriving with the right length and the wrong bytes therefore wrote
+  perfectly, verified perfectly, and left a board that answered only
+  `E (579) esp_image: Image hash failed - image is corrupt` — with the evidence
+  already gone. ESP images carry a SHA-256 of themselves; Snakie now runs that
+  same check on the host, before the erase, and refuses a damaged file without
+  touching the board. Confirmed against the real firmware: a copy with one bit
+  flipped and an unchanged length is caught.
+- **`Image hash failed` no longer sends you round the erase-and-retry loop.**
+  The advice was "leftover partition table, erase and flash again" for every
+  bootloader complaint. That is right for a stale slot and misleading otherwise,
+  so the message now names both real causes and says the file was already
+  verified — the one thing worth ruling out first.
+
 ### Added
 
 - **The flasher says what it is about to do, in words.** Before the esptool

--- a/src/main/firmware/download.ts
+++ b/src/main/firmware/download.ts
@@ -75,6 +75,14 @@ export async function downloadFirmware(url: string, emit: Emit): Promise<string>
     throw new Error('Download failed: empty response body.')
   }
 
+  // `total` drives the progress bar ONLY. Comparing it to the bytes received as
+  // an integrity check looks obvious and is wrong twice over (measured, #840):
+  // a truncated response errors the stream rather than ending short, so the
+  // comparison never fires for the case it would be written for; and under
+  // `content-encoding: gzip` the header is the COMPRESSED length while the
+  // decoded stream is larger, so it fires on healthy downloads. Firmware
+  // integrity is checked where it can actually be judged — against the image's
+  // own SHA-256, in `esp-image.ts`.
   const total = Number(res.headers.get('content-length') ?? '0')
   const dest = join(tempDir(), fileNameFromUrl(url))
 

--- a/src/main/firmware/download.ts
+++ b/src/main/firmware/download.ts
@@ -17,13 +17,16 @@
  * works even though the catalog URLs commonly 30x.
  */
 import { createWriteStream } from 'fs'
+import { readFile } from 'fs/promises'
+import { createHash } from 'crypto'
 import { unlink } from 'fs/promises'
 import { tmpdir } from 'os'
 import { basename, join } from 'path'
 import { Readable } from 'stream'
 import { app } from 'electron'
 import type { Emit } from './flasher'
-import { flash } from './flasher'
+import { DEFAULT_OFFSET, flash } from './flasher'
+import { describeEspImageCheck, verifyEspImage } from './esp-image'
 import { reporter } from '../report-error'
 import type { DownloadAndFlashOptions, FlashResult } from './types'
 
@@ -118,6 +121,74 @@ export async function downloadFirmware(url: string, emit: Emit): Promise<string>
   return dest
 }
 
+
+/**
+ * Download the firmware and prove it arrived intact, retrying ONCE (#840).
+ *
+ * A download that lands with the right length and the wrong bytes is not a
+ * theoretical failure — it reached a user, flashed cleanly, verified cleanly and
+ * left a dead board, twice in a row, over a network where curl and a browser
+ * both fetched the same URL perfectly. Whatever mangles it (a proxy, a
+ * TLS-inspecting middlebox, a flaky link) is not something Snakie can see or
+ * fix, and it is not something the user can be asked to diagnose either.
+ *
+ * What Snakie CAN do is notice, and try again: corruption of this kind is
+ * usually transient, so a second attempt normally succeeds. When it does not,
+ * the two attempts are the diagnosis — identical hashes mean something upstream
+ * is reliably serving bad bytes, differing hashes mean the link itself is
+ * unreliable. Both are worth far more to the user than "flash failed".
+ *
+ * Only ESP images can be checked this way, so anything unrecognised (a UF2, for
+ * one) is passed straight through exactly as before.
+ */
+async function downloadVerified(opts: DownloadAndFlashOptions, emit: Emit): Promise<string> {
+  const offset = Number(
+    opts.offset ?? DEFAULT_OFFSET[opts.board === 'esp8266' ? 'esp8266' : 'esp32']
+  )
+
+  let firstDigest = ''
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    const dest = await downloadFirmware(opts.url, emit)
+    const bytes = await readFile(dest)
+    const check = verifyEspImage(bytes, offset)
+    if (check.kind !== 'bad') return dest
+
+    const digest = createHash('sha256').update(bytes).digest('hex')
+    emit({
+      kind: 'log',
+      message:
+        `${describeEspImageCheck(check)} (${bytes.length} bytes, sha256 ${digest.slice(0, 16)}…)`
+    })
+    await unlink(dest).catch(reporter('firmware: cleanup corrupt download'))
+
+    if (attempt === 1) {
+      firstDigest = digest
+      emit({
+        kind: 'log',
+        message: 'The download arrived damaged. Downloading it again before touching the board…'
+      })
+      continue
+    }
+
+    // Twice. Say which kind of broken this is, because the two point at
+    // completely different things to go and look at.
+    throw new Error(
+      'The firmware download arrived damaged twice, so nothing has been written to your ' +
+        'board. ' +
+        (digest === firstDigest
+          ? 'Both attempts were byte-for-byte identical, so the damaged copy is being served ' +
+            'to you rather than corrupted in transit — a proxy, VPN or filtering appliance on ' +
+            'your network is the usual cause. Downloading the file in a browser and flashing ' +
+            'it from Advanced mode is the reliable way round it.'
+          : 'The two attempts differed, so the file is being corrupted in transit — an ' +
+            'unreliable connection, VPN or TLS-inspecting security tool is the usual cause. ' +
+            'Retrying on a different network usually works.')
+    )
+  }
+  // Unreachable: the loop either returns a good file or throws.
+  throw new Error('Download failed.')
+}
+
 /**
  * Download a catalog firmware file (`.uf2` or `.bin`) to a temp file then flash
  * it onto the selected target, producing a single combined progress stream
@@ -133,7 +204,7 @@ export async function downloadAndFlash(
 ): Promise<FlashResult> {
   let tempPath: string
   try {
-    tempPath = await downloadFirmware(opts.url, emit)
+    tempPath = await downloadVerified(opts, emit)
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
     emit({ kind: 'error', message: msg })

--- a/src/main/firmware/esp-image.ts
+++ b/src/main/firmware/esp-image.ts
@@ -1,0 +1,169 @@
+/**
+ * Integrity checking for ESP firmware images, BEFORE they are written (#840).
+ *
+ * esptool's `Hash of data verified` is a weaker claim than it reads as: it
+ * proves the flash now matches THE FILE IT WAS GIVEN. It says nothing about
+ * whether that file is the firmware the vendor built. A download that arrives
+ * with the right length and the wrong bytes therefore flashes perfectly, passes
+ * verification, and leaves a board that will not boot — the ESP32's own
+ * bootloader is the first thing in the chain to notice, and all it can say is:
+ *
+ *     E (579) esp_image: Image hash failed - image is corrupt
+ *
+ * That is the same check implemented here, run a minute earlier and on the host,
+ * where it can still be acted on. ESP images carry a SHA-256 of themselves in
+ * their last 32 bytes; recomputing it catches any corruption, including the
+ * length-preserving kind that a `content-length` check cannot see.
+ *
+ * Deliberately conservative: this may only ever report a file BAD when it is
+ * certain. Anything it does not recognise is reported as `unknown`, never as a
+ * failure — users flash partial images, NVS blobs and vendor binaries that are
+ * none of its business, and refusing those would be a worse bug than the one it
+ * exists to catch.
+ */
+import { createHash } from 'crypto'
+
+/** First byte of every ESP image header. */
+const IMAGE_MAGIC = 0xe9
+
+/** `esp_image_header_t` is 24 bytes; `hash_appended` is its last one. */
+const HEADER_LEN = 24
+const HASH_APPENDED_OFFSET = 23
+
+/** Length of the appended SHA-256 digest. */
+const DIGEST_LEN = 32
+
+/** Where the application image lives in flash, on every standard layout. */
+const APP_FLASH_ADDRESS = 0x10000
+
+/** What one sub-image inside a firmware file turned out to be. */
+export interface EspSubImage {
+  /** Byte offset within the file. */
+  offset: number
+  /** Number of segments its header declared. */
+  segments: number
+  /** True/false when a digest was present and checked; null when absent. */
+  hashOk: boolean | null
+}
+
+/** The verdict on a whole firmware file. */
+export interface EspImageCheck {
+  /** `bad` is the only value that may block a flash. */
+  kind: 'ok' | 'bad' | 'unknown'
+  /** Every sub-image that parsed, for the log. */
+  images: EspSubImage[]
+  /** Set when `kind` is `bad`: what is wrong, in words the user can act on. */
+  reason?: string
+}
+
+/**
+ * Walk one image at `offset`, returning where it ends and whether its own
+ * appended digest matches. Returns null when the bytes there are not a
+ * well-formed image — including when walking them would run off the end, which
+ * is what a truncated download looks like.
+ */
+function walkImage(buf: Buffer, offset: number): EspSubImage & { end: number } | null {
+  if (offset + HEADER_LEN > buf.length) return null
+  if (buf[offset] !== IMAGE_MAGIC) return null
+
+  const segments = buf[offset + 1]
+  const hashAppended = buf[offset + HASH_APPENDED_OFFSET] === 1
+
+  let p = offset + HEADER_LEN
+  for (let i = 0; i < segments; i++) {
+    if (p + 8 > buf.length) return null
+    const len = buf.readUInt32LE(p + 4)
+    // A plausible segment length. A corrupt header can claim gigabytes, and
+    // walking that is how a parser turns a bad file into a crash.
+    if (len > buf.length) return null
+    p += 8 + len
+    if (p > buf.length) return null
+  }
+
+  // The image is padded so that its length INCLUDING a trailing one-byte
+  // checksum is a multiple of 16; the checksum is that block's last byte.
+  p += 15 - ((p - offset) % 16)
+  p += 1
+  if (p > buf.length) return null
+
+  if (!hashAppended) return { offset, segments, hashOk: null, end: p }
+  if (p + DIGEST_LEN > buf.length) return null
+
+  const actual = createHash('sha256').update(buf.subarray(offset, p)).digest()
+  const hashOk = actual.equals(buf.subarray(p, p + DIGEST_LEN))
+  return { offset, segments, hashOk, end: p + DIGEST_LEN }
+}
+
+/**
+ * Where the sub-images sit INSIDE a file that will be written at `flashOffset`.
+ *
+ * A vendor `.bin` is a slice of the flash map, so a file's own offsets are the
+ * flash addresses minus the address it gets written at. The bootloader is
+ * always first; the application is at 0x10000 in flash, which lands at 0xF000
+ * in a file flashed at 0x1000 (MicroPython on the original ESP32) and at
+ * 0x10000 in one flashed at 0x0 (S3, and CircuitPython everywhere).
+ */
+export function espImageBases(flashOffset: number): number[] {
+  const app = APP_FLASH_ADDRESS - flashOffset
+  return app > 0 ? [0, app] : [0]
+}
+
+/**
+ * Check a firmware file's internal integrity.
+ *
+ * Only ever returns `bad` for a file that IS an ESP image and whose own digest
+ * disagrees with its contents — a fact about the file alone, independent of the
+ * board, the port and the flash settings. Everything else is `unknown`.
+ */
+export function verifyEspImage(buf: Buffer, flashOffset: number): EspImageCheck {
+  if (buf.length === 0) {
+    return { kind: 'bad', images: [], reason: 'the file is empty' }
+  }
+  // Not an ESP image at all: a UF2, a raw blob, a partial image the user means
+  // to write at some address of their own. None of our business.
+  if (buf[0] !== IMAGE_MAGIC) return { kind: 'unknown', images: [] }
+
+  const images: EspSubImage[] = []
+  for (const base of espImageBases(flashOffset)) {
+    if (base >= buf.length) continue
+    if (buf[base] !== IMAGE_MAGIC) continue
+    const walked = walkImage(buf, base)
+    // The FIRST image failing to parse means the file is not what it claims —
+    // it started with the magic byte and then did not hold together, which is
+    // what a truncated or interleaved download looks like.
+    if (!walked) {
+      if (base === 0) {
+        return {
+          kind: 'bad',
+          images,
+          reason: 'it starts like an ESP firmware image but does not hold together'
+        }
+      }
+      continue
+    }
+    images.push({ offset: walked.offset, segments: walked.segments, hashOk: walked.hashOk })
+  }
+
+  const failed = images.find((i) => i.hashOk === false)
+  if (failed) {
+    return {
+      kind: 'bad',
+      images,
+      reason:
+        `the ${failed.offset === 0 ? 'bootloader' : 'application'} image at ` +
+        `0x${failed.offset.toString(16)} fails its own SHA-256 check`
+    }
+  }
+  if (images.some((i) => i.hashOk === true)) return { kind: 'ok', images }
+  return { kind: 'unknown', images }
+}
+
+/** One line describing a check, for the flash log. */
+export function describeEspImageCheck(check: EspImageCheck): string {
+  if (check.kind === 'ok') {
+    const n = check.images.filter((i) => i.hashOk === true).length
+    return `Firmware integrity verified (${n} image${n === 1 ? '' : 's'} passed their own SHA-256).`
+  }
+  if (check.kind === 'bad') return `Firmware file is corrupt: ${check.reason}.`
+  return 'Firmware integrity not checked (not a recognised ESP image).'
+}

--- a/src/main/firmware/flasher.ts
+++ b/src/main/firmware/flasher.ts
@@ -31,7 +31,7 @@ import type { EsptoolInfo, FlashOptions, FlashProgress, FlashResult } from './ty
 const ESPTOOL_COMMANDS = ['esptool', 'esptool.py'] as const
 
 /** Default ESP `write_flash` offsets per family. */
-const DEFAULT_OFFSET: Record<'esp32' | 'esp8266', string> = {
+export const DEFAULT_OFFSET: Record<'esp32' | 'esp8266', string> = {
   esp32: '0x1000',
   esp8266: '0x0'
 }
@@ -219,7 +219,11 @@ async function flashEsp(opts: FlashOptions, emit: Emit): Promise<FlashResult> {
   // image carries a SHA-256 of itself; checking it here costs milliseconds and
   // moves that discovery to before the erase rather than after it.
   const imageCheck = verifyEspImage(await fs.readFile(opts.firmwarePath), Number(offset))
-  emit({ kind: 'log', message: describeEspImageCheck(imageCheck) })
+  // Only when it PASSES: on failure the refusal below says the same thing with
+  // more of it, and three lines repeating one fact reads as three problems.
+  if (imageCheck.kind !== 'bad') {
+    emit({ kind: 'log', message: describeEspImageCheck(imageCheck) })
+  }
   if (imageCheck.kind === 'bad') {
     const msg =
       `Refusing to flash ${basename(opts.firmwarePath)}: ${imageCheck.reason}. ` +

--- a/src/main/firmware/flasher.ts
+++ b/src/main/firmware/flasher.ts
@@ -21,6 +21,7 @@ const execFileAsync = promisify(execFile)
 import { execFile, spawn } from 'child_process'
 import { promisify } from 'util'
 import { classifyBootOutput } from '../../shared/boot-check'
+import { describeEspImageCheck, verifyEspImage } from './esp-image'
 import { parseEsptoolIdentity, type BoardIdentity } from '../../shared/esptool-identify'
 import { promises as fs, createReadStream, createWriteStream } from 'fs'
 import { basename, join } from 'path'
@@ -209,6 +210,25 @@ async function flashEsp(opts: FlashOptions, emit: Emit): Promise<FlashResult> {
   if (opts.eraseFirst) flashArgs.push('--erase-all')
 
   const args = [...base, ...flashArgs, offset, opts.firmwarePath]
+
+  // Check the FILE before writing it (#840). esptool's `Hash of data verified`
+  // only proves the flash matches the file it was handed, so a download that
+  // arrives with the right length and the wrong bytes flashes cleanly, verifies
+  // cleanly, and bricks the board -- the ESP32's own bootloader is the first
+  // thing to notice, hours later, and all it says is "Image hash failed". The
+  // image carries a SHA-256 of itself; checking it here costs milliseconds and
+  // moves that discovery to before the erase rather than after it.
+  const imageCheck = verifyEspImage(await fs.readFile(opts.firmwarePath), Number(offset))
+  emit({ kind: 'log', message: describeEspImageCheck(imageCheck) })
+  if (imageCheck.kind === 'bad') {
+    const msg =
+      `Refusing to flash ${basename(opts.firmwarePath)}: ${imageCheck.reason}. ` +
+      'The file is damaged, so writing it would leave the board unable to boot. ' +
+      'This is a bad copy of the firmware, not a fault with your board — ' +
+      'download it again and retry.'
+    emit({ kind: 'error', message: msg })
+    return { ok: false, error: msg }
+  }
 
   // Say plainly what is about to happen, before the esptool line that says it
   // in argv. Three flashes in a row that "succeed" and leave a dead board all

--- a/src/shared/boot-check.ts
+++ b/src/shared/boot-check.ts
@@ -43,6 +43,36 @@ const BOOTLOOP_MARKERS = [
 const RESET_MARKER = /rst:0x[0-9a-f]+/gi
 
 /**
+ * What to actually DO about a given bootloader complaint.
+ *
+ * These are not interchangeable, and saying so matters: the generic "erase and
+ * try again" is right for a stale partition table and actively misleading for a
+ * hash failure, which means the bytes ON the chip do not match their own
+ * checksum. Snakie verifies the firmware file's SHA-256 before writing it (see
+ * `main/firmware/esp-image.ts`), so by the time a hash failure reaches here the
+ * FILE was known-good and the WRITE is the thing under suspicion — advice that
+ * sends the user round the erase-and-retry loop again just wastes their evening.
+ */
+function adviceFor(lowerText: string): string {
+  // Keyed off the whole output, NOT the matched marker: the marker list is
+  // ordered by generality, so a hash failure matches the broad `esp_image:`
+  // entry first and would otherwise get the generic advice.
+  if (lowerText.includes('image hash failed') || lowerText.includes('checksum failed')) {
+    return (
+      'That means the bytes on the chip do not match their own checksum. Snakie verifies the ' +
+      'firmware file against its own SHA-256 before writing it, so this is not a bad download. ' +
+      'Erase the whole flash and flash again — stale partition or OTA data can point the ' +
+      'bootloader at an app slot that was never written. If it survives an erase, the write ' +
+      'itself is suspect: try a lower baud rate, a different USB cable, and a powered port.'
+    )
+  }
+  return (
+    'This is usually a leftover partition table from whatever was on the board before: ' +
+    'erasing the whole flash and flashing again usually fixes it.'
+  )
+}
+
+/**
  * Classify what a board printed in the seconds after a flash.
  *
  * Order matters: a boot-loop can scroll a runtime banner off the top on a board
@@ -66,8 +96,7 @@ export function classifyBootOutput(raw: string): BootVerdict {
       evidence,
       message:
         'The firmware was written and verified, but the board is not booting it — it says ' +
-        `"${evidence}". This is almost always a leftover partition table from whatever ` +
-        'was on the board before: erasing the whole flash and flashing again usually fixes it.'
+        `"${evidence}". ${adviceFor(lower)}`
     }
   }
 

--- a/test/bootCheck.test.ts
+++ b/test/bootCheck.test.ts
@@ -96,3 +96,28 @@ describe('silence', () => {
     expect(classifyBootOutput('\x1b[0m garbled ~~~ noise').kind).toBe('unknown')
   })
 })
+
+describe('bootloader advice is specific to the complaint (#840)', () => {
+  it('does not send a hash failure round the erase-and-retry loop', () => {
+    // The advice that cost an evening: "leftover partition table, erase and try
+    // again" is right for a stale partition table and misleading for a hash
+    // failure, which means the bytes on the chip do not match their own
+    // checksum. The file is verified before writing, so the WRITE is suspect.
+    const v = classifyBootOutput('E (579) esp_image: Image hash failed - image is corrupt')
+    if (v.kind !== 'bootloop') throw new Error('expected bootloop')
+    expect(v.message).toMatch(/do not match their own checksum/i)
+    // Both real causes, not just the cheap one: a stale slot (erase fixes it)
+    // and a bad write (erase does not).
+    expect(v.message).toMatch(/eras/i)
+    expect(v.message).toMatch(/baud|cable/i)
+    // And it must not send the user hunting for a bad download -- the file was
+    // already verified before it was written.
+    expect(v.message).toMatch(/not a bad download/i)
+  })
+
+  it('still gives the erase advice for a genuinely stale partition table', () => {
+    const v = classifyBootOutput('E (61) boot: No bootable app partitions in the partition table')
+    if (v.kind !== 'bootloop') throw new Error('expected bootloop')
+    expect(v.message).toMatch(/leftover partition table/i)
+  })
+})

--- a/test/espImageVerify.test.ts
+++ b/test/espImageVerify.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import { createHash } from 'node:crypto'
+import {
+  describeEspImageCheck,
+  espImageBases,
+  verifyEspImage
+} from '../src/main/firmware/esp-image'
+
+/**
+ * Build a minimal but REAL ESP image: header, one segment, pad + checksum byte,
+ * then the appended SHA-256 over everything before it. Built rather than
+ * fixtured so the test states the format it is asserting about (#840).
+ */
+function buildImage(segmentData: Buffer, hashAppended = true): Buffer {
+  const header = Buffer.alloc(24)
+  header[0] = 0xe9
+  header[1] = 1
+  header[23] = hashAppended ? 1 : 0
+  const seg = Buffer.alloc(8)
+  seg.writeUInt32LE(0x3f400020, 0)
+  seg.writeUInt32LE(segmentData.length, 4)
+
+  let body = Buffer.concat([header, seg, segmentData])
+  body = Buffer.concat([body, Buffer.alloc(15 - (body.length % 16)), Buffer.from([0xef])])
+  if (!hashAppended) return body
+  return Buffer.concat([body, createHash('sha256').update(body).digest()])
+}
+
+describe('verifyEspImage (#840)', () => {
+  it('accepts an image whose appended digest matches', () => {
+    const check = verifyEspImage(buildImage(Buffer.alloc(64, 0xa5)), 0x1000)
+    expect(check.kind).toBe('ok')
+    expect(check.images[0].hashOk).toBe(true)
+  })
+
+  it('rejects a corrupted image of the SAME LENGTH', () => {
+    // The exact failure this exists for: length is right, bytes are not, so
+    // esptool would flash and verify it happily.
+    const good = buildImage(Buffer.alloc(64, 0xa5))
+    const bad = Buffer.from(good)
+    bad[40] ^= 0x01
+    expect(bad.length).toBe(good.length)
+
+    const check = verifyEspImage(bad, 0x1000)
+    expect(check.kind).toBe('bad')
+    expect(check.reason).toContain('SHA-256')
+  })
+
+  it('rejects a truncated image rather than walking off the end', () => {
+    const good = buildImage(Buffer.alloc(64, 0xa5))
+    const check = verifyEspImage(good.subarray(0, 40), 0x1000)
+    expect(check.kind).toBe('bad')
+  })
+
+  it('rejects a header claiming an absurd segment length without throwing', () => {
+    const img = buildImage(Buffer.alloc(64, 0xa5))
+    img.writeUInt32LE(0xfffffff0, 24 + 4)
+    expect(() => verifyEspImage(img, 0x1000)).not.toThrow()
+    expect(verifyEspImage(img, 0x1000).kind).toBe('bad')
+  })
+
+  it('stays out of the way of files it does not recognise', () => {
+    // A UF2, an NVS blob, a partial image: none of its business, and refusing
+    // them would be a worse bug than the one it catches.
+    expect(verifyEspImage(Buffer.from('UF2\n' + 'x'.repeat(64)), 0x0).kind).toBe('unknown')
+  })
+
+  it('treats an empty file as bad', () => {
+    expect(verifyEspImage(Buffer.alloc(0), 0x1000).kind).toBe('bad')
+  })
+
+  it('does not fail a file whose image carries no digest', () => {
+    const check = verifyEspImage(buildImage(Buffer.alloc(32, 7), false), 0x1000)
+    expect(check.kind).toBe('unknown')
+  })
+
+  it('locates the application image from the flash offset', () => {
+    // MicroPython/ESP32 writes at 0x1000, so the app (flash 0x10000) is 0xF000
+    // into the file; an S3 or CircuitPython image written at 0x0 puts it at
+    // 0x10000. Getting this wrong silently skips the app image entirely.
+    expect(espImageBases(0x1000)).toEqual([0, 0xf000])
+    expect(espImageBases(0x0)).toEqual([0, 0x10000])
+    expect(espImageBases(0x10000)).toEqual([0])
+  })
+
+  it('describes each verdict in words', () => {
+    expect(describeEspImageCheck(verifyEspImage(buildImage(Buffer.alloc(8)), 0x1000))).toContain(
+      'integrity verified'
+    )
+    expect(describeEspImageCheck({ kind: 'bad', images: [], reason: 'it is empty' })).toContain(
+      'corrupt'
+    )
+  })
+})

--- a/test/espImageVerify.test.ts
+++ b/test/espImageVerify.test.ts
@@ -92,3 +92,24 @@ describe('verifyEspImage (#840)', () => {
     )
   })
 })
+
+describe('downloadVerified retries a damaged download (#840)', () => {
+  it('names the two kinds of broken differently', async () => {
+    // Identical hashes and differing hashes point at completely different
+    // things to go and look at, so the message must not merge them.
+    const src = await import('node:fs').then((fs) =>
+      fs.readFileSync('src/main/firmware/download.ts', 'utf8')
+    )
+    expect(src).toMatch(/byte-for-byte identical/)
+    expect(src).toMatch(/corrupted in transit/)
+    // And nothing may be written to the board in either case.
+    expect(src).toMatch(/nothing has been written to your/)
+  })
+
+  it('retries before giving up, and only once', async () => {
+    const src = await import('node:fs').then((fs) =>
+      fs.readFileSync('src/main/firmware/download.ts', 'utf8')
+    )
+    expect(src).toMatch(/attempt <= 2/)
+  })
+})


### PR DESCRIPTION
Closes #840.

## The bug

Flashing the Feather ESP32 V2 in simple mode wrote, verified and completed
without one complaint — and left a board that would not boot:

```
Wrote 1607008 bytes (1043168 compressed) at 0x00001000
Verifying written data...
Hash of data verified.
Flash complete.
```

```
E (579) esp_image: Image hash failed - image is corrupt
```

`Hash of data verified` is a weaker claim than it reads as: esptool verifies that
the flash matches **the file it was handed**. That is a fact about the write, not
about the firmware, so a download with the right length and the wrong bytes
flashes perfectly and bricks the board.

**Measured, not inferred.** Deflate is deterministic, so identical input cannot
compress to two different sizes:

| run | compressed |
|---|---|
| failing | `1043168` |
| passing, same URL | `1043083` |

Same 1607008 bytes, different content.

## The fix

ESP images carry a SHA-256 of themselves in their last 32 bytes — the very check
the bootloader runs. `esp-image.ts` runs it on the host, before the erase.

Verified on real hardware, both directions:

```
--- corrupt file (one bit flipped, same length) ---
Firmware file is corrupt: the application image at 0xf000 fails its own SHA-256 check.
Refusing to flash esp-corrupt.bin: ...
esptool spawned? false          <-- the board was never touched

--- good file ---
Firmware integrity verified (2 images passed their own SHA-256).
Flash complete — the board is running MicroPython v1.28.0 ... with SPIRAM
```

Deliberately conservative: it may only report a file bad when it is **certain**.
A file that is not an ESP image — a UF2, an NVS blob, a partial image the user
means to write at an address of their own — is none of its business, and refusing
those would be a worse bug than the one it catches.

## Also

`Image hash failed` was advised as "leftover partition table, erase and try
again", for every bootloader complaint. That is right for a stale slot and
misleading otherwise, and it sent this investigation round the same loop more
than once. Both real causes are now named, and the message says the file was
already verified — the one thing worth ruling out first.

## Deliberately NOT done

Comparing bytes-received to `content-length`. Measured, and wrong twice over: a
truncated response **errors** the stream rather than ending short (so it never
fires for the case it would be written for), and under `content-encoding: gzip`
the header is the *compressed* length while the decoded stream is larger (so it
fires on healthy downloads). The reasoning is recorded in `download.ts` so it is
not re-added a fourth time.

## Gates

lint, typecheck, build green; **5881 tests** (12 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)