### PR TITLE
fix(files): one Open Folder, next to the files it opens (#882)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **Open Folder now lives next to the files it opens** (#882). The main toolbar
+  and the Local files mini toolbar both carried a folder icon doing exactly the
+  same thing, and the action belongs beside the tree it re-roots — so the main
+  toolbar keeps New file and Save, and the folder icon stays in the Local files
+  panel. That panel can be collapsed, though, and the Electronics and Build
+  workspaces have no files panel at all, so removing the toolbar button on its
+  own would have left a user with nowhere to open a folder from. There is now a
+  **File ▸ Open Folder…** menu item with the usual `Cmd`/`Ctrl`-`O`, which also
+  reveals the Local files panel so the folder you picked appears rather than
+  landing silently behind a collapsed panel.
+
 - **Both file toolbars now sit the same way** (#868). The Device files actions
   shared the title's row and were pushed to one end of it, while the Local files
   actions had a centred row of their own — the same control in two places. Both

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -14,7 +14,7 @@ import { registerUpdater, checkForUpdatesManual } from './updater'
 import { registerBoardIpc, openBoardView, disposeBoard } from './board'
 import { registerFindIpc, disposeFind } from './find'
 import { registerInstrumentWindowsIpc, disposeInstrumentWindows } from './instrumentWindows'
-import { registerWorkspaceIpc, disposeWorkspace } from './workspace'
+import { registerWorkspaceIpc, requestOpenFolder, disposeWorkspace } from './workspace'
 import { registerConsoleWindowIpc, disposeConsoleWindow } from './consoleWindow'
 import { registerPartsIpc } from './parts/ipc'
 import { registerRobotIpc } from './robot/ipc'
@@ -250,7 +250,10 @@ app.whenReady().then(() => {
   // Build the application menu (issue #89). Its "Check for Updates…" item and
   // the clickable status-bar version both invoke the same user-initiated check.
   // Installed after `registerUpdater` so `checkForUpdatesManual` is assigned.
-  setupAppMenu(() => void checkForUpdatesManual(), openBoardView)
+  // File ▸ Open Folder… relays to the renderer, which owns the picker (#882);
+  // its resolver is captured by `registerWorkspaceIpc` below, and the menu only
+  // fires on a click, so registration order doesn't matter.
+  setupAppMenu(() => void checkForUpdatesManual(), openBoardView, requestOpenFolder)
 
   // Register the LLM (Claude) chat layer. All Anthropic API calls happen in the
   // main process; deltas stream back to whichever window is currently live.

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -6,12 +6,16 @@ import { app, Menu, type MenuItemConstructorOptions } from 'electron'
  * Snakie previously relied on Electron's default menu (and `autoHideMenuBar`).
  * To add a "Check for Updates…" command we build an explicit menu from the
  * standard roles so the normal Edit / View / Window behaviour is preserved —
- * we only insert our own item:
+ * we only insert our own items. "Check for Updates…" goes:
  *
  *   - macOS  → in the app menu (first menu, named after the app), just after
  *              "About Snakie", matching the platform convention;
  *   - Win/Linux → in a Help menu (created here, since the default template has
  *              none) alongside the About item.
+ *
+ * File ▸ Open Folder… (#882) and View ▸ Board View sit where their platform
+ * conventions put them, and carry the accelerators that make them reachable
+ * without hunting for a button.
  *
  * The item invokes the same `checkForUpdatesManual` the clickable status-bar
  * version triggers via IPC — a user-initiated GitHub update check (see
@@ -19,8 +23,14 @@ import { app, Menu, type MenuItemConstructorOptions } from 'electron'
  * GitHub Releases and prompts to download; unpackaged it shows a friendly note.
  *
  * @param onCheckForUpdates handler for the "Check for Updates…" item.
+ * @param onOpenBoard handler for the Board View item.
+ * @param onOpenFolder handler for the File ▸ Open Folder… item.
  */
-export function buildAppMenu(onCheckForUpdates: () => void, onOpenBoard: () => void): Menu {
+export function buildAppMenu(
+  onCheckForUpdates: () => void,
+  onOpenBoard: () => void,
+  onOpenFolder: () => void
+): Menu {
   const isMac = process.platform === 'darwin'
   const appName = app.name
 
@@ -36,6 +46,18 @@ export function buildAppMenu(onCheckForUpdates: () => void, onOpenBoard: () => v
     label: 'Board View',
     accelerator: 'CmdOrCtrl+Shift+B',
     click: () => onOpenBoard()
+  }
+
+  // Open Folder (#882). The main toolbar's folder icon was a duplicate of the
+  // Local Files panel's own, so it went — but that button was ALSO the only
+  // Open Folder reachable when the Files panel is collapsed, or in Electronics /
+  // Build where there is no files panel at all. The action lives here now, with
+  // the accelerator every editor uses for it, so removing the icon removed a
+  // duplicate rather than the ability.
+  const openFolderItem: MenuItemConstructorOptions = {
+    label: 'Open Folder…',
+    accelerator: 'CmdOrCtrl+O',
+    click: () => onOpenFolder()
   }
 
   const template: MenuItemConstructorOptions[] = [
@@ -61,7 +83,7 @@ export function buildAppMenu(onCheckForUpdates: () => void, onOpenBoard: () => v
       : []),
     {
       label: 'File',
-      submenu: [isMac ? { role: 'close' } : { role: 'quit' }]
+      submenu: [openFolderItem, { type: 'separator' }, isMac ? { role: 'close' } : { role: 'quit' }]
     },
     {
       label: 'Edit',
@@ -124,6 +146,10 @@ export function buildAppMenu(onCheckForUpdates: () => void, onOpenBoard: () => v
  * Build the application menu and install it as the global menu. Called once at
  * startup from `app.whenReady`.
  */
-export function setupAppMenu(onCheckForUpdates: () => void, onOpenBoard: () => void): void {
-  Menu.setApplicationMenu(buildAppMenu(onCheckForUpdates, onOpenBoard))
+export function setupAppMenu(
+  onCheckForUpdates: () => void,
+  onOpenBoard: () => void,
+  onOpenFolder: () => void
+): void {
+  Menu.setApplicationMenu(buildAppMenu(onCheckForUpdates, onOpenBoard, onOpenFolder))
 }

--- a/src/main/workspace.ts
+++ b/src/main/workspace.ts
@@ -6,9 +6,10 @@ import { BrowserWindow, ipcMain } from 'electron'
  * Two facts belong to the SESSION rather than to any one window, and until now
  * both were only reachable through the pop-out Board View window:
  *
- *   workspace:show      (any window → main → MAIN window)  switch workspace
- *   workspace:setFolder (main window → main, send)         publish the folder
- *   workspace:folder    (any window → main, invoke)        read it back
+ *   workspace:show       (any window → main → MAIN window)  switch workspace
+ *   workspace:setFolder  (main window → main, send)         publish the folder
+ *   workspace:folder     (any window → main, invoke)        read it back
+ *   workspace:openFolder (app menu → MAIN window)           run Open Folder
  *
  * WHY A RELAY. The workspace switcher lives inside `AppShell`, in the main
  * window. A detached instrument (`instrumentWindows.ts`) or the board window has
@@ -32,9 +33,28 @@ import { BrowserWindow, ipcMain } from 'electron'
  *  `undefined` = no folder open (the userData fallback, same as before). */
 let projectFolder: string | undefined
 
+/** Resolver for the main editor window, captured at IPC registration so the app
+ *  menu can reach the renderer that owns the folder picker (#882). */
+let resolveMainWindow: () => BrowserWindow | null = () => null
+
+/**
+ * Ask the main window to run its Open Folder action — the File menu item and its
+ * Cmd/Ctrl-O accelerator (#882).
+ *
+ * The picker itself belongs to the renderer: `fs.openFolderDialog` is what turns
+ * a chosen directory into the workspace's `currentFolder` (and remembers it for
+ * the next launch), so raising a dialog from here would open a folder nothing was
+ * listening for. The menu only pulls the trigger.
+ */
+export function requestOpenFolder(): void {
+  const mw = resolveMainWindow()
+  if (mw && !mw.isDestroyed()) mw.webContents.send('workspace:openFolder')
+}
+
 /** Register the workspace IPC. `getMainWindow` resolves the live editor window —
  *  the one that owns the workspace switcher. */
 export function registerWorkspaceIpc(getMainWindow: () => BrowserWindow | null): void {
+  resolveMainWindow = getMainWindow
   // Any window asks the MAIN window to show a workspace. Fire-and-forget: the
   // sender doesn't wait, and a request made while no main window exists is
   // simply dropped (there is nothing to switch).
@@ -54,4 +74,5 @@ export function registerWorkspaceIpc(getMainWindow: () => BrowserWindow | null):
 /** Forget the published folder (used on quit / in tests). */
 export function disposeWorkspace(): void {
   projectFolder = undefined
+  resolveMainWindow = () => null
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1331,6 +1331,13 @@ const workspace = {
     ipcRenderer.on('workspace:show', listener)
     return () => ipcRenderer.removeListener('workspace:show', listener)
   },
+  /** Subscribe to the app menu's File ▸ Open Folder… request (#882). The main
+   *  window listens and raises the picker; returns an unsubscribe function. */
+  onOpenFolder: (cb: () => void): (() => void) => {
+    const listener = (): void => cb()
+    ipcRenderer.on('workspace:openFolder', listener)
+    return () => ipcRenderer.removeListener('workspace:openFolder', listener)
+  },
   /** Publish the open project folder (the main window, when it changes). */
   setFolder: (folder?: string): void => ipcRenderer.send('workspace:setFolder', folder),
   /** The open project folder, or null when no folder is open. Readable from any

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -86,6 +86,7 @@ import {
   type InstallState
 } from '../lib/instrumentsLib'
 import { announceSaved, useWorkspace } from '../store/workspace'
+import { reporter } from '../lib/report-error'
 import { readRobotModel } from '../../../shared/krf'
 import { isUrdfPath } from './urdf-target'
 import { useEditorSettings } from '../store/settings'
@@ -225,7 +226,7 @@ export function AppShell(): JSX.Element {
   // us stream every edit / theme change to that window over IPC so it updates
   // live. `boardOpened` tracks whether the window has been opened this session
   // (so we only stream while it's open); it resets when the user closes it.
-  const { openFiles, activeId, currentFolder, reloadContent } = useWorkspace()
+  const { openFiles, activeId, currentFolder, reloadContent, openFolder } = useWorkspace()
   const activeFile = openFiles.find((f) => f.id === activeId) ?? null
   const [boardOpened, setBoardOpened] = useState(false)
 
@@ -1070,6 +1071,24 @@ export function AppShell(): JSX.Element {
     window.addEventListener(HELP_EVENT, handler)
     return () => window.removeEventListener(HELP_EVENT, handler)
   }, [setActivityView, setLeftCollapsed])
+
+  // File ▸ Open Folder… from the app menu, or its Cmd/Ctrl-O accelerator (#882).
+  // The main toolbar's folder icon was a duplicate of the Local Files panel's,
+  // so it went — but the panel can be COLLAPSED (and Electronics/Build have no
+  // files panel at all), which would have left no way in. The menu is always
+  // there, so this is the reachable path; revealing the Files view first means
+  // the folder lands somewhere the user can see, rather than silently behind a
+  // collapsed panel. Both reveal calls are the ones the Help deep-link above
+  // uses, for the same solo-workspace reason.
+  useEffect(() => {
+    const off = window.api.workspace.onOpenFolder(() => {
+      setActivityView('files')
+      setLeftCollapsed('files', false)
+      filesRef.current?.expand()
+      void openFolder().catch(reporter('open folder', { notify: "Couldn't open the folder." }))
+    })
+    return off
+  }, [openFolder, setActivityView, setLeftCollapsed])
 
   // The Parts Library + Part Editor live in the Board Viewer window now (it's the
   // only place that uses parts), so the main window no longer hosts them.

--- a/src/renderer/src/components/Toolbar.css
+++ b/src/renderer/src/components/Toolbar.css
@@ -1,9 +1,9 @@
 /*
  * Toolbar.css — small additions for the file-action icon group placed to the
- * LEFT of the Run button (New File / Open Folder / Save), plus the vertical
- * divider separating it from the Run/Stop group. Reuses the shared `.btn`
- * family from index.css; this only adds an icon-button sizing variant and the
- * divider so the shared stylesheet stays untouched.
+ * LEFT of the Run button (New File / Save), plus the vertical divider separating
+ * it from the Run/Stop group. Reuses the shared `.btn` family from index.css;
+ * this only adds an icon-button sizing variant and the divider so the shared
+ * stylesheet stays untouched.
  */
 
 .toolbar__divider {
@@ -35,8 +35,9 @@
   color: #3a7a34;
 }
 
-/* File-action group (New / Open / Save). The Skeuomorph skin fuses these into a
- * single segmented control; other themes keep them as spaced icon buttons. */
+/* File-action group (New / Save). Open Folder moved to the Local Files panel it
+ * acts on (#882). The Skeuomorph skin fuses these into a single segmented
+ * control; other themes keep them as spaced icon buttons. */
 .toolbar__seg {
   display: flex;
   align-items: center;

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -35,8 +35,6 @@ const NEW_FILE_ICON = ToolIcon(
     <rect x="5" y="10" width="6" height="2" />
   </g>
 )
-// folder (open folder)
-const OPEN_FOLDER_ICON = ToolIcon(<path d="M1 3h5l2 2h7v8H1z" fill="currentColor" />)
 // floppy disk (save)
 const SAVE_ICON = ToolIcon(
   <g fill="currentColor">
@@ -85,7 +83,7 @@ const SNAKE_LOGO = (
  * TOP TOOLBAR.
  *
  * Big, easy-to-click action buttons (Run / Stop) plus the file actions
- * (New / Open / Save, grouped as one segmented control). Run executes the
+ * (New / Save, grouped as one segmented control). Run executes the
  * active editor file on the device via MicroPython paste mode (output streams to
  * the existing Shell terminal); Stop sends an interrupt (Ctrl-C).
  *
@@ -93,15 +91,19 @@ const SNAKE_LOGO = (
  * {@link StatusBar} (issue #71); this toolbar still reads {@link useDeviceStatus}
  * only to enable/disable the Run/Stop buttons.
  *
- * Hosts the file actions (New / Open / Save), Run / Stop, and the centred
- * workspace switcher (Code · Electronics · Build). The Board View lives in the
- * Electronics workspace now, so the old pop-out board knob is gone (#…); the old
- * global panel-collapse knobs went in Soft Shell (#592) — each panel owns its own
- * collapse control. Settings + the theme picker live on the activity bar.
+ * Hosts the file actions (New / Save), Run / Stop, and the centred workspace
+ * switcher (Code · Electronics · Build). Open Folder used to sit between New and
+ * Save; it was the same action as the Local Files panel's own folder icon, so it
+ * now lives only there — next to the tree it re-roots (#882) — with File ▸ Open
+ * Folder… (Cmd/Ctrl-O) as the way in when that panel is collapsed or absent. The
+ * Board View lives in the Electronics workspace now, so the old pop-out board
+ * knob is gone (#…); the old global panel-collapse knobs went in Soft Shell
+ * (#592) — each panel owns its own collapse control. Settings + the theme picker
+ * live on the activity bar.
  */
 export function Toolbar(): JSX.Element {
   const status = useDeviceStatus()
-  const { openFiles, activeId, newFile, openFolder, saveFile } = useWorkspace()
+  const { openFiles, activeId, newFile, saveFile } = useWorkspace()
   const { markRun } = useConsole()
   const connected = status.state === 'connected'
   const activeFile = openFiles.find((f) => f.id === activeId)
@@ -196,10 +198,6 @@ export function Toolbar(): JSX.Element {
     }
   }, [running])
 
-  const handleOpenFolder = useCallback(() => {
-    void openFolder().catch(reporter('open folder', { notify: "Couldn't open the folder." }))
-  }, [openFolder])
-
   const handleSave = useCallback(() => {
     if (activeId) void saveFile(activeId).catch(reporter('save file', { notify: "Couldn't save the file." }))
   }, [activeId, saveFile])
@@ -225,15 +223,6 @@ export function Toolbar(): JSX.Element {
             aria-label="New file"
           >
             {NEW_FILE_ICON}
-          </button>
-          <button
-            type="button"
-            className="btn btn--ghost btn--icon toolbar__seg-btn toolbar__seg-btn--open"
-            onClick={handleOpenFolder}
-            title="Open folder"
-            aria-label="Open folder"
-          >
-            {OPEN_FOLDER_ICON}
           </button>
           <button
             type="button"

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -299,7 +299,7 @@
   text-shadow: 0 1px 0 #fff;
 }
 
-/* New / Open / Save fuse into one brushed-metal segmented control (the internal
+/* New / Save fuse into one brushed-metal segmented control (the internal
  * dividers were intentionally removed in the refined concept). */
 :root[data-theme='skeuomorph'] .toolbar__seg {
   gap: 0;
@@ -332,10 +332,6 @@
 :root[data-theme='skeuomorph'] .toolbar__seg .btn:active:not(:disabled) {
   transform: none;
   box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.22);
-}
-
-:root[data-theme='skeuomorph'] .toolbar__seg .toolbar__seg-btn--open {
-  color: #9a7b3a;
 }
 
 /* --- Buttons: glossy bevelled pills -------------------------------------- */
@@ -1023,7 +1019,7 @@
   text-shadow: 0 1px 0 #000;
 }
 
-/* New / Open / Save: one dark brushed-metal segmented control. */
+/* New / Save: one dark brushed-metal segmented control. */
 :root[data-theme='dark'] .toolbar__seg {
   gap: 0;
   border-radius: 9px;
@@ -1055,10 +1051,6 @@
 :root[data-theme='dark'] .toolbar__seg .btn:active:not(:disabled) {
   transform: none;
   box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.5);
-}
-
-:root[data-theme='dark'] .toolbar__seg .toolbar__seg-btn--open {
-  color: #e3bd6a;
 }
 
 /* --- Buttons: glossy bevelled dark pills --------------------------------- */

--- a/src/renderer/src/lib/preloadFallback.ts
+++ b/src/renderer/src/lib/preloadFallback.ts
@@ -203,6 +203,10 @@ if (!w.api) {
         workspaceListeners.add(cb)
         return () => workspaceListeners.delete(cb)
       },
+      // The Open Folder request comes from the DESKTOP app menu (#882); a browser
+      // has no menu bar to fire it, and the web build keeps its own Open Folder
+      // in the Local Files panel.
+      onOpenFolder: unsub,
       setFolder: (folder?: string): void => {
         workspaceFolder = folder && folder.trim() ? folder : undefined
       },

--- a/test/openFolderReachable.test.ts
+++ b/test/openFolderReachable.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+
+/**
+ * Open Folder stays reachable (#882).
+ *
+ * The main toolbar's folder icon was a duplicate of the Local Files panel's own,
+ * so it was removed. The risk in that removal is not cosmetic: the toolbar button
+ * was the only Open Folder that was ALWAYS on screen. The Files panel can be
+ * collapsed (`snakie.collapsed.files` / the layout store's `filesCollapsed`), and
+ * the solo workspaces — Electronics and Build — have no files panel at all, so
+ * "keep it in the mini toolbar" on its own would have left a user with a
+ * collapsed panel no way back to a folder.
+ *
+ * These are assertions about REACHABILITY, in the places where losing it would be
+ * silent. There is no DOM here (the suite runs in `environment: 'node'`), so the
+ * checks read the sources — which is also the only way to see the whole wire at
+ * once: menu → main → preload → renderer.
+ */
+
+const TOOLBAR = readFileSync('src/renderer/src/components/Toolbar.tsx', 'utf8')
+const LOCAL_TREE = readFileSync('src/renderer/src/components/LocalFileTree.tsx', 'utf8')
+const MENU = readFileSync('src/main/menu.ts', 'utf8')
+const MAIN = readFileSync('src/main/index.ts', 'utf8')
+const MAIN_WORKSPACE = readFileSync('src/main/workspace.ts', 'utf8')
+const PRELOAD = readFileSync('src/preload/index.ts', 'utf8')
+const FALLBACK = readFileSync('src/renderer/src/lib/preloadFallback.ts', 'utf8')
+const APP_SHELL = readFileSync('src/renderer/src/components/AppShell.tsx', 'utf8')
+
+/** The body of the `onOpenFolder` subscription in AppShell — what actually runs
+ *  when the menu item fires. */
+function openFolderHandler(): string {
+  const start = APP_SHELL.indexOf('window.api.workspace.onOpenFolder(')
+  expect(start, 'AppShell subscribes to the menu request').toBeGreaterThan(-1)
+  return APP_SHELL.slice(start, APP_SHELL.indexOf('return off', start))
+}
+
+describe('the duplicate is gone', () => {
+  it('the main toolbar no longer carries an Open Folder button', () => {
+    expect(TOOLBAR).not.toContain('Open folder')
+    // The icon and its handler go with it — a left-behind constant is dead code
+    // that reads like the button is still meant to be there.
+    expect(TOOLBAR).not.toContain('OPEN_FOLDER_ICON')
+    expect(TOOLBAR).not.toContain('handleOpenFolder')
+  })
+
+  it('leaves the toolbar group with New and Save only', () => {
+    // Both survivors are the actions the issue explicitly kept.
+    expect(TOOLBAR).toContain('aria-label="New file"')
+    expect(TOOLBAR).toContain('aria-label="Save active file"')
+  })
+})
+
+describe('the Local Files panel keeps it', () => {
+  it('has the folder button in its mini toolbar', () => {
+    expect(LOCAL_TREE).toContain('aria-label="Open folder"')
+    expect(LOCAL_TREE).toContain('onClick={handleOpenFolder}')
+  })
+
+  it('still offers it on first run, when there is no tree to show', () => {
+    // The empty state is the one moment a new user has no folder AND no
+    // breadcrumb — the standalone button is the whole path in.
+    const empty = LOCAL_TREE.slice(LOCAL_TREE.indexOf('localtree__empty'))
+    expect(empty).toContain('Open Folder')
+    expect(empty).toContain('handleOpenFolder')
+  })
+})
+
+describe('the app menu covers a collapsed or absent panel', () => {
+  it('offers File ▸ Open Folder… with the standard accelerator', () => {
+    expect(MENU).toContain("label: 'Open Folder…'")
+    expect(MENU).toContain("accelerator: 'CmdOrCtrl+O'")
+    // It has to be IN the File submenu, not merely declared: a menu item nothing
+    // lists is exactly as unreachable as the button that was removed.
+    const file = MENU.slice(MENU.indexOf("label: 'File'"))
+    expect(file.slice(0, file.indexOf(']'))).toContain('openFolderItem')
+  })
+
+  it('is wired to a real handler at startup', () => {
+    expect(MENU).toContain('click: () => onOpenFolder()')
+    expect(MAIN).toContain('requestOpenFolder')
+  })
+})
+
+describe('the wire from the menu to the picker', () => {
+  const CHANNEL = 'workspace:openFolder'
+
+  it('carries the request from main to the main window', () => {
+    expect(MAIN_WORKSPACE).toContain(`webContents.send('${CHANNEL}')`)
+    // A destroyed window would throw and take the menu click with it.
+    expect(MAIN_WORKSPACE).toContain('isDestroyed()')
+  })
+
+  it('is exposed over the bridge on the SAME channel, and unsubscribes', () => {
+    expect(PRELOAD).toContain(`ipcRenderer.on('${CHANNEL}'`)
+    expect(PRELOAD).toContain(`ipcRenderer.removeListener('${CHANNEL}'`)
+    expect(PRELOAD).toContain('onOpenFolder:')
+  })
+
+  it('is inert outside Electron, where there is no menu bar', () => {
+    expect(FALLBACK).toContain('onOpenFolder: unsub')
+  })
+
+  it('ends in the renderer actually opening a folder', () => {
+    expect(openFolderHandler()).toMatch(/openFolder\(\)/)
+  })
+})
+
+describe('the folder lands somewhere the user can see it', () => {
+  it('reveals the Files view before raising the picker', () => {
+    const body = openFolderHandler()
+    expect(body).toContain("setActivityView('files')")
+    // The solo workspaces gate their sidebar on the STORE flag, so an imperative
+    // `expand()` alone is a no-op there (the bug that hid Help deep-links).
+    expect(body).toContain("setLeftCollapsed('files', false)")
+    expect(body).toContain('filesRef.current?.expand()')
+  })
+})


### PR DESCRIPTION
Closes #882.

## What the issue asked for

> currently the local files toolbar shows icons for open folder and new file - both of these are already available via the main toolbar (new file, open folder and save)
> lets remove the open folder from the main toolbar, and keep it in the local files mini toolbar

The title says "remove duplicate icons from the local files toolbar", the body says remove it from the **main** toolbar. I followed the body: the action belongs next to the thing it acts on, so the Local files panel keeps its folder icon and the main toolbar keeps New file and Save.

## Why this is more than a delete

Before removing the button I went looking for the fallbacks the brief expected to find. **There were none.**

- **No keyboard shortcut.** Nothing in the renderer binds Cmd/Ctrl-O (or anything else) to Open Folder.
- **No menu item.** `src/main/menu.ts` builds the File menu with a single entry — Close on macOS, Quit elsewhere.

And two places where losing the toolbar button would have hurt:

- **The Files panel can be collapsed** (`filesCollapsed` in the layout store, migrated from `snakie.collapsed.files`). Collapsed, the Local files toolbar is not on screen at all.
- **Electronics and Build have no files panel.** They are "solo" workspaces: `AppShell`'s activity-bar handler explicitly keeps the sidebar hidden for Files there (`setActivityView(view); layout.setCollapsed('files', true)`). Only a Learn/Help lesson opens a sidebar in those workspaces.

So the change as literally specified would have left a user who had collapsed the panel — or who was in Electronics — with **no way to open a folder at all**. That is a trap, not a tidy-up, so I implemented the closest safe thing alongside the removal rather than narrowing the work.

## What now provides Open Folder

| Where | State |
| --- | --- |
| Local files mini toolbar (folder icon) | kept — this is what the issue asked for |
| Local files empty state ("▸ Open Folder" / "↻ Reopen …") | unchanged — the first-run path still works |
| Main toolbar | **removed** |
| **File ▸ Open Folder… (`Cmd`/`Ctrl`-`O`)** | **new** |

The menu item relays `workspace:openFolder` to the main window rather than raising a dialog in main, because `fs.openFolderDialog` in the renderer is what turns a chosen directory into the workspace's `currentFolder` and remembers it for next launch — a dialog raised in main would open a folder nothing was listening for. It crosses the process the same way `board:open` already does, reusing `workspace.ts`'s existing relay and `board.ts`'s `resolveMainWindow` pattern.

The renderer handler **reveals the Files view before raising the picker**: `setActivityView('files')` plus *both* `setLeftCollapsed('files', false)` and `filesRef.current?.expand()`. Both, because the solo workspaces gate their sidebar on the store flag and an imperative `expand()` alone is a no-op there — the same bug that once hid Help deep-links. Without this, opening a folder from the menu while the panel was collapsed would look like the menu item had done nothing.

## How I verified it

New `test/openFolderReachable.test.ts` (11 tests). It is deliberately weighted towards *the capability still exists somewhere reachable* rather than *a button was deleted* — it asserts the panel button, the first-run empty state, the menu item's presence **inside the File submenu**, the accelerator, and the whole wire end to end (main `send` → preload `on`/`removeListener` on the same channel → renderer subscribing and calling `openFolder()`), plus the store-flag reveal.

I broke each half in turn and confirmed the right test failed for the right reason, then restored:

| Break | Test that failed |
| --- | --- |
| Put the toolbar button back | `the main toolbar no longer carries an Open Folder button` |
| Drop the item from the File submenu | `offers File ▸ Open Folder… with the standard accelerator` |
| Rename the preload channel (`workspace:openFolderX`) | `is exposed over the bridge on the SAME channel, and unsubscribes` |
| Drop `setLeftCollapsed('files', false)` | `reveals the Files view before raising the picker` |
| Remove the Local files panel's own button | `has the folder button in its mini toolbar` |

## New File — your call, not mine

New File is duplicated too, and you didn't ask for it to move, so I left it. Worth noting the two are **not** quite the same action, which may be why it feels less redundant than the folder icon did:

- the main toolbar's always creates an untitled buffer;
- the panel's creates a file *in the current folder* when one is open, and falls back to an untitled buffer only when there isn't one (a deliberate fix so "create a file and run it" works on the web with no folder).

My recommendation: **keep both.** The toolbar's New file is the "just give me a scratch buffer" action and is the only one that works with the panel collapsed — removing it would need the same menu treatment this PR just gave Open Folder, for a smaller win. If you'd rather it went too, say so and it's a small follow-up.

## Themes

Both skins checked. The removed button's only skin-specific styling was `.toolbar__seg-btn--open` (an amber tint: `#9a7b3a` skeuomorph, `#e3bd6a` dark) — both rules are deleted with it, so no dead selectors are left. The group's own `:root[data-theme='…'] .toolbar__seg` rules are untouched and read correctly as a two-segment control in both skins. No new colours were introduced. `test/cssThemeTokens.test.ts` and `test/segmentedToolbar.test.ts` both still pass.

## Diff footprint

Kept clear of the in-flight PRs: `LocalFileTree.tsx`, `sync.ts` and the sync tagging (#881) are untouched; `store/workspace.ts` (#883) is untouched; `UploadControls`/`PartsPanel`/`ModulesPanel`/`PackagesPanel`/`DriverInstallBanner`/`TransferProgressDialog` (#878) are untouched. `AppShell.tsx` gains one import, one destructured value and one effect, placed next to the existing Help deep-link effect.

## Found but not fixed

- `docs/hardware-test-plan.md` has an "Open folder" manual-test row, but it's phrased against the capability ("Open a local folder; tree renders"), not the toolbar button, so it still reads correctly. No help article, onboarding or tutorial content refers to the main toolbar's folder button.
- The app menu has no other file commands (New File, Save, Save As all live only in the UI). Now that File has a real item in it, filling that menu out would be a reasonable follow-up — out of scope here.

## Gates

`npm run lint` ✅ (only the pre-existing `DriverInstallBanner.tsx` warning) · `npm run typecheck` ✅ · `npm test` ✅ 5996 passed / 289 files · `npm run build` ✅

`package.json` not bumped, as instructed. CHANGELOG entry added under `[Unreleased] › Changed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe
