### PR TITLE
feat(files): say which files the board runs by itself (#872)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,24 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   pointless to anyone who has not met the bug. The "Why?" article explains the
   soft-reset model and why an `isconnected()` guard, which is what everyone
   tries first, cannot fix it.
+- **`boot.py` is labelled in the device tree, and CircuitPython's file order is
+  corrected** (#872). A file listing cannot show the one thing a beginner most
+  needs to know: which file the board runs on its own, without being asked. The
+  tree already marked the program — `code.py` on CircuitPython, `main.py` on
+  MicroPython — but said nothing about `boot.py`, which is a separate, earlier
+  pass and means different things on the two runtimes. MicroPython runs it at
+  every reset, before `main.py`. CircuitPython runs it once at power-on, before
+  USB is set up — which is the only moment settings like a writable CIRCUITPY
+  drive can be changed — and does *not* re-run it when you reset the board.
+  `boot.py` now carries a "runs first" label whose tooltip says which of those
+  is happening, the program's label names the setup file that ran before it, and
+  a `boot.txt` shadowed by a `boot.py` is marked "ignored" like any other
+  shadowed file. The CircuitPython search order was also wrong: it followed
+  Adafruit's learn guide (`code.txt, code.py, main.txt, main.py`) where the
+  runtime's own `main.c` has `main.py` *before* `main.txt`, so a board carrying
+  both was told the wrong one runs. Nothing is labelled at all when no board is
+  connected or the connect probe could not name a runtime — a confident wrong
+  label about which file runs is worse than no label.
 
 ### Fixed
 

--- a/src/renderer/src/components/DeviceFileTree.tsx
+++ b/src/renderer/src/components/DeviceFileTree.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { DirEntry } from '../../../preload/index.d'
 import { useFileSelection } from '../store/file-selection'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
-import { bootFileNote } from './run-controls'
+import { bootRoleFor, type BootRole } from './run-controls'
 import { useWorkspace } from '../store/workspace'
 import { useSync } from '../store/sync'
 import { usageLabel, usedPct, type DiskUsage } from './disk-usage'
@@ -119,7 +119,7 @@ function DeviceRow({
   onDropInto,
   onDragOverRow,
   onDragLeaveRow,
-  bootNote
+  bootRole
 }: {
   row: FlatRow
   expanded: boolean
@@ -134,8 +134,8 @@ function DeviceRow({
   onDropInto: (e: React.DragEvent, dir: string) => void
   onDragOverRow: (e: React.DragEvent, row: FlatRow) => void
   onDragLeaveRow: () => void
-  /** Why this file does (or doesn't) run at boot — null for ordinary files (#755). */
-  bootNote: string | null
+  /** Why this file does (or doesn't) run at startup — null for ordinary files (#755, #872). */
+  bootRole: BootRole | null
 }): JSX.Element {
   const { path, entry, depth } = row
   return (
@@ -167,16 +167,18 @@ function DeviceRow({
         {entry.isDir ? (expanded ? '▼' : '▶') : '▤'}
       </span>
       <span className="tree-row__name">{entry.name}</span>
-      {/* Which file the board runs at boot (#755). CircuitPython tries code.py
-          before main.py, so a board carrying both runs only the first — and
-          editing the other looks like it does nothing. The marker says which
-          is which; the tooltip says why. */}
-      {bootNote && (
+      {/* Which files the board runs by itself (#755, #872). Two stages: the
+          setup file (`boot.py`) and then the program — and CircuitPython tries
+          code.py before main.py, so a board carrying both runs only the first
+          and editing the other looks like it does nothing. The marker says
+          which is which; the tooltip says what actually happens, which is the
+          part a file listing can never show. */}
+      {bootRole && (
         <span
-          className={`tree-row__boot${bootNote.includes('instead') ? ' tree-row__boot--shadowed' : ''}`}
-          title={bootNote}
+          className={`tree-row__boot${bootRole.shadowed ? ' tree-row__boot--shadowed' : ''}`}
+          title={bootRole.title}
         >
-          {bootNote.includes('instead') ? 'ignored' : 'runs at boot'}
+          {bootRole.label}
         </span>
       )}
       {/* Hover delete (#219): removes this row — or the whole selection when the
@@ -771,11 +773,11 @@ export function DeviceFileTree(): JSX.Element {
           <DeviceRow
             key={row.path}
             row={row}
-            bootNote={
+            bootRole={
               // Boot files only count in the ROOT — a `/lib/code.py` is just a
               // module. `depth === 0` is that test.
               row.depth === 0 && !row.entry.isDir
-                ? bootFileNote(row.entry.name, rootNames, status.runtime?.dialect)
+                ? bootRoleFor(row.entry.name, rootNames, status.runtime?.dialect)
                 : null
             }
             expanded={expanded.has(row.path)}

--- a/src/renderer/src/components/run-controls.ts
+++ b/src/renderer/src/components/run-controls.ts
@@ -70,45 +70,130 @@ export function stopTitle(s: StopTitleState): string {
 }
 
 /**
- * The files each runtime looks for at boot, in the order it tries them. The
- * FIRST one present is the one that runs; the rest are ignored, which is the
- * trap this exists to surface — a board with both `code.py` and `main.py` runs
- * only `code.py`, and editing `main.py` then appears to do nothing.
+ * Which of a runtime's two startup stages a file belongs to (#872).
  *
- * CircuitPython: `code.txt`, `code.py`, `main.txt`, `main.py`.
- * MicroPython: `boot.py` runs first and then `main.py`, but `boot.py` is setup
- * rather than the program, so `main.py` is the one worth pointing at.
+ * `boot` is the setup pass; `main` is the program. Two stages rather than one
+ * flat list because that is the shape of the real thing, and because they answer
+ * different questions for the reader: "what runs before my code" versus "which
+ * file IS my code".
  */
-export const BOOT_FILE_ORDER: Record<'circuitpython' | 'micropython', string[]> = {
-  circuitpython: ['code.txt', 'code.py', 'main.txt', 'main.py'],
-  micropython: ['main.py']
+export type BootStage = 'boot' | 'main'
+
+/**
+ * The files each runtime runs by itself, per stage, in the order it looks for
+ * them. Within a stage the FIRST name present wins and the rest are ignored,
+ * which is the trap this exists to surface — a CircuitPython board carrying both
+ * `code.py` and `main.py` runs only `code.py`, and editing `main.py` then
+ * appears to do nothing.
+ *
+ * Both lists are taken from the runtimes' own C, not from a guide:
+ *
+ * - CircuitPython `main.c` — `boot_py_filenames[] = {"boot.py", "boot.txt"}`
+ *   and `supported_filenames[] = {"code.txt", "code.py", "main.py", "main.txt"}`.
+ *   Note `main.py` BEFORE `main.txt`: Adafruit's own learn guide prints them the
+ *   other way round ("code.txt, code.py, main.txt and main.py … in that order"),
+ *   and that is where this table's previous ordering came from. The source is
+ *   what actually runs on the board, so the source wins.
+ * - MicroPython `ports/rp2/main.c` — `pyexec_file_if_exists("boot.py")` and then
+ *   `pyexec_file_if_exists("main.py")`. BOTH run, every reset; there is no
+ *   shadowing between the two and no `.txt` form.
+ */
+export const BOOT_FILE_ORDER: Record<
+  'circuitpython' | 'micropython',
+  Record<BootStage, string[]>
+> = {
+  circuitpython: {
+    boot: ['boot.py', 'boot.txt'],
+    main: ['code.txt', 'code.py', 'main.py', 'main.txt']
+  },
+  micropython: {
+    boot: ['boot.py'],
+    main: ['main.py']
+  }
 }
 
 /**
- * Which file in a device directory listing the board will actually run at boot,
- * or `null` when none of them is a boot file.
+ * Which file in a device directory listing the board will actually run for a
+ * given stage, or `null` when it will run none of them.
  *
  * `names` should be the ROOT listing — the boot files are only boot files there.
  * Returns the winner of the runtime's own search order, so a board carrying both
  * `code.py` and `main.py` names `code.py`.
  */
-export function bootFile(names: string[], dialect?: Dialect): string | null {
+export function bootFile(
+  names: string[],
+  dialect?: Dialect,
+  stage: BootStage = 'main'
+): string | null {
   if (dialect !== 'circuitpython' && dialect !== 'micropython') return null
   const present = new Set(names)
-  return BOOT_FILE_ORDER[dialect].find((f) => present.has(f)) ?? null
+  return BOOT_FILE_ORDER[dialect][stage].find((f) => present.has(f)) ?? null
+}
+
+/** The device-tree marker for one file: what it says, and what it means. */
+export interface BootRole {
+  /** Badge text. Short — it sits at the end of a tree row. */
+  label: string
+  /** Tooltip: what the board actually does with this file, and when. */
+  title: string
+  /** The runtime will skip this file because another one comes first. */
+  shadowed: boolean
 }
 
 /**
- * Why a file in the root is, or is not, the one that runs — the tooltip for the
- * marker in the device file tree. `null` for a file that has nothing to say,
- * which is most of them.
+ * What the SETUP file is for, per runtime. This is the half a file listing can
+ * never show, and the two runtimes are genuinely different here — so a single
+ * "runs at boot" sentence for both would be the "assume MicroPython everywhere"
+ * default that epic #209 exists to remove.
  */
-export function bootFileNote(name: string, names: string[], dialect?: Dialect): string | null {
+const BOOT_STAGE_NOTE: Record<'circuitpython' | 'micropython', string> = {
+  micropython:
+    'MicroPython runs this file first at every reset, before main.py. It is for setup — mounting storage, joining Wi-Fi — rather than for your program.',
+  circuitpython:
+    'CircuitPython runs this file once at power-on, before USB is set up — which is why settings like a writable CIRCUITPY drive can only be changed here. Resetting the board re-runs code.py but NOT this file.'
+}
+
+/**
+ * The role a file in the root plays at startup — the marker in the device file
+ * tree, and the tooltip that explains it. `null` for a file that has nothing to
+ * say, which is most of them.
+ *
+ * `null` is also the answer whenever the runtime is not known (no board, or a
+ * probe that could not name one). Guessing MicroPython would put a confident
+ * "runs at boot" on a `main.py` that a CircuitPython board may well ignore —
+ * exactly the wrong-by-default that #209 is about. Silence is the safe answer.
+ */
+export function bootRoleFor(name: string, names: string[], dialect?: Dialect): BootRole | null {
   if (dialect !== 'circuitpython' && dialect !== 'micropython') return null
   const order = BOOT_FILE_ORDER[dialect]
-  if (!order.includes(name)) return null
-  const winner = bootFile(names, dialect)
+  // The two lists are disjoint, so the first match is the only match.
+  const stage: BootStage | null = order.boot.includes(name)
+    ? 'boot'
+    : order.main.includes(name)
+      ? 'main'
+      : null
+  if (!stage) return null
+
   const runtime = dialect === 'circuitpython' ? 'CircuitPython' : 'MicroPython'
-  if (name === winner) return `${runtime} runs this file when the board starts`
-  return `${runtime} runs ${winner} instead — it comes first, so this file is ignored`
+  // Shadowing is per-stage: a `boot.py` never hides a `main.py`, because on both
+  // runtimes the setup file and the program are separate passes that both run.
+  const winner = bootFile(names, dialect, stage)
+  if (name !== winner) {
+    return {
+      label: 'ignored',
+      title: `${runtime} runs ${winner} instead — it comes first, so this file is ignored`,
+      shadowed: true
+    }
+  }
+  if (stage === 'boot') {
+    return { label: 'runs first', title: BOOT_STAGE_NOTE[dialect], shadowed: false }
+  }
+  // Name the setup file rather than hardcoding `boot.py`: on CircuitPython the
+  // board may be running a `boot.txt` instead.
+  const setup = bootFile(names, dialect, 'boot')
+  return {
+    label: 'runs at boot',
+    title: `${runtime} runs this file when the board starts${setup ? `, after ${setup}` : ''}`,
+    shadowed: false
+  }
 }

--- a/test/runControls.test.ts
+++ b/test/runControls.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { BOOT_FILE_ORDER, bootFile, bootFileNote, runTitle, stopTitle } from '../src/renderer/src/components/run-controls'
+import { BOOT_FILE_ORDER, bootFile, bootRoleFor, runTitle, stopTitle } from '../src/renderer/src/components/run-controls'
 
 /**
  * RUN / STOP / RESET SEMANTICS (#755, epic #209).
@@ -9,6 +9,13 @@ import { BOOT_FILE_ORDER, bootFile, bootFileNote, runTitle, stopTitle } from '..
  * CircuitPython their `code.py` stops and does not come back. So these tests
  * are about what the app promises, and about the boot-file rule, which is a
  * real trap: a board carrying both `code.py` and `main.py` runs only the first.
+ *
+ * The startup marker (#872) is the other half. The orders asserted below are the
+ * runtimes' OWN (CircuitPython `main.c`'s `boot_py_filenames` /
+ * `supported_filenames`; MicroPython `ports/rp2/main.c`), not a guide's — and
+ * the cases where the marker must stay SILENT matter as much as the ones where
+ * it speaks, because a confident wrong label about which file a board runs is
+ * worse than no label at all.
  */
 
 describe('runTitle', () => {
@@ -93,8 +100,8 @@ describe('bootFile', () => {
 
   it('follows the whole search order, including the .txt forms', () => {
     expect(bootFile(['main.py', 'code.txt'], 'circuitpython')).toBe('code.txt')
-    expect(bootFile(['main.py', 'main.txt'], 'circuitpython')).toBe('main.txt')
-    expect(bootFile(['main.py'], 'circuitpython')).toBe('main.py')
+    expect(bootFile(['main.txt', 'main.py'], 'circuitpython')).toBe('main.py')
+    expect(bootFile(['main.txt'], 'circuitpython')).toBe('main.txt')
   })
 
   it('is main.py on MicroPython — and code.py is NOT special there', () => {
@@ -108,36 +115,114 @@ describe('bootFile', () => {
     expect(bootFile(['code.py'], 'unknown')).toBeNull()
   })
 
-  it('the CircuitPython order is the documented one', () => {
-    expect(BOOT_FILE_ORDER.circuitpython).toEqual(['code.txt', 'code.py', 'main.txt', 'main.py'])
+  it('finds the SETUP file too — a separate pass from the program', () => {
+    expect(bootFile(['boot.py', 'main.py'], 'micropython', 'boot')).toBe('boot.py')
+    expect(bootFile(['boot.py', 'code.py'], 'circuitpython', 'boot')).toBe('boot.py')
+    // boot.py wins over boot.txt; boot.txt runs when it is on its own.
+    expect(bootFile(['boot.txt', 'boot.py'], 'circuitpython', 'boot')).toBe('boot.py')
+    expect(bootFile(['boot.txt'], 'circuitpython', 'boot')).toBe('boot.txt')
+    // MicroPython has no .txt form at all.
+    expect(bootFile(['boot.txt'], 'micropython', 'boot')).toBeNull()
+  })
+
+  it("the orders are the runtimes' own — main.py comes BEFORE main.txt", () => {
+    // CircuitPython main.c: supported_filenames[] = {"code.txt", "code.py",
+    // "main.py", "main.txt"}. Adafruit's learn guide prints the last two the
+    // other way round; the source is what actually runs on the board.
+    expect(BOOT_FILE_ORDER.circuitpython.main).toEqual([
+      'code.txt',
+      'code.py',
+      'main.py',
+      'main.txt'
+    ])
+    expect(BOOT_FILE_ORDER.circuitpython.boot).toEqual(['boot.py', 'boot.txt'])
+    expect(BOOT_FILE_ORDER.micropython).toEqual({ boot: ['boot.py'], main: ['main.py'] })
   })
 })
 
-describe('bootFileNote', () => {
+describe('bootRoleFor', () => {
   it('marks the file that runs', () => {
-    expect(bootFileNote('code.py', ['code.py', 'lib'], 'circuitpython')).toBe(
+    expect(bootRoleFor('code.py', ['code.py', 'lib'], 'circuitpython')).toEqual({
+      label: 'runs at boot',
+      title: 'CircuitPython runs this file when the board starts',
+      shadowed: false
+    })
+  })
+
+  it('explains the SHADOWED file, which is the whole point — editing it does nothing', () => {
+    expect(bootRoleFor('main.py', ['code.py', 'main.py'], 'circuitpython')).toEqual({
+      label: 'ignored',
+      title: 'CircuitPython runs code.py instead — it comes first, so this file is ignored',
+      shadowed: true
+    })
+  })
+
+  it('says nothing about an ordinary file', () => {
+    expect(bootRoleFor('helpers.py', ['code.py', 'helpers.py'], 'circuitpython')).toBeNull()
+    expect(bootRoleFor('lib', ['code.py', 'lib'], 'circuitpython')).toBeNull()
+    // boot_out.txt is what the board WROTE, not something it runs.
+    expect(bootRoleFor('boot_out.txt', ['boot_out.txt'], 'circuitpython')).toBeNull()
+  })
+
+  it('says nothing when the runtime is not known, rather than guessing', () => {
+    // The point of #209: an unlabelled main.py beats one confidently labelled
+    // "runs at boot" on a board that turns out to be CircuitPython.
+    expect(bootRoleFor('code.py', ['code.py'], undefined)).toBeNull()
+    expect(bootRoleFor('boot.py', ['boot.py'], undefined)).toBeNull()
+    expect(bootRoleFor('main.py', ['main.py'], 'unknown')).toBeNull()
+  })
+
+  it('does not call code.py a boot file on MicroPython', () => {
+    expect(bootRoleFor('code.py', ['code.py', 'main.py'], 'micropython')).toBeNull()
+    expect(bootRoleFor('main.py', ['code.py', 'main.py'], 'micropython')?.label).toBe('runs at boot')
+  })
+
+  it('labels boot.py on MicroPython as the setup pass that runs at every reset', () => {
+    const role = bootRoleFor('boot.py', ['boot.py', 'main.py'], 'micropython')
+    expect(role?.label).toBe('runs first')
+    expect(role?.shadowed).toBe(false)
+    expect(role?.title).toContain('MicroPython')
+    expect(role?.title).toContain('every reset')
+    expect(role?.title).toContain('main.py')
+  })
+
+  it('labels boot.py on CircuitPython with what is different there — once, before USB', () => {
+    const role = bootRoleFor('boot.py', ['boot.py', 'code.py'], 'circuitpython')
+    expect(role?.label).toBe('runs first')
+    expect(role?.shadowed).toBe(false)
+    expect(role?.title).toContain('CircuitPython')
+    expect(role?.title).toContain('once at power-on')
+    expect(role?.title).toContain('USB')
+    // The runtimes genuinely disagree here, so the two tooltips must not match.
+    expect(role?.title).not.toBe(bootRoleFor('boot.py', ['boot.py'], 'micropython')?.title)
+  })
+
+  it('never lets boot.py shadow the program — both passes run, on both runtimes', () => {
+    for (const dialect of ['micropython', 'circuitpython'] as const) {
+      const program = dialect === 'micropython' ? 'main.py' : 'code.py'
+      const role = bootRoleFor(program, ['boot.py', program], dialect)
+      expect(role?.shadowed).toBe(false)
+      expect(role?.label).toBe('runs at boot')
+      // …and it says which file went first, so the order is visible.
+      expect(role?.title).toContain('after boot.py')
+    }
+  })
+
+  it('names the setup file that is really there, not a hardcoded boot.py', () => {
+    expect(bootRoleFor('code.py', ['boot.txt', 'code.py'], 'circuitpython')?.title).toContain(
+      'after boot.txt'
+    )
+    // No setup file at all: no dangling "after" clause.
+    expect(bootRoleFor('code.py', ['code.py'], 'circuitpython')?.title).toBe(
       'CircuitPython runs this file when the board starts'
     )
   })
 
-  it('explains the SHADOWED file, which is the whole point — editing it does nothing', () => {
-    const note = bootFileNote('main.py', ['code.py', 'main.py'], 'circuitpython')
-    expect(note).toBe('CircuitPython runs code.py instead — it comes first, so this file is ignored')
-  })
-
-  it('says nothing about an ordinary file', () => {
-    expect(bootFileNote('helpers.py', ['code.py', 'helpers.py'], 'circuitpython')).toBeNull()
-    expect(bootFileNote('lib', ['code.py', 'lib'], 'circuitpython')).toBeNull()
-  })
-
-  it('says nothing when the runtime is not known, rather than guessing', () => {
-    expect(bootFileNote('code.py', ['code.py'], undefined)).toBeNull()
-  })
-
-  it('does not call code.py a boot file on MicroPython', () => {
-    expect(bootFileNote('code.py', ['code.py', 'main.py'], 'micropython')).toBeNull()
-    expect(bootFileNote('main.py', ['code.py', 'main.py'], 'micropython')).toBe(
-      'MicroPython runs this file when the board starts'
-    )
+  it('marks a shadowed boot.txt, so the ignored setup file is not a mystery either', () => {
+    expect(bootRoleFor('boot.txt', ['boot.py', 'boot.txt'], 'circuitpython')).toEqual({
+      label: 'ignored',
+      title: 'CircuitPython runs boot.py instead — it comes first, so this file is ignored',
+      shadowed: true
+    })
   })
 })


### PR DESCRIPTION
Closes #872

## What a file listing cannot tell you

Which file the board runs on its own, without being asked. The device tree
already marked the *program* (#755) — `code.py` on CircuitPython, `main.py` on
MicroPython — but said nothing at all about `boot.py`, which is the file whose
behaviour is least guessable and which differs most between the two runtimes.

| | MicroPython | CircuitPython |
|---|---|---|
| `boot.py` | runs at **every** reset, then `main.py` — **both** run | runs **once** at power-on, **before USB is set up**; a soft reboot re-runs `code.py` but **not** `boot.py` |
| the program | `main.py` | first of `code.txt`, `code.py`, `main.py`, `main.txt` |
| `.txt` forms | none | `boot.txt`, and the four above |

So `boot.py` now carries a **`runs first`** badge whose tooltip says which of
those two things is actually happening; the program's badge names the setup file
that ran before it (`… when the board starts, after boot.py`); and a `boot.txt`
shadowed by a `boot.py` is marked `ignored`, like any other shadowed file.

## Runtime precedence, and where it came from

Both orders are now read off the runtimes' own C rather than out of prose:

- **CircuitPython** — [`main.c`](https://github.com/adafruit/circuitpython/blob/main/main.c):
  `boot_py_filenames[] = {"boot.py", "boot.txt"}` (line ~855) and
  `supported_filenames[] = {"code.txt", "code.py", "main.py", "main.txt"}`
  (line ~460). `run_boot_py()` is called **once** in `main()`, *before* the
  `while (true)` loop that runs `code.py` — which is the source of the
  "a reset does not re-run it" claim.
- **MicroPython** — [`ports/rp2/main.c`](https://github.com/micropython/micropython/blob/master/ports/rp2/main.c):
  `pyexec_file_if_exists("boot.py")` and then `pyexec_file_if_exists("main.py")`,
  inside the soft-reset loop. Both run, every reset, with no shadowing and no
  `.txt` form.

**This turned up a real error.** The existing CircuitPython order was
`code.txt, code.py, main.txt, main.py` — which is what
[Adafruit's learn guide](https://learn.adafruit.com/welcome-to-circuitpython/creating-and-editing-code)
prints ("There are four options: code.txt, code.py, main.txt and main.py …in
that order"), and evidently where it came from. The runtime's own
`supported_filenames[]` has **`main.py` before `main.txt`**. A board carrying
both was being told the wrong one runs — worse than saying nothing — so the
order follows the source and a test pins it with that reasoning written down.

## Shape of the change

The old model was one flat ordered list per runtime, first-match-wins. That is
what made `boot.py` unrepresentable: on MicroPython it would have had to
"shadow" `main.py`, which is precisely what it does not do. `BOOT_FILE_ORDER` is
now two stages (`boot` / `main`), each with its own order, and shadowing is
computed **within** a stage.

`bootFileNote` returned a sentence that `DeviceFileTree` then sniffed with
`.includes('instead')` to choose both the badge text *and* the CSS class — so the
wording could not be changed without silently changing the styling. It is
replaced by `bootRoleFor(name, names, dialect) → { label, title, shadowed } | null`,
which hands over data instead. **No CSS change**: both positive labels reuse the
existing `.tree-row__boot`, which is already built from `--text-muted` /
`--bg-elevated` / `--border` / `--radius`, with `--warn` for the shadowed
variant — so it works in both skins as it did before.

## The two judgement calls

**Unknown runtime ⇒ no label.** Not a MicroPython guess. `bootRoleFor` returns
`null` whenever the connect probe has not named a runtime, and there are tests
for it. A confident "runs at boot" on a `main.py` that a CircuitPython board will
quietly ignore is exactly the assume-MicroPython default epic #209 exists to
remove.

**The local tree does not get the label.** Two reasons, and the first is
correctness: the shadowing verdict would have to be computed from the *local*
folder rather than the board's root, so it could stamp `ignored` on a file the
board will happily run (no `code.py` over there), or stay silent about one the
board's own `code.py` really does shadow. It would be a claim about a board that
may not have the file at all — and it would blink in and out as you plug and
unplug, on a panel that is about your project rather than the board. Second, the
row end there is already taken by a permanently-visible sync checkbox; the device
tree's badge only fits because it yields its slot to the hover trashcan.

## Tests

`bootRoleFor` and `bootFile` are pure and unit-tested in `test/runControls.test.ts`
(26 tests, `environment: 'node'`), including every case where the marker must
stay **silent**: unknown runtime, `'unknown'` dialect, ordinary files, `boot_out.txt`
(the board *wrote* that, it does not run it), and `code.py` on MicroPython.

**Verified the tests fail without the change**, as asked. Emptying
`micropython.boot` and restoring the old `main.txt`-before-`main.py` order → 5
failures (`expected undefined to be 'runs first'`, `expected 'main.txt' to be
'main.py'`, …). Emptying `circuitpython.boot` → 6 failures (`expected null to
deeply equal { label: 'ignored', … }`, `expected … to contain 'after boot.txt'`, …).
Each failed for its own reason; both breaks then reverted.

## Gates

| gate | result |
|---|---|
| `npm run lint` | pass — 0 errors, only the pre-existing `DriverInstallBanner.tsx` warning |
| `npm run typecheck` | pass (node + web + test) |
| `npm test` | pass — 288 files, 5991 tests |
| `npm run build` | pass |

Diff is 4 files and confined to the label, to stay clear of the `.mpy` work
landing in the same trees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe
