### PR TITLE
Write device files all-or-nothing (#864)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **An interrupted install no longer leaves a broken file on the board** (#864).
+  Driver and package installs wrote each file straight to its final name, so
+  stopping part-way — a disconnect, a cancel, an error on any one file — left a
+  truncated file that nothing knew was incomplete. The next import then failed
+  with a `SyntaxError` pointing into a vendor library, which reads as "that
+  library is broken" rather than "the install didn't finish". One real report
+  blamed line 159 of `lsm6dsox.py`, a line that is a perfectly ordinary `raise`
+  in the real file. Every file now arrives under a temporary name, is checked
+  against the size that should have landed, and is only then moved into place —
+  so the file on the board is the old one or the new one, never half of one, and
+  a short write fails loudly at install time instead of days later. The folder
+  copy does the same. Interrupted installs leave a `.snk-part` file behind,
+  which is inert and overwritten by the next attempt.
+
 ### Changed
 
 - **Both file toolbars now sit the same way** (#868). The Device files actions

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -49,6 +49,7 @@ import {
 import { writeFailureMessage } from '../shared/install-messages'
 import type { RuntimeInfo } from '../shared/dialect'
 import { deviceDirsFor } from '../shared/mip-resolve'
+import { writeAtomically, type AtomicOps } from '../shared/atomic-write'
 import type {
   CopilotDeviceCode,
   CopilotPollResult
@@ -365,6 +366,13 @@ const updates = {
  * Modulino range is 25 files, and over the raw REPL each is a run of hex-chunk
  * round-trips — and silence here reads as a hang.
  */
+/** {@link writeAtomically} over the device IPC channels (#864). */
+const deviceAtomicOps: AtomicOps = {
+  stat: (path) => unwrap<{ size: number }>(ipcRenderer.invoke('device:stat', path)),
+  rename: (from, to) => unwrap<void>(ipcRenderer.invoke('device:rename', from, to)),
+  remove: (path) => unwrap<void>(ipcRenderer.invoke('device:remove', path))
+}
+
 async function writeFilesToBoard(
   name: string,
   files: ModulePlanFile[],
@@ -387,13 +395,20 @@ async function writeFilesToBoard(
       // bytes channel, never the text one: a `.mpy` that took the string route
       // would be silently corrupted by the UTF-8 round-trip and land as a file
       // that imports as garbage.
-      if (file.encoding === 'base64') {
-        await unwrap<void>(
-          ipcRenderer.invoke('device:writeFileBytes', file.path, Buffer.from(file.contents, 'base64'))
-        )
-      } else {
-        await unwrap<void>(ipcRenderer.invoke('device:writeFile', file.path, file.contents))
-      }
+      const bytes =
+        file.encoding === 'base64' ? Buffer.from(file.contents, 'base64') : null
+      // All-or-nothing (#864): the file arrives under a temporary name and is
+      // moved into place once it is whole, so an interrupted install leaves
+      // debris rather than a truncated module that imports as a SyntaxError.
+      await writeAtomically(
+        deviceAtomicOps,
+        file.path,
+        bytes ? bytes.length : Buffer.byteLength(file.contents, 'utf8'),
+        (tmp) =>
+          bytes
+            ? unwrap<void>(ipcRenderer.invoke('device:writeFileBytes', tmp, bytes))
+            : unwrap<void>(ipcRenderer.invoke('device:writeFile', tmp, file.contents))
+      )
     }
     return { ok: true, log: `Wrote ${files.map((f) => f.path).join(', ')}` }
   } catch (err) {

--- a/src/renderer/src/lib/folder-transfer.ts
+++ b/src/renderer/src/lib/folder-transfer.ts
@@ -17,6 +17,7 @@ import {
   type LocalEntry,
   type TransferPlan
 } from '../../../shared/transfer-plan'
+import { writeAtomically, type AtomicOps } from '../../../shared/atomic-write'
 
 /** What the progress dialog is told as a transfer runs. */
 export interface TransferEvent {
@@ -86,6 +87,13 @@ export async function planUploadOf(localRoot: string, deviceDir: string): Promis
  * on after a failure and reporting success at the end is worse — the user would
  * have a folder that looks complete and is not.
  */
+/** {@link writeAtomically} over the renderer's device bridge (#864). */
+const deviceAtomicOps: AtomicOps = {
+  stat: (path) => window.api.device.stat(path),
+  rename: (from, to) => window.api.device.rename(from, to),
+  remove: (path) => window.api.device.remove(path)
+}
+
 export async function runFolderUpload(
   plan: TransferPlan,
   report: TransferReporter,
@@ -108,7 +116,12 @@ export async function runFolderUpload(
     report({ index: i, total: plan.files.length, label: file.label, state: 'copying' })
     try {
       const bytes = await window.api.fs.readFileBytes(file.local)
-      await window.api.device.writeFileBytes(file.device, bytes)
+      // All-or-nothing (#864): the same reason the driver installer does it.
+      // Stopping mid-file used to leave a truncated file under its real name,
+      // which for a .py is a SyntaxError somewhere nobody will think to look.
+      await writeAtomically(deviceAtomicOps, file.device, bytes.length, (tmp) =>
+        window.api.device.writeFileBytes(tmp, bytes)
+      )
       copied++
       report({ index: i, total: plan.files.length, label: file.label, state: 'done' })
     } catch (err) {

--- a/src/shared/atomic-write.ts
+++ b/src/shared/atomic-write.ts
@@ -1,0 +1,135 @@
+/**
+ * WRITE A DEVICE FILE ALL-OR-NOTHING (#864)
+ * =============================================================================
+ *
+ * A driver install writes each file straight to its final path. Interrupt it —
+ * a disconnect, a cancel, an error on any one file — and the partially-written
+ * file stays on the board **under its real name**, and nothing knows it is
+ * incomplete. The next import of that package then fails with a `SyntaxError`
+ * pointing into a vendor file, which reads as "the library is broken" rather
+ * than "the install didn't finish".
+ *
+ * That is not hypothetical. A reported ESP32 traceback blamed
+ * `/lib/lsm6dsox.py` line 159 — a line that is `raise ValueError(...)` in the
+ * real 362-line file, which parses cleanly. The copy on the board was a valid
+ * prefix of a 12 KB file and nothing else.
+ *
+ * So: write to a temporary name beside the target, check what landed, and only
+ * then move it into place. An interrupted install now leaves a stray temp file
+ * — inert, overwritten by the next attempt, and removed on the way out — and
+ * the real file is either the old one or the new one.
+ *
+ * HONEST LIMITS. `os.rename` onto an existing name overwrites on littlefs and
+ * fails with EEXIST on FAT, and Snakie supports boards with both. Where it
+ * fails we remove and retry, which leaves a one-round-trip window in which the
+ * file is ABSENT. That is a real gap, but it is a different and far better
+ * failure: a missing module raises `ImportError: no module named x`, which says
+ * what happened, instead of a syntax error deep inside someone else's library.
+ *
+ * Pure over an injected {@link AtomicOps}, so the desktop install path (which
+ * talks over `ipcRenderer`) and the renderer's folder transfer (which talks
+ * over `window.api`) share ONE implementation, and it unit-tests in node.
+ */
+
+/**
+ * The device file operations this needs, beyond the write itself — which the
+ * caller passes in per file, because the text and bytes channels are different
+ * calls and choosing between them is the caller's business.
+ */
+export interface AtomicOps {
+  /** Size of `path` in bytes. May throw or be unavailable — see below. */
+  stat: (path: string) => Promise<{ size: number }>
+  rename: (from: string, to: string) => Promise<void>
+  remove: (path: string) => Promise<void>
+}
+
+/**
+ * Suffix marking a half-written file. Deliberately unlovely and unlikely to
+ * collide with anything a user would name, and it sorts next to its target in a
+ * directory listing so a stray one is obvious rather than mysterious.
+ */
+export const TEMP_SUFFIX = '.snk-part'
+
+/**
+ * The temporary name for `path` — same directory, so the rename is a rename and
+ * not a copy across filesystems.
+ */
+export function tempPathFor(path: string): string {
+  return `${path}${TEMP_SUFFIX}`
+}
+
+/** Best-effort cleanup; a failure here must never mask the real error. */
+async function tryRemove(ops: AtomicOps, path: string): Promise<void> {
+  try {
+    await ops.remove(path)
+  } catch {
+    // The port may already be gone — which is exactly when this runs. The next
+    // install overwrites the temp anyway, so a leftover is untidy, not harmful.
+  }
+}
+
+/**
+ * Move `tmp` onto `target`, coping with a filesystem that will not rename onto
+ * an existing name.
+ */
+async function commit(ops: AtomicOps, tmp: string, target: string): Promise<void> {
+  try {
+    await ops.rename(tmp, target)
+    return
+  } catch {
+    // FAT refuses this; littlefs does not. Fall through to remove-and-retry.
+  }
+  await tryRemove(ops, target)
+  await ops.rename(tmp, target)
+}
+
+/**
+ * Check the bytes actually arrived, when the board will say.
+ *
+ * A size mismatch is a hard failure: it means a write returned without an error
+ * having written the wrong thing, which is the silent corruption this whole
+ * module exists to stop. A `stat` that THROWS is not — some paths (a mounted
+ * CIRCUITPY drive, a board mid-reset) can't answer, and refusing to install
+ * because the check itself was unavailable would trade a rare bug for a common
+ * one.
+ */
+async function verify(ops: AtomicOps, tmp: string, expectedBytes: number): Promise<void> {
+  let size: number
+  try {
+    size = (await ops.stat(tmp)).size
+  } catch {
+    return
+  }
+  if (typeof size !== 'number' || Number.isNaN(size)) return
+  if (size !== expectedBytes) {
+    throw new Error(
+      `short write: ${size} of ${expectedBytes} bytes arrived. The board may have run out of space.`
+    )
+  }
+}
+
+/**
+ * Write `target` all-or-nothing.
+ *
+ * `write` is handed the temporary path and must write the whole file there —
+ * the caller owns the choice of text or bytes channel. `expectedBytes` is the
+ * byte length that should land (`Buffer.byteLength` for text, not `.length`).
+ *
+ * Throws on failure, having removed the temporary first.
+ */
+export async function writeAtomically(
+  ops: AtomicOps,
+  target: string,
+  expectedBytes: number,
+  write: (tmpPath: string) => Promise<void>
+): Promise<void> {
+  const tmp = tempPathFor(target)
+  try {
+    await write(tmp)
+    await verify(ops, tmp, expectedBytes)
+    await commit(ops, tmp, target)
+  } catch (err) {
+    await tryRemove(ops, tmp)
+    throw err
+  }
+}

--- a/test/atomicWrite.test.ts
+++ b/test/atomicWrite.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from 'vitest'
+import { TEMP_SUFFIX, tempPathFor, writeAtomically, type AtomicOps } from '../src/shared/atomic-write'
+
+/**
+ * All-or-nothing device writes (#864).
+ *
+ * The bug these pin: a driver install wrote each file straight to its final
+ * path, so interrupting it left a TRUNCATED file under its real name. A user's
+ * board ended up with a 12 KB `lsm6dsox.py` cut off mid-way, and the symptom
+ * was `SyntaxError` at line 159 of a vendor library that parses perfectly —
+ * a report that points at the wrong thing entirely.
+ *
+ * So the property under test is: after any failure, the target is either
+ * untouched or complete, and never a prefix. The tests drive a fake board so
+ * every failure mode — a dead port mid-write, a filesystem that refuses to
+ * rename onto an existing name, a short write that did not throw — is
+ * reachable without hardware.
+ */
+
+/** A board that records what was asked of it, and can be made to fail. */
+function fakeBoard(opts: {
+  /** Fail the write to the temp path with this message. */
+  failWrite?: string
+  /** Refuse `rename` onto a name that already exists (FAT does; littlefs does not). */
+  renameRefusesOverwrite?: boolean
+  /** Report this size from `stat` instead of what was written. */
+  reportSize?: number
+  /** Make `stat` unavailable, as a mounted drive or a resetting board can be. */
+  statThrows?: boolean
+  /** Make cleanup fail too — the port is usually gone by then. */
+  removeThrows?: boolean
+  /** Seed the board with an existing file at this path. */
+  existing?: Record<string, number>
+}) {
+  const files: Record<string, number> = { ...(opts.existing ?? {}) }
+  const log: string[] = []
+
+  const ops: AtomicOps = {
+    stat: async (path) => {
+      log.push(`stat ${path}`)
+      if (opts.statThrows) throw new Error('cannot stat')
+      if (!(path in files)) throw new Error(`ENOENT ${path}`)
+      return { size: opts.reportSize ?? files[path] }
+    },
+    rename: async (from, to) => {
+      log.push(`rename ${from} -> ${to}`)
+      if (opts.renameRefusesOverwrite && to in files) throw new Error('EEXIST')
+      if (!(from in files)) throw new Error(`ENOENT ${from}`)
+      files[to] = files[from]
+      delete files[from]
+    },
+    remove: async (path) => {
+      log.push(`remove ${path}`)
+      if (opts.removeThrows) throw new Error('port closed')
+      delete files[path]
+    }
+  }
+
+  const write = async (path: string, bytes: number): Promise<void> => {
+    log.push(`write ${path}`)
+    if (opts.failWrite) throw new Error(opts.failWrite)
+    files[path] = bytes
+  }
+
+  return { ops, files, log, write }
+}
+
+const TARGET = '/lib/lsm6dsox.py'
+
+describe('tempPathFor', () => {
+  it('keeps the temporary beside its target', () => {
+    // Same directory, or the rename is a copy across filesystems and stops
+    // being the cheap atomic move this depends on.
+    expect(tempPathFor(TARGET)).toBe(`/lib/lsm6dsox.py${TEMP_SUFFIX}`)
+    expect(tempPathFor(TARGET).lastIndexOf('/')).toBe(TARGET.lastIndexOf('/'))
+  })
+})
+
+describe('a write that completes', () => {
+  it('lands under a temporary name and is moved into place', async () => {
+    const b = fakeBoard({})
+    await writeAtomically(b.ops, TARGET, 12039, (tmp) => b.write(tmp, 12039))
+
+    expect(b.files[TARGET]).toBe(12039)
+    expect(b.files[tempPathFor(TARGET)]).toBeUndefined()
+    // The real name is never written directly — that is the whole point.
+    expect(b.log).not.toContain(`write ${TARGET}`)
+    expect(b.log).toContain(`rename ${tempPathFor(TARGET)} -> ${TARGET}`)
+  })
+
+  it('replaces an existing file', async () => {
+    const b = fakeBoard({ existing: { [TARGET]: 999 } })
+    await writeAtomically(b.ops, TARGET, 12039, (tmp) => b.write(tmp, 12039))
+    expect(b.files[TARGET]).toBe(12039)
+  })
+})
+
+describe('a write interrupted part-way', () => {
+  it('leaves the old file untouched rather than a truncated new one', async () => {
+    // This is the reported bug. Before the fix the half-written bytes WERE the
+    // file, and the next import failed inside a vendor library.
+    const b = fakeBoard({ existing: { [TARGET]: 12039 }, failWrite: 'port closed' })
+    await expect(
+      writeAtomically(b.ops, TARGET, 12039, (tmp) => b.write(tmp, 12039))
+    ).rejects.toThrow('port closed')
+
+    expect(b.files[TARGET]).toBe(12039) // the good one, still there
+  })
+
+  it('leaves no file at all when there was none before', async () => {
+    const b = fakeBoard({ failWrite: 'port closed' })
+    await expect(
+      writeAtomically(b.ops, TARGET, 12039, (tmp) => b.write(tmp, 12039))
+    ).rejects.toThrow()
+    // An absent module raises ImportError, which names the problem. A truncated
+    // one raises SyntaxError somewhere nobody thinks to look.
+    expect(Object.keys(b.files)).toEqual([])
+  })
+
+  it('clears the temporary away', async () => {
+    const b = fakeBoard({})
+    await expect(
+      writeAtomically(b.ops, TARGET, 12039, async (tmp) => {
+        await b.write(tmp, 4096) // partial write, then the port dies
+        throw new Error('port closed')
+      })
+    ).rejects.toThrow('port closed')
+    expect(b.files[tempPathFor(TARGET)]).toBeUndefined()
+    expect(b.log).toContain(`remove ${tempPathFor(TARGET)}`)
+  })
+
+  it('reports the REAL error even when the cleanup also fails', async () => {
+    // The port being gone is exactly when cleanup runs, so it often cannot
+    // succeed. "port closed" is the useful message; "cannot remove" is noise.
+    const b = fakeBoard({ failWrite: 'port closed', removeThrows: true })
+    await expect(
+      writeAtomically(b.ops, TARGET, 12039, (tmp) => b.write(tmp, 12039))
+    ).rejects.toThrow('port closed')
+  })
+})
+
+describe('a filesystem that will not rename onto an existing name', () => {
+  it('removes the target and retries, so the write still lands', async () => {
+    // FAT refuses; littlefs does not. Snakie sees boards with both.
+    const b = fakeBoard({ renameRefusesOverwrite: true, existing: { [TARGET]: 999 } })
+    await writeAtomically(b.ops, TARGET, 12039, (tmp) => b.write(tmp, 12039))
+
+    expect(b.files[TARGET]).toBe(12039)
+    expect(b.log.filter((l) => l.startsWith('rename'))).toHaveLength(2)
+    expect(b.log).toContain(`remove ${TARGET}`)
+  })
+
+  it('does not pay that cost when the target is new', async () => {
+    const b = fakeBoard({ renameRefusesOverwrite: true })
+    await writeAtomically(b.ops, TARGET, 12039, (tmp) => b.write(tmp, 12039))
+    expect(b.log.filter((l) => l.startsWith('rename'))).toHaveLength(1)
+    expect(b.log).not.toContain(`remove ${TARGET}`)
+  })
+})
+
+describe('a short write that did not throw', () => {
+  it('is caught before it can replace a good file', async () => {
+    const b = fakeBoard({ existing: { [TARGET]: 12039 }, reportSize: 4096 })
+    await expect(
+      writeAtomically(b.ops, TARGET, 12039, (tmp) => b.write(tmp, 12039))
+    ).rejects.toThrow(/short write: 4096 of 12039/)
+
+    expect(b.files[TARGET]).toBe(12039) // untouched
+    expect(b.files[tempPathFor(TARGET)]).toBeUndefined()
+  })
+
+  it('names the likeliest cause, because the board will not', async () => {
+    const b = fakeBoard({ reportSize: 0 })
+    await expect(
+      writeAtomically(b.ops, TARGET, 12039, (tmp) => b.write(tmp, 12039))
+    ).rejects.toThrow(/run out of space/)
+  })
+})
+
+describe('a board that cannot answer stat', () => {
+  it('still installs — an unavailable check must not become a failed install', async () => {
+    // A mounted CIRCUITPY drive or a board mid-reset can refuse. Refusing to
+    // install because the optional check was unavailable trades a rare bug for
+    // a common one.
+    const b = fakeBoard({ statThrows: true })
+    await writeAtomically(b.ops, TARGET, 12039, (tmp) => b.write(tmp, 12039))
+    expect(b.files[TARGET]).toBe(12039)
+  })
+})
+
+describe('both write paths use it', () => {
+  it('the driver installer writes through writeAtomically', () => {
+    const src = readSrc('src/preload/index.ts')
+    expect(src).toContain('writeAtomically(')
+    // …and never straight at the destination.
+    expect(src).not.toMatch(/invoke\('device:writeFile', file\.path/)
+    expect(src).not.toMatch(/invoke\('device:writeFileBytes', file\.path/)
+  })
+
+  it('the folder transfer writes through writeAtomically', () => {
+    const src = readSrc('src/renderer/src/lib/folder-transfer.ts')
+    expect(src).toContain('writeAtomically(')
+    expect(src).not.toMatch(/writeFileBytes\(file\.device/)
+  })
+})
+
+function readSrc(path: string): string {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  return require('node:fs').readFileSync(path, 'utf8')
+}


### PR DESCRIPTION
Closes #864.

## The bug

A driver install wrote each file straight to its final path. Interrupt it — a disconnect, a cancel, an error on any one file — and the partially-written file stayed on the board **under its real name**, with nothing knowing it was incomplete.

The report that prompted this blamed `/lib/lsm6dsox.py` line 159. That line is `raise ValueError(...)` in the real 362-line file, and the whole thing parses cleanly under CPython — the copy on the board was a valid prefix of a 12 KB file and nothing else. The user reads `SyntaxError` in a vendor library and concludes the library is broken.

It is easy to reach: the modulino install writes 22 files back to back, and has a history of *looking* like a hang (#842) whose documented workaround was to click Disconnect — which is exactly the interruption that causes this.

## The fix

Each file arrives under a temporary name beside its target, is checked against the byte count that should have landed, and is only then moved into place. The file on the board is the old one or the new one, never half of one. A short write that somehow did not throw now fails loudly at install time instead of days later inside someone else's library.

The folder copy had the identical shape and gets the same treatment through the same helper — the two paths differ only in which channel they write on, so the ordering logic is written once.

## Two honest limits, both documented at the call site

**Rename is not universally atomic here.** `os.rename` onto an existing name overwrites on littlefs and fails with `EEXIST` on FAT, and Snakie sees boards with both. Where it fails we remove and retry, leaving a one-round-trip window in which the file is **absent**. That is a real gap — and a much better failure: `ImportError: no module named x` names the problem, a `SyntaxError` in a vendor file does not.

**A `stat` that throws does not fail the install.** A mounted CIRCUITPY drive or a board mid-reset cannot always answer, and refusing to install because the optional check was unavailable would trade a rare bug for a common one. A size *mismatch* is still a hard failure; only an unavailable check is waved through.

## Cost

Two extra round trips per file — one `stat`, one `rename`. On a 22-file package that is a couple of seconds on top of a transfer already dominated by round trips. The per-file progress line (`Writing 7/22 — …`) covers it, so it should not read as the hang #842 was about. Worth watching on your next modulino install.

## Debris

An install killed by a dead port leaves a `.snk-part` file behind — cleanup is best-effort and the port is usually already gone by then. It is inert, sorts next to its target so it is obvious rather than mysterious, and the next attempt overwrites it. That is strictly better than the truncated real file it replaces.

## Tests

14 new, driving a fake board so every failure mode is reachable without hardware: a dead port mid-write (old file untouched, no truncated new one), a filesystem that refuses to rename onto an existing name (removes and retries; and does *not* pay that cost when the target is new), a silent short write (caught before it can replace a good file), a `stat` that cannot answer (still installs), and a cleanup that also fails (the real error still propagates, not the cleanup's).

I checked they catch the actual bug: reverting `writeAtomically` to write straight at the destination fails 8 of the 14, including "leaves the old file untouched rather than a truncated new one".

Gates: lint ok · typecheck ok · **5,985 tests** ok · build ok.

## For your board right now

This fixes future installs; the already-truncated file is still there. On the board:

```python
import os; os.remove('/lib/lsm6dsox.py')
```

then reinstall the Modulino driver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe