### PR TITLE
fix(capabilities): stop the probe leaving its temporaries on the board (#846)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **The board capability probe no longer leaves its temporaries on the board**
+  (#846). Like every raw-REPL snippet it runs in the board's `__main__`, but it
+  predated the scratch-name discipline and cleaned up nothing — leaving `_ok`,
+  `_u`, `_o` and, because MicroPython's `exec` binds into globals even from
+  inside a function, the compiled `_n` and `_v` test functions holding their
+  code buffers for the whole session (plus `_t` and `_p` on firmware with thumb
+  and PIO). All of them were then listed in the Inspect panel as the user's own
+  variables. Measured on hardware before and after: the board's globals are now
+  identical across a probe, and detection is unchanged.
+
+
 - **Installing a large driver no longer looks like a hang** (#842). Files were
   streamed to the board in 256-byte chunks, one full raw-REPL round trip each.
   The Arduino Modulino package is 182KB across 25 files, so that was 714

--- a/src/renderer/src/lib/board-capabilities.ts
+++ b/src/renderer/src/lib/board-capabilities.ts
@@ -28,6 +28,7 @@
  *   not at all.
  */
 import type { BoardCapabilities } from '../../../shared/refactor/types'
+import { delScratch } from '../../../shared/device-scratch'
 
 /**
  * Python that reports what the firmware supports, as one JSON line.
@@ -41,24 +42,36 @@ import type { BoardCapabilities } from '../../../shared/refactor/types'
 export function buildCapabilityProbe(): string {
   return [
     'import json, os, gc, micropython',
-    'def _ok(s):',
+    'def _snk_ok(s):',
     '    try:',
-    '        exec(s)',
+    // The probe's test functions must NOT escape into the board's `__main__`.
+    // MicroPython's `exec` binds into GLOBALS even when called inside a
+    // function, so a bare `exec(s)` left `_n` and `_v` — the compiled native
+    // and viper functions — permanently bound, plus `_t`/`_p` on a board whose
+    // firmware has thumb and PIO. Measured on real hardware. Handing `exec` its
+    // own namespace confines them to a dict that is freed with the call.
+    "        exec(s, {'micropython': micropython})",
     '        return True',
     '    except Exception:',
     '        return False',
-    '_u = os.uname()',
-    '_o = {}',
-    "_o['native'] = _ok('@micropython.native\\ndef _n(): pass')",
-    "_o['viper'] = _ok('@micropython.viper\\ndef _v(): pass')",
-    "_o['thumb'] = _ok('@micropython.asm_thumb\\ndef _t(): nop()')",
-    "_o['xtensa'] = _ok('@micropython.asm_xtensa\\ndef _x(): nop()')",
-    "_o['rv32'] = _ok('@micropython.asm_rv32\\ndef _r(): nop()')",
-    "_o['pio'] = _ok('import rp2\\n@rp2.asm_pio()\\ndef _p(): rp2.PIO.OUT_LOW')",
-    "_o['machine'] = _u.machine",
-    "_o['version'] = _u.release",
-    "_o['mem'] = gc.mem_free()",
-    'print(json.dumps(_o))'
+    '_snk_u = os.uname()',
+    '_snk_o = {}',
+    "_snk_o['native'] = _snk_ok('@micropython.native\\ndef _n(): pass')",
+    "_snk_o['viper'] = _snk_ok('@micropython.viper\\ndef _v(): pass')",
+    "_snk_o['thumb'] = _snk_ok('@micropython.asm_thumb\\ndef _t(): nop()')",
+    "_snk_o['xtensa'] = _snk_ok('@micropython.asm_xtensa\\ndef _x(): nop()')",
+    "_snk_o['rv32'] = _snk_ok('@micropython.asm_rv32\\ndef _r(): nop()')",
+    "_snk_o['pio'] = _snk_ok('import rp2\\n@rp2.asm_pio()\\ndef _p(): rp2.PIO.OUT_LOW')",
+    "_snk_o['machine'] = _snk_u.machine",
+    "_snk_o['version'] = _snk_u.release",
+    "_snk_o['mem'] = gc.mem_free()",
+    'print(json.dumps(_snk_o))',
+    // Scratch discipline (#798): this runs in the user's `__main__`, so what it
+    // bound is unbound before it ends — otherwise the Inspect panel lists our
+    // temporaries as the user's variables, and the compiled test functions
+    // hold their code buffers for the life of the session.
+    delScratch('_snk_ok', '_snk_u', '_snk_o'),
+    'gc.collect()'
   ].join('\n')
 }
 

--- a/test/boardCapabilities.test.ts
+++ b/test/boardCapabilities.test.ts
@@ -34,8 +34,10 @@ describe('board capability probe (#634 §2.5)', () => {
     expect(probe).toContain('asm_xtensa')
     expect(probe).toContain('asm_rv32')
     expect(probe).toContain('rp2.asm_pio')
-    // Compiling is the whole test — nothing probed is ever called.
-    expect(probe).toContain('exec(s)')
+    // Compiling is the whole test — nothing probed is ever called. `exec` now
+    // gets its own namespace (#846) so the compiled functions cannot escape,
+    // but it is still an exec of source, not a call.
+    expect(probe).toMatch(/exec\(s,/)
   })
 
   it('parses a Pico probe into full RP2 capabilities', () => {
@@ -198,5 +200,32 @@ describe('on-device benchmark (#634 §3.7 "measure it, don\'t guess it")', () =>
     expect(formatDuration(4.25)).toBe('4.25 µs')
     expect(formatDuration(4200)).toBe('4.20 ms')
     expect(formatDuration(42000)).toBe('42.0 ms')
+  })
+})
+
+describe('the probe leaves nothing behind on the board (#846)', () => {
+  it('binds only prefixed scratch names, and unbinds them', () => {
+    // Measured on real hardware before this was fixed: the probe left `_ok`,
+    // `_u`, `_o` AND the compiled `_n`/`_v` test functions bound in the board's
+    // `__main__`, where the Inspect panel showed them as the user's variables.
+    const probe = buildCapabilityProbe()
+    // Every name this snippet BINDS at top level must carry the scratch prefix.
+    const bound = [...probe.matchAll(/^(?:def\s+)?(_[A-Za-z0-9_]*)\s*[=([]/gm)].map(
+      (m) => m[1]
+    )
+    expect(bound.length, 'the probe should bind something').toBeGreaterThan(0)
+    for (const name of bound) {
+      expect(name.startsWith('_snk_'), `${name} escapes the scratch prefix`).toBe(true)
+    }
+    expect(probe).toContain('del _snk_')
+  })
+
+  it('gives exec its own namespace so the test functions cannot escape', () => {
+    // MicroPython's `exec` binds into GLOBALS even from inside a function, so a
+    // bare `exec(s)` published `_n`/`_v` (and `_t`/`_p` where the firmware has
+    // thumb and PIO) into the user's namespace, holding their compiled code.
+    const probe = buildCapabilityProbe()
+    expect(probe).toMatch(/exec\(s,\s*\{'micropython': micropython\}\)/)
+    expect(probe).not.toMatch(/exec\(s\)/)
   })
 })


### PR DESCRIPTION
Closes #846. Found while auditing for more of the class behind #842.

## The leak

`buildCapabilityProbe` runs in the board's `__main__`, like every raw-REPL
snippet, but predates the `_snk_` scratch discipline (#798) and cleaned up
nothing. Measured on an ESP32 running MicroPython v1.29.0 — globals before and
after one `probeBoardCapabilities()`:

```
BEFORE : ['bdev', 'gc', 'json', 'micropython', 'os', 'vfs']
AFTER  : ['bdev', 'gc', 'json', 'micropython', 'os', 'vfs',
          '_n', '_o', '_ok', '_u', '_v']
```

`_n` and `_v` are the point: those are the **compiled native and viper test
functions**, which is hardware proof that MicroPython's `exec` binds into
GLOBALS even when called from inside a function. They hold their compiled code
buffers for the life of the session, and `_t`/`_p` leak too on firmware with
thumb and PIO.

All of them were then listed in the Inspect panel as the user's own variables —
the exact complaint #798 was filed about.

## The fix

Prefix the temporaries, unbind them, and give `exec` its own namespace so the
test functions are confined to a dict freed with the call:

```python
exec(s, {'micropython': micropython})
```

Verified on the same board — globals identical across a probe, detection
unchanged:

```
BEFORE : ['bdev', 'gc', 'json', 'micropython', 'os', 'vfs']
AFTER  : ['bdev', 'gc', 'json', 'micropython', 'os', 'vfs']
PROBE  : {"native": true, "viper": true, "mem": 160560, ...}
```

## The rest of the audit came back clean

- Every other file that binds `_snk_` names also releases them.
- The `it=` / `name=` bindings in the `listDir` snippets are function **locals**
  inside `def _snk_ls`, not globals.
- Console output is capped (`MAX_LINES = 500`); other renderer buffers use
  `slice(-N)`.
- `setInterval` without a matching clear appears only inside workers, which are
  terminated wholesale.

So this was the only live instance.

Gates: lint, typecheck, build green; **5891 tests** (2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)