### PR TITLE
feat(files): copy a folder to the board, with progress, and sync folders (#848)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Copy a whole folder to the board from the Files panel** (#848). Highlight a
+  folder on the left and a folder on the device, and **Upload to device** copies
+  the one into the other — recursively, keeping its name and its nesting. A
+  progress dialog shows the file list with a tick against each one as it lands,
+  and closes itself when the copy finishes (staying put if anything failed,
+  because an error nobody saw did not happen). Developer bookkeeping — `.git`,
+  `__pycache__`, `node_modules`, `.venv`, `.DS_Store`, `*.pyc` — is left on the
+  host; a `.git` directory alone would fill a Pico. Every file goes over the
+  bytes channel, so fonts, images and `.mpy` files arrive intact rather than
+  being quietly mangled by a UTF-8 round trip.
+- **Sync works for folders** (#848). The sync checkbox now appears next to
+  folders as well as files; a tagged folder and everything under it is pushed
+  into whichever device folder is highlighted. Tagged FILES keep their existing
+  destination, so nothing anyone already had set up moves.
+
 ### Fixed
 
 - **The board capability probe no longer leaves its temporaries on the board**

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -233,6 +233,17 @@ const device = {
   /** Write contents to a file (created/overwritten), chunked. */
   writeFile: (path: string, contents: string): Promise<void> =>
     unwrap(ipcRenderer.invoke('device:writeFile', path, contents)),
+  /**
+   * Write raw BYTES to a file on the board (#848).
+   *
+   * The text `writeFile` above round-trips through UTF-8, which silently
+   * mangles anything that is not text — a `.mpy`, a font, an image in an
+   * uploaded folder. The module installer has always used this channel for
+   * exactly that reason; a folder upload needs it for the same one, so it is
+   * exposed here rather than reached for through a private path.
+   */
+  writeFileBytes: (path: string, bytes: Uint8Array): Promise<void> =>
+    unwrap(ipcRenderer.invoke('device:writeFileBytes', path, Buffer.from(bytes))),
   /** Remove a file. */
   remove: (path: string): Promise<void> => unwrap(ipcRenderer.invoke('device:remove', path)),
   /** Create a directory. */

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -7,6 +7,7 @@ import { DiagnosticsProvider } from './store/diagnostics'
 import { SettingsProvider } from './store/settings'
 import { ConsoleProvider } from './store/console'
 import { SyncProvider } from './store/sync'
+import { FileSelectionProvider } from './store/file-selection'
 import { LayoutProvider } from './store/layout'
 import { TutorialsProvider } from './store/tutorials'
 import { IS_WEB } from './lib/env'
@@ -19,19 +20,24 @@ function App(): JSX.Element {
             panel sizes map to the right slots (#528). */}
         <LayoutProvider chatPane={!IS_WEB}>
           <WorkspaceProvider>
-            <SyncProvider>
-              <DiagnosticsProvider>
-                <ConsoleProvider>
-                  <TutorialsProvider>
-                    <AppShell />
-                    <UpdateNotifier />
-                    {/* The refactoring diff preview (#634): renders nothing
+            {/* What is highlighted in each half of the Files panel (#848).
+                Above SyncProvider because folder sync needs the device
+                selection to know where a synced folder lands. */}
+            <FileSelectionProvider>
+              <SyncProvider>
+                <DiagnosticsProvider>
+                  <ConsoleProvider>
+                    <TutorialsProvider>
+                      <AppShell />
+                      <UpdateNotifier />
+                      {/* The refactoring diff preview (#634): renders nothing
                         until a refactoring is proposed from the editor. */}
-                    <RefactorPreview />
-                  </TutorialsProvider>
-                </ConsoleProvider>
-              </DiagnosticsProvider>
-            </SyncProvider>
+                      <RefactorPreview />
+                    </TutorialsProvider>
+                  </ConsoleProvider>
+                </DiagnosticsProvider>
+              </SyncProvider>
+            </FileSelectionProvider>
           </WorkspaceProvider>
         </LayoutProvider>
       </SettingsProvider>

--- a/src/renderer/src/components/DeviceFileTree.tsx
+++ b/src/renderer/src/components/DeviceFileTree.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { DirEntry } from '../../../preload/index.d'
+import { useFileSelection } from '../store/file-selection'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { bootFileNote } from './run-controls'
 import { useWorkspace } from '../store/workspace'
@@ -274,6 +275,13 @@ export function DeviceFileTree(): JSX.Element {
 
   const selectedPath = primary?.path ?? null
   const selectedIsDir = primary?.isDir ?? false
+
+  // Publish the highlighted row so the transfer bridge knows where an upload
+  // should land (#848).
+  const { setDevice: publishSelection } = useFileSelection()
+  useEffect(() => {
+    publishSelection(primary)
+  }, [primary, publishSelection])
   const rows = useMemo(() => flattenTree(dirs, expanded), [dirs, expanded])
   // The ROOT listing decides which file boots (#755) — `code.py` beats `main.py`
   // only when both sit at the top level.

--- a/src/renderer/src/components/LocalFileTree.tsx
+++ b/src/renderer/src/components/LocalFileTree.tsx
@@ -3,6 +3,7 @@ import type { FsEntry } from '../../../main/fs/types'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { useWorkspace, FILE_SAVED_EVENT, type FileSavedDetail } from '../store/workspace'
 import { useSync } from '../store/sync'
+import { useFileSelection } from '../store/file-selection'
 import { ContextMenu, type ContextMenuItem, type ContextMenuPosition } from './ContextMenu'
 import { usePrompt } from './PromptModal'
 import './LocalFileTree.css'
@@ -159,26 +160,32 @@ function TreeNode({
           {entry.isDir ? (expanded ? '▼' : '▶') : '▤'}
         </span>
         <span className="tree-row__name">{entry.name}</span>
-        {!entry.isDir && (
-          <span className="tree-row__sync">
-            <input
-              type="checkbox"
-              className="tree-row__sync-check"
-              checked={isSynced(entry.path)}
-              onChange={() => toggleSync(entry.path)}
-              // Don't let toggling the checkbox also open the file / fire the row.
-              onClick={(e) => e.stopPropagation()}
-              onKeyDown={(e) => e.stopPropagation()}
-              title="Keep this file in sync with the device"
-              aria-label={`Keep ${entry.name} in sync with the device`}
-            />
-            {/* At rest a tagged file shows this green sync glyph in place of the
-                box; hovering/focusing the row swaps the real checkbox back in. */}
-            <span className="tree-row__sync-icon" aria-hidden>
-              ⇄
-            </span>
+        {/* Folders are taggable too (#848) — a whole folder is the unit people
+            actually keep in sync, and tagging its files one by one both misses
+            new files and is tedious. A tagged folder is pushed into whichever
+            device folder is highlighted at sync time. */}
+        <span className="tree-row__sync">
+          <input
+            type="checkbox"
+            className="tree-row__sync-check"
+            checked={isSynced(entry.path)}
+            onChange={() => toggleSync(entry.path)}
+            // Don't let toggling the checkbox also open the file / fire the row.
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
+            title={
+              entry.isDir
+                ? 'Keep this folder and its contents in sync with the device'
+                : 'Keep this file in sync with the device'
+            }
+            aria-label={`Keep ${entry.name} in sync with the device`}
+          />
+          {/* At rest a tagged entry shows this green sync glyph in place of the
+              box; hovering/focusing the row swaps the real checkbox back in. */}
+          <span className="tree-row__sync-icon" aria-hidden>
+            ⇄
           </span>
-        )}
+        </span>
       </div>
       {error && (
         <div className="tree-error" style={{ paddingLeft: `${depth * 14 + 22}px` }}>
@@ -219,12 +226,19 @@ export function LocalFileTree(): JSX.Element {
   const deviceStatus = useDeviceStatus()
   const connected = deviceStatus.state === 'connected'
   const { isSynced, toggleSync } = useSync()
+  // Publish what is highlighted so the transfer bridge between the two panes
+  // can see it (#848). The tree stays in charge of what selection MEANS.
+  const { setLocal: publishSelection } = useFileSelection()
   // The working folder now lives in the workspace store so the toolbar and tree
   // share one entry point; `root` is just a local alias for readability.
   const root = currentFolder
   const [entries, setEntries] = useState<FsEntry[]>([])
   const [selectedPath, setSelectedPath] = useState<string | null>(null)
   const [selectedIsDir, setSelectedIsDir] = useState(false)
+
+  useEffect(() => {
+    publishSelection(selectedPath ? { path: selectedPath, isDir: selectedIsDir } : null)
+  }, [selectedPath, selectedIsDir, publishSelection])
   const [error, setError] = useState<string | null>(null)
   const [menu, setMenu] = useState<MenuState | null>(null)
 

--- a/src/renderer/src/components/TransferProgressDialog.css
+++ b/src/renderer/src/components/TransferProgressDialog.css
@@ -1,0 +1,173 @@
+/*
+ * Folder-transfer progress dialog (#848).
+ *
+ * Same overlay treatment as PromptModal, and every colour comes from a theme
+ * token so it reads correctly in BOTH the dark and skeuomorph skins — a dialog
+ * that only works in one is a bug the author never sees.
+ */
+
+.transfer__backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1250;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+  padding: 1rem;
+}
+
+.transfer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  width: min(30rem, 100%);
+  max-height: min(28rem, 90vh);
+  padding: 1rem 1.1rem;
+  background: var(--bg-elevated);
+  color: var(--text);
+  border: var(--border-w) solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--pixel-shadow);
+  font-family: var(--font-ui);
+}
+
+.transfer__title {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text);
+  word-break: break-word;
+}
+
+/* --- Progress bar ---------------------------------------------------------- */
+
+.transfer__bar {
+  height: 0.6rem;
+  background: var(--bg-sunken);
+  border: var(--border-w) solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.transfer__bar-fill {
+  height: 100%;
+  background: var(--accent);
+  transition: width 120ms linear;
+}
+
+.transfer__bar-fill--error {
+  background: var(--danger, #c0392b);
+}
+
+.transfer__count {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+/* --- File list ------------------------------------------------------------- */
+
+.transfer__list {
+  flex: 1 1 auto;
+  min-height: 3rem;
+  margin: 0;
+  padding: 0.35rem 0;
+  list-style: none;
+  overflow-y: auto;
+  background: var(--bg-sunken);
+  border: var(--border-w) solid var(--border);
+  border-radius: var(--radius);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+}
+
+.transfer__row {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.12rem 0.55rem;
+  color: var(--text-muted);
+}
+
+.transfer__row--copying {
+  color: var(--text);
+  background: var(--bg-elevated);
+}
+
+.transfer__row--done {
+  color: var(--text);
+}
+
+.transfer__row--error {
+  color: var(--danger, #c0392b);
+}
+
+.transfer__tick {
+  flex: 0 0 auto;
+  width: 1em;
+  text-align: center;
+}
+
+.transfer__row--done .transfer__tick {
+  color: var(--accent);
+}
+
+.transfer__name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  direction: rtl;
+  text-align: left;
+}
+
+/* --- Footer ---------------------------------------------------------------- */
+
+.transfer__error {
+  margin: 0;
+  padding: 0.4rem 0.5rem;
+  background: var(--bg-sunken);
+  border: var(--border-w) solid var(--danger, #c0392b);
+  border-radius: var(--radius);
+  color: var(--danger, #c0392b);
+  font-size: 0.75rem;
+  word-break: break-word;
+}
+
+.transfer__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.transfer__btn {
+  padding: 0.3rem 0.8rem;
+  background: var(--bg-sunken);
+  color: var(--text);
+  border: var(--border-w) solid var(--border);
+  border-radius: var(--radius);
+  font-family: inherit;
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+
+.transfer__btn:hover {
+  background: var(--bg-elevated);
+}
+
+.transfer__btn--primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-contrast, #fff);
+}
+
+.transfer__btn--primary:hover {
+  filter: brightness(1.08);
+  background: var(--accent);
+}
+
+.transfer__btn:focus-visible {
+  outline: var(--border-w) solid var(--accent);
+  outline-offset: 2px;
+}

--- a/src/renderer/src/components/TransferProgressDialog.tsx
+++ b/src/renderer/src/components/TransferProgressDialog.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useRef } from 'react'
+import './TransferProgressDialog.css'
+
+/** One row in the dialog's file list. */
+export interface TransferRow {
+  label: string
+  state: 'pending' | 'copying' | 'done' | 'error'
+  error?: string
+}
+
+export interface TransferProgressDialogProps {
+  /** What is being copied, for the heading: `mylib → /lib`. */
+  title: string
+  rows: TransferRow[]
+  /** True while the transfer is still running. */
+  running: boolean
+  /** Set when the transfer finished badly; keeps the dialog open. */
+  error: string | null
+  /** Close it (also used by the auto-dismiss on success). */
+  onClose: () => void
+  /** Ask the running transfer to stop after the current file. */
+  onCancel: () => void
+}
+
+/** How long a finished, successful transfer stays on screen before closing. */
+export const AUTO_DISMISS_MS = 1200
+
+/**
+ * The folder-transfer progress dialog (#848).
+ *
+ * A folder copy is many per-file round trips over a serial link, so it takes
+ * real time — long enough that with no feedback it reads as a hang, which is
+ * exactly what happened with driver installs (#842). So this shows the two
+ * things that answer "is it stuck?": how far through it is, and which file it is
+ * on right now.
+ *
+ * It dismisses ITSELF on success, after a short pause. The pause is the point —
+ * vanishing the instant the last file lands makes it look like something went
+ * wrong, and leaving it up makes the user close a box that has nothing left to
+ * say. On FAILURE it stays put: an error the user did not see is an error that
+ * did not happen, as far as they are concerned.
+ */
+export function TransferProgressDialog({
+  title,
+  rows,
+  running,
+  error,
+  onClose,
+  onCancel
+}: TransferProgressDialogProps): JSX.Element {
+  const done = rows.filter((r) => r.state === 'done').length
+  const total = rows.length
+  const pct = total === 0 ? 100 : Math.round((done / total) * 100)
+  const listRef = useRef<HTMLUListElement>(null)
+
+  // Auto-dismiss, but only when there is nothing to read.
+  useEffect(() => {
+    if (running || error) return
+    const t = setTimeout(onClose, AUTO_DISMISS_MS)
+    return () => clearTimeout(t)
+  }, [running, error, onClose])
+
+  // Keep the file being copied in view; a long folder scrolls past otherwise.
+  useEffect(() => {
+    const el = listRef.current?.querySelector('.transfer__row--copying')
+    el?.scrollIntoView({ block: 'nearest' })
+  }, [rows])
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key !== 'Escape') return
+      // Escape means "stop", not "hide" — a dialog dismissed mid-copy would
+      // leave the transfer running with nothing reporting it.
+      if (running) onCancel()
+      else onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [running, onCancel, onClose])
+
+  return (
+    <div className="transfer__backdrop" role="presentation">
+      <div
+        className="transfer"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="transfer-title"
+        aria-busy={running}
+      >
+        <h2 className="transfer__title" id="transfer-title">
+          {title}
+        </h2>
+
+        <div
+          className="transfer__bar"
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={pct}
+          aria-label="Copy progress"
+        >
+          <div
+            className={`transfer__bar-fill${error ? ' transfer__bar-fill--error' : ''}`}
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+
+        <p className="transfer__count">
+          {error ? 'Stopped' : running ? 'Copying' : 'Copied'} {done} of {total}{' '}
+          {total === 1 ? 'file' : 'files'}
+        </p>
+
+        <ul className="transfer__list" ref={listRef}>
+          {rows.map((row) => (
+            <li key={row.label} className={`transfer__row transfer__row--${row.state}`}>
+              <span className="transfer__tick" aria-hidden="true">
+                {row.state === 'done' ? '☑' : row.state === 'error' ? '☒' : '☐'}
+              </span>
+              <span className="transfer__name" title={row.error ?? row.label}>
+                {row.label}
+              </span>
+            </li>
+          ))}
+        </ul>
+
+        {error && <p className="transfer__error">{error}</p>}
+
+        <div className="transfer__actions">
+          {running ? (
+            <button type="button" className="transfer__btn" onClick={onCancel}>
+              Cancel
+            </button>
+          ) : (
+            <button type="button" className="transfer__btn transfer__btn--primary" onClick={onClose}>
+              Close
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/UploadControls.tsx
+++ b/src/renderer/src/components/UploadControls.tsx
@@ -1,8 +1,12 @@
-import { useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { useWorkspace } from '../store/workspace'
 import { IS_WEB } from '../lib/env'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { usePrompt } from './PromptModal'
+import { useFileSelection } from '../store/file-selection'
+import { planUploadOf, runFolderUpload } from '../lib/folder-transfer'
+import { TransferProgressDialog, type TransferRow } from './TransferProgressDialog'
+import { hostBaseName } from '../../../shared/transfer-plan'
 import './UploadControls.css'
 
 type Feedback = { kind: 'success' | 'error' | 'info'; message: string } | null
@@ -66,13 +70,93 @@ export function UploadControls(): JSX.Element {
   const [busy, setBusy] = useState(false)
   const [feedback, setFeedback] = useState<Feedback>(null)
 
+  // Folder transfer (#848): the two panes' selections + the progress dialog.
+  const { local: localSel, deviceTargetDir } = useFileSelection()
+  const [transfer, setTransfer] = useState<{
+    title: string
+    rows: TransferRow[]
+    running: boolean
+    error: string | null
+  } | null>(null)
+  const cancelled = useRef(false)
+
   const activeFile = openFiles.find((f) => f.id === activeId) ?? null
 
-  const canUpload = connected && !!activeFile && !busy
+  // A highlighted FOLDER on the left turns the same button into "send that
+  // folder". It takes precedence over the active buffer: the user pointed at
+  // something specific, and quietly uploading a different file instead would be
+  // the wrong kind of clever.
+  const folderToUpload = localSel?.isDir ? localSel.path : null
+
+  const canUpload = connected && (!!folderToUpload || !!activeFile) && !busy
   const canDownload = !!activeFile && activeFile.source === 'device' && !busy
 
+  /** Copy the highlighted local folder into the highlighted device folder. */
+  const uploadFolder = useCallback(
+    async (localRoot: string): Promise<void> => {
+      cancelled.current = false
+      setBusy(true)
+      setFeedback(null)
+      const name = hostBaseName(localRoot)
+      const title = `Copying ${name} → ${deviceTargetDir}`
+      // Plan BEFORE the dialog claims a file count, so the list it shows is the
+      // real one rather than a guess that grows as the walk catches up.
+      setTransfer({ title, rows: [], running: true, error: null })
+      try {
+        const plan = await planUploadOf(localRoot, deviceTargetDir)
+        setTransfer({
+          title: `Copying ${name} → ${plan.root}`,
+          rows: plan.files.map((f) => ({ label: f.label, state: 'pending' as const })),
+          running: true,
+          error: null
+        })
+
+        const result = await runFolderUpload(
+          plan,
+          (event) => {
+            setTransfer((prev) =>
+              prev
+                ? {
+                    ...prev,
+                    rows: prev.rows.map((row, i) =>
+                      i === event.index
+                        ? { ...row, state: event.state, error: event.error }
+                        : row
+                    )
+                  }
+                : prev
+            )
+          },
+          () => cancelled.current
+        )
+
+        setTransfer((prev) =>
+          prev ? { ...prev, running: false, error: result.ok ? null : (result.error ?? null) } : prev
+        )
+        setFeedback(
+          result.ok
+            ? {
+                kind: 'success',
+                message: `Copied ${result.copied} file${result.copied === 1 ? '' : 's'} to ${plan.root}.`
+              }
+            : { kind: 'error', message: `Copy stopped: ${result.error}` }
+        )
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        setTransfer((prev) => (prev ? { ...prev, running: false, error: message } : prev))
+        setFeedback({ kind: 'error', message: `Copy failed: ${message}` })
+      } finally {
+        setBusy(false)
+      }
+    },
+    [deviceTargetDir]
+  )
+
   async function handleUpload(): Promise<void> {
-    if (!activeFile || !connected) return
+    if (!connected) return
+    // A highlighted folder wins over the active buffer (#848).
+    if (folderToUpload) return uploadFolder(folderToUpload)
+    if (!activeFile) return
     const defaultPath = `/${activeFile.name}`
     const destPath = await prompt('Upload to device path:', defaultPath)
     if (destPath == null) return // cancelled
@@ -140,9 +224,11 @@ export function UploadControls(): JSX.Element {
 
   const uploadTitle = !connected
     ? 'Connect a device to upload'
-    : !activeFile
-      ? 'Open a file to upload'
-      : `Upload ${activeFile.name} to device`
+    : folderToUpload
+      ? `Copy the folder ${hostBaseName(folderToUpload)} into ${deviceTargetDir} on the device`
+      : !activeFile
+        ? 'Select a folder, or open a file, to upload'
+        : `Upload ${activeFile.name} to device`
 
   const downloadTitle = !activeFile
     ? 'Open a file to download'
@@ -177,6 +263,18 @@ export function UploadControls(): JSX.Element {
           <ArrowDownIcon />
         </button>
       </div>
+      {transfer && (
+        <TransferProgressDialog
+          title={transfer.title}
+          rows={transfer.rows}
+          running={transfer.running}
+          error={transfer.error}
+          onCancel={() => {
+            cancelled.current = true
+          }}
+          onClose={() => setTransfer(null)}
+        />
+      )}
       {feedback && (
         <p
           className={`upload-controls__feedback upload-controls__feedback--${feedback.kind}`}

--- a/src/renderer/src/lib/folder-transfer.ts
+++ b/src/renderer/src/lib/folder-transfer.ts
@@ -1,0 +1,127 @@
+/**
+ * Walking a local folder and copying it to the board (#848).
+ *
+ * The DECISIONS — where each file lands, what gets skipped, what order
+ * directories are made in — live in `shared/transfer-plan.ts`, which is pure and
+ * tested. This module is the part that has to touch the disk and the board, and
+ * it is deliberately thin: walk, then execute a plan someone else worked out.
+ *
+ * Progress is reported per FILE rather than per byte. `FsEntry` carries no size,
+ * so a byte-accurate bar would mean a `stat` round trip for every file in the
+ * tree before a single one was copied — paying a real cost up front to make a
+ * bar smoother. The tick list the user sees is per-file anyway, so the two agree.
+ */
+import {
+  planFolderUpload,
+  shouldSkip,
+  type LocalEntry,
+  type TransferPlan
+} from '../../../shared/transfer-plan'
+
+/** What the progress dialog is told as a transfer runs. */
+export interface TransferEvent {
+  /** Index of the file just acted on, 0-based. */
+  index: number
+  /** How many files the whole transfer covers. */
+  total: number
+  /** The file's path relative to the folder being sent. */
+  label: string
+  /** `copying` when it starts, then one of the terminal two. */
+  state: 'copying' | 'done' | 'error'
+  /** Set when `state` is `error`. */
+  error?: string
+}
+
+export type TransferReporter = (event: TransferEvent) => void
+
+/** How deep a walk will go before giving up. */
+const MAX_DEPTH = 24
+
+/**
+ * Flatten a local folder into the entries a plan is built from.
+ *
+ * Skipped names (`.git`, `__pycache__`, …) are dropped WITH their contents — a
+ * skipped directory is never descended into, which is the whole point: the cost
+ * of `.git` is its thousands of objects, not its name.
+ *
+ * `MAX_DEPTH` is a loop guard, not a policy. A symlink cycle on the host would
+ * otherwise walk until the renderer runs out of memory, and no real board
+ * project is twenty-four directories deep.
+ */
+export async function walkLocalFolder(root: string): Promise<LocalEntry[]> {
+  const out: LocalEntry[] = []
+
+  async function visit(dir: string, depth: number): Promise<void> {
+    if (depth > MAX_DEPTH) return
+    const entries = await window.api.fs.readDir(dir)
+    for (const entry of entries) {
+      if (shouldSkip(entry.name, entry.isDir)) continue
+      out.push({ path: entry.path, isDir: entry.isDir })
+      if (entry.isDir) await visit(entry.path, depth + 1)
+    }
+  }
+
+  await visit(root, 0)
+  return out
+}
+
+/** Walk `localRoot` and work out everything that copying it into `deviceDir` means. */
+export async function planUploadOf(localRoot: string, deviceDir: string): Promise<TransferPlan> {
+  return planFolderUpload(localRoot, await walkLocalFolder(localRoot), deviceDir)
+}
+
+/**
+ * Execute a plan: make the directories, then copy the files.
+ *
+ * Every file goes over the BYTES channel. A folder is not a `.py` file — it can
+ * hold a font, a `.mpy`, an image — and the text channel round-trips through
+ * UTF-8, which corrupts all three silently. Sending everything as bytes costs
+ * nothing extra and removes a whole class of "it uploaded fine but the board
+ * can't read it".
+ *
+ * An existing directory is not an error: `mkdir` raises `EEXIST` for one, and a
+ * second upload into the same place is a normal thing to do.
+ *
+ * Stops at the first FILE that fails. A half-copied folder is bad, but carrying
+ * on after a failure and reporting success at the end is worse — the user would
+ * have a folder that looks complete and is not.
+ */
+export async function runFolderUpload(
+  plan: TransferPlan,
+  report: TransferReporter,
+  isCancelled: () => boolean = () => false
+): Promise<{ ok: boolean; error?: string; copied: number }> {
+  for (const dir of plan.dirs) {
+    if (isCancelled()) return { ok: false, error: 'Cancelled.', copied: 0 }
+    try {
+      await window.api.device.mkdir(dir)
+    } catch {
+      // Already there — the only failure this is allowed to swallow. A dir that
+      // genuinely cannot be made surfaces on the first write into it.
+    }
+  }
+
+  let copied = 0
+  for (let i = 0; i < plan.files.length; i++) {
+    if (isCancelled()) return { ok: false, error: 'Cancelled.', copied }
+    const file = plan.files[i]
+    report({ index: i, total: plan.files.length, label: file.label, state: 'copying' })
+    try {
+      const bytes = await window.api.fs.readFileBytes(file.local)
+      await window.api.device.writeFileBytes(file.device, bytes)
+      copied++
+      report({ index: i, total: plan.files.length, label: file.label, state: 'done' })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      report({
+        index: i,
+        total: plan.files.length,
+        label: file.label,
+        state: 'error',
+        error: message
+      })
+      return { ok: false, error: `${file.label}: ${message}`, copied }
+    }
+  }
+  return { ok: true, copied }
+}

--- a/src/renderer/src/store/file-selection.tsx
+++ b/src/renderer/src/store/file-selection.tsx
@@ -1,0 +1,91 @@
+/**
+ * What is highlighted in each half of the Files panel (#848).
+ *
+ * Both trees already track their own selection, and that was fine while nothing
+ * else needed to know. "Copy the selected folder into the selected folder" needs
+ * BOTH at once, from a third component that sits between them and owns neither —
+ * so the selections are published here rather than lifted into either tree.
+ *
+ * Deliberately a plain context holding two small values. It is not a mirror of
+ * the trees' internal state: the trees stay in charge of what selection MEANS
+ * (multi-select, shift ranges, drop targets), and simply announce the one thing
+ * the transfer bridge has to know.
+ */
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react'
+
+/** A highlighted row, on either side. */
+export interface FileSelection {
+  /** Absolute path — a host path on the local side, a device path on the board side. */
+  path: string
+  /** True when the row is a directory. */
+  isDir: boolean
+}
+
+export interface FileSelectionStore {
+  /** The highlighted row in the local (computer) tree. */
+  local: FileSelection | null
+  /** The highlighted row in the device (board) tree. */
+  device: FileSelection | null
+  setLocal: (selection: FileSelection | null) => void
+  setDevice: (selection: FileSelection | null) => void
+  /**
+   * The device DIRECTORY a transfer should land in.
+   *
+   * A file is a perfectly reasonable thing to have highlighted, and it names a
+   * folder just as well — its parent. Returning `/` when nothing is selected
+   * means the button is never dead for want of a click in the other pane.
+   */
+  deviceTargetDir: string
+}
+
+const FileSelectionContext = createContext<FileSelectionStore | null>(null)
+
+/** The parent directory of a device path: `/lib/x.py` → `/lib`, `/x.py` → `/`. */
+export function parentOf(path: string): string {
+  const parts = path.split('/').filter(Boolean)
+  parts.pop()
+  return parts.length === 0 ? '/' : `/${parts.join('/')}`
+}
+
+/** Resolve a selection to the device folder a transfer targets. */
+export function targetDirFor(selection: FileSelection | null): string {
+  if (!selection) return '/'
+  return selection.isDir ? selection.path : parentOf(selection.path)
+}
+
+export function FileSelectionProvider({ children }: { children: ReactNode }): JSX.Element {
+  const [local, setLocalState] = useState<FileSelection | null>(null)
+  const [device, setDeviceState] = useState<FileSelection | null>(null)
+
+  const setLocal = useCallback((s: FileSelection | null) => setLocalState(s), [])
+  const setDevice = useCallback((s: FileSelection | null) => setDeviceState(s), [])
+
+  const value = useMemo<FileSelectionStore>(
+    () => ({ local, device, setLocal, setDevice, deviceTargetDir: targetDirFor(device) }),
+    [local, device, setLocal, setDevice]
+  )
+
+  return (
+    <FileSelectionContext.Provider value={value}>{children}</FileSelectionContext.Provider>
+  )
+}
+
+/**
+ * Read the current selections.
+ *
+ * Returns an inert store when no provider is above it, so a tree rendered on its
+ * own (a test, a pop-out window) still works — publishing a selection nothing
+ * listens to is harmless, and the alternative is a crash in a file panel.
+ */
+export function useFileSelection(): FileSelectionStore {
+  const ctx = useContext(FileSelectionContext)
+  return (
+    ctx ?? {
+      local: null,
+      device: null,
+      setLocal: () => undefined,
+      setDevice: () => undefined,
+      deviceTargetDir: '/'
+    }
+  )
+}

--- a/src/renderer/src/store/sync.ts
+++ b/src/renderer/src/store/sync.ts
@@ -35,6 +35,25 @@ import {
   type ReactNode
 } from 'react'
 import { baseName, FILE_SAVED_EVENT, type FileSavedDetail } from './workspace'
+import { useFileSelection } from './file-selection'
+import { planUploadOf, runFolderUpload } from '../lib/folder-transfer'
+
+/**
+ * Is this local path a directory? (#848)
+ *
+ * Asked at SYNC time rather than remembered at tag time: a path tagged as a
+ * file could have been replaced by a folder since, and the tag list is
+ * persisted across sessions where anything may have happened to the disk.
+ * Anything unreadable answers "not a directory", so it takes the plain
+ * single-file route and fails there with a real message.
+ */
+async function isDirectory(path: string): Promise<boolean> {
+  try {
+    return (await window.api.fs.stat(path)).isDir
+  } catch {
+    return false
+  }
+}
 
 /** localStorage keys for the tagged paths + the sync-on-save flag. */
 const SYNCED_KEY = 'snakie.sync.paths'
@@ -147,6 +166,14 @@ function saveSyncOnSave(on: boolean): void {
 const SyncContext = createContext<SyncStore | null>(null)
 
 export function SyncProvider({ children }: { children: ReactNode }): JSX.Element {
+  // Where a tagged FOLDER lands. Held in a ref so the push loop reads the
+  // highlight as it is when the sync runs, not as it was when the callback was
+  // created — the user picks the destination by clicking it, and a stale
+  // closure would send the folder to wherever they had clicked previously.
+  const { deviceTargetDir } = useFileSelection()
+  const deviceTargetDirRef = useRef(deviceTargetDir)
+  deviceTargetDirRef.current = deviceTargetDir
+
   const [syncedPaths, setSyncedPaths] = useState<string[]>(() => loadSyncedPaths())
   const [syncOnSave, setSyncOnSaveState] = useState<boolean>(() => loadSyncOnSave())
   const [status, setStatus] = useState<SyncStatus>('idle')
@@ -210,6 +237,20 @@ export function SyncProvider({ children }: { children: ReactNode }): JSX.Element
       emitSyncStatus(`Syncing ${label}…`)
       try {
         for (const path of paths) {
+          // A tagged FOLDER syncs itself and everything under it, into whichever
+          // device folder is highlighted right now (#848). Tagging a folder is
+          // what people actually mean — tagging its files one at a time both
+          // misses newly added ones and is tedious.
+          //
+          // Files keep their existing destination (`/<basename>`) rather than
+          // following the highlight: changing that would silently relocate
+          // every file anyone already had tagged.
+          if (await isDirectory(path)) {
+            const plan = await planUploadOf(path, deviceTargetDirRef.current)
+            const result = await runFolderUpload(plan, () => undefined)
+            if (!result.ok) throw new Error(result.error ?? `Could not sync ${baseName(path)}`)
+            continue
+          }
           const content = await window.api.fs.readFile(path)
           await window.api.device.writeFile(deviceDestForLocal(path), content)
         }

--- a/src/shared/transfer-plan.ts
+++ b/src/shared/transfer-plan.ts
@@ -1,0 +1,221 @@
+/**
+ * Planning a folder → board transfer (#848).
+ *
+ * Uploading a folder is not "upload, but more times". It has to decide where
+ * every file LANDS, and getting that wrong writes someone's project into the
+ * wrong place on a board they then have to clean up by hand. So the mapping is
+ * worked out here — as pure functions over a walked list — and the part that
+ * actually touches the device just executes the plan.
+ *
+ * Dependency-free (no Electron, no `fs`, no React) for the usual reason: this is
+ * the half worth unit-testing, and it is testable only if a board and a disk are
+ * not required to ask it a question.
+ *
+ * ## Host paths in, device paths out
+ *
+ * Host paths arrive in whatever the platform uses — `C:\Users\kev\lib` on
+ * Windows, `/Users/kev/lib` elsewhere. Device paths are ALWAYS POSIX, absolute,
+ * and `/`-separated, because that is what MicroPython's filesystem is. Every
+ * function here takes the former and returns the latter; nothing round-trips a
+ * device path back into a host one.
+ */
+
+/** One entry from a walked local folder. Absolute host path. */
+export interface LocalEntry {
+  /** Absolute path on the host. */
+  path: string
+  /** True for a directory. */
+  isDir: boolean
+  /** Size in bytes; used only for the progress bar's denominator. */
+  size?: number
+}
+
+/** One file to copy, resolved to both ends. */
+export interface TransferFile {
+  /** Absolute host path to read. */
+  local: string
+  /** Absolute device path to write. */
+  device: string
+  /** Path shown in the progress dialog — relative to the folder being sent. */
+  label: string
+  /** Size in bytes, when the walk reported one. */
+  size: number
+}
+
+/** Everything a folder upload needs to do, in the order it must be done. */
+export interface TransferPlan {
+  /** The device folder the upload creates, e.g. `/lib/mylib`. */
+  root: string
+  /** Directories to create, PARENTS FIRST. */
+  dirs: string[]
+  /** Files to write, in walk order. */
+  files: TransferFile[]
+  /** Sum of `size` across `files`, for a byte-accurate progress bar. */
+  totalBytes: number
+}
+
+/** Split a host path on either separator, dropping empty segments. */
+function hostSegments(path: string): string[] {
+  return path.split(/[/\\]+/).filter(Boolean)
+}
+
+/**
+ * The last segment of a host path — the folder or file name.
+ *
+ * Trailing separators are ignored, so `/a/b/` and `/a/b` both name `b`. A path
+ * that is nothing but separators has no name and returns `''`, which callers
+ * treat as "not a usable source".
+ */
+export function hostBaseName(path: string): string {
+  const parts = hostSegments(path)
+  return parts.length > 0 ? parts[parts.length - 1] : ''
+}
+
+/**
+ * Normalise a device path: absolute, `/`-separated, no trailing slash.
+ *
+ * `''` and `'/'` both mean the root, which is the one path allowed to end in a
+ * slash — because it is nothing but one.
+ */
+export function normaliseDevicePath(path: string): string {
+  const parts = path.split(/[/\\]+/).filter(Boolean)
+  return parts.length === 0 ? '/' : `/${parts.join('/')}`
+}
+
+/** Join device path segments into one absolute, normalised device path. */
+export function deviceJoin(...parts: string[]): string {
+  return normaliseDevicePath(parts.join('/'))
+}
+
+/**
+ * Where `localPath` lands, given the folder being sent and the device folder it
+ * is being sent into.
+ *
+ * `localRoot` is the folder the user picked; its own NAME is part of the
+ * destination, so sending `~/code/mylib` into `/lib` produces `/lib/mylib/...`
+ * rather than scattering `mylib`'s contents directly into `/lib`. That is what
+ * "copy the folder into that folder" means everywhere else a file manager does
+ * it, and the alternative silently merges two trees.
+ *
+ * Returns `null` when `localPath` is not inside `localRoot` — a caller that
+ * walked a different tree than it planned would otherwise write files to
+ * confidently wrong places.
+ */
+export function deviceDestFor(
+  localRoot: string,
+  localPath: string,
+  deviceDir: string
+): string | null {
+  const rootParts = hostSegments(localRoot)
+  const pathParts = hostSegments(localPath)
+  const folderName = rootParts[rootParts.length - 1]
+  if (!folderName) return null
+  if (pathParts.length < rootParts.length) return null
+
+  // Compare case-sensitively: macOS and Windows are usually case-insensitive,
+  // but a mismatch here means the caller mixed up two trees, and quietly
+  // accepting it is how files land somewhere nobody chose.
+  for (let i = 0; i < rootParts.length; i++) {
+    if (rootParts[i] !== pathParts[i]) return null
+  }
+
+  const relative = pathParts.slice(rootParts.length)
+  return deviceJoin(deviceDir, folderName, ...relative)
+}
+
+/**
+ * Turn a walked folder into an ordered plan.
+ *
+ * `entries` is the flattened walk of `localRoot` (absolute host paths, dirs
+ * included). Order in, order out — except that directories are collected
+ * separately and sorted SHORTEST FIRST, because `mkdir` cannot create `/a/b`
+ * before `/a` and a walk is not obliged to hand them over in that order.
+ *
+ * The folder's own directory is always the first entry of `dirs`, even when the
+ * folder is empty: uploading an empty folder should still produce that folder.
+ */
+export function planFolderUpload(
+  localRoot: string,
+  entries: readonly LocalEntry[],
+  deviceDir: string
+): TransferPlan {
+  const folderName = hostBaseName(localRoot)
+  const root = deviceJoin(deviceDir, folderName)
+
+  const dirs = new Set<string>([root])
+  const files: TransferFile[] = []
+  const rootPrefixLen = hostSegments(localRoot).length
+
+  for (const entry of entries) {
+    const dest = deviceDestFor(localRoot, entry.path, deviceDir)
+    if (!dest) continue
+    if (entry.isDir) {
+      dirs.add(dest)
+      continue
+    }
+    files.push({
+      local: entry.path,
+      device: dest,
+      label: hostSegments(entry.path).slice(rootPrefixLen).join('/'),
+      size: entry.size ?? 0
+    })
+    // Every ancestor up to the root must exist before the file is written. A
+    // walk that lists files without their parent directories (or that we
+    // filtered) would otherwise fail on the first nested write.
+    const parts = dest.split('/').filter(Boolean)
+    for (let i = 1; i < parts.length; i++) {
+      const ancestor = `/${parts.slice(0, i).join('/')}`
+      // At or BELOW the upload root only. The target folder and everything
+      // above it is what the user selected — it already exists, and proposing
+      // to create it would have the transfer try to mkdir `/lib` on the way in.
+      if (ancestor === root || ancestor.startsWith(`${root}/`)) dirs.add(ancestor)
+    }
+  }
+
+  return {
+    root,
+    dirs: [...dirs]
+      // Parents first. Depth is the only thing that matters; the alphabetical
+      // tiebreak just makes the order deterministic for the tests.
+      .filter((d) => d !== '/')
+      .sort((a, b) => a.split('/').length - b.split('/').length || a.localeCompare(b)),
+    files,
+    totalBytes: files.reduce((sum, f) => sum + f.size, 0)
+  }
+}
+
+/**
+ * Should this file be sent to a board at all?
+ *
+ * A source folder on a developer's machine is full of things a microcontroller
+ * has no use for and no room for — a `.git` directory alone would exhaust a
+ * Pico's filesystem. Skipping them is not a preference, it is what makes
+ * "upload this folder" a safe thing to click.
+ *
+ * Deliberately a small, boring list of things that are never board files. It is
+ * NOT a general ignore mechanism: anything the user actually wrote gets sent.
+ */
+const SKIP_DIRS = new Set([
+  '.git',
+  '.svn',
+  '.hg',
+  '__pycache__',
+  'node_modules',
+  '.venv',
+  'venv',
+  '.mypy_cache',
+  '.pytest_cache',
+  '.idea',
+  '.vscode'
+])
+
+/** Files that are host bookkeeping and never belong on a board. */
+const SKIP_FILES = new Set(['.DS_Store', 'Thumbs.db', '.gitignore', '.gitattributes'])
+
+/** True when a walked name should be left on the host. */
+export function shouldSkip(name: string, isDir: boolean): boolean {
+  if (isDir) return SKIP_DIRS.has(name)
+  if (SKIP_FILES.has(name)) return true
+  // Editor droppings and compiled Python: never useful on the board.
+  return name.endsWith('.pyc') || name.endsWith('~')
+}

--- a/test/folderTransferUi.test.ts
+++ b/test/folderTransferUi.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { parentOf, targetDirFor } from '../src/renderer/src/store/file-selection'
+
+describe('device target directory (#848)', () => {
+  it('reads a parent off a device path', () => {
+    expect(parentOf('/lib/x.py')).toBe('/lib')
+    expect(parentOf('/x.py')).toBe('/')
+    expect(parentOf('/lib/sub/x.py')).toBe('/lib/sub')
+    expect(parentOf('/')).toBe('/')
+  })
+
+  it('uses a highlighted FOLDER as the destination', () => {
+    expect(targetDirFor({ path: '/lib', isDir: true })).toBe('/lib')
+  })
+
+  it('uses a highlighted FILE’s folder', () => {
+    // Highlighting a file names a folder perfectly well — its parent — so the
+    // button is not dead just because the click landed on a file.
+    expect(targetDirFor({ path: '/lib/thing.py', isDir: false })).toBe('/lib')
+  })
+
+  it('falls back to the device root when nothing is highlighted', () => {
+    expect(targetDirFor(null)).toBe('/')
+  })
+})
+
+describe('the transfer dialog reports the two things that answer "is it stuck?"', () => {
+  const src = readFileSync(
+    'src/renderer/src/components/TransferProgressDialog.tsx',
+    'utf8'
+  )
+
+  it('shows a progress bar with real ARIA values', () => {
+    expect(src).toContain('role="progressbar"')
+    expect(src).toMatch(/aria-valuenow=\{pct\}/)
+  })
+
+  it('ticks each file as it lands', () => {
+    // ☑ done, ☒ failed, ☐ not yet — the list is the receipt.
+    expect(src).toContain("row.state === 'done' ? '☑'")
+    expect(src).toContain("row.state === 'error' ? '☒'")
+  })
+
+  it('dismisses itself on success but STAYS on failure', () => {
+    // An error the user did not see is an error that did not happen, to them.
+    expect(src).toMatch(/if \(running \|\| error\) return/)
+    expect(src).toContain('setTimeout(onClose, AUTO_DISMISS_MS)')
+  })
+
+  it('treats Escape as "stop", not "hide", while running', () => {
+    // Dismissing mid-copy would leave the transfer running with nothing
+    // reporting it.
+    expect(src).toMatch(/if \(running\) onCancel\(\)/)
+  })
+})
+
+describe('the wiring holds the pieces together', () => {
+  it('publishes both trees’ selections', () => {
+    for (const f of ['LocalFileTree', 'DeviceFileTree']) {
+      const src = readFileSync(`src/renderer/src/components/${f}.tsx`, 'utf8')
+      expect(src, f).toContain('useFileSelection')
+    }
+  })
+
+  it('lets a highlighted folder take precedence over the active buffer', () => {
+    // The user pointed at something specific; uploading a different file
+    // instead would be the wrong kind of clever.
+    const src = readFileSync('src/renderer/src/components/UploadControls.tsx', 'utf8')
+    expect(src).toContain('if (folderToUpload) return uploadFolder(folderToUpload)')
+  })
+
+  it('sends every file over the BYTES channel', () => {
+    // A folder can hold a font, a .mpy, an image; the text channel round-trips
+    // through UTF-8 and corrupts all three silently.
+    const src = readFileSync('src/renderer/src/lib/folder-transfer.ts', 'utf8')
+    expect(src).toContain('window.api.device.writeFileBytes')
+    expect(src).not.toContain('window.api.device.writeFile(')
+  })
+
+  it('stops at the first failed file rather than reporting success at the end', () => {
+    const src = readFileSync('src/renderer/src/lib/folder-transfer.ts', 'utf8')
+    expect(src).toMatch(/return \{ ok: false, error: `\$\{file\.label\}/)
+  })
+
+  it('syncs a tagged folder into the highlight, read at sync time', () => {
+    // A stale closure would send the folder wherever the user had clicked
+    // previously.
+    const src = readFileSync('src/renderer/src/store/sync.ts', 'utf8')
+    expect(src).toContain('deviceTargetDirRef.current')
+    expect(src).toContain('await isDirectory(path)')
+  })
+})

--- a/test/transferPlan.test.ts
+++ b/test/transferPlan.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest'
+import {
+  deviceDestFor,
+  deviceJoin,
+  hostBaseName,
+  normaliseDevicePath,
+  planFolderUpload,
+  shouldSkip,
+  type LocalEntry
+} from '../src/shared/transfer-plan'
+
+describe('device path shaping', () => {
+  it('normalises to an absolute, single-separator path', () => {
+    expect(normaliseDevicePath('lib/foo')).toBe('/lib/foo')
+    expect(normaliseDevicePath('/lib//foo/')).toBe('/lib/foo')
+    expect(normaliseDevicePath('')).toBe('/')
+    expect(normaliseDevicePath('/')).toBe('/')
+  })
+
+  it('joins without doubling or dropping separators', () => {
+    expect(deviceJoin('/lib', 'mylib')).toBe('/lib/mylib')
+    expect(deviceJoin('/', 'mylib')).toBe('/mylib')
+    expect(deviceJoin('/lib/', '/mylib/', 'a.py')).toBe('/lib/mylib/a.py')
+  })
+
+  it('reads a folder name off either platform separator', () => {
+    expect(hostBaseName('/Users/kev/code/mylib')).toBe('mylib')
+    expect(hostBaseName('C:\\Users\\kev\\code\\mylib')).toBe('mylib')
+    expect(hostBaseName('/Users/kev/code/mylib/')).toBe('mylib')
+    expect(hostBaseName('/')).toBe('')
+  })
+})
+
+describe('deviceDestFor', () => {
+  it('copies the folder INTO the target, keeping its own name', () => {
+    // What every file manager means by "copy this folder into that folder".
+    // Flattening the contents straight into the target would silently merge
+    // two trees instead.
+    expect(deviceDestFor('/Users/kev/mylib', '/Users/kev/mylib/a.py', '/lib')).toBe(
+      '/lib/mylib/a.py'
+    )
+  })
+
+  it('preserves nesting', () => {
+    expect(deviceDestFor('/Users/kev/mylib', '/Users/kev/mylib/sub/deep/b.py', '/lib')).toBe(
+      '/lib/mylib/sub/deep/b.py'
+    )
+  })
+
+  it('handles the device root as a target', () => {
+    expect(deviceDestFor('/Users/kev/mylib', '/Users/kev/mylib/a.py', '/')).toBe('/mylib/a.py')
+  })
+
+  it('maps Windows sources onto POSIX device paths', () => {
+    expect(deviceDestFor('C:\\code\\mylib', 'C:\\code\\mylib\\sub\\a.py', '/lib')).toBe(
+      '/lib/mylib/sub/a.py'
+    )
+  })
+
+  it('refuses a path that is not inside the root', () => {
+    // A caller that walked a different tree than it planned would otherwise
+    // write files to confidently wrong places.
+    expect(deviceDestFor('/Users/kev/mylib', '/Users/kev/other/a.py', '/lib')).toBeNull()
+    expect(deviceDestFor('/Users/kev/mylib', '/Users/kev', '/lib')).toBeNull()
+  })
+})
+
+describe('planFolderUpload', () => {
+  const root = '/Users/kev/mylib'
+  const entries: LocalEntry[] = [
+    { path: '/Users/kev/mylib/sub', isDir: true },
+    { path: '/Users/kev/mylib/sub/deep/b.py', isDir: false, size: 200 },
+    { path: '/Users/kev/mylib/a.py', isDir: false, size: 100 },
+    { path: '/Users/kev/mylib/sub/deep', isDir: true }
+  ]
+
+  it('creates parent directories before their children', () => {
+    // `mkdir` cannot make /a/b before /a, and a walk is not obliged to hand
+    // them over in that order.
+    const plan = planFolderUpload(root, entries, '/lib')
+    expect(plan.dirs).toEqual(['/lib/mylib', '/lib/mylib/sub', '/lib/mylib/sub/deep'])
+  })
+
+  it('infers directories a walk did not list', () => {
+    // A file whose parent was never listed must still get its parent made.
+    const plan = planFolderUpload(
+      root,
+      [{ path: '/Users/kev/mylib/x/y/z.py', isDir: false, size: 1 }],
+      '/lib'
+    )
+    expect(plan.dirs).toEqual(['/lib/mylib', '/lib/mylib/x', '/lib/mylib/x/y'])
+  })
+
+  it('never proposes creating the device root', () => {
+    const plan = planFolderUpload(root, entries, '/')
+    expect(plan.dirs).not.toContain('/')
+    expect(plan.root).toBe('/mylib')
+  })
+
+  it('resolves every file to both ends, with a readable label', () => {
+    const plan = planFolderUpload(root, entries, '/lib')
+    expect(plan.files).toEqual([
+      {
+        local: '/Users/kev/mylib/sub/deep/b.py',
+        device: '/lib/mylib/sub/deep/b.py',
+        label: 'sub/deep/b.py',
+        size: 200
+      },
+      { local: '/Users/kev/mylib/a.py', device: '/lib/mylib/a.py', label: 'a.py', size: 100 }
+    ])
+  })
+
+  it('totals bytes for the progress bar', () => {
+    expect(planFolderUpload(root, entries, '/lib').totalBytes).toBe(300)
+  })
+
+  it('still creates the folder when it is empty', () => {
+    const plan = planFolderUpload(root, [], '/lib')
+    expect(plan.dirs).toEqual(['/lib/mylib'])
+    expect(plan.files).toEqual([])
+  })
+})
+
+describe('shouldSkip', () => {
+  it('leaves developer bookkeeping on the host', () => {
+    // A .git directory alone would exhaust a Pico's filesystem.
+    for (const d of ['.git', '__pycache__', 'node_modules', '.venv', '.vscode']) {
+      expect(shouldSkip(d, true), d).toBe(true)
+    }
+    expect(shouldSkip('.DS_Store', false)).toBe(true)
+    expect(shouldSkip('main.pyc', false)).toBe(true)
+    expect(shouldSkip('notes.txt~', false)).toBe(true)
+  })
+
+  it('sends everything the user actually wrote', () => {
+    // Not a general ignore mechanism — a boring list of never-board-files.
+    expect(shouldSkip('main.py', false)).toBe(false)
+    expect(shouldSkip('data.json', false)).toBe(false)
+    expect(shouldSkip('lib', true)).toBe(false)
+    expect(shouldSkip('.gitkeep', false)).toBe(false)
+  })
+
+  it('does not skip a FILE that shares a skipped directory name', () => {
+    expect(shouldSkip('.git', false)).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #848.

## Copy a folder

Highlight a folder on the left and a folder on the device, and **Upload to
device** copies the one **into** the other — recursively, keeping its own name
and its nesting, which is what "copy this folder into that folder" means
everywhere else. Previously the button could only send the active editor buffer,
and prompted for a destination path.

A highlighted folder takes precedence over the active buffer: the user pointed at
something specific, and uploading a different file instead would be the wrong
kind of clever.

**Where the logic lives.** The decisions — where each file lands, what is
skipped, what order directories are made in — are pure functions in
`shared/transfer-plan.ts`. That is the half worth testing, and it is only
testable if a board and a disk aren't needed to ask it a question.
`lib/folder-transfer.ts` walks and executes; it decides nothing.

Both trees kept their selection in local component state, and the transfer bridge
sits between them owning neither — so selections are now published through a
small context rather than lifted into either tree.

**Skips developer bookkeeping** (`.git`, `__pycache__`, `node_modules`, `.venv`,
`.DS_Store`, `*.pyc`). Not a preference: a `.git` directory alone would exhaust a
Pico's filesystem, and skipping it is what makes the button safe to click.

**Every file goes over the bytes channel.** A folder can hold a font, an image, a
`.mpy`; the text channel round-trips through UTF-8 and corrupts all three
silently. This needed `device.writeFileBytes` exposed on the preload API — the
IPC channel already existed and the module installer already used it for exactly
this reason.

## Progress

A folder copy is many per-file round trips over serial, so with no feedback it
reads as a hang — precisely what happened with driver installs (#842). The dialog
shows how far through it is and which file it is on, ticking each row as it
lands.

It **dismisses itself on success** after a short pause (vanishing instantly reads
as a fault; leaving it up makes the user close a box with nothing left to say)
and **stays on failure**, because an error nobody saw did not happen. Escape
means *stop*, not *hide* — dismissing mid-copy would leave the transfer running
with nothing reporting it.

## Sync folders

The checkbox was rendered only for non-directories, and `deviceDestForLocal`
hard-codes `/<basename>` — so sync could only ever write to the device **root**.
Folders are now taggable, and a tagged folder goes into whichever device folder
is highlighted, read at sync time through a ref (the user picks the destination
by clicking it; a stale closure would use wherever they clicked previously).

Tagged **files** keep their existing destination — changing that would silently
relocate every file anyone already had tagged.

## Verified on real hardware

ESP32, MicroPython v1.29.0:

```
DIRS : ["/lib/mylib","/lib/mylib/sub","/lib/mylib/sub/deep"]
ON BOARD:
  /lib/mylib/a.py 12        /lib/mylib/sub/b.py 6
  /lib/mylib/logo.png 13    /lib/mylib/sub/deep/c.py 6
PNG identical: true
```

Nested directories made parents-first, the skip list honoured, and the embedded
PNG copied back byte-for-byte — which is what the bytes channel buys.

Gates: lint, typecheck, build green; **5921 tests** (30 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)