### PR TITLE
Refactor rule: reset the WiFi interface before connecting (#871)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **A refactoring for the WiFi trap that only bites on the second Run** (#871).
+  Pressing Run does a soft reboot, which re-runs your file — but a soft reboot
+  does not reset the ESP32's radio, so a station left mid-connect by the previous
+  run makes the next `connect()` raise `OSError: Wifi Internal State Error`. The
+  code is correct on a cold boot and broken on the second Run, which points the
+  blame at whatever you changed in between. Snakie now spots
+  `wlan.active(True)` followed by `wlan.connect(…)` with no `active(False)`
+  first, and offers to insert it — with a comment, because the line looks
+  pointless to anyone who has not met the bug. The "Why?" article explains the
+  soft-reset model and why an `isconnected()` guard, which is what everyone
+  tries first, cannot fix it.
+
 ### Fixed
 
 - **An interrupted install no longer leaves a broken file on the board** (#864).

--- a/src/renderer/src/components/help/refactor-wifi-reset-before-connect.md
+++ b/src/renderer/src/components/help/refactor-wifi-reset-before-connect.md
@@ -1,0 +1,67 @@
+A soft reboot leaves the radio as the last run left it, and the next `connect()` raises.
+
+```python
+wlan = network.WLAN(network.STA_IF)
+wlan.active(True)                  # ← on a soft reboot the radio is still
+wlan.connect(SSID, PASSWORD)       #   mid-connect from the last run
+```
+
+```python
+wlan = network.WLAN(network.STA_IF)
+# A soft reboot leaves the radio as the last run left it.
+wlan.active(False)
+wlan.active(True)
+wlan.connect(SSID, PASSWORD)
+```
+
+## Why it matters
+
+Pressing **Run** does a *soft* reboot. Your program is cleared and the file runs
+again from the top — but a soft reboot does not reset the ESP32's WiFi hardware.
+The radio keeps whatever state the previous run left it in.
+
+If that state is "still trying to connect", the next `connect()` refuses:
+
+```
+MPY: soft reboot
+E (7111) wifi:sta is connecting, cannot set config
+Traceback (most recent call last):
+  File "boot.py", line 23, in <module>
+OSError: Wifi Internal State Error
+```
+
+This is a nasty one to meet, because the code is *correct on a cold boot*. Unplug
+the board, plug it back in, run it — fine. Press Run a second time — broken. So
+the evidence points at whatever you changed in between, which is almost never
+the problem.
+
+`active(False)` tears the interface down before you bring it back up, which
+clears that leftover state. On a cold boot the interface is already down, so the
+line does nothing and costs nothing. On every run after the first, it is the
+difference between working and not.
+
+## Why `isconnected()` is not the guard
+
+The obvious first attempt is:
+
+```python
+if not wlan.isconnected():
+    wlan.connect(SSID, PASSWORD)     # still raises
+```
+
+It does not help. The station is *connecting*, not connected — so
+`isconnected()` is `False`, the guard passes, and `connect()` raises exactly as
+before. Guarding on the connection state cannot fix a problem caused by the
+connection *attempt*.
+
+## Before you apply it
+
+- Bringing the interface down **drops a live connection** on purpose. That is
+  the point here, but it means this is not a change to apply blindly across a
+  file you have not read.
+- If your program deliberately keeps a connection alive across runs — a REPL
+  session you reconnect to, say — you want the opposite of this, and should
+  guard on `wlan.status()` instead.
+- Waiting for the connection afterwards is still your job. `connect()` returns
+  immediately; the radio takes a second or two, and `ifconfig()` will report
+  `0.0.0.0` until it is done.

--- a/src/shared/refactor/rules/index.ts
+++ b/src/shared/refactor/rules/index.ts
@@ -95,7 +95,8 @@ import { packIntoBufferRule } from './pack-into-buffer' // 85
 import { dropUModuleShimRule } from './drop-u-module-shim' // 86
 import { batchFileWritesRule } from './batch-file-writes' // 87
 import { integerDivisionRule } from './integer-division' // 88
-import { timerCallbackAllocationRule } from './timer-callback-allocation' // 89
+import { timerCallbackAllocationRule } from './timer-callback-allocation'
+import { wifiResetBeforeConnectRule } from './wifi-reset-before-connect' // 91
 
 // R6b — board-specific optimisation (§3.7)
 import { tryNativeEmitterRule } from './try-native-emitter' // 43
@@ -215,7 +216,8 @@ export const MICROPYTHON_RULES: RefactorRule<unknown>[] = [
   dropUModuleShimRule,
   batchFileWritesRule,
   integerDivisionRule,
-  timerCallbackAllocationRule
+  timerCallbackAllocationRule,
+  wifiResetBeforeConnectRule
 ]
 
 /** §3.7 — board-specific optimisation. Every rule here carries a `requires`

--- a/src/shared/refactor/rules/wifi-reset-before-connect.ts
+++ b/src/shared/refactor/rules/wifi-reset-before-connect.ts
@@ -1,0 +1,178 @@
+/**
+ * Rule 91 — **Reset the WiFi interface before connecting** (epic #634 §3.6,
+ * MicroPython), issue #871.
+ *
+ * ```python
+ * wlan = network.WLAN(network.STA_IF)
+ * wlan.active(True)                  # ← on a soft reboot the radio is still
+ * wlan.connect(SSID, PASSWORD)       #   mid-connect from the last run
+ * ```
+ *
+ * Why it matters: pressing Run does a **soft reboot**, which re-runs `boot.py`
+ * — but a soft reboot does not reset the ESP32's WiFi peripheral. The station
+ * interface keeps whatever state the previous run left it in, and if that state
+ * is "connecting", the next `connect()` refuses:
+ *
+ * ```
+ * E (7111) wifi:sta is connecting, cannot set config
+ * OSError: Wifi Internal State Error
+ * ```
+ *
+ * The code is correct on a cold boot and fails on the second Run, which is a
+ * particularly unhelpful way for a bug to present itself.
+ *
+ * The fix is to deinit the interface first. `active(False)` on an interface that
+ * is already down is a no-op, so it costs nothing on a cold boot and makes the
+ * soft-reset path work every time.
+ *
+ * Note what does NOT fix it: an `isconnected()` guard. The station is
+ * *connecting*, not connected, so the guard passes and `connect()` still
+ * raises — which is why people reach for it, watch it not help, and conclude
+ * the board is haunted.
+ *
+ * Not `safe`: bringing the interface down deliberately drops a live connection,
+ * so "Tidy this file" must never batch this one in silently.
+ */
+import type { AnyNode, Call, Expr } from '../ast'
+import { walk } from '../ast'
+import { dottedName } from '../expr'
+import { indentAt, lineStart, type TextEdit } from '../text'
+import { defineRule } from '../types'
+import type { RefactorContext, RefactorMatch } from '../types'
+
+interface WifiResetMatch {
+  /** The variable holding the interface, e.g. `wlan`. */
+  name: string
+  /** Offset of the line holding `name.active(True)`. */
+  lineAt: number
+}
+
+/** Is this expression the literal `True`? */
+function isTrue(node: Expr | undefined): boolean {
+  return node?.type === 'Constant' && node.kind === 'bool' && node.raw === 'True'
+}
+
+/** Is this expression the literal `False`? */
+function isFalse(node: Expr | undefined): boolean {
+  return node?.type === 'Constant' && node.kind === 'bool' && node.raw === 'False'
+}
+
+/**
+ * `x.active(…)` → `x`, for any dotted receiver. Returns null for a bare
+ * `active(…)` or anything that is not a method call on a plain name.
+ */
+function activeReceiver(node: AnyNode): { call: Call; name: string; arg?: Expr } | null {
+  if (node.type !== 'Call') return null
+  const dotted = dottedName(node.func)
+  if (!dotted || !dotted.endsWith('.active')) return null
+  const name = dotted.slice(0, -'.active'.length)
+  // Only a simple name receiver. `self.wlan.active(True)` is a real pattern but
+  // the name we would have to insert is `self.wlan`, and proving that refers to
+  // the same object across a method boundary is more than this rule should claim.
+  if (name.includes('.')) return null
+  return { call: node, name, arg: node.args[0] }
+}
+
+/**
+ * Names bound to a WLAN interface somewhere in this file.
+ *
+ * Anchoring on the constructor is what keeps the rule off everything else with
+ * an `active()` method — a Timer, a display driver, someone's own class. If the
+ * file never builds a `WLAN`, the rule has nothing to say about it.
+ */
+function wlanNames(ctx: RefactorContext): Set<string> {
+  const names = new Set<string>()
+  walk(ctx.module as AnyNode, (node) => {
+    if (node.type !== 'Assign') return
+    const value = node.value
+    if (value.type !== 'Call') return
+    const ctor = dottedName(value.func)
+    if (ctor !== 'WLAN' && ctor !== 'network.WLAN') return
+    for (const target of node.targets) {
+      if (target.type === 'Name') names.add(target.id)
+    }
+  })
+  return names
+}
+
+export const wifiResetBeforeConnectRule = defineRule<WifiResetMatch>({
+  id: 'wifi-reset-before-connect',
+  title: 'Reset the WiFi interface before connecting',
+  message: 'A soft reboot leaves the radio mid-connect, and the next connect() raises',
+  catalogue: 91,
+  category: 'micropython',
+  kind: 'quickfix',
+  severity: 'warning',
+  helpArticle: 'refactor-wifi-reset-before-connect',
+  // Bringing the interface down drops a live connection on purpose. Correct
+  // here, but not something to batch into a "tidy the file" sweep unasked.
+  safe: false,
+
+  detect(ctx: RefactorContext): RefactorMatch<WifiResetMatch>[] {
+    const names = wlanNames(ctx)
+    if (names.size === 0) return []
+
+    /** Every `name.active(True)`, `name.active(False)` and `name.connect(…)`. */
+    const ups = new Map<string, Call[]>()
+    const downs = new Map<string, Call[]>()
+    const connects = new Set<string>()
+
+    walk(ctx.module as AnyNode, (node) => {
+      const hit = activeReceiver(node)
+      if (hit && names.has(hit.name)) {
+        const bucket = isTrue(hit.arg) ? ups : isFalse(hit.arg) ? downs : null
+        if (bucket) {
+          const list = bucket.get(hit.name)
+          if (list) list.push(hit.call)
+          else bucket.set(hit.name, [hit.call])
+        }
+        return
+      }
+      if (node.type !== 'Call') return
+      const dotted = dottedName(node.func)
+      if (!dotted) return
+      const name = dotted.slice(0, dotted.lastIndexOf('.'))
+      if (dotted.endsWith('.connect') && names.has(name)) connects.add(name)
+    })
+
+    const out: RefactorMatch<WifiResetMatch>[] = []
+    for (const [name, calls] of ups) {
+      // No `connect()` means the file only brings the interface up — an access
+      // point, a scan — and the trap this rule is about needs a connect.
+      if (!connects.has(name)) continue
+      const first = calls.reduce((a, b) => (a.start <= b.start ? a : b))
+      // Already deinits before bringing it up? Then it survives a soft reboot
+      // and there is nothing to say.
+      const deinitsFirst = (downs.get(name) ?? []).some((d) => d.start < first.start)
+      if (deinitsFirst) continue
+
+      out.push({
+        ruleId: 'wifi-reset-before-connect',
+        start: first.start,
+        end: first.end,
+        message:
+          `Run does a soft reboot, which re-runs this file but leaves the radio as the last run ` +
+          `left it. Add \`${name}.active(False)\` first so \`connect()\` cannot raise ` +
+          `"Wifi Internal State Error"`,
+        data: { name, lineAt: lineStart(ctx.src, first.start) }
+      })
+    }
+    return out.sort((a, b) => a.start - b.start)
+  },
+
+  apply(match: RefactorMatch<WifiResetMatch>, ctx: RefactorContext): TextEdit[] | null {
+    const { name, lineAt } = match.data
+    // Match the indentation of the line being guarded, so this lands correctly
+    // inside a function or an `if` as readily as at module level.
+    const pad = indentAt(ctx.src, lineAt)
+    return [
+      {
+        start: lineAt,
+        end: lineAt,
+        // A comment, because the line looks pointless to anyone who has not met
+        // this bug — and a line that looks pointless gets deleted.
+        newText: `${pad}# A soft reboot leaves the radio as the last run left it.${ctx.eol}${pad}${name}.active(False)${ctx.eol}`
+      }
+    ]
+  }
+})

--- a/test/fixtures/refactor/wifi-reset-before-connect/after-2.py
+++ b/test/fixtures/refactor/wifi-reset-before-connect/after-2.py
@@ -1,0 +1,10 @@
+import network
+
+
+def bring_up(ssid, password):
+    sta = network.WLAN(network.STA_IF)
+    # A soft reboot leaves the radio as the last run left it.
+    sta.active(False)
+    sta.active(True)
+    sta.connect(ssid, password)
+    return sta

--- a/test/fixtures/refactor/wifi-reset-before-connect/after.py
+++ b/test/fixtures/refactor/wifi-reset-before-connect/after.py
@@ -1,0 +1,16 @@
+import network
+import time
+
+SSID = "workshop"
+PASSWORD = "hunter2"
+
+wlan = network.WLAN(network.STA_IF)
+# A soft reboot leaves the radio as the last run left it.
+wlan.active(False)
+wlan.active(True)
+wlan.connect(SSID, PASSWORD)
+
+while not wlan.isconnected():
+    time.sleep_ms(100)
+
+print("WiFi up:", wlan.ifconfig()[0])

--- a/test/fixtures/refactor/wifi-reset-before-connect/before-2.py
+++ b/test/fixtures/refactor/wifi-reset-before-connect/before-2.py
@@ -1,0 +1,8 @@
+import network
+
+
+def bring_up(ssid, password):
+    sta = network.WLAN(network.STA_IF)
+    sta.active(True)
+    sta.connect(ssid, password)
+    return sta

--- a/test/fixtures/refactor/wifi-reset-before-connect/before.py
+++ b/test/fixtures/refactor/wifi-reset-before-connect/before.py
@@ -1,0 +1,14 @@
+import network
+import time
+
+SSID = "workshop"
+PASSWORD = "hunter2"
+
+wlan = network.WLAN(network.STA_IF)
+wlan.active(True)
+wlan.connect(SSID, PASSWORD)
+
+while not wlan.isconnected():
+    time.sleep_ms(100)
+
+print("WiFi up:", wlan.ifconfig()[0])

--- a/test/fixtures/refactor/wifi-reset-before-connect/no-match/already-deinits.py
+++ b/test/fixtures/refactor/wifi-reset-before-connect/no-match/already-deinits.py
@@ -1,0 +1,6 @@
+import network
+
+wlan = network.WLAN(network.STA_IF)
+wlan.active(False)
+wlan.active(True)
+wlan.connect("workshop", "hunter2")

--- a/test/fixtures/refactor/wifi-reset-before-connect/no-match/attribute-receiver.py
+++ b/test/fixtures/refactor/wifi-reset-before-connect/no-match/attribute-receiver.py
@@ -1,0 +1,12 @@
+import network
+
+
+class Radio:
+    def __init__(self):
+        self.wlan = network.WLAN(network.STA_IF)
+
+    def up(self, ssid, password):
+        # An attribute receiver: proving this is the same object across a method
+        # boundary is more than the rule claims, so it stays quiet.
+        self.wlan.active(True)
+        self.wlan.connect(ssid, password)

--- a/test/fixtures/refactor/wifi-reset-before-connect/no-match/no-connect.py
+++ b/test/fixtures/refactor/wifi-reset-before-connect/no-match/no-connect.py
@@ -1,0 +1,6 @@
+import network
+
+# An access point is brought up but never connects out, so the trap does not apply.
+ap = network.WLAN(network.AP_IF)
+ap.active(True)
+ap.config(essid="snakie", password="hunter2")

--- a/test/fixtures/refactor/wifi-reset-before-connect/no-match/not-a-wlan.py
+++ b/test/fixtures/refactor/wifi-reset-before-connect/no-match/not-a-wlan.py
@@ -1,0 +1,6 @@
+from machine import Timer
+
+# Plenty of things have an active() method. Only a WLAN has this problem.
+watchdog = Timer(0)
+watchdog.active(True)
+watchdog.connect("nonsense")

--- a/test/wifiResetRule.test.ts
+++ b/test/wifiResetRule.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import { createContext, detectAll } from '../src/shared/refactor/engine'
+import { safeRules, ruleByCatalogue } from '../src/shared/refactor/rules'
+import { wifiResetBeforeConnectRule } from '../src/shared/refactor/rules/wifi-reset-before-connect'
+
+/**
+ * Rule 91 — reset the WiFi interface before connecting (#871).
+ *
+ * The golden fixtures already prove the rewrite and the four cases that must
+ * stay quiet. What they cannot express is the things a reader of the Problems
+ * panel actually experiences: whether the message names *their* variable, and
+ * whether "Tidy this file" is allowed to make this change without being asked.
+ */
+
+/** Matches this rule produces for `src`. */
+function matches(src: string): { start: number; message: string }[] {
+  const ctx = createContext(src, { fileName: 'boot.py' })
+  if (!ctx) throw new Error('fixture does not parse')
+  // Through the engine rather than calling `detect` directly, so the rule is
+  // exercised the way the editor exercises it.
+  return detectAll(ctx, [wifiResetBeforeConnectRule]).map((o) => ({
+    start: o.match.start,
+    // Every match this rule makes carries a message; the type is optional
+    // because other rules fall back to the rule's default.
+    message: o.match.message ?? ''
+  }))
+}
+
+const TRAP = `import network
+
+wlan = network.WLAN(network.STA_IF)
+wlan.active(True)
+wlan.connect("workshop", "hunter2")
+`
+
+describe('what the user is told', () => {
+  it('fires once on the line that brings the interface up', () => {
+    const found = matches(TRAP)
+    expect(found).toHaveLength(1)
+    expect(TRAP.slice(found[0].start, found[0].start + 17)).toBe('wlan.active(True)')
+  })
+
+  it('names the reader’s own variable, not a made-up one', () => {
+    // `wlan` is conventional but not universal; a message about `wlan` in a file
+    // that says `sta` is a message the reader has to translate.
+    expect(matches(TRAP.replace(/wlan/g, 'sta'))[0].message).toContain('sta.active(False)')
+  })
+
+  it('says WHY, because the line it asks for looks pointless otherwise', () => {
+    const message = matches(TRAP)[0].message
+    expect(message).toMatch(/soft reboot/i)
+    expect(message).toContain('Wifi Internal State Error')
+  })
+})
+
+describe('when it stays quiet', () => {
+  it('says nothing when the file already deinits first', () => {
+    expect(matches(TRAP.replace('wlan.active(True)', 'wlan.active(False)\nwlan.active(True)'))).toHaveLength(0)
+  })
+
+  it('says nothing about an access point, which never connects out', () => {
+    expect(
+      matches(`import network
+
+ap = network.WLAN(network.AP_IF)
+ap.active(True)
+ap.config(essid="snakie")
+`)
+    ).toHaveLength(0)
+  })
+
+  it('says nothing about other things with an active() method', () => {
+    // Anchoring on the WLAN constructor is what keeps this off every Timer,
+    // display driver and home-made class in the wild.
+    expect(
+      matches(`from machine import Timer
+
+t = Timer(0)
+t.active(True)
+t.connect("nonsense")
+`)
+    ).toHaveLength(0)
+  })
+
+  it('fires only on the FIRST active(True), not every one', () => {
+    const found = matches(`import network
+
+wlan = network.WLAN(network.STA_IF)
+wlan.active(True)
+wlan.connect("a", "b")
+wlan.active(True)
+`)
+    expect(found).toHaveLength(1)
+  })
+})
+
+describe('how it is classified', () => {
+  it('is not batched by "Tidy this file"', () => {
+    // Bringing the interface down drops a live connection on purpose. Right
+    // here, but not something to do to someone's file unasked.
+    expect(safeRules().map((r) => r.id)).not.toContain(wifiResetBeforeConnectRule.id)
+  })
+
+  it('is registered under its catalogue number', () => {
+    expect(ruleByCatalogue(91)?.id).toBe(wifiResetBeforeConnectRule.id)
+  })
+
+  it('is a warning, not a hint — this one is a crash, not a preference', () => {
+    expect(wifiResetBeforeConnectRule.severity).toBe('warning')
+  })
+})


### PR DESCRIPTION
Closes #871.

Rule 91, from the traceback you hit:

```
MPY: soft reboot
E (7111) wifi:sta is connecting, cannot set config
Traceback (most recent call last):
  File "boot.py", line 23, in <module>
OSError: Wifi Internal State Error
```

## Why this is worth a rule and not a doc note

Pressing Run does a **soft** reboot, which re-runs the file — but a soft reboot does not reset the ESP32's WiFi peripheral. The station keeps whatever state the previous run left it in, and if that state is "connecting", the next `connect()` refuses.

What makes it nasty is how it presents. The code is correct on a **cold** boot: unplug, replug, run — fine. Press Run a second time and it breaks. So the evidence points at whatever you changed in between, which is never the problem.

And it is Snakie's own Run behaviour that puts people in front of it, which seems a good reason for Snakie to be the thing that explains it.

## What it does

Fires on `X.active(True)` where `X` was assigned from `network.WLAN(…)`, the file also calls `X.connect(…)`, and nothing brings the interface down first. Offers to insert:

```python
wlan = network.WLAN(network.STA_IF)
# A soft reboot leaves the radio as the last run left it.
wlan.active(False)
wlan.active(True)
wlan.connect(SSID, PASSWORD)
```

The comment is deliberate. `active(False)` immediately before `active(True)` looks pointless to anyone who has not met this bug, and a line that looks pointless is a line the next person deletes.

## What keeps it quiet

Anchoring on the `WLAN` constructor is what keeps it off every `Timer`, display driver and home-made class with an `active()` method. An attribute receiver (`self.wlan.active(True)`) is deliberately left alone — proving that names the same object across a method boundary is more than this rule should claim. An access point that never connects out is left alone too.

`safe: false`, so **"Tidy this file" cannot batch it**: bringing the interface down drops a live connection on purpose. Right here, not something to do to someone's file unasked.

## The article

Covers the soft-reset model and, specifically, **why `isconnected()` is not the guard**. It is what everyone reaches for first, and it does not work — the station is *connecting*, not connected, so the guard passes and `connect()` raises exactly as before. Watching the obvious fix fail is what turns this from an afternoon into a week.

## Tests

Golden fixtures for the module-level and indented-in-a-function rewrites, plus four `no-match` cases (already deinits, access point with no connect, a non-WLAN object, an attribute receiver). The golden suite also checks idempotence and that bytes outside the edit are untouched, for free.

Ten focused tests cover what fixtures cannot: that the message names the reader's *own* variable rather than a conventional `wlan`, that it fires once rather than on every `active(True)`, and that it stays out of the safe-batch set.

Gates: lint ok · typecheck ok · **6,007 tests** ok · build ok.

## A note on scope

You said "fix 864 as a refactor rule". #864 — the truncated install — could not be one: it is Snakie's own install code, not user Python, and it is fixed properly in #870. This is the refactor rule from the *other* thing you pasted, which is the only one that fits the shape. If you meant something else by it, say and I will redo it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe