### PR TITLE
Put the Local and Device file actions in a toolbar (#865)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **The Local files and Device files actions sit in a toolbar** (#865). The
+  refresh / new file / new folder / open folder icons — and the device panel's
+  sync / refresh / new file / new folder — were four loose glyphs floating in a
+  panel header. They are now one segmented control, seamed like the main
+  toolbar's New / New folder / Open group, so a file operation looks like a file
+  operation wherever you are in the app. The fused look had only ever been
+  defined for the skeuomorph skin; this group is one definition that works in
+  both, and each is a labelled `toolbar` for screen readers.
+
+
 ### Fixed
 
 - **Two device writes at once no longer produce empty files** (#850). Each

--- a/src/renderer/src/components/DeviceFileTree.css
+++ b/src/renderer/src/components/DeviceFileTree.css
@@ -30,10 +30,12 @@
  * (issue #104). The shared `.btn.btn--icon` square-button rule lives in
  * `LocalFileTree.css`.
  */
+/* Segmented group (`.btn-seg` in index.css, #865) — it draws the seams between
+   the buttons itself, so a `gap` here would open the group's background up
+   through the middle of the control. */
 .devicetree__header-actions {
   display: flex;
   align-items: center;
-  gap: 0.2rem;
   flex: 0 0 auto;
 }
 

--- a/src/renderer/src/components/DeviceFileTree.tsx
+++ b/src/renderer/src/components/DeviceFileTree.tsx
@@ -719,7 +719,7 @@ export function DeviceFileTree(): JSX.Element {
         </span>
         {/* Icon-only header actions mirroring the local section (issue #104):
             the file-sync toggle (#178), then Refresh, New file, New folder. */}
-        <div className="devicetree__header-actions">
+        <div className="devicetree__header-actions btn-seg" role="toolbar" aria-label="Device file actions">
           {/* One sync toggle: turning it ON syncs the tagged files now AND keeps
               them auto-syncing on every save; turning it OFF stops auto-syncing.
               The icon turns into a green tick for a moment when a sync completes. */}

--- a/src/renderer/src/components/LocalFileTree.css
+++ b/src/renderer/src/components/LocalFileTree.css
@@ -41,15 +41,20 @@
   white-space: nowrap;
 }
 
+/* The file actions are a segmented group now (`.btn-seg` in index.css, #865),
+   which supplies the seams between the buttons — so no `gap` here: a gap would
+   show the group's own background through the middle of the control. */
 .localtree__header-actions {
   display: flex;
   align-items: center;
-  gap: 0.2rem;
   flex: 0 0 auto;
 }
-/* The 4 file-action icons sit CENTRED on their own row. */
+/* The 4 file-action icons sit CENTRED on their own row.
+   `align-self`, not `justify-content`: the header is a COLUMN flex with
+   `align-items: stretch`, so the group would otherwise be pulled to the full
+   panel width and read as a bar rather than a toolbar. */
 .localtree__header-actions--center {
-  justify-content: center;
+  align-self: center;
 }
 /* Collapse-the-Files-panel chevron, pinned top-right. */
 .localtree__collapse {

--- a/src/renderer/src/components/LocalFileTree.tsx
+++ b/src/renderer/src/components/LocalFileTree.tsx
@@ -539,7 +539,11 @@ export function LocalFileTree(): JSX.Element {
             </svg>
           </button>
         </div>
-        <div className="localtree__header-actions localtree__header-actions--center">
+        <div
+          className="localtree__header-actions localtree__header-actions--center btn-seg"
+          role="toolbar"
+          aria-label="File actions"
+        >
           <button
             className="btn btn--ghost btn--icon"
             onClick={() => void refresh()}

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -1839,6 +1839,76 @@ body {
   color: var(--accent);
 }
 
+/* --- Segmented icon group: the "mini toolbar" (#865) ----------------------
+ *
+ * A row of icon buttons fused into one instrument-like control, the way the
+ * main toolbar's New / New folder / Open group already reads. Used by the Local
+ * files and Device files panel headers so their file operations sit in a
+ * toolbar rather than floating as loose glyphs.
+ *
+ * SPECIFICITY, which is the whole difficulty here. The skeuomorph skin styles
+ * `.btn` at `:root[data-theme='skeuomorph'] .btn` — three components — so a
+ * plain `.btn-seg .btn` (two) loses to it and the children keep their pill
+ * borders and gradient inside the group. Each child rule is therefore written
+ * TWICE: once unscoped for the dark skin, once skin-scoped to outrank the
+ * skeuomorph pill. The existing `.toolbar__seg` block does the same thing for
+ * the same reason.
+ *
+ * Both skins are covered deliberately: the toolbar's fused look was only ever
+ * defined under skeuomorph, so the dark theme has three loose buttons. This
+ * group looks the same in both.
+ */
+.btn-seg {
+  display: inline-flex;
+  align-items: center;
+  gap: 0;
+  flex: 0 0 auto;
+  border: var(--border-w) solid var(--shellbd, var(--border));
+  border-radius: var(--radius);
+  background: var(--rail, var(--bg-sunken));
+  /* Clips the children's square corners back to the group's radius. */
+  overflow: hidden;
+}
+
+.btn-seg .btn,
+:root[data-theme='skeuomorph'] .btn-seg .btn {
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+/* Hairline between segments. On the button's own left edge rather than a
+   pseudo-element, so it goes when the button does. */
+.btn-seg .btn + .btn,
+:root[data-theme='skeuomorph'] .btn-seg .btn + .btn {
+  border-left: var(--border-w) solid var(--shellbd, var(--border));
+}
+
+.btn-seg .btn:hover:not(:disabled),
+:root[data-theme='skeuomorph'] .btn-seg .btn:hover:not(:disabled) {
+  background: var(--bg-elevated);
+}
+
+.btn-seg .btn:active:not(:disabled),
+:root[data-theme='skeuomorph'] .btn-seg .btn:active:not(:disabled) {
+  transform: none;
+  box-shadow: var(--pixel-shadow-active, inset 0 2px 4px rgba(0, 0, 0, 0.3));
+}
+
+/* A toggle inside the group (the device tree's sync switch) shows its ON state
+ * as a filled segment — it cannot use the usual accent BORDER, having none.
+ *
+ * BACKGROUND ONLY, deliberately. `.btn--ghost.is-active` already supplies the
+ * accent text colour, and the device tree overrides that with a green tick /
+ * red cross for the sync outcome using a doubled class (0,2,0). Setting `color`
+ * here would be (0,3,0) and silently win, so a completed sync would stop being
+ * green the moment auto-sync was on — which is most of the time. */
+.btn-seg .btn.is-active,
+:root[data-theme='skeuomorph'] .btn-seg .btn.is-active {
+  background: var(--bg-sunken);
+}
+
 /* Connection status indicator — placeholder, purely visual. */
 .conn-status {
   display: inline-flex;

--- a/test/segmentedToolbar.test.ts
+++ b/test/segmentedToolbar.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+
+/**
+ * The segmented icon group — the file panels' "mini toolbar" (#865).
+ *
+ * These are assertions about the CASCADE, which is where this feature is either
+ * right or broken and where nothing else would catch it: the group looks
+ * correct in one skin and falls apart in the other, and no unit test of any
+ * component would notice. The specific trap is that the skeuomorph skin styles
+ * `.btn` with three selector components, so an unscoped `.btn-seg .btn` (two)
+ * loses to it and the children keep their pill borders inside the group.
+ */
+
+const INDEX = readFileSync('src/renderer/src/index.css', 'utf8')
+
+/** The declaration block for a selector, or '' when the rule is absent. */
+function block(css: string, selector: string): string {
+  const i = css.indexOf(selector)
+  if (i === -1) return ''
+  const open = css.indexOf('{', i)
+  const close = css.indexOf('}', open)
+  return open === -1 || close === -1 ? '' : css.slice(open + 1, close)
+}
+
+describe('the group itself', () => {
+  it('exists, and fuses its children with no gap between them', () => {
+    const rule = block(INDEX, '\n.btn-seg {')
+    expect(rule).toContain('display: inline-flex')
+    // A gap would open the group's own background through the middle of what is
+    // meant to read as one control.
+    expect(rule).toMatch(/gap:\s*0;/)
+    expect(rule).toContain('overflow: hidden')
+  })
+
+  it('takes every colour from a theme token', () => {
+    // A literal here would look right in one skin and wrong in the other — the
+    // failure mode the whole two-skin rule exists to prevent.
+    const rule = block(INDEX, '\n.btn-seg {')
+    expect(rule).not.toMatch(/#[0-9a-fA-F]{3,8}\b/)
+    expect(rule).toContain('var(--')
+  })
+})
+
+describe('the skin-scoped twin of every child rule', () => {
+  // `:root[data-theme='skeuomorph'] .btn` outranks `.btn-seg .btn`, so each
+  // child rule has to be written twice. Losing one of the twins is a silent
+  // break in exactly one skin, which is why this is asserted rather than
+  // trusted.
+  const childRules = [
+    '.btn-seg .btn,',
+    '.btn-seg .btn + .btn,',
+    '.btn-seg .btn:hover:not(:disabled),',
+    '.btn-seg .btn:active:not(:disabled),',
+    '.btn-seg .btn.is-active,'
+  ]
+
+  for (const rule of childRules) {
+    const scoped = `:root[data-theme='skeuomorph'] ${rule.replace(/,$/, '')} {`
+    it(`pairs \`${rule.replace(/,$/, '')}\` with its skeuomorph twin`, () => {
+      expect(INDEX).toContain(rule)
+      expect(INDEX).toContain(scoped)
+    })
+  }
+
+  it('strips the pill off the children so they read as one control', () => {
+    const rule = block(INDEX, '\n.btn-seg .btn,')
+    expect(rule).toContain('border: none')
+    expect(rule).toContain('border-radius: 0')
+    expect(rule).toContain('background: transparent')
+  })
+
+  it('draws a seam between adjacent segments', () => {
+    expect(block(INDEX, '\n.btn-seg .btn + .btn,')).toContain('border-left:')
+  })
+})
+
+describe('the active toggle inside the group', () => {
+  it('fills its segment but does NOT set a colour', () => {
+    // The device tree colours its sync button green on success / red on failure
+    // with a doubled class (0,2,0). A `color` here would be (0,3,0) and win, so
+    // a completed sync would stop reading as green whenever auto-sync was on.
+    const rule = block(INDEX, '\n.btn-seg .btn.is-active,')
+    expect(rule).toContain('background:')
+    expect(rule).not.toMatch(/(^|[;\s])color:/)
+  })
+})
+
+describe('both file panels use it', () => {
+  const panels = [
+    {
+      name: 'Local files',
+      tsx: 'src/renderer/src/components/LocalFileTree.tsx',
+      css: 'src/renderer/src/components/LocalFileTree.css',
+      actions: '.localtree__header-actions {'
+    },
+    {
+      name: 'Device files',
+      tsx: 'src/renderer/src/components/DeviceFileTree.tsx',
+      css: 'src/renderer/src/components/DeviceFileTree.css',
+      actions: '.devicetree__header-actions {'
+    }
+  ]
+
+  for (const p of panels) {
+    it(`${p.name}: the header actions are a segmented group`, () => {
+      expect(readFileSync(p.tsx, 'utf8')).toContain('btn-seg')
+    })
+
+    it(`${p.name}: the group is a labelled toolbar for screen readers`, () => {
+      expect(readFileSync(p.tsx, 'utf8')).toMatch(/role="toolbar"/)
+    })
+
+    it(`${p.name}: its own rule sets no gap, which would break the seam`, () => {
+      // Component CSS loads after index.css, so a `gap` here beats the group's
+      // `gap: 0` at equal specificity and prises the buttons apart.
+      expect(block(readFileSync(p.css, 'utf8'), p.actions)).not.toMatch(/(^|[;\s])gap:/)
+    })
+  }
+})


### PR DESCRIPTION
Closes #865.

## Why

The two file panels' operations were four loose icon glyphs floating in a panel header, while the *same kind* of operation in the main toolbar — New, New folder, Open — sits in a fused segmented control. Same actions, two different visual grammars, in one window.

## What

Both panel headers now use one shared `.btn-seg` group, seamed together into a single instrument-like control that matches the main toolbar:

- **Local files** — refresh, new file, new folder, open folder
- **Device files** — sync, refresh, new file, new folder

Each group is also a labelled `role="toolbar"`, which is what it has been behaving as all along.

## Two things worth knowing about the CSS

**It works in both skins.** The fused look had only ever existed under skeuomorph — `.toolbar__seg` is defined nowhere else — so the dark theme has always shown three loose buttons in the main toolbar. The shared group is defined for both, so the file panels read the same either way.

**Every child rule is written twice.** The skeuomorph skin styles `.btn` at `:root[data-theme='skeuomorph'] .btn` — three selector components against `.btn-seg .btn`'s two — so without a skin-scoped twin the children keep their pill borders and gradients inside the group, and the control comes apart in exactly one theme. `.toolbar__seg` solved it the same way. This is pinned by tests because nothing else would notice.

One subtlety: the active-toggle rule sets a background and **deliberately no colour**. The device tree colours its sync button green on success and red on failure using a doubled class (0,2,0); a `color` here would be (0,3,0), silently win, and stop a completed sync reading as green whenever auto-sync was on — which is most of the time.

## Scope

**The main toolbar is untouched.** It already looks the way this is matching, and restyling a flagship surface is not what the issue asked for. Sharing the definition with it — so there is one segmented control rather than two — belongs with the dedupe work in #860.

## Tests

16 new tests, all about the cascade, because that is where this is either right or broken:

- every `.btn-seg .btn…` rule has its skeuomorph twin
- the group takes every colour from a theme token, no literals
- the active rule sets a background and no colour
- both panels carry the class and the toolbar role
- neither panel's own rule sets a `gap` — component CSS loads after `index.css`, so a gap there would beat the group's `gap: 0` at equal specificity and prise the buttons apart

I checked these fail for the right reasons: dropping one skeuomorph twin and adding a `color` to the active rule failed exactly those two tests, and nothing else.

Gates: lint ok · typecheck ok · **5,964 tests** ok · build ok.

## Not verified on screen

Same caveat as #866 — I have not looked at this in a running window, which for a purely visual change is the check that matters most. The specificity is reasoned and tested rather than observed. Worth a glance in both themes before merging, or say the word and I will drive it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe