### PR TITLE
A status-bar file-sync indicator, and the file list behind it (#863)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,19 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **A file-sync indicator in the status bar, with the list behind it** (#863).
+  When file sync is on — or when anything is tagged — a small sync glyph sits in
+  the status bar showing how many of the tagged files are on the board (`2/3`).
+  Hover it (or click, or tab to it) and it lists every tagged file with a tick
+  against the ones that have actually arrived, a cross against any that failed
+  with the reason, and an empty box against the rest. Each row names where the
+  file lands, once a sync has established it — a folder follows the highlighted
+  device folder, a file goes to `/<name>`, and the popup no longer leaves you
+  guessing which. The glyph dims when files are tagged but sync-on-save is off,
+  which is the state that quietly catches people out, and disappears entirely
+  when there is nothing to report. Unplugging the board clears the ticks: the
+  next board may be a different one, and a tick meaning "synced to something I
+  saw earlier" is worse than no tick at all.
 - **Copy a whole folder to the board from the Files panel** (#848). Highlight a
   folder on the left and a folder on the device, and **Upload to device** copies
   the one into the other — recursively, keeping its name and its nesting. A

--- a/src/renderer/src/components/StatusBar.tsx
+++ b/src/renderer/src/components/StatusBar.tsx
@@ -32,6 +32,7 @@ import {
 } from '../../../shared/firmware-runtime'
 import type { FirmwareCatalog, UpdateStatus } from '../../../preload/index.d'
 import { BulbIcon } from './ui-icons'
+import { SyncIndicator } from './SyncIndicator'
 import './StatusBar.css'
 
 /**
@@ -491,6 +492,11 @@ export function StatusBar({
       <div className="statusbar__spacer" />
 
       <div className="statusbar__group statusbar__group--right">
+        {/* File sync (#863). First in the right-hand group so it sits next to
+            the message area — the sync messages land there, and the popup that
+            explains them should be adjacent. Renders nothing at all when
+            nothing is tagged and sync is off. */}
+        <SyncIndicator />
         {changedCount != null && (
           <span
             className="statusbar__item"

--- a/src/renderer/src/components/SyncIndicator.css
+++ b/src/renderer/src/components/SyncIndicator.css
@@ -1,0 +1,171 @@
+/* --------------------------------------------------------------------------
+ * File-sync indicator + hover popup (#863)
+ *
+ * Lives in the status bar's right-hand group, which never gives way (#843), so
+ * everything here is `flex: 0 0 auto` and nothing wraps. Every colour is a
+ * theme token, so it reads correctly in BOTH the dark and skeuomorph skins —
+ * a popup that only works in one is a bug its author never sees.
+ * ------------------------------------------------------------------------ */
+
+.syncind {
+  position: relative;
+  display: inline-flex;
+  flex: 0 0 auto;
+}
+
+.syncind__btn {
+  /* `.statusbar__item` supplies the padding, height and nowrap. */
+  gap: 0.3rem;
+  background: none;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.syncind__count {
+  font-variant-numeric: tabular-nums;
+}
+
+/* Sync is ON: the same green the device tree uses for a completed sync, so the
+   two indicators mean the same thing in the same colour. */
+.syncind__btn--on {
+  color: var(--accent-2);
+}
+
+/* Tagged files but auto-sync switched off — present, deliberately quiet. */
+.syncind__btn--off {
+  color: var(--text-muted);
+}
+
+.syncind__btn--error {
+  color: var(--danger);
+}
+
+.syncind__btn--syncing {
+  color: var(--accent);
+}
+
+.syncind__btn--syncing svg {
+  animation: syncind-spin 0.9s linear infinite;
+}
+
+@keyframes syncind-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .syncind__btn--syncing svg {
+    animation: none;
+  }
+}
+
+.syncind__btn:hover,
+.syncind__btn:focus-visible {
+  background: var(--bg-sunken);
+}
+
+/* --- popup ---------------------------------------------------------------- */
+
+.syncind__popup {
+  /* Fixed, not absolute: the status bar sets `overflow: hidden`, which would
+     clip an absolutely-positioned child at the bar's own 1.6rem height. The
+     inline `right`/`bottom` come from the button's measured rect. */
+  position: fixed;
+  right: 10px;
+  bottom: 2.2rem;
+  z-index: 60;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  width: max-content;
+  min-width: 14rem;
+  max-width: 26rem;
+  padding: 0.45rem 0.55rem;
+  background: var(--bg-elevated);
+  color: var(--text);
+  border: var(--border-w) solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.4);
+  font-size: 0.72rem;
+  cursor: default;
+}
+
+.syncind__summary {
+  margin: 0;
+  color: var(--text);
+  font-weight: 600;
+}
+
+.syncind__empty {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.syncind__list {
+  /* The tag list has no upper bound, so it scrolls rather than growing past the
+     top of the window. */
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  max-height: 14rem;
+  overflow-y: auto;
+}
+
+.syncind__row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  padding: 0.1rem 0;
+  color: var(--text-muted);
+}
+
+.syncind__row--done {
+  color: var(--text);
+}
+
+.syncind__row--syncing {
+  color: var(--accent);
+}
+
+.syncind__row--error {
+  color: var(--danger);
+}
+
+.syncind__tick {
+  flex: 0 0 auto;
+  width: 1em;
+  text-align: center;
+}
+
+.syncind__row--done .syncind__tick {
+  color: var(--accent-2);
+}
+
+.syncind__name {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.syncind__dest,
+.syncind__err {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-muted);
+  font-size: 0.68rem;
+}
+
+.syncind__err {
+  color: var(--danger);
+}

--- a/src/renderer/src/components/SyncIndicator.tsx
+++ b/src/renderer/src/components/SyncIndicator.tsx
@@ -1,0 +1,229 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useSync, type SyncedFile } from '../store/sync'
+import './SyncIndicator.css'
+
+/**
+ * FILE-SYNC INDICATOR (#863)
+ * =============================================================================
+ *
+ * A small sync glyph in the status bar saying that file sync is on, and — on
+ * hover — the list of tagged files with a tick against each one that has
+ * actually reached the board.
+ *
+ * The question it answers is the one the existing UI could not: the device-tree
+ * toolbar glyph (#178) says *a* sync happened, and the status-bar message says
+ * what the last one did, but neither survives long enough to tell you whether
+ * the file you are about to run is the file that is on the board. This does,
+ * standing still, for every tagged path at once.
+ *
+ * The glyph appears when sync is on OR when anything is tagged — never on a
+ * fresh install with nothing set up, where it would be one more piece of chrome
+ * meaning nothing. When files are tagged but sync-on-save is off it renders
+ * dimmed, because "3 files tagged, none of them syncing on save" is exactly the
+ * state that catches people out.
+ */
+
+/** Two opposing arrows. A 12px status-bar-scale sibling of the device tree's
+ *  toolbar glyph; SVG rather than an emoji so it renders on a Pi (#549). */
+const SyncGlyph = (): JSX.Element => (
+  <svg width="12" height="12" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+    <g fill="currentColor">
+      <path d="M2 5h9V2l4 4-4 4V7H2z" />
+      <path d="M14 11H5v3l-4-4 4-4v3h9z" />
+    </g>
+  </svg>
+)
+
+/** The checkbox glyph for one row — same vocabulary as the transfer dialog (#848). */
+export function tickFor(state: SyncedFile['state']): string {
+  if (state === 'done') return '☑'
+  if (state === 'error') return '☒'
+  return '☐'
+}
+
+/** How the glyph itself reads. Exported so the mapping is testable on its own. */
+export type SyncMode = 'on' | 'off' | 'syncing' | 'error'
+
+/**
+ * Pick the glyph's mode. A failed file outranks a running sync: the thing the
+ * user needs to know is that something did not make it, and that survives the
+ * next sync starting.
+ */
+export function syncMode(
+  syncOnSave: boolean,
+  files: SyncedFile[],
+  status: 'idle' | 'syncing' | 'done' | 'error'
+): SyncMode {
+  if (!syncOnSave) return 'off'
+  if (files.some((f) => f.state === 'error')) return 'error'
+  return status === 'syncing' ? 'syncing' : 'on'
+}
+
+/** The one line at the top of the popup, and the button's accessible name. */
+export function syncSummary(syncOnSave: boolean, files: SyncedFile[]): string {
+  const total = files.length
+  const plural = total === 1 ? '' : 's'
+  if (!syncOnSave) return `File sync is off — ${total} file${plural} tagged`
+  if (total === 0) return 'File sync is on — no files tagged yet'
+  const done = files.filter((f) => f.state === 'done').length
+  return `File sync is on — ${done} of ${total} on the board`
+}
+
+/** How long the popup survives the pointer leaving, so the gap between the
+ *  button and the popup is crossable. */
+const HOVER_GRACE_MS = 160
+
+/** Where the popup sits: pinned to the button, in viewport coordinates. */
+interface Anchor {
+  right: number
+  bottom: number
+}
+
+/**
+ * Measure the button so the popup can be `position: fixed`.
+ *
+ * Fixed rather than absolute because the status bar sets `overflow: hidden` —
+ * an absolutely-positioned child is clipped at the bar's 1.6rem height, which
+ * is how the firmware popup ended up fixed too. Aligning the popup's right edge
+ * with the button's keeps it visually attached without it being a child in the
+ * layout sense.
+ */
+function anchorTo(el: HTMLElement | null): Anchor | null {
+  if (!el) return null
+  const r = el.getBoundingClientRect()
+  return {
+    right: Math.max(6, window.innerWidth - r.right),
+    bottom: Math.max(6, window.innerHeight - r.top + 6)
+  }
+}
+
+export function SyncIndicator(): JSX.Element | null {
+  const { syncOnSave, status, syncedFiles } = useSync()
+  const [open, setOpen] = useState(false)
+  const [anchor, setAnchor] = useState<Anchor | null>(null)
+  const btnRef = useRef<HTMLButtonElement | null>(null)
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const show = useCallback((): void => {
+    if (closeTimer.current) {
+      clearTimeout(closeTimer.current)
+      closeTimer.current = null
+    }
+    setAnchor(anchorTo(btnRef.current))
+    setOpen(true)
+  }, [])
+
+  /**
+   * Close on a short delay rather than immediately.
+   *
+   * The popup is `position: fixed` and sits a few pixels ABOVE the button, so
+   * the pointer travelling from one to the other crosses a strip that belongs
+   * to neither — which fires `mouseleave` and takes the popup away just as the
+   * user reaches for it. The grace period covers the gap, and a wobbling hand.
+   */
+  const hide = useCallback((): void => {
+    if (closeTimer.current) clearTimeout(closeTimer.current)
+    closeTimer.current = setTimeout(() => setOpen(false), HOVER_GRACE_MS)
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      if (closeTimer.current) clearTimeout(closeTimer.current)
+    }
+  }, [])
+
+  // Escape closes it, like every other transient surface in the app. A resize
+  // closes it too: the anchor was measured once and would otherwise leave the
+  // popup pointing at where the button used to be.
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    const onResize = (): void => setOpen(false)
+    window.addEventListener('keydown', onKey)
+    window.addEventListener('resize', onResize)
+    return () => {
+      window.removeEventListener('keydown', onKey)
+      window.removeEventListener('resize', onResize)
+    }
+  }, [open])
+
+  // Nothing tagged and sync off — there is nothing to report, so report nothing.
+  if (!syncOnSave && syncedFiles.length === 0) return null
+
+  const done = syncedFiles.filter((f) => f.state === 'done').length
+  const total = syncedFiles.length
+  const mode = syncMode(syncOnSave, syncedFiles, status)
+  const summary = syncSummary(syncOnSave, syncedFiles)
+
+  return (
+    <div
+      className="syncind"
+      onMouseEnter={show}
+      onMouseLeave={hide}
+      onFocus={show}
+      onBlur={hide}
+    >
+      <button
+        ref={btnRef}
+        type="button"
+        className={`statusbar__item syncind__btn syncind__btn--${mode}`}
+        aria-expanded={open}
+        aria-controls="syncind-popup"
+        aria-label={summary}
+        // Click toggles as well as hover, so this works by touch and by keyboard
+        // and not only with a pointer that can hover.
+        onClick={() => (open ? setOpen(false) : show())}
+      >
+        <SyncGlyph />
+        {total > 0 && (
+          <span className="syncind__count">
+            {done}/{total}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div
+          id="syncind-popup"
+          className="syncind__popup"
+          role="region"
+          aria-label="Files kept in sync with the board"
+          style={anchor ? { right: `${anchor.right}px`, bottom: `${anchor.bottom}px` } : undefined}
+        >
+          <p className="syncind__summary">{summary}</p>
+
+          {total === 0 ? (
+            <p className="syncind__empty">
+              Tick a file or folder in Local files to keep it in sync.
+            </p>
+          ) : (
+            <ul className="syncind__list">
+              {syncedFiles.map((f) => (
+                <li key={f.path} className={`syncind__row syncind__row--${f.state}`}>
+                  <span className="syncind__tick" aria-hidden="true">
+                    {tickFor(f.state)}
+                  </span>
+                  <span className="syncind__name" title={f.path}>
+                    {f.name}
+                  </span>
+                  {/* The destination is only shown once a sync has established
+                      it: a folder lands in the highlighted device folder and a
+                      file at /<name>, and guessing before we know would point at
+                      the wrong place. */}
+                  {f.dest && <span className="syncind__dest">{f.dest}</span>}
+                  {f.state === 'error' && f.error && (
+                    <span className="syncind__err" title={f.error}>
+                      {f.error}
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/store/sync.ts
+++ b/src/renderer/src/store/sync.ts
@@ -37,6 +37,7 @@ import {
 import { baseName, FILE_SAVED_EVENT, type FileSavedDetail } from './workspace'
 import { useFileSelection } from './file-selection'
 import { planUploadOf, runFolderUpload } from '../lib/folder-transfer'
+import { deviceJoin } from '../../../shared/transfer-plan'
 
 /**
  * Is this local path a directory? (#848)
@@ -107,6 +108,12 @@ export interface SyncStore {
   status: SyncStatus
   /** Last error message when `status === 'error'`. */
   error: string | null
+  /**
+   * One row per tagged path, in tag order, with its own state — what the
+   * status-bar sync popup lists (#863). `status` above says whether a sync is
+   * running; this says which files have actually reached the board.
+   */
+  syncedFiles: SyncedFile[]
   isSynced: (path: string) => boolean
   /** Tag / untag a local path (tagging pushes it once if a board is connected). */
   toggleSync: (path: string) => void
@@ -118,6 +125,119 @@ export interface SyncStore {
 /** Device destination for a synced local file: `/<basename>` (mirrors upload). */
 export function deviceDestForLocal(localPath: string): string {
   return `/${baseName(localPath)}`
+}
+
+// ---------------------------------------------------------------------------
+// Per-file sync state (#863)
+// ---------------------------------------------------------------------------
+//
+// The coarse {@link SyncStatus} answers "is a sync happening", which is all the
+// toolbar glyph needed. The status-bar popup asks a different question — "which
+// of my tagged files have actually reached this board?" — so each tagged path
+// carries its own state. Kept as plain data with pure transitions so the whole
+// thing unit-tests in node, like the rest of this store's helpers.
+
+/** What has happened to ONE tagged path, on the currently-connected board. */
+export type FileSyncState = 'pending' | 'syncing' | 'done' | 'error'
+
+/** The store's record for one tagged path. */
+export interface FileSyncRecord {
+  state: FileSyncState
+  /** Failure message when `state === 'error'`. */
+  error?: string
+  /**
+   * Whether the path turned out to be a directory. Undefined until a sync has
+   * actually looked (`isDirectory` is asked at sync time, not tag time), which
+   * is why the popup shows no destination for a path it has never pushed —
+   * a folder and a file land in different places, so guessing would mislead.
+   */
+  dir?: boolean
+}
+
+export type FileSyncMap = Readonly<Record<string, FileSyncRecord>>
+
+/** One row of the status-bar popup. */
+export interface SyncedFile {
+  path: string
+  name: string
+  state: FileSyncState
+  /** Where it lands on the device — absent until a sync has established it. */
+  dest?: string
+  error?: string
+}
+
+/** Set `state` on each of `paths`, leaving every other record untouched. */
+export function markFiles(
+  map: FileSyncMap,
+  paths: string[],
+  state: FileSyncState,
+  error?: string
+): FileSyncMap {
+  if (paths.length === 0) return map
+  const next: Record<string, FileSyncRecord> = { ...map }
+  for (const path of paths) {
+    const prev = next[path]
+    const rec: FileSyncRecord = { state }
+    if (state === 'error' && error) rec.error = error
+    if (prev?.dir !== undefined) rec.dir = prev.dir
+    next[path] = rec
+  }
+  return next
+}
+
+/** Record what a sync discovered about `path`: a directory, or a plain file. */
+export function markKind(map: FileSyncMap, path: string, dir: boolean): FileSyncMap {
+  const prev = map[path] ?? { state: 'pending' as FileSyncState }
+  if (prev.dir === dir) return map
+  return { ...map, [path]: { ...prev, dir } }
+}
+
+/**
+ * Bring the record map in line with the tagged list: newly tagged paths start
+ * `pending` (tagged but not yet on the board), untagged ones are forgotten.
+ */
+export function reconcileFiles(map: FileSyncMap, tagged: string[]): FileSyncMap {
+  const next: Record<string, FileSyncRecord> = {}
+  for (const path of tagged) next[path] = map[path] ?? { state: 'pending' }
+  return next
+}
+
+/**
+ * Forget what was synced. Called when the board goes away: the next board to
+ * arrive may be a different one, and a green tick that means "synced to some
+ * board I saw earlier" is worse than no tick at all.
+ */
+export function clearSyncMarks(map: FileSyncMap): FileSyncMap {
+  const next: Record<string, FileSyncRecord> = {}
+  for (const [path, rec] of Object.entries(map)) {
+    next[path] = rec.dir === undefined ? { state: 'pending' } : { state: 'pending', dir: rec.dir }
+  }
+  return next
+}
+
+/**
+ * The popup's rows, in tag order. `folderDest` is where a tagged FOLDER lands
+ * (the highlighted device folder, #848); files keep `/<basename>`.
+ */
+export function syncedFileList(
+  tagged: string[],
+  map: FileSyncMap,
+  folderDest: string
+): SyncedFile[] {
+  return tagged.map((path) => {
+    const rec = map[path] ?? { state: 'pending' as FileSyncState }
+    const name = baseName(path)
+    const row: SyncedFile = { path, name, state: rec.state }
+    if (rec.dir === true) row.dest = deviceJoin(folderDest, name)
+    else if (rec.dir === false) row.dest = deviceDestForLocal(path)
+    if (rec.error) row.error = rec.error
+    return row
+  })
+}
+
+/** How many tagged paths have reached the board, for the popup's summary. */
+export function syncedCount(files: SyncedFile[]): number {
+  return files.filter((f) => f.state === 'done').length
 }
 
 /** Parse the persisted tagged-paths list, tolerating missing / corrupt storage. */
@@ -178,6 +298,8 @@ export function SyncProvider({ children }: { children: ReactNode }): JSX.Element
   const [syncOnSave, setSyncOnSaveState] = useState<boolean>(() => loadSyncOnSave())
   const [status, setStatus] = useState<SyncStatus>('idle')
   const [error, setError] = useState<string | null>(null)
+  // Per-path state behind the status-bar popup (#863).
+  const [fileStates, setFileStates] = useState<FileSyncMap>({})
 
   // Latest values for use inside event handlers without re-subscribing.
   const connectedRef = useRef(false)
@@ -196,9 +318,20 @@ export function SyncProvider({ children }: { children: ReactNode }): JSX.Element
       })
       .catch(() => undefined)
     return window.api.device.onStatus((s) => {
+      const wasConnected = connectedRef.current
       connectedRef.current = s.state === 'connected'
+      // The board went away. Forget which files were synced: the next board to
+      // arrive may be a different one, and a tick meaning "synced to a board I
+      // saw earlier" is worse than no tick at all (#863).
+      if (wasConnected && !connectedRef.current) setFileStates(clearSyncMarks)
     })
   }, [])
+
+  // Keep the per-path records in step with the tagged list: a newly tagged path
+  // starts `pending`, an untagged one is forgotten.
+  useEffect(() => {
+    setFileStates((prev) => reconcileFiles(prev, syncedPaths))
+  }, [syncedPaths])
 
   useEffect(() => {
     return () => {
@@ -235,24 +368,40 @@ export function SyncProvider({ children }: { children: ReactNode }): JSX.Element
       setStatus('syncing')
       setError(null)
       emitSyncStatus(`Syncing ${label}…`)
+      // Each path reports its own outcome as the loop reaches it, so the popup
+      // ticks off files one by one instead of flipping all of them at the end
+      // (#863). A path the loop never reaches keeps whatever it had, which is
+      // right: it genuinely has not been pushed.
       try {
         for (const path of paths) {
-          // A tagged FOLDER syncs itself and everything under it, into whichever
-          // device folder is highlighted right now (#848). Tagging a folder is
-          // what people actually mean — tagging its files one at a time both
-          // misses newly added ones and is tedious.
-          //
-          // Files keep their existing destination (`/<basename>`) rather than
-          // following the highlight: changing that would silently relocate
-          // every file anyone already had tagged.
-          if (await isDirectory(path)) {
-            const plan = await planUploadOf(path, deviceTargetDirRef.current)
-            const result = await runFolderUpload(plan, () => undefined)
-            if (!result.ok) throw new Error(result.error ?? `Could not sync ${baseName(path)}`)
-            continue
+          setFileStates((prev) => markFiles(prev, [path], 'syncing'))
+          try {
+            // A tagged FOLDER syncs itself and everything under it, into whichever
+            // device folder is highlighted right now (#848). Tagging a folder is
+            // what people actually mean — tagging its files one at a time both
+            // misses newly added ones and is tedious.
+            //
+            // Files keep their existing destination (`/<basename>`) rather than
+            // following the highlight: changing that would silently relocate
+            // every file anyone already had tagged.
+            const dir = await isDirectory(path)
+            setFileStates((prev) => markKind(prev, path, dir))
+            if (dir) {
+              const plan = await planUploadOf(path, deviceTargetDirRef.current)
+              const result = await runFolderUpload(plan, () => undefined)
+              if (!result.ok) throw new Error(result.error ?? `Could not sync ${baseName(path)}`)
+            } else {
+              const content = await window.api.fs.readFile(path)
+              await window.api.device.writeFile(deviceDestForLocal(path), content)
+            }
+            setFileStates((prev) => markFiles(prev, [path], 'done'))
+          } catch (err) {
+            // Record which file failed before letting the run end — the popup's
+            // job is to name the one that went wrong, not just that one did.
+            const message = err instanceof Error ? err.message : String(err)
+            setFileStates((prev) => markFiles(prev, [path], 'error', message))
+            throw err
           }
-          const content = await window.api.fs.readFile(path)
-          await window.api.device.writeFile(deviceDestForLocal(path), content)
         }
         settle('done', null, label)
       } catch (err) {
@@ -318,11 +467,17 @@ export function SyncProvider({ children }: { children: ReactNode }): JSX.Element
         setStatus('syncing')
         setError(null)
         emitSyncStatus(`Syncing ${label}…`)
+        // Only a FILE can be saved from an editor buffer, so this path knows the
+        // kind without asking the disk (#863).
+        setFileStates((prev) => markFiles(markKind(prev, detail.path, false), [detail.path], 'syncing'))
         try {
           await window.api.device.writeFile(deviceDestForLocal(detail.path), detail.content)
+          setFileStates((prev) => markFiles(prev, [detail.path], 'done'))
           settle('done', null, label)
         } catch (err) {
-          settle('error', err instanceof Error ? err.message : String(err), label)
+          const message = err instanceof Error ? err.message : String(err)
+          setFileStates((prev) => markFiles(prev, [detail.path], 'error', message))
+          settle('error', message, label)
         }
       })()
     }
@@ -330,18 +485,34 @@ export function SyncProvider({ children }: { children: ReactNode }): JSX.Element
     return () => window.removeEventListener(FILE_SAVED_EVENT, handler)
   }, [settle])
 
+  const syncedFiles = useMemo(
+    () => syncedFileList(syncedPaths, fileStates, deviceTargetDir),
+    [syncedPaths, fileStates, deviceTargetDir]
+  )
+
   const store = useMemo<SyncStore>(
     () => ({
       syncedPaths,
       syncOnSave,
       status,
       error,
+      syncedFiles,
       isSynced,
       toggleSync,
       setSyncOnSave,
       syncNow
     }),
-    [syncedPaths, syncOnSave, status, error, isSynced, toggleSync, setSyncOnSave, syncNow]
+    [
+      syncedPaths,
+      syncOnSave,
+      status,
+      error,
+      syncedFiles,
+      isSynced,
+      toggleSync,
+      setSyncOnSave,
+      syncNow
+    ]
   )
 
   return createElement(SyncContext.Provider, { value: store }, children)

--- a/test/syncIndicator.test.ts
+++ b/test/syncIndicator.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'vitest'
+import {
+  clearSyncMarks,
+  markFiles,
+  markKind,
+  reconcileFiles,
+  syncedCount,
+  syncedFileList,
+  type FileSyncMap
+} from '../src/renderer/src/store/sync'
+import { syncMode, syncSummary, tickFor } from '../src/renderer/src/components/SyncIndicator'
+
+/**
+ * The status-bar file-sync popup (#863).
+ *
+ * The popup's whole job is to answer "which of my tagged files is actually on
+ * the board right now" — so these tests are about the RECORD KEEPING, which is
+ * where that answer is either right or wrong. The component itself is a thin
+ * map from this data onto three glyphs, and that mapping is tested directly at
+ * the bottom.
+ */
+
+const F = (state: 'pending' | 'syncing' | 'done' | 'error'): { state: typeof state } => ({ state })
+
+describe('reconcileFiles', () => {
+  it('gives a newly tagged path a pending record', () => {
+    expect(reconcileFiles({}, ['/a.py'])).toEqual({ '/a.py': { state: 'pending' } })
+  })
+
+  it('keeps what it already knows about a path that is still tagged', () => {
+    const before: FileSyncMap = { '/a.py': { state: 'done', dir: false } }
+    expect(reconcileFiles(before, ['/a.py'])).toEqual(before)
+  })
+
+  it('forgets a path that is no longer tagged', () => {
+    const before: FileSyncMap = { '/a.py': F('done'), '/b.py': F('done') }
+    expect(reconcileFiles(before, ['/a.py'])).toEqual({ '/a.py': F('done') })
+  })
+
+  it('does not resurrect a stale record when the same path is re-tagged', () => {
+    // Untag then re-tag: the record went with the tag, so the file starts
+    // pending again rather than claiming a tick it earned before it was dropped.
+    const tagged = reconcileFiles({ '/a.py': F('done') }, [])
+    expect(reconcileFiles(tagged, ['/a.py'])).toEqual({ '/a.py': { state: 'pending' } })
+  })
+})
+
+describe('markFiles', () => {
+  it('sets the state of the named paths only', () => {
+    const before: FileSyncMap = { '/a.py': F('pending'), '/b.py': F('pending') }
+    expect(markFiles(before, ['/a.py'], 'done')).toEqual({
+      '/a.py': { state: 'done' },
+      '/b.py': { state: 'pending' }
+    })
+  })
+
+  it('carries an error message only on the error state', () => {
+    expect(markFiles({}, ['/a.py'], 'error', 'no space left')).toEqual({
+      '/a.py': { state: 'error', error: 'no space left' }
+    })
+    // A later success must not leave the old failure attached to the row.
+    const failed = markFiles({}, ['/a.py'], 'error', 'no space left')
+    expect(markFiles(failed, ['/a.py'], 'done')).toEqual({ '/a.py': { state: 'done' } })
+  })
+
+  it('preserves what a previous sync learned about the path being a directory', () => {
+    const known = markKind({}, '/lib', true)
+    expect(markFiles(known, ['/lib'], 'done')).toEqual({ '/lib': { state: 'done', dir: true } })
+  })
+
+  it('returns the same object when there is nothing to mark', () => {
+    const before: FileSyncMap = { '/a.py': F('done') }
+    expect(markFiles(before, [], 'syncing')).toBe(before)
+  })
+})
+
+describe('clearSyncMarks', () => {
+  it('drops every tick when the board goes away', () => {
+    // A tick that means "synced to some board I saw earlier" is worse than none:
+    // the next board to arrive may be a different one.
+    const before: FileSyncMap = {
+      '/a.py': { state: 'done', dir: false },
+      '/lib': { state: 'error', error: 'boom', dir: true }
+    }
+    expect(clearSyncMarks(before)).toEqual({
+      '/a.py': { state: 'pending', dir: false },
+      '/lib': { state: 'pending', dir: true }
+    })
+  })
+
+  it('keeps the paths themselves — disconnecting does not untag anything', () => {
+    const before: FileSyncMap = { '/a.py': F('done'), '/b.py': F('pending') }
+    expect(Object.keys(clearSyncMarks(before))).toEqual(['/a.py', '/b.py'])
+  })
+})
+
+describe('syncedFileList', () => {
+  it('lists tagged paths in tag order, with their basenames', () => {
+    const rows = syncedFileList(['/home/kev/b.py', '/home/kev/a.py'], {}, '/')
+    expect(rows.map((r) => r.name)).toEqual(['b.py', 'a.py'])
+    expect(rows.every((r) => r.state === 'pending')).toBe(true)
+  })
+
+  it('shows no destination for a path no sync has looked at yet', () => {
+    // A folder and a file land in different places, so guessing before we know
+    // would point the user at somewhere the file is not.
+    const [row] = syncedFileList(['/home/kev/thing'], {}, '/lib')
+    expect(row.dest).toBeUndefined()
+  })
+
+  it('sends a known FILE to /<basename>', () => {
+    const map = markKind({}, '/home/kev/main.py', false)
+    expect(syncedFileList(['/home/kev/main.py'], map, '/lib')[0].dest).toBe('/main.py')
+  })
+
+  it('sends a known FOLDER into the highlighted device folder', () => {
+    const map = markKind({}, '/home/kev/snakeros', true)
+    expect(syncedFileList(['/home/kev/snakeros'], map, '/lib')[0].dest).toBe('/lib/snakeros')
+    // …and follows the highlight, because that is what folder sync does (#848).
+    expect(syncedFileList(['/home/kev/snakeros'], map, '/')[0].dest).toBe('/snakeros')
+  })
+
+  it('carries the failure message through to the row', () => {
+    const map = markFiles({}, ['/a.py'], 'error', 'device is full')
+    expect(syncedFileList(['/a.py'], map, '/')[0].error).toBe('device is full')
+  })
+})
+
+describe('syncedCount', () => {
+  it('counts only what actually reached the board', () => {
+    const files = syncedFileList(
+      ['/a.py', '/b.py', '/c.py', '/d.py'],
+      markFiles(markFiles(markFiles({}, ['/a.py', '/b.py'], 'done'), ['/c.py'], 'syncing'), ['/d.py'], 'error', 'x'),
+      '/'
+    )
+    expect(syncedCount(files)).toBe(2)
+  })
+})
+
+describe('the glyph', () => {
+  it('reads as off whenever auto-sync is off, however healthy the files are', () => {
+    const files = syncedFileList(['/a.py'], markFiles({}, ['/a.py'], 'done'), '/')
+    expect(syncMode(false, files, 'idle')).toBe('off')
+  })
+
+  it('reports a failed file ahead of a running sync', () => {
+    // The user needs to know something did not make it, and that outlives the
+    // next sync starting.
+    const files = syncedFileList(['/a.py'], markFiles({}, ['/a.py'], 'error', 'x'), '/')
+    expect(syncMode(true, files, 'syncing')).toBe('error')
+  })
+
+  it('spins while syncing and settles to on', () => {
+    const files = syncedFileList(['/a.py'], markFiles({}, ['/a.py'], 'syncing'), '/')
+    expect(syncMode(true, files, 'syncing')).toBe('syncing')
+    expect(syncMode(true, syncedFileList(['/a.py'], markFiles({}, ['/a.py'], 'done'), '/'), 'idle')).toBe('on')
+  })
+})
+
+describe('the summary line', () => {
+  it('says how many of the tagged files are on the board', () => {
+    const map = markFiles(reconcileFiles({}, ['/a.py', '/b.py', '/c.py']), ['/a.py'], 'done')
+    const files = syncedFileList(['/a.py', '/b.py', '/c.py'], map, '/')
+    expect(syncSummary(true, files)).toBe('File sync is on — 1 of 3 on the board')
+  })
+
+  it('names the state that catches people out: tagged files, sync off', () => {
+    const files = syncedFileList(['/a.py', '/b.py'], {}, '/')
+    expect(syncSummary(false, files)).toBe('File sync is off — 2 files tagged')
+  })
+
+  it('gets the singular right', () => {
+    expect(syncSummary(false, syncedFileList(['/a.py'], {}, '/'))).toBe(
+      'File sync is off — 1 file tagged'
+    )
+  })
+
+  it('says so when sync is on but nothing is tagged', () => {
+    expect(syncSummary(true, [])).toBe('File sync is on — no files tagged yet')
+  })
+})
+
+describe('the row glyph', () => {
+  it('uses the same three boxes as the folder transfer dialog (#848)', () => {
+    expect(tickFor('done')).toBe('☑')
+    expect(tickFor('error')).toBe('☒')
+    expect(tickFor('pending')).toBe('☐')
+    expect(tickFor('syncing')).toBe('☐')
+  })
+})


### PR DESCRIPTION
Closes #863.

## Why

File sync could tell you that *a* sync happened — the device-tree glyph goes green for a moment, the status bar posts a line that clears itself — but not whether the file you are about to run is the file that is on the board. That question had no answer that stands still, so the safe move was to re-upload by hand, which is the thing sync was for.

## What

A small sync glyph in the status bar's right-hand group (which never gives way, #843), showing `done/total` for the tagged files. Hover it — or click it, or tab to it — and it lists every tagged file:

- `☑` on the board
- `☒` failed, with the reason
- `☐` not yet

Same three boxes as the folder-transfer dialog (#848), so the vocabulary is one thing across the app. Each row also names **where** the file lands, once a sync has established it: a tagged folder follows the highlighted device folder while a tagged file goes to `/<name>`, and that difference was previously invisible.

The glyph is **absent** when nothing is tagged and sync is off — there is nothing to report and it would just be more chrome — and **dimmed** when files are tagged but sync-on-save is off, which is exactly the state that quietly catches people out.

## The store change

`SyncStatus` stayed coarse (`idle`/`syncing`/`done`/`error`) because that is all the toolbar glyph ever needed. The popup asks a different question, so each tagged path now carries its own record, updated as the push loop reaches it rather than all at once at the end — the list ticks off file by file, and a failure names the file it happened to.

Disconnecting the board clears the ticks. The next board to arrive may be a different one, and a tick meaning "synced to some board I saw earlier" is worse than no tick at all.

## Two details

- The popup is `position: fixed`, not absolute. The status bar sets `overflow: hidden`, which clips an absolutely-positioned child to the bar's own 1.6rem — the firmware popup hit this first and solved it the same way. The coordinates come from the button's measured rect so it still reads as attached.
- It closes on a 160ms delay. Fixed positioning puts the popup a few pixels above the button, so the pointer travelling between them crosses a strip belonging to neither; without the grace period the popup vanishes just as you reach for it.

## Tests

24 new tests. The record-keeping is pure functions over plain data, so the part that decides which file gets a tick is tested directly in node: the state transitions, the re-tag case (a re-tagged path starts pending rather than resurrecting an old tick), the destination rules for files vs folders, the disconnect reset, the summary line's pluralisation, and the glyph mode — including that a failed file outranks a running sync.

Gates: lint ok · typecheck ok · **5,948 tests** ok · build ok.

## Not verified on screen

I have not run this in a live window — doing so means a second Electron instance or a browser session on your desktop while you are working, and setting up a tagged file plus a connected board to make the popup appear at all. The layout copies the firmware popup's proven approach and the logic is unit-tested, but the visual check is still outstanding. Say the word and I will drive it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe