### PR TITLE
Open the Board Finder from the flash dialog (#893)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **A Board Finder, and the firmware picker finally knows every board** (#893).
+  The picker showed Thonny's catalogue, which lists no Adafruit boards at all
+  and no ESP32 variants — which is how an ESP32 Feather V2 ends up running a
+  build with its 2 MB of PSRAM switched off. Snakie now carries its own index,
+  generated from what MicroPython actually publishes: **225 boards from 54
+  manufacturers**, each with its photo, chip, features, the variants named and
+  described in upstream's own words, and the builds that exist. Open it from
+  **Board Finder**, beside Detect board in the flash dialog, and filter by
+  manufacturer, processor or features — or just search. Pick a board and the
+  dialog fills itself in, newest MicroPython selected, with the flash offset
+  taken from the figure the board itself publishes rather than one inferred from
+  its chip. The index is refreshed daily and is not tied to a Snakie release, so
+  a board added upstream shows up without waiting for an update; the full
+  catalogue ships with the app, so it works with no network at all.
+
+### Added
+
 - **Board Finder — a gallery of every board MicroPython builds for** (#893). The
   firmware picker showed Thonny's catalogue, which carries no Adafruit boards and
   no ESP32 variants; **Board Finder** in the status bar, beside Flash firmware,

--- a/src/renderer/src/components/FirmwareFlasher.css
+++ b/src/renderer/src/components/FirmwareFlasher.css
@@ -501,3 +501,32 @@
 .firmware-advanced-toggle:hover {
   color: #f4f6f8;
 }
+
+/* The Board Finder button, beside Detect board (#893).
+ *
+ * Detect is the happy path and stays prominent; this is the answer for a board
+ * that is not plugged in yet, or one detection could not name — the same
+ * question asked the other way round, so it sits beside it rather than
+ * competing with it. Quieter fill, same size and shape. */
+/* Detect and Board Finder sit on ONE row. `.firmware-detect` is
+   `align-self: flex-start` in a column, so two of them would stack. */
+.firmware-detect-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.firmware-detect-row .firmware-detect {
+  margin-bottom: 0;
+}
+
+.firmware-detect--finder {
+  background: rgba(255, 255, 255, 0.08);
+  color: #c7ccd4;
+}
+
+.firmware-detect--finder:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.14);
+  color: #f4f6f8;
+}

--- a/src/renderer/src/components/FirmwareFlasher.tsx
+++ b/src/renderer/src/components/FirmwareFlasher.tsx
@@ -35,6 +35,12 @@ import { hasWebUSB, isElectron } from '../lib/platform'
 import { flashEspInBrowser, requestEspPort } from '../lib/webFirmware/espFlash'
 import { flashMicrobitInBrowser, requestMicrobitDevice } from '../lib/webFirmware/microbitFlash'
 import { copyFirmwareToDrive } from '../lib/webFirmware/driveCopyFlash'
+import { BoardFinder } from './BoardFinder'
+import {
+  FLASH_BOARD_EVENT,
+  flasherSelectionFor,
+  type BoardFlashRequest
+} from './board-finder-bus'
 import './FirmwareFlasher.css'
 
 interface FirmwareFlasherProps {
@@ -216,6 +222,59 @@ export function FirmwareFlasher({
   // official build is what almost everyone wants and needs no prior knowledge;
   // picking a file off disk assumes you have already been somewhere else and
   // come back with the right one.
+  /**
+   * The Board Finder gallery (#893), opened from the button beside Detect board.
+   *
+   * It lives INSIDE the dialog rather than beside it in the status bar, because
+   * "which board is this?" is a question you have while the flasher is open —
+   * and answering it there means the pick lands in the dialog you are already
+   * looking at instead of opening a second one.
+   */
+  const [finderOpen, setFinderOpen] = useState(false)
+  const [finderOrigin, setFinderOrigin] = useState<{ x: number; y: number } | null>(null)
+  // Closing runs the grow backwards, so the gallery has to outlive the click
+  // that dismissed it — unmount on the click and there is nothing left to
+  // animate.
+  const [finderClosing, setFinderClosing] = useState(false)
+  const dropFinder = useCallback((): void => {
+    setFinderClosing(false)
+    setFinderOpen(false)
+  }, [])
+  const closeFinder = useCallback((): void => {
+    const still = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+    if (!finderOrigin || still) dropFinder()
+    else setFinderClosing(true)
+  }, [finderOrigin, dropFinder])
+  // Insurance: the unmount hangs off `animationend`, and a closing panel has
+  // pointer events off. If that event never arrives the gallery would be stuck
+  // on screen AND unclickable, so time it out regardless.
+  useEffect(() => {
+    if (!finderClosing) return
+    const t = setTimeout(dropFinder, 450)
+    return () => clearTimeout(t)
+  }, [finderClosing, dropFinder])
+
+  /**
+   * Take a board the gallery picked.
+   *
+   * Through the same window event the gallery already dispatches, rather than a
+   * callback prop: the flasher IS mounted when the gallery is open inside it, so
+   * it can simply listen, and the gallery needs no knowledge of who opened it.
+   */
+  useEffect(() => {
+    const onFlashBoard = (e: Event): void => {
+      const pick = flasherSelectionFor((e as CustomEvent<BoardFlashRequest>).detail)
+      setBoard(pick.board)
+      if (pick.offset) setOffset(pick.offset)
+      setSource('catalog')
+      setSelFamily(pick.family)
+      setSelVersionUrl(pick.url)
+      dropFinder()
+    }
+    window.addEventListener(FLASH_BOARD_EVENT, onFlashBoard)
+    return () => window.removeEventListener(FLASH_BOARD_EVENT, onFlashBoard)
+  }, [dropFinder])
+
   const [source, setSource] = useState<Source>('catalog')
   const [catalog, setCatalog] = useState<FirmwareCatalog | null>(null)
   const [catalogLoading, setCatalogLoading] = useState(false)
@@ -932,6 +991,7 @@ export function FirmwareFlasher({
   const finished = outcome === 'success' || outcome === 'error'
 
   return (
+    <>
     <div
       className="firmware-overlay"
       role="presentation"
@@ -1049,16 +1109,35 @@ export function FirmwareFlasher({
                 board — Detect and Identify were two buttons for two halves of
                 one question. Placed FIRST because it is the step that makes
                 every field below it unnecessary. */}
-            {isElectron() && (
+            <div className="firmware-detect-row">
+              {isElectron() && (
+                <button
+                  type="button"
+                  className="firmware-detect"
+                  onClick={() => void detectBoard()}
+                  disabled={flashing || identifying}
+                >
+                  {identifying ? 'Asking the board…' : '⟳ Detect board'}
+                </button>
+              )}
+              {/* Detect answers "what is plugged in"; this answers "what have I
+                  got" for a board that is not plugged in yet, or one detection
+                  could not name. Beside it, because they are the same question
+                  asked two ways. */}
               <button
                 type="button"
-                className="firmware-detect"
-                onClick={() => void detectBoard()}
-                disabled={flashing || identifying}
+                className="firmware-detect firmware-detect--finder"
+                onClick={(e) => {
+                  const r = e.currentTarget.getBoundingClientRect()
+                  setFinderOrigin({ x: r.left + r.width / 2, y: r.top + r.height / 2 })
+                  setFinderOpen(true)
+                }}
+                disabled={flashing}
+                title="Browse every board MicroPython builds for"
               >
-                {identifying ? 'Asking the board…' : '⟳ Detect board'}
+                ⌕ Board Finder
               </button>
-            )}
+            </div>
             <label className="firmware-field__label" htmlFor="firmware-profile">
               Board
             </label>
@@ -1732,5 +1811,17 @@ export function FirmwareFlasher({
         </footer>
       </div>
     </div>
+      {/* A SIBLING of the overlay, not a child: a full-screen gallery nested in
+          the modal's backdrop would be clipped by it and would inherit its
+          click-anywhere-to-dismiss. */}
+      {finderOpen && (
+        <BoardFinder
+          origin={finderOrigin}
+          closing={finderClosing}
+          onClosed={dropFinder}
+          onClose={closeFinder}
+        />
+      )}
+    </>
   )
 }

--- a/src/renderer/src/components/StatusBar.tsx
+++ b/src/renderer/src/components/StatusBar.tsx
@@ -4,7 +4,6 @@ import { useWorkspace } from '../store/workspace'
 import { useConsole } from '../store/console'
 import { useEditorSettings } from '../store/settings'
 import { FirmwareFlasher } from './FirmwareFlasher'
-import { BoardFinder } from './BoardFinder'
 import { CoffeeLink } from './CoffeeLink'
 import { updateButtonView } from './updateButton'
 import { liveWarningVisible } from './instrument-host'
@@ -32,7 +31,7 @@ import {
   firmwareRuntimeForDialect
 } from '../../../shared/firmware-runtime'
 import type { FirmwareCatalog, UpdateStatus } from '../../../preload/index.d'
-import { BulbIcon, ExpandIcon } from './ui-icons'
+import { BulbIcon } from './ui-icons'
 import { SyncIndicator } from './SyncIndicator'
 import './StatusBar.css'
 
@@ -97,31 +96,6 @@ export function StatusBar({
   const activeFile = openFiles.find((f) => f.id === activeId) ?? null
 
   const [flasherOpen, setFlasherOpen] = useState(false)
-  // The Board Finder gallery (#893), and where it should grow from. It lives
-  // beside the flasher because this is where a user comes to think about
-  // firmware, and the gallery exists to fix the board picker they find here.
-  const [finderOpen, setFinderOpen] = useState(false)
-  const [finderOrigin, setFinderOrigin] = useState<{ x: number; y: number } | null>(null)
-  // Closing runs the grow backwards, so the gallery has to outlive the click
-  // that dismissed it — unmount on click and there is nothing left to animate.
-  const [finderClosing, setFinderClosing] = useState(false)
-  const dropFinder = useCallback((): void => {
-    setFinderClosing(false)
-    setFinderOpen(false)
-  }, [])
-  const closeFinder = useCallback((): void => {
-    const still = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
-    if (!finderOrigin || still) dropFinder()
-    else setFinderClosing(true)
-  }, [finderOrigin, dropFinder])
-  // Insurance: the unmount hangs off `animationend`, and a closing panel has
-  // pointer events off. If that event never arrives the gallery would be stuck
-  // on screen AND unclickable, so time it out regardless.
-  useEffect(() => {
-    if (!finderClosing) return
-    const t = setTimeout(dropFinder, 450)
-    return () => clearTimeout(t)
-  }, [finderClosing, dropFinder])
   // A newer build than the connected device is running — MicroPython (#173) or
   // CircuitPython (#757) — plus dismissal. The update names its own runtime, so
   // the prompt never tells a CircuitPython user about a MicroPython release.
@@ -611,21 +585,6 @@ export function StatusBar({
               icon the Parts Library uses to expand into its catalog (#893). */}
           <button
             type="button"
-            className="statusbar__item statusbar__boards"
-            onClick={(e) => {
-              const b = e.currentTarget.getBoundingClientRect()
-              setFinderOrigin({ x: b.left + b.width / 2, y: b.top + b.height / 2 })
-              setFinderClosing(false)
-              setFinderOpen(true)
-            }}
-            title="Board Finder — browse every board MicroPython builds for, and flash one"
-            aria-label="Open the Board Finder"
-          >
-            <ExpandIcon size={13} />
-            <span>Board Finder</span>
-          </button>
-          <button
-            type="button"
             className="statusbar__item statusbar__flash"
             onClick={() => setFlasherOpen(true)}
             title={
@@ -642,14 +601,6 @@ export function StatusBar({
         </div>
       </div>
 
-      {finderOpen && (
-        <BoardFinder
-          origin={finderOrigin}
-          closing={finderClosing}
-          onClosed={dropFinder}
-          onClose={closeFinder}
-        />
-      )}
 
       {flasherOpen && (
         <FirmwareFlasher

--- a/src/renderer/src/components/board-finder-bus.ts
+++ b/src/renderer/src/components/board-finder-bus.ts
@@ -29,6 +29,8 @@
  * the payload type without pulling in the gallery component or the index.
  */
 import { defaultBuild, type BoardBuild, type IndexedBoard } from '../../../shared/board-index'
+import { flashTargetForFamily } from '../../../shared/firmware-runtime'
+import type { BoardType } from '../../../main/firmware/types'
 
 /** Window event name. `event.detail` is a {@link BoardFlashRequest}. */
 export const FLASH_BOARD_EVENT = 'snakie:flash-board'
@@ -89,4 +91,38 @@ export function requestFlash(board: IndexedBoard): boolean {
   if (!detail) return false
   window.dispatchEvent(new CustomEvent<BoardFlashRequest>(FLASH_BOARD_EVENT, { detail }))
   return true
+}
+
+/**
+ * What the flasher should select for a request (#893).
+ *
+ * Pure, so the mapping is testable without mounting a modal — and separate from
+ * the flasher so the gallery's end and the flasher's end agree on one rule
+ * rather than two.
+ *
+ * The OFFSET comes from upstream's own `deploy_options.flash_offset` when it
+ * says, and only falls back to inference when it does not. That matters more
+ * than it looks: the bootloader offset is per chip and not a simple "the
+ * original ESP32 versus the rest" — the S2 shares the original's `0x1000` while
+ * the S3 and every RISC-V part are `0x0`. Getting it wrong flashes cleanly and
+ * leaves a dead board, so a figure the board itself publishes beats one we work
+ * out.
+ *
+ * The chip family drives the board TYPE rather than the port, because the port
+ * is too coarse: `esp32` covers the S2, S3, C3, C6 and P4, which do not share an
+ * offset.
+ */
+export function flasherSelectionFor(req: BoardFlashRequest): {
+  board: BoardType
+  offset: string | undefined
+  url: string
+  family: string
+} {
+  const target = flashTargetForFamily(req.mcu || req.port)
+  return {
+    board: target.board,
+    offset: req.flashOffset ?? target.offset,
+    url: req.build.url,
+    family: req.mcu || req.port
+  }
 }

--- a/test/boardFlashHandoff.test.ts
+++ b/test/boardFlashHandoff.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import {
+  flashRequestFor,
+  flasherSelectionFor,
+  type BoardFlashRequest
+} from '../src/renderer/src/components/board-finder-bus'
+import type { IndexedBoard } from '../src/shared/board-index'
+
+/**
+ * Board Finder → flasher (#893).
+ *
+ * The offset is the dangerous part. It is per CHIP and not a simple "the
+ * original ESP32 versus the rest" — the S2 shares the original's `0x1000` while
+ * the S3 and every RISC-V part are `0x0`. Getting it wrong flashes cleanly and
+ * leaves a dead board, which is a failure with no error message attached to it.
+ */
+
+const board = (over: Partial<IndexedBoard> = {}): IndexedBoard => ({
+  id: 'ESP32_GENERIC',
+  port: 'esp32',
+  vendor: 'Espressif',
+  product: 'ESP32 / WROOM',
+  mcu: 'esp32',
+  features: [],
+  notes: [],
+  url: null,
+  variants: {},
+  flashOffset: '0x1000',
+  image: null,
+  thumb: null,
+  builds: [
+    {
+      build: 'ESP32_GENERIC',
+      variant: null,
+      version: '1.29.0',
+      date: '20260824',
+      url: 'https://micropython.org/resources/firmware/ESP32_GENERIC-20260824-v1.29.0.bin'
+    }
+  ],
+  ...over
+})
+
+describe('what gets handed over', () => {
+  it('carries enough to act without the index in hand', () => {
+    const req = flashRequestFor(board())
+    expect(req).toMatchObject({ boardId: 'ESP32_GENERIC', port: 'esp32', mcu: 'esp32' })
+    expect(req?.build.url).toContain('ESP32_GENERIC-20260824')
+  })
+
+  it('refuses for a board with no published firmware', () => {
+    // Three of the 225 publish none. Dispatching for one would open the flasher
+    // on an empty selection, which reads as the flasher being broken rather
+    // than the board having no build.
+    expect(flashRequestFor(board({ builds: [] }))).toBeNull()
+  })
+})
+
+describe('the offset, which is the part that can kill a board', () => {
+  const reqFor = (over: Partial<IndexedBoard>): BoardFlashRequest =>
+    flashRequestFor(board(over)) as BoardFlashRequest
+
+  it('prefers the figure the board itself publishes', () => {
+    // `deploy_options.flash_offset` is upstream's own answer for THIS board and
+    // beats anything inferred from a chip family.
+    expect(flasherSelectionFor(reqFor({ flashOffset: '0x1000' })).offset).toBe('0x1000')
+  })
+
+  it('falls back to the chip family only when upstream is silent', () => {
+    const s = flasherSelectionFor(reqFor({ flashOffset: null, mcu: 'esp32s3' }))
+    expect(s.offset).toBe('0x0')
+    expect(s.board).toBe('esp32')
+  })
+
+  it('keys off the CHIP, not the port — one port covers several offsets', () => {
+    // The `esp32` port holds the S2, S3, C3, C6 and P4, which do not agree.
+    const s2 = flasherSelectionFor(reqFor({ flashOffset: null, mcu: 'esp32s2', port: 'esp32' }))
+    const s3 = flasherSelectionFor(reqFor({ flashOffset: null, mcu: 'esp32s3', port: 'esp32' }))
+    expect(s2.offset).not.toBe(s3.offset)
+  })
+
+  it('routes a UF2 board to the drive copy, not esptool', () => {
+    const s = flasherSelectionFor(reqFor({ port: 'rp2', mcu: 'rp2040', flashOffset: null }))
+    expect(s.board).toBe('rp2040')
+  })
+})
+
+describe('both ends are wired', () => {
+  const flasher = readFileSync('src/renderer/src/components/FirmwareFlasher.tsx', 'utf8')
+
+  it('the gallery opens from beside Detect board, inside the dialog', () => {
+    // "Which board is this?" is a question you have while the flasher is open.
+    // Answering it there means the pick lands in the dialog you are already
+    // looking at rather than opening a second one.
+    expect(flasher).toContain('firmware-detect-row')
+    expect(flasher).toContain('Board Finder')
+  })
+
+  it('the flasher itself listens, since it is the thing that is mounted', () => {
+    expect(flasher).toContain('FLASH_BOARD_EVENT')
+    expect(flasher).toContain('flasherSelectionFor(')
+  })
+
+  it('the status bar no longer owns any of it', () => {
+    // It was there first; leaving a second entry point behind would give two
+    // ways in that disagree about where the pick lands.
+    const bar = readFileSync('src/renderer/src/components/StatusBar.tsx', 'utf8')
+    expect(bar).not.toContain('BoardFinder')
+    expect(bar).not.toContain('FLASH_BOARD_EVENT')
+  })
+
+  it('the gallery is a sibling of the modal, not a child of its backdrop', () => {
+    // Nested in the backdrop it would be clipped by it and would inherit its
+    // click-anywhere-to-dismiss.
+    const i = flasher.indexOf('{finderOpen && (')
+    expect(i).toBeGreaterThan(flasher.indexOf('</div>\n  )'))
+  })
+
+  it('a pick closes the gallery outright rather than animating back', () => {
+    expect(flasher).toContain('dropFinder()')
+  })
+})


### PR DESCRIPTION
Closes #893. **Stacked on #899**, which is stacked on #898.

Completes the gallery's hand-off to the flasher — and moves the entry point into the flash dialog, beside **Detect board**, as asked.

## Why beside Detect

They are the same question asked two ways. Detect answers *"what is plugged in"*; the Board Finder answers *"what have I got"* for a board that isn't plugged in yet, or one detection couldn't name — which is exactly the Feather V2 case that started all this.

And answering it *inside* the dialog means the pick lands in the flasher you're already looking at, rather than opening a second one.

## It made the wiring simpler, not more complex

The status-bar route needed three things to work: a listener in `StatusBar` (the flasher isn't mounted when the gallery dispatches, so a listener inside it would never hear the event meant to open it), a `preselect` prop, and a keyed remount so a mount-only effect would re-run on a second hand-over.

Inside the dialog, the flasher **is** mounted — so it listens for the gallery's own event directly. No prop, no remount, no keyed hack. `FirmwareFlasher.tsx` gains a listener instead of an API, which matters given #877 and #888 are both in flight against it.

## The offset is the part worth care

It comes from upstream's own `deploy_options.flash_offset` when the board publishes one, and only falls back to inference when it doesn't. The fallback keys off the **chip**, not the port: the `esp32` port covers the S2, S3, C3, C6 and P4, which don't agree — the S2 shares the original ESP32's `0x1000` while the S3 and every RISC-V part are `0x0`. Getting it wrong flashes cleanly and leaves a dead board, which is a failure with no error message attached to it. Three tests cover exactly that.

## Two details

The gallery renders as a **sibling** of the modal overlay, not a child — nested in the backdrop it would be clipped by it and inherit its click-anywhere-to-dismiss.

The closing animation moved across intact, `animationend` fallback timeout and all. A pick, though, closes it outright rather than animating back: the dialog underneath has just changed, so there's nothing to animate to.

## Tests

11, and I broke the offset logic two ways to check they bite: ignoring upstream's published offset, and keying off the port instead of the chip. Each failed for its own reason before I restored it.

Gates: lint ok · typecheck ok · **6,087 tests** ok · build ok.

**Not verified on screen.** The two buttons sharing a row is reasoned from `.firmware-detect` being `align-self: flex-start` in a column — worth a look.

## What this completes

With #898 (the index and daily refresh) and #899 (the gallery), #893 is done: 225 boards from 54 manufacturers, filterable by manufacturer / processor / features, opening the flash dialog on the newest MicroPython with the right offset. Storage and memory are shown as facts rather than filters, per the decision on the issue — **#897** tracks sourcing the real figures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe