### PR TITLE
The boards upstream will not build, and sourced flash/RAM figures (#902, #897)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **The boards MicroPython does not build for, and where the numbers come from**
+  (#902, #897). The Board Finder had 15 Adafruit boards and not one Adafruit
+  ESP32 board, because MicroPython publishes no firmware under any of those
+  names — there is no download page for an **ESP32 Feather V2**, and there never
+  was. That is precisely the board this epic exists for: its owner picked "ESP32
+  / WROOM" as the nearest thing and lost a week to 2 MB of PSRAM being switched
+  off. Five such boards now appear in the gallery — the ESP32 Feather V2, the
+  HUZZAH32, the QT Py ESP32-C3 and ESP32-S3, and a **micro:bit v2** where the
+  catalogue previously offered only the nRF51 v1 — each saying on its face which
+  build it flashes and why. Pick the Feather V2 and the flasher gets
+  `ESP32_GENERIC-SPIRAM` at `0x1000`, which is the file that would have saved the
+  week. If MicroPython ever adds one of these for real, the hand-written entry
+  stands down by itself.
+
+  There is also a **Runtime** filter — MicroPython and CircuitPython — with the
+  confirmed count on each chip and, underneath, the two things it cannot claim:
+  this is MicroPython's catalogue, so CircuitPython-only boards are not in it,
+  and a board is marked CircuitPython only where its board id was confirmed
+  against circuitpython.org. 49 boards are confirmed; the rest are unconfirmed
+  rather than unsupported, and the filter says so instead of implying otherwise.
+
+  And boards now state their **flash, RAM and PSRAM** — each naming where the
+  figure came from, because upstream publishes none of them and a number nobody
+  can check is not worth showing. 86 boards have a RAM figure (their chip's
+  SRAM, marked as the chip's rather than the board's) and 10 have a flash figure,
+  from the maker's own documentation. The rest say nothing rather than guessing:
+  an `stm32f4` spans 96 KB to 256 KB of SRAM, and a wrong flash size sends
+  someone to a board that cannot hold their program. Storage and memory still are
+  not filters at that coverage — a size control would hide the catalogue rather
+  than narrow it.
+
 - **A Board Finder, and the firmware picker finally knows every board** (#893).
   The picker showed Thonny's catalogue, which lists no Adafruit boards at all
   and no ESP32 variants — which is how an ESP32 Feather V2 ends up running a
@@ -42,7 +73,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   yes/no and no figure anywhere, so a size filter could only have drawn itself by
   quietly dropping most of the catalogue. They stay as ordinary feature chips, and
   a board's details say plainly that the size is not published rather than leaving
-  you to guess whether the absence means zero.
+  you to guess whether the absence means zero. (#897 later sourced the figures for
+  the boards where they could be sourced — see the entry above.)
 
 - **Minimise the copy dialog to the status bar, and bring it back** (#890). A
   folder copy or a driver install can be put away with **Minimise** — which sits

--- a/scripts/board-specs.mjs
+++ b/scripts/board-specs.mjs
@@ -1,0 +1,202 @@
+/**
+ * WHERE THE BOARD INDEX'S FLASH, RAM AND RUNTIME FIGURES COME FROM (#897, #902).
+ * =============================================================================
+ *
+ * `board.json` publishes no flash size and no RAM size. Its `features` list has
+ * `External Flash` and `External RAM` as booleans and nothing else, so the two
+ * numbers people most want when choosing a board are the two upstream does not
+ * have. This module is the answer to "then where did that number come from?",
+ * and every figure it emits carries a `source` saying so.
+ *
+ * THREE SOURCES, IN DESCENDING ORDER OF COVERAGE AND ASCENDING ORDER OF EFFORT:
+ *
+ *  1. **The chip's own SRAM**, from `mcu`. Exact, free, and correct for every
+ *     part in the family — but it is the CHIP's figure, so it is marked
+ *     `scope: 'chip'` and says nothing about the module. Every RP2040 has 264 KB
+ *     of SRAM; RP2040 boards ship with 2 MB to 16 MB of flash.
+ *
+ *     Only families whose SRAM is genuinely fixed are listed. `stm32f4` covers
+ *     the F401 at 96 KB and the F439 at 256 KB; `nrf52` covers the nRF52832 at
+ *     64 KB and the nRF52840 at 256 KB; `samd21`, `samd51` and `mimxrt` are the
+ *     same story. Those are ABSENT rather than averaged — a plausible wrong
+ *     number is worse than a blank, because a blank gets checked.
+ *
+ *  2. **Curated boards**, where a maker's page or upstream's own build
+ *     configuration states it outright. Small on purpose.
+ *
+ *  3. **The manufacturer `url` each board already carries.** That is the
+ *     authoritative source for the rest and it is per-vendor work with a review
+ *     step, not one parser: those pages have no common structure, and guessing
+ *     sends someone to a board that cannot hold their program. Left to a
+ *     follow-up, with the count of boards still unknown reported by the run.
+ *
+ * A NOTE ON WHAT LOOKS LIKE A SHORTCUT AND IS NOT. `ports/rp2/boards/<BOARD>/
+ * mpconfigboard.cmake` carries `MICROPY_HW_FLASH_STORAGE_BYTES`, which is
+ * tempting and wrong: it is the size of the FILESYSTEM partition, not of the
+ * flash. RPI_PICO sets 1441792 on a 2 MB part; RPI_PICO2 sets 3145728 on a 4 MB
+ * one, with the arithmetic in a comment. Deriving flash from it means guessing
+ * the firmware reservation, which varies. Likewise `ports/esp32/boards/<BOARD>/
+ * sdkconfig.board` mostly does not set a flash size at all — the boards inherit
+ * shared `sdkconfig` fragments — so there is no per-board figure to read.
+ *
+ * Kept as `.mjs` beside the generator that uses it, and pure, so `test/
+ * boardSpecs.test.ts` exercises the tables directly rather than diffing output.
+ */
+
+const KiB = 1024
+const MiB = 1024 * 1024
+
+/**
+ * Built-in SRAM per chip family, for families where it is fixed across the part.
+ *
+ * `source` names the datasheet rather than a URL, because these outlive any
+ * particular documentation URL and a reader can find them by that name.
+ */
+export const MCU_SRAM = {
+  rp2040: { bytes: 264 * KiB, source: 'Raspberry Pi RP2040 datasheet' },
+  rp2350: { bytes: 520 * KiB, source: 'Raspberry Pi RP2350 datasheet' },
+  esp32: { bytes: 520 * KiB, source: 'Espressif ESP32 datasheet' },
+  esp32s2: { bytes: 320 * KiB, source: 'Espressif ESP32-S2 datasheet' },
+  esp32s3: { bytes: 512 * KiB, source: 'Espressif ESP32-S3 datasheet' },
+  esp32c2: { bytes: 272 * KiB, source: 'Espressif ESP32-C2 datasheet' },
+  esp32c3: { bytes: 400 * KiB, source: 'Espressif ESP32-C3 datasheet' },
+  esp32c5: { bytes: 384 * KiB, source: 'Espressif ESP32-C5 datasheet (HP SRAM)' },
+  esp32c6: { bytes: 512 * KiB, source: 'Espressif ESP32-C6 datasheet (HP SRAM)' },
+  esp32p4: { bytes: 768 * KiB, source: 'Espressif ESP32-P4 datasheet (HP SRAM)' }
+  // esp32h2 and esp8266 are deliberately absent: the published figures for both
+  // disagree with each other often enough that I could not name one and stand
+  // behind it. Two boards and one board respectively — not worth a wrong number.
+}
+
+/**
+ * Boards whose sizes are stated by a source I have actually read.
+ *
+ * Seeded from `src/shared/board-profiles.ts`, which has carried some of these by
+ * hand since #756 ("8 MB flash, 2 MB PSRAM" on the Feather V2), plus the makers'
+ * own documentation for the rest. `flash` and `psram` are `board` scope; SRAM is
+ * left to {@link MCU_SRAM} so one chip's figure lives in one place.
+ *
+ * `psram: null` is a CLAIM, not a gap — it says the board has none — and is set
+ * only where the maker says so.
+ */
+export const CURATED_BOARDS = {
+  RPI_PICO: {
+    flash: { bytes: 2 * MiB, source: 'raspberrypi.com Pico series documentation' },
+    psram: null
+  },
+  RPI_PICO_W: {
+    flash: { bytes: 2 * MiB, source: 'raspberrypi.com Pico series documentation' },
+    psram: null
+  },
+  RPI_PICO2: {
+    flash: { bytes: 4 * MiB, source: 'raspberrypi.com Pico series documentation' },
+    psram: null
+  },
+  RPI_PICO2_W: {
+    flash: { bytes: 4 * MiB, source: 'raspberrypi.com Pico series documentation' },
+    psram: null
+  },
+  SEEED_XIAO_ESP32S3: {
+    // Upstream's own build configuration says it, in a comment above the
+    // `sdkconfig.spiram_oct` it selects because of it — which is better than a
+    // product page: it is what the firmware people flash is compiled for.
+    flash: {
+      bytes: 8 * MiB,
+      source: 'MicroPython ports/esp32/boards/SEEED_XIAO_ESP32S3/mpconfigboard.cmake'
+    },
+    psram: {
+      bytes: 8 * MiB,
+      source: 'MicroPython ports/esp32/boards/SEEED_XIAO_ESP32S3/mpconfigboard.cmake'
+    }
+  }
+}
+
+/**
+ * The flash / RAM / PSRAM to publish for one board, or nulls where nothing is
+ * known. `board` beats `chip`, and nothing is invented.
+ */
+export function specsForBoard(board) {
+  const curated = CURATED_BOARDS[board.id]
+  const sram = MCU_SRAM[board.mcu]
+  return {
+    flash: curated?.flash ? { ...curated.flash, scope: 'board' } : null,
+    ram: sram ? { ...sram, scope: 'chip' } : null,
+    psram: curated?.psram ? { ...curated.psram, scope: 'board' } : null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Which runtimes a board has a published build for
+// ---------------------------------------------------------------------------
+
+/**
+ * Thonny's curated CircuitPython catalogues — the same three files
+ * `shared/firmware-runtime.ts` verified in 2026-08, and the same records Snakie
+ * already flashes CircuitPython from. Fetched rather than vendored so a board
+ * added there this month is matched next time this runs.
+ */
+export const CIRCUITPYTHON_CATALOGS = [
+  'https://raw.githubusercontent.com/thonny/thonny/master/data/circuitpython-variants-uf2.json',
+  'https://raw.githubusercontent.com/thonny/thonny/master/data/circuitpython-variants-esptool.json',
+  'https://raw.githubusercontent.com/thonny/thonny/master/data/circuitpython-variants-daplink.json'
+]
+
+/** Case- and separator-insensitive, so `Pro Micro - RP2040` meets `pro_micro_rp2040`. */
+const norm = (s) => (s ?? '').toLowerCase().replace(/[^a-z0-9]+/g, '')
+
+/**
+ * Two lookups over the CircuitPython catalogue, and only two.
+ *
+ * MicroPython and CircuitPython name boards independently, so there is no
+ * general mapping between them — but there are two joins that are facts rather
+ * than guesses:
+ *
+ *   - **the same id.** `SEEED_XIAO_ESP32S3` lowercased IS CircuitPython's
+ *     `seeed_xiao_esp32s3`. Their id namespaces are separately maintained, but
+ *     an id that exists in CircuitPython's is unambiguously the board it names.
+ *   - **the same maker and the same product name.** `Raspberry Pi` + `Pico 2 W`
+ *     is one board, whoever is writing the catalogue.
+ *
+ * A vendor+model that resolves to more than one CircuitPython board is dropped
+ * rather than resolved by picking one: flashing the wrong `.uf2` leaves a board
+ * that needs re-flashing before it will talk again, so an ambiguous match is a
+ * reason to say nothing. Everything past these two — fuzzy names, shared chips,
+ * "it is probably the S3 one" — is guessing, and is not done.
+ */
+export function circuitPythonIndex(catalogs) {
+  const byId = new Set()
+  const byVendorModel = new Map()
+  for (const entry of catalogs.flat()) {
+    const m = /circuitpython\.org\/board\/([^/]+)\//.exec(entry?.info_url ?? '')
+    if (!m) continue
+    const id = m[1]
+    byId.add(id)
+    const key = `${norm(entry.vendor)}|${norm(entry.model)}`
+    const seen = byVendorModel.get(key)
+    if (seen === undefined) byVendorModel.set(key, id)
+    else if (seen !== id) byVendorModel.set(key, null) // ambiguous ⇒ say nothing
+  }
+  return { byId, byVendorModel }
+}
+
+/** The board's CircuitPython id, or null when neither join lands. */
+export function circuitPythonIdFor(board, index) {
+  const lower = board.id.toLowerCase()
+  if (index.byId.has(lower)) return lower
+  return index.byVendorModel.get(`${norm(board.vendor)}|${norm(board.product)}`) ?? null
+}
+
+/**
+ * The runtimes with a published, flashable build for this board.
+ *
+ * `micropython` iff something is actually published — three of the 225 sit in
+ * upstream's tree with no download page. `circuitpython` iff an id was
+ * confirmed; its absence means "not confirmed", which the gallery is careful to
+ * say rather than rendering as "no".
+ */
+export function runtimesForBoard(board, circuitPythonBoardId) {
+  const runtimes = []
+  if (board.builds.length > 0) runtimes.push('micropython')
+  if (circuitPythonBoardId) runtimes.push('circuitpython')
+  return runtimes
+}

--- a/scripts/build-board-index.mjs
+++ b/scripts/build-board-index.mjs
@@ -19,19 +19,33 @@
  * committed here as the bundled seed, so a fresh install and the offline
  * classroom build (#267) work with no network at all.
  *
- * WHAT UPSTREAM DOES NOT PUBLISH: flash size and RAM size. `features` carries
- * `External Flash` and `External RAM` as booleans and nothing more. So this
- * emits no `flashBytes`/`ramBytes` — the gallery shows storage and memory as
- * facts where a board profile happens to know them, and does not offer them as
- * filters, which would silently omit most of the catalogue.
+ * WHAT UPSTREAM DOES NOT PUBLISH: flash size, RAM size, and whether the board
+ * also runs CircuitPython. `features` carries `External Flash` and `External
+ * RAM` as booleans and nothing more. Those come from `board-specs.mjs` instead,
+ * which is where every figure's provenance lives — see #897 for why a number
+ * with no `source` is not published at all.
  *
  * Run:  node scripts/build-board-index.mjs [--tag v1.29.0] [--no-images]
+ *       node scripts/build-board-index.mjs --specs-only
+ *
+ * `--specs-only` re-reads the committed `boards.json` and rewrites just the
+ * derived fields — sizes, runtimes, CircuitPython ids. It exists because the
+ * curation in `board-specs.mjs` changes far more often than upstream's tree
+ * does, and a full run re-encodes 217 thumbnails into an unreviewable binary
+ * diff to say nothing about them.
  */
-import { mkdir, writeFile, rm } from 'node:fs/promises'
+import { mkdir, readFile, writeFile, rm } from 'node:fs/promises'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
+import {
+  CIRCUITPYTHON_CATALOGS,
+  circuitPythonIdFor,
+  circuitPythonIndex,
+  runtimesForBoard,
+  specsForBoard
+} from './board-specs.mjs'
 
 const run = promisify(execFile)
 const HERE = dirname(fileURLToPath(import.meta.url))
@@ -208,7 +222,61 @@ async function thumbnail(srcBytes, destPath) {
   }
 }
 
+/**
+ * Attach the derived fields to every board, in place.
+ *
+ * Shared by the full run and `--specs-only` so the two cannot drift: a seed
+ * enriched by the quick path has to be byte-identical to one the slow path would
+ * have produced, or the quick path is just a second, worse generator.
+ */
+function addSpecs(boards, cpIndex) {
+  for (const b of boards) {
+    const { flash, ram, psram } = specsForBoard(b)
+    b.flash = flash
+    b.ram = ram
+    b.psram = psram
+    b.circuitPythonBoardId = cpIndex ? circuitPythonIdFor(b, cpIndex) : null
+    b.runtimes = runtimesForBoard(b, b.circuitPythonBoardId)
+  }
+  return boards
+}
+
+/** The CircuitPython catalogue, or null when it cannot be reached. */
+async function loadCircuitPython() {
+  try {
+    const catalogs = await Promise.all(CIRCUITPYTHON_CATALOGS.map((u) => getJson(u)))
+    return circuitPythonIndex(catalogs)
+  } catch (err) {
+    // Not fatal, and deliberately loud: a board index whose CircuitPython column
+    // is silently empty looks exactly like one where no board runs it.
+    process.stderr.write(`  WARNING: CircuitPython catalogue unavailable (${err.message})\n`)
+    return null
+  }
+}
+
+/** Report what is known and what is not, because the gaps are the point (#897). */
+function reportCoverage(boards) {
+  const n = (f) => boards.filter(f).length
+  process.stderr.write(
+    `  flash size on ${n((b) => b.flash)}/${boards.length}, ` +
+      `RAM on ${n((b) => b.ram)}, PSRAM on ${n((b) => b.psram)}, ` +
+      `CircuitPython confirmed on ${n((b) => b.circuitPythonBoardId)}\n`
+  )
+}
+
+/** Rewrite the committed seed's derived fields without touching anything else. */
+async function specsOnly() {
+  const path = join(OUT_DIR, 'boards.json')
+  const doc = JSON.parse(await readFile(path, 'utf8'))
+  process.stderr.write(`Re-deriving specs for ${doc.boards.length} boards in ${path}\n`)
+  addSpecs(doc.boards, await loadCircuitPython())
+  doc.generated = new Date().toISOString().slice(0, 10)
+  await writeFile(path, `${JSON.stringify(doc, null, 2)}\n`)
+  reportCoverage(doc.boards)
+}
+
 async function main() {
+  if (flag('--specs-only')) return specsOnly()
   const tag = value('--tag', null) ?? (await newestReleaseTag())
   const withImages = !flag('--no-images')
   process.stderr.write(`Building board index from MicroPython ${tag}\n`)
@@ -262,6 +330,7 @@ async function main() {
   const ok = boards.filter((b) => b && !b.error)
   const failed = boards.length - ok.length
   ok.sort((a, b) => a.vendor.localeCompare(b.vendor) || a.product.localeCompare(b.product))
+  addSpecs(ok, await loadCircuitPython())
 
   const doc = {
     schema: SCHEMA,
@@ -277,6 +346,7 @@ async function main() {
     `  wrote ${ok.length} boards (${withBuilds} with published firmware, ` +
       `${withThumbs} with thumbnails${failed ? `, ${failed} failed` : ''})\n`
   )
+  reportCoverage(ok)
 }
 
 main().catch((err) => {

--- a/src/renderer/public/boards/boards.json
+++ b/src/renderer/public/boards/boards.json
@@ -31,6 +31,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ACTINIUS_ICARUS-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -61,6 +68,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ADAFRUIT_F405_EXPRESS-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -97,6 +111,14 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ADAFRUIT_FEATHER_M0_EXPRESS-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": "feather_m0_express",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -133,6 +155,14 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ADAFRUIT_FEATHER_M4_EXPRESS-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": "feather_m4_express",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -163,6 +193,14 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/FEATHER52-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": "feather_nrf52840_express",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -201,6 +239,18 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ADAFRUIT_FEATHER_RP2040-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 270336,
+        "source": "Raspberry Pi RP2040 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": "adafruit_feather_rp2040",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -241,6 +291,18 @@
           "date": "20260824",
           "url": "https://micropython.org/resources/firmware/ADAFRUIT_FEATHER_RP2350-RISCV-20260824-v1.29.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 532480,
+        "source": "Raspberry Pi RP2350 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": "adafruit_feather_rp2350",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -275,6 +337,14 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ADAFRUIT_ITSYBITSY_M0_EXPRESS-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": "itsybitsy_m0_express",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -309,6 +379,14 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ADAFRUIT_ITSYBITSY_M4_EXPRESS-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": "itsybitsy_m4_express",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -344,6 +422,18 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ADAFRUIT_ITSYBITSY_RP2040-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 270336,
+        "source": "Raspberry Pi RP2040 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": "adafruit_itsybitsy_rp2040",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -381,6 +471,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ADAFRUIT_METRO_M4_EXPRESS-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -418,6 +515,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ADAFRUIT_METRO_M7-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -451,6 +555,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ADAFRUIT_NEOKEY_TRINKEY-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -499,6 +610,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ADAFRUIT_QTPY_SAMD21-SPIFLASH-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -535,6 +653,18 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ADAFRUIT_QTPY_RP2040-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 270336,
+        "source": "Raspberry Pi RP2040 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": "adafruit_qtpy_rp2040",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -568,6 +698,14 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ADAFRUIT_TRINKET_M0-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": "trinket_m0",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -585,7 +723,12 @@
       "flashOffset": null,
       "image": "https://micropython.org/resources/micropython-media/boards/ALIF_ENSEMBLE/ensemble-devkit-gen-2.jpg",
       "thumb": "ALIF_ENSEMBLE.jpg",
-      "builds": []
+      "builds": [],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": []
     },
     {
       "id": "ARDUINO_GIGA",
@@ -622,6 +765,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ARDUINO_GIGA-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -659,6 +809,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ARDUINO_NANO_33_BLE_SENSE-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -695,6 +852,18 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ARDUINO_NANO_ESP32-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 524288,
+        "source": "Espressif ESP32-S3 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": "arduino_nano_esp32s3",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -734,6 +903,18 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ARDUINO_NANO_RP2040_CONNECT-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 270336,
+        "source": "Raspberry Pi RP2040 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": "arduino_nano_rp2040_connect",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -771,6 +952,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ARDUINO_NICLA_VISION-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -807,6 +995,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ARDUINO_OPTA-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -844,6 +1039,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ARDUINO_PORTENTA_C33-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -882,6 +1084,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ARDUINO_PORTENTA_H7-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -912,6 +1121,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ARDUINO_PRIMO-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -942,6 +1158,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/MICROBIT-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -993,6 +1216,18 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/CYTRON_MOTION_2350_PRO-RISCV-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 532480,
+        "source": "Raspberry Pi RP2350 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": "cytron_motion_2350_pro",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -1031,6 +1266,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/CYTRON_NANOXRP_CONTROLLER-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 270336,
+        "source": "Raspberry Pi RP2040 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -1126,6 +1372,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ESP32_GENERIC-SPIRAM-20260406-v1.28.0.bin"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 532480,
+        "source": "Espressif ESP32 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -1176,6 +1433,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ESP32_GENERIC_C2-FLASH_2M-20260406-v1.28.0.bin"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 278528,
+        "source": "Espressif ESP32-C2 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -1210,6 +1478,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ESP32_GENERIC_C3-20260406-v1.28.0.bin"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 409600,
+        "source": "Espressif ESP32-C3 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -1244,6 +1523,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ESP32_GENERIC_C5-20260406-v1.28.0.bin"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 393216,
+        "source": "Espressif ESP32-C5 datasheet (HP SRAM)",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -1277,6 +1567,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ESP32_GENERIC_C6-20260406-v1.28.0.bin"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 524288,
+        "source": "Espressif ESP32-C6 datasheet (HP SRAM)",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -1302,6 +1603,13 @@
           "date": "20260824",
           "url": "https://micropython.org/resources/firmware/ESP32_GENERIC_H2-20260824-v1.29.0.bin"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -1390,6 +1698,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ESP32_GENERIC_P4-C5_WIFI-20260406-v1.28.0.bin"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 786432,
+        "source": "Espressif ESP32-P4 datasheet (HP SRAM)",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -1424,6 +1743,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ESP32_GENERIC_S2-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 327680,
+        "source": "Espressif ESP32-S2 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -1475,6 +1805,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ESP32_GENERIC_S3-SPIRAM_OCT-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 524288,
+        "source": "Espressif ESP32-S3 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -1554,6 +1895,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ESP8266_GENERIC-FLASH_2M_ROMFS-20260406-v1.28.0.bin"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -1584,6 +1932,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/ESPRUINO_PICO-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -1614,6 +1969,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/DVK_BL652-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -1644,6 +2006,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/CERB40-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -1674,6 +2043,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/PYBD_SF2-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -1704,6 +2080,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/PYBD_SF3-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -1737,6 +2120,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/PYBD_SF6-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -1828,6 +2218,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/PYBLITEV10-NETWORK-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -1919,6 +2316,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/PYBV10-NETWORK-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -2010,6 +2414,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/PYBV11-NETWORK-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -2040,6 +2451,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/HYDRABUS-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -2070,6 +2488,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/BLUEIO_TAG_EVIM-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -2100,6 +2525,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/IBK_BLYST_NANO-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -2130,6 +2562,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/IDK_BLYST_NANO-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -2154,7 +2593,12 @@
       "flashOffset": null,
       "image": "https://micropython.org/resources/micropython-media/boards/KIT_PSE84_AI/kit_pse84_ai.jpg",
       "thumb": null,
-      "builds": []
+      "builds": [],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": []
     },
     {
       "id": "LEGO_HUB_NO6",
@@ -2184,6 +2628,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/LEGO_HUB_NO6-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -2214,6 +2665,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/LEGO_HUB_NO7-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -2246,6 +2704,17 @@
           "date": "20260824",
           "url": "https://micropython.org/resources/firmware/LILYGO_T3_S3-20260824-v1.29.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 524288,
+        "source": "Espressif ESP32-S3 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -2284,6 +2753,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/LILYGO_TTGO_LORA32-20260406-v1.28.0.bin"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 532480,
+        "source": "Espressif ESP32 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -2314,6 +2794,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/LIMIFROG-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -2351,6 +2838,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/M5STACK_ATOM-20260406-v1.28.0.bin"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 532480,
+        "source": "Espressif ESP32 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -2387,6 +2885,18 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/M5STACK_ATOMS3_LITE-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 524288,
+        "source": "Espressif ESP32-S3 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": "m5stack_atoms3_lite",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -2424,6 +2934,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/M5STACK_NANOC6-20260406-v1.28.0.bin"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 524288,
+        "source": "Espressif ESP32-C6 datasheet (HP SRAM)",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -2453,6 +2974,13 @@
           "date": "20260824",
           "url": "https://micropython.org/resources/firmware/M5STACK_NANOH2-20260824-v1.29.0.bin"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -2487,6 +3015,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/MACHDYNE_WERKZEUG-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 270336,
+        "source": "Raspberry Pi RP2040 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -2521,6 +3060,14 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/MAKERDIARY_RT1011_NANO_KIT-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": "makerdiary_imxrt1011_nanokit",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -2551,6 +3098,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NRF52840_MDK_USB_DONGLE-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -2581,6 +3135,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/GARATRONIC_NADHAT_F405-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -2611,6 +3172,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/GARATRONIC_PYBSTICK26_F411-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -2646,6 +3214,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/GARATRONIC_PYBSTICK26_ESP32C3-20260406-v1.28.0.bin"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 409600,
+        "source": "Espressif ESP32-C3 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -2681,6 +3260,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/GARATRONIC_PYBSTICK26_RP2040-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 270336,
+        "source": "Raspberry Pi RP2040 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -2713,6 +3303,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/SAMD_GENERIC_D21X18-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -2745,6 +3342,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/SAMD_GENERIC_D51X19-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -2777,6 +3381,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/SAMD_GENERIC_D51X20-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -2810,6 +3421,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/SAMD21_XPLAINED_PRO-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -2842,6 +3460,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/MIKROE_CLICKER2_STM32-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -2874,6 +3499,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/MIKROE_QUAIL-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -2904,6 +3536,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/RA4M1_CLICKER-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -2938,6 +3577,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/MINISAM_M4-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -2968,6 +3614,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NETDUINO_PLUS_2-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -2998,6 +3651,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/PCA10000-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -3028,6 +3688,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/PCA10001-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -3058,6 +3725,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/PCA10028-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -3088,6 +3762,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/PCA10031-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -3118,6 +3799,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/PCA10040-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -3148,6 +3836,14 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/PCA10056-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": "pca10056",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -3178,6 +3874,14 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/PCA10059-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": "pca10059",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -3208,6 +3912,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/PCA10090-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -3243,6 +3954,18 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NULLBITS_BIT_C_PRO-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 270336,
+        "source": "Raspberry Pi RP2040 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": "nullbits_bit_c_pro",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -3278,6 +4001,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/MIMXRT1010_EVK-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -3313,6 +4043,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/MIMXRT1015_EVK-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -3352,6 +4089,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/MIMXRT1020_EVK-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -3391,6 +4135,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/MIMXRT1050_EVK-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -3431,6 +4182,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/MIMXRT1060_EVK-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -3471,6 +4229,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/MIMXRT1064_EVK-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -3511,6 +4276,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/MIMXRT1170_EVK-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -3548,6 +4320,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/OLIMEX_ESP32_EVB-20260406-v1.28.0.bin"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 532480,
+        "source": "Espressif ESP32 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -3586,6 +4369,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/OLIMEX_ESP32_POE-20260406-v1.28.0.bin"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 532480,
+        "source": "Espressif ESP32 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -3620,6 +4414,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/OLIMEX_RT1010-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -3650,6 +4451,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/OLIMEX_E407-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -3680,6 +4488,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/OLIMEX_H407-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -3710,6 +4525,14 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/PARTICLE_XENON-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": "particle_xenon",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -3753,6 +4576,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/PHYBOARD_RT1170-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -3805,6 +4635,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/PIMORONI_PICOLIPO-FLASH_16M-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 270336,
+        "source": "Raspberry Pi RP2040 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -3856,6 +4697,18 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/PIMORONI_TINY2040-FLASH_8M-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 270336,
+        "source": "Raspberry Pi RP2040 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": "pimoroni_tiny2040",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -3889,6 +4742,14 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/TEENSY40-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": "teensy40",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -3924,6 +4785,14 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/TEENSY41-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": "teensy41",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -3961,6 +4830,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/POLOLU_3PI_2040_ROBOT-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 270336,
+        "source": "Raspberry Pi RP2040 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -3999,6 +4879,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/POLOLU_ZUMO_2040_ROBOT-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 270336,
+        "source": "Raspberry Pi RP2040 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -4020,7 +4911,12 @@
       "flashOffset": null,
       "image": "https://micropython.org/resources/micropython-media/boards/WIPY/wipy.jpg",
       "thumb": "WIPY.jpg",
-      "builds": []
+      "builds": [],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": []
     },
     {
       "id": "GARATRONIC_PYMATE_CORE8ADI8DOSC",
@@ -4043,6 +4939,13 @@
           "date": "20260824",
           "url": "https://micropython.org/resources/firmware/GARATRONIC_PYMATE_CORE8ADI8DOSC-20260824-v1.29.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -4077,6 +4980,22 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/RPI_PICO-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": {
+        "bytes": 2097152,
+        "source": "raspberrypi.com Pico series documentation",
+        "scope": "board"
+      },
+      "ram": {
+        "bytes": 270336,
+        "source": "Raspberry Pi RP2040 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": "raspberry_pi_pico",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -4127,6 +5046,22 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/RPI_PICO2-RISCV-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": {
+        "bytes": 4194304,
+        "source": "raspberrypi.com Pico series documentation",
+        "scope": "board"
+      },
+      "ram": {
+        "bytes": 532480,
+        "source": "Raspberry Pi RP2350 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": "raspberry_pi_pico2",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -4179,6 +5114,22 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/RPI_PICO2_W-RISCV-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": {
+        "bytes": 4194304,
+        "source": "raspberrypi.com Pico series documentation",
+        "scope": "board"
+      },
+      "ram": {
+        "bytes": 532480,
+        "source": "Raspberry Pi RP2350 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": "raspberry_pi_pico2_w",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -4215,6 +5166,22 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/RPI_PICO_W-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": {
+        "bytes": 2097152,
+        "source": "raspberrypi.com Pico series documentation",
+        "scope": "board"
+      },
+      "ram": {
+        "bytes": 270336,
+        "source": "Raspberry Pi RP2040 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": "raspberry_pi_pico_w",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -4245,6 +5212,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/EK_RA4M1-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -4275,6 +5249,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/EK_RA4W1-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -4305,6 +5286,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/EK_RA6M1-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -4335,6 +5323,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/EK_RA6M2-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -4371,6 +5366,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/SEEED_ARCH_MIX-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -4409,6 +5411,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/SEEED_WIO_TERMINAL-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -4438,6 +5447,18 @@
           "date": "20260824",
           "url": "https://micropython.org/resources/firmware/SEEED_XIAO_ESP32C3-20260824-v1.29.0.bin"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 409600,
+        "source": "Espressif ESP32-C3 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": "seeed_xiao_esp32c3",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -4469,6 +5490,17 @@
           "date": "20260824",
           "url": "https://micropython.org/resources/firmware/SEEED_XIAO_ESP32C5-20260824-v1.29.0.bin"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 393216,
+        "source": "Espressif ESP32-C5 datasheet (HP SRAM)",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -4506,6 +5538,18 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/SEEED_XIAO_ESP32C6-20260406-v1.28.0.bin"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 524288,
+        "source": "Espressif ESP32-C6 datasheet (HP SRAM)",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": "seeed_xiao_esp32c6",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -4537,6 +5581,26 @@
           "date": "20260824",
           "url": "https://micropython.org/resources/firmware/SEEED_XIAO_ESP32S3-20260824-v1.29.0.uf2"
         }
+      ],
+      "flash": {
+        "bytes": 8388608,
+        "source": "MicroPython ports/esp32/boards/SEEED_XIAO_ESP32S3/mpconfigboard.cmake",
+        "scope": "board"
+      },
+      "ram": {
+        "bytes": 524288,
+        "source": "Espressif ESP32-S3 datasheet",
+        "scope": "chip"
+      },
+      "psram": {
+        "bytes": 8388608,
+        "source": "MicroPython ports/esp32/boards/SEEED_XIAO_ESP32S3/mpconfigboard.cmake",
+        "scope": "board"
+      },
+      "circuitPythonBoardId": "seeed_xiao_esp32s3",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -4575,6 +5639,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/SEEED_XIAO_NRF52-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -4611,6 +5682,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/SEEED_XIAO_RP2040-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 270336,
+        "source": "Raspberry Pi RP2040 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -4663,6 +5745,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/SEEED_XIAO_RP2350-RISCV-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 532480,
+        "source": "Raspberry Pi RP2350 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -4695,6 +5788,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/SEEED_XIAO_SAMD21-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -4731,6 +5831,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/SIL_WESP32-20260406-v1.28.0.bin"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 532480,
+        "source": "Espressif ESP32 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -4769,6 +5880,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/SIL_MANT1S-20260406-v1.28.0.bin"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 532480,
+        "source": "Espressif ESP32 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -4804,6 +5926,18 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/SIL_RP2040_SHIM-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 270336,
+        "source": "Raspberry Pi RP2040 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": "silicognition_rp2040_shim",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -4839,6 +5973,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/SOLDERED_NULA_MINI-20260406-v1.28.0.bin"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 524288,
+        "source": "Espressif ESP32-C6 datasheet (HP SRAM)",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -4872,6 +6017,17 @@
           "date": "20260824",
           "url": "https://micropython.org/resources/firmware/SOLDERED_NULA_MAX_RP2350-20260824-v1.29.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 532480,
+        "source": "Raspberry Pi RP2350 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -4907,6 +6063,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/SPARKFUN_IOT_REDBOARD_ESP32-20260406-v1.28.0.bin"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 532480,
+        "source": "Espressif ESP32 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -4963,6 +6130,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/SPARKFUN_IOTNODE_LORAWAN_RP2350-RISCV-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 532480,
+        "source": "Raspberry Pi RP2350 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -4993,6 +6171,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/SPARKFUN_MICROMOD_STM32-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -5029,6 +6214,18 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/SPARKFUN_PROMICRO-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 270336,
+        "source": "Raspberry Pi RP2040 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": "sparkfun_pro_micro_rp2040",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -5082,6 +6279,18 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/SPARKFUN_PROMICRO_RP2350-RISCV-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 532480,
+        "source": "Raspberry Pi RP2350 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": "sparkfun_pro_micro_rp2350",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -5117,6 +6326,14 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/SPARKFUN_SAMD51_THING_PLUS-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": "sparkfun_samd51_thing_plus",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -5174,6 +6391,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/SPARKFUN_IOTREDBOARD_RP2350-RISCV-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 532480,
+        "source": "Raspberry Pi RP2350 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -5210,6 +6438,14 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/SPARKFUN_REDBOARD_TURBO-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": "sparkfun_redboard_turbo",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -5244,6 +6480,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/SPARKFUN_SAMD21_DEV_BREAKOUT-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -5283,6 +6526,18 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/SPARKFUN_THINGPLUS-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 270336,
+        "source": "Raspberry Pi RP2040 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": "sparkfun_thing_plus_rp2040",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -5324,6 +6579,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/SPARKFUN_THINGPLUS_ESP32C5-20260406-v1.28.0.bin"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 393216,
+        "source": "Espressif ESP32-C5 datasheet (HP SRAM)",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -5382,6 +6648,18 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/SPARKFUN_THINGPLUS_RP2350-RISCV-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 532480,
+        "source": "Raspberry Pi RP2350 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": "sparkfun_thing_plus_rp2350",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -5438,6 +6716,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/SPARKFUN_XRP_CONTROLLER-RISCV-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 532480,
+        "source": "Raspberry Pi RP2350 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -5476,6 +6765,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/SPARKFUN_XRP_CONTROLLER_BETA-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 270336,
+        "source": "Raspberry Pi RP2040 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -5506,6 +6806,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/B_L072Z_LRWAN1-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -5536,6 +6843,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/B_L475E_IOT01A-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -5566,6 +6880,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/STM32F4DISC-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -5596,6 +6917,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/STM32F411DISC-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -5626,6 +6954,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/STM32F429DISC-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -5656,6 +6991,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/STM32F469DISC-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -5686,6 +7028,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/STM32F7DISC-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -5716,6 +7065,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/STM32F769DISC-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -5746,6 +7102,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/STM32H7B3I_DK-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -5777,6 +7140,13 @@
           "date": "20260824",
           "url": "https://micropython.org/resources/firmware/STM32H747I_DISCO-20260824-v1.29.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -5807,6 +7177,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/STM32L476DISC-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -5837,6 +7214,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/STM32L496GDISC-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -5867,6 +7251,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NUCLEO_F091RC-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -5897,6 +7288,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NUCLEO_F401RE-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -5927,6 +7325,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NUCLEO_F411RE-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -5957,6 +7362,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NUCLEO_F412ZG-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -5987,6 +7399,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NUCLEO_F413ZH-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6017,6 +7436,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NUCLEO_F429ZI-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6047,6 +7473,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NUCLEO_F439ZI-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6077,6 +7510,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NUCLEO_F446RE-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6107,6 +7547,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NUCLEO_F722ZE-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6137,6 +7584,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NUCLEO_F746ZG-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6167,6 +7621,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NUCLEO_F756ZG-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6197,6 +7658,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NUCLEO_F767ZI-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6227,6 +7695,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NUCLEO_G0B1RE-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6257,6 +7732,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NUCLEO_G474RE-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6287,6 +7769,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NUCLEO_H563ZI-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6317,6 +7806,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NUCLEO_H723ZG-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6347,6 +7843,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NUCLEO_H743ZI-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6377,6 +7880,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NUCLEO_H743ZI2-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6407,6 +7917,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NUCLEO_H753ZI-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6437,6 +7954,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NUCLEO_H7A3ZI_Q-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6467,6 +7991,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NUCLEO_L073RZ-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6497,6 +8028,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NUCLEO_L152RE-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6527,6 +8065,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NUCLEO_L432KC-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6557,6 +8102,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NUCLEO_L452RE-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6587,6 +8139,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NUCLEO_L476RG-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6617,6 +8176,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NUCLEO_L4A6ZG-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6647,6 +8213,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NUCLEO_U5A5ZJ_Q-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6677,6 +8250,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NUCLEO_WB55-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6707,6 +8287,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/NUCLEO_WL55-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6737,6 +8324,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/STM32F439-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6767,6 +8361,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/USBDONGLE_WB55-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6797,6 +8398,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/EVK_NINA_B1-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6827,6 +8435,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/EVK_NINA_B3-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6868,6 +8483,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/UM_FEATHERS2-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 327680,
+        "source": "Espressif ESP32-S2 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6909,6 +8535,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/UM_FEATHERS2NEO-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 327680,
+        "source": "Espressif ESP32-S2 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6949,6 +8586,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/UM_FEATHERS3-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 524288,
+        "source": "Espressif ESP32-S3 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -6989,6 +8637,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/UM_FEATHERS3NEO-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 524288,
+        "source": "Espressif ESP32-S3 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -7027,6 +8686,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/UM_NANOS3-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 524288,
+        "source": "Espressif ESP32-S3 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -7065,6 +8735,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/UM_OMGS3-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 524288,
+        "source": "Espressif ESP32-S3 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -7105,6 +8786,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/UM_PROS3-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 524288,
+        "source": "Espressif ESP32-S3 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -7148,6 +8840,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/UM_RGBTOUCH_MINI-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 524288,
+        "source": "Espressif ESP32-S3 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -7186,6 +8889,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/UM_TINYC6-20260406-v1.28.0.bin"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 524288,
+        "source": "Espressif ESP32-C6 datasheet (HP SRAM)",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -7226,6 +8940,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/UM_TINYPICO-20260406-v1.28.0.bin"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 532480,
+        "source": "Espressif ESP32 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -7266,6 +8991,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/UM_TINYS2-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 327680,
+        "source": "Espressif ESP32-S2 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -7306,6 +9042,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/UM_TINYS3-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 524288,
+        "source": "Espressif ESP32-S3 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -7345,6 +9092,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/UM_TINYWATCHS3-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 524288,
+        "source": "Espressif ESP32-S3 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -7375,6 +9133,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/VCC_GND_F407VE-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -7405,6 +9170,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/VCC_GND_F407ZG-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -7435,6 +9207,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/VCC_GND_H743VI-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -7467,6 +9246,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/VK_RA6M5-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -7503,6 +9289,18 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/WAVESHARE_RP2040_LCD_0_96-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 270336,
+        "source": "Raspberry Pi RP2040 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": "waveshare_rp2040_lcd_0_96",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -7554,6 +9352,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/WAVESHARE_RP2040_PLUS-FLASH_16M-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 270336,
+        "source": "Raspberry Pi RP2040 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -7589,6 +9398,18 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/WAVESHARE_RP2040_ZERO-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 270336,
+        "source": "Raspberry Pi RP2040 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": "waveshare_rp2040_zero",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -7640,6 +9461,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/WAVESHARE_RP2350B_CORE-RISCV-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 532480,
+        "source": "Raspberry Pi RP2350 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -7668,6 +9500,18 @@
           "date": "20260824",
           "url": "https://micropython.org/resources/firmware/WAVESHARE_ESP32_S3_PICO-20260824-v1.29.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 524288,
+        "source": "Espressif ESP32-S3 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": "waveshare_esp32_s3_pico",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -7748,6 +9592,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/WEACTSTUDIO-FLASH_2M-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 270336,
+        "source": "Raspberry Pi RP2040 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -7778,6 +9633,13 @@
           "date": "20260824",
           "url": "https://micropython.org/resources/firmware/WEACTSTUDIO_MINI_STM32H723-20260824-v1.29.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -7815,6 +9677,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/WEACTSTUDIO_MINI_STM32H743-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -7845,6 +9714,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/WEACTSTUDIO_MINI_STM32U585-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -7896,6 +9772,17 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/WEACTSTUDIO_RP2350B_CORE-RISCV-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 532480,
+        "source": "Raspberry Pi RP2350 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -8002,6 +9889,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/WEACT_F411_BLACKPILL-V31_XTAL_8M-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -8037,6 +9931,18 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/LOLIN_C3_MINI-20260406-v1.28.0.bin"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 409600,
+        "source": "Espressif ESP32-C3 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": "lolin_c3_mini",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -8072,6 +9978,18 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/LOLIN_S2_MINI-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 327680,
+        "source": "Espressif ESP32-S2 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": "lolin_s2_mini",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -8109,6 +10027,18 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/LOLIN_S2_PICO-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 327680,
+        "source": "Espressif ESP32-S2 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": "lolin_s2_pico",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -8139,6 +10069,13 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/WT51822_S4AT-20260406-v1.28.0.hex"
         }
+      ],
+      "flash": null,
+      "ram": null,
+      "psram": null,
+      "circuitPythonBoardId": null,
+      "runtimes": [
+        "micropython"
       ]
     },
     {
@@ -8174,6 +10111,18 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/W5100S_EVB_PICO-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 270336,
+        "source": "Raspberry Pi RP2040 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": "wiznet_w5100s_evb_pico",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     },
     {
@@ -8209,6 +10158,18 @@
           "date": "20260406",
           "url": "https://micropython.org/resources/firmware/W5500_EVB_PICO-20260406-v1.28.0.uf2"
         }
+      ],
+      "flash": null,
+      "ram": {
+        "bytes": 270336,
+        "source": "Raspberry Pi RP2040 datasheet",
+        "scope": "chip"
+      },
+      "psram": null,
+      "circuitPythonBoardId": "wiznet_w5500_evb_pico",
+      "runtimes": [
+        "micropython",
+        "circuitpython"
       ]
     }
   ]

--- a/src/renderer/src/components/BoardFinder.css
+++ b/src/renderer/src/components/BoardFinder.css
@@ -643,3 +643,73 @@
   font-size: 11px;
   padding: 3px 8px;
 }
+
+/* --- the runtime facet (#902) --------------------------------------------- */
+
+/* The confirmed count, on the chip. Without it a bare "CircuitPython" chip reads
+   as the whole answer rather than as the subset it is. */
+.bfind__chip-n {
+  margin-left: 5px;
+  font-size: 10px;
+  font-weight: 700;
+  opacity: 0.7;
+  font-variant-numeric: tabular-nums;
+}
+
+/* What a facet cannot claim, printed under the facet. */
+.bfind__facet-note {
+  margin: 7px 0 0;
+  font-size: 10.5px;
+  line-height: 1.45;
+  color: var(--txt3, var(--text-muted));
+}
+
+/* --- boards Snakie carries and upstream does not (#902) ------------------- */
+
+/* On the card face: this board flashes another board's build. */
+.bfind__card-sub {
+  font-family: var(--font-mono), monospace;
+  font-size: 9.5px;
+  font-weight: 700;
+  color: var(--accent-ink, var(--accent));
+}
+
+/* The same thing on the details, given its own tinted block so it is read
+   before the specification rather than after it. */
+.bfind__sub {
+  padding: 10px 12px;
+  background: var(--shell, var(--bg-sunken));
+  border: 1px solid var(--shellbd, var(--border));
+  border-left: 3px solid var(--accent, var(--accent-ink));
+  border-radius: var(--radius);
+}
+.bfind__sub .bfind__section-name {
+  font-family: var(--font-mono), monospace;
+  color: var(--accent-ink, var(--accent));
+}
+.bfind__sub .bfind__note {
+  margin-top: 4px;
+}
+
+/* --- where a figure came from (#897) -------------------------------------- */
+
+/* Under the value, not beside it: the number is what is being read, and the
+   provenance is what makes it worth reading — but only on a second glance. */
+.bfind__src {
+  display: block;
+  margin-top: 1px;
+  font-family: var(--font-ui), sans-serif;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--txt3, var(--text-muted));
+}
+
+.bfind__code {
+  font-family: var(--font-mono), monospace;
+  font-size: 11px;
+  color: var(--head, var(--text));
+  background: var(--shell, var(--bg-sunken));
+  border: 1px solid var(--shellbd, var(--border));
+  border-radius: 4px;
+  padding: 1px 5px;
+}

--- a/src/renderer/src/components/BoardFinder.tsx
+++ b/src/renderer/src/components/BoardFinder.tsx
@@ -12,19 +12,28 @@ import {
   filterBoards,
   mcusOf,
   newestBuilds,
+  runtimeCounts,
   vendorsOf,
   defaultBuild,
   type BoardFilter,
   type IndexedBoard
 } from '../../../shared/board-index'
+import { withOverlay } from '../../../shared/board-overlay'
+import {
+  FIRMWARE_RUNTIMES,
+  FIRMWARE_RUNTIME_LABEL,
+  type FirmwareRuntime
+} from '../../../shared/firmware-runtime'
 import { loadBoardIndex, thumbUrl } from '../lib/board-index-source'
 import {
+  RUNTIME_CAVEAT,
   boardFacts,
   boardInitials,
   buildLabel,
   isFiltering,
   shelvesByVendor,
   toggleFeature,
+  toggleRuntime,
   variantList
 } from './board-finder'
 import { requestFlash } from './board-finder-bus'
@@ -43,11 +52,17 @@ import './BoardFinder.css'
  * Clicking a board asks the firmware flasher to open on it with the newest build
  * already chosen — see `board-finder-bus.ts`, which is the whole of that seam.
  *
- * ON THE FILTERS. There is no storage or memory filter, though the issue asks
- * for one: upstream publishes `External Flash` / `External RAM` as booleans and
- * no figure anywhere, so a size control could only have drawn itself by quietly
- * dropping most of the catalogue. They stay as ordinary feature chips, and the
- * board's details state them plainly as present-with-no-published-size.
+ * ON THE FILTERS. Storage and memory are still not filters (#897): there are
+ * sourced sizes now, but 5 boards of 225 have a flash figure, and a size control
+ * at that coverage hides the catalogue rather than narrowing it. They are stated
+ * as facts on the board instead, each naming where it came from. The RUNTIME
+ * filter (#902) does ship — see `RUNTIME_CAVEAT` for the limits it prints under
+ * itself, which are what make it honest enough to offer.
+ *
+ * ON THE BOARDS. The list is upstream's plus `board-overlay.ts` — boards
+ * MicroPython builds no firmware for under any name, which is why the Adafruit
+ * ESP32 Feather V2 that started this epic was unfindable. They carry a `snakie`
+ * origin and say on the card whose build they flash.
  */
 
 export interface BoardFinderProps {
@@ -108,6 +123,7 @@ export function BoardFinder({ onClose, origin, closing, onClosed }: BoardFinderP
   const [vendor, setVendor] = useState('')
   const [mcu, setMcu] = useState('')
   const [features, setFeatures] = useState<string[]>([])
+  const [runtimes, setRuntimes] = useState<FirmwareRuntime[]>([])
   const [flashableOnly, setFlashableOnly] = useState(false)
   const [showAllFeatures, setShowAllFeatures] = useState(false)
   // The board whose details are open, or null for the grid. A DETOUR, as in the
@@ -127,10 +143,13 @@ export function BoardFinder({ onClose, origin, closing, onClosed }: BoardFinderP
     return () => window.removeEventListener('keydown', onKey)
   }, [onClose, selected])
 
-  const all = useMemo(() => boards ?? [], [boards])
+  // The overlay is applied HERE rather than in the loader, so it re-applies to
+  // whichever document won — including one fetched later that may already carry
+  // a board the overlay is standing in for, which `withOverlay` then drops.
+  const all = useMemo(() => (boards ? withOverlay(boards) : []), [boards])
   const filter: BoardFilter = useMemo(
-    () => ({ text, vendor, mcu, features, flashableOnly }),
-    [text, vendor, mcu, features, flashableOnly]
+    () => ({ text, vendor, mcu, features, runtimes, flashableOnly }),
+    [text, vendor, mcu, features, runtimes, flashableOnly]
   )
   const matched = useMemo(() => filterBoards(all, filter), [all, filter])
 
@@ -140,6 +159,9 @@ export function BoardFinder({ onClose, origin, closing, onClosed }: BoardFinderP
   const mcus = useMemo(() => mcusOf(all), [all])
   const allFeatures = useMemo(() => featuresOf(all), [all])
   const shownFeatures = showAllFeatures ? allFeatures : allFeatures.slice(0, FEATURE_CHIP_LIMIT)
+  // Printed on the runtime chips. The number is the point: "CircuitPython 49"
+  // reads as a confirmed subset, where a bare chip would read as the answer.
+  const runtimeTotals = useMemo(() => runtimeCounts(all), [all])
 
   // Shelves are for BROWSING. Once anything is narrowing the catalogue the
   // result set IS the answer, and re-sectioning it by vendor fights the vendor
@@ -152,6 +174,7 @@ export function BoardFinder({ onClose, origin, closing, onClosed }: BoardFinderP
     setVendor('')
     setMcu('')
     setFeatures([])
+    setRuntimes([])
     setFlashableOnly(false)
   }, [])
 
@@ -238,6 +261,31 @@ export function BoardFinder({ onClose, origin, closing, onClosed }: BoardFinderP
                   </option>
                 ))}
               </select>
+            </div>
+
+            <div className="bfind__facet">
+              <h3 className="bfind__facet-name">Runtime</h3>
+              <div className="bfind__chips">
+                {FIRMWARE_RUNTIMES.map((r) => {
+                  const on = runtimes.includes(r)
+                  return (
+                    <button
+                      key={r}
+                      type="button"
+                      className={`bfind__chip${on ? ' is-on' : ''}`}
+                      aria-pressed={on}
+                      onClick={() => setRuntimes((prev) => toggleRuntime(prev, r))}
+                    >
+                      {FIRMWARE_RUNTIME_LABEL[r]}
+                      <span className="bfind__chip-n">{runtimeTotals[r]}</span>
+                    </button>
+                  )
+                })}
+              </div>
+              {/* The two things a bare "CircuitPython" chip would imply and
+                  cannot support, printed where the chip is rather than in a
+                  tooltip nobody opens. */}
+              <p className="bfind__facet-note">{RUNTIME_CAVEAT}</p>
             </div>
 
             <div className="bfind__facet">
@@ -378,6 +426,12 @@ function BoardCard({
             {extra > 0 && <span className="bfind__feat">+{extra}</span>}
           </span>
         )}
+        {/* Said on the FACE of the card, not buried in the details: picking a
+            board whose firmware is really another board's is the exact mistake
+            this epic exists to stop someone making by accident. */}
+        {board.substitute?.build && (
+          <span className="bfind__card-sub">Flashes {board.substitute.build}</span>
+        )}
         {board.builds.length === 0 && (
           <span className="bfind__card-nofw">No published firmware</span>
         )}
@@ -440,22 +494,55 @@ function BoardDetails({
         </div>
 
         <div>
+          {/* First, above the specification, because it changes what "flash
+              this board" means. */}
+          {board.substitute && (
+            <section className="bfind__section bfind__sub">
+              <h4 className="bfind__section-name">
+                {board.substitute.build
+                  ? `Flashes ${board.substitute.build}`
+                  : 'Firmware comes from elsewhere'}
+              </h4>
+              <p className="bfind__note">{board.substitute.why}</p>
+            </section>
+          )}
+
           <section className="bfind__section">
             <h4 className="bfind__section-name">Specification</h4>
             <dl className="bfind__facts">
               {facts.map((f) => (
                 <div className="bfind__row" key={f.label}>
                   <dt>{f.label}</dt>
-                  <dd>{f.value}</dd>
+                  <dd>
+                    {f.value}
+                    {f.source && <span className="bfind__src">{f.source}</span>}
+                  </dd>
                 </div>
               ))}
             </dl>
             {/* Said out loud, because its absence is otherwise read as a bug. */}
             <p className="bfind__note">
-              Flash and RAM sizes are not published in MicroPython’s board index, so
-              they are not shown or filtered on here.
+              MicroPython’s board index publishes no flash or RAM sizes, so every figure
+              above names where it came from. A board with none simply has no sourced
+              figure yet — which is also why storage and memory are not filters.
             </p>
           </section>
+
+          {board.circuitPythonBoardId && (
+            <section className="bfind__section">
+              <h4 className="bfind__section-name">Also runs CircuitPython</h4>
+              {/* The board id, because it is the thing that matters:
+                  CircuitPython builds are per BOARD, and this exact string is
+                  what its download is filed under and what `boot_out.txt`
+                  prints. Flashing a neighbouring board's `.uf2` is a board that
+                  needs re-flashing before it will talk again. */}
+              <p className="bfind__note">
+                CircuitPython board id{' '}
+                <code className="bfind__code">{board.circuitPythonBoardId}</code>. Choose
+                CircuitPython in the flash dialog to put it on.
+              </p>
+            </section>
+          )}
 
           {board.features.length > 0 && (
             <section className="bfind__section">

--- a/src/renderer/src/components/board-finder.ts
+++ b/src/renderer/src/components/board-finder.ts
@@ -11,16 +11,19 @@
  * Separate from the component, and DOM-free, so every one of those decisions is
  * a unit test in node rather than an assertion about JSX.
  *
- * WHY THERE IS NO STORAGE OR MEMORY FILTER. The issue asks for one and upstream
- * makes it impossible: `board.json` publishes `External Flash` and `External RAM`
- * as booleans in `features` and no figure anywhere. Those two stay where upstream
- * put them — ordinary feature chips, which is an honest question ("has external
- * flash?") the data can answer — and {@link boardFacts} states them again on the
- * board itself, alongside a plain admission that the SIZE is not published. A
- * "≥ 4 MB" control would have had to quietly drop most of the catalogue to draw
- * itself, which is worse than not offering it.
+ * WHY THERE IS STILL NO STORAGE OR MEMORY FILTER (#897). There are sourced sizes
+ * now, and they are stated on the board — but 5 of 225 boards have a flash
+ * figure and 81 have a RAM one, and 81 of those are the CHIP's SRAM rather than
+ * the module's. A "≥ 4 MB" control at that coverage is not a filter, it is a way
+ * of hiding 220 boards for being undocumented. It becomes one when the coverage
+ * does; until then the sizes are facts, each naming its source, and the missing
+ * ones say they are missing instead of quietly vanishing from a filtered list.
+ *
+ * THE RUNTIME FILTER (#902) does ship, because its data supports it and the one
+ * thing it cannot say is sayable out loud. See {@link RUNTIME_CAVEAT}.
  */
 import type { BoardBuild, BoardFilter, IndexedBoard } from '../../../shared/board-index'
+import type { FirmwareRuntime } from '../../../shared/firmware-runtime'
 
 // ---------------------------------------------------------------------------
 // Shelving
@@ -103,31 +106,72 @@ export function buildLabel(build: BoardBuild): string {
 export interface BoardFact {
   label: string
   value: string
+  /**
+   * Where the value came from, when it came from anywhere (#897).
+   *
+   * Shown beside the figure rather than hidden in a tooltip: the reason these
+   * numbers can be published at all is that each one can be checked, and a
+   * provenance nobody can see is the same as none.
+   */
+  source?: string
 }
 
 /** Features that are a yes/no upstream publishes but no figure to go with it. */
-const SIZELESS_FEATURES: readonly { feature: string; label: string }[] = [
-  { feature: 'External Flash', label: 'External flash' },
-  { feature: 'External RAM', label: 'External RAM' }
-]
+const SIZELESS_FEATURES: readonly { feature: string; label: string; sized: keyof IndexedBoard }[] =
+  [
+    { feature: 'External Flash', label: 'External flash', sized: 'flash' },
+    { feature: 'External RAM', label: 'External RAM', sized: 'psram' }
+  ]
 
 /** What upstream says when asked how big either of those is. */
 export const NO_SIZE_PUBLISHED = 'present — size not published'
 
 /**
+ * A byte count as people say it: `264 KB`, `8 MB`, `1.5 MB`.
+ *
+ * Binary units, because that is what these parts are sold in — a "2 MB" flash
+ * chip is 2 × 1024 × 1024 bytes — and no trailing `.0`, so the common sizes read
+ * as round numbers rather than as measurements.
+ */
+export function formatBytes(bytes: number): string {
+  const [unit, size] = bytes >= 1024 * 1024 ? ['MB', 1024 * 1024] : ['KB', 1024]
+  const n = bytes / size
+  return `${Number.isInteger(n) ? n : n.toFixed(1)} ${unit}`
+}
+
+/**
  * The facts a board's detail states, in display order.
  *
- * Only what upstream actually publishes. `External flash` / `External RAM`
- * appear here as the booleans they are, saying outright that the size is not
- * published — the alternative was to omit them, which invites the reader to
- * assume the board has neither.
+ * Sizes come first-hand or not at all: each one carries the source that makes it
+ * publishable, and a RAM figure that is really the CHIP's says so, because "the
+ * ESP32 has 520 KB" is a fact about every ESP32 board and therefore not much of
+ * a fact about this one.
+ *
+ * `External flash` / `External RAM` still appear as the booleans upstream
+ * publishes, but only where no sourced size has replaced them — otherwise a
+ * board would say "8 MB" and "size not published" in the same list.
  */
 export function boardFacts(board: IndexedBoard): BoardFact[] {
   const facts: BoardFact[] = [{ label: 'MCU', value: board.mcu || 'unknown' }]
   if (board.port) facts.push({ label: 'Port', value: board.port })
   if (board.flashOffset) facts.push({ label: 'Flash offset', value: board.flashOffset })
-  for (const { feature, label } of SIZELESS_FEATURES) {
-    if (board.features.includes(feature)) facts.push({ label, value: NO_SIZE_PUBLISHED })
+  if (board.flash) {
+    facts.push({ label: 'Flash', value: formatBytes(board.flash.bytes), source: board.flash.source })
+  }
+  if (board.ram) {
+    facts.push({
+      label: 'RAM',
+      value: `${formatBytes(board.ram.bytes)}${board.ram.scope === 'chip' ? ' (the chip’s SRAM)' : ''}`,
+      source: board.ram.source
+    })
+  }
+  if (board.psram) {
+    facts.push({ label: 'PSRAM', value: formatBytes(board.psram.bytes), source: board.psram.source })
+  }
+  for (const { feature, label, sized } of SIZELESS_FEATURES) {
+    if (board.features.includes(feature) && !board[sized]) {
+      facts.push({ label, value: NO_SIZE_PUBLISHED })
+    }
   }
   return facts
 }
@@ -153,11 +197,12 @@ export function variantList(board: IndexedBoard): { variant: string; description
  */
 export function activeFilterChips(
   filter: BoardFilter
-): { axis: 'vendor' | 'mcu' | 'feature'; value: string }[] {
-  const out: { axis: 'vendor' | 'mcu' | 'feature'; value: string }[] = []
+): { axis: 'vendor' | 'mcu' | 'feature' | 'runtime'; value: string }[] {
+  const out: { axis: 'vendor' | 'mcu' | 'feature' | 'runtime'; value: string }[] = []
   if (filter.vendor) out.push({ axis: 'vendor', value: filter.vendor })
   if (filter.mcu) out.push({ axis: 'mcu', value: filter.mcu })
   for (const f of filter.features ?? []) out.push({ axis: 'feature', value: f })
+  for (const r of filter.runtimes ?? []) out.push({ axis: 'runtime', value: r })
   return out
 }
 
@@ -176,3 +221,31 @@ export function toggleFeature(features: readonly string[], feature: string): str
     ? features.filter((f) => f !== feature)
     : [...features, feature]
 }
+
+/** Same toggle, typed for the runtime chips. */
+export function toggleRuntime(
+  runtimes: readonly FirmwareRuntime[],
+  runtime: FirmwareRuntime
+): FirmwareRuntime[] {
+  return runtimes.includes(runtime)
+    ? runtimes.filter((r) => r !== runtime)
+    : [...runtimes, runtime]
+}
+
+/**
+ * The one thing the runtime filter cannot say, said on screen (#902).
+ *
+ * The gallery is MicroPython's catalogue — that is where every entry comes from
+ * — so it is structurally incapable of listing a board that runs CircuitPython
+ * and not MicroPython, and there are hundreds of those. On top of that, the two
+ * projects name boards independently, so a board's CircuitPython build is only
+ * claimed where the id was confirmed; the rest are unknown rather than absent.
+ *
+ * Both limits are real, and both make a bare "CircuitPython" chip a small lie.
+ * Printing them under the chips is what makes the chips honest — and is the
+ * whole reason the filter could be shipped where the storage one could not.
+ */
+export const RUNTIME_CAVEAT =
+  'This is MicroPython’s catalogue, so CircuitPython-only boards are not in it. ' +
+  'CircuitPython is marked only where the board id was confirmed — the rest are ' +
+  'unconfirmed, not unsupported.'

--- a/src/shared/board-index.ts
+++ b/src/shared/board-index.ts
@@ -28,16 +28,26 @@
  *      Feather V2 in these 225. Fold the overlay into the fetched document and
  *      that board disappears again.
  *
- * NO FLASH OR RAM SIZE. Upstream does not publish either — `features` has
- * `External Flash` and `External RAM` as booleans and nothing more. So they are
- * absent here, shown as facts where a profile happens to know them, and NOT
- * offered as filters: a filter that silently omits most of the catalogue is
- * worse than no filter.
+ * FLASH AND RAM (#897). Upstream publishes neither — `features` has `External
+ * Flash` and `External RAM` as booleans and nothing more. So every figure here
+ * comes from somewhere else, and every figure therefore carries a {@link
+ * BoardSize.source} naming it. A number with no provenance is not worth
+ * publishing: a wrong flash size sends someone to a board that cannot hold their
+ * program. They are still NOT offered as filters — see `board-finder.ts` for the
+ * coverage that decision turns on.
  *
  * Pure — parsing, filtering and picking, no IO — so all of it unit-tests in node.
  */
+import type { FirmwareRuntime } from './firmware-runtime'
 
-/** The document shape this module understands. A newer one is refused. */
+/**
+ * The document shape this module understands. A newer one is refused.
+ *
+ * Deliberately NOT bumped by #897/#902, which only ADD optional fields: an older
+ * Snakie reading a newer document ignores what it does not know and still gets a
+ * complete picker, whereas a bump would make it refuse the document outright and
+ * fall back to a seed that ages with the install.
+ */
 export const BOARD_INDEX_SCHEMA = 1
 
 /** Where the published index lives, once the repo carrying it exists. */
@@ -56,6 +66,57 @@ export interface BoardBuild {
   date: string
   /** Absolute URL of the binary. */
   url: string
+}
+
+/**
+ * A memory or storage size, with the provenance that makes it publishable (#897).
+ *
+ * `source` is never optional and never empty. Upstream publishes no sizes at
+ * all, so every one of these was put here by somebody — and the reader has to be
+ * able to see by whom before trusting it enough to buy a board on.
+ */
+export interface BoardSize {
+  bytes: number
+  /** Where the figure came from: a URL, a datasheet, or who curated it. */
+  source: string
+  /**
+   * Whose figure this is.
+   *
+   * `chip` means it is the MCU's own — true of every part in that family and
+   * derived from `mcu` alone. That is exactly right for built-in SRAM and
+   * exactly wrong for flash, which lives on the module: every RP2040 has 264 KB
+   * of SRAM, and RP2040 boards ship with anywhere from 2 MB to 16 MB of flash.
+   * `board` means the figure is about this board specifically.
+   */
+  scope: 'board' | 'chip'
+}
+
+/**
+ * Where an entry came from (#902).
+ *
+ * `micropython` — upstream's own `board.json`, which is all 225 of them.
+ * `snakie` — Snakie's overlay in `board-overlay.ts`, for boards MicroPython
+ * builds no firmware under the name of at all. Set by the overlay, never by the
+ * document: the whole point of the overlay is that it stays in the app.
+ */
+export type BoardOrigin = 'micropython' | 'snakie'
+
+/**
+ * What an overlay board flashes, given upstream has no build of its own (#902).
+ *
+ * The Feather V2's answer is `ESP32_GENERIC-SPIRAM` — a build for a board that
+ * is not this one, and the correct thing to flash. That has to be said out loud
+ * on the card rather than quietly substituted, because "this is another board's
+ * firmware" is the kind of thing someone needs to know before they wonder why
+ * their board reports itself as a generic ESP32.
+ */
+export interface BoardSubstitute {
+  /** The upstream board whose build this one borrows, or null when none fits. */
+  boardId: string | null
+  /** The exact upstream build, e.g. `ESP32_GENERIC-SPIRAM`. */
+  build: string | null
+  /** Why that is the right build, in the reader's terms. Shown on the card. */
+  why: string
 }
 
 /** One board. */
@@ -83,6 +144,34 @@ export interface IndexedBoard {
   /** Bundled thumbnail filename, or null where none could be made. */
   thumb: string | null
   builds: BoardBuild[]
+  /** On-board flash, when a sourced figure exists (#897). Usually `board` scope. */
+  flash: BoardSize | null
+  /** Built-in SRAM (#897). Usually `chip` scope — it follows from `mcu`. */
+  ram: BoardSize | null
+  /** External PSRAM/SPIRAM, when the board has any and the size is sourced. */
+  psram: BoardSize | null
+  /**
+   * The runtimes with a published, flashable build for THIS board (#902).
+   *
+   * `micropython` iff `builds` is non-empty — three of the 225 are in upstream's
+   * tree with nothing published. `circuitpython` only where a CircuitPython
+   * board id was CONFIRMED against the published catalogue; its absence means
+   * "not confirmed", which is not the same as "does not exist", and the gallery
+   * says so rather than letting a filter imply otherwise.
+   */
+  runtimes: FirmwareRuntime[]
+  /**
+   * CircuitPython's own per-board key — the string `boot_out.txt` prints and the
+   * one its downloads are filed under (#756). Null when no build was confirmed.
+   *
+   * Never guessed. Flashing another board's `.uf2` leaves a board that needs
+   * re-flashing before it will talk again, so a wrong id here is worse than none.
+   */
+  circuitPythonBoardId: string | null
+  /** Upstream's catalogue, or Snakie's overlay (#902). */
+  origin: BoardOrigin
+  /** For an overlay board: whose firmware it flashes, and why. Null otherwise. */
+  substitute: BoardSubstitute | null
 }
 
 export interface BoardIndex {
@@ -106,6 +195,22 @@ const str = (v: unknown): string => (typeof v === 'string' ? v : '')
 const strOrNull = (v: unknown): string | null => (typeof v === 'string' && v ? v : null)
 const strList = (v: unknown): string[] =>
   Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : []
+
+/**
+ * A size, or null.
+ *
+ * A figure with no `source`, or a non-positive one, is DROPPED rather than shown
+ * unattributed — the rule #897 asks for, enforced at the door so no later layer
+ * has to remember it.
+ */
+function parseSize(raw: unknown): BoardSize | null {
+  if (!raw || typeof raw !== 'object') return null
+  const r = raw as Record<string, unknown>
+  const bytes = typeof r.bytes === 'number' && r.bytes > 0 ? r.bytes : 0
+  const source = str(r.source).trim()
+  if (!bytes || !source) return null
+  return { bytes, source, scope: r.scope === 'chip' ? 'chip' : 'board' }
+}
 
 function parseBuild(raw: unknown): BoardBuild | null {
   if (!raw || typeof raw !== 'object') return null
@@ -141,6 +246,10 @@ export function parseBoardIndex(raw: unknown): BoardIndex | null {
     const b = entry as Record<string, unknown>
     const id = str(b.id)
     if (!id) continue
+    const builds = Array.isArray(b.builds)
+      ? b.builds.map(parseBuild).filter((x): x is BoardBuild => x !== null)
+      : []
+    const circuitPythonBoardId = strOrNull(b.circuitPythonBoardId)
     boards.push({
       id,
       port: str(b.port),
@@ -159,9 +268,25 @@ export function parseBoardIndex(raw: unknown): BoardIndex | null {
       flashOffset: strOrNull(b.flashOffset),
       image: strOrNull(b.image),
       thumb: strOrNull(b.thumb),
-      builds: Array.isArray(b.builds)
-        ? b.builds.map(parseBuild).filter((x): x is BoardBuild => x !== null)
-        : []
+      builds,
+      flash: parseSize(b.flash),
+      ram: parseSize(b.ram),
+      psram: parseSize(b.psram),
+      // DERIVED, not read, when the document does not say — which is what a
+      // schema-1 document written before #902 looks like. It is a definition
+      // rather than a guess: this is MicroPython's index, so a board with a
+      // published build here runs MicroPython by construction.
+      runtimes: Array.isArray(b.runtimes)
+        ? (strList(b.runtimes).filter(
+            (r) => r === 'micropython' || r === 'circuitpython'
+          ) as FirmwareRuntime[])
+        : builds.length > 0
+          ? ['micropython']
+          : [],
+      circuitPythonBoardId,
+      // The document never carries these; the overlay is the only producer.
+      origin: 'micropython',
+      substitute: null
     })
   }
   return {
@@ -190,6 +315,13 @@ export interface BoardFilter {
   mcu?: string
   /** Every one of these must be present — filters narrow, they do not widen. */
   features?: string[]
+  /**
+   * Keep only boards with a confirmed build for every runtime listed (#902).
+   *
+   * Narrowing, like `features`: both ticked means "runs both", which is the
+   * question someone switching a class from one to the other actually has.
+   */
+  runtimes?: FirmwareRuntime[]
   /** Hide boards with no published firmware. */
   flashableOnly?: boolean
 }
@@ -205,6 +337,9 @@ export function matchesFilter(board: IndexedBoard, filter: BoardFilter): boolean
   if (filter.mcu && board.mcu !== filter.mcu) return false
   for (const f of filter.features ?? []) {
     if (!board.features.includes(f)) return false
+  }
+  for (const r of filter.runtimes ?? []) {
+    if (!board.runtimes.includes(r)) return false
   }
   const text = filter.text?.trim()
   if (text) {
@@ -243,6 +378,22 @@ export function featuresOf(boards: readonly IndexedBoard[]): string[] {
   return [...count.entries()]
     .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
     .map(([f]) => f)
+}
+
+/**
+ * How many boards each runtime has a confirmed build for.
+ *
+ * The count is the whole reason the runtime facet can be offered honestly: it is
+ * printed beside the chip, so "CircuitPython 49" says plainly that this is 49
+ * confirmed boards out of the catalogue rather than a complete answer. See
+ * `board-finder.ts` for what the gallery does with it.
+ */
+export function runtimeCounts(
+  boards: readonly IndexedBoard[]
+): Record<FirmwareRuntime, number> {
+  const counts: Record<FirmwareRuntime, number> = { micropython: 0, circuitpython: 0 }
+  for (const b of boards) for (const r of b.runtimes) counts[r] += 1
+  return counts
 }
 
 // ---------------------------------------------------------------------------

--- a/src/shared/board-overlay.ts
+++ b/src/shared/board-overlay.ts
@@ -1,0 +1,257 @@
+/**
+ * THE BOARDS UPSTREAM DOES NOT BUILD FOR (#902, epic #884).
+ * =============================================================================
+ *
+ * The board index has 15 Adafruit boards. It has no Adafruit ESP32 board at all,
+ * because MicroPython builds no firmware under any of those names — there is no
+ * `micropython.org/download/ADAFRUIT_FEATHER_ESP32_V2/`, and there never was.
+ * You are expected to know that the right file is `ESP32_GENERIC-SPIRAM`.
+ *
+ * That expectation is the whole reason this epic exists. A Feather V2 owner
+ * opened the model list, did not find their board, picked "ESP32 / WROOM" as the
+ * nearest thing, and flashed a build without SPIRAM — on a board whose 2 MB of
+ * PSRAM only the SPIRAM build initialises. A week of `ENOMEM`, mDNS allocation
+ * failures and an eventual ESP-IDF `abort()`.
+ *
+ * So "missing boards" does not mean boards someone forgot to fetch. It means
+ * boards that CANNOT come from the generator, because upstream has nothing to
+ * generate from. They can only be curated, and this is where.
+ *
+ * WHAT AN ENTRY MUST CARRY. Each borrows a real upstream build by its exact
+ * name, and says so on the card: substituting another board's firmware silently
+ * is how the original mistake was made, and doing it silently on the user's
+ * behalf is the same mistake with better manners. Every size names its source.
+ * Every CircuitPython id was checked against the published catalogue rather than
+ * inferred from the slug — a wrong `.uf2` leaves a board that needs re-flashing
+ * before it will talk again.
+ *
+ * WHAT AN ENTRY IS NOT. Not a board upstream already has under another name:
+ * {@link overlayEntries} stands an entry down the moment upstream publishes the
+ * real thing, so this list shrinks by itself instead of quietly double-listing.
+ *
+ * Pure and DOM-free, so the merge and the step-aside are unit tests in node.
+ */
+import type { BoardSize, IndexedBoard } from './board-index'
+import { newestBuilds } from './board-index'
+
+/** Byte sizes, spelled out so a typo in a zero cannot hide in a literal. */
+const KiB = 1024
+const MiB = 1024 * 1024
+
+/** Espressif's own figure for a chip's built-in SRAM. */
+const espressifSram = (bytes: number, chip: string): BoardSize => ({
+  bytes,
+  source: `Espressif ${chip} datasheet`,
+  scope: 'chip'
+})
+
+/** One board Snakie knows about and upstream does not. */
+export interface OverlayBoard {
+  /** Upstream's id if it ever adds this board — so the step-aside can match. */
+  id: string
+  vendor: string
+  product: string
+  port: string
+  mcu: string
+  features: string[]
+  /** The maker's own product page: the source every size below is checked at. */
+  url: string
+  /** esptool write offset, or null where the board is not flashed that way. */
+  flashOffset: string | null
+  flash: BoardSize | null
+  ram: BoardSize | null
+  psram: BoardSize | null
+  /** Confirmed against circuitpython.org's published catalogue, or null. */
+  circuitPythonBoardId: string | null
+  /** The upstream board whose build this borrows, or null when none fits. */
+  donorBoardId: string | null
+  /** The exact upstream build name, e.g. `ESP32_GENERIC-SPIRAM`. */
+  donorBuild: string | null
+  /** Why that build, said on the card. */
+  why: string
+  /** The `board-profiles.ts` entry carrying this board's flashing mechanics. */
+  profileId?: string
+}
+
+/**
+ * The curated set.
+ *
+ * Deliberately small. Every entry is a claim about somebody's hardware that
+ * Snakie will act on, so the bar is a maker's own page open in front of me, not
+ * a plausible-looking slug. The candidates that did not clear that bar are in
+ * the issue rather than here.
+ */
+export const OVERLAY_BOARDS: OverlayBoard[] = [
+  {
+    // The board this whole epic is about.
+    id: 'ADAFRUIT_FEATHER_ESP32_V2',
+    vendor: 'Adafruit',
+    product: 'ESP32 Feather V2',
+    port: 'esp32',
+    mcu: 'esp32',
+    features: ['BLE', 'WiFi'],
+    url: 'https://www.adafruit.com/product/5400',
+    // The original ESP32 — the one chip whose offset is not 0x0.
+    flashOffset: '0x1000',
+    flash: { bytes: 8 * MiB, source: 'adafruit.com/product/5400', scope: 'board' },
+    ram: espressifSram(520 * KiB, 'ESP32'),
+    psram: { bytes: 2 * MiB, source: 'adafruit.com/product/5400', scope: 'board' },
+    circuitPythonBoardId: 'adafruit_feather_esp32_v2',
+    donorBoardId: 'ESP32_GENERIC',
+    donorBuild: 'ESP32_GENERIC-SPIRAM',
+    why:
+      'MicroPython publishes no build under this board’s name. Its 2 MB of PSRAM is only ' +
+      'initialised by the SPIRAM variant of the generic ESP32 build, so that is the one ' +
+      'to flash — the plain build runs and leaves the PSRAM switched off.',
+    profileId: 'adafruit-feather-esp32-v2'
+  },
+  {
+    id: 'ADAFRUIT_HUZZAH32_FEATHER',
+    vendor: 'Adafruit',
+    product: 'HUZZAH32 – ESP32 Feather',
+    port: 'esp32',
+    mcu: 'esp32',
+    features: ['BLE', 'WiFi'],
+    url: 'https://www.adafruit.com/product/3405',
+    flashOffset: '0x1000',
+    flash: { bytes: 4 * MiB, source: 'adafruit.com/product/3405', scope: 'board' },
+    ram: espressifSram(520 * KiB, 'ESP32'),
+    // No PSRAM on the WROOM32 module — stated, because the V2 above has some and
+    // the two boards are one letter apart in a list.
+    psram: null,
+    circuitPythonBoardId: 'adafruit_feather_huzzah32',
+    donorBoardId: 'ESP32_GENERIC',
+    donorBuild: 'ESP32_GENERIC',
+    why:
+      'MicroPython publishes no build under this board’s name. It is a plain ESP32-WROOM-32 ' +
+      'with no PSRAM, so the standard generic ESP32 build is the right one — NOT the SPIRAM ' +
+      'variant its V2 successor needs.'
+  },
+  {
+    id: 'ADAFRUIT_QTPY_ESP32C3',
+    vendor: 'Adafruit',
+    product: 'QT Py ESP32-C3',
+    port: 'esp32',
+    mcu: 'esp32c3',
+    features: ['BLE', 'WiFi'],
+    url: 'https://www.adafruit.com/product/5405',
+    flashOffset: '0x0',
+    flash: { bytes: 4 * MiB, source: 'adafruit.com/product/5405', scope: 'board' },
+    ram: espressifSram(400 * KiB, 'ESP32-C3'),
+    psram: null,
+    circuitPythonBoardId: 'adafruit_qtpy_esp32c3',
+    donorBoardId: 'ESP32_GENERIC_C3',
+    donorBuild: 'ESP32_GENERIC_C3',
+    why: 'MicroPython publishes no build under this board’s name; the generic ESP32-C3 build runs on it.'
+  },
+  {
+    id: 'ADAFRUIT_QTPY_ESP32S3',
+    vendor: 'Adafruit',
+    product: 'QT Py ESP32-S3 (no PSRAM)',
+    port: 'esp32',
+    mcu: 'esp32s3',
+    features: ['BLE', 'WiFi'],
+    url: 'https://www.adafruit.com/product/5426',
+    flashOffset: '0x0',
+    flash: { bytes: 8 * MiB, source: 'adafruit.com/product/5426', scope: 'board' },
+    ram: espressifSram(512 * KiB, 'ESP32-S3'),
+    psram: null,
+    circuitPythonBoardId: 'adafruit_qtpy_esp32s3_nopsram',
+    donorBoardId: 'ESP32_GENERIC_S3',
+    donorBuild: 'ESP32_GENERIC_S3',
+    why:
+      'MicroPython publishes no build under this board’s name. This variant has no PSRAM, so ' +
+      'the STANDARD generic ESP32-S3 build is the right one — the SPIRAM_OCT variant would ' +
+      'print a PSRAM initialisation error at every boot.'
+  },
+  {
+    // Upstream's `MICROBIT` is the nRF51 v1, and the gallery showing only that
+    // is worse than showing nothing: it is the wrong board for almost everyone
+    // holding a micro:bit, and its firmware will not run on a v2.
+    id: 'MICROBIT_V2',
+    vendor: 'BBC',
+    product: 'micro:bit v2',
+    port: 'nrf',
+    mcu: 'nrf52',
+    features: ['BLE'],
+    url: 'https://tech.microbit.org/hardware/',
+    flashOffset: null,
+    flash: { bytes: 512 * KiB, source: 'tech.microbit.org/hardware (nRF52833)', scope: 'board' },
+    ram: { bytes: 128 * KiB, source: 'tech.microbit.org/hardware (nRF52833)', scope: 'board' },
+    psram: null,
+    circuitPythonBoardId: 'microbit_v2',
+    // No donor: MicroPython for the micro:bit is a separate project with its own
+    // releases, so there is no micropython.org build to borrow and pretending
+    // otherwise would hand someone an nRF51 image for an nRF52833 board.
+    donorBoardId: null,
+    donorBuild: null,
+    why:
+      'MicroPython for the micro:bit v2 is published by the micro:bit Foundation, not by ' +
+      'micropython.org, so there is no build here to flash. Get it from python.microbit.org.',
+    profileId: 'microbit-v2'
+  }
+]
+
+/**
+ * One overlay record as a gallery board, with its borrowed build resolved.
+ *
+ * The build is matched by its exact upstream NAME rather than by variant, so a
+ * donor that stops publishing that variant yields a board with no builds and a
+ * card that says so — which is the truth — rather than silently falling back to
+ * the plain build, which is the original bug.
+ */
+function toIndexedBoard(entry: OverlayBoard, upstream: readonly IndexedBoard[]): IndexedBoard {
+  const donor = entry.donorBoardId
+    ? upstream.find((b) => b.id === entry.donorBoardId)
+    : undefined
+  const borrowed = donor
+    ? newestBuilds(donor).filter((b) => b.build === entry.donorBuild)
+    : []
+  const runtimes: IndexedBoard['runtimes'] = []
+  if (borrowed.length > 0) runtimes.push('micropython')
+  if (entry.circuitPythonBoardId) runtimes.push('circuitpython')
+  return {
+    id: entry.id,
+    port: entry.port,
+    vendor: entry.vendor,
+    product: entry.product,
+    mcu: entry.mcu,
+    features: entry.features,
+    notes: [],
+    url: entry.url,
+    // Upstream's variant descriptions belong to the donor, not to this board.
+    variants: {},
+    flashOffset: entry.flashOffset,
+    // No photo: these boards have no entry in micropython.org's media, so the
+    // card draws its initials rather than borrowing the donor's picture — a
+    // generic DevKit photo on an Adafruit card would be a lie in the one place
+    // people look first.
+    image: null,
+    thumb: null,
+    builds: borrowed,
+    flash: entry.flash,
+    ram: entry.ram,
+    psram: entry.psram,
+    runtimes,
+    circuitPythonBoardId: entry.circuitPythonBoardId,
+    origin: 'snakie',
+    substitute: { boardId: entry.donorBoardId, build: entry.donorBuild, why: entry.why }
+  }
+}
+
+/**
+ * The overlay entries that still have a job to do.
+ *
+ * An entry whose id upstream has since published is dropped: the generated
+ * document is better than a hand-written one the moment it exists, and a
+ * catalogue that lists the same board twice is a bug report waiting to happen.
+ */
+export function overlayEntries(upstream: readonly IndexedBoard[]): IndexedBoard[] {
+  const known = new Set(upstream.map((b) => b.id))
+  return OVERLAY_BOARDS.filter((e) => !known.has(e.id)).map((e) => toIndexedBoard(e, upstream))
+}
+
+/** Upstream's catalogue plus the overlay — what the gallery actually shows. */
+export function withOverlay(upstream: readonly IndexedBoard[]): IndexedBoard[] {
+  return [...upstream, ...overlayEntries(upstream)]
+}

--- a/test/boardFinder.test.ts
+++ b/test/boardFinder.test.ts
@@ -51,6 +51,13 @@ const board = (over: Partial<IndexedBoard> = {}): IndexedBoard => ({
   image: null,
   thumb: null,
   builds: [build()],
+  flash: null,
+  ram: null,
+  psram: null,
+  runtimes: ['micropython'],
+  circuitPythonBoardId: null,
+  origin: 'micropython',
+  substitute: null,
   ...over
 })
 

--- a/test/boardFlashHandoff.test.ts
+++ b/test/boardFlashHandoff.test.ts
@@ -38,6 +38,13 @@ const board = (over: Partial<IndexedBoard> = {}): IndexedBoard => ({
       url: 'https://micropython.org/resources/firmware/ESP32_GENERIC-20260824-v1.29.0.bin'
     }
   ],
+  flash: null,
+  ram: null,
+  psram: null,
+  runtimes: ['micropython'],
+  circuitPythonBoardId: null,
+  origin: 'micropython',
+  substitute: null,
   ...over
 })
 

--- a/test/boardIndex.test.ts
+++ b/test/boardIndex.test.ts
@@ -45,6 +45,13 @@ const board = (over: Partial<IndexedBoard> = {}): IndexedBoard => ({
   image: null,
   thumb: null,
   builds: [],
+  flash: null,
+  ram: null,
+  psram: null,
+  runtimes: ['micropython'],
+  circuitPythonBoardId: null,
+  origin: 'micropython',
+  substitute: null,
   ...over
 })
 
@@ -86,6 +93,58 @@ describe('parsing a document', () => {
     expect(parseBoardIndex({ schema: 1, boards: [{ id: 'ESP32_GENERIC' }] })?.boards[0].product).toBe(
       'ESP32_GENERIC'
     )
+  })
+
+  it('drops a size with no source, because an unattributed number is not worth publishing', () => {
+    // #897's rule, enforced at the door. A wrong flash size sends someone to a
+    // board that cannot hold their program, so "8 MB, says who?" is not shippable.
+    const doc = parseBoardIndex({
+      schema: 1,
+      boards: [
+        {
+          id: 'X',
+          flash: { bytes: 8388608 },
+          ram: { bytes: 264 * 1024, source: 'RP2040 datasheet', scope: 'chip' },
+          psram: { bytes: 0, source: 'somewhere' }
+        }
+      ]
+    })
+    expect(doc?.boards[0].flash).toBeNull()
+    expect(doc?.boards[0].psram).toBeNull()
+    expect(doc?.boards[0].ram).toEqual({ bytes: 270336, source: 'RP2040 datasheet', scope: 'chip' })
+  })
+
+  it('treats an unrecognised scope as the board’s, never as the chip’s', () => {
+    // The wrong way round would be worse: "the chip's SRAM" is a caveat, and
+    // silently attaching it to a curated board figure would weaken a good number.
+    const doc = parseBoardIndex({
+      schema: 1,
+      boards: [{ id: 'X', flash: { bytes: 4096, source: 'a page', scope: 'nonsense' } }]
+    })
+    expect(doc?.boards[0].flash?.scope).toBe('board')
+  })
+
+  it('derives runtimes for a document written before the field existed', () => {
+    // Every schema-1 document published before #902 lacks `runtimes`. Defaulting
+    // to nothing would empty the runtime filter for the whole catalogue; the
+    // derivation is a definition, not a guess — this IS MicroPython's index.
+    const doc = parseBoardIndex({
+      schema: 1,
+      boards: [
+        { id: 'HAS', builds: [{ build: 'HAS', url: 'https://e/x.bin' }] },
+        { id: 'NONE', builds: [] }
+      ]
+    })
+    expect(doc?.boards[0].runtimes).toEqual(['micropython'])
+    expect(doc?.boards[1].runtimes).toEqual([])
+  })
+
+  it('keeps only runtimes it understands', () => {
+    const doc = parseBoardIndex({
+      schema: 1,
+      boards: [{ id: 'X', runtimes: ['micropython', 'pythonish', 42] }]
+    })
+    expect(doc?.boards[0].runtimes).toEqual(['micropython'])
   })
 })
 
@@ -135,6 +194,19 @@ describe('filtering', () => {
 
   it('can hide boards with no published firmware', () => {
     expect(filterBoards(boards, { flashableOnly: true }).map((b) => b.id)).toEqual(['D'])
+  })
+
+  it('narrows on runtime, and both ticked means both', () => {
+    const rt = [
+      board({ id: 'MP', runtimes: ['micropython'] }),
+      board({ id: 'BOTH', runtimes: ['micropython', 'circuitpython'] }),
+      board({ id: 'NEITHER', runtimes: [] })
+    ]
+    expect(filterBoards(rt, { runtimes: ['circuitpython'] }).map((b) => b.id)).toEqual(['BOTH'])
+    expect(
+      filterBoards(rt, { runtimes: ['micropython', 'circuitpython'] }).map((b) => b.id)
+    ).toEqual(['BOTH'])
+    expect(filterBoards(rt, { runtimes: ['micropython'] }).map((b) => b.id)).toEqual(['MP', 'BOTH'])
   })
 
   it('an empty filter keeps everything', () => {
@@ -236,11 +308,66 @@ describe('the generated seed that actually ships', () => {
     expect(previews).toEqual([])
   })
 
-  it('publishes no flash or RAM figures, because upstream does not', () => {
-    // If these ever appear, they came from somewhere that has to be named — see
-    // the follow-on issue about sourcing them from manufacturer product pages.
-    const raw = JSON.parse(readFileSync('src/renderer/public/boards/boards.json', 'utf8'))
-    expect(JSON.stringify(raw)).not.toContain('flashBytes')
-    expect(JSON.stringify(raw)).not.toContain('ramBytes')
+  /**
+   * This used to assert that NO flash or RAM figure appeared at all, on the
+   * grounds that upstream publishes none and anything that showed up must have
+   * come from somewhere unnamed. #897 answered that by naming the somewhere, so
+   * the tripwire moves rather than goes: the rule is no longer "no figures", it
+   * is "no figure without a source".
+   */
+  describe('the sizes it publishes, and their provenance (#897)', () => {
+    it('names a source for every figure, and never publishes a bare number', () => {
+      const raw = JSON.parse(readFileSync('src/renderer/public/boards/boards.json', 'utf8'))
+      for (const b of raw.boards) {
+        for (const key of ['flash', 'ram', 'psram'] as const) {
+          const size = b[key]
+          if (size === null || size === undefined) continue
+          expect(typeof size.bytes, `${b.id}.${key}`).toBe('number')
+          expect(size.bytes, `${b.id}.${key}`).toBeGreaterThan(0)
+          expect(String(size.source).trim(), `${b.id}.${key} source`).not.toBe('')
+          expect(['board', 'chip'], `${b.id}.${key} scope`).toContain(size.scope)
+        }
+      }
+    })
+
+    it('marks every MCU-derived RAM figure as the chip’s, not the board’s', () => {
+      // The distinction #897 asks for. "Every RP2040 has 264 KB" is a fact about
+      // the chip; presented as the board's it would imply the module was
+      // measured, and the module is where flash lives.
+      const pico = doc!.boards.find((b) => b.id === 'RPI_PICO')!
+      expect(pico.ram?.scope).toBe('chip')
+      expect(pico.ram?.bytes).toBe(264 * 1024)
+      // …while its flash IS the board's, from Raspberry Pi's own documentation.
+      expect(pico.flash?.scope).toBe('board')
+      expect(pico.flash?.bytes).toBe(2 * 1024 * 1024)
+    })
+
+    it('says nothing about chip families whose SRAM is not fixed', () => {
+      // stm32f4 spans 96 KB to 256 KB; nrf52 spans 64 KB to 256 KB. A plausible
+      // average would never get checked, which is what makes it dangerous.
+      for (const b of doc!.boards) {
+        if (['stm32f4', 'nrf52', 'samd21', 'samd51', 'mimxrt'].includes(b.mcu)) {
+          expect(b.ram, `${b.id} (${b.mcu})`).toBeNull()
+        }
+      }
+    })
+  })
+
+  it('confirms CircuitPython per board rather than per chip (#902)', () => {
+    // Per BOARD is the whole point: `raspberry_pi_pico` and
+    // `raspberry_pi_pico_w` are different files on the same chip, and flashing
+    // one to the other is a board that boots with the wrong pins.
+    const pico = doc!.boards.find((b) => b.id === 'RPI_PICO')!
+    const picoW = doc!.boards.find((b) => b.id === 'RPI_PICO_W')!
+    expect(pico.circuitPythonBoardId).toBe('raspberry_pi_pico')
+    expect(picoW.circuitPythonBoardId).toBe('raspberry_pi_pico_w')
+    expect(pico.runtimes).toContain('circuitpython')
+  })
+
+  it('claims no runtime for a board with nothing published', () => {
+    // Three of the 225 are in upstream's tree with no download page at all.
+    for (const b of doc!.boards) {
+      if (b.builds.length === 0) expect(b.runtimes, b.id).not.toContain('micropython')
+    }
   })
 })

--- a/test/boardOverlay.test.ts
+++ b/test/boardOverlay.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { newestBuilds, parseBoardIndex, type IndexedBoard } from '../src/shared/board-index'
+import { OVERLAY_BOARDS, overlayEntries, withOverlay } from '../src/shared/board-overlay'
+import { BOARD_PROFILES } from '../src/shared/board-profiles'
+import { boardFacts, formatBytes } from '../src/renderer/src/components/board-finder'
+import {
+  flashRequestFor,
+  flasherSelectionFor
+} from '../src/renderer/src/components/board-finder-bus'
+
+/**
+ * The boards upstream does not build for (#902).
+ *
+ * The bug, once: MicroPython publishes no firmware under the name "Adafruit
+ * ESP32 Feather V2" — there is no download page for it and there never was. Its
+ * owner opened the model list, did not find the board, picked "ESP32 / WROOM",
+ * and flashed a build without SPIRAM onto a board whose 2 MB of PSRAM only the
+ * SPIRAM build initialises. So the tests that matter are: the board is FINDABLE,
+ * it hands the flasher the SPIRAM build specifically, it says on its face that
+ * the build belongs to another board, and it steps aside if upstream ever
+ * publishes the real thing.
+ */
+
+const seed = parseBoardIndex(
+  JSON.parse(readFileSync('src/renderer/public/boards/boards.json', 'utf8'))
+)!
+
+const board = (over: Partial<IndexedBoard> = {}): IndexedBoard => ({
+  id: 'X',
+  port: 'esp32',
+  vendor: 'V',
+  product: 'P',
+  mcu: 'esp32',
+  features: [],
+  notes: [],
+  url: null,
+  variants: {},
+  flashOffset: null,
+  image: null,
+  thumb: null,
+  builds: [],
+  flash: null,
+  ram: null,
+  psram: null,
+  runtimes: [],
+  circuitPythonBoardId: null,
+  origin: 'micropython',
+  substitute: null,
+  ...over
+})
+
+describe('the board that started the epic', () => {
+  const all = withOverlay(seed.boards)
+  const feather = all.find((b) => b.id === 'ADAFRUIT_FEATHER_ESP32_V2')
+
+  it('is nowhere in upstream’s catalogue', () => {
+    // If this ever fails, upstream added it — and the overlay entry should go.
+    expect(seed.boards.find((b) => b.id === 'ADAFRUIT_FEATHER_ESP32_V2')).toBeUndefined()
+    expect(seed.boards.some((b) => b.vendor === 'Adafruit' && b.mcu.startsWith('esp32'))).toBe(false)
+  })
+
+  it('is in the gallery, as an Adafruit ESP32 board', () => {
+    expect(feather).toBeDefined()
+    expect(feather!.vendor).toBe('Adafruit')
+    expect(feather!.mcu).toBe('esp32')
+    expect(feather!.origin).toBe('snakie')
+  })
+
+  it('offers the SPIRAM build, and only that one', () => {
+    // The whole week of ENOMEM in one assertion.
+    expect(feather!.builds.map((b) => b.build)).toEqual(['ESP32_GENERIC-SPIRAM'])
+    expect(feather!.builds[0].url).toMatch(/ESP32_GENERIC-SPIRAM-\d{8}-v[\d.]+\.bin$/)
+  })
+
+  it('reaches the flasher with 0x1000 and the SPIRAM binary', () => {
+    // The end of the seam, not just the middle of it. The offset is per CHIP
+    // and this is the one that is not 0x0: get it wrong and esptool reports
+    // success, the ROM finds no bootloader where it looks, and the board never
+    // comes back — a failure with no error message attached to it.
+    const req = flashRequestFor(feather!)!
+    const sel = flasherSelectionFor(req)
+    expect(sel.offset).toBe('0x1000')
+    expect(sel.family).toBe('esp32')
+    expect(sel.url).toMatch(/ESP32_GENERIC-SPIRAM-/)
+  })
+
+  it('says whose build that is, rather than substituting it quietly', () => {
+    expect(feather!.substitute?.boardId).toBe('ESP32_GENERIC')
+    expect(feather!.substitute?.build).toBe('ESP32_GENERIC-SPIRAM')
+    expect(feather!.substitute?.why).toMatch(/PSRAM/)
+  })
+
+  it('states the 8 MB / 2 MB that a size-less catalogue could not', () => {
+    expect(feather!.flash?.bytes).toBe(8 * 1024 * 1024)
+    expect(feather!.psram?.bytes).toBe(2 * 1024 * 1024)
+    const facts = boardFacts(feather!)
+    expect(facts.find((f) => f.label === 'Flash')?.value).toBe('8 MB')
+    expect(facts.find((f) => f.label === 'PSRAM')?.value).toBe('2 MB')
+  })
+})
+
+describe('standing aside', () => {
+  it('drops an overlay board the moment upstream publishes it', () => {
+    // The overlay is a stopgap for a hole in someone else's catalogue. When the
+    // hole closes, a hand-written entry is strictly worse than a generated one —
+    // and two entries for one board is a bug report.
+    const upstreamAddedIt = [...seed.boards, board({ id: 'ADAFRUIT_FEATHER_ESP32_V2' })]
+    expect(overlayEntries(upstreamAddedIt).map((b) => b.id)).not.toContain(
+      'ADAFRUIT_FEATHER_ESP32_V2'
+    )
+    expect(withOverlay(upstreamAddedIt).filter((b) => b.id === 'ADAFRUIT_FEATHER_ESP32_V2')).toHaveLength(1)
+  })
+
+  it('offers no build at all when the donor stops publishing that variant', () => {
+    // Matched by exact build NAME, so a donor that drops the variant yields an
+    // empty build list and a card that says so. Falling back to the plain build
+    // would be the original mistake, made automatically.
+    const donorWithoutSpiram = seed.boards.map((b) =>
+      b.id === 'ESP32_GENERIC' ? { ...b, builds: b.builds.filter((x) => x.variant !== 'SPIRAM') } : b
+    )
+    const feather = overlayEntries(donorWithoutSpiram).find(
+      (b) => b.id === 'ADAFRUIT_FEATHER_ESP32_V2'
+    )!
+    expect(feather.builds).toEqual([])
+    expect(feather.runtimes).not.toContain('micropython')
+  })
+
+  it('adds nothing when there is no catalogue to overlay', () => {
+    // Every entry borrows a build; with no upstream there is nothing to borrow,
+    // and a gallery of unflashable cards is not a useful failure mode.
+    expect(overlayEntries([]).every((b) => b.builds.length === 0)).toBe(true)
+  })
+})
+
+describe('every overlay entry', () => {
+  it('names a source for every size it states', () => {
+    for (const e of OVERLAY_BOARDS) {
+      for (const [key, size] of Object.entries({ flash: e.flash, ram: e.ram, psram: e.psram })) {
+        if (!size) continue
+        expect(size.bytes, `${e.id}.${key}`).toBeGreaterThan(0)
+        expect(size.source.trim(), `${e.id}.${key}`).not.toBe('')
+      }
+    }
+  })
+
+  it('borrows a build that upstream actually publishes', () => {
+    // A donor id or build name with a typo in it produces a board that looks
+    // flashable in the source and is not in the app.
+    for (const e of OVERLAY_BOARDS) {
+      if (!e.donorBoardId) continue
+      const donor = seed.boards.find((b) => b.id === e.donorBoardId)
+      expect(donor, `${e.id} donor ${e.donorBoardId}`).toBeDefined()
+      expect(
+        newestBuilds(donor!).map((b) => b.build),
+        `${e.id} build ${e.donorBuild}`
+      ).toContain(e.donorBuild)
+    }
+  })
+
+  it('explains itself, because a borrowed build needs a reason', () => {
+    for (const e of OVERLAY_BOARDS) expect(e.why.length, e.id).toBeGreaterThan(40)
+  })
+
+  it('points at a board profile that exists, where it names one', () => {
+    for (const e of OVERLAY_BOARDS) {
+      if (!e.profileId) continue
+      expect(BOARD_PROFILES.map((p) => p.id), e.id).toContain(e.profileId)
+    }
+  })
+
+  it('claims CircuitPython only with a board id to back it', () => {
+    for (const e of OVERLAY_BOARDS) {
+      const entry = overlayEntries(seed.boards).find((b) => b.id === e.id)
+      if (!entry) continue
+      expect(entry.runtimes.includes('circuitpython'), e.id).toBe(Boolean(e.circuitPythonBoardId))
+    }
+  })
+})
+
+describe('the micro:bit the gallery was missing', () => {
+  const all = withOverlay(seed.boards)
+
+  it('shows a v2 next to upstream’s v1', () => {
+    // Upstream has MICROBIT — the nRF51 v1 — and nothing else. A gallery that
+    // offers only that is worse than one offering neither: it is the wrong board
+    // for almost everyone holding a micro:bit, and its firmware will not run.
+    expect(seed.boards.find((b) => b.id === 'MICROBIT')?.mcu).toBe('nrf51')
+    expect(all.find((b) => b.id === 'MICROBIT_V2')?.mcu).toBe('nrf52')
+  })
+
+  it('offers no firmware rather than the wrong firmware', () => {
+    const v2 = all.find((b) => b.id === 'MICROBIT_V2')!
+    expect(v2.builds).toEqual([])
+    expect(v2.substitute?.why).toMatch(/micro:bit Foundation/)
+  })
+})
+
+describe('formatting a size', () => {
+  it('reads the way the part is sold', () => {
+    expect(formatBytes(264 * 1024)).toBe('264 KB')
+    expect(formatBytes(2 * 1024 * 1024)).toBe('2 MB')
+    expect(formatBytes(8 * 1024 * 1024)).toBe('8 MB')
+  })
+
+  it('keeps one decimal for a size that is not round', () => {
+    expect(formatBytes(1.5 * 1024 * 1024)).toBe('1.5 MB')
+  })
+})
+
+describe('what a board’s details say about its sizes', () => {
+  it('marks a chip-derived RAM figure as the chip’s', () => {
+    const facts = boardFacts(
+      board({ ram: { bytes: 264 * 1024, source: 'RP2040 datasheet', scope: 'chip' } })
+    )
+    expect(facts.find((f) => f.label === 'RAM')?.value).toBe('264 KB (the chip’s SRAM)')
+  })
+
+  it('carries the source through to the screen', () => {
+    const facts = boardFacts(
+      board({ flash: { bytes: 4 * 1024 * 1024, source: 'adafruit.com/product/3405', scope: 'board' } })
+    )
+    expect(facts.find((f) => f.label === 'Flash')?.source).toBe('adafruit.com/product/3405')
+  })
+
+  it('does not say “size not published” beside a published size', () => {
+    // Upstream's `External RAM` boolean is still worth stating — but only where
+    // nothing better has replaced it, or the board contradicts itself.
+    const withSize = boardFacts(
+      board({
+        features: ['External RAM'],
+        psram: { bytes: 2 * 1024 * 1024, source: 'a page', scope: 'board' }
+      })
+    )
+    expect(withSize.map((f) => f.label)).not.toContain('External RAM')
+    const without = boardFacts(board({ features: ['External RAM'] }))
+    expect(without.find((f) => f.label === 'External RAM')?.value).toMatch(/not published/)
+  })
+})

--- a/test/boardSpecs.test.ts
+++ b/test/boardSpecs.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+// @ts-ignore — a plain .mjs beside the generator that uses it; the tables
+// are the thing under test, so they are imported rather than re-typed.
+import {
+  CURATED_BOARDS,
+  MCU_SRAM,
+  circuitPythonIdFor,
+  circuitPythonIndex,
+  runtimesForBoard,
+  specsForBoard
+} from '../scripts/board-specs.mjs'
+
+/**
+ * Where the board index's figures come from (#897, #902).
+ *
+ * `board.json` publishes no flash size and no RAM size, so every number in the
+ * index was put there by this module. These tests are about the two ways that
+ * goes wrong: publishing a number nobody can check, and publishing a number that
+ * is right for the family and wrong for the part.
+ */
+
+const board = (over: Record<string, unknown> = {}): Record<string, unknown> => ({
+  id: 'X',
+  vendor: 'V',
+  product: 'P',
+  mcu: 'esp32',
+  builds: [],
+  ...over
+})
+
+describe('SRAM derived from the chip', () => {
+  it('gives every RP2040 its 264 KB, marked as the chip’s figure', () => {
+    const { ram } = specsForBoard(board({ id: 'ANY_RP2040_BOARD', mcu: 'rp2040' }))
+    expect(ram.bytes).toBe(264 * 1024)
+    expect(ram.scope).toBe('chip')
+    expect(ram.source).toMatch(/RP2040/)
+  })
+
+  it('says nothing for a family whose SRAM is not fixed', () => {
+    // stm32f4 is 43 boards spanning 96 KB (F401) to 256 KB (F439); nrf52 spans
+    // the 64 KB nRF52832 and the 256 KB nRF52840. A wrong number here would be
+    // the single most misleading thing in the catalogue, because it looks exact.
+    for (const mcu of ['stm32f4', 'stm32h7', 'nrf52', 'nrf51', 'samd21', 'samd51', 'mimxrt']) {
+      expect(specsForBoard(board({ mcu })).ram, mcu).toBeNull()
+    }
+  })
+
+  it('never derives flash from the chip, because flash is not on the chip', () => {
+    // The distinction #897 turns on: RP2040 boards ship with 2 MB to 16 MB of
+    // flash and all of them have exactly 264 KB of SRAM.
+    for (const mcu of Object.keys(MCU_SRAM)) {
+      const { flash } = specsForBoard(board({ id: 'NOT_CURATED', mcu }))
+      expect(flash, mcu).toBeNull()
+    }
+  })
+
+  it('names a source for every family it does claim', () => {
+    for (const [mcu, entry] of Object.entries(MCU_SRAM) as [string, { bytes: number; source: string }][]) {
+      expect(entry.bytes, mcu).toBeGreaterThan(0)
+      expect(entry.source.trim(), mcu).not.toBe('')
+    }
+  })
+})
+
+describe('curated boards', () => {
+  it('states a Pico’s 2 MB as the board’s figure, not the chip’s', () => {
+    const { flash, ram } = specsForBoard(board({ id: 'RPI_PICO', mcu: 'rp2040' }))
+    expect(flash.bytes).toBe(2 * 1024 * 1024)
+    expect(flash.scope).toBe('board')
+    expect(ram.scope).toBe('chip')
+  })
+
+  it('names a source for every figure it states', () => {
+    for (const [id, entry] of Object.entries(CURATED_BOARDS) as [
+      string,
+      { flash?: { source: string }; psram?: { source: string } }
+    ][]) {
+      for (const key of ['flash', 'psram'] as const) {
+        const size = entry[key]
+        if (!size) continue
+        expect(size.source.trim(), `${id}.${key}`).not.toBe('')
+      }
+    }
+  })
+})
+
+describe('confirming a CircuitPython build', () => {
+  const catalog = [
+    [
+      { vendor: 'Raspberry Pi', model: 'Pico W', info_url: 'https://circuitpython.org/board/raspberry_pi_pico_w/' },
+      { vendor: 'Seeed', model: 'XIAO ESP32S3', info_url: 'https://circuitpython.org/board/seeed_xiao_esp32s3/' },
+      { vendor: 'Twins', model: 'Same Name', info_url: 'https://circuitpython.org/board/twin_a/' },
+      { vendor: 'Twins', model: 'Same Name', info_url: 'https://circuitpython.org/board/twin_b/' }
+    ]
+  ]
+  const index = circuitPythonIndex(catalog)
+
+  it('matches an id that is literally the same string', () => {
+    expect(circuitPythonIdFor(board({ id: 'SEEED_XIAO_ESP32S3', vendor: 'Seeed Studio', product: 'XIAO ESP32S3' }), index)).toBe(
+      'seeed_xiao_esp32s3'
+    )
+  })
+
+  it('matches the same maker and the same product, across naming styles', () => {
+    expect(circuitPythonIdFor(board({ id: 'RPI_PICO_W', vendor: 'Raspberry Pi', product: 'Pico W' }), index)).toBe(
+      'raspberry_pi_pico_w'
+    )
+  })
+
+  it('says nothing when a name resolves to more than one board', () => {
+    // Flashing the wrong `.uf2` leaves a board that needs re-flashing before it
+    // will talk again, so an ambiguous match is a reason to stay quiet.
+    expect(circuitPythonIdFor(board({ id: 'TWIN', vendor: 'Twins', product: 'Same Name' }), index)).toBeNull()
+  })
+
+  it('never guesses from the chip or a near-miss name', () => {
+    expect(circuitPythonIdFor(board({ id: 'RPI_PICO2_W', vendor: 'Raspberry Pi', product: 'Pico 2 W' }), index)).toBeNull()
+    expect(circuitPythonIdFor(board({ id: 'SOME_ESP32S3', vendor: 'Nobody', product: 'Thing' }), index)).toBeNull()
+  })
+})
+
+describe('which runtimes a board claims', () => {
+  it('claims MicroPython only when something is actually published', () => {
+    expect(runtimesForBoard(board({ builds: [] }), null)).toEqual([])
+    expect(runtimesForBoard(board({ builds: [{}] }), null)).toEqual(['micropython'])
+  })
+
+  it('claims CircuitPython only with a confirmed board id', () => {
+    expect(runtimesForBoard(board({ builds: [{}] }), 'raspberry_pi_pico')).toEqual([
+      'micropython',
+      'circuitpython'
+    ])
+  })
+})


### PR DESCRIPTION
Closes #902 and #897. **Replaces #908**, auto-closed when its base (#893's gallery) was deleted on merge — same work, replayed onto master.

## #902 — the premise needed correcting first

The index already had **15 Adafruit boards**. What it had **zero** of was Adafruit *ESP32* boards, because MicroPython builds no firmware under those names at all. So "missing" meant **uncreatable by the generator** — these can only come from Snakie's own overlay.

New `src/shared/board-overlay.ts` curates five, each stating on the card face whose build it flashes, and each standing down automatically if upstream ever publishes it:

- **ESP32 Feather V2** → `ESP32_GENERIC-SPIRAM` @ `0x1000` — the board that started this
- **HUZZAH32** → the plain build, because it has no PSRAM
- **QT Py ESP32-C3**
- **QT Py ESP32-S3** → the *standard* S3 build, precisely because it has no PSRAM
- **micro:bit v2** — upstream only publishes the nRF51 v1, which is the wrong board for nearly everyone

## The runtime filter, and its honest limits

Shipped, **with its limits printed on screen**. The index is derived from MicroPython's tree, so it structurally cannot list a CircuitPython-only board — 582 CircuitPython ids against 225 here. CircuitPython is claimed only by two *exact* joins: same id (25 boards) or same maker + same product name (19, zero ambiguous), with ambiguity dropped rather than guessed. **49 of 230 confirmed.** The caveat under the chips says both things: this is MicroPython's catalogue, and unconfirmed does not mean unsupported. A silently-incomplete filter would have been the dishonest version.

## #897 — provenance enforced, coverage stated

`flash` / `ram` / `psram` as `{ bytes, source, scope }` rather than bare numbers, because a bare number cannot carry the provenance the issue demands. **The parser drops any unsourced figure.**

Filled from: 11 chip families' SRAM verified against Espressif and Raspberry Pi datasheets; curated board figures quoted from Adafruit / raspberrypi.com / microbit.org; and upstream's own `mpconfigboard.cmake` for the XIAO S3.

**Still unknown: 220 of 230 boards lack a flash figure, 144 lack RAM.** `stm32f4`, `nrf52`, `samd21/51`, `mimxrt`, `esp32h2` and `esp8266` deliberately say *nothing*, and a test asserts they stay silent. So storage and RAM remain **facts, not filters** — the bar for filtering isn't met and pretending otherwise would hide most of the catalogue.

The `flashBytes`/`ramBytes` tripwire test from #898 **moved rather than went**: it now asserts "no figure without a source", plus scope correctness and the silence rule.

## A useful negative finding

`rp2`'s `MICROPY_HW_FLASH_STORAGE_BYTES` looks like a free flash-size source and **is not** — it is the filesystem partition, not the part (`RPI_PICO` reports 1441792 on a 2 MB chip). `esp32`'s `sdkconfig.board` mostly sets no flash size at all. Documented in the code so nobody re-walks it.

## Verification

Schema deliberately **not** bumped: the new fields are optional, and a bump would make older builds *refuse* new documents. Seed regenerated through a new `--specs-only` mode, so five new keys per board with no thumbnail churn.

Every new test proven by breaking the code: dropping the `source` guard, pointing the Feather V2 at the plain build, inventing an `stm32f4` figure, and resolving an ambiguous CircuitPython name — each failing for its own reason.

Gates after the replay onto master: lint ok · typecheck ok · tests ok · build ok.

## Found, not fixed

Upstream carries near-duplicate vendor spellings ("Silicognition" vs "Silicognition LLC", "WeAct" vs "WeAct Studio"), so those makers show as two shelves; normalising is its own judgement call. And the **Feather ESP32-S3 2 MB PSRAM** is a *quad*-PSRAM part for which upstream publishes only `SPIRAM_OCT` — there is currently no correct build, which is worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe