### PR TITLE
Reach the recommended build without a catalogue selection (#885)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The recommended firmware build is now reachable for the boards that need it**
+  (#885). A board profile can name the build a board actually requires — the
+  Adafruit ESP32 Feather V2 needs `ESP32_GENERIC-SPIRAM`, because only that build
+  turns on its 2 MB of PSRAM — and Snakie could already derive that build's
+  address and download it for you. But the derivation only ran once you had
+  picked a version out of the Family/Model dropdowns, which excluded exactly the
+  boards the recommendation exists for: the Feather V2 has no catalogue entry at
+  all, so its owner never makes a selection, so the recommendation never
+  resolved. What they got instead was a link to a download page headed
+  "ESP32 / WROOM" listing the plain build first — the opposite of the advice
+  printed directly above it. Snakie now finds the build from any release of the
+  same board, so Flash fetches it with nothing selected; where it still cannot,
+  the link says which file to look for and warns against the one at the top of
+  the page. Links in the flash dialog were also rendering in the browser's
+  default blue, which on that permanently dark panel is dark blue on dark grey.
+
 ### Added
 
 - **A refactoring for the WiFi trap that only bites on the second Run** (#871).

--- a/src/renderer/src/components/FirmwareFlasher.css
+++ b/src/renderer/src/components/FirmwareFlasher.css
@@ -445,14 +445,37 @@
 /* An inline choice inside a hint line — used when the identified chip is claimed
    by more than one board, so the dialog asks rather than guesses. Styled as a
    link, not a button: it sits mid-sentence. */
-.firmware-link {
+/* Links inside this dialog, whether a real anchor or a button dressed as one.
+ *
+ * NOT `var(--accent)`, and not the browser default. The panel is #1f2430 in
+ * both themes (see the note at the top of this file), so the default link blue
+ * lands as dark blue on dark grey — unreadable, and reported as such. `--accent`
+ * is no better: on the skeuomorph theme it is #b07d1e brass, which clears 4:1
+ * against this panel only just, at 0.72rem type.
+ *
+ * A light blue from the dialog's own palette instead, so it reads as a link and
+ * as text. */
+.firmware-link,
+.firmware-hint a {
   padding: 0;
   border: 0;
   background: none;
   font: inherit;
-  color: var(--accent);
+  color: #8fbfff;
   text-decoration: underline;
   cursor: pointer;
+}
+
+.firmware-hint a:hover,
+.firmware-link:hover {
+  color: #b8d8ff;
+}
+
+.firmware-link:focus-visible,
+.firmware-hint a:focus-visible {
+  outline: 2px solid #8fbfff;
+  outline-offset: 2px;
+  border-radius: 2px;
 }
 
 .firmware-link:hover {

--- a/src/renderer/src/components/FirmwareFlasher.tsx
+++ b/src/renderer/src/components/FirmwareFlasher.tsx
@@ -25,6 +25,7 @@ import {
   FIRMWARE_RUNTIME_LABEL,
   findBoardBuilds,
   flashTargetForDownload,
+  catalogBuildForBoard,
   siblingBuildUrl,
   flashTargetForFamily,
   isVendorUf2Family,
@@ -772,14 +773,31 @@ export function FirmwareFlasher({
    * is derivable from the one already selected. Derive it, CONFIRM it resolves,
    * and then it is just another thing Flash can fetch.
    */
+  /**
+   * Every download the selected family offers, so the recommended build can be
+   * derived from ONE of them when the user has selected nothing (#885).
+   */
+  const familyBuildUrls = useMemo(
+    () =>
+      (families.find((f) => f.family === selFamily)?.models ?? []).flatMap((m) =>
+        m.variants.flatMap((v) => v.versions.map((x) => x.url))
+      ),
+    [families, selFamily]
+  )
+
   useEffect(() => {
     const name = suggestedBuild?.name
-    if (!name || !selVersionUrl) {
+    // A starting URL to rewrite. The user's selection when there is one — and
+    // otherwise any build of the same board, because a board with no catalog
+    // entry of its own (the Feather V2) can never make a selection, and it is
+    // exactly that board whose profile names a build worth flashing.
+    const base = selVersionUrl || catalogBuildForBoard(familyBuildUrls, name ?? '')
+    if (!name || !base) {
       setRecommendedUrl(null)
       return undefined
     }
-    const candidate = siblingBuildUrl(selVersionUrl, name)
-    if (!candidate || candidate === selVersionUrl) {
+    const candidate = siblingBuildUrl(base, name)
+    if (!candidate || (selVersionUrl && candidate === selVersionUrl)) {
       setRecommendedUrl(null)
       return undefined
     }
@@ -797,7 +815,7 @@ export function FirmwareFlasher({
     return () => {
       alive = false
     }
-  }, [suggestedBuild?.name, selVersionUrl])
+  }, [suggestedBuild?.name, selVersionUrl, familyBuildUrls])
 
   /** The URL Flash will actually fetch. */
   const flashUrl = recommendedUrl && useRecommended ? recommendedUrl : selVersionUrl
@@ -848,7 +866,9 @@ export function FirmwareFlasher({
   )
 
   // The firmware to flash: a catalog URL (download) or a picked local path.
-  const haveFirmware = usingCatalog ? selVersionUrl.length > 0 : firmwarePath.length > 0
+  // `flashUrl`, not `selVersionUrl`: the recommended build is a real choice on
+  // its own, and for a board absent from the catalog it is the ONLY one (#885).
+  const haveFirmware = usingCatalog ? flashUrl.length > 0 : firmwarePath.length > 0
 
   // A micro:bit in maintenance mode (the MAINTENANCE drive) can't be flashed with
   // MicroPython — doing so can soft-brick it — so detect it and block the flash.
@@ -1197,14 +1217,30 @@ export function FirmwareFlasher({
             {profile?.preferredBuild && (
               <p className="firmware-hint">
                 Best build: <code>{profile.preferredBuild.name}</code>. {profile.preferredBuild.why}
-                {profile.preferredBuild.url && (
-                  <>
-                    {' '}
-                    <a href={profile.preferredBuild.url} target="_blank" rel="noreferrer">
-                      Download it
-                    </a>
-                    , then choose it as a local file.
-                  </>
+                {/* Once the build has been located, say so and stop sending
+                    people away: Flash fetches it. The manual link stays for the
+                    case where it could not be found, but it points at a PAGE —
+                    and for this board that page is headed "ESP32 / WROOM" and
+                    lists the plain build first, which is the opposite of the
+                    advice above it (#885). */}
+                {recommendedUrl ? (
+                  <> Snakie has found it and will download it when you press Flash.</>
+                ) : (
+                  profile.preferredBuild.url && (
+                    <>
+                      {' '}
+                      <a
+                        className="firmware-link"
+                        href={profile.preferredBuild.url}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        Find it on micropython.org
+                      </a>{' '}
+                      — look for <code>{profile.preferredBuild.name}</code>, not the plain build at
+                      the top of that page — then choose it as a local file.
+                    </>
+                  )
                 )}
               </p>
             )}

--- a/src/shared/firmware-runtime.ts
+++ b/src/shared/firmware-runtime.ts
@@ -405,6 +405,41 @@ export function newestStableVersion(
 }
 
 /**
+ * A catalog URL for the same BOARD that `buildName` is a variant of (#885).
+ *
+ * {@link siblingBuildUrl} rewrites one build's URL into another's, but it needs
+ * a URL to start from — and the dialog only had one once the user had picked a
+ * version out of the Family/Model/Version dropdowns. That gate quietly excluded
+ * the very boards `preferredBuild` exists for: an Adafruit ESP32 Feather V2 has
+ * no entry in the catalog at all, so its owner never makes a selection, so the
+ * recommended-build path never ran and they were sent to a download page for a
+ * different board instead.
+ *
+ * This finds a starting point without a selection: the first URL whose board
+ * token matches, searched by FILENAME rather than by family or model, because
+ * the catalog groups several vendors under one model name — "ESP32 / WROOM"
+ * holds both `ESP32_GENERIC` and `SPARKFUN_IOT_REDBOARD_ESP32` — and only the
+ * filename says which board a build is really for. Pass them newest-first, as
+ * the catalog serves them, so the recommendation matches the version on offer.
+ */
+export function catalogBuildForBoard(
+  urls: readonly string[],
+  buildName: string
+): string | null {
+  const name = buildName.trim()
+  const cut = name.lastIndexOf('-')
+  // No variant suffix means there is no "sibling" to look for.
+  if (cut <= 0) return null
+  const base = name.slice(0, cut)
+  for (const url of urls) {
+    const file = url.split('/').pop() ?? ''
+    const m = /^(.+)-(\d{8}-v[^/]+)$/.exec(file)
+    if (m && m[1] === base) return url
+  }
+  return null
+}
+
+/**
  * The URL of a DIFFERENT build of the same firmware release — issue #833.
  *
  * The firmware catalog cannot offer every build. Thonny's `ESP32 / WROOM` entry

--- a/test/preferredBuildLink.test.ts
+++ b/test/preferredBuildLink.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { catalogBuildForBoard, siblingBuildUrl } from '../src/shared/firmware-runtime'
+
+/**
+ * Reaching a board's recommended build without a catalog selection (#885).
+ *
+ * The bug: the recommended-build path was gated on `selVersionUrl`, the version
+ * the user picks out of the Family/Model/Version dropdowns. That gate excluded
+ * exactly the boards `preferredBuild` exists for. An Adafruit ESP32 Feather V2
+ * has no entry in the catalog at all — its owner opens the Model list, does not
+ * find their board, and never makes a selection — so the derivation never ran,
+ * and the dialog fell back to a link to a download page **headed "ESP32 /
+ * WROOM"** that lists the plain build first. The advice said SPIRAM; the link
+ * offered the opposite. That board then ran for a week with its 2 MB of PSRAM
+ * switched off.
+ */
+
+const FIRMWARE = 'https://micropython.org/resources/firmware'
+
+/** Real rows from Thonny's `micropython-variants-esptool.json`, newest first. */
+const ESP32_FAMILY_URLS = [
+  `${FIRMWARE}/ESP32_GENERIC-20260406-v1.28.0.bin`,
+  `${FIRMWARE}/ESP32_GENERIC-20251209-v1.27.0.bin`,
+  `${FIRMWARE}/SPARKFUN_IOT_REDBOARD_ESP32-20260406-v1.28.0.bin`,
+  `${FIRMWARE}/LILYGO_TTGO_LORA32-20260406-v1.28.0.bin`
+]
+
+describe('finding a starting point with nothing selected', () => {
+  it('finds a build of the same board', () => {
+    expect(catalogBuildForBoard(ESP32_FAMILY_URLS, 'ESP32_GENERIC-SPIRAM')).toBe(
+      `${FIRMWARE}/ESP32_GENERIC-20260406-v1.28.0.bin`
+    )
+  })
+
+  it('takes the NEWEST, so the recommendation matches the version on offer', () => {
+    // The catalog serves newest-first; recommending a build two releases behind
+    // what the same dialog would otherwise flash would be its own small bug.
+    expect(catalogBuildForBoard(ESP32_FAMILY_URLS, 'ESP32_GENERIC-SPIRAM')).toContain('v1.28.0')
+  })
+
+  it('does not wander onto another vendor sharing the model name', () => {
+    // "ESP32 / WROOM" holds Espressif's board AND SparkFun's. Only the filename
+    // says which board a build is for — deriving a Feather V2 recommendation
+    // from a SparkFun binary would be worse than the page link it replaces.
+    const picked = catalogBuildForBoard(ESP32_FAMILY_URLS, 'ESP32_GENERIC-SPIRAM')
+    expect(picked).not.toContain('SPARKFUN')
+    expect(picked).not.toContain('LILYGO')
+  })
+
+  it('handles a board name that itself contains a hyphen or underscore', () => {
+    const urls = [`${FIRMWARE}/ESP32_GENERIC_S3-20260406-v1.28.0.bin`]
+    expect(catalogBuildForBoard(urls, 'ESP32_GENERIC_S3-SPIRAM_OCT')).toBe(urls[0])
+  })
+
+  it('says nothing when the board is absent from the family', () => {
+    expect(catalogBuildForBoard(ESP32_FAMILY_URLS, 'ESP32_GENERIC_C6-SPIRAM')).toBeNull()
+  })
+
+  it('says nothing for a build name with no variant to strip', () => {
+    // `ESP32_GENERIC` is not a variant OF anything, so there is no sibling.
+    expect(catalogBuildForBoard(ESP32_FAMILY_URLS, 'ESP32_GENERIC')).toBeNull()
+  })
+})
+
+describe('the URL it produces is the one that actually exists', () => {
+  it('rewrites the board token and keeps the release', () => {
+    const base = catalogBuildForBoard(ESP32_FAMILY_URLS, 'ESP32_GENERIC-SPIRAM')
+    // Verified against micropython.org: this file resolves 200.
+    expect(siblingBuildUrl(base!, 'ESP32_GENERIC-SPIRAM')).toBe(
+      `${FIRMWARE}/ESP32_GENERIC-SPIRAM-20260406-v1.28.0.bin`
+    )
+  })
+
+  it('works for the octal-PSRAM S3 case too', () => {
+    const base = `${FIRMWARE}/ESP32_GENERIC_S3-20260406-v1.28.0.bin`
+    expect(siblingBuildUrl(base, 'ESP32_GENERIC_S3-SPIRAM_OCT')).toBe(
+      `${FIRMWARE}/ESP32_GENERIC_S3-SPIRAM_OCT-20260406-v1.28.0.bin`
+    )
+  })
+})
+
+describe('the dialog', () => {
+  const tsx = readFileSync('src/renderer/src/components/FirmwareFlasher.tsx', 'utf8')
+
+  it('no longer requires a catalog selection to find the recommended build', () => {
+    // The gate that caused this: `if (!name || !selVersionUrl) return`.
+    expect(tsx).toContain('selVersionUrl || catalogBuildForBoard(')
+  })
+
+  it('lets Flash run on the recommended build alone', () => {
+    // `haveFirmware` gated on `selVersionUrl`, so even once the build was found
+    // the button stayed disabled for a board with nothing selectable.
+    expect(tsx).toContain('usingCatalog ? flashUrl.length > 0')
+  })
+
+  it('stops sending the user to a page once it has the file', () => {
+    expect(tsx).toContain('will download it when you press Flash')
+  })
+
+  it('warns which build to pick when it still has to send them away', () => {
+    // That page is headed "ESP32 / WROOM" and offers the plain build first.
+    expect(tsx).toContain('not the plain build at')
+  })
+})
+
+describe('links in this dialog are readable', () => {
+  const css = readFileSync('src/renderer/src/components/FirmwareFlasher.css', 'utf8')
+
+  it('styles a plain anchor, not only the button dressed as one', () => {
+    // The anchor had NO colour rule at all, in a stylesheet whose own header
+    // says every foreground here must come from the dialog's palette — so it
+    // fell through to the browser default: dark blue on a #1f2430 panel.
+    expect(css).toContain('.firmware-hint a')
+  })
+
+  it('does not take the link colour from the theme', () => {
+    const block = css.slice(css.indexOf('.firmware-link,'), css.indexOf('.firmware-link:hover'))
+    expect(block).not.toContain('var(--accent)')
+    expect(block).toMatch(/color:\s*#[0-9a-f]{6}/i)
+  })
+
+  it('gives keyboard focus something visible', () => {
+    expect(css).toContain('.firmware-hint a:focus-visible')
+  })
+})


### PR DESCRIPTION
Closes #885. **Replaces #888**, which GitHub auto-closed when its base branch (#877) was deleted on merge — same branch, same commit, now rebased onto master with #877's commit dropped since it is already in.

## The bug is not the one the issue title suggests

I filed this as "the link sends you to a browser". Reading the code, the round trip is a symptom — **the feature already existed and simply never ran for this board.**

#833 taught the dialog to derive the recommended build's URL from a sibling and download it on Flash. But the derivation was gated on `selVersionUrl`:

```ts
if (!name || !selVersionUrl) { setRecommendedUrl(null); return }
```

`selVersionUrl` is the version picked from the **Family / Model / Version** dropdowns. That gate excluded exactly the boards `preferredBuild` exists for. The Adafruit ESP32 Feather V2 has no catalogue entry — MicroPython builds no firmware under that name, and the catalogue is Thonny's JSON, which has no Adafruit at all — so its owner opens the Model list, doesn't find their board, and never makes a selection. The recommendation never resolved.

What they got instead was `preferredBuild.url`: a download page **headed "ESP32 / WROOM"** that lists the plain build first. So the paragraph said *"Best build: ESP32_GENERIC-SPIRAM"* and the link directly under it offered the build that isn't. It can't be deep-linked either — that page has no anchor ids.

The cost wasn't theoretical: a board ran for a week with its 2 MB of PSRAM switched off, through `OSError: Wifi Internal State Error`, `ENOMEM` on every UDP send, mDNS allocation failures, and finally an ESP-IDF `abort()` with 52 bytes of internal heap left.

## What changed

**`catalogBuildForBoard(urls, buildName)`** in `firmware-runtime.ts`, beside the existing `siblingBuildUrl`. With no selection, the derivation starts from any build of the same board — matched by **filename**, not family or model, because the catalogue groups several vendors under one model name ("ESP32 / WROOM" holds both `ESP32_GENERIC` and `SPARKFUN_IOT_REDBOARD_ESP32`).

**`haveFirmware` moves to `flashUrl`** — the second half of the same gate: even once the build resolved, Flash stayed disabled because the check still asked whether a *catalogue version* was selected.

**The fallback stops being a trap.** When the build genuinely can't be resolved, the link stays — but names the file to look for and says not to take the one at the top of that page.

## The link colour

`FirmwareFlasher.css` opens by explaining that this dialog is dark in *both* themes so nothing may take its foreground from the theme tokens. Every colour in the file obeys — except the anchor, which had **no rule at all** and fell through to the browser default: dark blue on a `#1f2430` panel. `var(--accent)` wasn't the answer either (on skeuomorph that's `#b07d1e` brass, only just clearing 4:1 at 0.72rem). It now uses a light blue from the dialog's own palette, with a focus ring.

## Verified

Checked against **real** rows from Thonny's `micropython-variants-esptool.json`, and both derived URLs resolve `200`:

- `ESP32_GENERIC-SPIRAM-20260406-v1.28.0.bin`
- `ESP32_GENERIC_S3-SPIRAM_OCT-20260406-v1.28.0.bin`

15 tests. I broke the fix two ways and confirmed each failed for its own reason: restoring the original `selVersionUrl` gate, and making the board match naive "first URL wins".

Gates re-run after the rebase: lint ok · typecheck ok · tests ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe