### PR TITLE
Say when the board is busy, and let the user step aside (#889)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **The board says when it is busy, and you can get out of its way** (#889).
+  Installing a driver or copying a folder now shows a progress dialog — and that
+  dialog can be pushed aside so the app stays usable while the work runs on.
+  Closing it no longer means losing sight of the board: a sync glyph in the
+  status bar takes over, counting the steps left, and its popup lists what is
+  running with a **Stop** for the whole queue. It reappears on its own for work
+  you have not seen yet, and always for a failure, so dismissing it once cannot
+  hide the board from you for good. The Device Files panel grows a striped
+  hazard bar while files are being written, because a tree quietly changing
+  under you is worse than a slow one.
+
 ### Fixed
 
 - **The recommended firmware build is now reachable for the boards that need it**

--- a/src/renderer/src/components/DeviceFileTree.css
+++ b/src/renderer/src/components/DeviceFileTree.css
@@ -209,3 +209,44 @@
   outline-offset: -1.5px;
   background: color-mix(in srgb, var(--accent, #4ea1ff) 10%, transparent);
 }
+
+/* --- "the board is busy" hazard bar (#889) ---------------------------------
+ *
+ * Asked for explicitly: something unmistakable in the Device Files area while
+ * files are being written, because the modal can now be pushed aside (#889) and
+ * a silent tree that is quietly changing under you is worse than a slow one.
+ *
+ * Diagonal hazard stripes in the panel's own accent rather than literal yellow
+ * and black: the panel is a themed surface, and a saturated warning bar reads as
+ * an ERROR when nothing is wrong — the board is working, which is normal. The
+ * stripes carry the "do not touch this yet" meaning on their own.
+ *
+ * The animation is decorative, so it goes for anyone who asked for less motion;
+ * the bar itself stays, because the bar is the message.
+ */
+.devicetree__busy {
+  flex: 0 0 auto;
+  height: 4px;
+  background-image: repeating-linear-gradient(
+    45deg,
+    var(--accent) 0,
+    var(--accent) 6px,
+    transparent 6px,
+    transparent 12px
+  );
+  background-size: 17px 100%;
+  background-color: var(--bg-sunken);
+  animation: devicetree-hazard 0.6s linear infinite;
+}
+
+@keyframes devicetree-hazard {
+  to {
+    background-position: 17px 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .devicetree__busy {
+    animation: none;
+  }
+}

--- a/src/renderer/src/components/DeviceFileTree.tsx
+++ b/src/renderer/src/components/DeviceFileTree.tsx
@@ -1,10 +1,13 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState,
+  useSyncExternalStore
+} from 'react'
 import type { DirEntry } from '../../../preload/index.d'
 import { useFileSelection } from '../store/file-selection'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { bootRoleFor, type BootRole } from './run-controls'
 import { useWorkspace } from '../store/workspace'
 import { useSync } from '../store/sync'
+import { getDeviceQueueSnapshot, subscribeDeviceQueue } from '../lib/device-queue'
 import { usageLabel, usedPct, type DiskUsage } from './disk-usage'
 import { ContextMenu, type ContextMenuItem, type ContextMenuPosition } from './ContextMenu'
 import { iconProps, NewFileIcon, NewFolderIcon, RefreshIcon } from './file-tree-icons'
@@ -223,6 +226,13 @@ export function DeviceFileTree(): JSX.Element {
     setSyncOnSave,
     syncNow
   } = useSync()
+  // The board is being written to (#889). The modal can be pushed aside, so the
+  // tree says so itself — these are the files that are changing.
+  const queueBusy = useSyncExternalStore(
+    subscribeDeviceQueue,
+    () => getDeviceQueueSnapshot().busy,
+    () => getDeviceQueueSnapshot().busy
+  )
 
   // The loaded listings, flat (#219): path → entries, always including ROOT.
   const [dirs, setDirs] = useState<Map<string, DirEntry[]>>(new Map())
@@ -745,6 +755,13 @@ export function DeviceFileTree(): JSX.Element {
           </button>
         </div>
       </div>
+      {queueBusy && (
+        <div
+          className="devicetree__busy"
+          role="status"
+          aria-label="The board is busy — files are being written"
+        />
+      )}
 
       {/* No inline Rename/Delete bar: rename + delete live on the right-click
           context menu, and every row has a hover trashcan. */}

--- a/src/renderer/src/components/DeviceQueueDialog.tsx
+++ b/src/renderer/src/components/DeviceQueueDialog.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState, useSyncExternalStore } from 'react'
 import {
   cancelDeviceQueue,
   dismissDeviceQueue,
+  highestTaskId,
+  stayHidden,
   getDeviceQueueSnapshot,
   queueDialogAction,
   queueProgress,
@@ -42,6 +44,12 @@ export function DeviceQueueDialog(): JSX.Element | null {
     getDeviceQueueSnapshot
   )
   const [onScreen, setOnScreen] = useState(false)
+  /**
+   * The highest task id the user has pushed aside (#889). New work, or any
+   * failure, lapses it — see {@link stayHidden}.
+   */
+  const [hiddenThroughId, setHiddenThroughId] = useState<number | null>(null)
+  const hidden = stayHidden(snap, hiddenThroughId)
   const action = queueDialogAction(snap, onScreen)
 
   useEffect(() => {
@@ -63,7 +71,9 @@ export function DeviceQueueDialog(): JSX.Element | null {
     return () => clearTimeout(t)
   }, [action])
 
-  if (!onScreen || snap.tasks.length === 0) return null
+  // Pushed aside and nothing new since. The board is still working, and the
+  // status-bar indicator is what says so from here.
+  if (hidden || !onScreen || snap.tasks.length === 0) return null
 
   return (
     <TransferProgressDialog
@@ -73,7 +83,13 @@ export function DeviceQueueDialog(): JSX.Element | null {
       running={snap.busy}
       error={snap.error}
       onCancel={cancelDeviceQueue}
-      onClose={dismissDeviceQueue}
+      onClose={() => {
+        // Close means two different things depending on whether the board is
+        // still working: tidy away a finished run, or step out of the way of one
+        // that is still going. Both are "I am done looking at this".
+        if (snap.busy) setHiddenThroughId(highestTaskId(snap.tasks))
+        else dismissDeviceQueue()
+      }}
     />
   )
 }

--- a/src/renderer/src/components/SyncIndicator.css
+++ b/src/renderer/src/components/SyncIndicator.css
@@ -169,3 +169,27 @@
 .syncind__err {
   color: var(--danger);
 }
+
+/* --- Stop, for the device queue (#889) ------------------------------------- */
+
+.syncind__stop {
+  align-self: flex-start;
+  padding: 0.2rem 0.6rem;
+  background: var(--bg-sunken);
+  color: var(--danger);
+  border: var(--border-w) solid var(--border);
+  border-radius: var(--radius);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.syncind__stop:hover {
+  background: var(--bg-elevated);
+  border-color: var(--danger);
+}
+
+.syncind__stop:focus-visible {
+  outline: var(--border-w) solid var(--danger);
+  outline-offset: 2px;
+}

--- a/src/renderer/src/components/SyncIndicator.tsx
+++ b/src/renderer/src/components/SyncIndicator.tsx
@@ -1,5 +1,11 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react'
 import { useSync, type SyncedFile } from '../store/sync'
+import {
+  cancelDeviceQueue,
+  getDeviceQueueSnapshot,
+  queueProgress,
+  subscribeDeviceQueue
+} from '../lib/device-queue'
 import './SyncIndicator.css'
 
 /**
@@ -21,6 +27,15 @@ import './SyncIndicator.css'
  * meaning nothing. When files are tagged but sync-on-save is off it renders
  * dimmed, because "3 files tagged, none of them syncing on save" is exactly the
  * state that catches people out.
+ *
+ * It also reports the DEVICE OPERATION QUEUE (#889). Installing a driver or
+ * copying a folder puts a modal up, but that modal can now be pushed aside so
+ * the app stays usable — and the moment it is, something has to keep saying the
+ * board is busy. This is that something: it outranks the sync state while work
+ * is running, counts the steps, and offers a Stop, so the queue is never
+ * invisible and never unstoppable. One glyph rather than two adjacent ones,
+ * because from where the user sits "something is happening to my board" is a
+ * single question.
  */
 
 /** Two opposing arrows. A 12px status-bar-scale sibling of the device tree's
@@ -69,6 +84,13 @@ export function syncSummary(syncOnSave: boolean, files: SyncedFile[]): string {
   return `File sync is on — ${done} of ${total} on the board`
 }
 
+/** The summary line while the board is working (#889). */
+export function busySummary(count: number): string {
+  return count === 1
+    ? 'Working on the board — 1 operation'
+    : `Working on the board — ${count} operations`
+}
+
 /** How long the popup survives the pointer leaving, so the gap between the
  *  button and the popup is crossable. */
 const HOVER_GRACE_MS = 160
@@ -99,6 +121,11 @@ function anchorTo(el: HTMLElement | null): Anchor | null {
 
 export function SyncIndicator(): JSX.Element | null {
   const { syncOnSave, status, syncedFiles } = useSync()
+  const queue = useSyncExternalStore(
+    subscribeDeviceQueue,
+    getDeviceQueueSnapshot,
+    getDeviceQueueSnapshot
+  )
   const [open, setOpen] = useState(false)
   const [anchor, setAnchor] = useState<Anchor | null>(null)
   const btnRef = useRef<HTMLButtonElement | null>(null)
@@ -149,13 +176,19 @@ export function SyncIndicator(): JSX.Element | null {
     }
   }, [open])
 
-  // Nothing tagged and sync off — there is nothing to report, so report nothing.
-  if (!syncOnSave && syncedFiles.length === 0) return null
+  const live = queue.tasks.filter((t) => t.state === 'running' || t.state === 'waiting')
+  const busy = queue.busy && live.length > 0
 
-  const done = syncedFiles.filter((f) => f.state === 'done').length
-  const total = syncedFiles.length
-  const mode = syncMode(syncOnSave, syncedFiles, status)
-  const summary = syncSummary(syncOnSave, syncedFiles)
+  // Nothing tagged, sync off, board idle — nothing to report, so report nothing.
+  if (!busy && !syncOnSave && syncedFiles.length === 0) return null
+
+  const work = queueProgress(live)
+  const done = busy ? work.done : syncedFiles.filter((f) => f.state === 'done').length
+  const total = busy ? work.total : syncedFiles.length
+  // Board activity outranks sync state: a running install is the more urgent
+  // fact, and it is the one the user cannot otherwise see once the modal is gone.
+  const mode = busy ? 'syncing' : syncMode(syncOnSave, syncedFiles, status)
+  const summary = busy ? busySummary(live.length) : syncSummary(syncOnSave, syncedFiles)
 
   return (
     <div
@@ -194,7 +227,30 @@ export function SyncIndicator(): JSX.Element | null {
         >
           <p className="syncind__summary">{summary}</p>
 
-          {total === 0 ? (
+          {busy && (
+            <>
+              <ul className="syncind__list">
+                {live.map((t) => (
+                  <li
+                    key={t.id}
+                    className={`syncind__row syncind__row--${t.state === 'running' ? 'syncing' : 'pending'}`}
+                  >
+                    <span className="syncind__tick" aria-hidden="true">
+                      {t.state === 'running' ? '\u25b8' : '\u2610'}
+                    </span>
+                    <span className="syncind__name" title={t.label}>
+                      {t.label}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+              <button type="button" className="syncind__stop" onClick={cancelDeviceQueue}>
+                Stop
+              </button>
+            </>
+          )}
+
+          {total === 0 && !busy ? (
             <p className="syncind__empty">
               Tick a file or folder in Local files to keep it in sync.
             </p>

--- a/src/renderer/src/lib/device-queue.ts
+++ b/src/renderer/src/lib/device-queue.ts
@@ -346,6 +346,35 @@ export function queueTitle(tasks: readonly DeviceTaskView[]): string {
 }
 
 /**
+ * Should the modal stay out of the way after the user pushed it aside (#889)?
+ *
+ * Dismissing used to mean "clear the finished rows", which did nothing while
+ * work was still running — the modal simply stayed up, and a five-minute folder
+ * copy held the app hostage. The user asked to be able to close it and carry on,
+ * with the status bar keeping the board's activity visible.
+ *
+ * So a dismissal is remembered as the highest task id it covered, and it lapses
+ * on its own two ways: NEW work re-opens the modal (the user pushed aside the
+ * copy they knew about, not the install they have not seen yet), and a FAILURE
+ * always re-opens it, because an error nobody saw did not happen.
+ */
+export function stayHidden(
+  snap: DeviceQueueSnapshot,
+  hiddenThroughId: number | null
+): boolean {
+  if (hiddenThroughId === null) return false
+  if (snap.error) return false
+  return !snap.tasks.some((t) => t.id > hiddenThroughId)
+}
+
+/** The highest task id currently on the queue — what a dismissal covers. */
+export function highestTaskId(tasks: readonly DeviceTaskView[]): number | null {
+  let top: number | null = null
+  for (const t of tasks) if (top === null || t.id > top) top = t.id
+  return top
+}
+
+/**
  * What the modal should do about the current snapshot, given whether it is
  * already on screen. Pure, so the timing rules are testable without a DOM.
  *

--- a/test/deviceBusyIndicator.test.ts
+++ b/test/deviceBusyIndicator.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import {
+  highestTaskId,
+  stayHidden,
+  type DeviceQueueSnapshot,
+  type DeviceTaskView
+} from '../src/renderer/src/lib/device-queue'
+import { busySummary } from '../src/renderer/src/components/SyncIndicator'
+
+/**
+ * Saying that the board is busy, without holding the app hostage (#889).
+ *
+ * The queue (#837) put a modal up and kept it up: `dismissDeviceQueue` only
+ * cleared FINISHED rows, so closing it during a five-minute folder copy did
+ * nothing at all. The ask was to be able to step out of the way and carry on,
+ * with the busy state still visible somewhere — and to be able to stop the
+ * queue from there.
+ *
+ * The risk in "let them hide it" is obvious: hide it once and never hear about
+ * the board again. These pin the two rules that stop that happening.
+ */
+
+const task = (id: number, state: DeviceTaskView['state'] = 'running'): DeviceTaskView => ({
+  id,
+  key: `k${id}`,
+  label: `Task ${id}`,
+  state,
+  steps: []
+})
+
+const snap = (tasks: DeviceTaskView[], error: string | null = null): DeviceQueueSnapshot => ({
+  tasks,
+  busy: tasks.some((t) => t.state === 'running' || t.state === 'waiting'),
+  error
+})
+
+describe('pushing the modal aside', () => {
+  it('stays out of the way for the work that was pushed aside', () => {
+    expect(stayHidden(snap([task(1), task(2)]), 2)).toBe(true)
+  })
+
+  it('comes back for work the user has not seen', () => {
+    // They dismissed the folder copy they knew about. The driver install that
+    // started afterwards is a different thing and has to announce itself.
+    expect(stayHidden(snap([task(1), task(2), task(3)]), 2)).toBe(false)
+  })
+
+  it('comes back on a failure, always', () => {
+    // An error nobody saw did not happen, as far as the user is concerned.
+    expect(stayHidden(snap([task(1)], 'device is full'), 5)).toBe(false)
+  })
+
+  it('does nothing when the user never dismissed anything', () => {
+    expect(stayHidden(snap([task(1)]), null)).toBe(false)
+  })
+
+  it('a dismissal covers everything queued at the time, not just the running one', () => {
+    // Three queued, one running: dismissing means "all of this", or the modal
+    // reappears the instant the second one starts.
+    const tasks = [task(1), task(2, 'waiting'), task(3, 'waiting')]
+    expect(highestTaskId(tasks)).toBe(3)
+    expect(stayHidden(snap(tasks), highestTaskId(tasks))).toBe(true)
+  })
+
+  it('reads the highest id, not the last one added', () => {
+    expect(highestTaskId([task(7), task(2), task(5)])).toBe(7)
+    expect(highestTaskId([])).toBeNull()
+  })
+})
+
+describe('what the status bar says while the board works', () => {
+  it('counts the operations, with the singular right', () => {
+    expect(busySummary(1)).toBe('Working on the board — 1 operation')
+    expect(busySummary(3)).toBe('Working on the board — 3 operations')
+  })
+})
+
+describe('the indicator', () => {
+  const src = readFileSync('src/renderer/src/components/SyncIndicator.tsx', 'utf8')
+
+  it('appears while the board is busy even with nothing tagged', () => {
+    // The old guard returned null unless sync was on or something was tagged —
+    // which is most users, most of the time, including during an install.
+    expect(src).toContain('if (!busy && !syncOnSave && syncedFiles.length === 0) return null')
+  })
+
+  it('lets board activity outrank the sync state', () => {
+    // A running install is the more urgent fact, and the one the user cannot
+    // otherwise see once the modal has been pushed aside.
+    expect(src).toContain('busy ? \'syncing\' : syncMode(')
+    expect(src).toContain('busy ? busySummary(live.length) : syncSummary(')
+  })
+
+  it('offers a Stop, so the queue is never unstoppable from here', () => {
+    expect(src).toContain('onClick={cancelDeviceQueue}')
+  })
+
+  it('counts the queue steps, not the tagged files, while busy', () => {
+    expect(src).toContain('const work = queueProgress(live)')
+  })
+})
+
+describe('the device tree hazard bar', () => {
+  const tsx = readFileSync('src/renderer/src/components/DeviceFileTree.tsx', 'utf8')
+  const css = readFileSync('src/renderer/src/components/DeviceFileTree.css', 'utf8')
+
+  it('shows only while the board is being written to', () => {
+    expect(tsx).toContain('{queueBusy && (')
+    expect(tsx).toContain('devicetree__busy')
+  })
+
+  it('says what it means to a screen reader', () => {
+    // Stripes carry nothing without sight.
+    expect(tsx).toMatch(/aria-label="The board is busy[^"]*"/)
+  })
+
+  it('takes its colour from the theme, not from a literal hazard yellow', () => {
+    const rule = css.slice(css.indexOf('.devicetree__busy {'), css.indexOf('@keyframes devicetree-hazard'))
+    expect(rule).toContain('var(--accent)')
+    expect(rule).not.toMatch(/#[0-9a-f]{3,8}\b/i)
+  })
+
+  it('drops the animation for anyone who asked for less motion, keeping the bar', () => {
+    // The bar is the message; the movement is decoration.
+    const reduced = css.slice(css.indexOf('@media (prefers-reduced-motion: reduce)', css.indexOf('.devicetree__busy')))
+    expect(reduced).toContain('animation: none')
+    expect(reduced).not.toContain('display: none')
+  })
+})


### PR DESCRIPTION
Closes #889. **Replaces #891**, auto-closed when its base (#878) was deleted on merge — same work, replayed onto master.

## Most of #889 was already delivered by #878

The progress dialog, per-file steps, working cancel, and overlapping operations queued rather than racing. I checked before building rather than writing a second version. Two things it did **not** do turned out to be the important ones.

## 1. The modal could not be dismissed

`dismissDeviceQueue` only clears *finished* rows. Press Close during a five-minute folder copy and nothing happens — the live tasks remain, so the dialog is immediately shown again. The app was held hostage by its own progress dialog, which is the opposite of the "balance background copying with usability" the issue asks for.

Close now steps aside while work runs. Two rules stop that becoming *dismiss once, never hear about the board again*:

- **New work reopens it.** The user pushed aside the copy they knew about, not the driver install that started afterwards.
- **A failure always reopens it.** An error nobody saw did not happen.

## 2. Nothing said "busy" once the modal was gone

The issue suggested using the sync popup, which is the right call — so the status-bar glyph from #863 now reports board activity as well as sync tags:

- it appears while the board is working **even with nothing tagged**, which is most people most of the time (the old guard returned `null` unless sync was on);
- **board activity outranks sync state** — a running install is the more urgent fact, and the one you cannot otherwise see;
- the popup lists what is running, with a **Stop** for the whole queue.

One glyph rather than two adjacent ones: from where the user sits, "something is happening to my board" is a single question.

## 3. The hazard bar

Asked for explicitly, and now that the modal can be dismissed it earns its place — a tree quietly changing under you is worse than a slow one.

Themed stripes rather than literal hazard yellow: the board working is *normal*, and a saturated warning bar reads as an error when nothing is wrong. It carries an `aria-label`, because stripes say nothing without sight, and the animation drops under `prefers-reduced-motion` while the bar stays — the bar is the message.

## Not done, deliberately

**Byte-level progress.** The issue asks for it "ideally". `FsEntry` carries no size, so a byte-accurate bar means a `stat` round trip for every file in the tree before a single one is copied. `folder-transfer.ts` already documents that trade-off and reports per file; I kept it.

## Tests

15. I broke the two dangerous regressions and confirmed each failed for its own reason: making `stayHidden` return true unconditionally, and restoring the old visibility guard.

Gates re-run after the replay onto master: lint ok · typecheck ok · tests ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe