### PR TITLE
Minimise the copy dialog to the status bar, and back (#890)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Minimise the copy dialog to the status bar, and bring it back** (#890). A
+  folder copy or a driver install can be put away with **Minimise** — which sits
+  beside Cancel rather than replacing it, because "give me my app back" and
+  "stop touching my board" are different wishes. The sync popup then carries a
+  maximise control in its top-left corner to bring the dialog back. The popup
+  itself is now the same dark panel with white text the flash dialog uses:
+  taking its colours from the theme was correct by the rules and hard to read in
+  practice, since on the light skin it became brushed-metal grey under near-black
+  type, floating over a status bar that is itself elevated. Row states get strong
+  distinct colours — amber in flight, green arrived, red failed.
+
 - **The board says when it is busy, and you can get out of its way** (#889).
   Installing a driver or copying a folder now shows a progress dialog — and that
   dialog can be pushed aside so the app stays usable while the work runs on.

--- a/src/renderer/src/components/DeviceQueueDialog.tsx
+++ b/src/renderer/src/components/DeviceQueueDialog.tsx
@@ -2,8 +2,7 @@ import { useEffect, useState, useSyncExternalStore } from 'react'
 import {
   cancelDeviceQueue,
   dismissDeviceQueue,
-  highestTaskId,
-  stayHidden,
+  minimiseDeviceQueue,
   getDeviceQueueSnapshot,
   queueDialogAction,
   queueProgress,
@@ -44,12 +43,8 @@ export function DeviceQueueDialog(): JSX.Element | null {
     getDeviceQueueSnapshot
   )
   const [onScreen, setOnScreen] = useState(false)
-  /**
-   * The highest task id the user has pushed aside (#889). New work, or any
-   * failure, lapses it — see {@link stayHidden}.
-   */
-  const [hiddenThroughId, setHiddenThroughId] = useState<number | null>(null)
-  const hidden = stayHidden(snap, hiddenThroughId)
+  // Minimised state is the QUEUE's now, not this component's (#890): the round
+  // trip has two ends, and the status-bar popup owns the other one.
   const action = queueDialogAction(snap, onScreen)
 
   useEffect(() => {
@@ -71,9 +66,10 @@ export function DeviceQueueDialog(): JSX.Element | null {
     return () => clearTimeout(t)
   }, [action])
 
-  // Pushed aside and nothing new since. The board is still working, and the
-  // status-bar indicator is what says so from here.
-  if (hidden || !onScreen || snap.tasks.length === 0) return null
+  // Minimised and nothing new since. The board is still working, and the
+  // status-bar indicator is what says so from here — with a maximise that
+  // brings this back.
+  if (snap.minimised || !onScreen || snap.tasks.length === 0) return null
 
   return (
     <TransferProgressDialog
@@ -83,11 +79,12 @@ export function DeviceQueueDialog(): JSX.Element | null {
       running={snap.busy}
       error={snap.error}
       onCancel={cancelDeviceQueue}
+      minimiseLabel={snap.busy ? 'Minimise' : undefined}
       onClose={() => {
         // Close means two different things depending on whether the board is
-        // still working: tidy away a finished run, or step out of the way of one
-        // that is still going. Both are "I am done looking at this".
-        if (snap.busy) setHiddenThroughId(highestTaskId(snap.tasks))
+        // still working: tidy away a finished run, or minimise one that is still
+        // going. Both are "I am done looking at this".
+        if (snap.busy) minimiseDeviceQueue()
         else dismissDeviceQueue()
       }}
     />

--- a/src/renderer/src/components/SyncIndicator.css
+++ b/src/renderer/src/components/SyncIndicator.css
@@ -84,24 +84,58 @@
   min-width: 14rem;
   max-width: 26rem;
   padding: 0.45rem 0.55rem;
-  background: var(--bg-elevated);
-  color: var(--text);
-  border: var(--border-w) solid var(--border);
+  /* DARK IN BOTH THEMES, deliberately (#890) — the same #1f2430 panel and
+     #f4f6f8 ink the flash dialog uses, and for the same reason.
+     `--bg-elevated`/`--text` made this correct-by-the-rules and hard to read in
+     practice: on the skeuomorph skin it became brushed-metal grey under
+     near-black 0.72rem type, over a status bar that is itself elevated, so the
+     whole popup had almost no separation from what was behind it. A floating
+     readout wants maximum contrast, not theme continuity — it is a thing on top
+     of the app, not part of its surface. Every colour below is therefore this
+     popup's own; see FirmwareFlasher.css for the same decision. */
+  background: #1f2430;
+  color: #f4f6f8;
+  border: 1px solid rgba(255, 255, 255, 0.14);
   border-radius: var(--radius);
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.55);
   font-size: 0.72rem;
   cursor: default;
 }
 
 .syncind__summary {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
   margin: 0;
-  color: var(--text);
+  color: #f4f6f8;
   font-weight: 600;
+}
+
+/* Maximise, top-left of the popup (#890). */
+.syncind__max {
+  flex: 0 0 auto;
+  padding: 0 0.25rem;
+  background: none;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 3px;
+  color: #f4f6f8;
+  font: inherit;
+  line-height: 1.3;
+  cursor: pointer;
+}
+
+.syncind__max:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.syncind__max:focus-visible {
+  outline: 2px solid #8fbfff;
+  outline-offset: 1px;
 }
 
 .syncind__empty {
   margin: 0;
-  color: var(--text-muted);
+  color: #c7ccd4;
 }
 
 .syncind__list {
@@ -122,19 +156,22 @@
   align-items: baseline;
   gap: 0.4rem;
   padding: 0.1rem 0;
-  color: var(--text-muted);
+  color: #a8aeb8;
 }
 
 .syncind__row--done {
-  color: var(--text);
+  color: #f4f6f8;
 }
 
+/* Strong, distinct states (#890): amber for in-flight, green for arrived, red
+   for failed — each chosen against the #1f2430 panel rather than inherited from
+   a theme that knows nothing about it. */
 .syncind__row--syncing {
-  color: var(--accent);
+  color: #e7bf62;
 }
 
 .syncind__row--error {
-  color: var(--danger);
+  color: #ff9b8a;
 }
 
 .syncind__tick {
@@ -144,7 +181,7 @@
 }
 
 .syncind__row--done .syncind__tick {
-  color: var(--accent-2);
+  color: #6fdc9b;
 }
 
 .syncind__name {
@@ -162,12 +199,12 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: var(--text-muted);
+  color: #a8aeb8;
   font-size: 0.68rem;
 }
 
 .syncind__err {
-  color: var(--danger);
+  color: #ff9b8a;
 }
 
 /* --- Stop, for the device queue (#889) ------------------------------------- */
@@ -175,9 +212,9 @@
 .syncind__stop {
   align-self: flex-start;
   padding: 0.2rem 0.6rem;
-  background: var(--bg-sunken);
-  color: var(--danger);
-  border: var(--border-w) solid var(--border);
+  background: rgba(255, 255, 255, 0.06);
+  color: #ff9b8a;
+  border: 1px solid rgba(255, 155, 138, 0.5);
   border-radius: var(--radius);
   font: inherit;
   font-weight: 600;
@@ -185,11 +222,11 @@
 }
 
 .syncind__stop:hover {
-  background: var(--bg-elevated);
-  border-color: var(--danger);
+  background: rgba(255, 155, 138, 0.16);
+  border-color: #ff9b8a;
 }
 
 .syncind__stop:focus-visible {
-  outline: var(--border-w) solid var(--danger);
+  outline: 2px solid #ff9b8a;
   outline-offset: 2px;
 }

--- a/src/renderer/src/components/SyncIndicator.tsx
+++ b/src/renderer/src/components/SyncIndicator.tsx
@@ -4,6 +4,7 @@ import {
   cancelDeviceQueue,
   getDeviceQueueSnapshot,
   queueProgress,
+  restoreDeviceQueue,
   subscribeDeviceQueue
 } from '../lib/device-queue'
 import './SyncIndicator.css'
@@ -225,7 +226,23 @@ export function SyncIndicator(): JSX.Element | null {
           aria-label="Files kept in sync with the board"
           style={anchor ? { right: `${anchor.right}px`, bottom: `${anchor.bottom}px` } : undefined}
         >
-          <p className="syncind__summary">{summary}</p>
+          <p className="syncind__summary">
+            {/* Top-left, as asked (#890), and only when the dialog was minimised
+                — offering "maximise" with nothing to restore would be a button
+                that does nothing. */}
+            {queue.minimised && (
+              <button
+                type="button"
+                className="syncind__max"
+                onClick={restoreDeviceQueue}
+                title="Show the copy progress again"
+                aria-label="Show the copy progress again"
+              >
+                <span aria-hidden="true">{'\u2197'}</span>
+              </button>
+            )}
+            {summary}
+          </p>
 
           {busy && (
             <>

--- a/src/renderer/src/components/TransferProgressDialog.tsx
+++ b/src/renderer/src/components/TransferProgressDialog.tsx
@@ -31,6 +31,13 @@ export interface TransferProgressDialogProps {
   onClose: () => void
   /** Ask the running transfer to stop after the current file. */
   onCancel: () => void
+  /**
+   * Label for the close button while work is still running (#890). The device
+   * queue passes "Minimise", because there it puts the dialog into the status
+   * bar rather than ending anything — calling that "Close" would read as
+   * "stop", which is the button next to it.
+   */
+  minimiseLabel?: string
 }
 
 /** How long a finished, successful transfer stays on screen before closing. */
@@ -58,6 +65,7 @@ export function TransferProgressDialog({
   running,
   error,
   onClose,
+  minimiseLabel,
   onCancel
 }: TransferProgressDialogProps): JSX.Element {
   const done = progress ? progress.done : rows.filter((r) => r.state === 'done').length
@@ -146,9 +154,24 @@ export function TransferProgressDialog({
 
         <div className="transfer__actions">
           {running ? (
-            <button type="button" className="transfer__btn" onClick={onCancel}>
-              Cancel
-            </button>
+            <>
+              {/* Minimise sits BESIDE Cancel, never instead of it: "I want my
+                  app back" and "stop touching my board" are different wishes,
+                  and a dialog that offered only the second would make the first
+                  cost the transfer (#890). */}
+              {minimiseLabel && (
+                <button
+                  type="button"
+                  className="transfer__btn transfer__btn--primary"
+                  onClick={onClose}
+                >
+                  {minimiseLabel}
+                </button>
+              )}
+              <button type="button" className="transfer__btn" onClick={onCancel}>
+                Cancel
+              </button>
+            </>
           ) : (
             <button type="button" className="transfer__btn transfer__btn--primary" onClick={onClose}>
               Close

--- a/src/renderer/src/lib/device-queue.ts
+++ b/src/renderer/src/lib/device-queue.ts
@@ -64,6 +64,12 @@ export interface DeviceQueueSnapshot {
   busy: boolean
   /** The first failure still on the list; keeps the modal open. */
   error: string | null
+  /**
+   * The user has minimised the dialog to the status bar (#890). Shared state
+   * rather than the dialog's own, because the round trip has two ends: the
+   * dialog puts it away, and the status-bar popup brings it back.
+   */
+  minimised: boolean
 }
 
 /** What a task's `run` is handed so it can report progress and notice a cancel. */
@@ -116,7 +122,7 @@ let entries: Entry[] = []
 let chain: Promise<void> = Promise.resolve()
 const listeners = new Set<() => void>()
 
-let snapshot: DeviceQueueSnapshot = { tasks: [], busy: false, error: null }
+let snapshot: DeviceQueueSnapshot = { tasks: [], busy: false, error: null, minimised: false }
 
 function view(entry: Entry): DeviceTaskView {
   return {
@@ -129,13 +135,40 @@ function view(entry: Entry): DeviceTaskView {
   }
 }
 
+/** The highest task id the user has minimised away, or null. See {@link stayHidden}. */
+let minimisedThroughId: number | null = null
+
 function emit(): void {
-  snapshot = {
-    tasks: entries.map(view),
+  const tasks = entries.map(view)
+  const error = entries.find((e) => e.state === 'error')?.error ?? null
+  const next: DeviceQueueSnapshot = {
+    tasks,
     busy: entries.some((e) => e.state === 'running' || e.state === 'waiting'),
-    error: entries.find((e) => e.state === 'error')?.error ?? null
+    error,
+    minimised: false
   }
+  next.minimised = stayHidden(next, minimisedThroughId)
+  // A lapsed minimise (new work, or a failure) is forgotten outright, so the
+  // next Close starts from a clean slate rather than an id nobody remembers.
+  if (!next.minimised) minimisedThroughId = null
+  snapshot = next
   for (const l of listeners) l()
+}
+
+/**
+ * Put the dialog away while its work carries on (#890). The status-bar
+ * indicator is what reports the board from here, and its maximise control is
+ * what brings this back.
+ */
+export function minimiseDeviceQueue(): void {
+  minimisedThroughId = highestTaskId(snapshot.tasks)
+  emit()
+}
+
+/** Bring the dialog back — the status bar's maximise (#890). */
+export function restoreDeviceQueue(): void {
+  minimisedThroughId = null
+  emit()
 }
 
 /** Settle the caller's promise exactly once, whatever else happens to the entry. */
@@ -266,6 +299,7 @@ export function getDeviceQueueSnapshot(): DeviceQueueSnapshot {
 
 /** Test seam — empty the queue and drop the chain, listeners intact. */
 export function resetDeviceQueueForTest(): void {
+  minimisedThroughId = null
   entries = []
   chain = Promise.resolve()
   emit()
@@ -364,6 +398,11 @@ export function stayHidden(
 ): boolean {
   if (hiddenThroughId === null) return false
   if (snap.error) return false
+  // An empty queue is not "hidden", it is finished. Without this the flag
+  // survives the work it was hiding — `some()` over no tasks is false, so the
+  // snapshot kept reporting `minimised: true` after everything drained, and the
+  // popup grew a maximise button with nothing behind it to restore.
+  if (snap.tasks.length === 0) return false
   return !snap.tasks.some((t) => t.id > hiddenThroughId)
 }
 

--- a/test/deviceBusyIndicator.test.ts
+++ b/test/deviceBusyIndicator.test.ts
@@ -32,7 +32,8 @@ const task = (id: number, state: DeviceTaskView['state'] = 'running'): DeviceTas
 const snap = (tasks: DeviceTaskView[], error: string | null = null): DeviceQueueSnapshot => ({
   tasks,
   busy: tasks.some((t) => t.state === 'running' || t.state === 'waiting'),
-  error
+  error,
+  minimised: false
 })
 
 describe('pushing the modal aside', () => {
@@ -126,5 +127,114 @@ describe('the device tree hazard bar', () => {
     const reduced = css.slice(css.indexOf('@media (prefers-reduced-motion: reduce)', css.indexOf('.devicetree__busy')))
     expect(reduced).toContain('animation: none')
     expect(reduced).not.toContain('display: none')
+  })
+})
+
+/**
+ * Minimise and maximise the copy dialog (#890).
+ *
+ * #889 let the dialog be pushed aside, but the state lived inside the dialog —
+ * so nothing else could bring it back, and "minimise" was really just a
+ * one-way hide. Moving it onto the queue gives the round trip two ends: the
+ * dialog puts it away, the status-bar popup fetches it back.
+ */
+describe('the minimise round trip', () => {
+  it('is queue state, so both ends can reach it', async () => {
+    const q = await import('../src/renderer/src/lib/device-queue')
+    expect(typeof q.minimiseDeviceQueue).toBe('function')
+    expect(typeof q.restoreDeviceQueue).toBe('function')
+    expect(q.getDeviceQueueSnapshot()).toHaveProperty('minimised')
+  })
+
+  it('minimising an empty queue leaves nothing minimised', async () => {
+    const q = await import('../src/renderer/src/lib/device-queue')
+    q.resetDeviceQueueForTest()
+    q.minimiseDeviceQueue()
+    // Nothing to hide, so `highestTaskId` is null and the flag must not stick —
+    // otherwise the NEXT operation would open minimised.
+    expect(q.getDeviceQueueSnapshot().minimised).toBe(false)
+  })
+
+  it('stops being minimised once the work has drained', async () => {
+    // `some()` over an empty list is false, so the flag outlived the tasks it
+    // was hiding — and the popup then offered a maximise with nothing behind it.
+    expect(stayHidden(snap([]), 5)).toBe(false)
+  })
+
+  it('restoring clears it', async () => {
+    const q = await import('../src/renderer/src/lib/device-queue')
+    q.resetDeviceQueueForTest()
+    q.restoreDeviceQueue()
+    expect(q.getDeviceQueueSnapshot().minimised).toBe(false)
+  })
+})
+
+describe('the dialog offers Minimise beside Cancel, not instead of it', () => {
+  const dlg = readFileSync('src/renderer/src/components/TransferProgressDialog.tsx', 'utf8')
+  const queue = readFileSync('src/renderer/src/components/DeviceQueueDialog.tsx', 'utf8')
+
+  it('shows both while work is running', () => {
+    // "I want my app back" and "stop touching my board" are different wishes.
+    // A dialog offering only the second makes the first cost the transfer.
+    expect(dlg).toContain('{minimiseLabel && (')
+    expect(dlg).toContain('Cancel')
+  })
+
+  it('only calls it Minimise where it actually minimises', () => {
+    // A folder copy from the Files panel closes for real; the queue minimises.
+    expect(queue).toContain("minimiseLabel={snap.busy ? 'Minimise' : undefined}")
+  })
+
+  it('minimises rather than dismissing while busy', () => {
+    expect(queue).toContain('if (snap.busy) minimiseDeviceQueue()')
+  })
+
+  it('hides on the queue’s own flag, not a local copy', () => {
+    expect(queue).toContain('if (snap.minimised ||')
+  })
+})
+
+describe('the popup can bring the dialog back', () => {
+  const src = readFileSync('src/renderer/src/components/SyncIndicator.tsx', 'utf8')
+
+  it('offers maximise, top-left, only when there is something to restore', () => {
+    expect(src).toContain('{queue.minimised && (')
+    expect(src).toContain('onClick={restoreDeviceQueue}')
+  })
+
+  it('names the control for a screen reader', () => {
+    expect(src).toMatch(/aria-label="Show the copy progress again"/)
+  })
+})
+
+describe('the popup reads clearly (#890)', () => {
+  const css = readFileSync('src/renderer/src/components/SyncIndicator.css', 'utf8')
+  const popup = css.slice(css.indexOf('.syncind__popup {'), css.indexOf('/* --- Stop'))
+
+  it('uses the app’s dark panel and white ink, not the theme surface', () => {
+    // `--bg-elevated` over a status bar that is itself elevated left almost no
+    // separation, and on the skeuomorph skin put near-black 0.72rem type on
+    // brushed metal. A floating readout wants contrast, not continuity.
+    expect(popup).toContain('background: #1f2430')
+    expect(popup).toContain('color: #f4f6f8')
+  })
+
+  it('takes no foreground from the theme inside the popup', () => {
+    expect(popup).not.toContain('var(--text)')
+    expect(popup).not.toContain('var(--text-muted)')
+    expect(popup).not.toContain('var(--danger)')
+  })
+
+  it('keeps the status-bar GLYPH on theme tokens', () => {
+    // The glyph sits IN the status bar, which is a themed surface — it should
+    // match its surroundings, unlike the popup that floats above them.
+    const btn = css.slice(css.indexOf('.syncind__btn--on'), css.indexOf('.syncind__btn--syncing'))
+    expect(btn).toContain('var(--')
+  })
+
+  it('gives each row state its own strong colour', () => {
+    for (const c of ['#e7bf62', '#6fdc9b', '#ff9b8a']) {
+      expect(css, c).toContain(c)
+    }
   })
 })

--- a/test/deviceQueue.test.ts
+++ b/test/deviceQueue.test.ts
@@ -239,6 +239,7 @@ describe('when the modal should appear', () => {
     tasks: [task()],
     busy: true,
     error: null,
+    minimised: false,
     ...over
   })
 


### PR DESCRIPTION
Closes #890. **Replaces #892**, auto-closed when its base (#889) was deleted on merge — same work, replayed onto master.

## Minimise / maximise

#889 let the dialog be pushed aside, but the state lived inside the dialog component — nothing else could reach it, so "minimise" was really a one-way hide. The round trip has two ends, so the state moves onto the queue: the dialog puts it away, the status-bar popup fetches it back.

**Minimise sits beside Cancel, never instead of it.** "Give me my app back" and "stop touching my board" are different wishes, and a dialog offering only the second makes the first cost you the transfer. It is only labelled *Minimise* where it actually minimises — a plain folder copy from the Files panel still closes for real.

The popup gets a maximise control in its **top-left**, as asked, shown only while there is a dialog to restore.

## A bug this exposed in #889

Moving the flag onto the queue surfaced something worth naming. `stayHidden` asked whether any task outranked the minimised id — and `some()` over an empty list is `false`, so the flag **outlived the work it was hiding**. Once everything drained the snapshot still reported `minimised: true`, and the popup would have offered a maximise button with nothing behind it.

An empty queue isn't hidden, it's finished. Fixed, with a test that fails without it. I found it by checking whether a defensive line I'd written was reachable — it wasn't, and the reason it wasn't was the bug.

## The popup restyle

Taking its colours from the theme was correct by the rules and hard to read in practice: on the skeuomorph skin `--bg-elevated` became brushed-metal grey under near-black 0.72rem type, floating over a status bar that is *itself* elevated. It now uses the same `#1f2430` panel and `#f4f6f8` ink as the flash dialog, with row states in strong distinct colours — amber in flight, green arrived, red failed.

**The status-bar glyph keeps its theme tokens.** It sits *in* the status bar rather than above it, so there it should match its surroundings. There's a test pinning that distinction, because it's the sort of thing a future tidy-up would "fix" in the wrong direction.

## Tests

29 in the file, 14 new. I broke the stale-flag fix and confirmed only its own test failed, and confirmed the earlier #889 regressions still bite.

Gates re-run after the replay onto master: lint ok · typecheck ok · tests ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe