### PR TITLE
fix(install): tick a library install off file by file, and name its dependencies (#895)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,25 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **A library install now ticks off file by file, and names what it is really
+  installing** (#895). Installing the Arduino Modulino library looked like a
+  hang. It was not: it copies 22 files over the raw REPL, plus three dependency
+  packages — `lsm6dsox`, `ltr-381rgb-01` and `HS3003` — that its own
+  `package.json` pulls in transitively. But an install was enqueued as ONE
+  device-queue task whose `run` never declared any steps, so the whole thing was
+  a single motionless row for minutes at a time. That distinction matters more
+  than usual here, because the documented response to a hung install is
+  Disconnect, which mid-write is exactly what #864 exists to stop being
+  destructive. The install now declares its whole file list before the first
+  write — a list that grew as it went could never say how much was left — and
+  ticks each file off as it lands, with the dependency that brought a file named
+  beside it, so a pause on `lsm6dsox.py` reads as what it is rather than as
+  "still stuck on modulino". Every install gets this, not just the Modules
+  panel: the Packages panel, both Driver Install banners, the instruments-library
+  and missing-library banners, and the parts panel's "Works with" installs, on
+  the desktop and in the browser alike, because they all share one writer
+  underneath and the reporting was fixed there.
+
 - **The recommended firmware build is now reachable for the boards that need it**
   (#885). A board profile can name the build a board actually requires — the
   Adafruit ESP32 Feather V2 needs `ESP32_GENERIC-SPIRAM`, because only that build

--- a/src/main/modules/resolve.ts
+++ b/src/main/modules/resolve.ts
@@ -26,6 +26,7 @@ import {
   selectBundleMajor
 } from '../../shared/circuitpy-bundle'
 import type { RuntimeInfo } from '../../shared/dialect'
+import type { InstallFileEntry } from '../../shared/install-file-progress'
 import { createBundleHost, type BundleHost } from './bundle'
 
 /**
@@ -98,13 +99,14 @@ export function readBundledModuleSource(file: string): string {
 }
 
 /**
- * One file in a plan. `contents` is SOURCE TEXT unless `encoding` says
- * otherwise — `'base64'` marks a binary file (an Adafruit `.mpy`) that the
- * writer must decode back to bytes. Absent means `'utf8'`, so every plan built
- * before #758 keeps its meaning.
+ * One file in a plan: its device `path` and whichever dependency brought it
+ * (from {@link InstallFileEntry}), plus what to write there.
+ *
+ * `contents` is SOURCE TEXT unless `encoding` says otherwise — `'base64'` marks
+ * a binary file (an Adafruit `.mpy`) that the writer must decode back to bytes.
+ * Absent means `'utf8'`, so every plan built before #758 keeps its meaning.
  */
-export interface ModulePlanFile {
-  path: string
+export interface ModulePlanFile extends InstallFileEntry {
   contents: string
   encoding?: 'utf8' | 'base64'
 }
@@ -172,13 +174,18 @@ async function buildBundlePlan(
       inflate: host.inflate,
       target: MODULES_LIB_DIR
     })
+    // The bundle installs dependencies BEFORE the library that needs them, so
+    // the library the user asked for is the LAST one — the same slice
+    // `bundleInstallNote` takes to name the others.
+    const root = resolved.modules[resolved.modules.length - 1]
     return {
       id: def.id,
       importName: def.importName,
       files: resolved.files.map((f) => ({
         path: f.path,
         contents: Buffer.from(f.bytes).toString('base64'),
-        encoding: 'base64' as const
+        encoding: 'base64' as const,
+        dependency: f.module === root ? undefined : f.module
       })),
       spec: module,
       notes: [
@@ -257,7 +264,13 @@ export async function buildModuleInstallPlan(
     return {
       id: def.id,
       importName: def.importName,
-      files: resolved.files.map((f) => ({ path: f.path, contents: f.contents })),
+      files: resolved.files.map((f) => ({
+        path: f.path,
+        contents: f.contents,
+        // Root first (see the note above), so a file declared by anything else
+        // arrived transitively and is named by what brought it (#895).
+        dependency: f.package === resolved.packages[0] ? undefined : f.package
+      })),
       spec,
       notes
     }

--- a/src/main/packages/ipc.ts
+++ b/src/main/packages/ipc.ts
@@ -6,6 +6,7 @@ import { installNotes, installTarget } from '../../shared/packages/install'
 import { hostInstallNote, resolveFailureMessage } from '../../shared/install-messages'
 import { httpMipFetch, MipResolveError, resolveMipSpec } from '../../shared/mip-resolve'
 import type { InstallOptions, PackageInfo } from '../../shared/packages/types'
+import type { InstallFileEntry } from '../../shared/install-file-progress'
 
 /**
  * IPC for the MicroPython package installer (issue #20, reworked by #776).
@@ -26,7 +27,7 @@ import type { InstallOptions, PackageInfo } from '../../shared/packages/types'
 /** Payload returned by `packages:install` for the renderer to write. */
 export interface InstallPlan {
   /** Every file to write to the device, parents-before-children. */
-  files: { path: string; contents: string }[]
+  files: (InstallFileEntry & { contents: string })[]
   /** Non-fatal notes (e.g. the `.mpy` caveat) to surface in the UI. */
   notes: string[]
 }
@@ -73,7 +74,14 @@ export function registerPackagesIpc(): void {
           index: opts.index?.trim() || undefined
         })
         return {
-          files: resolved.files.map((f) => ({ path: f.path, contents: f.contents })),
+          files: resolved.files.map((f) => ({
+            path: f.path,
+            contents: f.contents,
+            // `resolveMipSpec` lists the root spec first, so a file declared by
+            // anything else came along transitively — named here so the install
+            // can say whose file it is stuck on (#895).
+            dependency: f.package === resolved.packages[0] ? undefined : f.package
+          })),
           // The provenance note the web backend already emits: what was
           // downloaded, WHICH DEPENDENCIES came with it, and where they went.
           // A package install that quietly brings four more packages should say

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -51,6 +51,10 @@ import { writeFailureMessage } from '../shared/install-messages'
 import type { RuntimeInfo } from '../shared/dialect'
 import { deviceDirsFor } from '../shared/mip-resolve'
 import { writeAtomically, type AtomicOps } from '../shared/atomic-write'
+import {
+  installPlanMessage,
+  type InstallFileProgress
+} from '../shared/install-file-progress'
 import type {
   CopilotDeviceCode,
   CopilotPollResult
@@ -397,7 +401,7 @@ const deviceAtomicOps: AtomicOps = {
 async function writeFilesToBoard(
   name: string,
   files: ModulePlanFile[],
-  onStep: (message: string) => void
+  onStep: (message: string, detail?: InstallFileProgress) => void
 ): Promise<{ ok: boolean; log: string }> {
   if (files.length === 0) {
     return { ok: false, log: `Couldn't install ${name}: nothing was resolved to write.` }
@@ -408,10 +412,19 @@ async function writeFilesToBoard(
       // An existing directory is fine — MicroPython raises EEXIST for it.
       await unwrap<void>(ipcRenderer.invoke('device:mkdir', dir)).catch(() => undefined)
     }
+    // Declare the whole list BEFORE the first write (#895). A progress list that
+    // grows as it goes cannot say how much is left, which is the question a user
+    // watching a 22-file install is actually asking.
+    onStep(installPlanMessage(files), {
+      files: files.map((f) => ({ path: f.path, dependency: f.dependency }))
+    })
     let done = 0
-    for (const file of files) {
+    for (const [index, file] of files.entries()) {
       current = file.path
-      onStep(`Writing ${++done}/${files.length} — ${file.path}…`)
+      onStep(`Writing ${++done}/${files.length} — ${file.path}…`, {
+        fileIndex: index,
+        fileState: 'running'
+      })
       // A base64 file is BINARY — an Adafruit `.mpy` (#758). It goes down the
       // bytes channel, never the text one: a `.mpy` that took the string route
       // would be silently corrupted by the UTF-8 round-trip and land as a file
@@ -430,6 +443,10 @@ async function writeFilesToBoard(
             ? unwrap<void>(ipcRenderer.invoke('device:writeFileBytes', tmp, bytes))
             : unwrap<void>(ipcRenderer.invoke('device:writeFile', tmp, file.contents))
       )
+      onStep(`Wrote ${done}/${files.length} — ${file.path}`, {
+        fileIndex: index,
+        fileState: 'done'
+      })
     }
     return { ok: true, log: `Wrote ${files.map((f) => f.path).join(', ')}` }
   } catch (err) {
@@ -495,8 +512,8 @@ const packages = {
     }
     for (const note of plan.notes) emit({ name, state: 'note', message: note })
 
-    const written = await writeFilesToBoard(name, plan.files, (message) =>
-      emit({ name, state: 'running', message })
+    const written = await writeFilesToBoard(name, plan.files, (message, detail) =>
+      emit({ name, state: 'running', message, ...detail })
     )
     emit({
       name,
@@ -508,7 +525,7 @@ const packages = {
 }
 
 /** Lifecycle event for a per-module install (#120). Mirrors `InstallProgress`. */
-export interface ModuleInstallProgress {
+export interface ModuleInstallProgress extends InstallFileProgress {
   /** The catalog module id being installed. */
   id: string
   /** Lifecycle state. */
@@ -603,8 +620,8 @@ const modules = {
     }
     for (const note of plan.notes) emit({ id, state: 'note', message: note })
 
-    const written = await writeFilesToBoard(id, plan.files, (message) =>
-      emit({ id, state: 'running', message })
+    const written = await writeFilesToBoard(id, plan.files, (message, detail) =>
+      emit({ id, state: 'running', message, ...detail })
     )
     emit({
       id,

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -73,6 +73,8 @@ import {
 } from './part-imports'
 import { installPartDriver } from './driver-install'
 import { enqueueDeviceTask } from '../lib/device-queue'
+import { installStepReporter } from '../lib/install-steps'
+import { installStepLabel } from '../../../shared/install-file-progress'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { useSkeletonSync } from '../hooks/useSkeletonSync'
 import {
@@ -728,11 +730,9 @@ export function AppShell(): JSX.Element {
         await enqueueDeviceTask({
           key: 'instruments-lib',
           label: 'Installing the instruments library',
-          run: async (): Promise<void> => {
+          run: async (ctx): Promise<void> => {
             const source = await window.api.instruments.librarySource()
             if (!source) throw new Error('library source unavailable')
-            await window.api.device.mkdir(INSTRUMENTS_LIB_DIR).catch(() => undefined)
-            await window.api.device.writeFile(INSTRUMENTS_LIB_PATH, source)
             // A legacy copy at the FS root (`/instruments.py`) shadows `/lib` on
             // MicroPython's sys.path, so updating only `/lib` would leave the OLD
             // root copy being imported. If one is there, overwrite it with the same
@@ -742,16 +742,27 @@ export function AppShell(): JSX.Element {
               .stat(INSTRUMENTS_ROOT_PATH)
               .then(() => true)
               .catch(() => false)
-            if (rootShadow) {
-              await window.api.device.writeFile(INSTRUMENTS_ROOT_PATH, source)
-            }
-            // Install the `snakie.py` hardware umbrella beside it (best-effort — an
+            // The `snakie.py` hardware umbrella goes beside it (best-effort — an
             // older bundle without it just skips this), so `from snakie import Servo`
             // works and a vendor `servo` module can't shadow ours.
             const umbrella = await window.api.instruments.umbrellaSource().catch(() => '')
-            if (umbrella) {
-              await window.api.device.writeFile(SNAKIE_LIB_PATH, umbrella)
-              if (rootShadow) await window.api.device.writeFile(SNAKIE_ROOT_PATH, umbrella)
+            // Both questions — is there a root shadow, is there an umbrella — are
+            // answered BEFORE the first write, so the step list is the real one
+            // rather than one that grows as it goes (#895).
+            const writes = [
+              { path: INSTRUMENTS_LIB_PATH, contents: source },
+              ...(rootShadow ? [{ path: INSTRUMENTS_ROOT_PATH, contents: source }] : []),
+              ...(umbrella ? [{ path: SNAKIE_LIB_PATH, contents: umbrella }] : []),
+              ...(umbrella && rootShadow
+                ? [{ path: SNAKIE_ROOT_PATH, contents: umbrella }]
+                : [])
+            ]
+            ctx.setSteps(writes.map((w) => installStepLabel(w.path)))
+            await window.api.device.mkdir(INSTRUMENTS_LIB_DIR).catch(() => undefined)
+            for (const [index, write] of writes.entries()) {
+              ctx.step(index, 'running')
+              await window.api.device.writeFile(write.path, write.contents)
+              ctx.step(index, 'done')
             }
           }
         })
@@ -957,7 +968,14 @@ export function AppShell(): JSX.Element {
             const res = await enqueueDeviceTask({
               key: `package:${t.url as string}`,
               label: `Installing ${t.module}`,
-              run: () => window.api.packages.install(t.url as string)
+              // Per-file steps (#895) — a `mip` spec can bring dependencies, and
+              // this banner is one of the places an install looked like a hang.
+              run: (ctx) =>
+                window.api.packages.install(
+                  t.url as string,
+                  undefined,
+                  installStepReporter(ctx)
+                )
             })
             if (!res.ok) throw new Error(res.log || `Failed to install ${t.module}`)
           }

--- a/src/renderer/src/components/ModulesPanel.tsx
+++ b/src/renderer/src/components/ModulesPanel.tsx
@@ -17,6 +17,7 @@ import {
 } from '../lib/modulesManager'
 import { probeOutdatedModules } from '../lib/moduleFreshness'
 import { enqueueDeviceTask } from '../lib/device-queue'
+import { installStepReporter } from '../lib/install-steps'
 import type { ModuleInstallProgress } from '../../../preload/index.d'
 
 /**
@@ -140,7 +141,9 @@ export function ModulesPanel(): JSX.Element {
       const result = await enqueueDeviceTask({
         key: `module:${def.id}`,
         label: `Installing ${def.name}`,
-        run: () => window.api.modules.install(def.id, onProgress)
+        // The install's own per-file progress becomes this task's steps (#895),
+        // so a 22-file package ticks off instead of sitting on one still row.
+        run: (ctx) => window.api.modules.install(def.id, installStepReporter(ctx, onProgress))
       })
       setInstalls((prev) => ({
         ...prev,

--- a/src/renderer/src/components/PackagesPanel.tsx
+++ b/src/renderer/src/components/PackagesPanel.tsx
@@ -13,6 +13,7 @@ import {
   type BoardPackage
 } from '../lib/board-packages'
 import { enqueueDeviceTask } from '../lib/device-queue'
+import { installStepReporter } from '../lib/install-steps'
 import { ModulesPanel } from './ModulesPanel'
 import type { InstallProgress, PackageInfo } from '../../../preload/index.d'
 
@@ -319,7 +320,9 @@ function PackagesTab(): JSX.Element {
         const result = await enqueueDeviceTask({
           key: `package:${name}`,
           label: `Installing ${name}`,
-          run: () =>
+          // Per-file steps (#895): a package that pulls dependencies in writes
+          // far more files than its name suggests, and says so as it goes.
+          run: (ctx) =>
             window.api.packages.install(
               name,
               {
@@ -327,7 +330,7 @@ function PackagesTab(): JSX.Element {
                 mpy: convertMpy,
                 index: customIndex.trim() || undefined
               },
-              onProgress
+              installStepReporter(ctx, onProgress)
             )
         })
         setInstalls((prev) => ({

--- a/src/renderer/src/components/PartsPanel.tsx
+++ b/src/renderer/src/components/PartsPanel.tsx
@@ -13,6 +13,7 @@ import { availableToInstall } from '../../../shared/part-registry'
 import type { BundledPartStatus } from '../../../shared/bundled-seed'
 import { moduleById, type ModuleDef } from '../../../shared/modules-catalog'
 import { enqueueDeviceTask } from '../lib/device-queue'
+import { installStepReporter } from '../lib/install-steps'
 import type { SuggestedModule } from '../../../shared/part'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import type {
@@ -922,7 +923,9 @@ function WorksWith({ suggests }: { suggests: SuggestedModule[] }): JSX.Element |
       await enqueueDeviceTask({
         key: `module:${def.id}`,
         label: `Installing ${def.name}`,
-        run: () => window.api.modules.install(def.id)
+        // Per-file steps (#895) — the same install the Modules panel runs, and
+        // "Works with" offers `modulino`, which is the 25-file one.
+        run: (ctx) => window.api.modules.install(def.id, installStepReporter(ctx))
       })
       setDone((n) => n + 1)
     } catch {

--- a/src/renderer/src/components/driver-install.ts
+++ b/src/renderer/src/components/driver-install.ts
@@ -20,7 +20,12 @@
  * driver it is on.
  */
 import { driverDeviceDirs, driverInstallMethod, driverModuleId } from './part-editor.util'
-import { DeviceOperationCancelled, enqueueDeviceTask } from '../lib/device-queue'
+import {
+  DeviceOperationCancelled,
+  enqueueDeviceTask,
+  type DeviceTaskContext
+} from '../lib/device-queue'
+import { installStepReporter } from '../lib/install-steps'
 import { moduleById } from '../../../shared/modules-catalog'
 import {
   parsePurgeCount,
@@ -83,7 +88,7 @@ export async function installPartDriver(
   return enqueueDeviceTask({
     key: `driver:${d.source}->${d.target}`,
     label: `Installing ${d.label?.trim() || d.source}`,
-    run: () => runDriverInstall(libraryId, partId, d)
+    run: (ctx) => runDriverInstall(libraryId, partId, d, ctx)
   }).catch((err) => ({
     ok: false,
     message: err instanceof Error ? err.message : String(err),
@@ -91,11 +96,19 @@ export async function installPartDriver(
   }))
 }
 
-/** The install sequence itself — always run through the device queue above. */
+/**
+ * The install sequence itself — always run through the device queue above.
+ *
+ * `ctx` is the queue task's, and its only job here is per-file steps (#895):
+ * the `module:` and `mip` routes both end in the shared writer, and a part
+ * whose driver is `module:modulino` is a 25-file install behind a one-line
+ * banner. The `copy` route is a single file and stays the task's own row.
+ */
 async function runDriverInstall(
   libraryId: string,
   partId: string,
-  d: DriverFile
+  d: DriverFile,
+  ctx: DeviceTaskContext
 ): Promise<DriverInstallResult> {
   try {
     const method = driverInstallMethod(d.source)
@@ -107,7 +120,7 @@ async function runDriverInstall(
       if (!moduleById(id)) {
         return { ok: false, message: `Unknown module "${id}" — it is not in the catalog.` }
       }
-      const res = await window.api.modules.install(id)
+      const res = await window.api.modules.install(id, installStepReporter(ctx))
       if (!res.ok) {
         return {
           ok: false,
@@ -118,7 +131,11 @@ async function runDriverInstall(
     }
     if (method === 'mip') {
       const target = d.target.trim()
-      const res = await window.api.packages.install(d.source, target ? { target } : undefined)
+      const res = await window.api.packages.install(
+        d.source,
+        target ? { target } : undefined,
+        installStepReporter(ctx)
+      )
       if (!res.ok) {
         return {
           ok: false,

--- a/src/renderer/src/lib/install-steps.ts
+++ b/src/renderer/src/lib/install-steps.ts
@@ -1,0 +1,50 @@
+/**
+ * AN INSTALL, AS THE DEVICE QUEUE'S STEPS (#895).
+ * =============================================================================
+ *
+ * The queue (#837) gives every task a list of sub-steps it can tick off, and
+ * the folder copy (#848) uses it: twelve files, twelve rows, each going pending
+ * → copying → done as it lands. A library install had exactly the same shape and
+ * used none of it. It was enqueued as ONE task whose `run` never called
+ * `ctx.setSteps`, so a Modulino install — 22 files plus three dependency
+ * packages, minutes over the raw REPL — showed a single motionless row for the
+ * whole thing. That is the reported bug: it looks like a hang, and the
+ * documented response to a hang is Disconnect, which mid-write is precisely
+ * what #864 exists to stop being destructive.
+ *
+ * The writer now reports the same facts structurally (see
+ * `shared/install-file-progress.ts`), so this is the whole adaptation: a
+ * progress callback that forwards the events on and turns them into step calls.
+ *
+ * Kept here rather than in `device-queue.ts` because the queue knows nothing
+ * about installs, and rather than in each panel because there are six callers
+ * and they should not each re-derive it.
+ */
+import { installStepLabels, type InstallFileProgress } from '../../../shared/install-file-progress'
+import type { DeviceTaskContext } from './device-queue'
+
+/**
+ * A progress callback that ticks `ctx`'s steps off file by file.
+ *
+ * `onEvent` is the caller's own handler, called for every event first — the
+ * panels collect `note` messages for their install log, and taking the queue's
+ * reporting must not cost them that.
+ *
+ * `fileIndex` indexes the file list, and the labels are built one-per-file from
+ * it, so it indexes the steps too; `ctx.step` ignores anything out of range,
+ * which is what makes an event arriving before its list harmless.
+ */
+export function installStepReporter<P extends InstallFileProgress>(
+  ctx: DeviceTaskContext,
+  onEvent?: (event: P) => void
+): (event: P) => void {
+  return (event: P): void => {
+    onEvent?.(event)
+    if (event.files) {
+      ctx.setSteps(installStepLabels(event.files))
+      return
+    }
+    if (event.fileIndex === undefined || event.fileState === undefined) return
+    ctx.step(event.fileIndex, event.fileState)
+  }
+}

--- a/src/renderer/src/web/web-install.ts
+++ b/src/renderer/src/web/web-install.ts
@@ -20,6 +20,11 @@ import {
   type MipFetch
 } from '../../../shared/mip-resolve'
 import { writeFailureMessage } from '../../../shared/install-messages'
+import {
+  installPlanMessage,
+  type InstallFileEntry,
+  type InstallFileProgress
+} from '../../../shared/install-file-progress'
 import { webCanFetch, webFetchRefusal } from './web-hosts'
 
 /**
@@ -49,9 +54,9 @@ export interface InstallDevice {
   writeFile(path: string, contents: string): Promise<void>
 }
 
-/** One file to put on the board. */
-export interface InstallFile {
-  path: string
+/** One file to put on the board: where it goes, what to write, and whichever
+ *  dependency brought it (from {@link InstallFileEntry}). */
+export interface InstallFile extends InstallFileEntry {
   contents: string
 }
 
@@ -69,13 +74,16 @@ export interface WriteOutcome {
  *
  * `onStep` matters more than it looks: over the raw REPL each file is a run of
  * hex-chunk round-trips, so a 25-file package spends a long time here and
- * silence reads as a hang.
+ * silence reads as a hang. It reports the same STRUCTURED detail its desktop
+ * twin does (#895) — the file list once, then an index per file — so the web
+ * build's install ticks off in the device-queue dialog exactly as the desktop's
+ * does, from the same renderer code.
  */
 export async function writeFilesToDevice(
   name: string,
   files: readonly InstallFile[],
   device: InstallDevice,
-  onStep: (message: string) => void = () => {}
+  onStep: (message: string, detail?: InstallFileProgress) => void = () => {}
 ): Promise<WriteOutcome> {
   if (files.length === 0) {
     return { ok: false, log: `Couldn't install ${name}: nothing was resolved to write.` }
@@ -86,11 +94,23 @@ export async function writeFilesToDevice(
       // An existing directory is fine — MicroPython raises EEXIST for it.
       await device.mkdir(dir).catch(() => undefined)
     }
+    // Declared BEFORE the first write: a list that grows as it goes cannot say
+    // how much is left, which is the question being asked.
+    onStep(installPlanMessage(files), {
+      files: files.map((f) => ({ path: f.path, dependency: f.dependency }))
+    })
     let done = 0
-    for (const file of files) {
+    for (const [index, file] of files.entries()) {
       current = file.path
-      onStep(`Writing ${++done}/${files.length} — ${file.path}…`)
+      onStep(`Writing ${++done}/${files.length} — ${file.path}…`, {
+        fileIndex: index,
+        fileState: 'running'
+      })
       await device.writeFile(file.path, file.contents)
+      onStep(`Wrote ${done}/${files.length} — ${file.path}`, {
+        fileIndex: index,
+        fileState: 'done'
+      })
     }
     return { ok: true, log: `Wrote ${files.map((f) => f.path).join(', ')}` }
   } catch (err) {

--- a/src/renderer/src/web/web-modules.ts
+++ b/src/renderer/src/web/web-modules.ts
@@ -27,7 +27,13 @@ import { driverSources } from 'virtual:snakie-standard-parts'
 import { MODULE_STUBS } from './web-lib-sources'
 import { MipResolveError, resolveMipSpec } from '../../../shared/mip-resolve'
 import { hostInstallNote, resolveFailureMessage } from '../../../shared/install-messages'
-import { webMipFetch, writeFilesToDevice, type InstallDevice } from './web-install'
+import {
+  webMipFetch,
+  writeFilesToDevice,
+  type InstallDevice,
+  type InstallFile
+} from './web-install'
+import type { InstallFileProgress } from '../../../shared/install-file-progress'
 
 const LIB_DIR = '/lib'
 
@@ -35,13 +41,13 @@ interface InstallPlan {
   id: string
   importName: string
   /** Every file to write, parents-before-children. */
-  files: { path: string; contents: string }[]
+  files: InstallFile[]
   /** The upstream spec these files came from, when there was one. */
   spec?: string
   notes: string[]
 }
 
-interface InstallProgress {
+interface InstallProgress extends InstallFileProgress {
   id: string
   state: 'started' | 'note' | 'running' | 'done' | 'error'
   message?: string
@@ -106,7 +112,12 @@ async function planFor(id: string): Promise<InstallPlan> {
     return {
       id,
       importName: def.importName,
-      files: resolved.files.map((f) => ({ path: f.path, contents: f.contents })),
+      files: resolved.files.map((f) => ({
+        path: f.path,
+        contents: f.contents,
+        // Root spec first, so anything else came along transitively (#895).
+        dependency: f.package === resolved.packages[0] ? undefined : f.package
+      })),
       spec,
       notes: [
         hostInstallNote({
@@ -180,7 +191,7 @@ export function createWebModulesApi(): Record<string, unknown> {
         id,
         plan.files,
         window.api.device as unknown as InstallDevice,
-        (message) => emit({ id, state: 'running', message })
+        (message, detail) => emit({ id, state: 'running', message, ...detail })
       )
       emit({
         id,

--- a/src/renderer/src/web/web-packages.ts
+++ b/src/renderer/src/web/web-packages.ts
@@ -41,7 +41,12 @@ import type {
 } from '../../../shared/packages/types'
 import { MipResolveError, resolveMipSpec } from '../../../shared/mip-resolve'
 import { resolveFailureMessage, hostInstallNote } from '../../../shared/install-messages'
-import { webMipFetch, writeFilesToDevice, type InstallDevice } from './web-install'
+import {
+  webMipFetch,
+  writeFilesToDevice,
+  type InstallDevice,
+  type InstallFile
+} from './web-install'
 
 /** Build the web `packages` API surface (merged over the fallback stub). */
 export function createWebPackagesApi(): Record<string, unknown> {
@@ -73,7 +78,7 @@ export function createWebPackagesApi(): Record<string, unknown> {
       emit({ name, state: 'started' })
       emit({ name, state: 'running', message: `Downloading ${name}…` })
 
-      let files: { path: string; contents: string }[]
+      let files: InstallFile[]
       const notes = installNotes(opts)
       try {
         const resolved = await resolveMipSpec(name, {
@@ -81,7 +86,12 @@ export function createWebPackagesApi(): Record<string, unknown> {
           target,
           index: opts.index?.trim() || undefined
         })
-        files = resolved.files.map((f) => ({ path: f.path, contents: f.contents }))
+        files = resolved.files.map((f) => ({
+          path: f.path,
+          contents: f.contents,
+          // Root spec first, so anything else came along transitively (#895).
+          dependency: f.package === resolved.packages[0] ? undefined : f.package
+        }))
         notes.push(
           hostInstallNote({
             name,
@@ -111,7 +121,7 @@ export function createWebPackagesApi(): Record<string, unknown> {
         name,
         files,
         window.api.device as unknown as InstallDevice,
-        (message) => emit({ name, state: 'running', message })
+        (message, detail) => emit({ name, state: 'running', message, ...detail })
       )
       emit({
         name,

--- a/src/shared/install-file-progress.ts
+++ b/src/shared/install-file-progress.ts
@@ -1,0 +1,130 @@
+/**
+ * Per-file detail on a library install (#895).
+ * =============================================================================
+ *
+ * Installing the Arduino Modulino package copies 22 files over the raw REPL,
+ * plus three dependency packages it pulls in transitively. That takes a while —
+ * and with nothing moving on screen there is no way to tell a slow install from
+ * a dead one. The reported symptom was "installing the modulino library appears
+ * to hang", and the documented workaround for a hang is Disconnect, which
+ * mid-write is exactly what #864 exists to stop being destructive.
+ *
+ * The information already existed. `writeFilesToBoard` has always reported every
+ * file as it went:
+ *
+ *     onStep(`Writing ${++done}/${files.length} — ${file.path}…`)
+ *
+ * but only as prose, inside the progress event's free-text `message`. Anything
+ * wanting the file, the index or the total had to parse that sentence back
+ * apart, which is not a thing to build on. So the same facts travel
+ * structurally as well, and the sentence stays exactly as it was for the panels
+ * that display it.
+ *
+ * Mixed into BOTH install progress payloads — modules and packages — because
+ * they share one writer underneath, and the fix belongs there rather than in
+ * each caller.
+ */
+
+/** What a file is doing, mirroring the device queue's own step states. */
+export type InstallFileState = 'running' | 'done' | 'error'
+
+/** One file an install will write. */
+export interface InstallFileEntry {
+  /** Absolute on-device path, e.g. `/lib/modulino/__init__.py`. */
+  path: string
+  /**
+   * The DEPENDENCY package that brought this file, when it is not one of the
+   * package the user actually asked for.
+   *
+   * Set by whoever built the plan, because that is the only place both halves
+   * are known — and it is set rather than derived because "which package is
+   * root" is not the same question for the two resolvers: a `mip` resolution
+   * lists the root FIRST and the Adafruit bundle lists it LAST. Recording the
+   * answer once beats two call sites each guessing at it.
+   *
+   * Absent means "this is the package that was asked for", which is why the
+   * common case — a one-file bundled driver — needs nothing at all.
+   */
+  dependency?: string
+}
+
+/**
+ * The structured half of an install progress event. Every field is optional:
+ * an install emits notes, errors and lifecycle states that have nothing to do
+ * with any particular file.
+ */
+export interface InstallFileProgress {
+  /**
+   * Every file this install will write, in the order they will be written.
+   * Emitted ONCE, before the first write — a progress list that grows as it
+   * goes cannot show how much is left, which is the question being asked.
+   */
+  files?: readonly InstallFileEntry[]
+  /** Index into {@link files} of the file this event concerns. */
+  fileIndex?: number
+  /** What just happened to it. */
+  fileState?: InstallFileState
+}
+
+/**
+ * A package spec, shortened to something worth putting in a list.
+ *
+ * Specs arrive in the shapes `mip` accepts: a bare index name (`lsm6dsox`), a
+ * `github:` path (`github:arduino/arduino-modulino-mpy`), or a URL ending in a
+ * file. The tail is the part that identifies it; the host, the owner and the
+ * `.py` are shared by everything around it and only cost width.
+ */
+export function packageDisplayName(spec: string): string {
+  const trimmed = spec.trim()
+  const bare = trimmed
+    .replace(/^[a-z][a-z0-9+.-]*:/i, '') // github: / gitlab: / https:
+    .replace(/[?#].*$/, '')
+    .replace(/\/+$/, '')
+  const tail = bare.split('/').filter(Boolean).pop() ?? ''
+  return tail.replace(/\.(py|mpy|json)$/i, '') || trimmed
+}
+
+/**
+ * A short label for one file in the progress list.
+ *
+ * The device path, minus the `/lib/` every library install shares — twenty-two
+ * rows all starting with the same five characters spend the width that tells
+ * them apart. A path outside `/lib` is left whole, because then the location IS
+ * the information.
+ */
+export function installStepLabel(devicePath: string): string {
+  return devicePath.startsWith('/lib/') ? devicePath.slice('/lib/'.length) : devicePath
+}
+
+/**
+ * The step labels for a whole install, one per file, in write order.
+ *
+ * Files from a dependency are named by the package that brought them. That is
+ * the other half of the reported bug: a `modulino` install also fetches
+ * `lsm6dsox`, `ltr-381rgb-01` and `HS3003`, and an unlabelled row part-way down
+ * a 25-file list reads as "still stuck on modulino" when it is really working
+ * through something the user never asked for by name — which is exactly the
+ * moment they most want to know why.
+ */
+export function installStepLabels(files: readonly InstallFileEntry[]): string[] {
+  return files.map((file) =>
+    file.dependency
+      ? `${packageDisplayName(file.dependency)} — ${installStepLabel(file.path)}`
+      : installStepLabel(file.path)
+  )
+}
+
+/**
+ * The sentence that announces the write leg, before the first file goes down.
+ *
+ * It counts the dependency files separately because that count is the answer to
+ * "why is this taking so long for one small driver".
+ */
+export function installPlanMessage(files: readonly InstallFileEntry[]): string {
+  const total = files.length
+  const deps = new Set(files.map((f) => f.dependency).filter(Boolean))
+  const plural = total === 1 ? '' : 's'
+  if (deps.size === 0) return `Writing ${total} file${plural}…`
+  const packages = deps.size === 1 ? 'package' : 'packages'
+  return `Writing ${total} file${plural}, including ${deps.size} dependency ${packages}…`
+}

--- a/src/shared/packages/types.ts
+++ b/src/shared/packages/types.ts
@@ -5,6 +5,7 @@
  * serialize cleanly across the Electron IPC boundary and can be re-used by the
  * preload typings and the renderer.
  */
+import type { InstallFileProgress } from '../install-file-progress'
 
 /** A package surfaced by search or discovery. */
 export interface PackageInfo {
@@ -51,7 +52,7 @@ export interface InstallRequest {
  * an install runs. `state` drives the UI; `message` carries human-readable
  * detail (log line, error text, or a graceful note such as the `.mpy` caveat).
  */
-export interface InstallProgress {
+export interface InstallProgress extends InstallFileProgress {
   /** The package this event concerns. */
   name: string
   state: 'started' | 'running' | 'note' | 'done' | 'error'

--- a/test/installProgress.test.ts
+++ b/test/installProgress.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  installPlanMessage,
+  installStepLabel,
+  installStepLabels,
+  packageDisplayName,
+  type InstallFileProgress
+} from '../src/shared/install-file-progress'
+import { installStepReporter } from '../src/renderer/src/lib/install-steps'
+import {
+  enqueueDeviceTask,
+  getDeviceQueueSnapshot,
+  queueProgress,
+  queueRows,
+  resetDeviceQueueForTest,
+  type DeviceStepState,
+  type DeviceTaskContext
+} from '../src/renderer/src/lib/device-queue'
+import { writeFilesToDevice, type InstallFile } from '../src/renderer/src/web/web-install'
+
+/**
+ * AN INSTALL HAS TO LOOK LIKE IT IS MOVING (#895).
+ *
+ * The bug these pin: a library install was enqueued as ONE device-queue task
+ * whose `run` never touched `ctx.setSteps`, so the Arduino Modulino package —
+ * 22 files plus three dependency packages, minutes over the raw REPL — showed a
+ * single motionless row for the whole install. It reads as a hang, and the
+ * documented response to a hang is Disconnect, which mid-write is exactly what
+ * #864 exists to stop being destructive.
+ *
+ * So the property under test is the one the user sees: after the plan resolves,
+ * the queue knows how many files there are, ticks them off one at a time, and
+ * names the dependency that brought each file it did not obviously ask for.
+ *
+ * The last test drives the REAL writer into the REAL queue over a fake board,
+ * so it fails if either end of the chain stops reporting — not only if the
+ * label helpers regress.
+ */
+
+/** A `DeviceTaskContext` that records what it was told. */
+function fakeContext(): DeviceTaskContext & {
+  labels: string[]
+  moves: [number, DeviceStepState][]
+} {
+  const labels: string[] = []
+  const moves: [number, DeviceStepState][] = []
+  return {
+    labels,
+    moves,
+    cancelled: false,
+    setSteps(next): void {
+      labels.length = 0
+      labels.push(...next)
+    },
+    step(index, state): void {
+      moves.push([index, state])
+    }
+  }
+}
+
+/** A board that records its writes, and can be made to pause on one of them. */
+function fakeDevice(pauseOn?: string): {
+  writes: string[]
+  release: () => void
+  mkdir(p: string): Promise<void>
+  writeFile(p: string, c: string): Promise<void>
+} {
+  const writes: string[] = []
+  let release = (): void => {}
+  const held = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  return {
+    writes,
+    release: () => release(),
+    mkdir: async () => {},
+    writeFile: async (p) => {
+      if (p === pauseOn) await held
+      writes.push(p)
+    }
+  }
+}
+
+/** Let every pending microtask + timer callback run. */
+const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 0))
+
+/** Spin the loop until `ready`, so a test never counts the queue's awaits. */
+async function settle(ready: () => boolean): Promise<void> {
+  for (let i = 0; i < 100 && !ready(); i++) await tick()
+}
+
+beforeEach(() => resetDeviceQueueForTest())
+
+describe('a file becomes a row the user can watch (#895)', () => {
+  it('drops the `/lib/` every library shares, and keeps a path that is not in it', () => {
+    // Twenty-two rows all starting with the same five characters spend the
+    // width that tells them apart; a path outside /lib IS the information.
+    expect(installStepLabel('/lib/modulino/__init__.py')).toBe('modulino/__init__.py')
+    expect(installStepLabel('/instruments.py')).toBe('/instruments.py')
+  })
+
+  it('names the dependency that brought a file the user never asked for', () => {
+    const labels = installStepLabels([
+      { path: '/lib/modulino/__init__.py' },
+      { path: '/lib/modulino/movement.py' },
+      { path: '/lib/lsm6dsox.py', dependency: 'lsm6dsox' },
+      { path: '/lib/micropython_hs3003.py', dependency: 'HS3003' }
+    ])
+    expect(labels).toEqual([
+      'modulino/__init__.py',
+      'modulino/movement.py',
+      'lsm6dsox — lsm6dsox.py',
+      'HS3003 — micropython_hs3003.py'
+    ])
+  })
+})
+
+describe('a package spec, shortened to something worth listing (#895)', () => {
+  it('keeps the tail that identifies it and drops what every sibling shares', () => {
+    expect(packageDisplayName('github:arduino/arduino-modulino-mpy')).toBe(
+      'arduino-modulino-mpy'
+    )
+    expect(packageDisplayName('lsm6dsox')).toBe('lsm6dsox')
+    expect(
+      packageDisplayName(
+        'github:micropython/micropython-lib/micropython/drivers/storage/sdcard/sdcard.py'
+      )
+    ).toBe('sdcard')
+    expect(packageDisplayName('https://example.com/drivers/thing.mpy')).toBe('thing')
+  })
+
+  it('falls back to the spec rather than showing nothing', () => {
+    expect(packageDisplayName('github:')).toBe('github:')
+  })
+})
+
+describe('the sentence that announces the write leg (#895)', () => {
+  it('counts the dependency packages, because that is why it is slow', () => {
+    expect(installPlanMessage([{ path: '/lib/vl53l0x.py' }])).toBe('Writing 1 file…')
+    expect(
+      installPlanMessage([
+        { path: '/lib/modulino/__init__.py' },
+        { path: '/lib/lsm6dsox.py', dependency: 'lsm6dsox' },
+        { path: '/lib/ltr381rgb.py', dependency: 'ltr-381rgb-01' }
+      ])
+    ).toBe('Writing 3 files, including 2 dependency packages…')
+  })
+
+  it('says "package" when there is one of them', () => {
+    expect(
+      installPlanMessage([
+        { path: '/lib/modulino/__init__.py' },
+        { path: '/lib/lsm6dsox.py', dependency: 'lsm6dsox' }
+      ])
+    ).toBe('Writing 2 files, including 1 dependency package…')
+  })
+})
+
+describe('install progress becomes the queue task’s steps (#895)', () => {
+  it('declares the whole list before the first file moves', () => {
+    const ctx = fakeContext()
+    const report = installStepReporter(ctx)
+    report({
+      files: [{ path: '/lib/a.py' }, { path: '/lib/b.py', dependency: 'bee' }]
+    })
+    expect(ctx.labels).toEqual(['a.py', 'bee — b.py'])
+    expect(ctx.moves).toEqual([])
+  })
+
+  it('moves the step the event names', () => {
+    const ctx = fakeContext()
+    const report = installStepReporter(ctx)
+    report({ files: [{ path: '/lib/a.py' }, { path: '/lib/b.py' }] })
+    report({ fileIndex: 0, fileState: 'running' })
+    report({ fileIndex: 0, fileState: 'done' })
+    report({ fileIndex: 1, fileState: 'error' })
+    expect(ctx.moves).toEqual([
+      [0, 'running'],
+      [0, 'done'],
+      [1, 'error']
+    ])
+  })
+
+  it('still hands every event to the caller, whose install log needs the notes', () => {
+    // The panels collect `note` messages for their install log. Taking the
+    // queue's reporting must not cost them that.
+    const ctx = fakeContext()
+    const seen: string[] = []
+    const report = installStepReporter<InstallFileProgress & { message?: string }>(
+      ctx,
+      (event) => {
+        if (event.message) seen.push(event.message)
+      }
+    )
+    report({ message: 'Downloaded modulino with its dependencies lsm6dsox…' })
+    report({ files: [{ path: '/lib/a.py' }] })
+    report({ message: 'Writing 1 file…', fileIndex: 0, fileState: 'running' })
+    expect(seen).toEqual([
+      'Downloaded modulino with its dependencies lsm6dsox…',
+      'Writing 1 file…'
+    ])
+    expect(ctx.labels).toEqual(['a.py'])
+  })
+
+  it('ignores an event that is about no file at all', () => {
+    const ctx = fakeContext()
+    const report = installStepReporter(ctx)
+    report({ files: [{ path: '/lib/a.py' }] })
+    report({ fileIndex: 0 })
+    report({ fileState: 'done' })
+    expect(ctx.moves).toEqual([])
+  })
+})
+
+describe('the whole chain: a real install into the real queue (#895)', () => {
+  /** A plan shaped like the reported one — a package plus a dependency. */
+  const plan: InstallFile[] = [
+    { path: '/lib/modulino/__init__.py', contents: 'a' },
+    { path: '/lib/modulino/movement.py', contents: 'b' },
+    { path: '/lib/lsm6dsox.py', contents: 'c', dependency: 'lsm6dsox' }
+  ]
+
+  it('shows one row per file, ticking off as the board takes them', async () => {
+    const device = fakeDevice('/lib/lsm6dsox.py')
+    const done = enqueueDeviceTask({
+      key: 'module:modulino',
+      label: 'Installing Arduino Modulino',
+      run: (ctx) => {
+        // Exactly what the two install backends do with the writer's `onStep`:
+        // fold the structured detail into the progress event they already emit.
+        const report = installStepReporter<InstallFileProgress>(ctx)
+        return writeFilesToDevice('modulino', plan, device, (_message, detail) =>
+          report({ ...detail })
+        )
+      }
+    })
+    await settle(() => device.writes.length === 2)
+
+    // Held on the last file: the queue knows there are three, and that two are
+    // finished. Before this, the whole install was a single motionless row.
+    const midway = getDeviceQueueSnapshot().tasks
+    expect(queueProgress(midway)).toEqual({ done: 2, total: 3 })
+    expect(queueRows(midway).map((r) => r.label)).toEqual([
+      'Installing Arduino Modulino',
+      'modulino/__init__.py',
+      'modulino/movement.py',
+      'lsm6dsox — lsm6dsox.py'
+    ])
+    expect(queueRows(midway).map((r) => r.state)).toEqual([
+      'copying',
+      'done',
+      'done',
+      'copying'
+    ])
+
+    device.release()
+    const outcome = await done
+    expect(outcome.ok).toBe(true)
+    await settle(() => !getDeviceQueueSnapshot().busy)
+    expect(queueProgress(getDeviceQueueSnapshot().tasks)).toEqual({ done: 3, total: 3 })
+  })
+})

--- a/test/webPackages.test.ts
+++ b/test/webPackages.test.ts
@@ -8,6 +8,7 @@ import {
 import { webMipFetch, writeFilesToDevice } from '../src/renderer/src/web/web-install'
 import { createWebPackagesApi } from '../src/renderer/src/web/web-packages'
 import { MipResolveError } from '../src/shared/mip-resolve'
+import type { InstallFileProgress } from '../src/shared/install-file-progress'
 import { CURATED_PACKAGES } from '../src/shared/packages/registry'
 
 /**
@@ -130,18 +131,35 @@ describe('writing a resolved package to the device', () => {
 
   it('reports per-file progress, so a 25-file package does not look hung', async () => {
     const steps: string[] = []
+    const details: InstallFileProgress[] = []
     await writeFilesToDevice(
       'pkg',
       [
         { path: '/lib/a.py', contents: 'a' },
-        { path: '/lib/b.py', contents: 'b' }
+        { path: '/lib/b.py', contents: 'b', dependency: 'bee' }
       ],
       fakeDevice(),
-      (m) => steps.push(m)
+      (m, detail) => {
+        steps.push(m)
+        if (detail) details.push(detail)
+      }
     )
-    expect(steps).toHaveLength(2)
-    expect(steps[1]).toContain('2/2')
-    expect(steps[1]).toContain('/lib/b.py')
+    // The whole list is declared BEFORE the first write (#895) — a progress
+    // list that grows as it goes cannot say how much is left — and then each
+    // file reports starting and landing, in prose and structurally at once.
+    expect(steps[0]).toContain('2 files')
+    expect(details[0].files).toEqual([
+      { path: '/lib/a.py', dependency: undefined },
+      { path: '/lib/b.py', dependency: 'bee' }
+    ])
+    expect(steps.at(-1)).toContain('2/2')
+    expect(steps.at(-1)).toContain('/lib/b.py')
+    expect(details.slice(1)).toEqual([
+      { fileIndex: 0, fileState: 'running' },
+      { fileIndex: 0, fileState: 'done' },
+      { fileIndex: 1, fileState: 'running' },
+      { fileIndex: 1, fileState: 'done' }
+    ])
   })
 
   it('tolerates a directory that already exists', async () => {


### PR DESCRIPTION
Closes #895.

## The problem

Installing the Arduino Modulino library looked like a hang. It was not — it
copies 22 files over the raw REPL, plus three dependency packages (`lsm6dsox`,
`ltr-381rgb-01`, `HS3003`) its own `package.json` pulls in transitively. But an
install was enqueued as **one** device-queue task whose `run` never called
`ctx.setSteps`, so 25 files were a single motionless row for minutes at a time.

That distinction matters more than usual, because the documented response to a
hung install is **Disconnect** — which mid-write is exactly what #864 exists to
stop being destructive. An install that says nothing invites the one action that
used to leave a truncated file on the board.

## What changed

The facts already existed: `writeFilesToBoard` has always reported every file.
They just had nowhere structured to go — only prose inside the progress event's
free-text `message`, which nothing can build on without parsing the sentence back
apart. So they now travel structurally as well, and `message` is unchanged for
the panels that display it.

- **`src/shared/install-file-progress.ts`** — the shape (`files` once before the
  first write, then `fileIndex`/`fileState` per file), plus the pure label
  helpers: `installStepLabels`, `packageDisplayName`, `installPlanMessage`.
- **Both payloads** (`ModuleInstallProgress`, `InstallProgress`) mix it in, and
  `writeFilesToBoard` emits it — they share one writer underneath, so the
  reporting was fixed there rather than in each caller.
- **`src/renderer/src/lib/install-steps.ts`** — `installStepReporter(ctx, onEvent?)`
  turns those events into `ctx.setSteps` / `ctx.step`, exactly as the folder copy
  of #848 does. `onEvent` still gets every event first, so the panels keep
  collecting `note` messages for their install log.
- **`src/renderer/src/web/web-install.ts`** reports the same detail, so the
  browser build ticks off from the same renderer code.

The whole list is declared **before** the first write. A list that grows as it
goes cannot say how much is left, which is the question a user watching a 25-file
install is actually asking.

### Every install, not just the Modules panel

One line each, all through the shared reporter:

| Call site | Route |
|---|---|
| `ModulesPanel` | `modules.install` |
| `PackagesPanel` | `packages.install` |
| `driver-install.ts` | both Driver Install banners — `module:` and `mip` routes |
| `AppShell` missing-library banner | `packages.install` |
| `AppShell` instruments-library banner | writes its own files |
| `PartsPanel` "Works with" | `modules.install` |

The instruments-library banner does not go through the shared writer, so it now
resolves both of its conditionals (is there a root shadow? is there an umbrella?)
**before** the first write and declares its real list — same rule, locally
applied. The `copy` route in `driver-install.ts` is a single file and stays the
task's own row.

### The dependencies are named

A `modulino` install silently also fetches three other packages, and an
unlabelled row part-way down reads as "still stuck on modulino". Each plan file
now records the dependency that brought it, so the rows read:

```
Installing Arduino Modulino
  modulino/__init__.py
  modulino/movement.py
  …
  lsm6dsox — lsm6dsox.py
  ltr-381rgb-01 — ltr381rgb.py
  HS3003 — micropython_hs3003.py
```

It is recorded where the plan is built, because "which package is root" is not
the same question for the two resolvers: a `mip` resolution lists the root
**first**, the Adafruit bundle lists it **last**. Answering it once beats five
call sites each guessing.

## What an install shows now

The device-queue dialog gets one row per file under the task, ticking
pending → copying → done as each lands, with a `n of N` count from
`queueProgress` (which counts leaves, so 25 files reads as 25 things to do rather
than one). Cancel and minimise are unaffected. A one-file install still shows a
single step and, being quick, usually never gets past the dialog's 400 ms reveal
delay.

## The round-trip cost of #864, measured

#864 made each file a write plus a `stat` and a `rename`. Counted by driving the
real `writeAtomically` over counting ops, against the Modulino package as the
device layer's own comment records it (182 KB across 25 files, 1 KB chunks):

| | round trips |
|---|---|
| chunk round trips (payload) | 182 |
| write leg before #864 (open + chunks + close) | **250** |
| write leg after #864 (+ `stat` + `rename` per file) | **300** (+50, **+20%**) |
| FAT board, re-install over existing files | **350** (+100, +40%) |

The FAT row is the `commit()` fallback: `os.rename` onto an existing name fails
with EEXIST there, so it becomes remove-then-rename. It only applies when the
target already exists — a first install renames cleanly on FAT too.

The +20% is round-trip *count*, not wall clock. The 182 payload trips each carry
~2 KB of hex (≈180 ms of transmission alone at 115200 baud); the 50 added ones
are one-line snippets, ~6 KB on the wire in total against ~364 KB of hex — under
2%. So the cost is 50 × the fixed raw-REPL overhead (enter, exec, read to
prompt), not 20% more time. It remains the right trade — the alternative is a
truncated file that imports as a `SyntaxError` in a vendor library — and it is
now visible while it is being paid.

## Tests

`test/installProgress.test.ts` (11 new, `environment: 'node'`, all pure): the
label helpers, the reporter against a fake `DeviceTaskContext`, and a whole-chain
test that drives the **real** writer through the **real** device queue over a
fake board and asserts the rows and the `n of N` count mid-flight and at the end.

`test/webPackages.test.ts`'s per-file progress test was updated: it asserted
exactly two messages, and the stream is now richer (the plan, then each file
starting and landing). It now asserts the contract — plan first, then structured
per-file detail — rather than a count.

**Verified they fail without the fix.** Removing `ctx.setSteps` from the reporter
fails 3 tests; removing the plan declaration from the writer fails the whole-chain
test; dropping the dependency prefix from the labels fails 3. Restored, all 11
pass.

## Also in here

The parked branch carried a stray edit that routed **text** file writes down the
bytes channel (`device:writeFileBytes` with a `Buffer.from(contents, 'utf8')`).
It contradicted the comment directly above it, made the ternary a no-op, and had
nothing to do with progress reporting — reverted to `device:writeFile`.

## Gates

`npm run lint` (0 errors; the one `DriverInstallBanner.tsx` warning is
pre-existing), `npm run typecheck`, `npm test` (6294 passed), `npm run build` —
all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe
