### PR TITLE
Make the two file toolbars consistent (#868)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **Both file toolbars now sit the same way** (#868). The Device files actions
+  shared the title's row and were pushed to one end of it, while the Local files
+  actions had a centred row of their own — the same control in two places. Both
+  now span the full width of their panel with the icons centred. The device
+  panel's sync and tick glyphs were also drawn 14 units wide inside the same
+  14px box where refresh is drawn 10, which made them read as bigger icons; they
+  are redrawn to match. Refresh, New file and New folder had been defined twice,
+  byte for byte, once in each panel — they are one shared set now, so the two
+  toolbars cannot drift apart again.
+
 - **The Local files and Device files actions sit in a toolbar** (#865). The
   refresh / new file / new folder / open folder icons — and the device panel's
   sync / refresh / new file / new folder — were four loose glyphs floating in a

--- a/src/renderer/src/components/DeviceFileTree.css
+++ b/src/renderer/src/components/DeviceFileTree.css
@@ -8,17 +8,29 @@
  */
 
 /*
- * Header row (title + Refresh). At narrow panel widths the Refresh button used
- * to be clipped off the right edge (issue #85): allow the row to wrap and let
- * the title shrink so Refresh always stays reachable.
+ * The header is a COLUMN: title, then the file-operations toolbar on its own
+ * full-width row (#868) — the same shape as the Local panel, whose actions have
+ * always sat that way. Before this the device actions were pushed to one end of
+ * the title row by the base rule's `space-between`, so the two panels' toolbars
+ * disagreed about where a file operation lives. Overrides the base
+ * `.devicetree__header` in index.css, which is a centred row.
+ *
+ * This also retires the wrap that #85 added: the buttons had been clipped off
+ * the right edge at narrow panel widths, which cannot happen once they have a
+ * row to themselves.
  */
 .devicetree__header {
-  flex-wrap: wrap;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: flex-start;
+  gap: 0.35rem;
 }
 
 .devicetree__title {
   min-width: 0;
-  flex: 1 1 auto;
+  /* `0 0 auto`, not `1 1 auto`: the header is a column now, so a growing title
+     would take the space the toolbar sits in. */
+  flex: 0 0 auto;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -29,10 +41,12 @@
  * local section's `.localtree__header-actions` so the two file panes match
  * (issue #104). The shared `.btn.btn--icon` square-button rule lives in
  * `LocalFileTree.css`.
+ *
+ * Full-width segmented group (`.btn-seg btn-seg--full` in index.css, #865/#868)
+ * — it draws the seams between the buttons and centres them itself, so a `gap`
+ * here would open the group's own background up through the middle of the
+ * control, and a `justify-content` would fight the centring.
  */
-/* Segmented group (`.btn-seg` in index.css, #865) — it draws the seams between
-   the buttons itself, so a `gap` here would open the group's background up
-   through the middle of the control. */
 .devicetree__header-actions {
   display: flex;
   align-items: center;

--- a/src/renderer/src/components/DeviceFileTree.tsx
+++ b/src/renderer/src/components/DeviceFileTree.tsx
@@ -7,6 +7,7 @@ import { useWorkspace } from '../store/workspace'
 import { useSync } from '../store/sync'
 import { usageLabel, usedPct, type DiskUsage } from './disk-usage'
 import { ContextMenu, type ContextMenuItem, type ContextMenuPosition } from './ContextMenu'
+import { iconProps, NewFileIcon, NewFolderIcon, RefreshIcon } from './file-tree-icons'
 import { Placeholder } from './Placeholder'
 import { usePrompt } from './PromptModal'
 import {
@@ -44,69 +45,35 @@ import './DeviceFileTree.css'
  */
 
 /**
- * Inline pixel icons matching the retro toolbar style (16×16, crispEdges),
- * mirroring the `LocalFileTree` header actions so the two file panes stay
- * visually consistent (issue #104).
+ * Refresh / New file / New folder are SHARED with the Local panel — see
+ * {@link file://./file-tree-icons.tsx}. They used to be a second, byte-identical
+ * copy here, which is how two toolbars meant to match stop matching (#868).
+ * Only the two device-specific glyphs are drawn below.
  */
-const iconProps = {
-  viewBox: '0 0 16 16',
-  width: 14,
-  height: 14,
-  shapeRendering: 'crispEdges' as const,
-  'aria-hidden': true,
-  focusable: false
-}
 
-// circular arrows (refresh) — re-read the device's root listing
-const RefreshIcon = (): JSX.Element => (
-  <svg {...iconProps}>
-    <g fill="currentColor">
-      <path d="M3 8a5 5 0 0 1 8.5-3.5L13 3v4H9l1.6-1.6A3 3 0 0 0 5 8z" />
-      <path d="M13 8a5 5 0 0 1-8.5 3.5L3 13V9h4l-1.6 1.6A3 3 0 0 0 11 8z" />
-    </g>
-  </svg>
-)
-
-// page with a `+` (new file)
-const NewFileIcon = (): JSX.Element => (
-  <svg {...iconProps}>
-    <g fill="currentColor">
-      <path d="M3 1h6l4 4v10H3z M9 1v4h4" />
-      <rect x="7" y="8" width="2" height="6" />
-      <rect x="5" y="10" width="6" height="2" />
-    </g>
-  </svg>
-)
-
-// folder with a `+` (new folder)
-const NewFolderIcon = (): JSX.Element => (
-  <svg {...iconProps}>
-    <g fill="currentColor">
-      <path d="M1 3h5l2 2h7v9H1z" />
-      <rect x="7" y="8" width="2" height="5" fill="var(--bg-elevated)" />
-      <rect x="5.5" y="9.5" width="5" height="2" fill="var(--bg-elevated)" />
-    </g>
-  </svg>
-)
-
-// two opposing arrows (sync) — push tagged local files to the device (#178)
+// two opposing arrows (sync) — push tagged local files to the device (#178).
+//
+// Drawn inside x/y 3..13, matching Refresh. The original spanned 1..15 — 14
+// units wide against its neighbours' 10 — which made it read as a bigger icon
+// at an identical 14px, reported as such in #868.
 const SyncIcon = (): JSX.Element => (
   <svg {...iconProps}>
     <g fill="currentColor">
-      <path d="M2 5h9V2l4 4-4 4V7H2z" />
-      <path d="M14 11H5v3l-4-4 4-4v3h9z" />
+      <path d="M3 5h7V3l3 3-3 3V7H3z" />
+      <path d="M13 11H6v2l-3-3 3-3v2h7z" />
     </g>
   </svg>
 )
 
-// checkmark — shown briefly when a sync completes (#178)
+// checkmark — shown briefly when a sync completes (#178). Same 3..13 box as the
+// sync arrows it replaces, so the button does not appear to change size.
 const CheckIcon = (): JSX.Element => (
   <svg {...iconProps}>
     <path
-      d="M2 8l4 4 8-9"
+      d="M3 8l3.5 3.5 6.5-7"
       fill="none"
       stroke="currentColor"
-      strokeWidth="2.5"
+      strokeWidth="2.2"
       strokeLinecap="round"
       strokeLinejoin="round"
     />
@@ -719,7 +686,11 @@ export function DeviceFileTree(): JSX.Element {
         </span>
         {/* Icon-only header actions mirroring the local section (issue #104):
             the file-sync toggle (#178), then Refresh, New file, New folder. */}
-        <div className="devicetree__header-actions btn-seg" role="toolbar" aria-label="Device file actions">
+        <div
+          className="devicetree__header-actions btn-seg btn-seg--full"
+          role="toolbar"
+          aria-label="Device file actions"
+        >
           {/* One sync toggle: turning it ON syncs the tagged files now AND keeps
               them auto-syncing on every save; turning it OFF stops auto-syncing.
               The icon turns into a green tick for a moment when a sync completes. */}

--- a/src/renderer/src/components/LocalFileTree.css
+++ b/src/renderer/src/components/LocalFileTree.css
@@ -41,20 +41,15 @@
   white-space: nowrap;
 }
 
-/* The file actions are a segmented group now (`.btn-seg` in index.css, #865),
-   which supplies the seams between the buttons — so no `gap` here: a gap would
-   show the group's own background through the middle of the control. */
+/* The file actions are a FULL-WIDTH segmented group (`.btn-seg btn-seg--full`
+   in index.css, #865/#868), which supplies the seams between the buttons and
+   centres them itself — so no `gap` and no `justify-content` here. A gap would
+   show the group's own background through the middle of the control, and the
+   `--center` modifier this rule used to carry is now the group's own job. */
 .localtree__header-actions {
   display: flex;
   align-items: center;
   flex: 0 0 auto;
-}
-/* The 4 file-action icons sit CENTRED on their own row.
-   `align-self`, not `justify-content`: the header is a COLUMN flex with
-   `align-items: stretch`, so the group would otherwise be pulled to the full
-   panel width and read as a bar rather than a toolbar. */
-.localtree__header-actions--center {
-  align-self: center;
 }
 /* Collapse-the-Files-panel chevron, pinned top-right. */
 .localtree__collapse {

--- a/src/renderer/src/components/LocalFileTree.tsx
+++ b/src/renderer/src/components/LocalFileTree.tsx
@@ -6,6 +6,7 @@ import { useSync } from '../store/sync'
 import { useFileSelection } from '../store/file-selection'
 import { ContextMenu, type ContextMenuItem, type ContextMenuPosition } from './ContextMenu'
 import { usePrompt } from './PromptModal'
+import { iconProps, NewFileIcon, NewFolderIcon, RefreshIcon } from './file-tree-icons'
 import './LocalFileTree.css'
 
 /**
@@ -25,52 +26,12 @@ import './LocalFileTree.css'
  * "open folder" icon launches the native picker.
  */
 
-/** Inline pixel icons matching the retro toolbar style (16×16, crispEdges). */
-const iconProps = {
-  viewBox: '0 0 16 16',
-  width: 14,
-  height: 14,
-  shapeRendering: 'crispEdges' as const,
-  'aria-hidden': true,
-  focusable: false
-}
-
-// page with a `+` (new file)
-const NewFileIcon = (): JSX.Element => (
-  <svg {...iconProps}>
-    <g fill="currentColor">
-      <path d="M3 1h6l4 4v10H3z M9 1v4h4" />
-      <rect x="7" y="8" width="2" height="6" />
-      <rect x="5" y="10" width="6" height="2" />
-    </g>
-  </svg>
-)
-
-// folder with a `+` (new folder)
-const NewFolderIcon = (): JSX.Element => (
-  <svg {...iconProps}>
-    <g fill="currentColor">
-      <path d="M1 3h5l2 2h7v9H1z" />
-      <rect x="7" y="8" width="2" height="5" fill="var(--bg-elevated)" />
-      <rect x="5.5" y="9.5" width="5" height="2" fill="var(--bg-elevated)" />
-    </g>
-  </svg>
-)
-
+/** The rest of the toolbar's icons are shared with the Device panel — see
+ *  {@link file://./file-tree-icons.tsx}. This one is local-only. */
 // folder (open a different folder)
 const OpenFolderIcon = (): JSX.Element => (
   <svg {...iconProps}>
     <path d="M1 3h5l2 2h7v8H1z" fill="currentColor" />
-  </svg>
-)
-
-// circular arrows (refresh) — re-read the current folder's listing
-const RefreshIcon = (): JSX.Element => (
-  <svg {...iconProps}>
-    <g fill="currentColor">
-      <path d="M3 8a5 5 0 0 1 8.5-3.5L13 3v4H9l1.6-1.6A3 3 0 0 0 5 8z" />
-      <path d="M13 8a5 5 0 0 1-8.5 3.5L3 13V9h4l-1.6 1.6A3 3 0 0 0 11 8z" />
-    </g>
   </svg>
 )
 
@@ -540,7 +501,7 @@ export function LocalFileTree(): JSX.Element {
           </button>
         </div>
         <div
-          className="localtree__header-actions localtree__header-actions--center btn-seg"
+          className="localtree__header-actions btn-seg btn-seg--full"
           role="toolbar"
           aria-label="File actions"
         >

--- a/src/renderer/src/components/file-tree-icons.tsx
+++ b/src/renderer/src/components/file-tree-icons.tsx
@@ -1,0 +1,63 @@
+/**
+ * Icons shared by the two file panels' toolbars (#868).
+ * =============================================================================
+ *
+ * Refresh, New file and New folder were defined SEPARATELY in `LocalFileTree`
+ * and `DeviceFileTree` — byte-for-byte identical, including the `iconProps`
+ * that size them. Two copies of the same drawing is how two toolbars that are
+ * meant to match stop matching, which is what #868 is about. One definition,
+ * imported by both, cannot drift.
+ *
+ * Conventions differ from {@link file://./ui-icons.tsx} on purpose: these are a
+ * 16×16 box drawn with FILLS and `crispEdges`, matching the file panels' dense
+ * 14px chrome, where `ui-icons` is a 24×24 stroked set for larger surfaces.
+ *
+ * OPTICAL SIZE. Every glyph here is drawn inside roughly x/y 1..15 with its
+ * visual mass in 3..13, so they read as the same size sitting side by side. A
+ * glyph that fills more of its box looks bigger even at identical dimensions —
+ * that was the device panel's sync arrows, reported in #868 as "ever so
+ * slightly larger". They were not larger; they were drawn 14 units wide next to
+ * neighbours drawn 10.
+ */
+
+/** Shared sizing for every file-panel icon — 14px in a 16-unit box. */
+export const iconProps = {
+  viewBox: '0 0 16 16',
+  width: 14,
+  height: 14,
+  shapeRendering: 'crispEdges' as const,
+  'aria-hidden': true,
+  focusable: false
+}
+
+/** Page with a `+` — new file. */
+export const NewFileIcon = (): JSX.Element => (
+  <svg {...iconProps}>
+    <g fill="currentColor">
+      <path d="M3 1h6l4 4v10H3z M9 1v4h4" />
+      <rect x="7" y="8" width="2" height="6" />
+      <rect x="5" y="10" width="6" height="2" />
+    </g>
+  </svg>
+)
+
+/** Folder with a `+` — new folder. */
+export const NewFolderIcon = (): JSX.Element => (
+  <svg {...iconProps}>
+    <g fill="currentColor">
+      <path d="M1 3h5l2 2h7v9H1z" />
+      <rect x="7" y="8" width="2" height="5" fill="var(--bg-elevated)" />
+      <rect x="5.5" y="9.5" width="5" height="2" fill="var(--bg-elevated)" />
+    </g>
+  </svg>
+)
+
+/** Circular arrows — re-read the listing. */
+export const RefreshIcon = (): JSX.Element => (
+  <svg {...iconProps}>
+    <g fill="currentColor">
+      <path d="M3 8a5 5 0 0 1 8.5-3.5L13 3v4H9l1.6-1.6A3 3 0 0 0 5 8z" />
+      <path d="M13 8a5 5 0 0 1-8.5 3.5L3 13V9h4l-1.6 1.6A3 3 0 0 0 11 8z" />
+    </g>
+  </svg>
+)

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -1870,6 +1870,16 @@ body {
   overflow: hidden;
 }
 
+/* Full-width variant: the group spans its container and centres its buttons, so
+ * a panel's file operations read as one toolbar strip across the panel rather
+ * than a cluster floating at one end (#868). Declared AFTER `.btn-seg` — equal
+ * specificity, so order is what makes `display: flex` win over `inline-flex`. */
+.btn-seg--full {
+  display: flex;
+  width: 100%;
+  justify-content: center;
+}
+
 .btn-seg .btn,
 :root[data-theme='skeuomorph'] .btn-seg .btn {
   border: none;
@@ -2290,12 +2300,15 @@ body {
   color: var(--text-muted);
 }
 
-.devicetree__header .btn {
-  padding: 0.25rem 0.5rem;
-  font-size: 0.78rem;
-  font-weight: 500;
-  flex: 0 0 auto;
-}
+/* The device header holds nothing but icon buttons now (#868), and this rule
+ * only ever fought `.btn.btn--icon` over their padding — a fight it happened to
+ * lose on file order alone, which is not a thing to leave load-bearing when the
+ * complaint being fixed is "one panel's icons look bigger than the other's".
+ * Removed rather than re-specified: the icon-button rule already sizes them,
+ * identically in both panels.
+ *
+ * .devicetree__header .btn { padding: 0.25rem 0.5rem; … }
+ */
 
 .devicetree__tree {
   flex: 1 1 auto;

--- a/test/segmentedToolbar.test.ts
+++ b/test/segmentedToolbar.test.ts
@@ -13,6 +13,35 @@ import { readFileSync } from 'node:fs'
  */
 
 const INDEX = readFileSync('src/renderer/src/index.css', 'utf8')
+const LOCAL_TSX = readFileSync('src/renderer/src/components/LocalFileTree.tsx', 'utf8')
+const DEVICE_TSX = readFileSync('src/renderer/src/components/DeviceFileTree.tsx', 'utf8')
+const ICONS = readFileSync('src/renderer/src/components/file-tree-icons.tsx', 'utf8')
+
+/** The bounding box of every `d="…"` and `<rect>` in an icon's source, in the
+ *  16-unit viewBox — how BIG a glyph reads, which is not the same as the px it
+ *  is rendered at. */
+function glyphBox(src: string, name: string): { w: number; h: number } {
+  const start = src.indexOf(`const ${name} = `)
+  if (start === -1) throw new Error(`no icon named ${name}`)
+  const body = src.slice(start, src.indexOf('\n)', start))
+  const xs: number[] = []
+  const ys: number[] = []
+  // Path data: every number, alternating x/y from the first move.
+  for (const m of body.matchAll(/d="([^"]+)"/g)) {
+    const nums = (m[1].match(/-?\d*\.?\d+/g) ?? []).map(Number)
+    // Absolute-ish approximation: the glyphs here are drawn with absolute
+    // commands and short relative runs, so min/max over all coordinates is a
+    // fair read of the box they occupy.
+    nums.forEach((n, i) => (i % 2 === 0 ? xs : ys).push(n))
+  }
+  for (const m of body.matchAll(/<rect x="([\d.]+)" y="([\d.]+)" width="([\d.]+)" height="([\d.]+)"/g)) {
+    const [x, y, w, h] = m.slice(1).map(Number)
+    xs.push(x, x + w)
+    ys.push(y, y + h)
+  }
+  if (xs.length === 0) throw new Error(`no geometry in ${name}`)
+  return { w: Math.max(...xs) - Math.min(...xs), h: Math.max(...ys) - Math.min(...ys) }
+}
 
 /** The declaration block for a selector, or '' when the rule is absent. */
 function block(css: string, selector: string): string {
@@ -117,4 +146,70 @@ describe('both file panels use it', () => {
       expect(block(readFileSync(p.css, 'utf8'), p.actions)).not.toMatch(/(^|[;\s])gap:/)
     })
   }
+})
+
+
+describe('the full-width variant (#868)', () => {
+  it('spans the panel and centres its buttons', () => {
+    const rule = block(INDEX, '\n.btn-seg--full {')
+    expect(rule).toContain('width: 100%')
+    expect(rule).toContain('justify-content: center')
+    // `display: flex` has to beat `.btn-seg`'s `inline-flex` at equal
+    // specificity, which only works if this rule comes after it.
+    expect(rule).toContain('display: flex')
+    expect(INDEX.indexOf('.btn-seg--full {')).toBeGreaterThan(INDEX.indexOf('\n.btn-seg {'))
+  })
+
+  it('is used by BOTH panels, so neither toolbar hugs one end', () => {
+    expect(LOCAL_TSX).toContain('btn-seg btn-seg--full')
+    expect(DEVICE_TSX).toContain('btn-seg btn-seg--full')
+  })
+
+  it('gives the device header a row of its own for the toolbar', () => {
+    // It used to share the title's row, where the base rule's `space-between`
+    // pushed it to one end — the asymmetry reported in #868.
+    const rule = block(readFileSync('src/renderer/src/components/DeviceFileTree.css', 'utf8'), '.devicetree__header {')
+    expect(rule).toContain('flex-direction: column')
+    expect(rule).not.toContain('space-between')
+  })
+
+  it('leaves nothing competing to re-pad the device icon buttons', () => {
+    // A live `.devicetree__header .btn` padding rule and `.btn.btn--icon` tie on
+    // specificity, so which one wins is decided by CSS file order — not a thing
+    // to leave load-bearing when the complaint is "one panel's icons look
+    // bigger". Commented out, not just outranked.
+    expect(INDEX).not.toMatch(/^\.devicetree__header \.btn \{/m)
+  })
+})
+
+describe('one set of icons, one size (#868)', () => {
+  it('is defined once and imported by both panels', () => {
+    for (const name of ['RefreshIcon', 'NewFileIcon', 'NewFolderIcon']) {
+      expect(ICONS, name).toContain(`export const ${name}`)
+      // Neither panel keeps its own copy — that is how they drifted.
+      expect(LOCAL_TSX, `${name} in LocalFileTree`).not.toContain(`const ${name} = (`)
+      expect(DEVICE_TSX, `${name} in DeviceFileTree`).not.toContain(`const ${name} = (`)
+    }
+    for (const tsx of [LOCAL_TSX, DEVICE_TSX]) {
+      expect(tsx).toContain("from './file-tree-icons'")
+    }
+  })
+
+  it('sizes them from one shared `iconProps`', () => {
+    expect(ICONS).toContain('export const iconProps')
+    expect(LOCAL_TSX).not.toContain('const iconProps = {')
+    expect(DEVICE_TSX).not.toContain('const iconProps = {')
+  })
+
+  it('draws the device-only glyphs to the same optical size as the shared ones', () => {
+    // The reported "ever so slightly larger" was real but not a sizing bug: the
+    // sync arrows were drawn 14 units wide inside the same 14px box where
+    // Refresh is drawn 10, so they carried more ink and read bigger.
+    const ref = glyphBox(ICONS, 'RefreshIcon')
+    for (const name of ['SyncIcon', 'CheckIcon']) {
+      const box = glyphBox(DEVICE_TSX, name)
+      expect(box.w, `${name} width`).toBeLessThanOrEqual(ref.w)
+      expect(box.h, `${name} height`).toBeLessThanOrEqual(ref.h)
+    }
+  })
 })


### PR DESCRIPTION
Closes #868. Follows #867.

Three reported inconsistencies, and the reason behind each.

## Position: the device toolbar hugged one end

The Device files actions shared the title's row, where the base rule's `space-between` pushed them to it; the Local files actions had a centred row of their own. Same control, two places.

The device header is a column now, so its toolbar gets a row to itself, and **both** groups span the full width of their panel with the icons centred — one strip across the panel rather than a cluster at one end.

That also retires the wrap #85 added to stop the device buttons being clipped off the right edge at narrow widths. It cannot happen once they have a row to themselves.

## Size: real, but not a sizing bug

The icons were **not** different sizes. Both panels used identical `iconProps` — 14px in a 16-unit box — and the shared square-button padding.

But the sync arrows were *drawn* 14 units wide (`M2 5h9V2l4 4…`, spanning x 1→15) next to neighbours drawn 10 (refresh spans 3→13). Half again as much ink in the same box reads as a bigger icon. So the report was right, just about the artwork rather than the dimensions. The sync and tick glyphs are redrawn inside the same 3..13 box as refresh.

## Why they could disagree at all

Refresh, New file and New folder were defined **twice, byte for byte** — once in each panel. Two copies of one drawing is how two toolbars meant to match stop matching. They are one shared `file-tree-icons.tsx` now, along with the `iconProps` that size them, so this particular drift cannot recur.

## One removal worth a look

`.devicetree__header .btn` set a padding that ties on specificity with `.btn.btn--icon`, so which one won was decided by **CSS file order**. Leaving that load-bearing while fixing a complaint about one panel's icons looking bigger than the other's is asking for the report again, so it is gone — the icon-button rule already sizes them, identically in both panels. Nothing else in that header is a non-icon button.

## Tests

23 in the file now, 7 of them new: the full-width variant on both panels, the device header having its own row and no `space-between`, one icon definition rather than two, no competing padding rule, and a glyph **bounding-box** check that the device-only icons are drawn no larger than the shared ones.

That last one fails against the previous artwork — I checked, restoring the old sync path fails exactly that test and nothing else.

Gates: lint ok · typecheck ok · **5,971 tests** ok · build ok.

## Still not verified on screen

Third PR in a row where I have not looked at the result in a running window, and this one is entirely visual. The geometry is reasoned and tested rather than observed. It would be worth a glance in both themes — or say the word and I will drive the app and screenshot it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe