### PR TITLE
feat(sim): set the simulated board's memory, and say what that can't do (#901)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,26 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **The simulated board's memory is yours to set, with a cog in the console**
+  (#901). Picked from the port dropdown, the Simulated device now carries a cog
+  that sets the heap its MicroPython interpreter boots with — presets in the
+  region of an ESP8266, an ESP32 with its PSRAM off, a Pico, or a board with
+  PSRAM working, plus a custom size. The point is to meet a tight board's first
+  `MemoryError` at your desk rather than on hardware.
+
+  The dialog is equally clear about what the setting is *not*, because the
+  WebAssembly build only goes so far. It **is** a real knob: `loadMicroPython()`
+  takes a `heapsize` and passes it to `mp_js_init`, and with a small heap a big
+  allocation genuinely fails. But it is a **starting** heap, not a ceiling —
+  that build grows its heap on demand, so the allocation that just raised
+  `MemoryError` succeeds when you retry it, and no setting here can starve a
+  program that grows gradually. And `gc.mem_free()` reports the WebAssembly
+  heap's headroom, around 128 MB, whatever you choose. Both facts are stated in
+  the dialog rather than left to be discovered; a memory setting that quietly
+  failed to bound memory would be worse than none. Changing the heap needs a
+  restart (it is fixed when the interpreter starts), so the button says so, and
+  warns that restarting clears the simulator's files exactly as Stop does.
+
 - **A refactoring for the WiFi trap that only bites on the second Run** (#871).
   Pressing Run does a soft reboot, which re-runs your file — but a soft reboot
   does not reset the ESP32's radio, so a station left mid-connect by the previous

--- a/src/main/device/MicroPythonRuntime.ts
+++ b/src/main/device/MicroPythonRuntime.ts
@@ -12,8 +12,13 @@ const defaultWorkerPath = join(dirname(fileURLToPath(import.meta.url)), WORKER_F
  * can be unit-tested against a lightweight fake without loading WebAssembly.
  */
 export interface ReplRuntime {
-  /** Boot the runtime; `onOutput` receives REPL output as raw byte chunks. */
-  init(onOutput: (chunk: Buffer) => void): Promise<void>
+  /**
+   * Boot the runtime; `onOutput` receives REPL output as raw byte chunks.
+   * `heapBytes` is the GC heap the interpreter starts with (#901); the runtime
+   * REMEMBERS it, because a Stop reboots the worker and the fresh interpreter
+   * has to come back with the same heap the user asked for.
+   */
+  init(onOutput: (chunk: Buffer) => void, heapBytes?: number): Promise<void>
   /** Feed raw input bytes (keystrokes, paste-mode payloads, control chars). */
   feed(data: string): Promise<void>
   /**
@@ -69,6 +74,8 @@ export class MicroPythonRuntime implements ReplRuntime {
   /** In-flight feed/run count — >0 means the interpreter is busy/running. */
   private busy = 0
   private readonly workerPath: string
+  /** GC heap for every spawn, including the Stop reboot (#901). */
+  private heapBytes: number | undefined
 
   /** `workerFile` overrides the bundled worker path. Falls back to
    *  `SNAKIE_MP_WORKER` (set by the vitest setup, which compiles the worker to a
@@ -77,8 +84,9 @@ export class MicroPythonRuntime implements ReplRuntime {
     this.workerPath = workerFile ?? process.env.SNAKIE_MP_WORKER ?? defaultWorkerPath
   }
 
-  async init(onOutput: (chunk: Buffer) => void): Promise<void> {
+  async init(onOutput: (chunk: Buffer) => void, heapBytes?: number): Promise<void> {
     this.onOutput = onOutput
+    this.heapBytes = heapBytes
     await this.spawn()
   }
 
@@ -105,7 +113,7 @@ export class MicroPythonRuntime implements ReplRuntime {
       this.readyResolve = res
       this.readyReject = rej
     })
-    worker.postMessage({ type: 'init' })
+    worker.postMessage({ type: 'init', heapBytes: this.heapBytes })
     return ready
   }
 

--- a/src/main/device/SimulatedDevice.ts
+++ b/src/main/device/SimulatedDevice.ts
@@ -3,12 +3,14 @@ import { scratchBlock } from '../../shared/device-scratch'
 import { VIRTUAL_PORT_PATH } from '../../shared/virtual-device'
 import { MicroPythonRuntime, type ReplRuntime } from './MicroPythonRuntime'
 import { isProbeCode, simulateProbeResponse, simulatedTelemetryFrame } from '../../shared/simulation'
+import { clampSimHeapBytes, SIM_HEAP_DEFAULT_BYTES } from '../../shared/sim-memory'
 import type { RuntimeInfo } from '../../shared/dialect'
 import type {
   ConnectionState,
   DeviceStatus,
   DirEntry,
   ExecResult,
+  SimMemoryState,
   SnakieDevice,
   StatResult
 } from './types'
@@ -54,6 +56,10 @@ export class SimulatedDevice extends EventEmitter implements SnakieDevice {
   private readonly runtime: ReplRuntime
   /** Latest control payload per target (for inspection / future feedback). */
   private readonly control = new Map<string, string>()
+  /** GC heap the NEXT boot will use (#901) — set from the console's cog. */
+  private heapBytes = SIM_HEAP_DEFAULT_BYTES
+  /** GC heap the LIVE interpreter actually started with; null when not running. */
+  private bootedHeapBytes: number | null = null
 
   constructor(runtime: ReplRuntime = new MicroPythonRuntime()) {
     super()
@@ -86,16 +92,32 @@ export class SimulatedDevice extends EventEmitter implements SnakieDevice {
     return this.state === 'connected'
   }
 
+  /**
+   * The simulated board's heap (#901). `setMemory` only names what the NEXT boot
+   * will use: the heap is fixed at `mp_js_init`, so it cannot be applied to a
+   * running interpreter — the caller restarts the simulator to take it up.
+   */
+  setMemory(bytes: number): void {
+    this.heapBytes = clampSimHeapBytes(bytes)
+  }
+
+  getMemory(): SimMemoryState {
+    return { configured: this.heapBytes, booted: this.bootedHeapBytes }
+  }
+
   async connect(): Promise<void> {
     if (this.state === 'connected') return
     // Mimic the real flow: a brief "connecting" then "connected".
     this.setState('connecting')
     try {
       // Boot the interpreter; its banner + prompt stream out via `data`.
-      await this.runtime.init((chunk) => this.emit('data', chunk))
+      await this.runtime.init((chunk) => this.emit('data', chunk), this.heapBytes)
+      this.bootedHeapBytes = this.heapBytes
     } catch (err) {
       // The REPL couldn't start — still connect so the instruments + Board
       // Viewer work; just print a notice instead of a live Python prompt.
+      // No interpreter came up, so no heap was chosen — don't claim one.
+      this.bootedHeapBytes = null
       const reason = err instanceof Error ? err.message : String(err)
       this.emit(
         'data',
@@ -113,6 +135,7 @@ export class SimulatedDevice extends EventEmitter implements SnakieDevice {
   async disconnect(): Promise<void> {
     this.stopTelemetry()
     this.control.clear()
+    this.bootedHeapBytes = null
     this.runtime.dispose()
     if (this.state !== 'disconnected') this.setState('disconnected')
   }

--- a/src/main/device/ipc.ts
+++ b/src/main/device/ipc.ts
@@ -139,6 +139,17 @@ export function registerDeviceIpc(getWebContents: () => WebContents | undefined)
 
   ipcMain.handle('device:disconnect', () => wrap(() => getActive().disconnect()))
 
+  // The simulated board's heap (#901). Addressed to the SIMULATOR, not to
+  // `getActive()` — the console's cog sets it whether or not the sim is the
+  // backend in use, and the value has to be in place before the next boot.
+  ipcMain.handle('device:setSimMemory', (_e, bytes: number) =>
+    wrap(async () => {
+      simDev.setMemory(bytes)
+      return simDev.getMemory()
+    })
+  )
+  ipcMain.handle('device:getSimMemory', () => wrap(async () => simDev.getMemory()))
+
   ipcMain.handle('device:getStatus', () => wrap(async () => getActive().getStatus()))
 
   ipcMain.handle('device:exec', (_e, code: string) => wrap(() => getActive().exec(code)))

--- a/src/main/device/mp-node-worker.ts
+++ b/src/main/device/mp-node-worker.ts
@@ -22,7 +22,7 @@ const MP_MJS = '@micropython/micropython-webassembly-pyscript/micropython.mjs'
 const MP_WASM = '@micropython/micropython-webassembly-pyscript/micropython.wasm'
 
 type InMsg =
-  | { type: 'init' }
+  | { type: 'init'; heapBytes?: number }
   | { type: 'feed'; id: number; data: string }
   | { type: 'run'; id: number; code: string }
   | { type: 'runStream'; id: number; code: string }
@@ -78,7 +78,11 @@ port.on('message', async (msg: InMsg): Promise<void> => {
       url: require.resolve(MP_WASM),
       linebuffer: false,
       stdout: collect,
-      stderr: collect
+      stderr: collect,
+      // The GC heap the interpreter starts with (#901). Omitted → the port's own
+      // 1 MB default. It is fixed here, at `mp_js_init` — which is why changing
+      // it costs a restart rather than applying to a live session.
+      ...(msg.heapBytes ? { heapsize: msg.heapBytes } : {})
     })
     mp = loaded
     const timer = setInterval(flush, 16)

--- a/src/main/device/types.ts
+++ b/src/main/device/types.ts
@@ -38,6 +38,17 @@ export interface ConnectOptions {
   baudRate?: number
 }
 
+/**
+ * The simulated board's heap setting (#901). `configured` is what the next boot
+ * will use; `booted` is what the interpreter actually started with, or null when
+ * nothing is running. They differ exactly when a restart is still owed — the
+ * heap is fixed at `mp_js_init`, so a change cannot reach a live interpreter.
+ */
+export interface SimMemoryState {
+  configured: number
+  booted: number | null
+}
+
 /** Connection lifecycle states. */
 export type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'error'
 

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -56,6 +56,7 @@ export type {
   ExecResult,
   DirEntry,
   StatResult,
+  SimMemoryState,
   IpcResult
 } from '../main/device/types'
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -20,6 +20,7 @@ import type {
   ExecResult,
   IpcResult,
   PortInfo,
+  SimMemoryState,
   StatResult
 } from '../main/device/types'
 import type { FsEntry, FsStat } from '../main/fs/types'
@@ -198,6 +199,13 @@ const device = {
     unwrap(ipcRenderer.invoke('device:connect', path, opts)),
   /** Close the active connection. */
   disconnect: (): Promise<void> => unwrap(ipcRenderer.invoke('device:disconnect')),
+  /** Set the GC heap the SIMULATED board boots with (#901). Returns the new
+   *  state; `booted` still names the live interpreter's heap, so a caller can
+   *  see that a restart is owed. */
+  setSimMemory: (bytes: number): Promise<SimMemoryState> =>
+    unwrap(ipcRenderer.invoke('device:setSimMemory', bytes)),
+  /** The simulated board's configured vs actually-booted heap (#901). */
+  getSimMemory: (): Promise<SimMemoryState> => unwrap(ipcRenderer.invoke('device:getSimMemory')),
   /** Current connection status snapshot. */
   getStatus: (): Promise<DeviceStatus> => unwrap(ipcRenderer.invoke('device:getStatus')),
   /** Run code in the raw REPL, returning captured stdout/stderr. */

--- a/src/renderer/src/components/ConnectionControl.tsx
+++ b/src/renderer/src/components/ConnectionControl.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
-import { isVirtualPort, VIRTUAL_PORT_LABEL } from '../../../shared/virtual-device'
+import { isVirtualPort, VIRTUAL_PORT_LABEL, VIRTUAL_PORT_PATH } from '../../../shared/virtual-device'
+import { SimMemoryDialog } from './SimMemoryDialog'
+import { pushSimHeapBytes, readSimHeapBytes, writeSimHeapBytes } from '../store/sim-memory'
 import type { DeviceStatus, PortCircuitPy, PortInfo } from '../../../preload/index.d'
 
 /**
@@ -35,9 +37,17 @@ export function ConnectionControl({ status }: ConnectionControlProps): JSX.Eleme
   const [selected, setSelected] = useState<string>('')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  // Simulated-device memory (#901): the stored preference, the heap the live
+  // simulator actually booted with, and whether the cog's dialog is open.
+  const [memOpen, setMemOpen] = useState(false)
+  const [heapBytes, setHeapBytes] = useState(readSimHeapBytes)
+  const [bootedHeap, setBootedHeap] = useState<number | null>(null)
 
   const connected = status.state === 'connected'
   const connecting = status.state === 'connecting' || busy
+  // The cog belongs to the SELECTED port, not the connected one — the setting is
+  // about the simulator's next boot, so it has to be reachable before connecting.
+  const simSelected = isVirtualPort(selected)
 
   const refreshPorts = useCallback(async (): Promise<void> => {
     try {
@@ -55,6 +65,31 @@ export function ConnectionControl({ status }: ConnectionControlProps): JSX.Eleme
   useEffect(() => {
     void refreshPorts()
   }, [refreshPorts])
+
+  // Hand the stored heap to the device layer once, on mount, so a preference set
+  // in an earlier session is in force before anything auto-connects the sim
+  // (the web build does so ~400ms after first render) (#901).
+  useEffect(() => {
+    void pushSimHeapBytes(readSimHeapBytes())
+  }, [])
+
+  // What the LIVE simulator booted with — the device layer owns that truth, so
+  // the dialog can say honestly whether a restart is still owed. Re-read on
+  // every connection change, since connecting is what fixes a heap in place.
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const state = await window.api.device.getSimMemory?.()
+        if (!cancelled && state) setBootedHeap(state.booted)
+      } catch {
+        /* an older preload has no such channel — the dialog just won't offer a restart */
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [status.state, status.path])
 
   // Keep the dropdown showing the active port while connected.
   // Keep the dropdown showing the active port while connected. A board picked via
@@ -81,6 +116,50 @@ export function ConnectionControl({ status }: ConnectionControlProps): JSX.Eleme
       setBusy(false)
     }
   }, [connected, selected])
+
+  /** Persist a new simulated heap and hand it to the device layer. */
+  const saveHeap = useCallback(async (bytes: number): Promise<number> => {
+    const stored = writeSimHeapBytes(bytes)
+    setHeapBytes(stored)
+    await pushSimHeapBytes(stored)
+    return stored
+  }, [])
+
+  const handleSaveHeap = useCallback(
+    (bytes: number): void => {
+      void saveHeap(bytes)
+      setMemOpen(false)
+    },
+    [saveHeap]
+  )
+
+  /**
+   * Save AND restart the simulator, because the heap is fixed at interpreter
+   * start-up. A disconnect/connect cycle is the supported way to get a fresh
+   * interpreter — the same terminate-and-respawn Stop performs — so the RAM
+   * filesystem resets with it, which the dialog warns about before we get here.
+   */
+  const handleSaveAndRestartHeap = useCallback(
+    (bytes: number): void => {
+      setMemOpen(false)
+      void (async () => {
+        setError(null)
+        setBusy(true)
+        try {
+          await saveHeap(bytes)
+          await window.api.device.disconnect()
+          await window.api.device.connect(VIRTUAL_PORT_PATH)
+          const state = await window.api.device.getSimMemory?.()
+          if (state) setBootedHeap(state.booted)
+        } catch (err) {
+          setError(err instanceof Error ? err.message : String(err))
+        } finally {
+          setBusy(false)
+        }
+      })()
+    },
+    [saveHeap]
+  )
 
   return (
     <div className="conn-control" title={error ?? undefined}>
@@ -125,6 +204,28 @@ export function ConnectionControl({ status }: ConnectionControlProps): JSX.Eleme
           )
         })}
       </select>
+      {/* Memory cog — only for the simulated board, which is the only device
+          whose RAM we get to choose (#901). */}
+      {simSelected && (
+        <button
+          type="button"
+          className="btn btn--ghost btn--sm conn-control__cog"
+          onClick={() => setMemOpen(true)}
+          title="Simulated device memory"
+          aria-label="Simulated device memory"
+        >
+          <svg width="13" height="13" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+            <circle cx="8" cy="8" r="2.2" fill="none" stroke="currentColor" strokeWidth="1.3" />
+            <path
+              d="M8 1.6v1.6M8 12.8v1.6M14.4 8h-1.6M3.2 8H1.6M12.5 3.5l-1.1 1.1M4.6 11.4l-1.1 1.1M12.5 12.5l-1.1-1.1M4.6 4.6 3.5 3.5"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.3"
+              strokeLinecap="round"
+            />
+          </svg>
+        </button>
+      )}
       <button
         type="button"
         className={`btn btn--sm ${connected ? 'btn--danger' : 'btn--primary'}`}
@@ -133,6 +234,15 @@ export function ConnectionControl({ status }: ConnectionControlProps): JSX.Eleme
       >
         {connected ? 'Disconnect' : connecting ? 'Connecting…' : 'Connect'}
       </button>
+      {memOpen && (
+        <SimMemoryDialog
+          value={heapBytes}
+          booted={bootedHeap}
+          onSave={handleSaveHeap}
+          onSaveAndRestart={handleSaveAndRestartHeap}
+          onClose={() => setMemOpen(false)}
+        />
+      )}
     </div>
   )
 }

--- a/src/renderer/src/components/SimMemoryDialog.css
+++ b/src/renderer/src/components/SimMemoryDialog.css
@@ -1,0 +1,188 @@
+/*
+ * Simulated-device memory dialog (SimMemoryDialog.tsx, #901).
+ *
+ * Follows the PromptModal overlay pattern — a centred card over a dimmed
+ * backdrop — and takes every colour from the shared tokens, so it reads
+ * correctly on both the skeuomorph parchment and the dark skin.
+ */
+
+.simmem-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+  padding: 1rem;
+}
+
+.simmem {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  width: min(30rem, 100%);
+  max-height: calc(100vh - 2rem);
+  overflow-y: auto;
+  padding: 1rem 1.1rem;
+  background: var(--bg-elevated);
+  color: var(--text);
+  border: var(--border-w) solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--pixel-shadow);
+  font-family: var(--font-ui);
+}
+
+.simmem__title {
+  margin: 0;
+  font-family: var(--font-pixel);
+  font-size: 0.9rem;
+}
+
+.simmem__lede {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.simmem__presets {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin: 0;
+  padding: 0.5rem;
+  border: var(--border-w) solid var(--border);
+  border-radius: var(--radius);
+}
+
+.simmem__legend {
+  padding: 0 0.3rem;
+  font-family: var(--font-pixel);
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+
+.simmem__preset {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.35rem 0.4rem;
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+
+.simmem__preset:hover {
+  background: var(--bg-sunken);
+}
+
+/* The chosen row is marked with the accent, which is defined in both skins —
+   never a literal, which would only ever look right in one of them. */
+.simmem__preset--on {
+  background: var(--bg-sunken);
+  box-shadow: inset 2px 0 0 var(--accent);
+}
+
+.simmem__preset input {
+  margin-top: 0.15rem;
+  accent-color: var(--accent);
+}
+
+.simmem__preset-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.simmem__preset-label {
+  font-size: 0.82rem;
+}
+
+.simmem__preset-hint {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+.simmem__custom {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  font-size: 0.8rem;
+}
+
+.simmem__custom-field {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.simmem__input {
+  width: 7rem;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--text);
+  background: var(--bg-sunken);
+  border: var(--border-w) solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.35rem 0.45rem;
+}
+
+.simmem__input:focus-visible {
+  outline: var(--border-w) solid var(--accent);
+  outline-offset: 2px;
+}
+
+.simmem__unit {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.simmem__caveat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  padding: 0.6rem 0.7rem;
+  font-size: 0.75rem;
+  line-height: 1.45;
+  color: var(--text-muted);
+  background: var(--bg-sunken);
+  border-radius: var(--radius);
+  border-left: 3px solid var(--accent);
+}
+
+.simmem__caveat p {
+  margin: 0;
+}
+
+.simmem__caveat strong {
+  color: var(--text);
+}
+
+.simmem__caveat code,
+.simmem__lede code,
+.simmem__status code {
+  font-family: var(--font-mono);
+  font-size: 0.95em;
+}
+
+.simmem__status {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.simmem__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+/* The cog beside the port dropdown. It inherits the shell header's ghost-chip
+   treatment from ShellPanel.css, so only the glyph box needs setting here. */
+.conn-control__cog {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.35rem;
+  line-height: 0;
+}

--- a/src/renderer/src/components/SimMemoryDialog.tsx
+++ b/src/renderer/src/components/SimMemoryDialog.tsx
@@ -1,0 +1,198 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useFocusTrap } from '../hooks/useFocusTrap'
+import {
+  clampSimHeapBytes,
+  formatSimHeap,
+  simHeapNeedsRestart,
+  SIM_HEAP_MAX_BYTES,
+  SIM_HEAP_MIN_BYTES,
+  SIM_HEAP_PRESETS
+} from '../../../shared/sim-memory'
+import './SimMemoryDialog.css'
+
+/**
+ * SIMULATED DEVICE — MEMORY (issue #901).
+ * =============================================================================
+ *
+ * The cog beside the port dropdown, shown only while the simulator is the
+ * selected port. It sets the GC heap the virtual board boots with, which the
+ * MicroPython WASM port really does accept (`loadMicroPython({ heapsize })` →
+ * `mp_js_init(pystack, heapsize)`).
+ *
+ * The dialog spends as much space saying what the setting ISN'T as offering it,
+ * on purpose. Two things would otherwise mislead someone who came here to
+ * reproduce a board running out of RAM:
+ *
+ *  - the heap AUTO-GROWS, so this is a starting size and not a cap; and
+ *  - `gc.mem_free()` reports the WASM headroom, not this number.
+ *
+ * Both are stated in the body rather than buried in a tooltip, because a memory
+ * setting that quietly failed to bound memory would be worse than no setting.
+ *
+ * Applying costs a restart: the heap is fixed at `mp_js_init`, so it cannot
+ * reach a live interpreter. When the simulator is running with a different heap
+ * the primary button restarts it — and says that this clears the simulator's
+ * files, because a restart re-spawns the worker and its RAM filesystem goes
+ * with it (the same thing Stop does).
+ */
+
+interface SimMemoryDialogProps {
+  /** Heap the setting currently holds (the next boot's). */
+  value: number
+  /** Heap the LIVE simulator started with; null when it isn't running. */
+  booted: number | null
+  /** Persist a new heap. */
+  onSave: (bytes: number) => void
+  /** Save AND restart the simulator so the new heap takes effect. */
+  onSaveAndRestart: (bytes: number) => void
+  onClose: () => void
+}
+
+export function SimMemoryDialog({
+  value,
+  booted,
+  onSave,
+  onSaveAndRestart,
+  onClose
+}: SimMemoryDialogProps): JSX.Element {
+  const [draft, setDraft] = useState(value)
+  // The custom field is kept as TEXT so a half-typed number ("", "1") doesn't
+  // get clamped out from under the caret on every keystroke.
+  const [customKb, setCustomKb] = useState(String(Math.round(value / 1024)))
+  const dialogRef = useFocusTrap<HTMLDivElement>(true)
+
+  useEffect(() => {
+    setDraft(value)
+    setCustomKb(String(Math.round(value / 1024)))
+  }, [value])
+
+  const pick = useCallback((bytes: number): void => {
+    setDraft(bytes)
+    setCustomKb(String(Math.round(bytes / 1024)))
+  }, [])
+
+  const onCustom = useCallback((text: string): void => {
+    setCustomKb(text)
+    const kb = Number(text)
+    if (Number.isFinite(kb) && kb > 0) setDraft(clampSimHeapBytes(kb * 1024))
+  }, [])
+
+  // A restart is owed when the simulator is live on a different heap. When it
+  // isn't running there is nothing to restart — saving is the whole action.
+  const needsRestart = simHeapNeedsRestart(booted, draft)
+
+  return (
+    <div
+      className="simmem-overlay"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div
+        className="simmem"
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="simmem-title"
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') {
+            e.preventDefault()
+            onClose()
+          }
+        }}
+      >
+        <h2 className="simmem__title" id="simmem-title">
+          Simulated device memory
+        </h2>
+        <p className="simmem__lede">
+          How much heap the virtual board starts with. Useful for meeting a tight
+          board&rsquo;s first <code>MemoryError</code> at your desk instead of on hardware.
+        </p>
+
+        <fieldset className="simmem__presets">
+          <legend className="simmem__legend">Starting heap</legend>
+          {SIM_HEAP_PRESETS.map((preset) => (
+            <label
+              key={preset.id}
+              className={`simmem__preset${draft === preset.bytes ? ' simmem__preset--on' : ''}`}
+            >
+              <input
+                type="radio"
+                name="simmem-preset"
+                value={preset.bytes}
+                checked={draft === preset.bytes}
+                onChange={() => pick(preset.bytes)}
+              />
+              <span className="simmem__preset-text">
+                <span className="simmem__preset-label">{preset.label}</span>
+                <span className="simmem__preset-hint">{preset.hint}</span>
+              </span>
+            </label>
+          ))}
+        </fieldset>
+
+        <label className="simmem__custom">
+          <span className="simmem__custom-label">Or a custom size</span>
+          <span className="simmem__custom-field">
+            <input
+              type="number"
+              className="simmem__input"
+              min={Math.round(SIM_HEAP_MIN_BYTES / 1024)}
+              max={Math.round(SIM_HEAP_MAX_BYTES / 1024)}
+              step={16}
+              value={customKb}
+              onChange={(e) => onCustom(e.target.value)}
+            />
+            <span className="simmem__unit">KB</span>
+          </span>
+        </label>
+
+        {/* The honest part. Both of these would otherwise be discovered the hard
+            way, by someone trusting the setting to bound the simulator's RAM. */}
+        <div className="simmem__caveat">
+          <p>
+            <strong>This is a starting heap, not a limit.</strong> The MicroPython
+            WebAssembly build grows its heap on demand: an allocation that
+            doesn&rsquo;t fit raises <code>MemoryError</code>, and then the retry
+            succeeds because the collector has just taken more room. So a small
+            heap reproduces a tight board&rsquo;s <em>first</em> failure, but it
+            won&rsquo;t starve a program that grows gradually.
+          </p>
+          <p>
+            <code>gc.mem_free()</code> reports the WebAssembly heap&rsquo;s
+            headroom &mdash; around 128&nbsp;MB &mdash; whatever you choose here.
+            On the simulator it answers a different question than it does on a
+            board.
+          </p>
+        </div>
+
+        <p className="simmem__status" role="status">
+          {booted === null
+            ? 'The simulator isn’t running. It will start with this heap.'
+            : needsRestart
+              ? `The simulator is running with ${formatSimHeap(booted)}. Restarting it clears its files, exactly like Stop does.`
+              : `The simulator is running with ${formatSimHeap(booted)}.`}
+        </p>
+
+        <div className="simmem__actions">
+          <button type="button" className="btn btn--ghost" onClick={onClose}>
+            Cancel
+          </button>
+          {needsRestart ? (
+            <button
+              type="button"
+              className="btn btn--primary"
+              onClick={() => onSaveAndRestart(draft)}
+            >
+              Save and restart simulator
+            </button>
+          ) : (
+            <button type="button" className="btn btn--primary" onClick={() => onSave(draft)}>
+              Save
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/store/sim-memory.ts
+++ b/src/renderer/src/store/sim-memory.ts
@@ -1,0 +1,54 @@
+/**
+ * Simulated-device memory setting (#901) — persistence + push to the device layer.
+ *
+ * The heap the simulator boots with is a RENDERER preference (it lives in
+ * localStorage with the rest of the UI state), but the interpreter is booted by
+ * the device layer — the main process on the desktop, a Web Worker on the web.
+ * So the value has to be pushed across whenever it changes, and once at startup
+ * so a preference set in an earlier session is in force before anything
+ * auto-connects.
+ *
+ * Deliberately plain functions rather than a context: there is one number, it is
+ * read at boot time, and the dialog that edits it is the only writer.
+ */
+import { clampSimHeapBytes, SIM_HEAP_DEFAULT_BYTES } from '../../../shared/sim-memory'
+
+const STORAGE_KEY = 'snakie.simHeapBytes'
+
+/**
+ * The stored heap preference, clamped. Anything unreadable or corrupt falls back
+ * to the default — a bad stored value must never stop the simulator booting.
+ */
+export function readSimHeapBytes(): number {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (raw === null) return SIM_HEAP_DEFAULT_BYTES
+    return clampSimHeapBytes(JSON.parse(raw))
+  } catch {
+    return SIM_HEAP_DEFAULT_BYTES
+  }
+}
+
+/** Persist the preference. Returns the clamped value actually stored. */
+export function writeSimHeapBytes(bytes: number): number {
+  const clamped = clampSimHeapBytes(bytes)
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(clamped))
+  } catch {
+    // Storage disabled / full — the value still reaches the device layer below,
+    // so the current session honours it even if the next one won't.
+  }
+  return clamped
+}
+
+/**
+ * Hand the preference to the device layer so the simulator's NEXT boot uses it.
+ * Best-effort: an older preload without the channel must not break the console.
+ */
+export async function pushSimHeapBytes(bytes: number): Promise<void> {
+  try {
+    await window.api.device.setSimMemory?.(bytes)
+  } catch {
+    /* the simulator simply keeps the heap it already had */
+  }
+}

--- a/src/renderer/src/web/mp.worker.ts
+++ b/src/renderer/src/web/mp.worker.ts
@@ -22,7 +22,7 @@ import { SIM_MACHINE_PY } from '../../../shared/sim-machine'
 import { INSTRUMENTS_PY, SNAKIE_PY } from './web-lib-sources'
 
 type InMsg =
-  | { type: 'init' }
+  | { type: 'init'; heapBytes?: number }
   | { type: 'feed'; id: number; data: string }
   | { type: 'run'; id: number; code: string }
   | { type: 'runStream'; id: number; code: string }
@@ -94,7 +94,11 @@ self.onmessage = async (e: MessageEvent<InMsg>): Promise<void> => {
       url: mpWasmUrl,
       linebuffer: false,
       stdout: collect,
-      stderr: collect
+      stderr: collect,
+      // The GC heap the interpreter starts with (#901). Omitted → the port's own
+      // 1 MB default. It is fixed here, at `mp_js_init` — which is why changing
+      // it costs a restart rather than applying to a live session.
+      ...(msg.heapBytes ? { heapsize: msg.heapBytes } : {})
     })
     setInterval(flush, 24)
     // The WASM port has no `machine` module — install a simulated one so

--- a/src/renderer/src/web/web-device-router.ts
+++ b/src/renderer/src/web/web-device-router.ts
@@ -54,6 +54,13 @@ export function createWebDeviceRouter(): Record<string, unknown> {
       await call(active, 'disconnect')
     },
 
+    // The heap setting belongs to the SIMULATOR, so it goes there whichever
+    // backend happens to be active — the console's cog is reachable while a
+    // real board is connected, and the value must be in place before the next
+    // simulator boot (#901).
+    setSimMemory: async (bytes: number): Promise<unknown> => call(sim, 'setSimMemory', bytes),
+    getSimMemory: async (): Promise<unknown> => call(sim, 'getSimMemory'),
+
     getStatus: async () => call(active, 'getStatus'),
 
     // ── Everything else delegates to the active backend ──────────────────────

--- a/src/renderer/src/web/web-device.ts
+++ b/src/renderer/src/web/web-device.ts
@@ -18,6 +18,7 @@ import { WorkerMicroPythonRuntime } from './worker-runtime'
 import { scratchBlock } from '../../../shared/device-scratch'
 import { VIRTUAL_PORT_PATH, VIRTUAL_PORT_LABEL } from '../../../shared/virtual-device'
 import { isProbeCode, simulateProbeResponse, simulatedTelemetryFrame } from '../../../shared/simulation'
+import { clampSimHeapBytes, SIM_HEAP_DEFAULT_BYTES } from '../../../shared/sim-memory'
 import type { RuntimeInfo } from '../../../shared/dialect'
 
 /** How often the simulated board "prints" a telemetry frame (matches the desktop sim). */
@@ -81,6 +82,11 @@ export function createWebDeviceApi(): Record<string, unknown> {
   // radar animate on the web sim with no hardware or running program.
   let tick = 0
   let telemetry: ReturnType<typeof setInterval> | null = null
+  // The GC heap the NEXT boot uses, and the one the LIVE interpreter started
+  // with (#901) — the twin of the desktop SimulatedDevice's pair. They differ
+  // exactly while a restart is owed, because the heap is fixed at `mp_js_init`.
+  let heapBytes = SIM_HEAP_DEFAULT_BYTES
+  let bootedHeapBytes: number | null = null
 
   const emitData = (chunk: Uint8Array): void => dataSubs.forEach((cb) => cb(chunk))
 
@@ -121,8 +127,11 @@ export function createWebDeviceApi(): Record<string, unknown> {
       setState('connecting')
       runtime = new WorkerMicroPythonRuntime()
       try {
-        await runtime.init(emitData)
+        await runtime.init(emitData, heapBytes)
+        bootedHeapBytes = heapBytes
       } catch (err) {
+        // No interpreter came up, so no heap was chosen — don't claim one.
+        bootedHeapBytes = null
         emitData(
           enc.encode(
             `\r\nSimulated device — Python REPL unavailable (${String(err)}).\r\n>>> `
@@ -133,8 +142,16 @@ export function createWebDeviceApi(): Record<string, unknown> {
       startTelemetry()
     },
 
+    setSimMemory: async (bytes: number) => {
+      heapBytes = clampSimHeapBytes(bytes)
+      return { configured: heapBytes, booted: bootedHeapBytes }
+    },
+
+    getSimMemory: async () => ({ configured: heapBytes, booted: bootedHeapBytes }),
+
     disconnect: async () => {
       stopTelemetry()
+      bootedHeapBytes = null
       runtime?.dispose()
       runtime = null
       if (state !== 'disconnected') setState('disconnected')

--- a/src/renderer/src/web/worker-runtime.ts
+++ b/src/renderer/src/web/worker-runtime.ts
@@ -26,9 +26,14 @@ export class WorkerMicroPythonRuntime {
   private readyReject: ((err: Error) => void) | null = null
   /** In-flight feed/run count — >0 means the interpreter is running. */
   private busy = 0
+  /** GC heap for every spawn, including the Stop reboot (#901). */
+  private heapBytes: number | undefined
 
-  async init(onOutput: (chunk: Uint8Array) => void): Promise<void> {
+  /** `heapBytes` is the GC heap the interpreter starts with (#901) — remembered,
+   *  so the reboot a Stop performs comes back with the heap the user asked for. */
+  async init(onOutput: (chunk: Uint8Array) => void, heapBytes?: number): Promise<void> {
     this.onOutput = onOutput
+    this.heapBytes = heapBytes
     await this.spawn()
   }
 
@@ -54,7 +59,7 @@ export class WorkerMicroPythonRuntime {
       this.readyResolve = res
       this.readyReject = rej
     })
-    worker.postMessage({ type: 'init' })
+    worker.postMessage({ type: 'init', heapBytes: this.heapBytes })
     return ready
   }
 

--- a/src/shared/sim-memory.ts
+++ b/src/shared/sim-memory.ts
@@ -1,0 +1,133 @@
+/**
+ * SIMULATED-DEVICE MEMORY — how much heap the virtual board boots with (#901).
+ * =============================================================================
+ *
+ * The simulator runs the official MicroPython WebAssembly port, and
+ * `loadMicroPython()` accepts a `heapsize` which it hands straight to
+ * `mp_js_init(pystack, heapsize)` — so the GC heap the interpreter starts with
+ * IS ours to choose. That is the knob this module describes.
+ *
+ * What it is NOT — and the UI says so, because getting this wrong would be worse
+ * than having no setting at all:
+ *
+ *  - **It is a starting heap, not a ceiling.** This build auto-grows the GC heap
+ *    (MicroPython's split-heap auto mode): when an allocation doesn't fit, the
+ *    GC mallocs another region and the NEXT attempt succeeds. Measured against
+ *    the bundled 1.28.0 build with a 64 KB heap, `bytearray(300*1024)` raises
+ *    MemoryError on the first try and then succeeds on the second, third and
+ *    fourth — growing well past the configured size. So a small heap reproduces
+ *    the *first-allocation* failure a tight board gives you, but it will not
+ *    starve a program that allocates gradually, and it cannot make the simulator
+ *    run out of memory the way real hardware does.
+ *
+ *  - **It is not what `gc.mem_free()` reports.** The WASM port reports the
+ *    linear memory's headroom (~128 MB) regardless of `heapsize`, so
+ *    `gc.mem_free()` on the simulator answers a different question than it does
+ *    on a board. Naming the configured heap in the dialog is what makes that
+ *    number explicable.
+ *
+ * Everything here is pure so the decisions are unit-tested without Electron, a
+ * DOM or a WebAssembly load.
+ */
+
+/** The MicroPython WASM port's own default heap (1 MB) — our default too. */
+export const SIM_HEAP_DEFAULT_BYTES = 1024 * 1024
+
+/** Smallest heap offered. It boots below this, but the REPL stops being usable. */
+export const SIM_HEAP_MIN_BYTES = 16 * 1024
+
+/** Largest heap offered. Past this the setting stops meaning anything useful. */
+export const SIM_HEAP_MAX_BYTES = 64 * 1024 * 1024
+
+/** A named starting heap, sized in the region of some real board's free RAM. */
+export interface SimHeapPreset {
+  id: string
+  label: string
+  bytes: number
+  /** What this is roughly like on real hardware — deliberately hedged. */
+  hint: string
+}
+
+/**
+ * The offered heaps. The hints say "roughly" and mean it: a board's free heap
+ * moves with its firmware build, and (per the note above) this is the heap the
+ * simulator STARTS with rather than a cap, so none of these is an emulation of
+ * the named board — just a comparable starting point.
+ */
+export const SIM_HEAP_PRESETS: readonly SimHeapPreset[] = [
+  {
+    id: 'esp8266',
+    label: 'Very tight — 32 KB',
+    bytes: 32 * 1024,
+    hint: 'Roughly an ESP8266. A big buffer fails on its first allocation.'
+  },
+  {
+    id: 'esp32',
+    label: 'Tight — 128 KB',
+    bytes: 128 * 1024,
+    hint: 'Roughly an ESP32 with its PSRAM switched off.'
+  },
+  {
+    id: 'pico',
+    label: 'Small — 192 KB',
+    bytes: 192 * 1024,
+    hint: 'Roughly a Pico / RP2040 after MicroPython has booted.'
+  },
+  {
+    id: 'default',
+    label: 'Default — 1 MB',
+    bytes: SIM_HEAP_DEFAULT_BYTES,
+    hint: "The MicroPython WASM port's own default. Nothing fails for size."
+  },
+  {
+    id: 'psram',
+    label: 'Roomy — 8 MB',
+    bytes: 8 * 1024 * 1024,
+    hint: 'Roughly an ESP32 with its PSRAM working.'
+  }
+] as const
+
+/**
+ * Coerce anything (a corrupt localStorage value, a half-typed number field) into
+ * a heap size the interpreter will accept: a whole number of KB inside the
+ * offered range. Garbage falls back to the default rather than throwing — a bad
+ * stored value must never stop the simulator booting.
+ */
+export function clampSimHeapBytes(value: unknown): number {
+  const n = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(n) || n <= 0) return SIM_HEAP_DEFAULT_BYTES
+  // Whole KB — `mp_js_init` takes a byte count, but an odd byte figure in the UI
+  // reads as false precision for a number this approximate.
+  const kb = Math.round(n / 1024)
+  const bytes = kb * 1024
+  if (bytes < SIM_HEAP_MIN_BYTES) return SIM_HEAP_MIN_BYTES
+  if (bytes > SIM_HEAP_MAX_BYTES) return SIM_HEAP_MAX_BYTES
+  return bytes
+}
+
+/** Render a heap size the way the presets read: "192 KB", "1 MB", "1.5 MB". */
+export function formatSimHeap(bytes: number): string {
+  const mb = bytes / (1024 * 1024)
+  if (mb >= 1) {
+    // Trim a trailing ".0" so a round figure doesn't read as a measurement.
+    const text = mb.toFixed(1).replace(/\.0$/, '')
+    return `${text} MB`
+  }
+  return `${Math.round(bytes / 1024)} KB`
+}
+
+/** The preset a heap size corresponds to exactly, or null for a custom size. */
+export function simHeapPresetFor(bytes: number): SimHeapPreset | null {
+  return SIM_HEAP_PRESETS.find((p) => p.bytes === bytes) ?? null
+}
+
+/**
+ * Does the running interpreter still need restarting to pick `wanted` up?
+ *
+ * The heap is fixed at `mp_js_init`, so a change only lands when the interpreter
+ * is re-instantiated. `booted` is what the live simulator actually started with
+ * (null when nothing is running — then there is nothing to restart).
+ */
+export function simHeapNeedsRestart(booted: number | null, wanted: number): boolean {
+  return booted !== null && booted !== wanted
+}

--- a/test/simHeapRuntime.test.ts
+++ b/test/simHeapRuntime.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest'
+import { MicroPythonRuntime } from '../src/main/device/MicroPythonRuntime'
+import { SimulatedDevice } from '../src/main/device/SimulatedDevice'
+import type { ReplRuntime } from '../src/main/device/MicroPythonRuntime'
+import { SIM_HEAP_DEFAULT_BYTES } from '../src/shared/sim-memory'
+
+/**
+ * The simulated board's heap setting, against the REAL interpreter (#901).
+ *
+ * These load MicroPython for real (in the worker the vitest globalSetup
+ * compiles), because the whole question the issue asks — "if the wasm allows
+ * it" — can only be answered by the interpreter itself. Asserting on a mock
+ * would prove we send a message, not that the heap changes.
+ *
+ * What is asserted is deliberately narrow, and matches what the WASM build
+ * actually does: with a small heap a large allocation fails on its FIRST
+ * attempt, and with the default heap the same allocation succeeds. It is not
+ * asserted that the small heap caps total memory — it does not. The build grows
+ * its heap on demand, so the retry succeeds; that is exactly why the dialog
+ * calls this a starting heap rather than a limit.
+ */
+
+/** Ask the interpreter to make one big allocation, and report what happened. */
+const tryBigAlloc = async (rt: MicroPythonRuntime): Promise<string> =>
+  rt.runCaptured(
+    [
+      'try:',
+      '    _b = bytearray(600 * 1024)',
+      '    print("ALLOCATED")',
+      '    del _b',
+      'except MemoryError:',
+      '    print("MEMORYERROR")'
+    ].join('\n')
+  )
+
+describe('simulated device heap (real WebAssembly)', () => {
+  it('a small starting heap makes a big first allocation fail', async () => {
+    const rt = new MicroPythonRuntime()
+    await rt.init(() => {}, 64 * 1024)
+    expect(await tryBigAlloc(rt)).toContain('MEMORYERROR')
+    rt.dispose()
+  }, 30000)
+
+  it('the default heap lets the same allocation through', async () => {
+    const rt = new MicroPythonRuntime()
+    await rt.init(() => {}, SIM_HEAP_DEFAULT_BYTES)
+    expect(await tryBigAlloc(rt)).toContain('ALLOCATED')
+    rt.dispose()
+  }, 30000)
+
+  it('a small heap still boots a usable REPL, machine module and all', async () => {
+    // A tight heap must not cost the lesson-critical `from machine import Pin`
+    // — the sim seeds that stub at boot, and it allocates.
+    const rt = new MicroPythonRuntime()
+    const out: Buffer[] = []
+    await rt.init((c) => out.push(c), 64 * 1024)
+    await rt.feed('from machine import Pin\rp = Pin(25, Pin.OUT)\rp.on()\rprint("pinval", p.value())\r')
+    await new Promise((r) => setTimeout(r, 120))
+    const text = Buffer.concat(out).toString('utf8')
+    expect(text).toContain('pinval 1')
+    expect(text).not.toContain('ImportError')
+    rt.dispose()
+  }, 30000)
+
+  it('the Stop reboot brings the SAME heap back, not the default', async () => {
+    // Stop terminates and re-spawns the worker; if the heap were only passed on
+    // the first spawn, one Stop would silently hand the user a 1 MB board back.
+    const rt = new MicroPythonRuntime()
+    await rt.init(() => {}, 64 * 1024)
+    const running = rt.feed('\x05import time\r\nwhile True:\r\n    time.sleep_ms(20)\r\n\x04').catch(() => undefined)
+    await new Promise((r) => setTimeout(r, 400))
+    await rt.interrupt() // busy → reboot
+    await running
+    expect(await tryBigAlloc(rt)).toContain('MEMORYERROR')
+    rt.dispose()
+  }, 30000)
+})
+
+/** Records what heap the device asked its runtime to boot with. */
+class RecordingRuntime implements ReplRuntime {
+  heapBytes: number | undefined
+  async init(_onOutput: (chunk: Buffer) => void, heapBytes?: number): Promise<void> {
+    this.heapBytes = heapBytes
+  }
+  async feed(): Promise<void> {}
+  async runCaptured(): Promise<string> {
+    return ''
+  }
+  async runStream(): Promise<void> {}
+  async interrupt(): Promise<void> {}
+  dispose(): void {}
+}
+
+describe('SimulatedDevice memory setting', () => {
+  it('boots the interpreter with the configured heap', async () => {
+    const runtime = new RecordingRuntime()
+    const dev = new SimulatedDevice(runtime)
+    dev.setMemory(128 * 1024)
+    await dev.connect()
+    expect(runtime.heapBytes).toBe(128 * 1024)
+    await dev.disconnect()
+  })
+
+  it('defaults to the WASM port’s own 1 MB heap', async () => {
+    const runtime = new RecordingRuntime()
+    const dev = new SimulatedDevice(runtime)
+    await dev.connect()
+    expect(runtime.heapBytes).toBe(SIM_HEAP_DEFAULT_BYTES)
+    await dev.disconnect()
+  })
+
+  it('clamps a nonsense setting rather than passing it to mp_js_init', async () => {
+    const runtime = new RecordingRuntime()
+    const dev = new SimulatedDevice(runtime)
+    dev.setMemory(-1)
+    await dev.connect()
+    expect(runtime.heapBytes).toBe(SIM_HEAP_DEFAULT_BYTES)
+    await dev.disconnect()
+  })
+
+  it('reports configured vs booted, so the UI knows a restart is owed', async () => {
+    const dev = new SimulatedDevice(new RecordingRuntime())
+    expect(dev.getMemory()).toEqual({ configured: SIM_HEAP_DEFAULT_BYTES, booted: null })
+
+    dev.setMemory(192 * 1024)
+    await dev.connect()
+    expect(dev.getMemory()).toEqual({ configured: 192 * 1024, booted: 192 * 1024 })
+
+    // Changing it while connected must NOT claim the live interpreter moved.
+    dev.setMemory(32 * 1024)
+    expect(dev.getMemory()).toEqual({ configured: 32 * 1024, booted: 192 * 1024 })
+
+    await dev.disconnect()
+    expect(dev.getMemory()).toEqual({ configured: 32 * 1024, booted: null })
+  })
+})

--- a/test/simMemory.test.ts
+++ b/test/simMemory.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+import {
+  clampSimHeapBytes,
+  formatSimHeap,
+  simHeapNeedsRestart,
+  simHeapPresetFor,
+  SIM_HEAP_DEFAULT_BYTES,
+  SIM_HEAP_MAX_BYTES,
+  SIM_HEAP_MIN_BYTES,
+  SIM_HEAP_PRESETS
+} from '../src/shared/sim-memory'
+
+/**
+ * The simulated board's heap decisions (#901) — pure, so they're tested without
+ * Electron, a DOM or a WebAssembly load.
+ */
+
+describe('clampSimHeapBytes', () => {
+  it('keeps a sensible size untouched', () => {
+    expect(clampSimHeapBytes(192 * 1024)).toBe(192 * 1024)
+  })
+
+  it('clamps to the offered range at both ends', () => {
+    expect(clampSimHeapBytes(1)).toBe(SIM_HEAP_MIN_BYTES)
+    expect(clampSimHeapBytes(SIM_HEAP_MAX_BYTES * 4)).toBe(SIM_HEAP_MAX_BYTES)
+  })
+
+  it('rounds to whole KB, so the UI never shows false precision', () => {
+    expect(clampSimHeapBytes(100_500)).toBe(98 * 1024)
+  })
+
+  it('falls back to the default for anything unusable — a corrupt stored value must never stop the sim booting', () => {
+    for (const bad of [NaN, Infinity, -1, 0, null, undefined, 'nonsense', {}, []]) {
+      expect(clampSimHeapBytes(bad)).toBe(SIM_HEAP_DEFAULT_BYTES)
+    }
+  })
+
+  it('accepts a numeric string (what a number input hands back)', () => {
+    expect(clampSimHeapBytes('196608')).toBe(192 * 1024)
+  })
+})
+
+describe('formatSimHeap', () => {
+  it('reads in KB below a megabyte and MB above', () => {
+    expect(formatSimHeap(32 * 1024)).toBe('32 KB')
+    expect(formatSimHeap(192 * 1024)).toBe('192 KB')
+    expect(formatSimHeap(1024 * 1024)).toBe('1 MB')
+    expect(formatSimHeap(8 * 1024 * 1024)).toBe('8 MB')
+  })
+
+  it('keeps one decimal for a size between the two', () => {
+    expect(formatSimHeap(1536 * 1024)).toBe('1.5 MB')
+  })
+})
+
+describe('SIM_HEAP_PRESETS', () => {
+  it('every preset is inside the offered range and survives clamping', () => {
+    for (const preset of SIM_HEAP_PRESETS) {
+      expect(preset.bytes).toBeGreaterThanOrEqual(SIM_HEAP_MIN_BYTES)
+      expect(preset.bytes).toBeLessThanOrEqual(SIM_HEAP_MAX_BYTES)
+      expect(clampSimHeapBytes(preset.bytes)).toBe(preset.bytes)
+    }
+  })
+
+  it('offers the WASM port’s own default, so "put it back" is one click', () => {
+    expect(SIM_HEAP_PRESETS.some((p) => p.bytes === SIM_HEAP_DEFAULT_BYTES)).toBe(true)
+  })
+
+  it('hedges every hardware comparison — none of these emulates the named board', () => {
+    for (const preset of SIM_HEAP_PRESETS) {
+      if (/ESP|Pico|RP2040/i.test(preset.hint)) expect(preset.hint).toMatch(/Roughly/)
+    }
+  })
+})
+
+describe('simHeapPresetFor', () => {
+  it('finds the preset for an exact size', () => {
+    expect(simHeapPresetFor(SIM_HEAP_DEFAULT_BYTES)?.id).toBe('default')
+  })
+
+  it('returns null for a custom size', () => {
+    expect(simHeapPresetFor(123 * 1024)).toBeNull()
+  })
+})
+
+describe('simHeapNeedsRestart', () => {
+  it('is false when nothing is running — there is nothing to restart', () => {
+    expect(simHeapNeedsRestart(null, 32 * 1024)).toBe(false)
+  })
+
+  it('is false when the live interpreter already has the wanted heap', () => {
+    expect(simHeapNeedsRestart(192 * 1024, 192 * 1024)).toBe(false)
+  })
+
+  it('is true when the live interpreter booted with a different heap', () => {
+    // The heap is fixed at mp_js_init, so this can only be resolved by a restart.
+    expect(simHeapNeedsRestart(1024 * 1024, 32 * 1024)).toBe(true)
+  })
+})

--- a/test/simMemoryDialog.test.tsx
+++ b/test/simMemoryDialog.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { SimMemoryDialog } from '../src/renderer/src/components/SimMemoryDialog'
+import { SIM_HEAP_DEFAULT_BYTES, SIM_HEAP_PRESETS } from '../src/shared/sim-memory'
+
+/**
+ * The simulated-device memory dialog rendered to static HTML (#901) — vitest
+ * runs in node, and SSR markup is what the browser mounts.
+ *
+ * The assertions that matter are the honest ones: the dialog has to say that the
+ * heap is a starting size rather than a cap, and that `gc.mem_free()` doesn't
+ * report it. Someone tidying this copy up should have to update a test.
+ */
+
+const html = (node: Parameters<typeof renderToStaticMarkup>[0]): string =>
+  renderToStaticMarkup(node)
+
+const render = (over: Partial<Parameters<typeof SimMemoryDialog>[0]> = {}): string =>
+  html(
+    <SimMemoryDialog
+      value={SIM_HEAP_DEFAULT_BYTES}
+      booted={null}
+      onSave={() => {}}
+      onSaveAndRestart={() => {}}
+      onClose={() => {}}
+      {...over}
+    />
+  )
+
+describe('SimMemoryDialog', () => {
+  it('offers every preset, with the current one selected', () => {
+    const out = render({ value: 192 * 1024 })
+    for (const preset of SIM_HEAP_PRESETS) expect(out).toContain(preset.label)
+    expect(out).toContain('simmem__preset--on')
+  })
+
+  it('says the heap is a starting size, not a limit', () => {
+    const out = render()
+    expect(out).toContain('starting heap, not a limit')
+    expect(out).toContain('grows its heap on demand')
+  })
+
+  it('explains that gc.mem_free() does not report this number', () => {
+    // Without this the setting looks broken the first time anyone checks it.
+    const out = render()
+    expect(out).toContain('gc.mem_free()')
+    expect(out).toContain('128')
+  })
+
+  it('when the simulator is not running: saving is the whole action', () => {
+    const out = render({ booted: null })
+    expect(out).toContain('will start with this heap')
+    expect(out).toContain('>Save<')
+    expect(out).not.toContain('Save and restart simulator')
+  })
+
+  it('when the live heap already matches: no restart is offered', () => {
+    const out = render({ value: 192 * 1024, booted: 192 * 1024 })
+    expect(out).toContain('running with 192 KB')
+    expect(out).not.toContain('Save and restart simulator')
+  })
+
+  it('when the live heap differs: offers a restart and warns it clears the files', () => {
+    const out = render({ value: 32 * 1024, booted: 1024 * 1024 })
+    expect(out).toContain('Save and restart simulator')
+    expect(out).toContain('running with 1 MB')
+    expect(out).toContain('clears its files')
+  })
+
+  it('is a labelled modal dialog', () => {
+    const out = render()
+    expect(out).toContain('role="dialog"')
+    expect(out).toContain('aria-modal="true"')
+    expect(out).toContain('aria-labelledby="simmem-title"')
+  })
+})


### PR DESCRIPTION
Closes #901

The issue said *"if the wasm allows it"*. It half does — and the half it doesn't is the part worth being careful about, so I checked before designing the control.

## Does the WASM allow it? Yes for the heap, no for a cap

**How I established it.** Read the actual API in `node_modules/@micropython/micropython-webassembly-pyscript/micropython.mjs` (v1.28.0-6), then ran the interpreter against it rather than trusting the signature.

`loadMicroPython()` destructures `{pystack, heapsize, url, stdin, stdout, stderr, linebuffer, romfs}` (defaults `pystack: 2048`, `heapsize: 1048576`) and ends with:

```js
Module.ccall("mp_js_init", "null", ["number","number"], [pystack, heapsize])
```

So the heap really is passed to `mp_js_init`. Neither backend was passing it, so both ran on the port's 1 MB default.

**But it is a starting heap, not a ceiling.** Measured, booting the real interpreter at `heapsize: 64 * 1024` and retrying the same allocation:

```
attempt 0 MemoryError
attempt 1 OK   mem_alloc 308288
attempt 2 OK   mem_alloc 615504
attempt 3 OK   mem_alloc 922720
```

The build grows its heap on demand (MicroPython's split-heap auto mode): the allocation that just failed succeeds on retry, and keeps growing well past the configured size. Allocating in 8 KB chunks reached 4 MB on a "64 KB" heap; an unbounded version of that loop ran until I killed it. So **no setting here can make the simulator run out of memory the way an ESP32 does** — a small heap reproduces a tight board's *first* allocation failure and nothing more.

**And `gc.mem_free()` doesn't report it.** Straight after boot, with nothing allocated:

| `heapsize` | `gc.mem_free()` |
| --- | --- |
| 16 KB | 134,233,152 |
| 64 KB | 134,280,768 |
| 1 MB | 135,234,048 |
| 16 MB | 150,486,080 |

It reports the WebAssembly linear memory's headroom (~128 MB) regardless. That is exactly the thing the issue's fallback plan was about, so naming the configured heap in the dialog is what makes that number explicable.

I also checked `pystack`, the other memory-ish knob, and left it alone: it caps recursion depth (1024 → 100 frames, 2048 → 155) but 8192 also gives 155, so above a low threshold MicroPython's own limit binds instead. Not a useful memory control.

## What I built

A cog beside the port dropdown in the console, shown when the **selected** port is the simulator — selected rather than connected, because the setting concerns the next boot and has to be reachable before connecting.

- Presets in the region of an ESP8266 (32 KB), an ESP32 with PSRAM off (128 KB), a Pico (192 KB), the WASM default (1 MB) and a board with PSRAM (8 MB), plus a custom KB field. Every hint says "roughly" — none of these emulates the named board, and a test enforces that hedge.
- **The dialog states both limits above in its body**, not in a tooltip. A memory setting that quietly failed to bound memory would be worse than no setting, which is why this is prose in the UI rather than only in the PR.
- Applying costs a restart (the heap is fixed at `mp_js_init`), so the primary button becomes **"Save and restart simulator"** only when the live interpreter is on a different heap, and the status line warns that restarting clears the simulator's files — exactly as Stop does. Nothing silently pretends to apply to a running session.

Plumbed through both backends — desktop (`SimulatedDevice` → `MicroPythonRuntime` → `mp-node-worker`) and web (`web-device` → `worker-runtime` → `mp.worker`). Both runtimes **remember** the heap rather than taking it per-spawn, because Stop is terminate-and-respawn: without that, one Stop would quietly hand back a 1 MB board. `SimulatedDevice` tracks `configured` vs `booted` so the UI can tell honestly whether a restart is still owed.

## Tests

`test/simHeapRuntime.test.ts` loads MicroPython **for real** (via the existing worker harness) — "does the wasm allow it" cannot be answered by asserting we posted a message. It covers the small heap failing a big first allocation, the default heap allowing it, a tight heap still booting a usable REPL with `from machine import Pin`, and the Stop reboot coming back on the *same* heap. It deliberately does **not** assert that a small heap caps total memory, because it doesn't. Plus pure-logic tests (`simMemory.test.ts`) and SSR markup tests that pin the honest copy (`simMemoryDialog.test.tsx`).

**Verified each test fails without the change**, then restored:

- dropping `heapsize` from the worker → the small-heap and Stop-reboot cases fail (`expected 'ALLOCATED' to contain 'MEMORYERROR'`);
- removing the clamp → `clamps to the offered range at both ends` fails;
- softening the "starting heap, not a limit" copy → its dialog test fails.

## Gates

`npm run lint` (only the pre-existing `DriverInstallBanner.tsx` warning), `npm run typecheck`, `npm test` (297 files, 6132 tests), `npm run build` — all green, re-run after rebasing onto current master. `CHANGELOG.md` under `[Unreleased]`; no `package.json` bump.

## Found but not fixed

- Both themes are handled via tokens only, but I could not exercise the dialog in a running app — this environment is headless and tests are `environment: 'node'`. The markup and tokens are verified; the visual result isn't.
- The simulator's `gc.mem_free()` remains misleading in the REPL itself. Explaining it in the dialog is the honest minimum; actually making it report the configured heap would need a patched WASM build, which is a much larger piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe
