### PR TITLE
fix(sync): scope sync tags to the folder on screen (#881)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,19 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **File sync no longer remembers files you can't see** (#881). A sync tag was an
+  absolute path with no memory of the folder it was made in, so it outlived that
+  folder: open a different project and yesterday's tags were still tagged, still
+  counted in the status bar, and still pushed to the board on every save — for
+  files nowhere in the tree on screen. Tags are now scoped to the open folder.
+  Only what is inside it syncs, whatever the stored list happens to contain, so
+  a list left by an older version or by a crash mid-change can't push an
+  invisible file either. Opening a different folder asks first, and then forgets
+  the tags the new folder can't show, saying in the status bar how many went. The
+  breadcrumb is left alone deliberately: it only ever re-roots UP to a parent,
+  which widens the tree, so nothing that was visible stops being visible and
+  peeking one level up costs you nothing.
+
 - **An interrupted install no longer leaves a broken file on the board** (#864).
   Driver and package installs wrote each file straight to its final name, so
   stopping part-way — a disconnect, a cancel, an error on any one file — left a

--- a/src/renderer/src/components/LocalFileTree.tsx
+++ b/src/renderer/src/components/LocalFileTree.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { FsEntry } from '../../../main/fs/types'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { useWorkspace, FILE_SAVED_EVENT, type FileSavedDetail } from '../store/workspace'
-import { useSync } from '../store/sync'
+import { forgetTagsPrompt, useSync } from '../store/sync'
 import { useFileSelection } from '../store/file-selection'
 import { ContextMenu, type ContextMenuItem, type ContextMenuPosition } from './ContextMenu'
 import { usePrompt } from './PromptModal'
@@ -24,6 +24,12 @@ import './LocalFileTree.css'
  * working folder: each segment is a button that re-roots the tree to that
  * ancestor via `openFolderPath`. When no folder is open yet, a single small
  * "open folder" icon launches the native picker.
+ *
+ * Opening a different folder asks first when files are tagged for syncing
+ * (#881): tags belong to the folder they were made in, and the ones the new
+ * folder can't show are forgotten. The breadcrumb doesn't ask — it only ever
+ * re-roots to an ANCESTOR, which widens the tree, so nothing that was visible
+ * stops being visible and no tag is lost.
  */
 
 /** The rest of the toolbar's icons are shared with the Device panel — see
@@ -186,7 +192,7 @@ export function LocalFileTree(): JSX.Element {
   const prompt = usePrompt()
   const deviceStatus = useDeviceStatus()
   const connected = deviceStatus.state === 'connected'
-  const { isSynced, toggleSync } = useSync()
+  const { isSynced, toggleSync, syncedPaths } = useSync()
   // Publish what is highlighted so the transfer bridge between the two panes
   // can see it (#848). The tree stays in charge of what selection MEANS.
   const { setLocal: publishSelection } = useFileSelection()
@@ -241,12 +247,18 @@ export function LocalFileTree(): JSX.Element {
   }, [root])
 
   const handleOpenFolder = useCallback(async (): Promise<void> => {
+    // Say what opening a folder costs before the picker takes the screen (#881):
+    // sync tags belong to the folder they were made in, and the ones the new
+    // folder can't show are dropped. `window.confirm` because `window.prompt`
+    // doesn't work in Electron's renderer — and a yes/no needs nothing more.
+    const warning = forgetTagsPrompt(syncedPaths.length)
+    if (warning && !window.confirm(warning)) return
     try {
       await openFolder()
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
     }
-  }, [openFolder])
+  }, [openFolder, syncedPaths])
 
   // Web only (#476): a folder persisted from a previous visit that needs a click
   // to re-grant permission. `reopenFolderName` is absent on desktop, so this

--- a/src/renderer/src/store/sync.ts
+++ b/src/renderer/src/store/sync.ts
@@ -14,6 +14,14 @@
  * existing "Upload to board" default). The set of tagged paths and the
  * sync-on-save flag persist in localStorage so they survive a reload.
  *
+ * Tags are SCOPED TO THE FOLDER THE LOCAL TREE IS SHOWING (#881). A tagged path
+ * is an absolute one, and it used to outlive the folder it was made in: open a
+ * different project and yesterday's tags were still there, invisible, still
+ * pushing files to the board. So the store reads `currentFolder` from the
+ * workspace store — which is why {@link SyncProvider} must sit inside
+ * `<WorkspaceProvider>` — and everything it exposes is filtered to that folder.
+ * Tags left outside it are dropped for good when the folder changes.
+ *
  * Auto-sync-on-save is wired through the `FILE_SAVED_EVENT` window event the
  * workspace store dispatches, so this store stays decoupled from save plumbing.
  *
@@ -34,7 +42,7 @@ import {
   useState,
   type ReactNode
 } from 'react'
-import { baseName, FILE_SAVED_EVENT, type FileSavedDetail } from './workspace'
+import { baseName, FILE_SAVED_EVENT, useWorkspace, type FileSavedDetail } from './workspace'
 import { useFileSelection } from './file-selection'
 import { planUploadOf, runFolderUpload } from '../lib/folder-transfer'
 import { deviceJoin } from '../../../shared/transfer-plan'
@@ -101,7 +109,11 @@ function emitSyncStatus(text: string, lingerMs?: number): void {
 export type SyncStatus = 'idle' | 'syncing' | 'done' | 'error'
 
 export interface SyncStore {
-  /** Local paths currently tagged to keep in sync. */
+  /**
+   * Local paths currently tagged to keep in sync — always within the folder the
+   * local tree is showing (#881). Nothing outside it is ever handed out, so a
+   * count taken from here is a count of tags the user can actually see.
+   */
   syncedPaths: string[]
   /** Whether saving a tagged file auto-uploads it. */
   syncOnSave: boolean
@@ -125,6 +137,75 @@ export interface SyncStore {
 /** Device destination for a synced local file: `/<basename>` (mirrors upload). */
 export function deviceDestForLocal(localPath: string): string {
   return `/${baseName(localPath)}`
+}
+
+// ---------------------------------------------------------------------------
+// Tag scope (#881)
+// ---------------------------------------------------------------------------
+
+/**
+ * Is `path` inside the folder the local tree is rooted at?
+ *
+ * "Inside" means REACHABLE in that tree, not literally on screen: a file in a
+ * collapsed subfolder is one click from being seen, and folding a folder away
+ * must not quietly stop its files syncing. A path that IS the root is not under
+ * it — the tree lists the root's children, so the root never has a tick box of
+ * its own.
+ *
+ * Compared segment by segment so `/a/b` doesn't swallow `/a/bb`, and so a
+ * Windows path (`C:\kev\lib`) answers the same as a POSIX one. Case is compared
+ * exactly, for the same reason `deviceDestFor` does it: both sides come from the
+ * same `fs.readDir` listing, so a difference in case means two different trees
+ * rather than two spellings of one.
+ */
+export function isUnderFolder(folder: string | null, path: string): boolean {
+  if (!folder) return false
+  const root = folder.split(/[/\\]+/).filter(Boolean)
+  const parts = path.split(/[/\\]+/).filter(Boolean)
+  if (root.length === 0 || parts.length <= root.length) return false
+  return root.every((seg, i) => seg === parts[i])
+}
+
+/**
+ * The tags that belong to `folder`, in tag order.
+ *
+ * This is the SAFETY half of #881, and it deliberately doesn't lean on the
+ * forgetting half: a list persisted by an older version, or one that survived a
+ * crash midway through a folder change, is still filtered through here before
+ * anything is pushed. A file the user cannot see never reaches their board,
+ * whatever state storage is in.
+ */
+export function pathsInFolder(paths: string[], folder: string | null): string[] {
+  return paths.filter((p) => isUnderFolder(folder, p))
+}
+
+/**
+ * What to ask before the folder picker opens (#881) — or null when there is
+ * nothing to lose by opening it.
+ *
+ * Asked BEFORE the native dialog because that is the last moment we can offer a
+ * way out: once a folder has been chosen, the tags outside it are already gone.
+ * The wording hedges on purpose. The picker may yet land on a folder that still
+ * contains the tagged files (their parent, say), and those tags are kept —
+ * promising they will all be forgotten would be a lie half the time.
+ */
+export function forgetTagsPrompt(tagged: number): string | null {
+  if (tagged <= 0) return null
+  const one = tagged === 1
+  return (
+    `${tagged} file${one ? ' is' : 's are'} tagged to keep in sync with the board.\n\n` +
+    `Opening a different folder forgets ${one ? 'that tag' : 'those tags'}, unless ` +
+    `${one ? 'the file is' : 'the files are'} inside the folder you pick.\n\n` +
+    `Open a different folder?`
+  )
+}
+
+/** The status-bar line for tags dropped by a folder change (#881). */
+export function forgotTagsMessage(dropped: number): string {
+  const one = dropped === 1
+  return `Forgot ${dropped} sync tag${one ? '' : 's'} — ${
+    one ? "that file isn't" : "those files aren't"
+  } in this folder`
 }
 
 // ---------------------------------------------------------------------------
@@ -294,6 +375,9 @@ export function SyncProvider({ children }: { children: ReactNode }): JSX.Element
   const deviceTargetDirRef = useRef(deviceTargetDir)
   deviceTargetDirRef.current = deviceTargetDir
 
+  // The folder the local tree is showing. Every tag is scoped to it (#881).
+  const { currentFolder } = useWorkspace()
+
   const [syncedPaths, setSyncedPaths] = useState<string[]>(() => loadSyncedPaths())
   const [syncOnSave, setSyncOnSaveState] = useState<boolean>(() => loadSyncOnSave())
   const [status, setStatus] = useState<SyncStatus>('idle')
@@ -305,9 +389,47 @@ export function SyncProvider({ children }: { children: ReactNode }): JSX.Element
   const connectedRef = useRef(false)
   const syncedRef = useRef(syncedPaths)
   const onSaveRef = useRef(syncOnSave)
+  const folderRef = useRef(currentFolder)
   const lingerTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   syncedRef.current = syncedPaths
   onSaveRef.current = syncOnSave
+  folderRef.current = currentFolder
+
+  /**
+   * The tags that belong to the folder on screen — the store's whole public
+   * surface is built from this rather than from the raw list (#881), so a tag
+   * the user cannot see is invisible to the tick boxes, to the status-bar popup
+   * and to every push, even in the moment before the prune below removes it.
+   */
+  const scopedPaths = useMemo(
+    () => pathsInFolder(syncedPaths, currentFolder),
+    [syncedPaths, currentFolder]
+  )
+
+  /**
+   * Changing the working folder forgets the tags that folder can't show (#881).
+   *
+   * Pruning rather than clearing outright: what makes a tag a problem is being
+   * invisible, so a tag that is still in the tree is still honest. That is what
+   * makes the breadcrumb's `..` safe to leave unguarded — it can only widen the
+   * tree, so nothing that was visible stops being visible, and nothing is lost.
+   *
+   * This also runs on the FIRST folder of the session, which is where a list
+   * persisted by an older version gets cleaned up rather than merely hidden.
+   * A null folder prunes nothing: at launch the tree is briefly rootless while
+   * the last folder is restored, and wiping the tags in that gap would mean
+   * they never survived a restart at all.
+   */
+  useEffect(() => {
+    if (!currentFolder) return
+    const kept = pathsInFolder(syncedRef.current, currentFolder)
+    const dropped = syncedRef.current.length - kept.length
+    if (dropped === 0) return
+    syncedRef.current = kept
+    saveSyncedPaths(kept)
+    setSyncedPaths(kept)
+    emitSyncStatus(forgotTagsMessage(dropped), DONE_LINGER_MS)
+  }, [currentFolder])
 
   // Track the live device connection so we only auto-push when a board is there.
   useEffect(() => {
@@ -328,10 +450,12 @@ export function SyncProvider({ children }: { children: ReactNode }): JSX.Element
   }, [])
 
   // Keep the per-path records in step with the tagged list: a newly tagged path
-  // starts `pending`, an untagged one is forgotten.
+  // starts `pending`, an untagged one is forgotten. Reconciled against the
+  // SCOPED list so the popup's rows and the store's tags stay the same set
+  // (#863 + #881) — a path out of scope has no row, so it needs no record.
   useEffect(() => {
-    setFileStates((prev) => reconcileFiles(prev, syncedPaths))
-  }, [syncedPaths])
+    setFileStates((prev) => reconcileFiles(prev, scopedPaths))
+  }, [scopedPaths])
 
   useEffect(() => {
     return () => {
@@ -411,11 +535,14 @@ export function SyncProvider({ children }: { children: ReactNode }): JSX.Element
     [settle]
   )
 
+  // "Sync now" pushes what is in the tree, not what storage happens to hold
+  // (#881) — the filter is repeated here rather than trusted from the prune
+  // effect, so a stale list can't be pushed in the render before it runs.
   const syncNow = useCallback(async (): Promise<void> => {
-    await pushPaths(syncedRef.current)
+    await pushPaths(pathsInFolder(syncedRef.current, folderRef.current))
   }, [pushPaths])
 
-  const isSynced = useCallback((path: string): boolean => syncedPaths.includes(path), [syncedPaths])
+  const isSynced = useCallback((path: string): boolean => scopedPaths.includes(path), [scopedPaths])
 
   const toggleSync = useCallback(
     (path: string): void => {
@@ -461,6 +588,9 @@ export function SyncProvider({ children }: { children: ReactNode }): JSX.Element
       if (!detail || detail.source !== 'local') return
       if (!onSaveRef.current || !connectedRef.current) return
       if (!syncedRef.current.includes(detail.path)) return
+      // A buffer can be open from anywhere — including a file left over from a
+      // folder the tree is no longer showing. Saving it must not push it (#881).
+      if (!isUnderFolder(folderRef.current, detail.path)) return
       const label = baseName(detail.path)
       void (async (): Promise<void> => {
         if (lingerTimer.current) clearTimeout(lingerTimer.current)
@@ -486,13 +616,13 @@ export function SyncProvider({ children }: { children: ReactNode }): JSX.Element
   }, [settle])
 
   const syncedFiles = useMemo(
-    () => syncedFileList(syncedPaths, fileStates, deviceTargetDir),
-    [syncedPaths, fileStates, deviceTargetDir]
+    () => syncedFileList(scopedPaths, fileStates, deviceTargetDir),
+    [scopedPaths, fileStates, deviceTargetDir]
   )
 
   const store = useMemo<SyncStore>(
     () => ({
-      syncedPaths,
+      syncedPaths: scopedPaths,
       syncOnSave,
       status,
       error,
@@ -503,7 +633,7 @@ export function SyncProvider({ children }: { children: ReactNode }): JSX.Element
       syncNow
     }),
     [
-      syncedPaths,
+      scopedPaths,
       syncOnSave,
       status,
       error,

--- a/test/syncScope.test.ts
+++ b/test/syncScope.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest'
+import {
+  forgetTagsPrompt,
+  forgotTagsMessage,
+  isUnderFolder,
+  pathsInFolder,
+  reconcileFiles,
+  syncedFileList,
+  markFiles
+} from '../src/renderer/src/store/sync'
+
+/**
+ * Sync tags are scoped to the folder on screen (#881).
+ *
+ * The bug these guard against is a quiet one: a tag is an absolute path, it
+ * outlived the folder it was made in, and so opening a different project left
+ * yesterday's files still being pushed to the board with nothing on screen to
+ * say so. Two separate properties fix it, and they are tested separately on
+ * purpose — the filtering has to hold on its own, without relying on the
+ * forgetting having happened, because a list persisted by an older version has
+ * never been through a folder change at all.
+ */
+
+describe('isUnderFolder', () => {
+  it('accepts a file directly inside the folder', () => {
+    expect(isUnderFolder('/home/kev/proj', '/home/kev/proj/main.py')).toBe(true)
+  })
+
+  it('accepts a file deep inside it — a collapsed subfolder is still in the tree', () => {
+    // "Visible" means reachable by expanding, not literally on screen: folding a
+    // folder away must not quietly stop its files syncing.
+    expect(isUnderFolder('/home/kev/proj', '/home/kev/proj/lib/drivers/oled.py')).toBe(true)
+  })
+
+  it('rejects a file in a different project', () => {
+    expect(isUnderFolder('/home/kev/proj', '/home/kev/other/main.py')).toBe(false)
+  })
+
+  it('rejects an ANCESTOR of the folder — up is out of the tree, not in it', () => {
+    expect(isUnderFolder('/home/kev/proj', '/home/kev/main.py')).toBe(false)
+  })
+
+  it('rejects the folder itself: the tree lists its children, so it has no tick box', () => {
+    expect(isUnderFolder('/home/kev/proj', '/home/kev/proj')).toBe(false)
+    expect(isUnderFolder('/home/kev/proj/', '/home/kev/proj')).toBe(false)
+  })
+
+  it('does not let one folder swallow a sibling whose name starts the same', () => {
+    // A prefix match on the raw string would take `/home/kev/proj2` for a child
+    // of `/home/kev/proj`, and push a whole other project's files.
+    expect(isUnderFolder('/home/kev/proj', '/home/kev/proj2/main.py')).toBe(false)
+    expect(isUnderFolder('/home/kev/proj', '/home/kev/projector/main.py')).toBe(false)
+  })
+
+  it('answers the same for a Windows path as for a POSIX one', () => {
+    expect(isUnderFolder('C:\\Users\\kev\\proj', 'C:\\Users\\kev\\proj\\lib\\main.py')).toBe(true)
+    expect(isUnderFolder('C:\\Users\\kev\\proj', 'C:\\Users\\kev\\other\\main.py')).toBe(false)
+    expect(isUnderFolder('D:\\proj', 'C:\\proj\\main.py')).toBe(false)
+  })
+
+  it('compares case exactly — a difference in case means a different tree', () => {
+    expect(isUnderFolder('/home/kev/Proj', '/home/kev/proj/main.py')).toBe(false)
+  })
+
+  it('has nothing in scope when no folder is open', () => {
+    expect(isUnderFolder(null, '/home/kev/proj/main.py')).toBe(false)
+    expect(isUnderFolder('', '/home/kev/proj/main.py')).toBe(false)
+  })
+})
+
+describe('pathsInFolder', () => {
+  it('keeps only the tags the open folder can show, in tag order', () => {
+    const tagged = ['/home/kev/proj/b.py', '/home/kev/other/x.py', '/home/kev/proj/a.py']
+    expect(pathsInFolder(tagged, '/home/kev/proj')).toEqual([
+      '/home/kev/proj/b.py',
+      '/home/kev/proj/a.py'
+    ])
+  })
+
+  it('keeps a tagged FOLDER, which syncs recursively (#848)', () => {
+    expect(pathsInFolder(['/home/kev/proj/lib'], '/home/kev/proj')).toEqual(['/home/kev/proj/lib'])
+  })
+
+  it('drops everything while no folder is open, without being told to', () => {
+    // A tag list restored from storage before the last folder has been restored
+    // is not yet anybody's list: nothing is on screen, so nothing may be pushed.
+    expect(pathsInFolder(['/home/kev/proj/a.py'], null)).toEqual([])
+  })
+
+  it('filters a list persisted by an older version, which never saw a folder change', () => {
+    // The safety half must not depend on the forgetting half having run.
+    const stale = ['/home/kev/2019-project/blink.py', '/home/kev/proj/main.py']
+    expect(pathsInFolder(stale, '/home/kev/proj')).toEqual(['/home/kev/proj/main.py'])
+  })
+
+  it('keeps every tag when the tree is re-rooted UP to a parent', () => {
+    // The breadcrumb only ever widens the tree, which is why it is left
+    // unguarded: nothing that was visible stops being visible.
+    const tagged = ['/home/kev/proj/a.py', '/home/kev/proj/lib/b.py']
+    expect(pathsInFolder(tagged, '/home/kev')).toEqual(tagged)
+  })
+
+  it('drops the tags that fall outside a NARROWER root', () => {
+    const tagged = ['/home/kev/proj/a.py', '/home/kev/proj/lib/b.py']
+    expect(pathsInFolder(tagged, '/home/kev/proj/lib')).toEqual(['/home/kev/proj/lib/b.py'])
+  })
+})
+
+describe('the record keeping stays coherent with the scope (#863)', () => {
+  it('drops the popup row for a tag that is no longer in the folder', () => {
+    // The glyph's count, the summary line and the rows all read from this, so a
+    // scoped-out tag has to leave all of them at once — a "1 of 2 on the board"
+    // where the missing one cannot be seen is exactly the confusion in #881.
+    const before = markFiles({}, ['/home/kev/proj/a.py', '/home/kev/other/x.py'], 'done')
+    const scoped = pathsInFolder(Object.keys(before), '/home/kev/proj')
+    const map = reconcileFiles(before, scoped)
+    expect(Object.keys(map)).toEqual(['/home/kev/proj/a.py'])
+    expect(syncedFileList(scoped, map, '/').map((r) => r.name)).toEqual(['a.py'])
+  })
+})
+
+describe('forgetTagsPrompt', () => {
+  it('says nothing when there is nothing to lose', () => {
+    expect(forgetTagsPrompt(0)).toBeNull()
+  })
+
+  it('hedges, because the folder picked may yet contain the tagged files', () => {
+    const message = forgetTagsPrompt(3)
+    expect(message).toContain('3 files are tagged')
+    expect(message).toContain('unless the files are inside the folder you pick')
+  })
+
+  it('gets the singular right', () => {
+    const message = forgetTagsPrompt(1)
+    expect(message).toContain('1 file is tagged')
+    expect(message).toContain('that tag')
+    expect(message).toContain('unless the file is inside the folder you pick')
+  })
+})
+
+describe('forgotTagsMessage', () => {
+  it('says how many tags went, and why', () => {
+    expect(forgotTagsMessage(2)).toBe("Forgot 2 sync tags — those files aren't in this folder")
+    expect(forgotTagsMessage(1)).toBe("Forgot 1 sync tag — that file isn't in this folder")
+  })
+})


### PR DESCRIPTION
Closes #881.

A sync tag is an absolute path with no memory of the folder it was made in, and the list persists in `localStorage` — so a tag outlived its folder. Open a different project and yesterday's tags were still tagged, still counted in the status-bar popup, and still pushed to the board on every save, for files nowhere in the tree on screen. Nothing visible could explain where those writes came from.

## Two properties, deliberately independent

**Scope.** `pathsInFolder` filters the tag list to the open folder, and the store's whole public surface is built from the filtered list — `syncedPaths`, `syncedFiles`, `isSynced`, "Sync now", and the sync-on-save handler. This holds *without* anything having been forgotten first, which is the point: a list persisted by an older version has never been through a folder change, and neither has one that survived a crash halfway through it. A file the user cannot see cannot reach the board, whatever state storage is in.

**Forgetting.** Opening a folder asks first — `window.confirm`, before the native picker, which is the last moment there is a way out — and the tags the new folder can't show are then dropped from storage for good, with a status-bar line saying how many went. The prune is keyed off the folder *actually changing* rather than off the button, so cancelling the picker costs nothing, and the first folder of a session gets a stale list cleaned up rather than merely hidden. A null folder prunes nothing: the tree is briefly rootless at launch while the last folder is restored, and wiping the tags in that gap would mean they never survived a restart at all.

It **prunes** rather than clearing outright, because what makes a tag a problem is being *invisible* — a tag still in the tree is still honest. Picking an unrelated project drops everything, as the issue asks; picking a subfolder or a parent keeps what is still on screen.

## The breadcrumb question

**The breadcrumb does not warn and does not clear, and it doesn't need to.** It only ever re-roots to an **ancestor** (`..`), which *widens* the tree — so every tag that was visible is still visible, `pathsInFolder` keeps all of them, and nothing is lost. There is nothing to warn about, and clearing tags because someone clicked `..` to peek one level up would be exactly the nasty surprise the brief warns against. The pruning rule earns this for free: it is stated in terms of visibility, not in terms of which control was clicked, so the two navigation paths need no special-casing between them.

The web-only "Reopen &lt;folder&gt;" button is likewise unguarded — it only appears when *no* folder is open, where the scoped tag count is always 0, so the prompt would never fire anyway. Its prune still runs and still announces itself in the status bar.

## Details

- `isUnderFolder` compares segment by segment, so `/a/b` doesn't swallow `/a/b2` and a Windows path answers the same as a POSIX one. Case is compared exactly, for the same reason `deviceDestFor` does it.
- "Inside" means **reachable in the tree**, not literally on screen: folding a folder away must not quietly stop its files syncing. That is also what makes the rule sensible for a tagged **folder** (#848) — a folder tag inside the root syncs recursively exactly as before.
- **#863 stays coherent.** The per-path record map is reconciled against the same scoped list, so a scoped-out tag leaves the popup rows, the glyph's count and the summary line *together* — never a "1 of 2 on the board" whose missing file can't be found. `test/syncIndicator.test.ts` is untouched and passing.

## Tests

New `test/syncScope.test.ts` (20 cases, pure helpers, `node` environment like the rest). I verified they fail without the fix by breaking it two ways and restoring:

- filtering turned into a passthrough (the old behaviour) → 5 failures, including the #863 coherence case;
- the segment compare replaced with a naive `startsWith` → 2 failures, on the sibling-prefix (`/a/b` vs `/a/b2`) and root-itself cases.

## Gates

`npm run lint` (clean but for the known pre-existing `DriverInstallBanner.tsx` warning) · `npm run typecheck` · `npm test` (6005 passing) · `npm run build` — all green.

No collision with the in-flight PRs: this touches `store/sync.ts`, `components/LocalFileTree.tsx`, `CHANGELOG.md` and a new test file — none of #878's files, and not `store/workspace.ts` (#883).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe
