### PR TITLE
The Board Finder gallery, and its hand-off to the flash dialog (#893)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **A Board Finder, and the firmware picker finally knows every board** (#893).
+  The picker showed Thonny's catalogue, which lists no Adafruit boards at all
+  and no ESP32 variants — which is how an ESP32 Feather V2 ends up running a
+  build with its 2 MB of PSRAM switched off. Snakie now carries its own index,
+  generated from what MicroPython actually publishes: **225 boards from 54
+  manufacturers**, each with its photo, chip, features, the variants named and
+  described in upstream's own words, and the builds that exist. Open it from
+  **Board Finder**, beside Detect board in the flash dialog, and filter by
+  manufacturer, processor or features — or just search. Pick a board and the
+  dialog fills itself in, newest MicroPython selected, with the flash offset
+  taken from the figure the board itself publishes rather than one inferred from
+  its chip. The index is refreshed daily and is not tied to a Snakie release, so
+  a board added upstream shows up without waiting for an update; the full
+  catalogue ships with the app, so it works with no network at all.
+
+### Added
+
 - **Board Finder — a gallery of every board MicroPython builds for** (#893). The
   firmware picker showed Thonny's catalogue, which carries no Adafruit boards and
   no ESP32 variants; **Board Finder** in the status bar, beside Flash firmware,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Board Finder — a gallery of every board MicroPython builds for** (#893). The
+  firmware picker showed Thonny's catalogue, which carries no Adafruit boards and
+  no ESP32 variants; **Board Finder** in the status bar, beside Flash firmware,
+  opens all 225 boards from 54 vendors as a photo gallery, built like the parts
+  catalog and popped out with the same corner-bracket icon. Filter by
+  manufacturer, processor and features, search across all of it, or hide the
+  three boards that publish no firmware. Open a board and you get upstream's own
+  description of each **variant** — the thing a picker cannot infer, and the
+  thing that gets flashed wrong — plus its builds, its specification and a link
+  to the vendor's page. Clicking through hands the flasher the board with the
+  newest build already chosen.
+
+  The issue also asked to filter by storage and memory, and that is deliberately
+  absent: MicroPython's index publishes `External Flash` and `External RAM` as
+  yes/no and no figure anywhere, so a size filter could only have drawn itself by
+  quietly dropping most of the catalogue. They stay as ordinary feature chips, and
+  a board's details say plainly that the size is not published rather than leaving
+  you to guess whether the absence means zero.
+
 - **Minimise the copy dialog to the status bar, and bring it back** (#890). A
   folder copy or a driver install can be put away with **Minimise** — which sits
   beside Cancel rather than replacing it, because "give me my app back" and

--- a/src/renderer/src/components/BoardFinder.css
+++ b/src/renderer/src/components/BoardFinder.css
@@ -1,0 +1,645 @@
+/*
+ * Board Finder (#893, epic #884) — the full-screen board gallery.
+ *
+ * A sibling of the Parts Catalog (`pcat__`), with one deliberate difference: the
+ * catalog paints itself a fixed light "shop" surface, while this is ordinary
+ * panel chrome and takes every colour from the theme tokens, so it reads
+ * correctly on the parchment skin and the dark one alike. Unique `bfind__` BEM
+ * prefix — this CSS is global, so a shared prefix would collide.
+ */
+
+.bfind {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  align-items: stretch;
+  justify-content: stretch;
+  font-family: var(--font-ui), system-ui, sans-serif;
+  color: var(--head, var(--text));
+}
+
+.bfind__backdrop {
+  position: absolute;
+  inset: 0;
+  /* Theme-neutral: a dim over whatever is behind, in either skin. */
+  background: rgba(15, 20, 18, 0.55);
+  backdrop-filter: blur(2px);
+}
+
+.bfind__panel {
+  position: relative;
+  margin: 24px;
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--panel, var(--bg-elevated));
+  border: 1px solid var(--shellbd, var(--border));
+  border-radius: 16px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+  overflow: hidden;
+}
+
+/* Grow out of the control that opened it, the way the parts catalog does. */
+@keyframes bfind-grow {
+  from {
+    opacity: 0;
+    transform: scale(0.86);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+@keyframes bfind-shrink {
+  from {
+    opacity: 1;
+    transform: scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: scale(0.86);
+  }
+}
+.bfind__panel.is-growing {
+  transform-origin: var(--bfind-ox, 50%) var(--bfind-oy, 50%);
+  animation: bfind-grow 0.22s ease-out both;
+}
+.bfind__panel.is-closing {
+  transform-origin: var(--bfind-ox, 50%) var(--bfind-oy, 50%);
+  animation: bfind-shrink 0.2s ease-in both;
+  pointer-events: none;
+}
+@media (prefers-reduced-motion: reduce) {
+  .bfind__panel.is-growing,
+  .bfind__panel.is-closing {
+    animation: none;
+  }
+}
+
+/* --- header --------------------------------------------------------------- */
+
+.bfind__head {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 16px;
+  background: var(--shell, var(--bg-sunken));
+  border-bottom: 1px solid var(--shellbd, var(--border));
+}
+
+.bfind__title {
+  font-size: 16px;
+  font-weight: 800;
+  letter-spacing: 0.01em;
+  color: var(--head, var(--text));
+}
+
+/* What the catalogue is and how old it is — quiet, but it answers "is this
+   stale?" without a click. */
+.bfind__meta {
+  font-size: 11px;
+  color: var(--txt3, var(--text-muted));
+  font-family: var(--font-mono), monospace;
+}
+
+.bfind__search {
+  width: 260px;
+  max-width: 40vw;
+  height: 32px;
+  padding: 0 10px;
+  font-family: var(--font-ui), sans-serif;
+  font-size: 13px;
+  color: var(--head, var(--text));
+  background: var(--card, var(--bg-elevated));
+  border: 1px solid var(--shellbd, var(--border));
+  border-radius: var(--radius);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.08);
+  outline: none;
+}
+.bfind__search:focus {
+  border-color: var(--green, var(--accent));
+}
+.bfind__search::placeholder {
+  color: var(--txt4, var(--text-muted));
+}
+
+.bfind__spacer {
+  flex: 1 1 auto;
+}
+
+.bfind__count {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--txt2, var(--text-muted));
+}
+
+.bfind__close {
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  font-size: 15px;
+  color: var(--head, var(--text));
+  background: var(--card, var(--bg-elevated));
+  border: 1px solid var(--shellbd, var(--border));
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+.bfind__close:hover {
+  border-color: var(--txt4, var(--text-muted));
+}
+
+/* --- body ----------------------------------------------------------------- */
+
+.bfind__body {
+  flex: 1 1 auto;
+  display: flex;
+  min-height: 0;
+}
+
+.bfind__sidebar {
+  width: 232px;
+  flex: 0 0 auto;
+  overflow-y: auto;
+  padding: 14px;
+  background: var(--shell, var(--bg-sunken));
+  border-right: 1px solid var(--shellbd, var(--border));
+}
+
+.bfind__facet {
+  margin-bottom: 16px;
+}
+
+.bfind__facet-name {
+  margin: 0 0 6px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--txt3, var(--text-muted));
+}
+
+.bfind__select {
+  width: 100%;
+  height: 30px;
+  padding: 0 8px;
+  font-family: var(--font-ui), sans-serif;
+  font-size: 12px;
+  color: var(--head, var(--text));
+  background: var(--card, var(--bg-elevated));
+  border: 1px solid var(--shellbd, var(--border));
+  border-radius: var(--radius);
+  cursor: pointer;
+  outline: none;
+}
+.bfind__select:focus {
+  border-color: var(--green, var(--accent));
+}
+
+.bfind__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.bfind__chip {
+  font-family: var(--font-ui), sans-serif;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--txt2, var(--text-muted));
+  background: var(--card, var(--bg-elevated));
+  border: 1px solid var(--shellbd, var(--border));
+  border-radius: 999px;
+  padding: 3px 9px;
+  cursor: pointer;
+}
+.bfind__chip:hover {
+  border-color: var(--txt4, var(--text-muted));
+}
+.bfind__chip.is-on {
+  color: var(--greentext, var(--accent-ink));
+  background: var(--greenpill, var(--bg-sunken));
+  border-color: var(--green, var(--accent));
+}
+
+/* The "only boards with published firmware" switch — 3 of the 225 have none. */
+.bfind__toggle {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12px;
+  color: var(--txt2, var(--text-muted));
+  cursor: pointer;
+}
+.bfind__toggle input {
+  accent-color: var(--green, var(--accent));
+}
+
+.bfind__clear {
+  width: 100%;
+  font-family: var(--font-ui), sans-serif;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--head, var(--text));
+  background: var(--card, var(--bg-elevated));
+  border: 1px solid var(--shellbd, var(--border));
+  border-radius: var(--radius);
+  padding: 5px 8px;
+  cursor: pointer;
+}
+.bfind__clear:hover {
+  border-color: var(--txt4, var(--text-muted));
+}
+
+/* --- the grid ------------------------------------------------------------- */
+
+.bfind__shelves {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 16px 18px 28px;
+}
+
+.bfind__shelf {
+  margin-bottom: 22px;
+}
+
+.bfind__shelf-name {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 10px;
+  font-size: 13px;
+  font-weight: 800;
+  color: var(--head, var(--text));
+}
+
+.bfind__shelf-count {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--txt3, var(--text-muted));
+  background: var(--card, var(--bg-elevated));
+  border: 1px solid var(--shellbd, var(--border));
+  border-radius: 999px;
+  padding: 1px 8px;
+}
+
+.bfind__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(178px, 1fr));
+  gap: 12px;
+}
+
+.bfind__empty,
+.bfind__loading {
+  padding: 40px 8px;
+  text-align: center;
+  font-size: 13px;
+  color: var(--txt3, var(--text-muted));
+}
+
+/* --- a board card --------------------------------------------------------- */
+
+.bfind__card {
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+  padding: 0;
+  font: inherit;
+  color: var(--head, var(--text));
+  background: var(--card, var(--bg-elevated));
+  border: 1px solid var(--shellbd, var(--border));
+  border-radius: 12px;
+  overflow: hidden;
+  cursor: pointer;
+  transition:
+    border-color 0.14s ease,
+    transform 0.08s ease;
+}
+.bfind__card:hover {
+  border-color: var(--green, var(--accent));
+}
+.bfind__card:active {
+  transform: translateY(1px);
+}
+.bfind__card:focus-visible {
+  outline: 2px solid var(--accent, var(--green));
+  outline-offset: 2px;
+}
+
+.bfind__card-img {
+  aspect-ratio: 4 / 3;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  background: var(--bg-sunken, var(--shell));
+  border-bottom: 1px solid var(--shellbd, var(--border));
+}
+.bfind__card-img img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+/* A board with no thumbnail (8 of the 225) gets its initials, not a broken
+   image icon. */
+.bfind__noimg {
+  font-family: var(--font-mono), monospace;
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--txt4, var(--text-muted));
+}
+
+.bfind__card-body {
+  padding: 8px 10px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.bfind__card-vendor {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--txt3, var(--text-muted));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bfind__card-name {
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.25;
+  color: var(--head, var(--text));
+}
+
+.bfind__card-mcu {
+  font-family: var(--font-mono), monospace;
+  font-size: 11px;
+  color: var(--txt2, var(--text-muted));
+}
+
+.bfind__card-feats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 3px;
+}
+
+.bfind__feat {
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  color: var(--txt2, var(--text-muted));
+  background: var(--bg-sunken, var(--shell));
+  border: 1px solid var(--shellbd, var(--border));
+  border-radius: 4px;
+  padding: 1px 5px;
+}
+
+/* Says at a glance that this one cannot be flashed from here. */
+.bfind__card-nofw {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--warn, var(--accent-ink));
+}
+
+/* --- a board's details, over the grid ------------------------------------- */
+
+.bfind__details {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--panel, var(--bg-elevated));
+  animation: bfind-grow 0.18s ease-out both;
+}
+@media (prefers-reduced-motion: reduce) {
+  .bfind__details {
+    animation: none;
+  }
+}
+
+.bfind__det-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  background: var(--shell, var(--bg-sunken));
+  border-bottom: 1px solid var(--shellbd, var(--border));
+}
+
+.bfind__back {
+  font-family: var(--font-ui), sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--head, var(--text));
+  background: var(--card, var(--bg-elevated));
+  border: 1px solid var(--shellbd, var(--border));
+  border-radius: var(--radius);
+  padding: 5px 11px;
+  cursor: pointer;
+}
+.bfind__back:hover {
+  border-color: var(--txt4, var(--text-muted));
+}
+
+.bfind__det-title {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+.bfind__det-vendor {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--txt3, var(--text-muted));
+}
+.bfind__det-name {
+  font-size: 16px;
+  font-weight: 800;
+  color: var(--head, var(--text));
+}
+
+/* The primary action — the Soft Shell gold button, as elsewhere in the app. */
+.bfind__flash {
+  font-family: var(--font-ui), sans-serif;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--goldink, var(--accent-contrast));
+  background: var(--grad-gold, var(--accent));
+  border: none;
+  border-radius: var(--radius);
+  box-shadow: inset 0 1px 0 var(--pillinset, transparent);
+  padding: 9px 16px;
+  cursor: pointer;
+}
+.bfind__flash:hover:not(:disabled) {
+  filter: brightness(1.05);
+}
+.bfind__flash:disabled {
+  color: var(--txt4, var(--text-muted));
+  background: var(--card, var(--bg-elevated));
+  border: 1px solid var(--shellbd, var(--border));
+  box-shadow: none;
+  cursor: not-allowed;
+}
+
+.bfind__det-body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 18px 20px 28px;
+  display: grid;
+  grid-template-columns: minmax(220px, 320px) 1fr;
+  gap: 24px;
+  align-items: start;
+}
+@media (max-width: 760px) {
+  .bfind__det-body {
+    grid-template-columns: 1fr;
+  }
+}
+
+.bfind__det-img {
+  aspect-ratio: 4 / 3;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  background: var(--bg-sunken, var(--shell));
+  border: 1px solid var(--shellbd, var(--border));
+  border-radius: 12px;
+}
+.bfind__det-img img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.bfind__section {
+  margin-bottom: 20px;
+}
+
+.bfind__section-name {
+  margin: 0 0 8px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--txt3, var(--text-muted));
+}
+
+/* A dt/dd pair needs a wrapper to carry React's key, and that wrapper must not
+   become a grid cell itself — `contents` lets the pair land in the parent grid. */
+.bfind__row {
+  display: contents;
+}
+
+/* Facts — a definition list, because that is what it is. */
+.bfind__facts {
+  margin: 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 4px 14px;
+  font-size: 12.5px;
+}
+.bfind__facts dt {
+  font-weight: 700;
+  color: var(--txt2, var(--text-muted));
+}
+.bfind__facts dd {
+  margin: 0;
+  font-family: var(--font-mono), monospace;
+  color: var(--head, var(--text));
+}
+
+/* The honest footnote about what upstream does not publish. */
+.bfind__note {
+  margin: 8px 0 0;
+  font-size: 11.5px;
+  line-height: 1.5;
+  color: var(--txt3, var(--text-muted));
+}
+
+.bfind__variants {
+  margin: 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 5px 14px;
+  font-size: 12.5px;
+}
+.bfind__variants dt {
+  font-family: var(--font-mono), monospace;
+  font-weight: 700;
+  color: var(--accent-ink, var(--accent));
+}
+.bfind__variants dd {
+  margin: 0;
+  color: var(--txt2, var(--text-muted));
+}
+
+.bfind__builds {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.bfind__build {
+  display: flex;
+  align-items: baseline;
+  gap: 9px;
+  font-size: 12px;
+  padding: 6px 10px;
+  background: var(--card, var(--bg-elevated));
+  border: 1px solid var(--shellbd, var(--border));
+  border-radius: var(--radius);
+}
+
+.bfind__build-name {
+  font-family: var(--font-mono), monospace;
+  font-weight: 700;
+  color: var(--head, var(--text));
+}
+.bfind__build-ver {
+  font-family: var(--font-mono), monospace;
+  color: var(--txt2, var(--text-muted));
+}
+
+/* The one that a click on the board would actually flash. */
+.bfind__build-default {
+  margin-left: auto;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--greentext, var(--accent-ink));
+}
+
+.bfind__link {
+  font-size: 12.5px;
+  color: var(--accent-ink, var(--accent));
+  text-decoration: none;
+  border-bottom: 1px solid var(--shellbd, var(--border));
+}
+.bfind__link:hover {
+  border-bottom-color: var(--accent, var(--accent-ink));
+}
+
+.bfind__feats-big {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.bfind__feats-big .bfind__feat {
+  font-size: 11px;
+  padding: 3px 8px;
+}

--- a/src/renderer/src/components/BoardFinder.tsx
+++ b/src/renderer/src/components/BoardFinder.tsx
@@ -1,0 +1,534 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type JSX
+} from 'react'
+import {
+  featuresOf,
+  filterBoards,
+  mcusOf,
+  newestBuilds,
+  vendorsOf,
+  defaultBuild,
+  type BoardFilter,
+  type IndexedBoard
+} from '../../../shared/board-index'
+import { loadBoardIndex, thumbUrl } from '../lib/board-index-source'
+import {
+  boardFacts,
+  boardInitials,
+  buildLabel,
+  isFiltering,
+  shelvesByVendor,
+  toggleFeature,
+  variantList
+} from './board-finder'
+import { requestFlash } from './board-finder-bus'
+import './BoardFinder.css'
+
+/**
+ * BOARD FINDER (#893, epic #884) — the full-screen board gallery.
+ * =============================================================================
+ * Every board MicroPython builds for — 225 of them, 54 vendors — as a gallery
+ * with the filters that actually narrow it: vendor, MCU, features, and a search
+ * box. A sibling of the Parts Catalog (#613): same pop-out affordance, same
+ * shelves-then-flat-grid behaviour, same details-over-the-grid detour. It differs
+ * in taking its colours from the theme tokens rather than painting itself a fixed
+ * light surface, because this is panel chrome and follows the skin.
+ *
+ * Clicking a board asks the firmware flasher to open on it with the newest build
+ * already chosen — see `board-finder-bus.ts`, which is the whole of that seam.
+ *
+ * ON THE FILTERS. There is no storage or memory filter, though the issue asks
+ * for one: upstream publishes `External Flash` / `External RAM` as booleans and
+ * no figure anywhere, so a size control could only have drawn itself by quietly
+ * dropping most of the catalogue. They stay as ordinary feature chips, and the
+ * board's details state them plainly as present-with-no-published-size.
+ */
+
+export interface BoardFinderProps {
+  onClose: () => void
+  /** Viewport centre of the control that opened it, so it can grow out of it.
+   *  Absent means no animation rather than one from an arbitrary corner. */
+  origin?: { x: number; y: number } | null
+  /** Play the closing animation. The caller keeps this mounted until it hears
+   *  {@link onClosed} — unmounting on the click leaves nothing to animate. */
+  closing?: boolean
+  /** The shrink has finished; safe to unmount. */
+  onClosed?: () => void
+}
+
+/** How many feature chips the sidebar shows before "Show all". `featuresOf`
+ *  orders commonest-first, so the eight that lead are the ones worth offering;
+ *  the remaining nineteen tail off into single-board curiosities. */
+const FEATURE_CHIP_LIMIT = 8
+
+export function BoardFinder({ onClose, origin, closing, onClosed }: BoardFinderProps): JSX.Element {
+  // The panel is inset from the viewport, so the button's viewport position has
+  // to be re-expressed in the PANEL's own box before it can be a transform-origin
+  // — measured rather than assumed, so the two cannot drift apart.
+  const panelRef = useRef<HTMLDivElement>(null)
+  useLayoutEffect(() => {
+    const el = panelRef.current
+    if (!el || !origin) return
+    const r = el.getBoundingClientRect()
+    el.style.setProperty('--bfind-ox', `${origin.x - r.left}px`)
+    el.style.setProperty('--bfind-oy', `${origin.y - r.top}px`)
+  }, [origin])
+
+  const [boards, setBoards] = useState<IndexedBoard[] | null>(null)
+  const [generated, setGenerated] = useState('')
+  const [micropython, setMicropython] = useState('')
+
+  // The seed draws immediately; `onUpdate` fires only if a genuinely newer
+  // published document arrives, so there is no spinner to sit through.
+  useEffect(() => {
+    let live = true
+    void loadBoardIndex((next) => {
+      if (!live) return
+      setBoards(next.boards)
+      setGenerated(next.generated)
+      setMicropython(next.micropython)
+    }).then((index) => {
+      if (!live) return
+      setBoards(index.boards)
+      setGenerated(index.generated)
+      setMicropython(index.micropython)
+    })
+    return () => {
+      live = false
+    }
+  }, [])
+
+  const [text, setText] = useState('')
+  const [vendor, setVendor] = useState('')
+  const [mcu, setMcu] = useState('')
+  const [features, setFeatures] = useState<string[]>([])
+  const [flashableOnly, setFlashableOnly] = useState(false)
+  const [showAllFeatures, setShowAllFeatures] = useState(false)
+  // The board whose details are open, or null for the grid. A DETOUR, as in the
+  // Parts Catalog: the details render OVER the grid, which stays mounted, so
+  // closing them restores the filters and the scroll position by never having
+  // torn them down.
+  const [selected, setSelected] = useState<IndexedBoard | null>(null)
+
+  // Esc backs out one step: out of a board's details first, then the gallery.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key !== 'Escape') return
+      if (selected) setSelected(null)
+      else onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose, selected])
+
+  const all = useMemo(() => boards ?? [], [boards])
+  const filter: BoardFilter = useMemo(
+    () => ({ text, vendor, mcu, features, flashableOnly }),
+    [text, vendor, mcu, features, flashableOnly]
+  )
+  const matched = useMemo(() => filterBoards(all, filter), [all, filter])
+
+  // The options come from the WHOLE catalogue, not the current result set: a
+  // vendor list that shrinks as you filter cannot be used to change your mind.
+  const vendors = useMemo(() => vendorsOf(all), [all])
+  const mcus = useMemo(() => mcusOf(all), [all])
+  const allFeatures = useMemo(() => featuresOf(all), [all])
+  const shownFeatures = showAllFeatures ? allFeatures : allFeatures.slice(0, FEATURE_CHIP_LIMIT)
+
+  // Shelves are for BROWSING. Once anything is narrowing the catalogue the
+  // result set IS the answer, and re-sectioning it by vendor fights the vendor
+  // filter that is already on screen.
+  const filtering = isFiltering(filter)
+  const shelves = useMemo(() => (filtering ? [] : shelvesByVendor(matched)), [filtering, matched])
+
+  const clearFilters = useCallback((): void => {
+    setText('')
+    setVendor('')
+    setMcu('')
+    setFeatures([])
+    setFlashableOnly(false)
+  }, [])
+
+  const flash = useCallback(
+    (board: IndexedBoard): void => {
+      if (requestFlash(board)) onClose()
+    },
+    [onClose]
+  )
+
+  return (
+    <div className="bfind" role="dialog" aria-modal="true" aria-label="Board Finder">
+      <div className="bfind__backdrop" onClick={onClose} aria-hidden />
+      <div
+        className={`bfind__panel${closing ? ' is-closing' : origin ? ' is-growing' : ''}`}
+        ref={panelRef}
+        // Only the panel's OWN animation ends the close: the details view
+        // animates inside it and bubbles its event up here.
+        onAnimationEnd={(e) => {
+          if (closing && e.target === e.currentTarget) onClosed?.()
+        }}
+      >
+        <header className="bfind__head">
+          <span className="bfind__title">Board Finder</span>
+          {micropython && (
+            <span className="bfind__meta" title={`Board index generated ${generated}`}>
+              {micropython}
+            </span>
+          )}
+          <input
+            className="bfind__search"
+            type="search"
+            placeholder="Search boards…"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            aria-label="Search boards"
+          />
+          <span className="bfind__spacer" />
+          <span className="bfind__count" aria-live="polite">
+            {boards === null ? '' : `${matched.length} of ${all.length} boards`}
+          </span>
+          <button
+            type="button"
+            className="bfind__close"
+            onClick={onClose}
+            aria-label="Close Board Finder"
+            title="Close (Esc)"
+          >
+            ✕
+          </button>
+        </header>
+
+        <div className="bfind__body">
+          <aside className="bfind__sidebar">
+            <div className="bfind__facet">
+              <h3 className="bfind__facet-name">Manufacturer</h3>
+              <select
+                className="bfind__select"
+                value={vendor}
+                onChange={(e) => setVendor(e.target.value)}
+                aria-label="Filter by manufacturer"
+              >
+                <option value="">All manufacturers</option>
+                {vendors.map((v) => (
+                  <option key={v} value={v}>
+                    {v}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="bfind__facet">
+              <h3 className="bfind__facet-name">Processor</h3>
+              <select
+                className="bfind__select"
+                value={mcu}
+                onChange={(e) => setMcu(e.target.value)}
+                aria-label="Filter by processor"
+              >
+                <option value="">All processors</option>
+                {mcus.map((m) => (
+                  <option key={m} value={m}>
+                    {m}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="bfind__facet">
+              <h3 className="bfind__facet-name">Features</h3>
+              <div className="bfind__chips">
+                {shownFeatures.map((f) => {
+                  const on = features.includes(f)
+                  return (
+                    <button
+                      key={f}
+                      type="button"
+                      className={`bfind__chip${on ? ' is-on' : ''}`}
+                      aria-pressed={on}
+                      onClick={() => setFeatures((prev) => toggleFeature(prev, f))}
+                    >
+                      {f}
+                    </button>
+                  )
+                })}
+                {allFeatures.length > FEATURE_CHIP_LIMIT && (
+                  <button
+                    type="button"
+                    className="bfind__chip"
+                    onClick={() => setShowAllFeatures((v) => !v)}
+                  >
+                    {showAllFeatures ? 'Show fewer' : `+${allFeatures.length - FEATURE_CHIP_LIMIT} more`}
+                  </button>
+                )}
+              </div>
+            </div>
+
+            <div className="bfind__facet">
+              <label className="bfind__toggle">
+                <input
+                  type="checkbox"
+                  checked={flashableOnly}
+                  onChange={(e) => setFlashableOnly(e.target.checked)}
+                />
+                Only boards with firmware
+              </label>
+            </div>
+
+            {filtering && (
+              <button type="button" className="bfind__clear" onClick={clearFilters}>
+                Clear filters
+              </button>
+            )}
+          </aside>
+
+          <div className="bfind__shelves">
+            {boards === null && <div className="bfind__loading">Loading boards…</div>}
+            {boards !== null && matched.length === 0 && (
+              <div className="bfind__empty">
+                {all.length === 0
+                  ? 'The board index could not be read.'
+                  : 'No boards match these filters.'}
+              </div>
+            )}
+
+            {/* Filtered ⇒ ONE grid; the card carries the vendor the shelf
+                heading used to supply, so collapsing loses nothing. */}
+            {filtering && matched.length > 0 && (
+              <div className="bfind__grid">
+                {matched.map((b) => (
+                  <BoardCard key={b.id} board={b} onOpen={() => setSelected(b)} />
+                ))}
+              </div>
+            )}
+
+            {!filtering &&
+              shelves.map((shelf) => (
+                <section className="bfind__shelf" key={shelf.vendor}>
+                  <h3 className="bfind__shelf-name">
+                    {shelf.vendor}
+                    <span className="bfind__shelf-count">{shelf.boards.length}</span>
+                  </h3>
+                  <div className="bfind__grid">
+                    {shelf.boards.map((b) => (
+                      <BoardCard key={b.id} board={b} onOpen={() => setSelected(b)} />
+                    ))}
+                  </div>
+                </section>
+              ))}
+          </div>
+        </div>
+
+        {selected && (
+          <BoardDetails
+            key={selected.id}
+            board={selected}
+            onBack={() => setSelected(null)}
+            onFlash={() => flash(selected)}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+/** How many feature chips fit on a card before it starts to look like a list. */
+const CARD_FEATURE_LIMIT = 3
+
+/** One board in the grid. */
+function BoardCard({
+  board,
+  onOpen
+}: {
+  board: IndexedBoard
+  onOpen: () => void
+}): JSX.Element {
+  const src = thumbUrl(board.thumb)
+  const extra = board.features.length - CARD_FEATURE_LIMIT
+  return (
+    <button type="button" className="bfind__card" onClick={onOpen}>
+      <span className="bfind__card-img">
+        {src ? (
+          // 217 of these, so they load as they are scrolled to rather than all
+          // at once. The alt is empty because the card's own text names the
+          // board — announcing it twice is noise, not access.
+          <img src={src} alt="" loading="lazy" draggable={false} />
+        ) : (
+          <span className="bfind__noimg" aria-hidden="true">
+            {boardInitials(board)}
+          </span>
+        )}
+      </span>
+      <span className="bfind__card-body">
+        <span className="bfind__card-vendor">{board.vendor || 'Unknown'}</span>
+        <span className="bfind__card-name">{board.product}</span>
+        <span className="bfind__card-mcu">{board.mcu}</span>
+        {board.features.length > 0 && (
+          <span className="bfind__card-feats">
+            {board.features.slice(0, CARD_FEATURE_LIMIT).map((f) => (
+              <span className="bfind__feat" key={f}>
+                {f}
+              </span>
+            ))}
+            {extra > 0 && <span className="bfind__feat">+{extra}</span>}
+          </span>
+        )}
+        {board.builds.length === 0 && (
+          <span className="bfind__card-nofw">No published firmware</span>
+        )}
+      </span>
+    </button>
+  )
+}
+
+/** A board's full details, over the grid rather than instead of it. */
+function BoardDetails({
+  board,
+  onBack,
+  onFlash
+}: {
+  board: IndexedBoard
+  onBack: () => void
+  onFlash: () => void
+}): JSX.Element {
+  const src = thumbUrl(board.thumb)
+  const facts = boardFacts(board)
+  const variants = variantList(board)
+  const builds = newestBuilds(board)
+  const chosen = defaultBuild(board)
+
+  return (
+    <div className="bfind__details" role="group" aria-label={`${board.vendor} ${board.product}`}>
+      <header className="bfind__det-head">
+        <button type="button" className="bfind__back" onClick={onBack}>
+          ← All boards
+        </button>
+        <span className="bfind__det-title">
+          <span className="bfind__det-vendor">{board.vendor || 'Unknown'}</span>
+          <span className="bfind__det-name">{board.product}</span>
+        </span>
+        <span className="bfind__spacer" />
+        <button
+          type="button"
+          className="bfind__flash"
+          onClick={onFlash}
+          disabled={!chosen}
+          title={
+            chosen
+              ? `Flash MicroPython ${chosen.version} (${buildLabel(chosen)}) to a ${board.product}`
+              : 'MicroPython publishes no firmware for this board'
+          }
+        >
+          {chosen ? `⚡ Flash MicroPython ${chosen.version}` : 'No firmware published'}
+        </button>
+      </header>
+
+      <div className="bfind__det-body">
+        <div className="bfind__det-img">
+          {src ? (
+            <img src={src} alt={`${board.vendor} ${board.product}`} loading="lazy" />
+          ) : (
+            <span className="bfind__noimg" aria-hidden="true">
+              {boardInitials(board)}
+            </span>
+          )}
+        </div>
+
+        <div>
+          <section className="bfind__section">
+            <h4 className="bfind__section-name">Specification</h4>
+            <dl className="bfind__facts">
+              {facts.map((f) => (
+                <div className="bfind__row" key={f.label}>
+                  <dt>{f.label}</dt>
+                  <dd>{f.value}</dd>
+                </div>
+              ))}
+            </dl>
+            {/* Said out loud, because its absence is otherwise read as a bug. */}
+            <p className="bfind__note">
+              Flash and RAM sizes are not published in MicroPython’s board index, so
+              they are not shown or filtered on here.
+            </p>
+          </section>
+
+          {board.features.length > 0 && (
+            <section className="bfind__section">
+              <h4 className="bfind__section-name">Features</h4>
+              <div className="bfind__feats-big">
+                {board.features.map((f) => (
+                  <span className="bfind__feat" key={f}>
+                    {f}
+                  </span>
+                ))}
+                {/* Upstream's `notes` are attributes it marks as NOT worth
+                    filtering on — still worth reading, so they sit here. */}
+                {board.notes.map((n) => (
+                  <span className="bfind__feat" key={n}>
+                    {n}
+                  </span>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {variants.length > 0 && (
+            <section className="bfind__section">
+              <h4 className="bfind__section-name">Variants</h4>
+              {/* Upstream's own words — a variant's purpose is exactly the thing
+                  a picker cannot infer, and getting it wrong is what #893 is about. */}
+              <dl className="bfind__variants">
+                {variants.map((v) => (
+                  <div className="bfind__row" key={v.variant}>
+                    <dt>{v.variant}</dt>
+                    <dd>{v.description}</dd>
+                  </div>
+                ))}
+              </dl>
+            </section>
+          )}
+
+          <section className="bfind__section">
+            <h4 className="bfind__section-name">Builds</h4>
+            {builds.length === 0 ? (
+              <p className="bfind__note">
+                MicroPython publishes no firmware for this board, so it cannot be flashed
+                from here.
+              </p>
+            ) : (
+              <ul className="bfind__builds">
+                {builds.map((b) => (
+                  <li className="bfind__build" key={b.build}>
+                    <span className="bfind__build-name">{buildLabel(b)}</span>
+                    <span className="bfind__build-ver">v{b.version}</span>
+                    {chosen && b.build === chosen.build && (
+                      <span className="bfind__build-default">Default</span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          {board.url && (
+            <section className="bfind__section">
+              <a
+                className="bfind__link"
+                href={board.url}
+                target="_blank"
+                rel="noreferrer noopener"
+              >
+                {board.vendor} product page ↗
+              </a>
+            </section>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/FirmwareFlasher.css
+++ b/src/renderer/src/components/FirmwareFlasher.css
@@ -566,3 +566,32 @@
   opacity: 0.55;
   cursor: not-allowed;
 }
+
+/* The Board Finder button, beside Detect board (#893).
+ *
+ * Detect is the happy path and stays prominent; this is the answer for a board
+ * that is not plugged in yet, or one detection could not name — the same
+ * question asked the other way round, so it sits beside it rather than
+ * competing with it. Quieter fill, same size and shape. */
+/* Detect and Board Finder sit on ONE row. `.firmware-detect` is
+   `align-self: flex-start` in a column, so two of them would stack. */
+.firmware-detect-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.firmware-detect-row .firmware-detect {
+  margin-bottom: 0;
+}
+
+.firmware-detect--finder {
+  background: rgba(255, 255, 255, 0.08);
+  color: #c7ccd4;
+}
+
+.firmware-detect--finder:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.14);
+  color: #f4f6f8;
+}

--- a/src/renderer/src/components/FirmwareFlasher.tsx
+++ b/src/renderer/src/components/FirmwareFlasher.tsx
@@ -43,6 +43,12 @@ import { hasWebUSB, isElectron } from '../lib/platform'
 import { flashEspInBrowser, requestEspPort } from '../lib/webFirmware/espFlash'
 import { flashMicrobitInBrowser, requestMicrobitDevice } from '../lib/webFirmware/microbitFlash'
 import { copyFirmwareToDrive } from '../lib/webFirmware/driveCopyFlash'
+import { BoardFinder } from './BoardFinder'
+import {
+  FLASH_BOARD_EVENT,
+  flasherSelectionFor,
+  type BoardFlashRequest
+} from './board-finder-bus'
 import './FirmwareFlasher.css'
 
 interface FirmwareFlasherProps {
@@ -251,6 +257,59 @@ export function FirmwareFlasher({
   // official build is what almost everyone wants and needs no prior knowledge;
   // picking a file off disk assumes you have already been somewhere else and
   // come back with the right one.
+  /**
+   * The Board Finder gallery (#893), opened from the button beside Detect board.
+   *
+   * It lives INSIDE the dialog rather than beside it in the status bar, because
+   * "which board is this?" is a question you have while the flasher is open —
+   * and answering it there means the pick lands in the dialog you are already
+   * looking at instead of opening a second one.
+   */
+  const [finderOpen, setFinderOpen] = useState(false)
+  const [finderOrigin, setFinderOrigin] = useState<{ x: number; y: number } | null>(null)
+  // Closing runs the grow backwards, so the gallery has to outlive the click
+  // that dismissed it — unmount on the click and there is nothing left to
+  // animate.
+  const [finderClosing, setFinderClosing] = useState(false)
+  const dropFinder = useCallback((): void => {
+    setFinderClosing(false)
+    setFinderOpen(false)
+  }, [])
+  const closeFinder = useCallback((): void => {
+    const still = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+    if (!finderOrigin || still) dropFinder()
+    else setFinderClosing(true)
+  }, [finderOrigin, dropFinder])
+  // Insurance: the unmount hangs off `animationend`, and a closing panel has
+  // pointer events off. If that event never arrives the gallery would be stuck
+  // on screen AND unclickable, so time it out regardless.
+  useEffect(() => {
+    if (!finderClosing) return
+    const t = setTimeout(dropFinder, 450)
+    return () => clearTimeout(t)
+  }, [finderClosing, dropFinder])
+
+  /**
+   * Take a board the gallery picked.
+   *
+   * Through the same window event the gallery already dispatches, rather than a
+   * callback prop: the flasher IS mounted when the gallery is open inside it, so
+   * it can simply listen, and the gallery needs no knowledge of who opened it.
+   */
+  useEffect(() => {
+    const onFlashBoard = (e: Event): void => {
+      const pick = flasherSelectionFor((e as CustomEvent<BoardFlashRequest>).detail)
+      setBoard(pick.board)
+      if (pick.offset) setOffset(pick.offset)
+      setSource('catalog')
+      setSelFamily(pick.family)
+      setSelVersionUrl(pick.url)
+      dropFinder()
+    }
+    window.addEventListener(FLASH_BOARD_EVENT, onFlashBoard)
+    return () => window.removeEventListener(FLASH_BOARD_EVENT, onFlashBoard)
+  }, [dropFinder])
+
   const [source, setSource] = useState<Source>('catalog')
   const [catalog, setCatalog] = useState<FirmwareCatalog | null>(null)
   const [catalogLoading, setCatalogLoading] = useState(false)
@@ -1047,6 +1106,7 @@ export function FirmwareFlasher({
   const retry = retryAction(outcome)
 
   return (
+    <>
     <div
       className="firmware-overlay"
       role="presentation"
@@ -1164,19 +1224,40 @@ export function FirmwareFlasher({
                 board — Detect and Identify were two buttons for two halves of
                 one question. Placed FIRST because it is the step that makes
                 every field below it unnecessary. */}
-            {isElectron() && (
+            <div className="firmware-detect-row">
+              {isElectron() && (
+                <button
+                  type="button"
+                  className="firmware-detect"
+                  onClick={() => void detectBoard()}
+                  disabled={flashing || identifying}
+                >
+                  {identifying ? 'Asking the board…' : '⟳ Detect board'}
+                </button>
+              )}
+              {/* Detect answers "what is plugged in"; this answers "what have I
+                  got" for a board that is not plugged in yet, or one detection
+                  could not name. Beside it, because they are the same question
+                  asked two ways. */}
               <button
                 type="button"
-                className="firmware-detect"
-                onClick={() => void detectBoard()}
-                disabled={flashing || identifying}
+                className="firmware-detect firmware-detect--finder"
+                onClick={(e) => {
+                  const r = e.currentTarget.getBoundingClientRect()
+                  setFinderOrigin({ x: r.left + r.width / 2, y: r.top + r.height / 2 })
+                  setFinderOpen(true)
+                }}
+                disabled={flashing}
+                title="Browse every board MicroPython builds for"
               >
-                {identifying ? 'Asking the board…' : '⟳ Detect board'}
+                ⌕ Board Finder
               </button>
-            )}
+            </div>
             {/* Detect ran into the REPL holding the port (#845). Said out loud,
                 with the way out attached — knowing a port is busy is only half
-                of it when the thing holding it is this same app. */}
+                of it when the thing holding it is this same app.
+                BELOW the button row, not inside it: it is a full-width status
+                message about what Detect just found, not a third button. */}
             {detectConflict && (
               <div
                 className="firmware-banner firmware-banner--warn firmware-conflict"
@@ -1899,5 +1980,17 @@ export function FirmwareFlasher({
         </footer>
       </div>
     </div>
+      {/* A SIBLING of the overlay, not a child: a full-screen gallery nested in
+          the modal's backdrop would be clipped by it and would inherit its
+          click-anywhere-to-dismiss. */}
+      {finderOpen && (
+        <BoardFinder
+          origin={finderOrigin}
+          closing={finderClosing}
+          onClosed={dropFinder}
+          onClose={closeFinder}
+        />
+      )}
+    </>
   )
 }

--- a/src/renderer/src/components/StatusBar.css
+++ b/src/renderer/src/components/StatusBar.css
@@ -350,7 +350,16 @@
   color: var(--text);
 }
 
-/* Flash-firmware action — compact, sits at the far right. */
+/* Flash-firmware action — compact, sits at the far right. The Board Finder
+   pop-out (#893) sits beside it and wears exactly the same chrome, because they
+   are two halves of one job: find the board, then flash it. */
+.statusbar__boards {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.statusbar__boards,
 .statusbar__flash {
   background: transparent;
   border: var(--border-w) solid var(--border);
@@ -362,11 +371,13 @@
   line-height: 1.3rem;
 }
 
+.statusbar__boards:hover,
 .statusbar__flash:hover {
   border-color: var(--accent);
   color: var(--accent);
 }
 
+.statusbar__boards:focus-visible,
 .statusbar__flash:focus-visible {
   outline: var(--border-w) solid var(--accent);
   outline-offset: 1px;

--- a/src/renderer/src/components/StatusBar.tsx
+++ b/src/renderer/src/components/StatusBar.tsx
@@ -4,6 +4,7 @@ import { useWorkspace } from '../store/workspace'
 import { useConsole } from '../store/console'
 import { useEditorSettings } from '../store/settings'
 import { FirmwareFlasher } from './FirmwareFlasher'
+import { BoardFinder } from './BoardFinder'
 import { CoffeeLink } from './CoffeeLink'
 import { updateButtonView } from './updateButton'
 import { liveWarningVisible } from './instrument-host'
@@ -31,7 +32,7 @@ import {
   firmwareRuntimeForDialect
 } from '../../../shared/firmware-runtime'
 import type { FirmwareCatalog, UpdateStatus } from '../../../preload/index.d'
-import { BulbIcon } from './ui-icons'
+import { BulbIcon, ExpandIcon } from './ui-icons'
 import { SyncIndicator } from './SyncIndicator'
 import './StatusBar.css'
 
@@ -96,6 +97,31 @@ export function StatusBar({
   const activeFile = openFiles.find((f) => f.id === activeId) ?? null
 
   const [flasherOpen, setFlasherOpen] = useState(false)
+  // The Board Finder gallery (#893), and where it should grow from. It lives
+  // beside the flasher because this is where a user comes to think about
+  // firmware, and the gallery exists to fix the board picker they find here.
+  const [finderOpen, setFinderOpen] = useState(false)
+  const [finderOrigin, setFinderOrigin] = useState<{ x: number; y: number } | null>(null)
+  // Closing runs the grow backwards, so the gallery has to outlive the click
+  // that dismissed it — unmount on click and there is nothing left to animate.
+  const [finderClosing, setFinderClosing] = useState(false)
+  const dropFinder = useCallback((): void => {
+    setFinderClosing(false)
+    setFinderOpen(false)
+  }, [])
+  const closeFinder = useCallback((): void => {
+    const still = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+    if (!finderOrigin || still) dropFinder()
+    else setFinderClosing(true)
+  }, [finderOrigin, dropFinder])
+  // Insurance: the unmount hangs off `animationend`, and a closing panel has
+  // pointer events off. If that event never arrives the gallery would be stuck
+  // on screen AND unclickable, so time it out regardless.
+  useEffect(() => {
+    if (!finderClosing) return
+    const t = setTimeout(dropFinder, 450)
+    return () => clearTimeout(t)
+  }, [finderClosing, dropFinder])
   // A newer build than the connected device is running — MicroPython (#173) or
   // CircuitPython (#757) — plus dismissal. The update names its own runtime, so
   // the prompt never tells a CircuitPython user about a MicroPython release.
@@ -581,6 +607,23 @@ export function StatusBar({
               </button>
             </div>
           )}
+          {/* Pop the board catalogue out full-screen — the same corner-bracket
+              icon the Parts Library uses to expand into its catalog (#893). */}
+          <button
+            type="button"
+            className="statusbar__item statusbar__boards"
+            onClick={(e) => {
+              const b = e.currentTarget.getBoundingClientRect()
+              setFinderOrigin({ x: b.left + b.width / 2, y: b.top + b.height / 2 })
+              setFinderClosing(false)
+              setFinderOpen(true)
+            }}
+            title="Board Finder — browse every board MicroPython builds for, and flash one"
+            aria-label="Open the Board Finder"
+          >
+            <ExpandIcon size={13} />
+            <span>Board Finder</span>
+          </button>
           <button
             type="button"
             className="statusbar__item statusbar__flash"
@@ -598,6 +641,15 @@ export function StatusBar({
           </button>
         </div>
       </div>
+
+      {finderOpen && (
+        <BoardFinder
+          origin={finderOrigin}
+          closing={finderClosing}
+          onClosed={dropFinder}
+          onClose={closeFinder}
+        />
+      )}
 
       {flasherOpen && (
         <FirmwareFlasher

--- a/src/renderer/src/components/StatusBar.tsx
+++ b/src/renderer/src/components/StatusBar.tsx
@@ -4,7 +4,6 @@ import { useWorkspace } from '../store/workspace'
 import { useConsole } from '../store/console'
 import { useEditorSettings } from '../store/settings'
 import { FirmwareFlasher } from './FirmwareFlasher'
-import { BoardFinder } from './BoardFinder'
 import { CoffeeLink } from './CoffeeLink'
 import { updateButtonView } from './updateButton'
 import { liveWarningVisible } from './instrument-host'
@@ -32,7 +31,7 @@ import {
   firmwareRuntimeForDialect
 } from '../../../shared/firmware-runtime'
 import type { FirmwareCatalog, UpdateStatus } from '../../../preload/index.d'
-import { BulbIcon, ExpandIcon } from './ui-icons'
+import { BulbIcon } from './ui-icons'
 import { SyncIndicator } from './SyncIndicator'
 import './StatusBar.css'
 
@@ -97,31 +96,6 @@ export function StatusBar({
   const activeFile = openFiles.find((f) => f.id === activeId) ?? null
 
   const [flasherOpen, setFlasherOpen] = useState(false)
-  // The Board Finder gallery (#893), and where it should grow from. It lives
-  // beside the flasher because this is where a user comes to think about
-  // firmware, and the gallery exists to fix the board picker they find here.
-  const [finderOpen, setFinderOpen] = useState(false)
-  const [finderOrigin, setFinderOrigin] = useState<{ x: number; y: number } | null>(null)
-  // Closing runs the grow backwards, so the gallery has to outlive the click
-  // that dismissed it — unmount on click and there is nothing left to animate.
-  const [finderClosing, setFinderClosing] = useState(false)
-  const dropFinder = useCallback((): void => {
-    setFinderClosing(false)
-    setFinderOpen(false)
-  }, [])
-  const closeFinder = useCallback((): void => {
-    const still = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
-    if (!finderOrigin || still) dropFinder()
-    else setFinderClosing(true)
-  }, [finderOrigin, dropFinder])
-  // Insurance: the unmount hangs off `animationend`, and a closing panel has
-  // pointer events off. If that event never arrives the gallery would be stuck
-  // on screen AND unclickable, so time it out regardless.
-  useEffect(() => {
-    if (!finderClosing) return
-    const t = setTimeout(dropFinder, 450)
-    return () => clearTimeout(t)
-  }, [finderClosing, dropFinder])
   // A newer build than the connected device is running — MicroPython (#173) or
   // CircuitPython (#757) — plus dismissal. The update names its own runtime, so
   // the prompt never tells a CircuitPython user about a MicroPython release.
@@ -611,21 +585,6 @@ export function StatusBar({
               icon the Parts Library uses to expand into its catalog (#893). */}
           <button
             type="button"
-            className="statusbar__item statusbar__boards"
-            onClick={(e) => {
-              const b = e.currentTarget.getBoundingClientRect()
-              setFinderOrigin({ x: b.left + b.width / 2, y: b.top + b.height / 2 })
-              setFinderClosing(false)
-              setFinderOpen(true)
-            }}
-            title="Board Finder — browse every board MicroPython builds for, and flash one"
-            aria-label="Open the Board Finder"
-          >
-            <ExpandIcon size={13} />
-            <span>Board Finder</span>
-          </button>
-          <button
-            type="button"
             className="statusbar__item statusbar__flash"
             onClick={() => setFlasherOpen(true)}
             title={
@@ -642,14 +601,6 @@ export function StatusBar({
         </div>
       </div>
 
-      {finderOpen && (
-        <BoardFinder
-          origin={finderOrigin}
-          closing={finderClosing}
-          onClosed={dropFinder}
-          onClose={closeFinder}
-        />
-      )}
 
       {flasherOpen && (
         <FirmwareFlasher

--- a/src/renderer/src/components/board-finder-bus.ts
+++ b/src/renderer/src/components/board-finder-bus.ts
@@ -1,0 +1,92 @@
+/**
+ * Board Finder → firmware flasher bus (#893, epic #884).
+ * =============================================================================
+ *
+ * Clicking a board in the Board Finder asks the firmware flasher to open on that
+ * board, with the build already chosen. A window CustomEvent rather than a prop,
+ * for the reason `settingsBus.ts` and `sprite-editor-bus.ts` use one: the gallery
+ * and the flasher have no common ancestor short of the app shell, and the flasher
+ * is under active change elsewhere — a seam it does not have to be edited to gain
+ * is the whole point.
+ *
+ * WIRING THE OTHER END. Nothing listens yet. The listener belongs wherever the
+ * flasher's selection state lives, and looks like every other host in this app:
+ *
+ * ```ts
+ * useEffect(() => {
+ *   const onFlashBoard = (e: Event): void => {
+ *     const req = (e as CustomEvent<BoardFlashRequest>).detail
+ *     setFlasherOpen(true)
+ *     // req.build.url is the binary; req.port says HOW it goes on; req.flashOffset
+ *     // says where. Nothing here needs the board index to be loaded.
+ *   }
+ *   window.addEventListener(FLASH_BOARD_EVENT, onFlashBoard)
+ *   return () => window.removeEventListener(FLASH_BOARD_EVENT, onFlashBoard)
+ * }, [])
+ * ```
+ *
+ * Kept in its own tiny DOM-free module so that listener can import the event and
+ * the payload type without pulling in the gallery component or the index.
+ */
+import { defaultBuild, type BoardBuild, type IndexedBoard } from '../../../shared/board-index'
+
+/** Window event name. `event.detail` is a {@link BoardFlashRequest}. */
+export const FLASH_BOARD_EVENT = 'snakie:flash-board'
+
+/**
+ * Everything the flasher needs to act, and nothing it has to look up again — so
+ * a listener never needs the board index in hand.
+ */
+export interface BoardFlashRequest {
+  /** Upstream's board id, e.g. `ESP32_GENERIC`. */
+  boardId: string
+  /** e.g. `Espressif`. */
+  vendor: string
+  /** e.g. `ESP32 / WROOM`. */
+  product: string
+  /** The MicroPython port — this decides HOW the binary goes on the board:
+   *  `rp2` and `samd` are a UF2 drive copy, `esp32`/`esp8266` are esptool. */
+  port: string
+  /** Chip family, e.g. `esp32s3`. */
+  mcu: string
+  /** Where the binary is written (`0x1000` on esp32), or null when upstream does
+   *  not say — for a UF2 board there is no offset to say. */
+  flashOffset: string | null
+  /** The build to offer, already chosen: newest version, plain over variant. */
+  build: BoardBuild
+}
+
+/**
+ * The request for a board, or null when there is nothing to flash.
+ *
+ * Three of the 225 boards publish no firmware at all. Those must not dispatch:
+ * an event the flasher cannot honour would open it on an empty selection, which
+ * reads as the flasher being broken rather than the board having no build. The
+ * gallery checks this and disables the action instead.
+ */
+export function flashRequestFor(board: IndexedBoard): BoardFlashRequest | null {
+  const build = defaultBuild(board)
+  if (!build) return null
+  return {
+    boardId: board.id,
+    vendor: board.vendor,
+    product: board.product,
+    port: board.port,
+    mcu: board.mcu,
+    flashOffset: board.flashOffset,
+    build
+  }
+}
+
+/**
+ * Ask the flasher to open on this board.
+ *
+ * Returns false when the board has no published build, so a caller that reaches
+ * here anyway fails visibly rather than silently doing nothing.
+ */
+export function requestFlash(board: IndexedBoard): boolean {
+  const detail = flashRequestFor(board)
+  if (!detail) return false
+  window.dispatchEvent(new CustomEvent<BoardFlashRequest>(FLASH_BOARD_EVENT, { detail }))
+  return true
+}

--- a/src/renderer/src/components/board-finder-bus.ts
+++ b/src/renderer/src/components/board-finder-bus.ts
@@ -29,6 +29,8 @@
  * the payload type without pulling in the gallery component or the index.
  */
 import { defaultBuild, type BoardBuild, type IndexedBoard } from '../../../shared/board-index'
+import { flashTargetForFamily } from '../../../shared/firmware-runtime'
+import type { BoardType } from '../../../main/firmware/types'
 
 /** Window event name. `event.detail` is a {@link BoardFlashRequest}. */
 export const FLASH_BOARD_EVENT = 'snakie:flash-board'
@@ -89,4 +91,38 @@ export function requestFlash(board: IndexedBoard): boolean {
   if (!detail) return false
   window.dispatchEvent(new CustomEvent<BoardFlashRequest>(FLASH_BOARD_EVENT, { detail }))
   return true
+}
+
+/**
+ * What the flasher should select for a request (#893).
+ *
+ * Pure, so the mapping is testable without mounting a modal — and separate from
+ * the flasher so the gallery's end and the flasher's end agree on one rule
+ * rather than two.
+ *
+ * The OFFSET comes from upstream's own `deploy_options.flash_offset` when it
+ * says, and only falls back to inference when it does not. That matters more
+ * than it looks: the bootloader offset is per chip and not a simple "the
+ * original ESP32 versus the rest" — the S2 shares the original's `0x1000` while
+ * the S3 and every RISC-V part are `0x0`. Getting it wrong flashes cleanly and
+ * leaves a dead board, so a figure the board itself publishes beats one we work
+ * out.
+ *
+ * The chip family drives the board TYPE rather than the port, because the port
+ * is too coarse: `esp32` covers the S2, S3, C3, C6 and P4, which do not share an
+ * offset.
+ */
+export function flasherSelectionFor(req: BoardFlashRequest): {
+  board: BoardType
+  offset: string | undefined
+  url: string
+  family: string
+} {
+  const target = flashTargetForFamily(req.mcu || req.port)
+  return {
+    board: target.board,
+    offset: req.flashOffset ?? target.offset,
+    url: req.build.url,
+    family: req.mcu || req.port
+  }
 }

--- a/src/renderer/src/components/board-finder.ts
+++ b/src/renderer/src/components/board-finder.ts
@@ -1,0 +1,178 @@
+/**
+ * BOARD FINDER — the gallery's own decisions (#893, epic #884).
+ * =============================================================================
+ *
+ * `shared/board-index.ts` owns the index: parsing, filtering, and picking a
+ * build. This module owns what the GALLERY does with it — how boards are shelved,
+ * what a card shows when it has no photo, and which of upstream's fields are
+ * stated as facts. The request that reaches the firmware flasher is next door in
+ * `board-finder-bus.ts`, so a listener can import it without the gallery.
+ *
+ * Separate from the component, and DOM-free, so every one of those decisions is
+ * a unit test in node rather than an assertion about JSX.
+ *
+ * WHY THERE IS NO STORAGE OR MEMORY FILTER. The issue asks for one and upstream
+ * makes it impossible: `board.json` publishes `External Flash` and `External RAM`
+ * as booleans in `features` and no figure anywhere. Those two stay where upstream
+ * put them — ordinary feature chips, which is an honest question ("has external
+ * flash?") the data can answer — and {@link boardFacts} states them again on the
+ * board itself, alongside a plain admission that the SIZE is not published. A
+ * "≥ 4 MB" control would have had to quietly drop most of the catalogue to draw
+ * itself, which is worse than not offering it.
+ */
+import type { BoardBuild, BoardFilter, IndexedBoard } from '../../../shared/board-index'
+
+// ---------------------------------------------------------------------------
+// Shelving
+// ---------------------------------------------------------------------------
+
+/** One vendor's boards, the gallery's browsing unit. */
+export interface VendorShelf {
+  vendor: string
+  boards: IndexedBoard[]
+}
+
+/** Shelf heading for a board whose vendor upstream left blank. */
+export const UNKNOWN_VENDOR = 'Other'
+
+/**
+ * Group boards into vendor shelves — the Parts Catalog's category shelves, for a
+ * catalogue whose natural sections are makers.
+ *
+ * Vendors alphabetically, `Other` last; boards within a shelf by product name so
+ * a vendor's range reads in order rather than in upstream's file order.
+ */
+export function shelvesByVendor(boards: readonly IndexedBoard[]): VendorShelf[] {
+  const byVendor = new Map<string, IndexedBoard[]>()
+  for (const b of boards) {
+    const vendor = b.vendor.trim() || UNKNOWN_VENDOR
+    const shelf = byVendor.get(vendor)
+    if (shelf) shelf.push(b)
+    else byVendor.set(vendor, [b])
+  }
+  return [...byVendor.entries()]
+    .sort(([a], [b]) => {
+      // `Other` is a bucket, not a maker, so it sorts below the real ones
+      // wherever its name would otherwise land.
+      if (a === UNKNOWN_VENDOR) return 1
+      if (b === UNKNOWN_VENDOR) return -1
+      return a.localeCompare(b)
+    })
+    .map(([vendor, list]) => ({
+      vendor,
+      boards: [...list].sort((x, y) => x.product.localeCompare(y.product))
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Cards
+// ---------------------------------------------------------------------------
+
+/**
+ * The two letters a photo-less board shows instead (8 of the 225 have no thumb).
+ *
+ * Initials of the first two words, so `Feather RP2350` reads `FR` rather than
+ * `FE` — a vendor's range is mostly one-word-apart, and the second word is what
+ * tells two of them apart. Falls back to the board id, which is never empty.
+ */
+export function boardInitials(board: IndexedBoard): string {
+  const words = board.product.trim().split(/\s+/).filter(Boolean)
+  if (words.length >= 2) return (words[0][0] + words[1][0]).toUpperCase()
+  const source = words[0] || board.id
+  return source.slice(0, 2).toUpperCase()
+}
+
+/**
+ * What a build is called in the variant list.
+ *
+ * A null variant is upstream's plain build; calling it "Standard" rather than
+ * leaving it blank matters, because it sits in a list beside named variants and
+ * an unlabelled row reads as a rendering fault.
+ */
+export const PLAIN_BUILD_LABEL = 'Standard'
+
+export function buildLabel(build: BoardBuild): string {
+  return build.variant ?? PLAIN_BUILD_LABEL
+}
+
+// ---------------------------------------------------------------------------
+// Facts
+// ---------------------------------------------------------------------------
+
+/** One stated fact on a board's detail. */
+export interface BoardFact {
+  label: string
+  value: string
+}
+
+/** Features that are a yes/no upstream publishes but no figure to go with it. */
+const SIZELESS_FEATURES: readonly { feature: string; label: string }[] = [
+  { feature: 'External Flash', label: 'External flash' },
+  { feature: 'External RAM', label: 'External RAM' }
+]
+
+/** What upstream says when asked how big either of those is. */
+export const NO_SIZE_PUBLISHED = 'present — size not published'
+
+/**
+ * The facts a board's detail states, in display order.
+ *
+ * Only what upstream actually publishes. `External flash` / `External RAM`
+ * appear here as the booleans they are, saying outright that the size is not
+ * published — the alternative was to omit them, which invites the reader to
+ * assume the board has neither.
+ */
+export function boardFacts(board: IndexedBoard): BoardFact[] {
+  const facts: BoardFact[] = [{ label: 'MCU', value: board.mcu || 'unknown' }]
+  if (board.port) facts.push({ label: 'Port', value: board.port })
+  if (board.flashOffset) facts.push({ label: 'Flash offset', value: board.flashOffset })
+  for (const { feature, label } of SIZELESS_FEATURES) {
+    if (board.features.includes(feature)) facts.push({ label, value: NO_SIZE_PUBLISHED })
+  }
+  return facts
+}
+
+/** Upstream's variants as an ordered list — plain first is the BUILD list's job;
+ *  this is the descriptions, by variant id, so the order is stable between renders. */
+export function variantList(board: IndexedBoard): { variant: string; description: string }[] {
+  return Object.entries(board.variants)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([variant, description]) => ({ variant, description }))
+}
+
+// ---------------------------------------------------------------------------
+// Filters
+// ---------------------------------------------------------------------------
+
+/**
+ * The filter's active selections, for the "clear" affordance and the chip row.
+ *
+ * Free text is deliberately NOT a chip: it has its own visible input with its own
+ * clear, and echoing it as a removable chip gives one value two controls that can
+ * disagree.
+ */
+export function activeFilterChips(
+  filter: BoardFilter
+): { axis: 'vendor' | 'mcu' | 'feature'; value: string }[] {
+  const out: { axis: 'vendor' | 'mcu' | 'feature'; value: string }[] = []
+  if (filter.vendor) out.push({ axis: 'vendor', value: filter.vendor })
+  if (filter.mcu) out.push({ axis: 'mcu', value: filter.mcu })
+  for (const f of filter.features ?? []) out.push({ axis: 'feature', value: f })
+  return out
+}
+
+/** Whether anything is narrowing the catalogue — including the search box. */
+export function isFiltering(filter: BoardFilter): boolean {
+  return (
+    activeFilterChips(filter).length > 0 ||
+    (filter.text ?? '').trim().length > 0 ||
+    filter.flashableOnly === true
+  )
+}
+
+/** Add or remove one feature, so the chips toggle rather than only accumulate. */
+export function toggleFeature(features: readonly string[], feature: string): string[] {
+  return features.includes(feature)
+    ? features.filter((f) => f !== feature)
+    : [...features, feature]
+}

--- a/src/renderer/src/components/ui-icons.tsx
+++ b/src/renderer/src/components/ui-icons.tsx
@@ -117,6 +117,16 @@ export const BulbIcon = ({ size }: { size?: number }): JSX.Element =>
     size
   )
 
+/** Corner brackets — pop a panel out to full screen. The Parts Library's
+ *  toolbar draws the same glyph on its own 16×16 grid (`actionIcon('expand')`
+ *  in {@link file://./PartsPanel.tsx}); the Board Finder reuses it deliberately
+ *  (#893), so "expand this into a gallery" reads the same wherever it appears. */
+export const ExpandIcon = ({ size }: { size?: number }): JSX.Element =>
+  svg(
+    g(<path d="M9.5 4.5H5a.5.5 0 0 0-.5.5v4.5M14.5 4.5H19a.5.5 0 0 1 .5.5v4.5M9.5 19.5H5a.5.5 0 0 1-.5-.5v-4.5M14.5 19.5H19a.5.5 0 0 0 .5-.5v-4.5" />),
+    size
+  )
+
 /** An open folder — "Open…" buttons. */
 export const FolderOpenIcon = ({ size }: { size?: number }): JSX.Element =>
   svg(

--- a/test/boardFinder.test.ts
+++ b/test/boardFinder.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import {
+  NO_SIZE_PUBLISHED,
+  PLAIN_BUILD_LABEL,
+  UNKNOWN_VENDOR,
+  activeFilterChips,
+  boardFacts,
+  boardInitials,
+  buildLabel,
+  isFiltering,
+  shelvesByVendor,
+  toggleFeature,
+  variantList
+} from '../src/renderer/src/components/board-finder'
+import {
+  FLASH_BOARD_EVENT,
+  flashRequestFor,
+  requestFlash
+} from '../src/renderer/src/components/board-finder-bus'
+import type { BoardBuild, IndexedBoard } from '../src/shared/board-index'
+
+/**
+ * The Board Finder gallery's own decisions (#893) — shelving, the photo-less
+ * placeholder, which of upstream's fields are stated as facts, and the request
+ * that reaches the firmware flasher.
+ *
+ * `shared/board-index.ts` owns parsing/filtering/picking; this covers only what
+ * the gallery adds on top, which is why it can stay DOM-free and run in node.
+ */
+
+const build = (over: Partial<BoardBuild> = {}): BoardBuild => ({
+  build: 'RPI_PICO',
+  variant: null,
+  version: '1.29.0',
+  date: '20260824',
+  url: 'https://micropython.org/resources/firmware/RPI_PICO-20260824-v1.29.0.uf2',
+  ...over
+})
+
+const board = (over: Partial<IndexedBoard> = {}): IndexedBoard => ({
+  id: 'RPI_PICO',
+  port: 'rp2',
+  vendor: 'Raspberry Pi',
+  product: 'Pico',
+  mcu: 'rp2040',
+  features: [],
+  notes: [],
+  url: null,
+  variants: {},
+  flashOffset: null,
+  image: null,
+  thumb: null,
+  builds: [build()],
+  ...over
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('shelvesByVendor', () => {
+  it('groups by vendor, alphabetically, products sorted within a shelf', () => {
+    const shelves = shelvesByVendor([
+      board({ id: 'B', vendor: 'Pimoroni', product: 'Tiny 2040' }),
+      board({ id: 'A', vendor: 'Adafruit', product: 'QT Py' }),
+      board({ id: 'C', vendor: 'Pimoroni', product: 'Badger 2040' })
+    ])
+    expect(shelves.map((s) => s.vendor)).toEqual(['Adafruit', 'Pimoroni'])
+    expect(shelves[1].boards.map((b) => b.product)).toEqual(['Badger 2040', 'Tiny 2040'])
+  })
+
+  it('buckets a blank vendor under Other, and puts it last despite the alphabet', () => {
+    // 'Other' would sort between Adafruit and Pimoroni on name alone — it is a
+    // bucket, not a maker, so it belongs below both.
+    const shelves = shelvesByVendor([
+      board({ id: 'P', vendor: 'Pimoroni' }),
+      board({ id: 'X', vendor: '   ' }),
+      board({ id: 'A', vendor: 'Adafruit' })
+    ])
+    expect(shelves.map((s) => s.vendor)).toEqual(['Adafruit', 'Pimoroni', UNKNOWN_VENDOR])
+  })
+})
+
+describe('boardInitials', () => {
+  it('takes one letter from each of the first two words', () => {
+    // Not the first two letters: an Adafruit range is mostly "Feather …", so
+    // 'FE' would be identical across a dozen boards.
+    expect(boardInitials(board({ product: 'Feather RP2350' }))).toBe('FR')
+  })
+
+  it('falls back to the first two letters of a single-word product', () => {
+    expect(boardInitials(board({ product: 'Pico' }))).toBe('PI')
+  })
+
+  it('falls back to the board id when the product name is empty', () => {
+    expect(boardInitials(board({ product: '', id: 'ESP32_GENERIC' }))).toBe('ES')
+  })
+})
+
+describe('buildLabel', () => {
+  it('names the plain build rather than leaving the row blank', () => {
+    expect(buildLabel(build({ variant: null }))).toBe(PLAIN_BUILD_LABEL)
+  })
+
+  it('uses upstream’s variant id when there is one', () => {
+    expect(buildLabel(build({ variant: 'SPIRAM' }))).toBe('SPIRAM')
+  })
+})
+
+describe('boardFacts', () => {
+  it('states MCU and port, and the flash offset only when upstream gives one', () => {
+    const plain = boardFacts(board())
+    expect(plain).toEqual([
+      { label: 'MCU', value: 'rp2040' },
+      { label: 'Port', value: 'rp2' }
+    ])
+    const withOffset = boardFacts(board({ flashOffset: '0x1000' }))
+    expect(withOffset).toContainEqual({ label: 'Flash offset', value: '0x1000' })
+  })
+
+  it('reports external flash/RAM as present with the size explicitly unpublished', () => {
+    // The whole storage/memory decision: upstream publishes a boolean and no
+    // figure, so the fact says so instead of implying a number exists.
+    const facts = boardFacts(board({ features: ['External Flash', 'External RAM', 'WiFi'] }))
+    expect(facts).toContainEqual({ label: 'External flash', value: NO_SIZE_PUBLISHED })
+    expect(facts).toContainEqual({ label: 'External RAM', value: NO_SIZE_PUBLISHED })
+    // …and no fact invents a size for either of them.
+    expect(facts.every((f) => !/\d+\s*(MB|KB|GB)/i.test(f.value))).toBe(true)
+  })
+
+  it('omits external flash/RAM entirely when the board does not list them', () => {
+    expect(boardFacts(board({ features: ['WiFi'] })).map((f) => f.label)).toEqual(['MCU', 'Port'])
+  })
+})
+
+describe('variantList', () => {
+  it('lists upstream’s own descriptions, ordered by variant id', () => {
+    const list = variantList(
+      board({ variants: { SPIRAM: 'Support for SPIRAM / WROVER', OTA: 'Over-the-air updates' } })
+    )
+    expect(list).toEqual([
+      { variant: 'OTA', description: 'Over-the-air updates' },
+      { variant: 'SPIRAM', description: 'Support for SPIRAM / WROVER' }
+    ])
+  })
+})
+
+describe('the filter chips', () => {
+  it('lists vendor, mcu and every feature — but never the search text', () => {
+    // Free text has its own input with its own clear; a second control for the
+    // same value is a control that can disagree with it.
+    const chips = activeFilterChips({
+      vendor: 'Adafruit',
+      mcu: 'esp32s3',
+      features: ['WiFi', 'BLE'],
+      text: 'feather'
+    })
+    expect(chips).toEqual([
+      { axis: 'vendor', value: 'Adafruit' },
+      { axis: 'mcu', value: 'esp32s3' },
+      { axis: 'feature', value: 'WiFi' },
+      { axis: 'feature', value: 'BLE' }
+    ])
+  })
+
+  it('counts search text and the flashable toggle as filtering, though neither is a chip', () => {
+    expect(isFiltering({})).toBe(false)
+    expect(isFiltering({ text: '  ' })).toBe(false)
+    expect(isFiltering({ text: 'pico' })).toBe(true)
+    expect(isFiltering({ flashableOnly: true })).toBe(true)
+    expect(isFiltering({ features: ['WiFi'] })).toBe(true)
+  })
+})
+
+describe('toggleFeature', () => {
+  it('adds a feature that is off and removes one that is on', () => {
+    expect(toggleFeature([], 'WiFi')).toEqual(['WiFi'])
+    expect(toggleFeature(['WiFi', 'BLE'], 'WiFi')).toEqual(['BLE'])
+  })
+})
+
+describe('the flasher hand-off', () => {
+  it('carries everything the flasher needs and nothing it must look up again', () => {
+    const req = flashRequestFor(
+      board({ port: 'esp32', mcu: 'esp32s3', flashOffset: '0x0', builds: [build()] })
+    )
+    expect(req).toEqual({
+      boardId: 'RPI_PICO',
+      vendor: 'Raspberry Pi',
+      product: 'Pico',
+      port: 'esp32',
+      mcu: 'esp32s3',
+      flashOffset: '0x0',
+      build: build()
+    })
+  })
+
+  it('offers the newest version, and its plain build over a variant', () => {
+    const req = flashRequestFor(
+      board({
+        builds: [
+          build({ date: '20250101', version: '1.28.0' }),
+          build({ date: '20260824', variant: 'SPIRAM' }),
+          build({ date: '20260824', variant: null })
+        ]
+      })
+    )
+    expect(req?.build.version).toBe('1.29.0')
+    expect(req?.build.variant).toBeNull()
+  })
+
+  it('refuses a board with no published firmware', () => {
+    // Three of the 225 publish none. Dispatching for them would open the flasher
+    // on an empty selection, which reads as the flasher being broken.
+    expect(flashRequestFor(board({ builds: [] }))).toBeNull()
+  })
+
+  it('dispatches the request on the window, and reports false rather than firing an empty one', () => {
+    const events: CustomEvent[] = []
+    vi.stubGlobal('window', { dispatchEvent: (e: CustomEvent) => (events.push(e), true) })
+
+    expect(requestFlash(board())).toBe(true)
+    expect(requestFlash(board({ builds: [] }))).toBe(false)
+
+    expect(events).toHaveLength(1)
+    expect(events[0].type).toBe(FLASH_BOARD_EVENT)
+    expect((events[0].detail as { boardId: string }).boardId).toBe('RPI_PICO')
+  })
+})

--- a/test/boardFlashHandoff.test.ts
+++ b/test/boardFlashHandoff.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import {
+  flashRequestFor,
+  flasherSelectionFor,
+  type BoardFlashRequest
+} from '../src/renderer/src/components/board-finder-bus'
+import type { IndexedBoard } from '../src/shared/board-index'
+
+/**
+ * Board Finder → flasher (#893).
+ *
+ * The offset is the dangerous part. It is per CHIP and not a simple "the
+ * original ESP32 versus the rest" — the S2 shares the original's `0x1000` while
+ * the S3 and every RISC-V part are `0x0`. Getting it wrong flashes cleanly and
+ * leaves a dead board, which is a failure with no error message attached to it.
+ */
+
+const board = (over: Partial<IndexedBoard> = {}): IndexedBoard => ({
+  id: 'ESP32_GENERIC',
+  port: 'esp32',
+  vendor: 'Espressif',
+  product: 'ESP32 / WROOM',
+  mcu: 'esp32',
+  features: [],
+  notes: [],
+  url: null,
+  variants: {},
+  flashOffset: '0x1000',
+  image: null,
+  thumb: null,
+  builds: [
+    {
+      build: 'ESP32_GENERIC',
+      variant: null,
+      version: '1.29.0',
+      date: '20260824',
+      url: 'https://micropython.org/resources/firmware/ESP32_GENERIC-20260824-v1.29.0.bin'
+    }
+  ],
+  ...over
+})
+
+describe('what gets handed over', () => {
+  it('carries enough to act without the index in hand', () => {
+    const req = flashRequestFor(board())
+    expect(req).toMatchObject({ boardId: 'ESP32_GENERIC', port: 'esp32', mcu: 'esp32' })
+    expect(req?.build.url).toContain('ESP32_GENERIC-20260824')
+  })
+
+  it('refuses for a board with no published firmware', () => {
+    // Three of the 225 publish none. Dispatching for one would open the flasher
+    // on an empty selection, which reads as the flasher being broken rather
+    // than the board having no build.
+    expect(flashRequestFor(board({ builds: [] }))).toBeNull()
+  })
+})
+
+describe('the offset, which is the part that can kill a board', () => {
+  const reqFor = (over: Partial<IndexedBoard>): BoardFlashRequest =>
+    flashRequestFor(board(over)) as BoardFlashRequest
+
+  it('prefers the figure the board itself publishes', () => {
+    // `deploy_options.flash_offset` is upstream's own answer for THIS board and
+    // beats anything inferred from a chip family.
+    expect(flasherSelectionFor(reqFor({ flashOffset: '0x1000' })).offset).toBe('0x1000')
+  })
+
+  it('falls back to the chip family only when upstream is silent', () => {
+    const s = flasherSelectionFor(reqFor({ flashOffset: null, mcu: 'esp32s3' }))
+    expect(s.offset).toBe('0x0')
+    expect(s.board).toBe('esp32')
+  })
+
+  it('keys off the CHIP, not the port — one port covers several offsets', () => {
+    // The `esp32` port holds the S2, S3, C3, C6 and P4, which do not agree.
+    const s2 = flasherSelectionFor(reqFor({ flashOffset: null, mcu: 'esp32s2', port: 'esp32' }))
+    const s3 = flasherSelectionFor(reqFor({ flashOffset: null, mcu: 'esp32s3', port: 'esp32' }))
+    expect(s2.offset).not.toBe(s3.offset)
+  })
+
+  it('routes a UF2 board to the drive copy, not esptool', () => {
+    const s = flasherSelectionFor(reqFor({ port: 'rp2', mcu: 'rp2040', flashOffset: null }))
+    expect(s.board).toBe('rp2040')
+  })
+})
+
+describe('both ends are wired', () => {
+  const flasher = readFileSync('src/renderer/src/components/FirmwareFlasher.tsx', 'utf8')
+
+  it('the gallery opens from beside Detect board, inside the dialog', () => {
+    // "Which board is this?" is a question you have while the flasher is open.
+    // Answering it there means the pick lands in the dialog you are already
+    // looking at rather than opening a second one.
+    expect(flasher).toContain('firmware-detect-row')
+    expect(flasher).toContain('Board Finder')
+  })
+
+  it('the flasher itself listens, since it is the thing that is mounted', () => {
+    expect(flasher).toContain('FLASH_BOARD_EVENT')
+    expect(flasher).toContain('flasherSelectionFor(')
+  })
+
+  it('the status bar no longer owns any of it', () => {
+    // It was there first; leaving a second entry point behind would give two
+    // ways in that disagree about where the pick lands.
+    const bar = readFileSync('src/renderer/src/components/StatusBar.tsx', 'utf8')
+    expect(bar).not.toContain('BoardFinder')
+    expect(bar).not.toContain('FLASH_BOARD_EVENT')
+  })
+
+  it('the gallery is a sibling of the modal, not a child of its backdrop', () => {
+    // Nested in the backdrop it would be clipped by it and would inherit its
+    // click-anywhere-to-dismiss.
+    const i = flasher.indexOf('{finderOpen && (')
+    expect(i).toBeGreaterThan(flasher.indexOf('</div>\n  )'))
+  })
+
+  it('a pick closes the gallery outright rather than animating back', () => {
+    expect(flasher).toContain('dropFinder()')
+  })
+})


### PR DESCRIPTION
Closes #893. **Replaces #899 and #900**, both auto-closed when their base (#898) was deleted on merge — same work, replayed onto master.

Builds on #898 (the board index, now merged). Together they finish #893.

## The gallery

A full-screen Board Finder modelled on the Parts Catalog — same pop-out affordance, same shelves-until-you-filter behaviour, same details-over-the-grid detour that preserves filters and scroll position.

**Filters:** manufacturer, processor, features, free text, plus *only boards with firmware* (3 of the 225 publish none). Options come from the whole catalogue, not the filtered set, so a filter list never shrinks out from under you. Features are ordered commonest-first, so WiFi and BLE lead rather than `Audio Codec`.

**Cards** carry the board photo (`loading="lazy"`, real `alt`), vendor, product, MCU and feature chips. The 8 boards with no thumbnail get initials, not a broken image. Details show upstream's own variant descriptions, the builds available, and the vendor's product page.

**No storage or memory filters**, per the decision on the issue — upstream publishes neither figure, and a filter that silently omits most of the catalogue is worse than none. #897 tracks sourcing the real numbers.

## The entry point moved

Originally a status-bar button. It now opens from **beside Detect board, inside the flash dialog** — they are the same question asked two ways. Detect answers *"what is plugged in"*; the Board Finder answers *"what have I got"* for a board that isn't plugged in yet, or one detection couldn't name. Which is exactly the Feather V2 case that started this.

That also made the wiring **simpler**. From the status bar it needed a listener there (the flasher isn't mounted when the gallery dispatches, so a listener inside it would never hear the event meant to open it), a `preselect` prop, and a keyed remount so a mount-only effect would re-run. Inside the dialog the flasher *is* mounted, so it listens for the gallery's own event directly — no prop, no remount.

## The offset is the part that can kill a board

It comes from upstream's own `deploy_options.flash_offset` when the board publishes one, and only falls back to inference when it doesn't. The fallback keys off the **chip**, not the port: the `esp32` port covers the S2, S3, C3, C6 and P4, which don't agree — the S2 shares the original ESP32's `0x1000` while the S3 and every RISC-V part are `0x0`. Wrong offset flashes cleanly and leaves a dead board.

## Conflict resolved on the way

Master gained #877's port-conflict banner in the same region of `FirmwareFlasher.tsx`. Both belong: the banner now sits **below** the button row rather than inside it, since it's a full-width status message about what Detect just found, not a third button. The CSS conflict had split a rule across the marker, so the two sides shared a closing brace — repaired, and brace balance verified.

## Tests

18 for the gallery, 11 for the hand-off. The hand-off's offset logic was checked by breaking it two ways — ignoring upstream's published offset, and keying off the port instead of the chip — each failing for its own reason.

Gates after the replay and conflict resolution: lint ok · typecheck ok · **6,204 tests** ok · build ok.

**Not verified on screen.** The two buttons sharing a row is reasoned from `.firmware-detect` being `align-self: flex-start` in a column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe