### PR TITLE
fix(device): serialise the whole file-write sequence (#850)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Two device writes at once no longer produce empty files** (#850). Each
+  individual `exec` was serialised, which keeps the raw-REPL protocol intact,
+  but a file write is `open` → chunks → `close` with the handle held in a single
+  global on the board between the steps. Two writes running together interleaved
+  legally at the exec level and destroyed each other: the second `open` rebound
+  the handle, the first write's chunks went elsewhere, and both files ended up
+  created and blank. The whole sequence now takes an exclusive lock, in the
+  desktop device layer and in the web build's client, which had the identical
+  bug. The Upload button also guards against a second click starting a transfer
+  before the first has registered — the disabled state depends on React state,
+  which lands too late to stop a quick double click.
+
+
 ### Added
 
 - **Copy a whole folder to the board from the Files panel** (#848). Highlight a

--- a/src/main/device/MicroPythonDevice.ts
+++ b/src/main/device/MicroPythonDevice.ts
@@ -123,6 +123,39 @@ export class MicroPythonDevice extends EventEmitter implements SnakieDevice {
    */
   private opQueue: Promise<unknown> = Promise.resolve()
 
+  /**
+   * Serializes multi-step FILESYSTEM sequences (#850).
+   *
+   * {@link opQueue} makes each `exec` atomic, which keeps the raw-REPL protocol
+   * intact but is not enough on its own: a file write is `open`, then N chunk
+   * writes, then `close`, and the handle lives in ONE global on the board
+   * (`_snk_f`) that has to survive between them. Two writes running at once
+   * therefore interleave perfectly legally at the exec level and destroy each
+   * other — the second `open` rebinds `_snk_f`, the first write's chunks go to
+   * the second file or nowhere, and both files end up created and EMPTY.
+   *
+   * That is not hypothetical: it is what a folder upload racing a sync push (or
+   * a second click on Upload) produced. Serializing costs nothing real — two
+   * transfers over one UART do not go faster for being interleaved.
+   */
+  private fsQueue: Promise<unknown> = Promise.resolve()
+
+  /**
+   * Run `body` with exclusive use of the board's filesystem scratch state.
+   *
+   * Chains rather than rejects, so a caller never fails because someone else is
+   * mid-transfer; it simply waits its turn. A body that throws does not poison
+   * the queue.
+   */
+  private withFsLock<T>(body: () => Promise<T>): Promise<T> {
+    const run = this.fsQueue.then(body, body)
+    this.fsQueue = run.then(
+      () => undefined,
+      () => undefined
+    )
+    return run
+  }
+
   /** True once we have entered raw REPL and not yet exited it. */
   private inRawRepl = false
 
@@ -917,6 +950,19 @@ export class MicroPythonDevice extends EventEmitter implements SnakieDevice {
   async writeFile(path: string, contents: string | Buffer, chunkSize = 1024): Promise<void> {
     const mount = await this.driveMount()
     if (mount) return driveWriteFile(mount, path, contents)
+    // EXCLUSIVE for the whole open→chunks→close sequence (#850). Per-exec
+    // serialization is not enough: the handle lives in one global between the
+    // steps, so an interleaved second write rebinds it and both files land
+    // empty.
+    return this.withFsLock(() => this.writeFileLocked(path, contents, chunkSize))
+  }
+
+  /** The body of {@link writeFile}; only ever called holding the FS lock. */
+  private async writeFileLocked(
+    path: string,
+    contents: string | Buffer,
+    chunkSize: number
+  ): Promise<void> {
     const data = Buffer.isBuffer(contents) ? contents : Buffer.from(contents, 'utf8')
     // Open the file once, then stream hex chunks via repeated exec calls so we
     // never put a multi-megabyte literal on a single line. `_snk_f` is the one

--- a/src/renderer/src/components/UploadControls.tsx
+++ b/src/renderer/src/components/UploadControls.tsx
@@ -79,6 +79,16 @@ export function UploadControls(): JSX.Element {
     error: string | null
   } | null>(null)
   const cancelled = useRef(false)
+  /**
+   * Guards against a SECOND upload starting before the first has registered
+   * (#850).
+   *
+   * `busy` disables the button, but React state lands asynchronously — two
+   * quick clicks both read the old value, both pass, and two transfers write
+   * the same paths at once. A ref updates synchronously, so the second click
+   * sees the first immediately.
+   */
+  const inFlight = useRef(false)
 
   const activeFile = openFiles.find((f) => f.id === activeId) ?? null
 
@@ -154,6 +164,16 @@ export function UploadControls(): JSX.Element {
 
   async function handleUpload(): Promise<void> {
     if (!connected) return
+    if (inFlight.current) return
+    inFlight.current = true
+    try {
+      await runUpload()
+    } finally {
+      inFlight.current = false
+    }
+  }
+
+  async function runUpload(): Promise<void> {
     // A highlighted folder wins over the active buffer (#848).
     if (folderToUpload) return uploadFolder(folderToUpload)
     if (!activeFile) return

--- a/src/shared/raw-repl.ts
+++ b/src/shared/raw-repl.ts
@@ -109,6 +109,29 @@ export class RawReplClient {
   private opQueue: Promise<unknown> = Promise.resolve()
 
   /**
+   * Serializes multi-step FILESYSTEM sequences (#850) — see the desktop
+   * `MicroPythonDevice` for the full account.
+   *
+   * `opQueue` above makes each `eval` atomic, which is what the raw-REPL
+   * protocol needs and is NOT enough for a file write: that is `open`, then N
+   * chunks, then `close`, with the handle living in one global (`_snk_f`)
+   * between them. Two writes at once interleave legally at the eval level and
+   * wreck each other — the second `open` rebinds the global, the first write's
+   * chunks go elsewhere, and both files end up created and empty.
+   */
+  private fsQueue: Promise<unknown> = Promise.resolve()
+
+  /** Run `body` with exclusive use of the board's filesystem scratch state. */
+  private withFsLock<T>(body: () => Promise<T>): Promise<T> {
+    const run = this.fsQueue.then(body, body)
+    this.fsQueue = run.then(
+      () => undefined,
+      () => undefined
+    )
+    return run
+  }
+
+  /**
    * @param transport the byte transport (Web Serial in the browser).
    * @param onConsole receives user-facing REPL bytes (everything not consumed by
    *        an in-flight exec) — wire to the terminal.
@@ -413,6 +436,16 @@ export class RawReplClient {
   }
 
   async writeFile(path: string, contents: string | Uint8Array, chunkSize = 256): Promise<void> {
+    // EXCLUSIVE for the whole open→chunks→close sequence (#850).
+    return this.withFsLock(() => this.writeFileLocked(path, contents, chunkSize))
+  }
+
+  /** The body of {@link writeFile}; only ever called holding the FS lock. */
+  private async writeFileLocked(
+    path: string,
+    contents: string | Uint8Array,
+    chunkSize: number
+  ): Promise<void> {
     const bytes = typeof contents === 'string' ? enc.encode(contents) : contents
     // `_snk_f` outlives its snippet on purpose — the next chunk writes through
     // it — so it carries the prefix and is unbound on close (#798).

--- a/test/deviceWriteSerialisation.test.ts
+++ b/test/deviceWriteSerialisation.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest'
+import { tmpdir } from 'node:os'
+
+vi.mock('electron', () => ({ app: { getPath: () => tmpdir() } }))
+
+/**
+ * Concurrent writes must not interleave (#850).
+ *
+ * The bug this pins: `opQueue` makes each `exec` atomic, which keeps the
+ * raw-REPL protocol intact, but a file write is `open` → N chunks → `close`
+ * with the handle living in ONE global on the board between the steps. Two
+ * writes at once interleave legally at the exec level and destroy each other —
+ * the second `open` rebinds `_snk_f`, the first write's chunks go to the second
+ * file or nowhere, and both files end up created and EMPTY. Which is exactly
+ * what a user saw: every file present, every file 0 bytes.
+ *
+ * Asserted by recording the ORDER of snippets a device runs, so the test states
+ * the property (no other file's open appears between mine) rather than
+ * re-describing the implementation.
+ */
+async function deviceWithRecorder(): Promise<{
+  dev: { writeFile: (p: string, c: Buffer) => Promise<void> }
+  log: string[]
+}> {
+  const { MicroPythonDevice } = await import('../src/main/device/MicroPythonDevice')
+  const dev = new MicroPythonDevice() as unknown as {
+    writeFile: (p: string, c: Buffer) => Promise<void>
+    eval: (code: string) => Promise<string>
+    driveMount: () => Promise<string | null>
+  }
+  const log: string[] = []
+  // Stand in for the wire: record the snippet, yield to the event loop so a
+  // competing sequence gets every chance to slip in, then resolve.
+  dev.eval = async (code: string): Promise<string> => {
+    log.push(code)
+    await new Promise((r) => setTimeout(r, 0))
+    return ''
+  }
+  dev.driveMount = async (): Promise<string | null> => null
+  return { dev, log }
+}
+
+/** The path each recorded snippet acted on, for `open` lines only. */
+function opens(log: string[]): string[] {
+  return log
+    .filter((line) => line.includes("_snk_f=open("))
+    .map((line) => /_snk_f=open\('([^']+)'/.exec(line)?.[1] ?? '?')
+}
+
+describe('concurrent device writes (#850)', () => {
+  it('does not interleave two writes', async () => {
+    const { dev, log } = await deviceWithRecorder()
+
+    await Promise.all([
+      dev.writeFile('/a.txt', Buffer.from('A'.repeat(4096))),
+      dev.writeFile('/b.txt', Buffer.from('B'.repeat(4096)))
+    ])
+
+    // Each file is opened exactly once...
+    expect(opens(log)).toHaveLength(2)
+
+    // ...and everything between the first open and its close belongs to it.
+    const firstOpen = log.findIndex((l) => l.includes("_snk_f=open("))
+    const firstClose = log.findIndex((l, i) => i > firstOpen && l.includes('_snk_f.close()'))
+    expect(firstClose).toBeGreaterThan(firstOpen)
+    const between = log.slice(firstOpen + 1, firstClose)
+    expect(
+      between.some((l) => l.includes("_snk_f=open(")),
+      'a second open appeared inside the first write — the handle was rebound'
+    ).toBe(false)
+  })
+
+  it('writes every byte of both files', async () => {
+    const { dev, log } = await deviceWithRecorder()
+    await Promise.all([
+      dev.writeFile('/a.txt', Buffer.from('A'.repeat(3000))),
+      dev.writeFile('/b.txt', Buffer.from('B'.repeat(3000)))
+    ])
+    // 3000 bytes of 'A' is 0x41 repeated; count the hex actually written.
+    const hexA = log
+      .filter((l) => l.includes('unhexlify'))
+      .join('')
+      .split('41').length - 1
+    expect(hexA).toBeGreaterThanOrEqual(3000)
+  })
+
+  it('a failed write does not wedge the queue for the next one', async () => {
+    const { dev, log } = await deviceWithRecorder()
+    const raw = dev as unknown as { eval: (c: string) => Promise<string> }
+    const good = raw.eval
+    raw.eval = async (code: string): Promise<string> => {
+      if (code.includes("_snk_f=open('/bad.txt'")) throw new Error('nope')
+      return good(code)
+    }
+    await expect(dev.writeFile('/bad.txt', Buffer.from('x'))).rejects.toThrow()
+    // The lock must have been released, or this would hang rather than fail.
+    await dev.writeFile('/fine.txt', Buffer.from('y'))
+    expect(opens(log)).toContain('/fine.txt')
+  })
+})


### PR DESCRIPTION
Closes #850.

Copying a folder created every file on the board and left every one **blank**; a
second click on Upload copied them correctly.

## Cause

`opQueue` serialises each individual `exec` — its own comment says *"two callers
never interleave on the wire"* — and that is not enough. A write is not one exec:

```
_snk_f = open(path, 'wb')     # exec 1
_snk_f.write(...)             # exec 2..N
_snk_f.close()                # exec N+1
```

`_snk_f` is a **single global on the board**, documented as "the one scratch
global that must OUTLIVE its snippet". And `replWrite`, which reads like a lock,
is only an error-translating try/catch. So two writes interleave perfectly
legally at the exec level:

```
A: _snk_f = open('/lib/a.py','wb')
B: _snk_f = open('/lib/b.py','wb')   ← rebinds; A's handle is gone
A: _snk_f.write(...)                  ← lands in b.py, or nowhere
```

Every `open` succeeds, so every file is **created**, and the content goes to the
wrong handle. All files present, all empty.

The wire protocol was never the problem. The **stateful sequence across several
execs** was.

## Fix

Serialise the whole `open → chunks → close` behind an exclusive FS lock, in the
desktop `MicroPythonDevice` **and** the web build's `RawReplClient`, which has
the identical structure and the identical bug. Costs nothing real — two transfers
over one UART do not go faster for being interleaved.

Plus a synchronous ref guard on the Upload handler: `busy` disables the button,
but React state lands asynchronously, so two quick clicks both read the old value
and both start a transfer over the same paths. That is one of the two triggers;
the other is any concurrent writer (a sync push, sync-on-save, a second panel).

## The test earns its place

It records the **order** of snippets a device runs and asserts no other file's
`open` appears inside a write's open→close span. Confirmed to catch the bug —
with the lock bypassed:

```
× does not interleave two writes
  → a second open appeared inside the first write — the handle was rebound
```

and with it restored, green.

## Note for later

The web `RawReplClient` still writes 256-byte chunks; the desktop path went to
1024 in #842. Worth bringing to parity, deliberately not done here — that path
has no hardware coverage in this change.

Gates: lint, typecheck, build green; **5924 tests** (3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)