### PR TITLE
fix(device): queue device file operations, and say when the board is busy (#837)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,23 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   BOOTSEL is exempt — a drive copy never touches the serial port — and so is the
   simulated device, which holds no hardware. Connected to one board and flashing
   a second stays silent, since nothing is in the way.
+- **Two installs offered at once no longer race each other** (#837). A freshly
+  connected board can put several offers on screen together — the instruments
+  library, the missing-library banner, the Board View's driver banner, the
+  Modules and Packages panels — and accepting a second one started it there and
+  then, on top of the first. The individual writes were already safe (#850), but
+  the two operations still took turns at the port, each reporting progress over
+  the other, and the app showed a state no single install was in. Every device
+  file operation now goes through one queue: the first runs, the rest wait their
+  turn, and two offers of the same driver install it once rather than twice.
+  While the board is busy, a modal says what is running and what is queued
+  behind it, so the app cannot look ready for work it would refuse — with a
+  Cancel that hands you straight back to the interface, without waiting for a
+  board that has stopped answering. It waits a moment before appearing, so a
+  quick one-file upload does not flash a dialog up and straight back down, and
+  it stays put on failure. The folder copy's per-file tick list from #848 is now
+  the queue's view of that one operation, so there is one progress dialog rather
+  than two that could disagree about the same board.
 
 - **An interrupted install no longer leaves a broken file on the board** (#864).
   Driver and package installs wrote each file straight to its final name, so

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,4 +1,5 @@
 import { AppShell } from './components/AppShell'
+import { DeviceQueueDialog } from './components/DeviceQueueDialog'
 import { PromptProvider } from './components/PromptModal'
 import { RefactorPreview } from './components/RefactorPreview'
 import { UpdateNotifier } from './components/UpdateNotifier'
@@ -30,6 +31,9 @@ function App(): JSX.Element {
                     <TutorialsProvider>
                       <AppShell />
                       <UpdateNotifier />
+                      {/* The board-is-busy modal (#837): renders nothing until
+                        a device file operation is queued. */}
+                      <DeviceQueueDialog />
                       {/* The refactoring diff preview (#634): renders nothing
                         until a refactoring is proposed from the editor. */}
                       <RefactorPreview />

--- a/src/renderer/src/board-main.tsx
+++ b/src/renderer/src/board-main.tsx
@@ -27,6 +27,7 @@ import './lib/preloadFallback'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import ReactDOM from 'react-dom/client'
 import { BoardGraph } from './components/BoardGraph'
+import { DeviceQueueDialog } from './components/DeviceQueueDialog'
 import { OPEN_PART_EDITOR_EVENT, PARTS_CHANGED_EVENT, type OpenPartEditorDetail } from './components/PartsPanel'
 import { PartEditor } from './components/PartEditor'
 import { preloadPartImages } from './components/part-image-preload'
@@ -290,6 +291,9 @@ function BoardWindowApp(): JSX.Element {
         libraries={libraries}
         onAddToProject={addToProject}
       />
+      {/* The board-is-busy modal (#837). This window has its OWN device queue —
+          the driver banner installs from here — so it needs its own copy. */}
+      <DeviceQueueDialog />
       {/* Electronics ⇄ Build reconcile (#717) — the same self-contained control
           as the in-window pane; fixed here (this window is all board). */}
       <div className="esync__float esync__float--window">

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -72,6 +72,7 @@ import {
   type RequiredModule
 } from './part-imports'
 import { installPartDriver } from './driver-install'
+import { enqueueDeviceTask } from '../lib/device-queue'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { useSkeletonSync } from '../hooks/useSkeletonSync'
 import {
@@ -721,30 +722,39 @@ export function AppShell(): JSX.Element {
     setLibError(null)
     void (async (): Promise<void> => {
       try {
-        const source = await window.api.instruments.librarySource()
-        if (!source) throw new Error('library source unavailable')
-        await window.api.device.mkdir(INSTRUMENTS_LIB_DIR).catch(() => undefined)
-        await window.api.device.writeFile(INSTRUMENTS_LIB_PATH, source)
-        // A legacy copy at the FS root (`/instruments.py`) shadows `/lib` on
-        // MicroPython's sys.path, so updating only `/lib` would leave the OLD
-        // root copy being imported. If one is there, overwrite it with the same
-        // new source so `import instruments` gets the current code wherever it
-        // resolves from.
-        const rootShadow = await window.api.device
-          .stat(INSTRUMENTS_ROOT_PATH)
-          .then(() => true)
-          .catch(() => false)
-        if (rootShadow) {
-          await window.api.device.writeFile(INSTRUMENTS_ROOT_PATH, source)
-        }
-        // Install the `snakie.py` hardware umbrella beside it (best-effort — an
-        // older bundle without it just skips this), so `from snakie import Servo`
-        // works and a vendor `servo` module can't shadow ours.
-        const umbrella = await window.api.instruments.umbrellaSource().catch(() => '')
-        if (umbrella) {
-          await window.api.device.writeFile(SNAKIE_LIB_PATH, umbrella)
-          if (rootShadow) await window.api.device.writeFile(SNAKIE_ROOT_PATH, umbrella)
-        }
+        // Queued (#837): this banner and the missing-library banner below can be
+        // on screen together for a freshly connected board, and taking both
+        // offers used to start both writes at once.
+        await enqueueDeviceTask({
+          key: 'instruments-lib',
+          label: 'Installing the instruments library',
+          run: async (): Promise<void> => {
+            const source = await window.api.instruments.librarySource()
+            if (!source) throw new Error('library source unavailable')
+            await window.api.device.mkdir(INSTRUMENTS_LIB_DIR).catch(() => undefined)
+            await window.api.device.writeFile(INSTRUMENTS_LIB_PATH, source)
+            // A legacy copy at the FS root (`/instruments.py`) shadows `/lib` on
+            // MicroPython's sys.path, so updating only `/lib` would leave the OLD
+            // root copy being imported. If one is there, overwrite it with the same
+            // new source so `import instruments` gets the current code wherever it
+            // resolves from.
+            const rootShadow = await window.api.device
+              .stat(INSTRUMENTS_ROOT_PATH)
+              .then(() => true)
+              .catch(() => false)
+            if (rootShadow) {
+              await window.api.device.writeFile(INSTRUMENTS_ROOT_PATH, source)
+            }
+            // Install the `snakie.py` hardware umbrella beside it (best-effort — an
+            // older bundle without it just skips this), so `from snakie import Servo`
+            // works and a vendor `servo` module can't shadow ours.
+            const umbrella = await window.api.instruments.umbrellaSource().catch(() => '')
+            if (umbrella) {
+              await window.api.device.writeFile(SNAKIE_LIB_PATH, umbrella)
+              if (rootShadow) await window.api.device.writeFile(SNAKIE_ROOT_PATH, umbrella)
+            }
+          }
+        })
         setLibState('present')
         // The device's files changed — tell every window so e.g. the Device
         // Files tree re-lists and shows the fresh /lib/instruments.py.
@@ -942,7 +952,13 @@ export function AppShell(): JSX.Element {
               if (!res.ok) throw new Error(res.message || `Failed to install ${t.module}`)
             }
           } else {
-            const res = await window.api.packages.install(t.url as string)
+            // Queued like every other device file operation (#837) — the driver
+            // route above already is, via `installPartDriver`.
+            const res = await enqueueDeviceTask({
+              key: `package:${t.url as string}`,
+              label: `Installing ${t.module}`,
+              run: () => window.api.packages.install(t.url as string)
+            })
             if (!res.ok) throw new Error(res.log || `Failed to install ${t.module}`)
           }
         }

--- a/src/renderer/src/components/DeviceQueueDialog.tsx
+++ b/src/renderer/src/components/DeviceQueueDialog.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState, useSyncExternalStore } from 'react'
+import {
+  cancelDeviceQueue,
+  dismissDeviceQueue,
+  getDeviceQueueSnapshot,
+  queueDialogAction,
+  queueProgress,
+  queueRows,
+  queueTitle,
+  subscribeDeviceQueue
+} from '../lib/device-queue'
+import { TransferProgressDialog } from './TransferProgressDialog'
+
+/**
+ * THE BOARD-IS-BUSY MODAL (#837).
+ *
+ * Thonny puts a modal up while it writes to the board, and it is the right
+ * answer: a serial file operation is slow, most of the app cannot be used
+ * meanwhile, and a UI that stays fully live while secretly refusing to work is
+ * the thing that reads as broken. So this covers the app for as long as the
+ * device queue has work — showing what is running, what is waiting behind it,
+ * and a Cancel that hands the app straight back.
+ *
+ * Two timing rules keep it from becoming a nuisance:
+ *  - it waits {@link SHOW_AFTER_MS} before appearing, so uploading one small
+ *    file does not flash a dialog on and off;
+ *  - it dismisses itself shortly after the last task succeeds (the dialog's own
+ *    behaviour), and stays put on failure.
+ *
+ * It is mounted in BOTH renderer entries — the main window and the popped-out
+ * Board View — because each has its own queue, and the Board View's driver
+ * banner installs from over there.
+ */
+
+/** How long the board must be busy before the modal is worth showing. */
+export const SHOW_AFTER_MS = 400
+
+export function DeviceQueueDialog(): JSX.Element | null {
+  const snap = useSyncExternalStore(
+    subscribeDeviceQueue,
+    getDeviceQueueSnapshot,
+    getDeviceQueueSnapshot
+  )
+  const [onScreen, setOnScreen] = useState(false)
+  const action = queueDialogAction(snap, onScreen)
+
+  useEffect(() => {
+    if (action === 'hide') {
+      setOnScreen(false)
+      return
+    }
+    if (action === 'show') {
+      setOnScreen(true)
+      return
+    }
+    if (action === 'clear') {
+      // Finished before anyone saw it. Drop the rows now, or they would turn up
+      // as history in front of the next operation.
+      dismissDeviceQueue()
+      return
+    }
+    const t = setTimeout(() => setOnScreen(true), SHOW_AFTER_MS)
+    return () => clearTimeout(t)
+  }, [action])
+
+  if (!onScreen || snap.tasks.length === 0) return null
+
+  return (
+    <TransferProgressDialog
+      title={queueTitle(snap.tasks)}
+      rows={queueRows(snap.tasks)}
+      progress={queueProgress(snap.tasks)}
+      running={snap.busy}
+      error={snap.error}
+      onCancel={cancelDeviceQueue}
+      onClose={dismissDeviceQueue}
+    />
+  )
+}

--- a/src/renderer/src/components/DriverInstallBanner.tsx
+++ b/src/renderer/src/components/DriverInstallBanner.tsx
@@ -199,22 +199,27 @@ export function DriverInstallBanner({ needs }: DriverInstallBannerProps): JSX.El
   const setStatus = (id: string, status: DriverStatus): void =>
     setStatuses((prev) => ({ ...prev, [id]: status }))
 
-  const installOne = async (need: PartDriverNeed, d: DriverFile): Promise<void> => {
+  const installOne = async (need: PartDriverNeed, d: DriverFile): Promise<boolean> => {
     const id = driverKey(need, d)
     setStatus(id, { state: 'installing' })
     // The mip/copy sequence lives in the shared installer (also used by the main
     // editor's missing-library banner, #166) — this wrapper just maps to status.
     const res = await installPartDriver(need.libraryId, need.partId, d)
     setStatus(id, { state: res.ok ? 'ok' : 'error', message: res.message, note: res.note })
+    return !res.cancelled
   }
 
   const installAll = async (): Promise<void> => {
     if (running || !connected) return
     setRunning(true)
     try {
+      // A row that fails does NOT stop the run — installing what can be
+      // installed is the useful behaviour. A CANCEL does (#837): the user asked
+      // for the board to be left alone, and queueing the next driver behind
+      // their cancel would be answering a different question.
       for (const need of visibleNeeds) {
         for (const d of need.drivers) {
-          await installOne(need, d)
+          if (!(await installOne(need, d))) return
         }
       }
     } finally {

--- a/src/renderer/src/components/ModulesPanel.tsx
+++ b/src/renderer/src/components/ModulesPanel.tsx
@@ -16,6 +16,7 @@ import {
   type ModuleInstallUiState
 } from '../lib/modulesManager'
 import { probeOutdatedModules } from '../lib/moduleFreshness'
+import { enqueueDeviceTask } from '../lib/device-queue'
 import type { ModuleInstallProgress } from '../../../preload/index.d'
 
 /**
@@ -31,7 +32,9 @@ import type { ModuleInstallProgress } from '../../../preload/index.d'
  * Mechanism (all via `window.api.modules`, mirroring the Packages tab): the main
  * process resolves a per-module install plan — a bundled `.py`'s contents, or an
  * upstream package downloaded there (#776) — and the files are written over the
- * existing serialized device channel. Already-installed detection is a cheap
+ * existing serialized device channel. Each install goes through the shared
+ * DEVICE QUEUE (#837), so a second INSTALL click waits its turn instead of
+ * racing the first for the port. Already-installed detection is a cheap
  * `import <name>` probe on the board (`probeInstalled`) — re-run on connect +
  * after each install.
  *
@@ -134,7 +137,11 @@ export function ModulesPanel(): JSX.Element {
       if (p.state === 'note' && p.message) collected.push(p.message)
     }
     try {
-      const result = await window.api.modules.install(def.id, onProgress)
+      const result = await enqueueDeviceTask({
+        key: `module:${def.id}`,
+        label: `Installing ${def.name}`,
+        run: () => window.api.modules.install(def.id, onProgress)
+      })
       setInstalls((prev) => ({
         ...prev,
         [def.id]: {

--- a/src/renderer/src/components/PackagesPanel.tsx
+++ b/src/renderer/src/components/PackagesPanel.tsx
@@ -12,6 +12,7 @@ import {
   missingProjectImports,
   type BoardPackage
 } from '../lib/board-packages'
+import { enqueueDeviceTask } from '../lib/device-queue'
 import { ModulesPanel } from './ModulesPanel'
 import type { InstallProgress, PackageInfo } from '../../../preload/index.d'
 
@@ -312,15 +313,23 @@ function PackagesTab(): JSX.Element {
         if (p.state === 'note' && p.message) collectedNotes.push(p.message)
       }
       try {
-        const result = await window.api.packages.install(
-          name,
-          {
-            overwrite,
-            mpy: convertMpy,
-            index: customIndex.trim() || undefined
-          },
-          onProgress
-        )
+        // Queued (#837): installing two packages at once used to start two
+        // downloads that then took turns at the port, each reporting over the
+        // other. The second click now waits behind the first.
+        const result = await enqueueDeviceTask({
+          key: `package:${name}`,
+          label: `Installing ${name}`,
+          run: () =>
+            window.api.packages.install(
+              name,
+              {
+                overwrite,
+                mpy: convertMpy,
+                index: customIndex.trim() || undefined
+              },
+              onProgress
+            )
+        })
         setInstalls((prev) => ({
           ...prev,
           [name]: {

--- a/src/renderer/src/components/PartsPanel.tsx
+++ b/src/renderer/src/components/PartsPanel.tsx
@@ -12,6 +12,7 @@ import { encodePartDrag } from './part-drag'
 import { availableToInstall } from '../../../shared/part-registry'
 import type { BundledPartStatus } from '../../../shared/bundled-seed'
 import { moduleById, type ModuleDef } from '../../../shared/modules-catalog'
+import { enqueueDeviceTask } from '../lib/device-queue'
 import type { SuggestedModule } from '../../../shared/part'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import type {
@@ -916,7 +917,13 @@ function WorksWith({ suggests }: { suggests: SuggestedModule[] }): JSX.Element |
   const install = useCallback(async (def: ModuleDef): Promise<void> => {
     setBusy(def.id)
     try {
-      await window.api.modules.install(def.id)
+      // Queued (#837) — and keyed the same way the Modules panel keys it, so
+      // clicking INSTALL in both places installs the module once.
+      await enqueueDeviceTask({
+        key: `module:${def.id}`,
+        label: `Installing ${def.name}`,
+        run: () => window.api.modules.install(def.id)
+      })
       setDone((n) => n + 1)
     } catch {
       // The Modules panel is the place with a full install log; here a failure

--- a/src/renderer/src/components/TransferProgressDialog.css
+++ b/src/renderer/src/components/TransferProgressDialog.css
@@ -1,5 +1,5 @@
 /*
- * Folder-transfer progress dialog (#848).
+ * Folder-transfer / device-queue progress dialog (#848, #837).
  *
  * Same overlay treatment as PromptModal, and every colour comes from a theme
  * token so it reads correctly in BOTH the dark and skeuomorph skins — a dialog
@@ -88,6 +88,12 @@
   gap: 0.45rem;
   padding: 0.12rem 0.55rem;
   color: var(--text-muted);
+}
+
+/* A queued task's own steps (#837) — the files inside a folder copy. Indented
+   so the list reads as a tree rather than a flat run of unrelated names. */
+.transfer__row--sub .transfer__name {
+  padding-left: 1rem;
 }
 
 .transfer__row--copying {

--- a/src/renderer/src/components/TransferProgressDialog.tsx
+++ b/src/renderer/src/components/TransferProgressDialog.tsx
@@ -3,15 +3,26 @@ import './TransferProgressDialog.css'
 
 /** One row in the dialog's file list. */
 export interface TransferRow {
+  /** React key. Falls back to the label, which is unique for a file list but
+   *  not for a queue, where a step can share a name with the task above it. */
+  id?: string
   label: string
   state: 'pending' | 'copying' | 'done' | 'error'
   error?: string
+  /** A sub-step of the row above it — one file of a queued folder copy. */
+  indent?: boolean
 }
 
 export interface TransferProgressDialogProps {
   /** What is being copied, for the heading: `mylib → /lib`. */
   title: string
   rows: TransferRow[]
+  /**
+   * How far through we are. Defaults to counting `rows`, which is right when
+   * every row is a file; the device queue passes its own because a row there can
+   * be a heading over the steps that actually count (#837).
+   */
+  progress?: { done: number; total: number }
   /** True while the transfer is still running. */
   running: boolean
   /** Set when the transfer finished badly; keeps the dialog open. */
@@ -43,13 +54,14 @@ export const AUTO_DISMISS_MS = 1200
 export function TransferProgressDialog({
   title,
   rows,
+  progress,
   running,
   error,
   onClose,
   onCancel
 }: TransferProgressDialogProps): JSX.Element {
-  const done = rows.filter((r) => r.state === 'done').length
-  const total = rows.length
+  const done = progress ? progress.done : rows.filter((r) => r.state === 'done').length
+  const total = progress ? progress.total : rows.length
   const pct = total === 0 ? 100 : Math.round((done / total) * 100)
   const listRef = useRef<HTMLUListElement>(null)
 
@@ -105,14 +117,21 @@ export function TransferProgressDialog({
           />
         </div>
 
+        {/* Deliberately noun-free: the same dialog now reports a folder copy and
+            a queue of driver installs, and "3 of 12 files" is a lie about one of
+            them. The title says what is happening; this says how far in. */}
         <p className="transfer__count">
-          {error ? 'Stopped' : running ? 'Copying' : 'Copied'} {done} of {total}{' '}
-          {total === 1 ? 'file' : 'files'}
+          {error ? 'Stopped' : running ? 'Working' : 'Finished'} — {done} of {total}
         </p>
 
         <ul className="transfer__list" ref={listRef}>
           {rows.map((row) => (
-            <li key={row.label} className={`transfer__row transfer__row--${row.state}`}>
+            <li
+              key={row.id ?? row.label}
+              className={`transfer__row transfer__row--${row.state}${
+                row.indent ? ' transfer__row--sub' : ''
+              }`}
+            >
               <span className="transfer__tick" aria-hidden="true">
                 {row.state === 'done' ? '☑' : row.state === 'error' ? '☒' : '☐'}
               </span>

--- a/src/renderer/src/components/UploadControls.tsx
+++ b/src/renderer/src/components/UploadControls.tsx
@@ -5,7 +5,7 @@ import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { usePrompt } from './PromptModal'
 import { useFileSelection } from '../store/file-selection'
 import { planUploadOf, runFolderUpload } from '../lib/folder-transfer'
-import { TransferProgressDialog, type TransferRow } from './TransferProgressDialog'
+import { enqueueDeviceTask } from '../lib/device-queue'
 import { hostBaseName } from '../../../shared/transfer-plan'
 import './UploadControls.css'
 
@@ -70,15 +70,8 @@ export function UploadControls(): JSX.Element {
   const [busy, setBusy] = useState(false)
   const [feedback, setFeedback] = useState<Feedback>(null)
 
-  // Folder transfer (#848): the two panes' selections + the progress dialog.
+  // Folder transfer (#848): the two panes' selections.
   const { local: localSel, deviceTargetDir } = useFileSelection()
-  const [transfer, setTransfer] = useState<{
-    title: string
-    rows: TransferRow[]
-    running: boolean
-    error: string | null
-  } | null>(null)
-  const cancelled = useRef(false)
   /**
    * Guards against a SECOND upload starting before the first has registered
    * (#850).
@@ -86,7 +79,9 @@ export function UploadControls(): JSX.Element {
    * `busy` disables the button, but React state lands asynchronously — two
    * quick clicks both read the old value, both pass, and two transfers write
    * the same paths at once. A ref updates synchronously, so the second click
-   * sees the first immediately.
+   * sees the first immediately. (The device queue would serialise them anyway
+   * since #837, but a click that quietly does nothing beats one that queues a
+   * duplicate.)
    */
   const inFlight = useRef(false)
 
@@ -101,60 +96,49 @@ export function UploadControls(): JSX.Element {
   const canUpload = connected && (!!folderToUpload || !!activeFile) && !busy
   const canDownload = !!activeFile && activeFile.source === 'device' && !busy
 
-  /** Copy the highlighted local folder into the highlighted device folder. */
+  /**
+   * Copy the highlighted local folder into the highlighted device folder.
+   *
+   * The copy is a QUEUED device task (#837), so it can neither start on top of a
+   * running driver install nor have one start on top of it, and the shared
+   * board-is-busy modal reports it — the per-file tick list of #848 is now this
+   * task's steps.
+   */
   const uploadFolder = useCallback(
     async (localRoot: string): Promise<void> => {
-      cancelled.current = false
       setBusy(true)
       setFeedback(null)
       const name = hostBaseName(localRoot)
-      const title = `Copying ${name} → ${deviceTargetDir}`
-      // Plan BEFORE the dialog claims a file count, so the list it shows is the
-      // real one rather than a guess that grows as the walk catches up.
-      setTransfer({ title, rows: [], running: true, error: null })
       try {
-        const plan = await planUploadOf(localRoot, deviceTargetDir)
-        setTransfer({
-          title: `Copying ${name} → ${plan.root}`,
-          rows: plan.files.map((f) => ({ label: f.label, state: 'pending' as const })),
-          running: true,
-          error: null
-        })
-
-        const result = await runFolderUpload(
-          plan,
-          (event) => {
-            setTransfer((prev) =>
-              prev
-                ? {
-                    ...prev,
-                    rows: prev.rows.map((row, i) =>
-                      i === event.index
-                        ? { ...row, state: event.state, error: event.error }
-                        : row
-                    )
-                  }
-                : prev
+        const { root, copied } = await enqueueDeviceTask({
+          key: `folder:${localRoot}->${deviceTargetDir}`,
+          label: `Copying ${name} → ${deviceTargetDir}`,
+          run: async (ctx) => {
+            // Plan BEFORE claiming a file count, so the list the modal shows is
+            // the real one rather than a guess that grows as the walk catches up.
+            const plan = await planUploadOf(localRoot, deviceTargetDir)
+            ctx.setSteps(plan.files.map((f) => f.label))
+            const result = await runFolderUpload(
+              plan,
+              (event) =>
+                ctx.step(
+                  event.index,
+                  event.state === 'copying' ? 'running' : event.state,
+                  event.error
+                ),
+              () => ctx.cancelled
             )
-          },
-          () => cancelled.current
-        )
-
-        setTransfer((prev) =>
-          prev ? { ...prev, running: false, error: result.ok ? null : (result.error ?? null) } : prev
-        )
-        setFeedback(
-          result.ok
-            ? {
-                kind: 'success',
-                message: `Copied ${result.copied} file${result.copied === 1 ? '' : 's'} to ${plan.root}.`
-              }
-            : { kind: 'error', message: `Copy stopped: ${result.error}` }
-        )
+            if (!result.ok) throw new Error(result.error ?? 'Copy stopped.')
+            return { root: plan.root, copied: result.copied }
+          }
+        })
+        setFeedback({
+          kind: 'success',
+          message: `Copied ${copied} file${copied === 1 ? '' : 's'} to ${root}.`
+        })
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
-        setTransfer((prev) => (prev ? { ...prev, running: false, error: message } : prev))
-        setFeedback({ kind: 'error', message: `Copy failed: ${message}` })
+        setFeedback({ kind: 'error', message: `Copy stopped: ${message}` })
       } finally {
         setBusy(false)
       }
@@ -188,7 +172,11 @@ export function UploadControls(): JSX.Element {
     setBusy(true)
     setFeedback({ kind: 'info', message: `Uploading ${activeFile.name}…` })
     try {
-      await window.api.device.writeFile(dest, activeFile.content)
+      await enqueueDeviceTask({
+        key: `write:${dest}`,
+        label: `Uploading ${activeFile.name} → ${dest}`,
+        run: () => window.api.device.writeFile(dest, activeFile.content)
+      })
       setFeedback({
         kind: 'success',
         message: `Uploaded to ${dest}. Refresh the board tree to see it.`
@@ -283,18 +271,6 @@ export function UploadControls(): JSX.Element {
           <ArrowDownIcon />
         </button>
       </div>
-      {transfer && (
-        <TransferProgressDialog
-          title={transfer.title}
-          rows={transfer.rows}
-          running={transfer.running}
-          error={transfer.error}
-          onCancel={() => {
-            cancelled.current = true
-          }}
-          onClose={() => setTransfer(null)}
-        />
-      )}
       {feedback && (
         <p
           className={`upload-controls__feedback upload-controls__feedback--${feedback.kind}`}

--- a/src/renderer/src/components/driver-install.ts
+++ b/src/renderer/src/components/driver-install.ts
@@ -11,8 +11,16 @@
  * read via `parts.readDriverSource` in main (past the renderer CSP) and copied
  * to its target path, creating each ancestor folder first (MicroPython has no
  * recursive mkdir).
+ *
+ * Every route is QUEUED (#837). Two banners can be on screen at once for a fresh
+ * board — the Board View's driver banner and the editor's missing-library banner
+ * — and accepting both used to start both, each fighting the other for the port.
+ * Wrapping the sequence here rather than at each banner means both callers (and
+ * any future one) get the queue for free, and the board-is-busy modal names the
+ * driver it is on.
  */
 import { driverDeviceDirs, driverInstallMethod, driverModuleId } from './part-editor.util'
+import { DeviceOperationCancelled, enqueueDeviceTask } from '../lib/device-queue'
 import { moduleById } from '../../../shared/modules-catalog'
 import {
   parsePurgeCount,
@@ -33,6 +41,12 @@ export interface DriverInstallResult {
    * case that used to cost an hour of debugging now explains itself.
    */
   note?: string
+  /**
+   * The user cancelled the device queue while this driver was queued or running
+   * (#837). A caller installing a LIST of drivers must stop on it: cancelling
+   * and then watching the next install start is not a cancel.
+   */
+  cancelled?: boolean
 }
 
 /**
@@ -59,6 +73,26 @@ async function clearStaleModule(target: string): Promise<string | undefined> {
 
 /** Install ONE driver file onto the connected board. Never throws. */
 export async function installPartDriver(
+  libraryId: string,
+  partId: string,
+  d: DriverFile
+): Promise<DriverInstallResult> {
+  // Queued, and keyed by what it PUTS on the board rather than by which part
+  // asked for it: two parts needing the same driver is the common case, and
+  // installing it twice in a row is a round trip nobody benefits from.
+  return enqueueDeviceTask({
+    key: `driver:${d.source}->${d.target}`,
+    label: `Installing ${d.label?.trim() || d.source}`,
+    run: () => runDriverInstall(libraryId, partId, d)
+  }).catch((err) => ({
+    ok: false,
+    message: err instanceof Error ? err.message : String(err),
+    cancelled: err instanceof DeviceOperationCancelled
+  }))
+}
+
+/** The install sequence itself — always run through the device queue above. */
+async function runDriverInstall(
   libraryId: string,
   partId: string,
   d: DriverFile

--- a/src/renderer/src/lib/device-queue.ts
+++ b/src/renderer/src/lib/device-queue.ts
@@ -1,0 +1,374 @@
+/**
+ * ONE QUEUE FOR EVERY DEVICE FILE OPERATION (#837).
+ *
+ * The device layer already serialises the WIRE: `opQueue` makes each `exec`
+ * atomic and `withFsLock` makes a whole file-write sequence atomic (#850), so
+ * two writes can no longer shred each other. What it does not do is stop two
+ * OPERATIONS being started at once — and Snakie routinely offers several at the
+ * same moment: the instruments-library banner, the missing-library banner, the
+ * Board View's driver banner and the Modules panel can all be on screen for one
+ * freshly-connected board. Accepting two of them used to start two installs that
+ * interleaved their round trips, each reporting progress over the other, taking
+ * turns at the port and finishing in an order nobody asked for.
+ *
+ * So operations queue HERE, one level above the wire: the first one runs, the
+ * rest wait their turn, and the whole lot is described by a single snapshot the
+ * modal renders. Serialising at the wire keeps files intact; serialising here is
+ * what makes the app tell the truth about what the board is doing.
+ *
+ * Three properties are worth stating, because each of them is a bug we hit:
+ *
+ *  - **Dedupe by key.** Two banners can want the same driver. Enqueuing a key
+ *    that is already waiting or running JOINS that task rather than installing
+ *    the same module twice.
+ *  - **Cancel releases the user immediately.** A wedged board cannot be made to
+ *    return, so cancelling detaches the UI from the running task (its caller's
+ *    promise rejects, the modal goes away) instead of waiting for something that
+ *    may never happen. The internal chain still awaits the abandoned task before
+ *    starting the next one, so a later operation cannot overlap it — it simply
+ *    shows as waiting, which is the truth.
+ *  - **No nesting.** A task's `run` must not enqueue another task: it would wait
+ *    for the queue it is itself holding. Enqueue at the top of a user action,
+ *    and call the device directly inside it.
+ */
+
+import type { TransferRow } from '../components/TransferProgressDialog'
+
+/** Where one queued operation is. `cancelled` is terminal, like `error`. */
+export type DeviceTaskState = 'waiting' | 'running' | 'done' | 'error' | 'cancelled'
+
+/** Where one of a task's own sub-steps is (the per-file ticks of a folder copy). */
+export type DeviceStepState = 'pending' | 'running' | 'done' | 'error'
+
+/** One sub-step of a task — a single file in a folder copy, say. */
+export interface DeviceStep {
+  label: string
+  state: DeviceStepState
+  error?: string
+}
+
+/** The read-only view of a queued task that the modal renders. */
+export interface DeviceTaskView {
+  id: number
+  key: string
+  label: string
+  state: DeviceTaskState
+  error?: string
+  steps: readonly DeviceStep[]
+}
+
+/** Everything the modal needs, rebuilt on each change so its identity is stable. */
+export interface DeviceQueueSnapshot {
+  tasks: readonly DeviceTaskView[]
+  /** True while anything is running OR waiting — i.e. the board is busy. */
+  busy: boolean
+  /** The first failure still on the list; keeps the modal open. */
+  error: string | null
+}
+
+/** What a task's `run` is handed so it can report progress and notice a cancel. */
+export interface DeviceTaskContext {
+  /** True once the user cancelled — a long task must check it between steps. */
+  readonly cancelled: boolean
+  /** Declare the steps this task will work through, in order. */
+  setSteps(labels: readonly string[]): void
+  /** Move one step on. Out-of-range indexes are ignored. */
+  step(index: number, state: DeviceStepState, error?: string): void
+}
+
+/** A unit of work that touches the board's filesystem. */
+export interface DeviceTask<T> {
+  /** Identity for dedupe: `module:vl53l0x`, `folder:/home/kev/lib`, … */
+  key: string
+  /** What the modal calls it: "Installing VL53L0X". */
+  label: string
+  run(ctx: DeviceTaskContext): Promise<T>
+}
+
+/** Thrown into a caller whose task was cancelled or dropped from the queue. */
+export class DeviceOperationCancelled extends Error {
+  constructor(label: string) {
+    super(`${label} was cancelled.`)
+    this.name = 'DeviceOperationCancelled'
+  }
+}
+
+interface Entry<T = unknown> {
+  id: number
+  key: string
+  label: string
+  state: DeviceTaskState
+  error?: string
+  steps: DeviceStep[]
+  task: DeviceTask<T>
+  /** Raised by a cancel; read through `ctx.cancelled`. */
+  cancelled: boolean
+  /** Guards the caller's promise against being settled twice. */
+  settled: boolean
+  resolve: (value: T) => void
+  reject: (err: unknown) => void
+  promise: Promise<T>
+}
+
+let nextId = 1
+let entries: Entry[] = []
+/** The serialisation chain — every task is appended to it, so they run in turn. */
+let chain: Promise<void> = Promise.resolve()
+const listeners = new Set<() => void>()
+
+let snapshot: DeviceQueueSnapshot = { tasks: [], busy: false, error: null }
+
+function view(entry: Entry): DeviceTaskView {
+  return {
+    id: entry.id,
+    key: entry.key,
+    label: entry.label,
+    state: entry.state,
+    error: entry.error,
+    steps: entry.steps
+  }
+}
+
+function emit(): void {
+  snapshot = {
+    tasks: entries.map(view),
+    busy: entries.some((e) => e.state === 'running' || e.state === 'waiting'),
+    error: entries.find((e) => e.state === 'error')?.error ?? null
+  }
+  for (const l of listeners) l()
+}
+
+/** Settle the caller's promise exactly once, whatever else happens to the entry. */
+function settle(entry: Entry, ok: boolean, value: unknown): void {
+  if (entry.settled) return
+  entry.settled = true
+  if (ok) entry.resolve(value)
+  else entry.reject(value)
+}
+
+async function runEntry(entry: Entry): Promise<void> {
+  // Cancelled while it sat in the queue — never touch the board for it.
+  if (entry.state !== 'waiting') return
+  entry.state = 'running'
+  emit()
+
+  const ctx: DeviceTaskContext = {
+    get cancelled(): boolean {
+      return entry.cancelled
+    },
+    setSteps(labels): void {
+      entry.steps = labels.map((label) => ({ label, state: 'pending' as const }))
+      emit()
+    },
+    step(index, state, error): void {
+      if (index < 0 || index >= entry.steps.length) return
+      entry.steps = entry.steps.map((s, i) => (i === index ? { ...s, state, error } : s))
+      emit()
+    }
+  }
+
+  try {
+    const value = await entry.task.run(ctx)
+    // A cancel already settled the caller and took the row off the list; the
+    // board finishing afterwards changes nothing the user can still see.
+    if (entry.cancelled) return
+    entry.state = 'done'
+    settle(entry, true, value)
+  } catch (err) {
+    if (entry.cancelled) return
+    entry.state = 'error'
+    entry.error = err instanceof Error ? err.message : String(err)
+    settle(entry, false, err)
+  } finally {
+    emit()
+  }
+}
+
+/**
+ * Put one device operation in the queue and get its result back.
+ *
+ * Resolves with whatever `run` returned, rejects with whatever it threw — so a
+ * call site keeps the try/catch it already had. A cancelled task rejects with
+ * {@link DeviceOperationCancelled}.
+ */
+export function enqueueDeviceTask<T>(task: DeviceTask<T>): Promise<T> {
+  const pending = entries.find(
+    (e) => e.key === task.key && (e.state === 'waiting' || e.state === 'running')
+  )
+  // Two banners can offer the same driver. The second click should watch the
+  // first install, not start a second one behind it.
+  if (pending) return pending.promise as Promise<T>
+
+  let resolve!: (value: T) => void
+  let reject!: (err: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+
+  const entry: Entry<T> = {
+    id: nextId++,
+    key: task.key,
+    label: task.label,
+    state: 'waiting',
+    steps: [],
+    task,
+    cancelled: false,
+    settled: false,
+    resolve,
+    reject,
+    promise
+  }
+  entries = [...entries, entry as Entry]
+  emit()
+  chain = chain.then(() => runEntry(entry as Entry))
+  return promise
+}
+
+/**
+ * Stop everything and hand the app back to the user.
+ *
+ * Waiting tasks are dropped outright. The running one is asked to stop (it sees
+ * `ctx.cancelled`) and then ABANDONED: its caller is rejected and its row taken
+ * off the list right away, because a board that has stopped answering will not
+ * start answering just because we waited longer. The chain still holds until it
+ * really settles, so nothing new can overlap it.
+ */
+export function cancelDeviceQueue(): void {
+  for (const entry of entries) {
+    if (entry.state !== 'waiting' && entry.state !== 'running') continue
+    entry.cancelled = true
+    entry.state = 'cancelled'
+    settle(entry, false, new DeviceOperationCancelled(entry.label))
+  }
+  entries = []
+  emit()
+}
+
+/** Clear the finished rows (the modal's Close). Anything still live stays. */
+export function dismissDeviceQueue(): void {
+  entries = entries.filter((e) => e.state === 'waiting' || e.state === 'running')
+  emit()
+}
+
+/** Subscribe to queue changes (for `useSyncExternalStore`). */
+export function subscribeDeviceQueue(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+/** The current snapshot; its identity only changes when the queue does. */
+export function getDeviceQueueSnapshot(): DeviceQueueSnapshot {
+  return snapshot
+}
+
+/** Test seam — empty the queue and drop the chain, listeners intact. */
+export function resetDeviceQueueForTest(): void {
+  entries = []
+  chain = Promise.resolve()
+  emit()
+}
+
+// --- The view the modal renders ---------------------------------------------
+
+/** A task's row state, in the dialog's vocabulary. A cancelled task reads as a
+ *  failure because that is what it is: work that did not happen. */
+function taskRowState(state: DeviceTaskState): TransferRow['state'] {
+  if (state === 'running') return 'copying'
+  if (state === 'done') return 'done'
+  if (state === 'error' || state === 'cancelled') return 'error'
+  return 'pending'
+}
+
+function stepRowState(state: DeviceStepState): TransferRow['state'] {
+  return state === 'running' ? 'copying' : state
+}
+
+/**
+ * Flatten the queue into the dialog's rows: one row per task, with its own steps
+ * listed indented underneath. Pure.
+ *
+ * A task keeps its step rows after it finishes — a folder copy that collapsed
+ * back to a single line the moment it succeeded would throw away the receipt
+ * the user was reading.
+ */
+export function queueRows(tasks: readonly DeviceTaskView[]): TransferRow[] {
+  const rows: TransferRow[] = []
+  for (const task of tasks) {
+    rows.push({
+      id: `task-${task.id}`,
+      label: task.label,
+      state: taskRowState(task.state),
+      error: task.error
+    })
+    task.steps.forEach((step, i) => {
+      rows.push({
+        id: `task-${task.id}-step-${i}`,
+        label: step.label,
+        state: stepRowState(step.state),
+        error: step.error,
+        indent: true
+      })
+    })
+  }
+  return rows
+}
+
+/**
+ * How far through the queue we are, counting LEAVES: a task with steps is
+ * counted by its steps, one without by itself. Counting both would make a
+ * twelve-file copy report thirteen things to do. Pure.
+ */
+export function queueProgress(tasks: readonly DeviceTaskView[]): {
+  done: number
+  total: number
+} {
+  let done = 0
+  let total = 0
+  for (const task of tasks) {
+    if (task.steps.length > 0) {
+      total += task.steps.length
+      done += task.steps.filter((s) => s.state === 'done').length
+    } else {
+      total += 1
+      if (task.state === 'done') done += 1
+    }
+  }
+  return { done, total }
+}
+
+/** The dialog heading: one operation names itself, several get a count. Pure. */
+export function queueTitle(tasks: readonly DeviceTaskView[]): string {
+  if (tasks.length === 1) return tasks[0].label
+  return `Working on the board — ${tasks.length} operations`
+}
+
+/**
+ * What the modal should do about the current snapshot, given whether it is
+ * already on screen. Pure, so the timing rules are testable without a DOM.
+ *
+ *  - `hide`  — nothing queued.
+ *  - `show`  — put it up (or keep it up).
+ *  - `arm`   — work is running but has not been on screen yet: start the reveal
+ *              delay. Most installs finish in well under it, and flashing a
+ *              modal up and straight back down for a one-file write is worse
+ *              than saying nothing at all.
+ *  - `clear` — everything finished before the delay elapsed, so nobody ever saw
+ *              the dialog; drop the finished rows rather than leaving them to
+ *              appear in front of the NEXT operation.
+ */
+export type QueueDialogAction = 'hide' | 'show' | 'arm' | 'clear'
+
+export function queueDialogAction(
+  snap: DeviceQueueSnapshot,
+  onScreen: boolean
+): QueueDialogAction {
+  if (snap.tasks.length === 0) return 'hide'
+  // A failure always surfaces, however quick it was — an error the user never
+  // saw is an error that did not happen, as far as they are concerned.
+  if (snap.error) return 'show'
+  if (snap.busy) return onScreen ? 'show' : 'arm'
+  return onScreen ? 'show' : 'clear'
+}

--- a/test/deviceQueue.test.ts
+++ b/test/deviceQueue.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { readFileSync } from 'node:fs'
+import {
+  DeviceOperationCancelled,
+  cancelDeviceQueue,
+  dismissDeviceQueue,
+  enqueueDeviceTask,
+  getDeviceQueueSnapshot,
+  queueDialogAction,
+  queueProgress,
+  queueRows,
+  queueTitle,
+  resetDeviceQueueForTest,
+  type DeviceTaskView
+} from '../src/renderer/src/lib/device-queue'
+
+/**
+ * Device operations must QUEUE, not race (#837).
+ *
+ * The bug this pins: `withFsLock` (#850) made each file-write sequence atomic on
+ * the wire, but nothing stopped two OPERATIONS being started at once. A freshly
+ * connected board can show the instruments-library banner, the missing-library
+ * banner, the Board View's driver banner and the Modules panel together —
+ * accepting two of them started two installs that then took turns at the port,
+ * each reporting progress over the other.
+ *
+ * Asserted by recording when each task's `run` STARTS, so the test states the
+ * property (the second one does not begin until the first has finished) rather
+ * than re-describing the implementation.
+ */
+
+/** A promise plus its settle functions — stands in for a slow board. */
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+  let resolve!: (v: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+/** Let every pending microtask + timer callback run. */
+const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 0))
+
+beforeEach(() => resetDeviceQueueForTest())
+
+describe('the device queue runs one operation at a time (#837)', () => {
+  it('holds the second task until the first has finished', async () => {
+    const log: string[] = []
+    const first = deferred<void>()
+    const second = deferred<void>()
+
+    const a = enqueueDeviceTask({
+      key: 'a',
+      label: 'Installing A',
+      run: async () => {
+        log.push('a:start')
+        await first.promise
+        log.push('a:end')
+      }
+    })
+    const b = enqueueDeviceTask({
+      key: 'b',
+      label: 'Installing B',
+      run: async () => {
+        log.push('b:start')
+        await second.promise
+        log.push('b:end')
+      }
+    })
+
+    await tick()
+    // The whole point: B has not touched the board yet.
+    expect(log).toEqual(['a:start'])
+    expect(getDeviceQueueSnapshot().tasks.map((t) => t.state)).toEqual(['running', 'waiting'])
+    expect(getDeviceQueueSnapshot().busy).toBe(true)
+
+    first.resolve()
+    await a
+    await tick()
+    expect(log).toEqual(['a:start', 'a:end', 'b:start'])
+
+    second.resolve()
+    await b
+    await tick()
+    expect(log).toEqual(['a:start', 'a:end', 'b:start', 'b:end'])
+    expect(getDeviceQueueSnapshot().busy).toBe(false)
+  })
+
+  it('joins a task already queued under the same key instead of repeating it', async () => {
+    // Two banners can offer the same driver; installing it twice is a round trip
+    // nobody benefits from.
+    let runs = 0
+    const gate = deferred<string>()
+    const run = (): Promise<string> => {
+      runs++
+      return gate.promise
+    }
+
+    const a = enqueueDeviceTask({ key: 'module:vl53l0x', label: 'Installing VL53L0X', run })
+    const b = enqueueDeviceTask({ key: 'module:vl53l0x', label: 'Installing VL53L0X', run })
+    await tick()
+
+    expect(getDeviceQueueSnapshot().tasks).toHaveLength(1)
+    gate.resolve('installed')
+    expect(await a).toBe('installed')
+    expect(await b).toBe('installed')
+    expect(runs).toBe(1)
+  })
+
+  it('gives the caller back whatever the task returned, and whatever it threw', async () => {
+    await expect(
+      enqueueDeviceTask({ key: 'ok', label: 'ok', run: async () => 42 })
+    ).resolves.toBe(42)
+    await expect(
+      enqueueDeviceTask({
+        key: 'bad',
+        label: 'bad',
+        run: async () => {
+          throw new Error('OSError: 28')
+        }
+      })
+    ).rejects.toThrow('OSError: 28')
+    // A failure stays on the list so the modal can show it.
+    expect(getDeviceQueueSnapshot().error).toBe('OSError: 28')
+    dismissDeviceQueue()
+    expect(getDeviceQueueSnapshot().tasks).toHaveLength(0)
+  })
+})
+
+describe('cancelling hands the app back even when the board is wedged', () => {
+  it('releases the UI without waiting for a task that never returns', async () => {
+    // A board that has stopped answering will not start answering because we
+    // waited longer — so cancel detaches rather than joining the hang.
+    const stuck = enqueueDeviceTask({
+      key: 'stuck',
+      label: 'Copying mylib → /lib',
+      run: () => new Promise<void>(() => {})
+    })
+    let behindRan = false
+    const behind = enqueueDeviceTask({
+      key: 'behind',
+      label: 'Installing VL53L0X',
+      run: async () => {
+        behindRan = true
+      }
+    })
+    await tick()
+
+    cancelDeviceQueue()
+
+    const snap = getDeviceQueueSnapshot()
+    expect(snap.tasks).toHaveLength(0)
+    expect(snap.busy).toBe(false)
+    await expect(stuck).rejects.toBeInstanceOf(DeviceOperationCancelled)
+    await expect(behind).rejects.toBeInstanceOf(DeviceOperationCancelled)
+
+    // The task that was still waiting never touched the board at all.
+    await tick()
+    expect(behindRan).toBe(false)
+  })
+
+  it('tells a cooperative task to stop', async () => {
+    let sawCancel = false
+    const started = deferred<void>()
+    const task = enqueueDeviceTask({
+      key: 'copy',
+      label: 'Copying mylib → /lib',
+      run: async (ctx) => {
+        started.resolve()
+        await tick()
+        sawCancel = ctx.cancelled
+      }
+    })
+    await started.promise
+    cancelDeviceQueue()
+    await expect(task).rejects.toBeInstanceOf(DeviceOperationCancelled)
+    await tick()
+    expect(sawCancel).toBe(true)
+  })
+})
+
+// --- The view the modal renders ---------------------------------------------
+
+function task(over: Partial<DeviceTaskView> = {}): DeviceTaskView {
+  return { id: 1, key: 'k', label: 'Installing X', state: 'running', steps: [], ...over }
+}
+
+describe('what the modal is told', () => {
+  it('lists a task’s own steps indented under it', () => {
+    const rows = queueRows([
+      task({
+        id: 7,
+        label: 'Copying mylib → /lib',
+        steps: [
+          { label: 'a.py', state: 'done' },
+          { label: 'b.py', state: 'running' }
+        ]
+      })
+    ])
+    expect(rows.map((r) => [r.label, r.state, r.indent ?? false])).toEqual([
+      ['Copying mylib → /lib', 'copying', false],
+      ['a.py', 'done', true],
+      ['b.py', 'copying', true]
+    ])
+    // Distinct keys: a step can share a name with the task above it.
+    expect(new Set(rows.map((r) => r.id)).size).toBe(3)
+  })
+
+  it('reads a cancelled task as a failure, because that is what it is', () => {
+    expect(queueRows([task({ state: 'cancelled' })])[0].state).toBe('error')
+  })
+
+  it('counts leaves, so a twelve-file copy is not thirteen things to do', () => {
+    expect(
+      queueProgress([
+        task({
+          id: 1,
+          steps: [
+            { label: 'a', state: 'done' },
+            { label: 'b', state: 'done' },
+            { label: 'c', state: 'pending' }
+          ]
+        }),
+        task({ id: 2, state: 'waiting' })
+      ])
+    ).toEqual({ done: 2, total: 4 })
+  })
+
+  it('names a single operation, and counts several', () => {
+    expect(queueTitle([task({ label: 'Installing VL53L0X' })])).toBe('Installing VL53L0X')
+    expect(queueTitle([task({ id: 1 }), task({ id: 2 })])).toContain('2 operations')
+  })
+})
+
+describe('when the modal should appear', () => {
+  const snap = (
+    over: Partial<ReturnType<typeof getDeviceQueueSnapshot>> = {}
+  ): ReturnType<typeof getDeviceQueueSnapshot> => ({
+    tasks: [task()],
+    busy: true,
+    error: null,
+    ...over
+  })
+
+  it('stays away when there is nothing queued', () => {
+    expect(queueDialogAction(snap({ tasks: [], busy: false }), false)).toBe('hide')
+    expect(queueDialogAction(snap({ tasks: [], busy: false }), true)).toBe('hide')
+  })
+
+  it('arms a delay rather than flashing up for a one-file write', () => {
+    expect(queueDialogAction(snap(), false)).toBe('arm')
+  })
+
+  it('stays up once it is up', () => {
+    expect(queueDialogAction(snap(), true)).toBe('show')
+  })
+
+  it('surfaces a failure however quick it was', () => {
+    // An error the user never saw is an error that did not happen, to them.
+    expect(queueDialogAction(snap({ busy: false, error: 'OSError: 28' }), false)).toBe('show')
+  })
+
+  it('clears rows nobody ever saw, so they don’t front the NEXT operation', () => {
+    expect(queueDialogAction(snap({ busy: false }), false)).toBe('clear')
+  })
+})
+
+describe('the wiring holds the pieces together', () => {
+  const read = (p: string): string => readFileSync(p, 'utf8')
+
+  it('routes every device file operation through the queue', () => {
+    const sites: [string, string][] = [
+      // The two driver banners share this installer, so wrapping it here queues
+      // both of them.
+      ['src/renderer/src/components/driver-install.ts', 'enqueueDeviceTask'],
+      ['src/renderer/src/components/ModulesPanel.tsx', 'enqueueDeviceTask'],
+      ['src/renderer/src/components/PackagesPanel.tsx', 'enqueueDeviceTask'],
+      ['src/renderer/src/components/PartsPanel.tsx', 'enqueueDeviceTask'],
+      // The instruments-library banner + the missing-library banner's mip route.
+      ['src/renderer/src/components/AppShell.tsx', 'enqueueDeviceTask'],
+      ['src/renderer/src/components/UploadControls.tsx', 'enqueueDeviceTask']
+    ]
+    for (const [file, needle] of sites) expect(read(file), file).toContain(needle)
+  })
+
+  it('leaves no second progress dialog to contradict the first', () => {
+    // Two dialogs on screen could say different things about one board.
+    const src = read('src/renderer/src/components/UploadControls.tsx')
+    expect(src).not.toContain('TransferProgressDialog')
+  })
+
+  it('mounts the busy modal in BOTH renderer entries', () => {
+    // The popped-out Board View has its own queue — its driver banner installs
+    // from over there — so it needs its own copy of the modal.
+    for (const entry of ['src/renderer/src/App.tsx', 'src/renderer/src/board-main.tsx']) {
+      expect(read(entry), entry).toContain('<DeviceQueueDialog />')
+    }
+  })
+
+  it('stops a RUN of driver installs when the user cancels', () => {
+    // A failed row does not stop the run — installing what can be installed is
+    // useful. A cancel must: queueing the next driver behind the user's cancel
+    // answers a different question from the one they asked.
+    expect(read('src/renderer/src/components/driver-install.ts')).toContain(
+      'cancelled: err instanceof DeviceOperationCancelled'
+    )
+    expect(read('src/renderer/src/components/DriverInstallBanner.tsx')).toContain(
+      'if (!(await installOne(need, d))) return'
+    )
+  })
+
+  it('keeps the folder copy’s per-file receipt (#848) as the task’s steps', () => {
+    const src = read('src/renderer/src/components/UploadControls.tsx')
+    expect(src).toContain('ctx.setSteps(plan.files.map((f) => f.label))')
+    expect(src).toContain('() => ctx.cancelled')
+  })
+})


### PR DESCRIPTION
Closes #837.

## The bug

A freshly connected board can put several install offers on screen at once — the
instruments library, the missing-library banner, the Board View's driver banner,
the Modules and Packages panels. Accepting a second one **started it there and
then, on top of the first**.

#850 made the individual writes safe, but that is one level below the problem:
the two *operations* still ran together, taking turns at the port, each
reporting progress over the other, and the app showed a state no single install
was in. Nothing anywhere said the board was busy, so the UI looked ready for
work it would not do.

## What changed

**One queue above the wire.** `src/renderer/src/lib/device-queue.ts` owns what is
running and what is waiting. Every device file operation goes through it:

- both driver banners, via the shared `installPartDriver` — wrapping it there
  rather than at each banner means a future caller gets the queue for free;
- the Modules panel, the Packages panel and the Parts panel's "Works with" rows;
- the instruments-library banner and the missing-library banner's `mip` route;
- the folder copy and the single-file upload in `UploadControls`.

Tasks are **keyed**, so two banners offering the same driver install it once
rather than twice.

**A blocking, cancellable modal.** `DeviceQueueDialog` reuses
`TransferProgressDialog` (from #848) rather than adding a second dialog — two of
them could have been on screen disagreeing about the same board. A queued folder
copy's per-file tick list is now that task's *steps*, so the receipt #848 added
survives, indented under the operation it belongs to. The dialog waits 400 ms
before appearing (flashing a modal up and down for a one-file write is worse
than saying nothing), auto-dismisses shortly after success, and stays put on
failure. It is mounted in both renderer entries, because the popped-out Board
View installs drivers from over there.

**Cancel actually releases you.** A board that has stopped answering will not
start answering because we waited longer. So a cancel drops the waiting tasks,
raises `ctx.cancelled` for the running one, and then *abandons* it: the caller
is rejected and the modal goes immediately, instead of holding the user inside
the hang they are trying to escape. The internal chain still awaits the
abandoned task before starting anything else, so a later operation cannot
overlap it — it simply shows as waiting, which is the truth. A cancel also stops
a *run* of driver installs, since queueing the next driver behind the user's
cancel answers a different question from the one they asked.

## Deliberately NOT done

- **The auto-sync store (#863) is untouched.** It writes one file at a time on
  save and has its own status UI; putting a modal in front of every Ctrl+S would
  be a cure worse than the disease. Its writes still serialise at the device
  layer, so nothing can corrupt.
- **The queue is per renderer window.** The popped-out Board View has its own, so
  a main-window install and a board-window install can still start together.
  They meet at the device layer's lock, so the files stay intact; making the
  queue cross-window would mean moving ownership into main, which is a much
  larger change than this issue needs.
- No changes to `FirmwareFlasher.tsx`, `DeviceFileTree.tsx` badges or `.mpy`
  handling.

## Tests

`test/deviceQueue.test.ts` — 19 tests. The queue's behaviour is asserted by
recording when each task's `run` *starts*, so the test states the property
rather than re-describing the implementation; the modal's timing and row-flatten
rules are extracted as pure functions (`queueDialogAction`, `queueRows`,
`queueProgress`, `queueTitle`) and tested directly, per the node-env convention.

**Verified they fail without the fix**, each for the right reason:

| break | test that failed |
| --- | --- |
| unchain the queue (`void runEntry(...)`) | "holds the second task until the first has finished" (`['a:start','b:start']`), and "releases the UI without waiting for a task that never returns" |
| remove the key dedupe | "joins a task already queued under the same key" (2 tasks, not 1) |
| drop the reveal delay | "arms a delay rather than flashing up for a one-file write" |

Restored afterwards; full suite green.

## Gates

| gate | result |
| --- | --- |
| `npm run lint` | pass — 1 pre-existing warning in `DriverInstallBanner.tsx` (`useEffect` dep), not introduced here |
| `npm run typecheck` | pass |
| `npm test` | pass — 289 files, 6004 tests |
| `npm run build` | pass |

Every new style token is a theme custom property (`--bg-sunken`, `--text`,
`--accent`, `--danger`, `--border`, `--radius`), and the one new rule is a
padding, so both skins are covered; `test/cssThemeTokens.test.ts` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe
