### PR TITLE
Raise the Board Finder above the dialog, and tidy the layout (#896)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Board Finder opened behind the flash dialog** (#893). It was given the
+  Parts Catalog's stacking order, which is right for a gallery opened from a
+  panel with nothing above it — but wrong for one opened from a button inside a
+  modal. It rendered behind the dialog that launched it: invisible, unreachable,
+  and with the dialog still modal in front of it.
+
+### Changed
+
+- **The flash dialog reads as fewer decisions** (#896). Detect board and Board
+  Finder have moved to sit beside the Board dropdown rather than floating above
+  the label they fill in — the dropdown is the answer, and those two buttons are
+  the ways of supplying it. Family and Model are now side by side, since Family
+  narrows Model and they are one decision made in two steps; stacked, they read
+  as two unrelated questions and made the dialog a row taller for nothing. Both
+  fall back to a single column on a narrow window.
+
 ### Added
 
 - **The boards MicroPython does not build for, and where the numbers come from**

--- a/src/renderer/src/components/BoardFinder.css
+++ b/src/renderer/src/components/BoardFinder.css
@@ -11,7 +11,12 @@
 .bfind {
   position: fixed;
   inset: 0;
-  z-index: 200;
+  /* ABOVE the flash dialog's overlay (1100), which is the only thing that opens
+     this — it is reached from the button beside Detect board, so a value below
+     that renders the gallery behind the dialog that launched it and traps the
+     user. Still below the transfer/queue dialog (1250), which reports work in
+     progress and must stay on top of everything. */
+  z-index: 1150;
   display: flex;
   align-items: stretch;
   justify-content: stretch;

--- a/src/renderer/src/components/FirmwareFlasher.css
+++ b/src/renderer/src/components/FirmwareFlasher.css
@@ -573,13 +573,27 @@
  * that is not plugged in yet, or one detection could not name — the same
  * question asked the other way round, so it sits beside it rather than
  * competing with it. Quieter fill, same size and shape. */
-/* Detect and Board Finder sit on ONE row. `.firmware-detect` is
-   `align-self: flex-start` in a column, so two of them would stack. */
+/* The Board dropdown and its two fill-in buttons on one row (#896).
+ *
+ * The select takes the room and the buttons keep their size, so a long board
+ * name is what gives way rather than "Detect board" wrapping to two lines. They
+ * wrap to their own line before that happens on a narrow dialog. */
 .firmware-detect-row {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 0.5rem;
   margin-bottom: 0.5rem;
+}
+
+.firmware-detect-row .firmware-select {
+  flex: 1 1 12rem;
+  min-width: 0;
+  margin-bottom: 0;
+}
+
+.firmware-detect-row .firmware-detect {
+  flex: 0 0 auto;
 }
 
 .firmware-detect-row .firmware-detect {
@@ -594,4 +608,29 @@
 .firmware-detect--finder:hover:not(:disabled) {
   background: rgba(255, 255, 255, 0.14);
   color: #f4f6f8;
+}
+
+/* Family and Model side by side (#896).
+ *
+ * Family narrows Model, so they are one decision in two steps and read as that
+ * when adjacent. `minmax(0, 1fr)` rather than `1fr`: a grid track's default
+ * `min-width: auto` refuses to shrink below its widest option, and some board
+ * names in that list are long enough to push the second column off the dialog. */
+.firmware-cols {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0 0.6rem;
+}
+
+.firmware-col {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+/* One column on a narrow dialog, where two would leave each too tight to read. */
+@media (max-width: 30rem) {
+  .firmware-cols {
+    grid-template-columns: 1fr;
+  }
 }

--- a/src/renderer/src/components/FirmwareFlasher.tsx
+++ b/src/renderer/src/components/FirmwareFlasher.tsx
@@ -1219,12 +1219,55 @@ export function FirmwareFlasher({
               offset and the firmware family, and warns if the chosen build is for
               a different chip. Optional — "Other" leaves every field manual. */}
           <div className="firmware-field">
-            {/* The one action for "what have I plugged in" (#833). It scans, then
-                asks whatever it found what it is, and selects the matching
-                board — Detect and Identify were two buttons for two halves of
-                one question. Placed FIRST because it is the step that makes
-                every field below it unnecessary. */}
+            {/* Detect ran into the REPL holding the port (#845). Said out loud,
+                with the way out attached — knowing a port is busy is only half
+                of it when the thing holding it is this same app.
+                BELOW the button row, not inside it: it is a full-width status
+                message about what Detect just found, not a third button. */}
+            {detectConflict && (
+              <div
+                className="firmware-banner firmware-banner--warn firmware-conflict"
+                role="status"
+              >
+                <p className="firmware-conflict__text">{detectConflict.reason}</p>
+                <button
+                  type="button"
+                  className="firmware-conflict__action"
+                  onClick={() => void disconnectAndDetect()}
+                  disabled={disconnecting || identifying}
+                  title="Close the REPL connection and detect the board again"
+                >
+                  {disconnecting ? 'Disconnecting…' : 'Disconnect and detect'}
+                </button>
+              </div>
+            )}
+            <label className="firmware-field__label" htmlFor="firmware-profile">
+              Board
+            </label>
+            {/* The dropdown and the two ways of filling it in, on one row (#896).
+                Naming the board is the step that fills in the board type, the
+                flash offset and the firmware family — so the answer and the two
+                buttons that can supply it belong together, rather than the
+                buttons floating above the label they act on.
+                Detect asks what is plugged in; Board Finder answers "what have I
+                got" for a board that is not plugged in, or one detection could
+                not name. */}
             <div className="firmware-detect-row">
+              <select
+                id="firmware-profile"
+                className="firmware-select"
+                value={profileId}
+                disabled={flashing}
+                onChange={(e) => handleProfileChange(e.target.value)}
+              >
+                <option value="">Other / set up manually…</option>
+                {BOARD_PROFILES.map((b) => (
+                  <option key={b.id} value={b.id}>
+                    {b.label}
+                  </option>
+                ))}
+              </select>
+
               {isElectron() && (
                 <button
                   type="button"
@@ -1253,45 +1296,6 @@ export function FirmwareFlasher({
                 ⌕ Board Finder
               </button>
             </div>
-            {/* Detect ran into the REPL holding the port (#845). Said out loud,
-                with the way out attached — knowing a port is busy is only half
-                of it when the thing holding it is this same app.
-                BELOW the button row, not inside it: it is a full-width status
-                message about what Detect just found, not a third button. */}
-            {detectConflict && (
-              <div
-                className="firmware-banner firmware-banner--warn firmware-conflict"
-                role="status"
-              >
-                <p className="firmware-conflict__text">{detectConflict.reason}</p>
-                <button
-                  type="button"
-                  className="firmware-conflict__action"
-                  onClick={() => void disconnectAndDetect()}
-                  disabled={disconnecting || identifying}
-                  title="Close the REPL connection and detect the board again"
-                >
-                  {disconnecting ? 'Disconnecting…' : 'Disconnect and detect'}
-                </button>
-              </div>
-            )}
-            <label className="firmware-field__label" htmlFor="firmware-profile">
-              Board
-            </label>
-            <select
-              id="firmware-profile"
-              className="firmware-select"
-              value={profileId}
-              disabled={flashing}
-              onChange={(e) => handleProfileChange(e.target.value)}
-            >
-              <option value="">Other / set up manually…</option>
-              {BOARD_PROFILES.map((b) => (
-                <option key={b.id} value={b.id}>
-                  {b.label}
-                </option>
-              ))}
-            </select>
             {profile?.notes && <p className="firmware-hint">{profile.notes}</p>}
             {/* Advisory, not a warning: a board runs on the plain build too, it
                 just may not get everything the board can do. */}
@@ -1720,41 +1724,50 @@ export function FirmwareFlasher({
 
               {catalog && !catalogLoading && (
                 <>
-                  <label className="firmware-field__label" htmlFor="firmware-cat-family">
-                    Family
-                  </label>
-                  <select
-                    id="firmware-cat-family"
-                    className="firmware-select"
-                    value={selFamily}
-                    disabled={flashing}
-                    onChange={(e) => setSelFamily(e.target.value)}
-                  >
-                    <option value="">Select a family…</option>
-                    {families.map((f) => (
-                      <option key={f.family} value={f.family}>
-                        {f.family}
-                      </option>
-                    ))}
-                  </select>
-
-                  <label className="firmware-field__label" htmlFor="firmware-cat-model">
-                    Model
-                  </label>
-                  <select
-                    id="firmware-cat-model"
-                    className="firmware-select"
-                    value={selModel}
-                    disabled={flashing || !family}
-                    onChange={(e) => setSelModel(e.target.value)}
-                  >
-                    <option value="">Select a model…</option>
-                    {models.map((m) => (
-                      <option key={`${m.vendor}|${m.model}`} value={`${m.vendor}|${m.model}`}>
-                        {m.label}
-                      </option>
-                    ))}
-                  </select>
+                  {/* Two columns (#896). Family narrows Model, so they are one
+                      decision made in two steps — side by side they read as
+                      that, and stacked they read as two unrelated questions
+                      with the dialog growing a row taller for no reason. */}
+                  <div className="firmware-cols">
+                    <div className="firmware-col">
+                      <label className="firmware-field__label" htmlFor="firmware-cat-family">
+                        Family
+                      </label>
+                      <select
+                        id="firmware-cat-family"
+                        className="firmware-select"
+                        value={selFamily}
+                        disabled={flashing}
+                        onChange={(e) => setSelFamily(e.target.value)}
+                      >
+                        <option value="">Select a family…</option>
+                        {families.map((f) => (
+                          <option key={f.family} value={f.family}>
+                            {f.family}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div className="firmware-col">
+                      <label className="firmware-field__label" htmlFor="firmware-cat-model">
+                        Model
+                      </label>
+                      <select
+                        id="firmware-cat-model"
+                        className="firmware-select"
+                        value={selModel}
+                        disabled={flashing || !family}
+                        onChange={(e) => setSelModel(e.target.value)}
+                      >
+                        <option value="">Select a model…</option>
+                        {models.map((m) => (
+                          <option key={`${m.vendor}|${m.model}`} value={`${m.vendor}|${m.model}`}>
+                            {m.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  </div>
 
                   {model && (
                     <>

--- a/test/flashDialogLayout.test.ts
+++ b/test/flashDialogLayout.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+
+/**
+ * The flash dialog's layout, and the stacking that made the gallery useless
+ * (#896, and a regression in #893).
+ *
+ * The z-index one is the important test here. The Board Finder was given
+ * `z-index: 200` — copied from the Parts Catalog, where it opens from a panel
+ * with nothing above it. But the gallery is now reached from a button INSIDE
+ * the flash dialog, whose overlay is 1100. So it opened behind the dialog that
+ * launched it, invisible and unreachable, with the dialog still modal in front
+ * of it. Two correct-looking numbers from two different contexts.
+ */
+
+const flasherCss = readFileSync('src/renderer/src/components/FirmwareFlasher.css', 'utf8')
+const finderCss = readFileSync('src/renderer/src/components/BoardFinder.css', 'utf8')
+const tsx = readFileSync('src/renderer/src/components/FirmwareFlasher.tsx', 'utf8')
+
+/** The `z-index` of the first rule for `selector` in `css`. */
+function zIndexOf(css: string, selector: string): number {
+  const at = css.indexOf(selector)
+  expect(at, `${selector} not found`).toBeGreaterThan(-1)
+  const block = css.slice(at, css.indexOf('}', at))
+  const m = /z-index:\s*(\d+)/.exec(block)
+  expect(m, `no z-index on ${selector}`).not.toBeNull()
+  return Number(m![1])
+}
+
+describe('the Board Finder is reachable once opened', () => {
+  it('stacks ABOVE the dialog that opens it', () => {
+    // It is launched from the button beside Detect board. Anything at or below
+    // the overlay's z-index puts it behind a modal and traps the user.
+    const finder = zIndexOf(finderCss, '.bfind {')
+    const overlay = zIndexOf(flasherCss, '.firmware-overlay {')
+    expect(finder).toBeGreaterThan(overlay)
+  })
+
+  it('stays BELOW the progress dialog, which reports work in flight', () => {
+    const finder = zIndexOf(finderCss, '.bfind {')
+    const transfer = zIndexOf(
+      readFileSync('src/renderer/src/components/TransferProgressDialog.css', 'utf8'),
+      '.transfer__backdrop {'
+    )
+    expect(finder).toBeLessThan(transfer)
+  })
+})
+
+describe('the Board row (#896)', () => {
+  it('puts Detect and Board Finder to the RIGHT of the dropdown', () => {
+    // The dropdown is the answer; the buttons are two ways of supplying it. The
+    // buttons used to float above the label they act on.
+    const row = tsx.indexOf('firmware-detect-row')
+    const select = tsx.indexOf('id="firmware-profile"')
+    const detect = tsx.indexOf('⟳ Detect board')
+    const finder = tsx.indexOf('⌕ Board Finder')
+    expect(row).toBeLessThan(select)
+    expect(select).toBeLessThan(detect)
+    expect(detect).toBeLessThan(finder)
+  })
+
+  it('lets the board name give way, not the button labels', () => {
+    const at = flasherCss.indexOf('.firmware-detect-row .firmware-select')
+    const block = flasherCss.slice(at, flasherCss.indexOf('}', at))
+    expect(block).toContain('flex: 1 1')
+    expect(block).toContain('min-width: 0')
+  })
+})
+
+describe('Family and Model side by side (#896)', () => {
+  it('is two columns', () => {
+    const at = flasherCss.indexOf('.firmware-cols {')
+    const block = flasherCss.slice(at, flasherCss.indexOf('}', at))
+    expect(block).toContain('grid-template-columns')
+    // `minmax(0, 1fr)`, not `1fr`: a grid track's default `min-width: auto`
+    // refuses to shrink below its widest option, and some model names are long
+    // enough to push the second column off the dialog.
+    expect(block).toContain('minmax(0, 1fr)')
+  })
+
+  it('collapses to one column when two would be too tight', () => {
+    expect(flasherCss).toMatch(/@media \(max-width: 30rem\)[\s\S]*?grid-template-columns: 1fr/)
+  })
+
+  it('keeps Family before Model, since Family narrows Model', () => {
+    const family = tsx.indexOf('id="firmware-cat-family"')
+    const model = tsx.indexOf('id="firmware-cat-model"')
+    expect(family).toBeLessThan(model)
+  })
+})


### PR DESCRIPTION
Closes #896, and fixes a regression from #893.

## The gallery opened behind the dialog

Reported: *"the new board finder is opening up behind the firmware flasher dialog making it unaccessible"*. Correct, and my fault.

`BoardFinder.css` was given `z-index: 200`, copied from the Parts Catalog — right there, where the gallery opens from a panel with nothing above it. But #893 moved the entry point **inside** the flash dialog, whose overlay is `1100`. So it rendered behind the very dialog that launched it: invisible, unreachable, and with the dialog still modal in front of it.

Two correct-looking numbers from two different contexts, which is why the test asserts the **relationship** between them rather than either value — a future dialog that raises its own overlay would otherwise re-break this silently.

Raised to `1150`: above the dialog, still below the transfer/queue dialog at `1250`, which reports work in flight and has to stay on top of everything.

## #896 — which I listed and didn't action

Both changes as asked.

**Detect board and Board Finder move to the right of the Board dropdown.** The dropdown is the answer; those two buttons are the two ways of supplying it. They were floating above the label they act on. The select takes the room and the buttons keep their size, so a long board name gives way rather than "Detect board" wrapping to two lines — and the row wraps entirely before that happens on a narrow dialog.

**Family and Model become two columns.** Family narrows Model, so they're one decision made in two steps and read as that when adjacent; stacked, they read as two unrelated questions and cost the dialog a row for nothing.

One detail worth naming: the columns are `minmax(0, 1fr)`, not `1fr`. A grid track's default `min-width: auto` refuses to shrink below its widest content, and some model names in that list are long enough to push the second column off the dialog. They collapse to one column below 30rem, where two would leave each too tight to read.

## Tests

7 new. I restored the original `z-index: 200` and confirmed the stacking test fails — it reproduces exactly the bug you hit.

Gates: lint ok · typecheck ok · **6,283 tests** ok · build ok.

**Not verified on screen** — the layout is reasoned from the flex and grid rules. Worth a look, since it's the third change to this dialog today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe