### PR TITLE
fix(flasher): say when the REPL has the port, and let a run go again (#845, #838)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,32 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   breadcrumb is left alone deliberately: it only ever re-roots UP to a parent,
   which widens the tree, so nothing that was visible stops being visible and
   peeking one level up costs you nothing.
+- **A finished flash can go back instead of only closing** (#838). Done was the
+  only way out of a completed run, and it shut the dialog — throwing away the
+  board, the runtime, the firmware version, the port and every advanced option
+  chosen to get there. That is precisely the moment you want them: a flash that
+  failed usually failed for one reason you can now fix, and re-picking all six
+  selections to change one of them is the complaint. A second button sits beside
+  Done — **Try again** after a failure, **Flash another** after a success — and
+  returns to the options with everything still selected. It clears only what the
+  run produced: the log, the progress bar and the outcome banner.
+
+### Fixed
+
+- **Detect now says when the board is still connected to the REPL** (#845). A
+  serial port can only be open once, so while Snakie holds one for the REPL,
+  esptool cannot open it to ask the board what it is. That failure came back as
+  an empty identity — indistinguishable from a board that is merely not in
+  download mode — so the dialog offered the BOOT/RESET dance, which cannot
+  possibly free a port held by the app asking you to do it, and the real cause
+  was never said out loud. Detect now checks first and, when the REPL has the
+  port, names it and offers **Disconnect and detect** rather than doing it
+  behind your back: dropping the connection stops whatever the board is running,
+  empties the shell and takes the instruments' live feeds with it, which is a
+  fine thing to do on purpose and a bad thing to have happen to you. A board in
+  BOOTSEL is exempt — a drive copy never touches the serial port — and so is the
+  simulated device, which holds no hardware. Connected to one board and flashing
+  a second stays silent, since nothing is in the way.
 
 - **An interrupted install no longer leaves a broken file on the board** (#864).
   Driver and package installs wrote each file straight to its final name, so

--- a/src/renderer/src/components/FirmwareFlasher.css
+++ b/src/renderer/src/components/FirmwareFlasher.css
@@ -501,3 +501,45 @@
 .firmware-advanced-toggle:hover {
   color: #f4f6f8;
 }
+
+/* The REPL is holding the port Detect needs (#845). A warning with its own way
+   out attached, because "that port is busy" is only half the story when the
+   thing holding it is this same app. Laid out on the warning banner, so its
+   colours are the dialog's own dark palette in BOTH themes — see the note at the
+   top of this file. */
+.firmware-conflict {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.55rem;
+  margin-bottom: 0.5rem;
+}
+
+.firmware-conflict__text {
+  /* Wraps first and takes the whole row when the button no longer fits beside it. */
+  flex: 1 1 16rem;
+  margin: 0;
+}
+
+.firmware-conflict__action {
+  flex: 0 0 auto;
+  padding: 0.35rem 0.7rem;
+  font-family: var(--font-ui);
+  font-size: 0.76rem;
+  font-weight: 600;
+  color: #f4f6f8;
+  background: rgba(255, 255, 255, 0.12);
+  border: var(--border-w) solid var(--accent);
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+
+.firmware-conflict__action:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.firmware-conflict__action:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}

--- a/src/renderer/src/components/FirmwareFlasher.tsx
+++ b/src/renderer/src/components/FirmwareFlasher.tsx
@@ -30,7 +30,14 @@ import {
   isVendorUf2Family,
   type FirmwareRuntime
 } from '../../../shared/firmware-runtime'
+import {
+  replPortConflict,
+  heldSerialPort,
+  retryAction,
+  type PortConflict
+} from '../../../shared/flash-dialog'
 import { useFocusTrap } from '../hooks/useFocusTrap'
+import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { hasWebUSB, isElectron } from '../lib/platform'
 import { flashEspInBrowser, requestEspPort } from '../lib/webFirmware/espFlash'
 import { flashMicrobitInBrowser, requestMicrobitDevice } from '../lib/webFirmware/microbitFlash'
@@ -142,6 +149,15 @@ export function FirmwareFlasher({
   const [identity, setIdentity] = useState<BoardIdentity | null>(null)
   const [identifying, setIdentifying] = useState(false)
   /**
+   * Detect could not run because the REPL has the port (#845).
+   *
+   * Set by Detect rather than derived from the connection, so the message
+   * appears because an action was taken and could not be carried out — not as a
+   * standing warning next to a board somebody is happily using.
+   */
+  const [detectConflict, setDetectConflict] = useState<PortConflict | null>(null)
+  const [disconnecting, setDisconnecting] = useState(false)
+  /**
    * Whether the advanced fields are showing (#833). Closed by default.
    *
    * Everything behind it is either derived from the board once it is known — the
@@ -206,6 +222,24 @@ export function FirmwareFlasher({
   const [autoScroll, setAutoScroll] = useState(true)
   // Move focus into the dialog on open, trap Tab, and restore it on close.
   const dialogRef = useFocusTrap<HTMLDivElement>()
+
+  /**
+   * The live REPL connection — because esptool and the REPL want the same port
+   * and only one of them can have it (#845).
+   *
+   * Mirrored into a ref for the same reason `profileRef` is: Detect `await`s a
+   * port scan before it needs this, by which point the callback's captured
+   * `status` can be a connection ago.
+   */
+  const deviceStatus = useDeviceStatus()
+  const statusRef = useRef(deviceStatus)
+  useEffect(() => {
+    statusRef.current = deviceStatus
+    // A board disconnected by any route — this dialog's button, the status bar,
+    // unplugging it — settles the question, so retract the message rather than
+    // leave it accusing a port nobody holds.
+    if (!heldSerialPort(deviceStatus)) setDetectConflict(null)
+  }, [deviceStatus])
 
   // --- Which Python is being flashed (#756) ---
   const [runtime, setRuntime] = useState<FirmwareRuntime>(initialRuntime ?? 'micropython')
@@ -655,16 +689,62 @@ export function FirmwareFlasher({
    * When it cannot work the board out it opens the advanced fields, because at
    * that point they stop being clutter and become the only way through. When it
    * can, they stay shut: there is nothing left to decide.
+   *
+   * `portIsFree` is set only by {@link disconnectAndDetect}, which has just let
+   * go of the port itself: the `device:status` push confirming that has not
+   * arrived yet, so the check below would still see the connection it just
+   * closed.
    */
-  const detectBoard = useCallback(async (): Promise<void> => {
+  const detectBoard = useCallback(async (portIsFree = false): Promise<void> => {
     const found = await refreshDetection()
     const serial = (found ?? []).find((c) => c.source === 'serial')
-    const known = serial?.port ? await identifyBoard(serial.port) : false
     // A UF2 / drive board has no esptool to interrogate, so detection alone
     // settles it — a mount that was found counts as a success.
     const drive = (found ?? []).some((c) => c.source !== 'serial')
+    /**
+     * Ask BEFORE esptool does (#845). A port Snakie holds for the REPL cannot be
+     * opened a second time, and `identifyBoard` reports that failure as an EMPTY
+     * identity — the same answer a board that is simply not in download mode
+     * gives. So the dialog said "hold BOOT, tap RESET", which cannot possibly fix
+     * a port held by the app doing the asking, and the real cause went unsaid.
+     *
+     * A drive board is exempt: nothing about it goes through the serial port, so
+     * an RP2040 in BOOTSEL is flashable with a REPL open on something else.
+     */
+    const conflict =
+      portIsFree || (drive && !serial)
+        ? null
+        : replPortConflict(statusRef.current, serial?.port)
+    setDetectConflict(conflict)
+    // Disconnecting is the way through this one; the advanced fields are not.
+    if (conflict) return
+    const known = serial?.port ? await identifyBoard(serial.port) : false
     if (!known && !drive) setAdvancedOpen(true)
   }, [refreshDetection, identifyBoard])
+
+  /**
+   * Hand the port back, then detect (#845).
+   *
+   * Snakie could take the port without asking — it has to end up free either
+   * way, since flashing needs it too. It asks because the board may be part-way
+   * through something: dropping the REPL stops whatever is running, empties the
+   * shell and takes every instrument's live feed with it. That is a fine thing
+   * to do on purpose and a bad thing to have happen to you, so it is one button
+   * with its consequence written on it rather than a silent side effect of
+   * pressing Detect.
+   */
+  const disconnectAndDetect = useCallback(async (): Promise<void> => {
+    setDisconnecting(true)
+    try {
+      await window.api.device.disconnect()
+    } catch {
+      // Already gone, or never really open — either way the port is free now,
+      // and detection below is the honest way to find out what is on it.
+    } finally {
+      setDisconnecting(false)
+    }
+    await detectBoard(true)
+  }, [detectBoard])
 
   /**
    * The build worth flashing for this board, from whichever source knows.
@@ -812,12 +892,25 @@ export function FirmwareFlasher({
     selectedMaintenance
   ])
 
-  const resetRun = useCallback((): void => {
+  /**
+   * Clear the RUN — and only the run (#838).
+   *
+   * The log, the progress bar and the outcome banner are everything a flash
+   * produced; the board, the runtime, the version, the port, the offset and the
+   * erase choice are everything the user put in. Nothing here may touch the
+   * second list: re-picking all of it after a flash that failed for a reason
+   * they have just fixed is the whole of the complaint.
+   */
+  const clearRun = useCallback((): void => {
     setLog([])
     setPercent(null)
     setOutcome('idle')
-    setFlashing(true)
   }, [])
+
+  const resetRun = useCallback((): void => {
+    clearRun()
+    setFlashing(true)
+  }, [clearRun])
 
   const handleFlash = useCallback(async (): Promise<void> => {
     resetRun()
@@ -930,6 +1023,8 @@ export function FirmwareFlasher({
   ])
 
   const finished = outcome === 'success' || outcome === 'error'
+  /** The second way out of a finished run — back, rather than out (#838). */
+  const retry = retryAction(outcome)
 
   return (
     <div
@@ -1058,6 +1153,26 @@ export function FirmwareFlasher({
               >
                 {identifying ? 'Asking the board…' : '⟳ Detect board'}
               </button>
+            )}
+            {/* Detect ran into the REPL holding the port (#845). Said out loud,
+                with the way out attached — knowing a port is busy is only half
+                of it when the thing holding it is this same app. */}
+            {detectConflict && (
+              <div
+                className="firmware-banner firmware-banner--warn firmware-conflict"
+                role="status"
+              >
+                <p className="firmware-conflict__text">{detectConflict.reason}</p>
+                <button
+                  type="button"
+                  className="firmware-conflict__action"
+                  onClick={() => void disconnectAndDetect()}
+                  disabled={disconnecting || identifying}
+                  title="Close the REPL connection and detect the board again"
+                >
+                  {disconnecting ? 'Disconnecting…' : 'Disconnect and detect'}
+                </button>
+              </div>
             )}
             <label className="firmware-field__label" htmlFor="firmware-profile">
               Board
@@ -1688,14 +1803,30 @@ export function FirmwareFlasher({
 
         <footer className="firmware-modal__footer">
           {finished ? (
-            <button
-              type="button"
-              className="btn btn--primary btn--lg"
-              onClick={onClose}
-              autoFocus
-            >
-              Done
-            </button>
+            <>
+              {/* Done used to be the only way out of a finished run, and it
+                  closed the dialog — losing the board, the version and every
+                  advanced option chosen to get here, right at the moment a
+                  failed flash makes you want to change one of them (#838). */}
+              {retry && (
+                <button
+                  type="button"
+                  className="btn btn--ghost"
+                  onClick={clearRun}
+                  title={retry.title}
+                >
+                  {retry.label}
+                </button>
+              )}
+              <button
+                type="button"
+                className="btn btn--primary btn--lg"
+                onClick={onClose}
+                autoFocus
+              >
+                Done
+              </button>
+            </>
           ) : (
             <>
               <button

--- a/src/shared/flash-dialog.ts
+++ b/src/shared/flash-dialog.ts
@@ -1,0 +1,115 @@
+/**
+ * DECISIONS THE FLASH DIALOG MAKES — pulled out of the component.
+ * =============================================================================
+ *
+ * `FirmwareFlasher.tsx` is Electron-only and a thousand-odd lines of JSX, so the
+ * two judgements below could not be checked without a window and a board. They
+ * are the ones worth checking:
+ *
+ *  - **Can the board even be interrogated?** (#845) A serial port can only be
+ *    open once. While Snakie holds one for the REPL, esptool cannot open it —
+ *    and `identifyBoard` reports that as an EMPTY identity, which is exactly
+ *    what a board that is merely not in download mode reports. So the dialog
+ *    told people to hold BOOT and tap RESET, a hardware dance that cannot fix a
+ *    port held by the very app asking them to do it.
+ *
+ *  - **What is offered once a run has finished?** (#838) A finished flash had
+ *    one way out, Done, and it closed the dialog — throwing away the board, the
+ *    version and every advanced option chosen to get there. After a FAILED
+ *    flash, which is when you most want to change one thing and go again.
+ *
+ * Structural types rather than an import of the device layer's `DeviceStatus`,
+ * so `shared/` stays free of a dependency on `main/` (the same reasoning as
+ * `git-stage.ts`).
+ */
+import { isVirtualPort } from './virtual-device'
+
+/** Just the parts of the device layer's `DeviceStatus` these decisions read. */
+export interface ConnectionSnapshot {
+  state: 'disconnected' | 'connecting' | 'connected' | 'error'
+  path?: string
+}
+
+/**
+ * The REAL serial port Snakie currently has (or is opening) for the REPL, or
+ * null when it holds none.
+ *
+ * `connecting` counts: the port is already being opened by then, and esptool
+ * loses the race just as thoroughly as it does against a settled connection.
+ * The simulated device (#135) does NOT count — its `snakie://virtual` sentinel
+ * is not a port and nothing is holding any hardware.
+ */
+export function heldSerialPort(status: ConnectionSnapshot | null | undefined): string | null {
+  if (!status) return null
+  if (status.state !== 'connected' && status.state !== 'connecting') return null
+  if (!status.path || isVirtualPort(status.path)) return null
+  return status.path
+}
+
+/** A port esptool cannot have, because Snakie is already using it. */
+export interface PortConflict {
+  /** The port Snakie is holding. */
+  port: string
+  /** One paragraph saying what is in the way and what to do about it. */
+  reason: string
+}
+
+/**
+ * Whether the REPL connection is standing in the way of talking to `targetPort`.
+ *
+ * `targetPort` is the port about to be handed to esptool. Omit it — because
+ * detection recognised no serial board at all — and the held port is reported
+ * anyway: a board Snakie has an open REPL to is, by definition, a board that is
+ * plugged in, and "nothing found" while one demonstrably is there is the same
+ * complaint wearing a different hat. Naming a DIFFERENT port is the case that
+ * must NOT warn: a maker with two boards plugged in, connected to one and
+ * flashing the other, has nothing in their way.
+ */
+export function replPortConflict(
+  status: ConnectionSnapshot | null | undefined,
+  targetPort?: string
+): PortConflict | null {
+  const held = heldSerialPort(status)
+  if (!held) return null
+  if (targetPort && targetPort !== held) return null
+  return {
+    port: held,
+    reason:
+      `Snakie is using ${held} for the REPL, and a serial port can only be open once — ` +
+      'so esptool cannot open it to ask the board what it is. Disconnect the board and ' +
+      'try again; flashing needs the port to itself too.'
+  }
+}
+
+/** How a flash run ended, as the dialog tracks it. */
+export type RunOutcome = 'idle' | 'success' | 'error'
+
+/** The second way out of a finished run: back to the dialog, selections intact. */
+export interface RetryAction {
+  label: string
+  title: string
+}
+
+/**
+ * What to offer alongside Done once a run has finished (#838), or null while
+ * one is still being set up — there is nothing to go back FROM yet.
+ *
+ * The wording splits on the outcome because the intent does. After a failure you
+ * are retrying the same flash with one thing changed; after a success you are
+ * almost always holding the next board.
+ */
+export function retryAction(outcome: RunOutcome): RetryAction | null {
+  if (outcome === 'error') {
+    return {
+      label: '◂ Try again',
+      title: 'Back to the options, with everything you chose still selected'
+    }
+  }
+  if (outcome === 'success') {
+    return {
+      label: '◂ Flash another',
+      title: 'Back to the options, with everything you chose still selected'
+    }
+  }
+  return null
+}

--- a/test/flasherRetryAndPortConflict.test.ts
+++ b/test/flasherRetryAndPortConflict.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  heldSerialPort,
+  replPortConflict,
+  retryAction,
+  type ConnectionSnapshot
+} from '../src/shared/flash-dialog'
+import { VIRTUAL_PORT_PATH } from '../src/shared/virtual-device'
+
+/**
+ * #845 — Detect silently failed while the board was connected.
+ * #838 — a finished flash had one way out, and it lost every selection.
+ *
+ * The decisions live in `shared/flash-dialog.ts` so they can be checked here
+ * without a board or a window; the wiring is checked at SOURCE level for the
+ * reason `flasherSimpleMode.test.ts` gives — the dialog is Electron-only, so
+ * `isElectron()` is false under a renderer and every branch that matters is
+ * skipped.
+ */
+const SRC = readFileSync(
+  join(__dirname, '..', 'src/renderer/src/components/FirmwareFlasher.tsx'),
+  'utf-8'
+)
+
+const connected = (path?: string): ConnectionSnapshot => ({ state: 'connected', path })
+
+describe('#845 — the port the REPL is holding', () => {
+  it('reports the port Snakie has open', () => {
+    expect(heldSerialPort(connected('/dev/cu.usbserial-10'))).toBe('/dev/cu.usbserial-10')
+  })
+
+  it('counts a connection still being opened — esptool loses that race too', () => {
+    expect(heldSerialPort({ state: 'connecting', path: 'COM4' })).toBe('COM4')
+  })
+
+  it('holds nothing when disconnected, errored, or pathless', () => {
+    expect(heldSerialPort({ state: 'disconnected', path: '/dev/ttyUSB0' })).toBeNull()
+    expect(heldSerialPort({ state: 'error', path: '/dev/ttyUSB0' })).toBeNull()
+    expect(heldSerialPort({ state: 'connected' })).toBeNull()
+    expect(heldSerialPort(undefined)).toBeNull()
+  })
+
+  it('does not count the simulated device — it holds no hardware', () => {
+    // `snakie://virtual` is a sentinel, not a port (#135). Blocking Detect on it
+    // would be a warning about a conflict that cannot exist.
+    expect(heldSerialPort(connected(VIRTUAL_PORT_PATH))).toBeNull()
+  })
+
+  it('conflicts when Detect is about to hand esptool the very port it holds', () => {
+    const c = replPortConflict(connected('/dev/ttyUSB0'), '/dev/ttyUSB0')
+    expect(c?.port).toBe('/dev/ttyUSB0')
+    // The point of the fix: the reason names the port AND the app holding it,
+    // instead of the BOOT/RESET advice that cannot fix this.
+    expect(c?.reason).toContain('/dev/ttyUSB0')
+    expect(c?.reason).toMatch(/REPL/)
+    expect(c?.reason).toMatch(/[Dd]isconnect/)
+  })
+
+  it('reports it even when detection recognised no serial board at all', () => {
+    // An open REPL proves a board is plugged in; "found nothing" alongside that
+    // is the same complaint wearing a different hat.
+    expect(replPortConflict(connected('/dev/ttyUSB0'))?.port).toBe('/dev/ttyUSB0')
+  })
+
+  it('stays quiet about a DIFFERENT port — two boards, one connected', () => {
+    // Connected to one board, flashing the other: nothing is in the way.
+    expect(replPortConflict(connected('/dev/ttyUSB0'), '/dev/ttyUSB1')).toBeNull()
+  })
+
+  it('stays quiet when nothing is connected', () => {
+    expect(replPortConflict({ state: 'disconnected' }, '/dev/ttyUSB0')).toBeNull()
+  })
+})
+
+describe('#845 — Detect asks before esptool does', () => {
+  const detect = /const detectBoard = useCallback\(async[\s\S]*?\n {2}\}, \[[^\]]*\]\)/.exec(SRC)
+
+  it('checks the connection and bails out before identifying', () => {
+    expect(detect, 'detectBoard not found').toBeTruthy()
+    const body = detect![0]
+    expect(body).toContain('replPortConflict')
+    expect(body).toContain('setDetectConflict')
+    // The bail-out has to come BEFORE the esptool call, or the check has bought
+    // nothing: esptool still fails and still reports an empty identity.
+    expect(body.indexOf('setDetectConflict')).toBeLessThan(body.indexOf('identifyBoard('))
+    expect(body).toMatch(/if \(conflict\) return/)
+  })
+
+  it('exempts a drive board — BOOTSEL needs no serial port', () => {
+    expect(detect![0]).toMatch(/drive && !serial/)
+  })
+
+  it('offers to disconnect rather than doing it behind the user’s back', () => {
+    const fn = /const disconnectAndDetect = useCallback\(async[\s\S]*?\n {2}\}, \[[^\]]*\]\)/.exec(SRC)
+    expect(fn, 'disconnectAndDetect not found').toBeTruthy()
+    expect(fn![0]).toContain('window.api.device.disconnect()')
+    // It re-detects with the check skipped: the status push confirming the
+    // disconnect has not landed yet, so the check would still see it connected.
+    expect(fn![0]).toContain('detectBoard(true)')
+    // …and the button that calls it is the ONLY route to it. Detect itself must
+    // never disconnect a board that may be mid-run.
+    expect(SRC).toContain('Disconnect and detect')
+    expect(detect![0]).not.toContain('device.disconnect')
+  })
+})
+
+describe('#838 — a second way out of a finished run', () => {
+  it('offers nothing to go back to while the run is still being set up', () => {
+    expect(retryAction('idle')).toBeNull()
+  })
+
+  it('offers a retry after a failure and another flash after a success', () => {
+    expect(retryAction('error')?.label).toMatch(/try again/i)
+    expect(retryAction('success')?.label).toMatch(/flash another/i)
+    for (const outcome of ['error', 'success'] as const) {
+      // Both say the same thing about what survives, because both do.
+      expect(retryAction(outcome)?.title).toMatch(/still selected/i)
+    }
+  })
+
+  it('the finished footer renders it beside Done', () => {
+    const footer = /<footer className="firmware-modal__footer">[\s\S]*?<\/footer>/.exec(SRC)
+    expect(footer, 'footer not found').toBeTruthy()
+    expect(footer![0]).toContain('retry.label')
+    expect(footer![0]).toContain('onClick={clearRun}')
+    // Done still closes; going back must not.
+    expect(footer![0]).toContain('onClick={onClose}')
+  })
+
+  it('going back clears the RUN and nothing the user chose', () => {
+    const fn = /const clearRun = useCallback\(\(\): void => \{[\s\S]*?\n {2}\}, \[\]\)/.exec(SRC)
+    expect(fn, 'clearRun not found').toBeTruthy()
+    const body = fn![0]
+    for (const run of ['setLog([])', 'setPercent(null)', "setOutcome('idle')"]) {
+      expect(body, `clearRun should reset ${run}`).toContain(run)
+    }
+    // The whole point of the issue: everything chosen to get here survives.
+    for (const setter of [
+      'setRuntime',
+      'setBoard',
+      'setProfileId',
+      'setPort',
+      'setMountPath',
+      'setOffset',
+      'setFirmwarePath',
+      'setEraseFirst',
+      'setSource',
+      'setCatalog',
+      'setSelFamily',
+      'setSelModel',
+      'setSelVariant',
+      'setSelVersionUrl',
+      'setUseRecommended'
+    ]) {
+      expect(body, `clearRun must not touch ${setter} — that is a selection`).not.toContain(setter)
+    }
+  })
+
+  it('starting a flash goes through the same clear, so the two cannot drift', () => {
+    const fn = /const resetRun = useCallback\(\(\): void => \{[\s\S]*?\n {2}\}, \[[^\]]*\]\)/.exec(SRC)
+    expect(fn, 'resetRun not found').toBeTruthy()
+    expect(fn![0]).toContain('clearRun()')
+    expect(fn![0]).toContain('setFlashing(true)')
+  })
+})


### PR DESCRIPTION
Closes #845
Closes #838

Both issues change the same dialog (`FirmwareFlasher.tsx`, ~1,700 lines), so
they ship together rather than as two PRs that would conflict with each other.

## #845 — Detect silently failed while the board was connected

A serial port can only be open once. While Snakie holds one for the REPL,
esptool cannot open it — and `identifyBoard` reports that failure as an **empty
identity**, byte for byte the same answer a board that is merely not in download
mode gives. So Detect fell through to the one branch it has for an empty
identity:

> Could not reach the board. Hold BOOT, tap RESET, release BOOT to put it in
> download mode, then try again.

That is a hardware dance which cannot possibly free a port held by the very app
asking you to do it. It also opened the advanced fields, implying the way through
was to set the offset by hand. The real cause was never said out loud.

Detect now checks the live connection **before** handing esptool a port, and when
the REPL has that port it names it and offers a way out.

### Which behaviour, and why

The issue offered two: tell the user, or just disconnect. I went with **tell the
user and offer a one-click disconnect**, and the code supports that read rather
than contradicting it:

- The connection is global app state — `useDeviceStatus` notes it has ~18
  consumers. Dropping it stops whatever the board is running, empties the shell,
  and takes every instrument's and the Board Viewer's live feed with it.
- Nothing else in the app takes the port away on the user's behalf. The dialog's
  existing voice is to explain and block (the wrong-file-kind guard, the
  micro:bit maintenance-mode guard), not to act.
- The port has to end up free either way, since flashing needs it too — so the
  cost of asking is one click, and the cost of not asking is a program killed
  without warning and a shell that died for no visible reason.

So: a warning that names the port, and a **Disconnect and detect** button next to
it that closes the connection and re-runs detection.

### Deliberately narrow

The check stays quiet in the three cases where there is genuinely no conflict:

- **A board in BOOTSEL** — a drive copy never touches the serial port, so an
  RP2040 is flashable with a REPL open on something else.
- **The simulated device** (#135) — `snakie://virtual` is a sentinel, not a port.
- **A different port** — connected to one board and flashing a second is a real
  setup with nothing in its way.

It *does* fire when detection recognised no serial board at all: an open REPL
proves a board is plugged in, and "found nothing" alongside that is the same
complaint wearing a different hat.

The message is retracted automatically when the board disconnects by any route —
this button, the status bar, or unplugging it.

## #838 — a finished run can go back instead of only closing

Done was the only way out of a completed flash, and it closed the dialog —
losing the board, the runtime, the firmware version, the port, the offset and the
erase choice. That is exactly the moment you want them: a failed flash usually
failed for one reason you can now fix, and re-picking six selections to change
one of them is the whole annoyance.

A second button now sits beside Done: **Try again** after a failure, **Flash
another** after a success (the intent differs, so the wording does). It clears
only what the run produced — the log, the progress bar, the outcome banner — and
touches nothing the user chose. Starting a flash goes through the same
`clearRun`, so the two paths cannot drift apart.

## Tests

`test/flasherRetryAndPortConflict.test.ts` (16 tests). The decisions are extracted
into `src/shared/flash-dialog.ts` as pure functions and unit-tested directly; the
wiring is checked at source level for the reason `flasherSimpleMode.test.ts`
already documents — the dialog is Electron-only, so under `environment: 'node'`
`isElectron()` is false and every branch that matters is skipped.

**Each test was verified to fail without the fix.** Seven separate breaks were
applied and reverted, each failing exactly the test that guards it:

| Break | Test that failed |
| --- | --- |
| `heldSerialPort` ignores the virtual sentinel | does not count the simulated device |
| `replPortConflict` drops the target-port guard | stays quiet about a DIFFERENT port |
| `retryAction` returns nothing for `error` | offers a retry after a failure… |
| `detectBoard` skips the conflict check (old behaviour) | checks the connection and bails out before identifying |
| `clearRun` also resets `port` | going back clears the RUN and nothing the user chose |
| footer reverts to a lone Done | the finished footer renders it beside Done |
| Detect disconnects silently instead of asking | 3 tests in "Detect asks before esptool does" |

## Theming

New UI is the conflict banner and its button. This dialog is deliberately **dark
in both themes** — `FirmwareFlasher.css` carries a long comment explaining that
pulling `--text`/`--text-muted` in here puts near-black parchment text on a
near-black panel, which is a bug it has already had. The new elements follow that
established rule: the dialog's own light palette for foreground, structural
tokens (`--accent`, `--radius`, `--border-w`, `--font-ui`) for everything else —
the same recipe as the neighbouring `.firmware-detect` button. No hardcoded
theme-dependent colour, and `test/cssThemeTokens.test.ts` passes.

## Gates

| Gate | Result |
| --- | --- |
| `npm run lint` | clean — only the pre-existing `DriverInstallBanner.tsx` warning |
| `npm run typecheck` | clean (node + web + test) |
| `npm test` | 6,001 passed / 289 files |
| `npm run build` | built |

## What I verified, and what I did not

**Verified:** the four gates above; the seven break-and-restore checks; that the
existing flasher tests (`flasherSimpleMode`, `flashSummaryLine`, `espImageVerify`,
`downloadFlashParity`) still pass unchanged.

**Not verified:** anything against real hardware — no board was available. In
particular I have not watched esptool actually fail to open a held port on a real
ESP32, nor confirmed the disconnect-then-detect sequence completes cleanly on a
physical board (there may be a settling delay after the OS releases the port that
only hardware will reveal). The *decision* is fully covered by tests; the
round-trip through the serial driver is not.

## One thing found and not fixed

The backlog note about `xtensa: false` on an ESP32 board profile appears to be a
false alarm. There is no `xtensa` field on any board profile — the only
occurrence is a **runtime capability probe** in
`src/renderer/src/lib/board-capabilities.ts`, which compiles an
`@micropython.asm_xtensa` function on the board and records whether it worked.
Stock ESP32 MicroPython builds ship with the inline Xtensa assembler disabled, so
`xtensa: false` there correctly means "this firmware has no inline Xtensa
assembler", not "this chip is not Xtensa". Left alone, as instructed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe
