### PR TITLE
Reach the recommended build without a catalogue selection (#885)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The recommended firmware build is now reachable for the boards that need it**
+  (#885). A board profile can name the build a board actually requires — the
+  Adafruit ESP32 Feather V2 needs `ESP32_GENERIC-SPIRAM`, because only that build
+  turns on its 2 MB of PSRAM — and Snakie could already derive that build's
+  address and download it for you. But the derivation only ran once you had
+  picked a version out of the Family/Model dropdowns, which excluded exactly the
+  boards the recommendation exists for: the Feather V2 has no catalogue entry at
+  all, so its owner never makes a selection, so the recommendation never
+  resolved. What they got instead was a link to a download page headed
+  "ESP32 / WROOM" listing the plain build first — the opposite of the advice
+  printed directly above it. Snakie now finds the build from any release of the
+  same board, so Flash fetches it with nothing selected; where it still cannot,
+  the link says which file to look for and warns against the one at the top of
+  the page. Links in the flash dialog were also rendering in the browser's
+  default blue, which on that permanently dark panel is dark blue on dark grey.
+
 ### Added
 
 - **A finished flash can go back instead of only closing** (#838). Done was the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,34 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **A finished flash can go back instead of only closing** (#838). Done was the
+  only way out of a completed run, and it shut the dialog — throwing away the
+  board, the runtime, the firmware version, the port and every advanced option
+  chosen to get there. That is precisely the moment you want them: a flash that
+  failed usually failed for one reason you can now fix, and re-picking all six
+  selections to change one of them is the complaint. A second button sits beside
+  Done — **Try again** after a failure, **Flash another** after a success — and
+  returns to the options with everything still selected. It clears only what the
+  run produced: the log, the progress bar and the outcome banner.
+
 ### Fixed
+
+- **Detect now says when the board is still connected to the REPL** (#845). A
+  serial port can only be open once, so while Snakie holds one for the REPL,
+  esptool cannot open it to ask the board what it is. That failure came back as
+  an empty identity — indistinguishable from a board that is merely not in
+  download mode — so the dialog offered the BOOT/RESET dance, which cannot
+  possibly free a port held by the app asking you to do it, and the real cause
+  was never said out loud. Detect now checks first and, when the REPL has the
+  port, names it and offers **Disconnect and detect** rather than doing it
+  behind your back: dropping the connection stops whatever the board is running,
+  empties the shell and takes the instruments' live feeds with it, which is a
+  fine thing to do on purpose and a bad thing to have happen to you. A board in
+  BOOTSEL is exempt — a drive copy never touches the serial port — and so is the
+  simulated device, which holds no hardware. Connected to one board and flashing
+  a second stays silent, since nothing is in the way.
 
 - **An interrupted install no longer leaves a broken file on the board** (#864).
   Driver and package installs wrote each file straight to its final name, so

--- a/src/renderer/src/components/FirmwareFlasher.css
+++ b/src/renderer/src/components/FirmwareFlasher.css
@@ -501,3 +501,45 @@
 .firmware-advanced-toggle:hover {
   color: #f4f6f8;
 }
+
+/* The REPL is holding the port Detect needs (#845). A warning with its own way
+   out attached, because "that port is busy" is only half the story when the
+   thing holding it is this same app. Laid out on the warning banner, so its
+   colours are the dialog's own dark palette in BOTH themes — see the note at the
+   top of this file. */
+.firmware-conflict {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.55rem;
+  margin-bottom: 0.5rem;
+}
+
+.firmware-conflict__text {
+  /* Wraps first and takes the whole row when the button no longer fits beside it. */
+  flex: 1 1 16rem;
+  margin: 0;
+}
+
+.firmware-conflict__action {
+  flex: 0 0 auto;
+  padding: 0.35rem 0.7rem;
+  font-family: var(--font-ui);
+  font-size: 0.76rem;
+  font-weight: 600;
+  color: #f4f6f8;
+  background: rgba(255, 255, 255, 0.12);
+  border: var(--border-w) solid var(--accent);
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+
+.firmware-conflict__action:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.firmware-conflict__action:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}

--- a/src/renderer/src/components/FirmwareFlasher.css
+++ b/src/renderer/src/components/FirmwareFlasher.css
@@ -445,14 +445,37 @@
 /* An inline choice inside a hint line — used when the identified chip is claimed
    by more than one board, so the dialog asks rather than guesses. Styled as a
    link, not a button: it sits mid-sentence. */
-.firmware-link {
+/* Links inside this dialog, whether a real anchor or a button dressed as one.
+ *
+ * NOT `var(--accent)`, and not the browser default. The panel is #1f2430 in
+ * both themes (see the note at the top of this file), so the default link blue
+ * lands as dark blue on dark grey — unreadable, and reported as such. `--accent`
+ * is no better: on the skeuomorph theme it is #b07d1e brass, which clears 4:1
+ * against this panel only just, at 0.72rem type.
+ *
+ * A light blue from the dialog's own palette instead, so it reads as a link and
+ * as text. */
+.firmware-link,
+.firmware-hint a {
   padding: 0;
   border: 0;
   background: none;
   font: inherit;
-  color: var(--accent);
+  color: #8fbfff;
   text-decoration: underline;
   cursor: pointer;
+}
+
+.firmware-hint a:hover,
+.firmware-link:hover {
+  color: #b8d8ff;
+}
+
+.firmware-link:focus-visible,
+.firmware-hint a:focus-visible {
+  outline: 2px solid #8fbfff;
+  outline-offset: 2px;
+  border-radius: 2px;
 }
 
 .firmware-link:hover {

--- a/src/renderer/src/components/FirmwareFlasher.tsx
+++ b/src/renderer/src/components/FirmwareFlasher.tsx
@@ -30,7 +30,14 @@ import {
   isVendorUf2Family,
   type FirmwareRuntime
 } from '../../../shared/firmware-runtime'
+import {
+  replPortConflict,
+  heldSerialPort,
+  retryAction,
+  type PortConflict
+} from '../../../shared/flash-dialog'
 import { useFocusTrap } from '../hooks/useFocusTrap'
+import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { hasWebUSB, isElectron } from '../lib/platform'
 import { flashEspInBrowser, requestEspPort } from '../lib/webFirmware/espFlash'
 import { flashMicrobitInBrowser, requestMicrobitDevice } from '../lib/webFirmware/microbitFlash'
@@ -142,6 +149,15 @@ export function FirmwareFlasher({
   const [identity, setIdentity] = useState<BoardIdentity | null>(null)
   const [identifying, setIdentifying] = useState(false)
   /**
+   * Detect could not run because the REPL has the port (#845).
+   *
+   * Set by Detect rather than derived from the connection, so the message
+   * appears because an action was taken and could not be carried out — not as a
+   * standing warning next to a board somebody is happily using.
+   */
+  const [detectConflict, setDetectConflict] = useState<PortConflict | null>(null)
+  const [disconnecting, setDisconnecting] = useState(false)
+  /**
    * Whether the advanced fields are showing (#833). Closed by default.
    *
    * Everything behind it is either derived from the board once it is known — the
@@ -206,6 +222,24 @@ export function FirmwareFlasher({
   const [autoScroll, setAutoScroll] = useState(true)
   // Move focus into the dialog on open, trap Tab, and restore it on close.
   const dialogRef = useFocusTrap<HTMLDivElement>()
+
+  /**
+   * The live REPL connection — because esptool and the REPL want the same port
+   * and only one of them can have it (#845).
+   *
+   * Mirrored into a ref for the same reason `profileRef` is: Detect `await`s a
+   * port scan before it needs this, by which point the callback's captured
+   * `status` can be a connection ago.
+   */
+  const deviceStatus = useDeviceStatus()
+  const statusRef = useRef(deviceStatus)
+  useEffect(() => {
+    statusRef.current = deviceStatus
+    // A board disconnected by any route — this dialog's button, the status bar,
+    // unplugging it — settles the question, so retract the message rather than
+    // leave it accusing a port nobody holds.
+    if (!heldSerialPort(deviceStatus)) setDetectConflict(null)
+  }, [deviceStatus])
 
   // --- Which Python is being flashed (#756) ---
   const [runtime, setRuntime] = useState<FirmwareRuntime>(initialRuntime ?? 'micropython')
@@ -655,16 +689,62 @@ export function FirmwareFlasher({
    * When it cannot work the board out it opens the advanced fields, because at
    * that point they stop being clutter and become the only way through. When it
    * can, they stay shut: there is nothing left to decide.
+   *
+   * `portIsFree` is set only by {@link disconnectAndDetect}, which has just let
+   * go of the port itself: the `device:status` push confirming that has not
+   * arrived yet, so the check below would still see the connection it just
+   * closed.
    */
-  const detectBoard = useCallback(async (): Promise<void> => {
+  const detectBoard = useCallback(async (portIsFree = false): Promise<void> => {
     const found = await refreshDetection()
     const serial = (found ?? []).find((c) => c.source === 'serial')
-    const known = serial?.port ? await identifyBoard(serial.port) : false
     // A UF2 / drive board has no esptool to interrogate, so detection alone
     // settles it — a mount that was found counts as a success.
     const drive = (found ?? []).some((c) => c.source !== 'serial')
+    /**
+     * Ask BEFORE esptool does (#845). A port Snakie holds for the REPL cannot be
+     * opened a second time, and `identifyBoard` reports that failure as an EMPTY
+     * identity — the same answer a board that is simply not in download mode
+     * gives. So the dialog said "hold BOOT, tap RESET", which cannot possibly fix
+     * a port held by the app doing the asking, and the real cause went unsaid.
+     *
+     * A drive board is exempt: nothing about it goes through the serial port, so
+     * an RP2040 in BOOTSEL is flashable with a REPL open on something else.
+     */
+    const conflict =
+      portIsFree || (drive && !serial)
+        ? null
+        : replPortConflict(statusRef.current, serial?.port)
+    setDetectConflict(conflict)
+    // Disconnecting is the way through this one; the advanced fields are not.
+    if (conflict) return
+    const known = serial?.port ? await identifyBoard(serial.port) : false
     if (!known && !drive) setAdvancedOpen(true)
   }, [refreshDetection, identifyBoard])
+
+  /**
+   * Hand the port back, then detect (#845).
+   *
+   * Snakie could take the port without asking — it has to end up free either
+   * way, since flashing needs it too. It asks because the board may be part-way
+   * through something: dropping the REPL stops whatever is running, empties the
+   * shell and takes every instrument's live feed with it. That is a fine thing
+   * to do on purpose and a bad thing to have happen to you, so it is one button
+   * with its consequence written on it rather than a silent side effect of
+   * pressing Detect.
+   */
+  const disconnectAndDetect = useCallback(async (): Promise<void> => {
+    setDisconnecting(true)
+    try {
+      await window.api.device.disconnect()
+    } catch {
+      // Already gone, or never really open — either way the port is free now,
+      // and detection below is the honest way to find out what is on it.
+    } finally {
+      setDisconnecting(false)
+    }
+    await detectBoard(true)
+  }, [detectBoard])
 
   /**
    * The build worth flashing for this board, from whichever source knows.
@@ -812,12 +892,25 @@ export function FirmwareFlasher({
     selectedMaintenance
   ])
 
-  const resetRun = useCallback((): void => {
+  /**
+   * Clear the RUN — and only the run (#838).
+   *
+   * The log, the progress bar and the outcome banner are everything a flash
+   * produced; the board, the runtime, the version, the port, the offset and the
+   * erase choice are everything the user put in. Nothing here may touch the
+   * second list: re-picking all of it after a flash that failed for a reason
+   * they have just fixed is the whole of the complaint.
+   */
+  const clearRun = useCallback((): void => {
     setLog([])
     setPercent(null)
     setOutcome('idle')
-    setFlashing(true)
   }, [])
+
+  const resetRun = useCallback((): void => {
+    clearRun()
+    setFlashing(true)
+  }, [clearRun])
 
   const handleFlash = useCallback(async (): Promise<void> => {
     resetRun()
@@ -930,6 +1023,8 @@ export function FirmwareFlasher({
   ])
 
   const finished = outcome === 'success' || outcome === 'error'
+  /** The second way out of a finished run — back, rather than out (#838). */
+  const retry = retryAction(outcome)
 
   return (
     <div
@@ -1058,6 +1153,26 @@ export function FirmwareFlasher({
               >
                 {identifying ? 'Asking the board…' : '⟳ Detect board'}
               </button>
+            )}
+            {/* Detect ran into the REPL holding the port (#845). Said out loud,
+                with the way out attached — knowing a port is busy is only half
+                of it when the thing holding it is this same app. */}
+            {detectConflict && (
+              <div
+                className="firmware-banner firmware-banner--warn firmware-conflict"
+                role="status"
+              >
+                <p className="firmware-conflict__text">{detectConflict.reason}</p>
+                <button
+                  type="button"
+                  className="firmware-conflict__action"
+                  onClick={() => void disconnectAndDetect()}
+                  disabled={disconnecting || identifying}
+                  title="Close the REPL connection and detect the board again"
+                >
+                  {disconnecting ? 'Disconnecting…' : 'Disconnect and detect'}
+                </button>
+              </div>
             )}
             <label className="firmware-field__label" htmlFor="firmware-profile">
               Board
@@ -1688,14 +1803,30 @@ export function FirmwareFlasher({
 
         <footer className="firmware-modal__footer">
           {finished ? (
-            <button
-              type="button"
-              className="btn btn--primary btn--lg"
-              onClick={onClose}
-              autoFocus
-            >
-              Done
-            </button>
+            <>
+              {/* Done used to be the only way out of a finished run, and it
+                  closed the dialog — losing the board, the version and every
+                  advanced option chosen to get here, right at the moment a
+                  failed flash makes you want to change one of them (#838). */}
+              {retry && (
+                <button
+                  type="button"
+                  className="btn btn--ghost"
+                  onClick={clearRun}
+                  title={retry.title}
+                >
+                  {retry.label}
+                </button>
+              )}
+              <button
+                type="button"
+                className="btn btn--primary btn--lg"
+                onClick={onClose}
+                autoFocus
+              >
+                Done
+              </button>
+            </>
           ) : (
             <>
               <button

--- a/src/renderer/src/components/FirmwareFlasher.tsx
+++ b/src/renderer/src/components/FirmwareFlasher.tsx
@@ -25,6 +25,7 @@ import {
   FIRMWARE_RUNTIME_LABEL,
   findBoardBuilds,
   flashTargetForDownload,
+  catalogBuildForBoard,
   siblingBuildUrl,
   flashTargetForFamily,
   isVendorUf2Family,
@@ -772,14 +773,31 @@ export function FirmwareFlasher({
    * is derivable from the one already selected. Derive it, CONFIRM it resolves,
    * and then it is just another thing Flash can fetch.
    */
+  /**
+   * Every download the selected family offers, so the recommended build can be
+   * derived from ONE of them when the user has selected nothing (#885).
+   */
+  const familyBuildUrls = useMemo(
+    () =>
+      (families.find((f) => f.family === selFamily)?.models ?? []).flatMap((m) =>
+        m.variants.flatMap((v) => v.versions.map((x) => x.url))
+      ),
+    [families, selFamily]
+  )
+
   useEffect(() => {
     const name = suggestedBuild?.name
-    if (!name || !selVersionUrl) {
+    // A starting URL to rewrite. The user's selection when there is one — and
+    // otherwise any build of the same board, because a board with no catalog
+    // entry of its own (the Feather V2) can never make a selection, and it is
+    // exactly that board whose profile names a build worth flashing.
+    const base = selVersionUrl || catalogBuildForBoard(familyBuildUrls, name ?? '')
+    if (!name || !base) {
       setRecommendedUrl(null)
       return undefined
     }
-    const candidate = siblingBuildUrl(selVersionUrl, name)
-    if (!candidate || candidate === selVersionUrl) {
+    const candidate = siblingBuildUrl(base, name)
+    if (!candidate || (selVersionUrl && candidate === selVersionUrl)) {
       setRecommendedUrl(null)
       return undefined
     }
@@ -797,7 +815,7 @@ export function FirmwareFlasher({
     return () => {
       alive = false
     }
-  }, [suggestedBuild?.name, selVersionUrl])
+  }, [suggestedBuild?.name, selVersionUrl, familyBuildUrls])
 
   /** The URL Flash will actually fetch. */
   const flashUrl = recommendedUrl && useRecommended ? recommendedUrl : selVersionUrl
@@ -848,7 +866,9 @@ export function FirmwareFlasher({
   )
 
   // The firmware to flash: a catalog URL (download) or a picked local path.
-  const haveFirmware = usingCatalog ? selVersionUrl.length > 0 : firmwarePath.length > 0
+  // `flashUrl`, not `selVersionUrl`: the recommended build is a real choice on
+  // its own, and for a board absent from the catalog it is the ONLY one (#885).
+  const haveFirmware = usingCatalog ? flashUrl.length > 0 : firmwarePath.length > 0
 
   // A micro:bit in maintenance mode (the MAINTENANCE drive) can't be flashed with
   // MicroPython — doing so can soft-brick it — so detect it and block the flash.
@@ -1197,14 +1217,30 @@ export function FirmwareFlasher({
             {profile?.preferredBuild && (
               <p className="firmware-hint">
                 Best build: <code>{profile.preferredBuild.name}</code>. {profile.preferredBuild.why}
-                {profile.preferredBuild.url && (
-                  <>
-                    {' '}
-                    <a href={profile.preferredBuild.url} target="_blank" rel="noreferrer">
-                      Download it
-                    </a>
-                    , then choose it as a local file.
-                  </>
+                {/* Once the build has been located, say so and stop sending
+                    people away: Flash fetches it. The manual link stays for the
+                    case where it could not be found, but it points at a PAGE —
+                    and for this board that page is headed "ESP32 / WROOM" and
+                    lists the plain build first, which is the opposite of the
+                    advice above it (#885). */}
+                {recommendedUrl ? (
+                  <> Snakie has found it and will download it when you press Flash.</>
+                ) : (
+                  profile.preferredBuild.url && (
+                    <>
+                      {' '}
+                      <a
+                        className="firmware-link"
+                        href={profile.preferredBuild.url}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        Find it on micropython.org
+                      </a>{' '}
+                      — look for <code>{profile.preferredBuild.name}</code>, not the plain build at
+                      the top of that page — then choose it as a local file.
+                    </>
+                  )
                 )}
               </p>
             )}

--- a/src/shared/firmware-runtime.ts
+++ b/src/shared/firmware-runtime.ts
@@ -405,6 +405,41 @@ export function newestStableVersion(
 }
 
 /**
+ * A catalog URL for the same BOARD that `buildName` is a variant of (#885).
+ *
+ * {@link siblingBuildUrl} rewrites one build's URL into another's, but it needs
+ * a URL to start from — and the dialog only had one once the user had picked a
+ * version out of the Family/Model/Version dropdowns. That gate quietly excluded
+ * the very boards `preferredBuild` exists for: an Adafruit ESP32 Feather V2 has
+ * no entry in the catalog at all, so its owner never makes a selection, so the
+ * recommended-build path never ran and they were sent to a download page for a
+ * different board instead.
+ *
+ * This finds a starting point without a selection: the first URL whose board
+ * token matches, searched by FILENAME rather than by family or model, because
+ * the catalog groups several vendors under one model name — "ESP32 / WROOM"
+ * holds both `ESP32_GENERIC` and `SPARKFUN_IOT_REDBOARD_ESP32` — and only the
+ * filename says which board a build is really for. Pass them newest-first, as
+ * the catalog serves them, so the recommendation matches the version on offer.
+ */
+export function catalogBuildForBoard(
+  urls: readonly string[],
+  buildName: string
+): string | null {
+  const name = buildName.trim()
+  const cut = name.lastIndexOf('-')
+  // No variant suffix means there is no "sibling" to look for.
+  if (cut <= 0) return null
+  const base = name.slice(0, cut)
+  for (const url of urls) {
+    const file = url.split('/').pop() ?? ''
+    const m = /^(.+)-(\d{8}-v[^/]+)$/.exec(file)
+    if (m && m[1] === base) return url
+  }
+  return null
+}
+
+/**
  * The URL of a DIFFERENT build of the same firmware release — issue #833.
  *
  * The firmware catalog cannot offer every build. Thonny's `ESP32 / WROOM` entry

--- a/src/shared/flash-dialog.ts
+++ b/src/shared/flash-dialog.ts
@@ -1,0 +1,115 @@
+/**
+ * DECISIONS THE FLASH DIALOG MAKES — pulled out of the component.
+ * =============================================================================
+ *
+ * `FirmwareFlasher.tsx` is Electron-only and a thousand-odd lines of JSX, so the
+ * two judgements below could not be checked without a window and a board. They
+ * are the ones worth checking:
+ *
+ *  - **Can the board even be interrogated?** (#845) A serial port can only be
+ *    open once. While Snakie holds one for the REPL, esptool cannot open it —
+ *    and `identifyBoard` reports that as an EMPTY identity, which is exactly
+ *    what a board that is merely not in download mode reports. So the dialog
+ *    told people to hold BOOT and tap RESET, a hardware dance that cannot fix a
+ *    port held by the very app asking them to do it.
+ *
+ *  - **What is offered once a run has finished?** (#838) A finished flash had
+ *    one way out, Done, and it closed the dialog — throwing away the board, the
+ *    version and every advanced option chosen to get there. After a FAILED
+ *    flash, which is when you most want to change one thing and go again.
+ *
+ * Structural types rather than an import of the device layer's `DeviceStatus`,
+ * so `shared/` stays free of a dependency on `main/` (the same reasoning as
+ * `git-stage.ts`).
+ */
+import { isVirtualPort } from './virtual-device'
+
+/** Just the parts of the device layer's `DeviceStatus` these decisions read. */
+export interface ConnectionSnapshot {
+  state: 'disconnected' | 'connecting' | 'connected' | 'error'
+  path?: string
+}
+
+/**
+ * The REAL serial port Snakie currently has (or is opening) for the REPL, or
+ * null when it holds none.
+ *
+ * `connecting` counts: the port is already being opened by then, and esptool
+ * loses the race just as thoroughly as it does against a settled connection.
+ * The simulated device (#135) does NOT count — its `snakie://virtual` sentinel
+ * is not a port and nothing is holding any hardware.
+ */
+export function heldSerialPort(status: ConnectionSnapshot | null | undefined): string | null {
+  if (!status) return null
+  if (status.state !== 'connected' && status.state !== 'connecting') return null
+  if (!status.path || isVirtualPort(status.path)) return null
+  return status.path
+}
+
+/** A port esptool cannot have, because Snakie is already using it. */
+export interface PortConflict {
+  /** The port Snakie is holding. */
+  port: string
+  /** One paragraph saying what is in the way and what to do about it. */
+  reason: string
+}
+
+/**
+ * Whether the REPL connection is standing in the way of talking to `targetPort`.
+ *
+ * `targetPort` is the port about to be handed to esptool. Omit it — because
+ * detection recognised no serial board at all — and the held port is reported
+ * anyway: a board Snakie has an open REPL to is, by definition, a board that is
+ * plugged in, and "nothing found" while one demonstrably is there is the same
+ * complaint wearing a different hat. Naming a DIFFERENT port is the case that
+ * must NOT warn: a maker with two boards plugged in, connected to one and
+ * flashing the other, has nothing in their way.
+ */
+export function replPortConflict(
+  status: ConnectionSnapshot | null | undefined,
+  targetPort?: string
+): PortConflict | null {
+  const held = heldSerialPort(status)
+  if (!held) return null
+  if (targetPort && targetPort !== held) return null
+  return {
+    port: held,
+    reason:
+      `Snakie is using ${held} for the REPL, and a serial port can only be open once — ` +
+      'so esptool cannot open it to ask the board what it is. Disconnect the board and ' +
+      'try again; flashing needs the port to itself too.'
+  }
+}
+
+/** How a flash run ended, as the dialog tracks it. */
+export type RunOutcome = 'idle' | 'success' | 'error'
+
+/** The second way out of a finished run: back to the dialog, selections intact. */
+export interface RetryAction {
+  label: string
+  title: string
+}
+
+/**
+ * What to offer alongside Done once a run has finished (#838), or null while
+ * one is still being set up — there is nothing to go back FROM yet.
+ *
+ * The wording splits on the outcome because the intent does. After a failure you
+ * are retrying the same flash with one thing changed; after a success you are
+ * almost always holding the next board.
+ */
+export function retryAction(outcome: RunOutcome): RetryAction | null {
+  if (outcome === 'error') {
+    return {
+      label: '◂ Try again',
+      title: 'Back to the options, with everything you chose still selected'
+    }
+  }
+  if (outcome === 'success') {
+    return {
+      label: '◂ Flash another',
+      title: 'Back to the options, with everything you chose still selected'
+    }
+  }
+  return null
+}

--- a/test/flasherRetryAndPortConflict.test.ts
+++ b/test/flasherRetryAndPortConflict.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  heldSerialPort,
+  replPortConflict,
+  retryAction,
+  type ConnectionSnapshot
+} from '../src/shared/flash-dialog'
+import { VIRTUAL_PORT_PATH } from '../src/shared/virtual-device'
+
+/**
+ * #845 — Detect silently failed while the board was connected.
+ * #838 — a finished flash had one way out, and it lost every selection.
+ *
+ * The decisions live in `shared/flash-dialog.ts` so they can be checked here
+ * without a board or a window; the wiring is checked at SOURCE level for the
+ * reason `flasherSimpleMode.test.ts` gives — the dialog is Electron-only, so
+ * `isElectron()` is false under a renderer and every branch that matters is
+ * skipped.
+ */
+const SRC = readFileSync(
+  join(__dirname, '..', 'src/renderer/src/components/FirmwareFlasher.tsx'),
+  'utf-8'
+)
+
+const connected = (path?: string): ConnectionSnapshot => ({ state: 'connected', path })
+
+describe('#845 — the port the REPL is holding', () => {
+  it('reports the port Snakie has open', () => {
+    expect(heldSerialPort(connected('/dev/cu.usbserial-10'))).toBe('/dev/cu.usbserial-10')
+  })
+
+  it('counts a connection still being opened — esptool loses that race too', () => {
+    expect(heldSerialPort({ state: 'connecting', path: 'COM4' })).toBe('COM4')
+  })
+
+  it('holds nothing when disconnected, errored, or pathless', () => {
+    expect(heldSerialPort({ state: 'disconnected', path: '/dev/ttyUSB0' })).toBeNull()
+    expect(heldSerialPort({ state: 'error', path: '/dev/ttyUSB0' })).toBeNull()
+    expect(heldSerialPort({ state: 'connected' })).toBeNull()
+    expect(heldSerialPort(undefined)).toBeNull()
+  })
+
+  it('does not count the simulated device — it holds no hardware', () => {
+    // `snakie://virtual` is a sentinel, not a port (#135). Blocking Detect on it
+    // would be a warning about a conflict that cannot exist.
+    expect(heldSerialPort(connected(VIRTUAL_PORT_PATH))).toBeNull()
+  })
+
+  it('conflicts when Detect is about to hand esptool the very port it holds', () => {
+    const c = replPortConflict(connected('/dev/ttyUSB0'), '/dev/ttyUSB0')
+    expect(c?.port).toBe('/dev/ttyUSB0')
+    // The point of the fix: the reason names the port AND the app holding it,
+    // instead of the BOOT/RESET advice that cannot fix this.
+    expect(c?.reason).toContain('/dev/ttyUSB0')
+    expect(c?.reason).toMatch(/REPL/)
+    expect(c?.reason).toMatch(/[Dd]isconnect/)
+  })
+
+  it('reports it even when detection recognised no serial board at all', () => {
+    // An open REPL proves a board is plugged in; "found nothing" alongside that
+    // is the same complaint wearing a different hat.
+    expect(replPortConflict(connected('/dev/ttyUSB0'))?.port).toBe('/dev/ttyUSB0')
+  })
+
+  it('stays quiet about a DIFFERENT port — two boards, one connected', () => {
+    // Connected to one board, flashing the other: nothing is in the way.
+    expect(replPortConflict(connected('/dev/ttyUSB0'), '/dev/ttyUSB1')).toBeNull()
+  })
+
+  it('stays quiet when nothing is connected', () => {
+    expect(replPortConflict({ state: 'disconnected' }, '/dev/ttyUSB0')).toBeNull()
+  })
+})
+
+describe('#845 — Detect asks before esptool does', () => {
+  const detect = /const detectBoard = useCallback\(async[\s\S]*?\n {2}\}, \[[^\]]*\]\)/.exec(SRC)
+
+  it('checks the connection and bails out before identifying', () => {
+    expect(detect, 'detectBoard not found').toBeTruthy()
+    const body = detect![0]
+    expect(body).toContain('replPortConflict')
+    expect(body).toContain('setDetectConflict')
+    // The bail-out has to come BEFORE the esptool call, or the check has bought
+    // nothing: esptool still fails and still reports an empty identity.
+    expect(body.indexOf('setDetectConflict')).toBeLessThan(body.indexOf('identifyBoard('))
+    expect(body).toMatch(/if \(conflict\) return/)
+  })
+
+  it('exempts a drive board — BOOTSEL needs no serial port', () => {
+    expect(detect![0]).toMatch(/drive && !serial/)
+  })
+
+  it('offers to disconnect rather than doing it behind the user’s back', () => {
+    const fn = /const disconnectAndDetect = useCallback\(async[\s\S]*?\n {2}\}, \[[^\]]*\]\)/.exec(SRC)
+    expect(fn, 'disconnectAndDetect not found').toBeTruthy()
+    expect(fn![0]).toContain('window.api.device.disconnect()')
+    // It re-detects with the check skipped: the status push confirming the
+    // disconnect has not landed yet, so the check would still see it connected.
+    expect(fn![0]).toContain('detectBoard(true)')
+    // …and the button that calls it is the ONLY route to it. Detect itself must
+    // never disconnect a board that may be mid-run.
+    expect(SRC).toContain('Disconnect and detect')
+    expect(detect![0]).not.toContain('device.disconnect')
+  })
+})
+
+describe('#838 — a second way out of a finished run', () => {
+  it('offers nothing to go back to while the run is still being set up', () => {
+    expect(retryAction('idle')).toBeNull()
+  })
+
+  it('offers a retry after a failure and another flash after a success', () => {
+    expect(retryAction('error')?.label).toMatch(/try again/i)
+    expect(retryAction('success')?.label).toMatch(/flash another/i)
+    for (const outcome of ['error', 'success'] as const) {
+      // Both say the same thing about what survives, because both do.
+      expect(retryAction(outcome)?.title).toMatch(/still selected/i)
+    }
+  })
+
+  it('the finished footer renders it beside Done', () => {
+    const footer = /<footer className="firmware-modal__footer">[\s\S]*?<\/footer>/.exec(SRC)
+    expect(footer, 'footer not found').toBeTruthy()
+    expect(footer![0]).toContain('retry.label')
+    expect(footer![0]).toContain('onClick={clearRun}')
+    // Done still closes; going back must not.
+    expect(footer![0]).toContain('onClick={onClose}')
+  })
+
+  it('going back clears the RUN and nothing the user chose', () => {
+    const fn = /const clearRun = useCallback\(\(\): void => \{[\s\S]*?\n {2}\}, \[\]\)/.exec(SRC)
+    expect(fn, 'clearRun not found').toBeTruthy()
+    const body = fn![0]
+    for (const run of ['setLog([])', 'setPercent(null)', "setOutcome('idle')"]) {
+      expect(body, `clearRun should reset ${run}`).toContain(run)
+    }
+    // The whole point of the issue: everything chosen to get here survives.
+    for (const setter of [
+      'setRuntime',
+      'setBoard',
+      'setProfileId',
+      'setPort',
+      'setMountPath',
+      'setOffset',
+      'setFirmwarePath',
+      'setEraseFirst',
+      'setSource',
+      'setCatalog',
+      'setSelFamily',
+      'setSelModel',
+      'setSelVariant',
+      'setSelVersionUrl',
+      'setUseRecommended'
+    ]) {
+      expect(body, `clearRun must not touch ${setter} — that is a selection`).not.toContain(setter)
+    }
+  })
+
+  it('starting a flash goes through the same clear, so the two cannot drift', () => {
+    const fn = /const resetRun = useCallback\(\(\): void => \{[\s\S]*?\n {2}\}, \[[^\]]*\]\)/.exec(SRC)
+    expect(fn, 'resetRun not found').toBeTruthy()
+    expect(fn![0]).toContain('clearRun()')
+    expect(fn![0]).toContain('setFlashing(true)')
+  })
+})

--- a/test/preferredBuildLink.test.ts
+++ b/test/preferredBuildLink.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { catalogBuildForBoard, siblingBuildUrl } from '../src/shared/firmware-runtime'
+
+/**
+ * Reaching a board's recommended build without a catalog selection (#885).
+ *
+ * The bug: the recommended-build path was gated on `selVersionUrl`, the version
+ * the user picks out of the Family/Model/Version dropdowns. That gate excluded
+ * exactly the boards `preferredBuild` exists for. An Adafruit ESP32 Feather V2
+ * has no entry in the catalog at all — its owner opens the Model list, does not
+ * find their board, and never makes a selection — so the derivation never ran,
+ * and the dialog fell back to a link to a download page **headed "ESP32 /
+ * WROOM"** that lists the plain build first. The advice said SPIRAM; the link
+ * offered the opposite. That board then ran for a week with its 2 MB of PSRAM
+ * switched off.
+ */
+
+const FIRMWARE = 'https://micropython.org/resources/firmware'
+
+/** Real rows from Thonny's `micropython-variants-esptool.json`, newest first. */
+const ESP32_FAMILY_URLS = [
+  `${FIRMWARE}/ESP32_GENERIC-20260406-v1.28.0.bin`,
+  `${FIRMWARE}/ESP32_GENERIC-20251209-v1.27.0.bin`,
+  `${FIRMWARE}/SPARKFUN_IOT_REDBOARD_ESP32-20260406-v1.28.0.bin`,
+  `${FIRMWARE}/LILYGO_TTGO_LORA32-20260406-v1.28.0.bin`
+]
+
+describe('finding a starting point with nothing selected', () => {
+  it('finds a build of the same board', () => {
+    expect(catalogBuildForBoard(ESP32_FAMILY_URLS, 'ESP32_GENERIC-SPIRAM')).toBe(
+      `${FIRMWARE}/ESP32_GENERIC-20260406-v1.28.0.bin`
+    )
+  })
+
+  it('takes the NEWEST, so the recommendation matches the version on offer', () => {
+    // The catalog serves newest-first; recommending a build two releases behind
+    // what the same dialog would otherwise flash would be its own small bug.
+    expect(catalogBuildForBoard(ESP32_FAMILY_URLS, 'ESP32_GENERIC-SPIRAM')).toContain('v1.28.0')
+  })
+
+  it('does not wander onto another vendor sharing the model name', () => {
+    // "ESP32 / WROOM" holds Espressif's board AND SparkFun's. Only the filename
+    // says which board a build is for — deriving a Feather V2 recommendation
+    // from a SparkFun binary would be worse than the page link it replaces.
+    const picked = catalogBuildForBoard(ESP32_FAMILY_URLS, 'ESP32_GENERIC-SPIRAM')
+    expect(picked).not.toContain('SPARKFUN')
+    expect(picked).not.toContain('LILYGO')
+  })
+
+  it('handles a board name that itself contains a hyphen or underscore', () => {
+    const urls = [`${FIRMWARE}/ESP32_GENERIC_S3-20260406-v1.28.0.bin`]
+    expect(catalogBuildForBoard(urls, 'ESP32_GENERIC_S3-SPIRAM_OCT')).toBe(urls[0])
+  })
+
+  it('says nothing when the board is absent from the family', () => {
+    expect(catalogBuildForBoard(ESP32_FAMILY_URLS, 'ESP32_GENERIC_C6-SPIRAM')).toBeNull()
+  })
+
+  it('says nothing for a build name with no variant to strip', () => {
+    // `ESP32_GENERIC` is not a variant OF anything, so there is no sibling.
+    expect(catalogBuildForBoard(ESP32_FAMILY_URLS, 'ESP32_GENERIC')).toBeNull()
+  })
+})
+
+describe('the URL it produces is the one that actually exists', () => {
+  it('rewrites the board token and keeps the release', () => {
+    const base = catalogBuildForBoard(ESP32_FAMILY_URLS, 'ESP32_GENERIC-SPIRAM')
+    // Verified against micropython.org: this file resolves 200.
+    expect(siblingBuildUrl(base!, 'ESP32_GENERIC-SPIRAM')).toBe(
+      `${FIRMWARE}/ESP32_GENERIC-SPIRAM-20260406-v1.28.0.bin`
+    )
+  })
+
+  it('works for the octal-PSRAM S3 case too', () => {
+    const base = `${FIRMWARE}/ESP32_GENERIC_S3-20260406-v1.28.0.bin`
+    expect(siblingBuildUrl(base, 'ESP32_GENERIC_S3-SPIRAM_OCT')).toBe(
+      `${FIRMWARE}/ESP32_GENERIC_S3-SPIRAM_OCT-20260406-v1.28.0.bin`
+    )
+  })
+})
+
+describe('the dialog', () => {
+  const tsx = readFileSync('src/renderer/src/components/FirmwareFlasher.tsx', 'utf8')
+
+  it('no longer requires a catalog selection to find the recommended build', () => {
+    // The gate that caused this: `if (!name || !selVersionUrl) return`.
+    expect(tsx).toContain('selVersionUrl || catalogBuildForBoard(')
+  })
+
+  it('lets Flash run on the recommended build alone', () => {
+    // `haveFirmware` gated on `selVersionUrl`, so even once the build was found
+    // the button stayed disabled for a board with nothing selectable.
+    expect(tsx).toContain('usingCatalog ? flashUrl.length > 0')
+  })
+
+  it('stops sending the user to a page once it has the file', () => {
+    expect(tsx).toContain('will download it when you press Flash')
+  })
+
+  it('warns which build to pick when it still has to send them away', () => {
+    // That page is headed "ESP32 / WROOM" and offers the plain build first.
+    expect(tsx).toContain('not the plain build at')
+  })
+})
+
+describe('links in this dialog are readable', () => {
+  const css = readFileSync('src/renderer/src/components/FirmwareFlasher.css', 'utf8')
+
+  it('styles a plain anchor, not only the button dressed as one', () => {
+    // The anchor had NO colour rule at all, in a stylesheet whose own header
+    // says every foreground here must come from the dialog's palette — so it
+    // fell through to the browser default: dark blue on a #1f2430 panel.
+    expect(css).toContain('.firmware-hint a')
+  })
+
+  it('does not take the link colour from the theme', () => {
+    const block = css.slice(css.indexOf('.firmware-link,'), css.indexOf('.firmware-link:hover'))
+    expect(block).not.toContain('var(--accent)')
+    expect(block).toMatch(/color:\s*#[0-9a-f]{6}/i)
+  })
+
+  it('gives keyboard focus something visible', () => {
+    expect(css).toContain('.firmware-hint a:focus-visible')
+  })
+})


### PR DESCRIPTION
Closes #885. **Stacked on #877** — it rewrites the same regions of `FirmwareFlasher.tsx`, so this targets that branch and should retarget to master once #877 merges.

## The bug is not the one the issue title suggests

I filed this as "the link sends you to a browser". Reading the code, the round trip is a symptom — **the feature already existed and simply never ran for this board.**

#833 taught the dialog to derive the recommended build's URL from a sibling and download it on Flash. But the derivation was gated on `selVersionUrl`:

```ts
if (!name || !selVersionUrl) { setRecommendedUrl(null); return }
```

`selVersionUrl` is the version picked from the **Family / Model / Version** dropdowns. That gate excluded exactly the boards `preferredBuild` exists for. The Adafruit ESP32 Feather V2 has no catalogue entry — MicroPython builds no firmware under that name, and the catalogue is Thonny's JSON, which has no Adafruit at all — so its owner opens the Model list, doesn't find their board, and never makes a selection. The recommendation never resolved.

What they got instead was `preferredBuild.url`: a download page **headed "ESP32 / WROOM"** that lists the plain build first. So the paragraph said *"Best build: ESP32_GENERIC-SPIRAM"* and the link directly under it offered the build that isn't. It can't be deep-linked either — that page has no anchor ids, the section is a bare `<h2>`.

The cost wasn't theoretical: a board ran for a week with its 2 MB of PSRAM switched off, through `OSError: Wifi Internal State Error`, `ENOMEM` on every UDP send, mDNS allocation failures, and finally an ESP-IDF `abort()` with 52 bytes of internal heap left.

## What changed

**`catalogBuildForBoard(urls, buildName)`** in `firmware-runtime.ts`, beside the existing `siblingBuildUrl`. With no selection, the derivation starts from any build of the same board.

Matching is by **filename**, not by family or model. The catalogue groups several vendors under one model name — "ESP32 / WROOM" holds both `ESP32_GENERIC` and `SPARKFUN_IOT_REDBOARD_ESP32` — and only the filename says which board a build is really for. Deriving a Feather V2 recommendation from a SparkFun binary would be worse than the page link it replaces.

**`haveFirmware` moves to `flashUrl`.** That was the second half of the same gate: even once the build resolved, Flash stayed disabled because the check still asked whether a *catalogue version* was selected.

**The fallback stops being a trap.** When the build genuinely can't be resolved, the link stays — but it names the file to look for and says not to take the one at the top of that page.

## The link colour

`FirmwareFlasher.css` opens by explaining that this dialog is dark in *both* themes, so nothing may take its foreground from the theme tokens. Every colour in the file obeys — except the anchor, which had **no rule at all** and fell through to the browser default: dark blue on a `#1f2430` panel.

`var(--accent)` wasn't the answer either — on the skeuomorph theme that's `#b07d1e` brass, which only just clears 4:1 at 0.72rem type. It now uses a light blue from the dialog's own palette, with a visible focus ring, applied to `.firmware-link` and plain anchors alike.

## Verified

The derivation is checked against **real** rows from Thonny's `micropython-variants-esptool.json`, and I confirmed both derived URLs resolve `200` on micropython.org:

- `ESP32_GENERIC-SPIRAM-20260406-v1.28.0.bin`
- `ESP32_GENERIC_S3-SPIRAM_OCT-20260406-v1.28.0.bin`

15 tests. I broke the fix two ways and confirmed each failed for its own reason before restoring: restoring the original `selVersionUrl` gate → the two dialog tests fail; making the board match naive "first URL wins" → the cross-vendor safety test fails.

Gates: lint ok · typecheck ok · **6,016 tests** ok · build ok.

**Not verified on screen.** The colour is reasoned from contrast against the known panel value, not observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe