### PR TITLE
fix(modules,ui): slow install looking like a hang, present driver looking absent, vanishing Flash button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Installing a large driver no longer looks like a hang** (#842). Files were
+  streamed to the board in 256-byte chunks, one full raw-REPL round trip each.
+  The Arduino Modulino package is 182KB across 25 files, so that was 714
+  sequential round trips — and since progress was only reported per file, the
+  UI sat perfectly still for minutes at a time. The chunk size is a latency
+  budget rather than a memory one, so it is now 1KB: the same install needs 179
+  round trips instead of 714.
+- **A driver that is installed is no longer reported missing** (#842). The
+  install probe ran one `import` per catalog module in a single batch and kept
+  every one of them resident, so probing `modulino` — whose `__init__` eagerly
+  imports nineteen submodules and three dependency packages — could exhaust the
+  board's memory. `MemoryError` is an `Exception` like any other, so the probe's
+  `except Exception: pass` swallowed it and called the driver absent. Each probe
+  now releases what it imported, submodules included, before the next one runs.
+- **The Flash button is no longer clipped off a narrowed window** (#843). The
+  status bar's right-hand group inherited `flex-shrink: 1`, so it was squeezed
+  while its fixed-width children kept their size and overflowed it — and the
+  bar's `overflow: hidden` quietly cut off the last one. The right-hand group
+  (changed files, line count, saved state, version, coffee, Flash) is now fixed;
+  the status message on the left is what gives way.
+
+
 - **A corrupt firmware download no longer flashes and verifies cleanly, then
   refuses to boot** (#840). esptool's `Hash of data verified` is a weaker claim
   than it reads as: it proves the flash matches *the file it was handed*, and

--- a/src/main/device/MicroPythonDevice.ts
+++ b/src/main/device/MicroPythonDevice.ts
@@ -914,7 +914,7 @@ export class MicroPythonDevice extends EventEmitter implements SnakieDevice {
    * sent in hex-encoded chunks so that arbitrary binary content survives the
    * text-oriented REPL transport.
    */
-  async writeFile(path: string, contents: string | Buffer, chunkSize = 256): Promise<void> {
+  async writeFile(path: string, contents: string | Buffer, chunkSize = 1024): Promise<void> {
     const mount = await this.driveMount()
     if (mount) return driveWriteFile(mount, path, contents)
     const data = Buffer.isBuffer(contents) ? contents : Buffer.from(contents, 'utf8')
@@ -922,6 +922,15 @@ export class MicroPythonDevice extends EventEmitter implements SnakieDevice {
     // never put a multi-megabyte literal on a single line. `_snk_f` is the one
     // scratch global that must OUTLIVE its snippet — the handle is what the next
     // chunk writes to — so it carries the prefix and is unbound on close (#798).
+    //
+    // The chunk size is a LATENCY budget, not a memory one. Every chunk is a
+    // full raw-REPL round trip — send, await the OK, read back, await the
+    // prompt — so the cost of a transfer is dominated by how many of them there
+    // are, not by how many bytes each carries. At the original 256 the Arduino
+    // Modulino package (182KB across 25 files) needed 714 sequential round
+    // trips and looked to the user like a hang; at 1024 it needs 179. The line
+    // this puts on the wire is ~2KB of hex, which is comfortable on every board
+    // Snakie supports, and the decoded buffer on the board is 1KB.
     const open = [
       'import sys',
       'try:\n import ubinascii\nexcept ImportError:\n import binascii as ubinascii',

--- a/src/renderer/src/components/StatusBar.css
+++ b/src/renderer/src/components/StatusBar.css
@@ -30,9 +30,31 @@
 .statusbar__group--left {
   flex: 1 1 auto;
   min-width: 0;
+  /* Clip here rather than letting the message run on. Without this the left
+     group's non-shrinkable items (port, runtime) overflow their own box and
+     draw straight over the right-hand group instead of being cut off. */
+  overflow: hidden;
 }
 
 .statusbar__spacer {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+/* The right-hand group NEVER gives way (#843).
+ *
+ * `.statusbar__group` sets no `flex`, so this inherited the initial
+ * `flex-shrink: 1` and was squeezed as the window narrowed. Its children are
+ * `flex: 0 0 auto` and so kept their width, which meant they overflowed the
+ * shrinking group and — with `overflow: hidden` on the bar — the LAST of them
+ * was silently clipped off the right edge. That is the Flash button, the one
+ * control on this bar that does something.
+ *
+ * Everything in this group is either a fact worth reading at a glance (line
+ * count, saved state, changed files, version) or a button; none of it is
+ * something to truncate. The message area on the left is what may give way,
+ * which is what the `--left` rules above arrange. */
+.statusbar__group--right {
   flex: 0 0 auto;
 }
 
@@ -263,6 +285,9 @@
 .statusbar__flash-wrap {
   position: relative;
   display: inline-flex;
+  /* Last item in the row that must stay whole — pinned explicitly so a future
+     `flex` on an ancestor cannot start shrinking it again. */
+  flex: 0 0 auto;
 }
 
 .statusbar__fw-badge {

--- a/src/shared/modules-catalog.ts
+++ b/src/shared/modules-catalog.ts
@@ -522,20 +522,48 @@ export const MODULE_PRESENT = '<<SNAKIE_MOD_PRESENT>>'
  * interpreter: delete the file and the probe still succeeds; pop the cache entry
  * and it correctly fails. Popping is safe for a running program, because objects
  * already bound to that module stay alive through their own references.
+ *
+ * **And evicted again afterwards, with a collect (#842).** The probes are
+ * concatenated and run as ONE exec over the whole catalog, so without this every
+ * driver the board owns stays resident in RAM simultaneously. That is affordable
+ * for a one-file driver and emphatically not for `modulino`, whose `__init__`
+ * eagerly imports nineteen submodules and three dependency packages. On a board
+ * with modest free RAM the import then fails for want of memory — and because
+ * `MemoryError` is an `Exception` like any other, the probe swallows it and
+ * reports the driver ABSENT when it is installed and perfectly good.
+ *
+ * The eviction is by PREFIX: dropping `modulino` alone would leave the nineteen
+ * `modulino.*` submodules cached and holding exactly the memory this is trying
+ * to release.
  */
 export function importProbeSnippet(importName: string): string {
   // importName is a catalog constant (a bare module name) so it never contains
   // quotes — but sanitise defensively all the same to a safe identifier.
   const name = importName.replace(/[^A-Za-z0-9_]/g, '')
+  // Drop `name` AND every `name.*` submodule. A bare pop of the package leaves
+  // its submodules cached, which both keeps the memory and lets a stale
+  // submodule answer for a file that is gone.
+  const purge = [
+    '_snk_k = None',
+    'for _snk_k in list(sys.modules):',
+    `    if _snk_k == '${name}' or _snk_k.startswith('${name}.'):`,
+    '        sys.modules.pop(_snk_k, None)'
+  ]
   return [
-    'import sys',
+    'import sys, gc',
     // Ask the FILESYSTEM, not the cache.
-    `sys.modules.pop('${name}', None)`,
+    ...purge,
     'try:',
     `    __import__('${name}')`,
     `    print('${MODULE_PRESENT}')`,
     'except Exception:',
-    '    pass'
+    '    pass',
+    // Release it again before the next probe in the batch runs, so peak memory
+    // is one driver rather than the whole catalog.
+    ...purge,
+    '_snk_k = None',
+    'del _snk_k',
+    'gc.collect()'
   ].join('\n')
 }
 

--- a/test/modulesCatalog.test.ts
+++ b/test/modulesCatalog.test.ts
@@ -157,8 +157,27 @@ describe('importProbeSnippet', () => {
     // A user deleted /lib/lsm6ds3.py, re-added the part, and was never offered
     // the install.
     const snippet = importProbeSnippet('lsm6ds3')
-    expect(snippet).toContain("sys.modules.pop('lsm6ds3', None)")
+    expect(snippet).toContain('sys.modules.pop(_snk_k, None)')
+    expect(snippet).toContain("_snk_k == 'lsm6ds3'")
     expect(snippet).toContain('import sys')
+  })
+
+  it('evicts SUBMODULES too, not just the package name (#842)', () => {
+    // `modulino` eagerly imports nineteen submodules; dropping the package name
+    // alone leaves every `modulino.*` entry cached, holding exactly the memory
+    // the eviction exists to release.
+    const snippet = importProbeSnippet('modulino')
+    expect(snippet).toContain("_snk_k.startswith('modulino.')")
+  })
+
+  it('releases the module and collects AFTER probing (#842)', () => {
+    // The probes run concatenated as one exec over the whole catalog. Without a
+    // release between them every driver stays resident at once, and a probe
+    // that fails for want of memory is indistinguishable from one that is
+    // genuinely absent — `MemoryError` is an `Exception` like any other.
+    const snippet = importProbeSnippet('modulino')
+    expect(snippet.lastIndexOf('sys.modules.pop')).toBeGreaterThan(snippet.indexOf('__import__'))
+    expect(snippet.trimEnd().endsWith('gc.collect()')).toBe(true)
   })
 
   it('pops BEFORE it imports — order is the whole point', () => {
@@ -170,7 +189,8 @@ describe('importProbeSnippet', () => {
   it('sanitises the name in the eviction too, not just the import', () => {
     // Both spots interpolate the name; missing one would reopen the injection.
     const snippet = importProbeSnippet("os'); import evil #")
-    expect(snippet).toContain("sys.modules.pop('osimportevil', None)")
+    expect(snippet).toContain("_snk_k == 'osimportevil'")
+    expect(snippet).toContain("_snk_k.startswith('osimportevil.')")
     expect(snippet).not.toContain("os');")
   })
 })

--- a/test/statusBarLayout.test.ts
+++ b/test/statusBarLayout.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+
+/**
+ * The status bar's shrink order (#843).
+ *
+ * Asserted against the stylesheet because the bug is a LAYOUT one that only
+ * appears at a narrow window: the right-hand group inherited `flex-shrink: 1`,
+ * its fixed-width children overflowed it, and the bar's `overflow: hidden`
+ * quietly cut the Flash button off the right edge. Nothing throws, nothing
+ * logs — the control is simply not there any more.
+ */
+const css = readFileSync('src/renderer/src/components/StatusBar.css', 'utf8')
+
+/** The body of one rule, so a declaration can be attributed to its selector. */
+function rule(selector: string): string {
+  const i = css.indexOf(`${selector} {`)
+  expect(i, `${selector} should exist`).toBeGreaterThan(-1)
+  return css.slice(i, css.indexOf('}', i))
+}
+
+describe('status bar shrink order (#843)', () => {
+  it('never shrinks the right-hand group', () => {
+    // Line count, saved state, changed files, version, coffee and Flash all
+    // live here, and every one of them must stay visible.
+    expect(rule('.statusbar__group--right')).toMatch(/flex:\s*0\s+0\s+auto/)
+  })
+
+  it('lets the message area on the left give way instead', () => {
+    const left = rule('.statusbar__group--left')
+    expect(left).toMatch(/flex:\s*1\s+1\s+auto/)
+    expect(left).toMatch(/min-width:\s*0/)
+    // ...and clip, so its fixed-width items cannot draw over the right group.
+    expect(left).toMatch(/overflow:\s*hidden/)
+  })
+
+  it('keeps the flash button whole', () => {
+    expect(rule('.statusbar__flash-wrap')).toMatch(/flex:\s*0\s+0\s+auto/)
+  })
+
+  it('puts the flash button last, hard against the right edge', () => {
+    const tsx = readFileSync('src/renderer/src/components/StatusBar.tsx', 'utf8')
+    const right = tsx.indexOf('statusbar__group--right')
+    expect(tsx.indexOf('statusbar__flash-wrap')).toBeGreaterThan(right)
+    // Nothing may follow it inside the group.
+    const after = tsx.slice(tsx.indexOf('statusbar__flash-wrap'))
+    expect(after.indexOf('</footer>')).toBeGreaterThan(-1)
+  })
+})


### PR DESCRIPTION
Closes #842, closes #843.

Three defects behind two reports.

## `modulino` reported missing when it is installed (#842)

`probeInstalled` concatenates a probe for **every** catalog module into one
`device:exec`, and each probe left what it imported resident in `sys.modules`.
`modulino` is not one file — its `__init__` eagerly imports nineteen submodules
and pulls in three dependency packages:

```
from .movement import ModulinoMovement   # -> lsm6dsox
from .light import ModulinoLight         # -> ltr381rgb
from .distance import ModulinoDistance   # -> modulino/lib/vl53l4cd
```

So it costs far more memory than any other entry, and nothing was released
between probes. On a board with modest free RAM the import fails for want of
memory — and `MemoryError` is an `Exception` like any other, so the probe's
`except Exception: pass` swallowed it and reported the driver **absent**.

The eviction also only popped the bare package name, leaving all nineteen
`modulino.*` submodules cached and holding exactly the memory it was trying to
free. It now purges by prefix, and releases + collects after the probe as well
as before it.

## Installing it looks like a hang (#842)

`writeFile` streamed **256-byte chunks**, one full raw-REPL round trip each. The
resolved modulino plan is **182,685 bytes across 25 files**:

| chunk | round trips |
|---|---|
| 256 (before) | **714** |
| 1024 (after) | **179** |

Progress is reported per *file*, so during the 32KB `ltr381rgb/device.py` (128
round trips) the UI did not move at all. It was never deadlocked — just far too
slow to look alive, which is why disconnecting appeared to cancel it.

256 dates from the first device-layer commit (#25), was never a measured
constraint, and nothing overrides it. The chunk size is a **latency** budget,
not a memory one.

## The Flash button is clipped off a narrow window (#843)

`.statusbar__group` declares no `flex`, so the right-hand group inherited
`flex-shrink: 1` and was squeezed as the window narrowed. Its children are all
`flex: 0 0 auto` and kept their widths, so they overflowed the shrinking group —
and with `overflow: hidden` on the bar, the **last** of them was silently cut
off. That is the Flash button, the one control on the bar that does something.

The right-hand group (changed files, line count, saved state, version, coffee,
Flash) is now fixed; the status **message** on the left gives way instead, and
is clipped rather than allowed to draw over its neighbour.

## Verification

The install path was measured against the real catalog: the host-side resolve
returns 25 files / 182,685 bytes in ~7s, which is what the round-trip arithmetic
above is based on.

**Not yet exercised against a board with modulino on it** — the dev machine's
only board was held by a running session. Worth a real-world check that the
probe now reports it present.

Gates: lint, typecheck, build green; **5889 tests** (10 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)