### PR TITLE
One command channel for the app menu, and View ▸ Workspace on it (#914, #916)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Switch workspace from the menu, and one command channel behind it** (#914,
+  #916). **View ▸ Workspace** lists Code, Electronics and Build with a radio tick
+  on the one you are in, and **Cmd/Ctrl 1, 2 and 3** switch between them — the
+  first keyboard route to the three workspaces, and the shortcuts #920 asks for.
+  The tick follows the switch wherever it happens: pick Electronics in the
+  switcher and the menu agrees, because the renderer publishes what the menu
+  should show and the menu rebuilds. The submenu is built from the workspace list
+  itself, so a fourth workspace would appear in it — correctly labelled — with
+  nothing here edited.
+
+  Underneath, the menu now reaches the app through **one typed command channel**
+  instead of a hand-built one per item. Adding File ▸ Open Folder… cost six edits
+  — its own IPC channel, a relay, a preload subscription, a stub for the web
+  build, a listener, and another argument on `buildAppMenu` — and the menu work
+  still to come would have repeated that a dozen times, which is how a menu ends
+  up with items that quietly do nothing. There is now one id list shared by the
+  main process, the preload and the renderer, one dispatcher, and a test that
+  every id has a handler and every handler an id. Open Folder moved onto it and
+  its own channel is gone. State travels back the same way, so an item that
+  should grey out has somewhere to learn that it should.
+
 - **The boards MicroPython does not build for, and where the numbers come from**
   (#902, #897). The Board Finder had 15 Adafruit boards and not one Adafruit
   ESP32 board, because MicroPython publishes no firmware under any of those

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,12 +15,12 @@ import { registerUpdater, checkForUpdatesManual } from './updater'
 import { registerBoardIpc, openBoardView, disposeBoard } from './board'
 import { registerFindIpc, disposeFind } from './find'
 import { registerInstrumentWindowsIpc, disposeInstrumentWindows } from './instrumentWindows'
-import { registerWorkspaceIpc, requestOpenFolder, disposeWorkspace } from './workspace'
+import { registerWorkspaceIpc, disposeWorkspace } from './workspace'
 import { registerConsoleWindowIpc, disposeConsoleWindow } from './consoleWindow'
 import { registerPartsIpc } from './parts/ipc'
 import { registerRobotIpc } from './robot/ipc'
 import { registerFeedbackIpc } from './feedback/ipc'
-import { setupAppMenu } from './menu'
+import { setupAppMenu, disposeAppMenu } from './menu'
 
 // Disable GPU / hardware-accelerated rendering on the Raspberry Pi build (Linux
 // arm64). The Pi's GL stack can't report VSync timing to Chromium, which floods
@@ -252,10 +252,18 @@ app.whenReady().then(() => {
   // Build the application menu (issue #89). Its "Check for Updates…" item and
   // the clickable status-bar version both invoke the same user-initiated check.
   // Installed after `registerUpdater` so `checkForUpdatesManual` is assigned.
-  // File ▸ Open Folder… relays to the renderer, which owns the picker (#882);
-  // its resolver is captured by `registerWorkspaceIpc` below, and the menu only
-  // fires on a click, so registration order doesn't matter.
-  setupAppMenu(() => void checkForUpdatesManual(), openBoardView, requestOpenFolder)
+  // Everything else the menu does travels over the one `menu:command` channel to
+  // the main window (#914) — File ▸ Open Folder… relays to the renderer, which
+  // owns the picker (#882), and View ▸ Workspace to the layout store (#916). The
+  // window resolver is a closure and the menu only fires on a click, so
+  // registration order doesn't matter.
+  setupAppMenu(
+    {
+      'app.checkForUpdates': () => void checkForUpdatesManual(),
+      'view.boardWindow': openBoardView
+    },
+    () => mainWindow
+  )
 
   // Register the LLM (Claude) chat layer. All Anthropic API calls happen in the
   // main process; deltas stream back to whichever window is currently live.
@@ -319,4 +327,5 @@ app.on('before-quit', () => {
   disposeInstrumentWindows()
   disposeConsoleWindow()
   disposeWorkspace()
+  disposeAppMenu()
 })

--- a/src/main/menu-template.ts
+++ b/src/main/menu-template.ts
@@ -1,0 +1,203 @@
+import type { MenuItemConstructorOptions } from 'electron'
+import {
+  EMPTY_MENU_STATE,
+  workspaceMenuCommand,
+  type MenuCommand,
+  type MenuState
+} from '../shared/menu-commands'
+import { WORKSPACE_IDS, WORKSPACE_INFO } from '../shared/workspaces'
+
+/**
+ * The application menu as PLAIN DATA (#914).
+ *
+ * Split out of `menu.ts` so the shape of the menu — which items exist, what
+ * each one fires, which are ticked or greyed — is a pure function of the app
+ * name, the platform and the renderer's {@link MenuState}. `menu.ts` keeps the
+ * two lines that need Electron (`app.name` and `Menu.buildFromTemplate`), and
+ * the decisions are testable directly, without a running app.
+ *
+ * Every item that DOES something goes through `onCommand(id)`: one callback for
+ * the whole menu, rather than a positional argument per item (which is how
+ * `buildAppMenu(onCheckForUpdates, onOpenBoard, onOpenFolder)` was heading).
+ * `menu.ts` routes each id to the main process or to the main window.
+ */
+
+export interface MenuTemplateOptions {
+  /** `app.name` — the macOS app menu's title. */
+  appName: string
+  /** macOS puts About / Check for Updates in the app menu, and keeps Close
+   *  rather than Quit at the bottom of File. */
+  isMac: boolean
+  /** What the renderer last said about itself (ticks + greyed-out items).
+   *  Defaults to "nothing to say", so the menu built at startup is complete. */
+  state?: MenuState
+  /** Fires when any command item is clicked. */
+  onCommand: (id: MenuCommand) => void
+}
+
+/** A menu item that fires `id`, wearing whatever the renderer said about it. */
+function commandItem(
+  id: MenuCommand,
+  label: string,
+  o: MenuTemplateOptions,
+  extra: Omit<MenuItemConstructorOptions, 'label' | 'click' | 'enabled' | 'checked'> = {}
+): MenuItemConstructorOptions {
+  const state = o.state ?? EMPTY_MENU_STATE
+  // Electron only reads `checked` on a checkbox or radio item, so a plain item
+  // doesn't carry one — a tick nothing can show is a claim about the menu that
+  // isn't true.
+  const ticks = extra.type === 'radio' || extra.type === 'checkbox'
+  return {
+    label,
+    // Absent from the map = normal. Only an explicit `false` greys an item out,
+    // so an item nobody has published state for is usable rather than dead.
+    enabled: state.enabled[id] !== false,
+    ...(ticks ? { checked: state.checked[id] === true } : {}),
+    click: () => o.onCommand(id),
+    ...extra
+  }
+}
+
+/**
+ * View ▸ Workspace (#916) — built from `WORKSPACE_IDS`, labelled from
+ * `WORKSPACE_INFO`, so a fourth workspace appears here on its own and the menu
+ * can never disagree with the in-app switcher about what the three are called.
+ *
+ * `type: 'radio'` with the active one ticked from {@link MenuState}: the switch
+ * can happen in either place, and the tick follows.
+ *
+ * Cmd/Ctrl 1-2-3 (#920 asks for exactly these). Monaco binds Cmd+S, Cmd+F,
+ * Cmd+H and Cmd+Shift+1 — but nothing that is a plain modifier plus a digit —
+ * so the accelerators are free. Numbering stops at 9 because there is no Cmd+10.
+ */
+export function workspaceSubmenu(o: MenuTemplateOptions): MenuItemConstructorOptions[] {
+  return WORKSPACE_IDS.map((id, i) =>
+    commandItem(workspaceMenuCommand(id), WORKSPACE_INFO[id].label, o, {
+      type: 'radio',
+      ...(i < 9 ? { accelerator: `CmdOrCtrl+${i + 1}` } : {})
+    })
+  )
+}
+
+/**
+ * Application menu (issue #89).
+ *
+ * Snakie previously relied on Electron's default menu (and `autoHideMenuBar`).
+ * To add a "Check for Updates…" command we build an explicit menu from the
+ * standard roles so the normal Edit / View / Window behaviour is preserved —
+ * we only insert our own items. "Check for Updates…" goes:
+ *
+ *   - macOS  → in the app menu (first menu, named after the app), just after
+ *              "About Snakie", matching the platform convention;
+ *   - Win/Linux → in a Help menu (created here, since the default template has
+ *              none) alongside the About item.
+ *
+ * File ▸ Open Folder… (#882), View ▸ Board View and View ▸ Workspace (#916) sit
+ * where their platform conventions put them, and carry the accelerators that
+ * make them reachable without hunting for a button.
+ */
+export function appMenuTemplate(o: MenuTemplateOptions): MenuItemConstructorOptions[] {
+  const isMac = o.isMac
+
+  // The same user-initiated GitHub update check the clickable status-bar version
+  // triggers over IPC (see `updater.ts`): in packaged builds it checks GitHub
+  // Releases and prompts to download; unpackaged it shows a friendly note.
+  const checkForUpdatesItem = commandItem('app.checkForUpdates', 'Check for Updates…', o)
+
+  // Opener for the Board View window (#185). The open windows themselves are
+  // listed automatically by the `role: 'windowMenu'` Window menu (now that the
+  // window has native chrome); this item just opens/focuses it from the keyboard.
+  const boardViewItem = commandItem('view.boardWindow', 'Board View', o, {
+    accelerator: 'CmdOrCtrl+Shift+B'
+  })
+
+  // Open Folder (#882). The main toolbar's folder icon was a duplicate of the
+  // Local Files panel's own, so it went — but that button was ALSO the only
+  // Open Folder reachable when the Files panel is collapsed, or in Electronics /
+  // Build where there is no files panel at all. The action lives here now, with
+  // the accelerator every editor uses for it, so removing the icon removed a
+  // duplicate rather than the ability.
+  const openFolderItem = commandItem('file.openFolder', 'Open Folder…', o, {
+    accelerator: 'CmdOrCtrl+O'
+  })
+
+  return [
+    // macOS app menu (omitted on Windows/Linux). About → Check for Updates → …
+    ...(isMac
+      ? ([
+          {
+            label: o.appName,
+            submenu: [
+              { role: 'about' },
+              checkForUpdatesItem,
+              { type: 'separator' },
+              { role: 'services' },
+              { type: 'separator' },
+              { role: 'hide' },
+              { role: 'hideOthers' },
+              { role: 'unhide' },
+              { type: 'separator' },
+              { role: 'quit' }
+            ]
+          }
+        ] as MenuItemConstructorOptions[])
+      : []),
+    {
+      label: 'File',
+      submenu: [openFolderItem, { type: 'separator' }, isMac ? { role: 'close' } : { role: 'quit' }]
+    },
+    {
+      label: 'Edit',
+      submenu: [
+        { role: 'undo' },
+        { role: 'redo' },
+        { type: 'separator' },
+        { role: 'cut' },
+        { role: 'copy' },
+        { role: 'paste' },
+        ...(isMac
+          ? ([
+              { role: 'pasteAndMatchStyle' },
+              { role: 'delete' },
+              { role: 'selectAll' }
+            ] as MenuItemConstructorOptions[])
+          : ([
+              { role: 'delete' },
+              { type: 'separator' },
+              { role: 'selectAll' }
+            ] as MenuItemConstructorOptions[]))
+      ]
+    },
+    {
+      label: 'View',
+      submenu: [
+        { role: 'reload' },
+        { role: 'forceReload' },
+        { role: 'toggleDevTools' },
+        { type: 'separator' },
+        { label: 'Workspace', submenu: workspaceSubmenu(o) },
+        boardViewItem,
+        { type: 'separator' },
+        { role: 'resetZoom' },
+        { role: 'zoomIn' },
+        { role: 'zoomOut' },
+        { type: 'separator' },
+        { role: 'togglefullscreen' }
+      ]
+    },
+    // The Window menu uses the standard `windowMenu` role so the OS manages it —
+    // on macOS that AUTO-LISTS every open window (the main editor, the Board View
+    // and Find & Replace), which is what #185 wanted; this works now that those
+    // windows have native chrome (frameless windows were skipped by the OS list).
+    { role: 'windowMenu' },
+    {
+      role: 'help',
+      submenu: [
+        // On macOS "Check for Updates…" lives in the app menu, so the Help menu
+        // only needs the About item on Windows/Linux (macOS already has About in
+        // its app menu). Keep a Help menu everywhere for a consistent home.
+        ...(isMac ? [] : ([{ role: 'about' }, checkForUpdatesItem] as MenuItemConstructorOptions[]))
+      ]
+    }
+  ]
+}

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,155 +1,120 @@
-import { app, Menu, type MenuItemConstructorOptions } from 'electron'
+import { app, BrowserWindow, ipcMain, Menu } from 'electron'
+import { appMenuTemplate } from './menu-template'
+import {
+  EMPTY_MENU_STATE,
+  coerceMenuState,
+  type MainMenuCommand,
+  type MenuCommand,
+  type MenuState
+} from '../shared/menu-commands'
 
 /**
- * Application menu (issue #89).
+ * The application menu, and the one channel it talks to the app through (#914).
  *
- * Snakie previously relied on Electron's default menu (and `autoHideMenuBar`).
- * To add a "Check for Updates…" command we build an explicit menu from the
- * standard roles so the normal Edit / View / Window behaviour is preserved —
- * we only insert our own items. "Check for Updates…" goes:
+ * `menu-template.ts` decides what the menu LOOKS like; this file owns the two
+ * halves that need a live app:
  *
- *   - macOS  → in the app menu (first menu, named after the app), just after
- *              "About Snakie", matching the platform convention;
- *   - Win/Linux → in a Help menu (created here, since the default template has
- *              none) alongside the About item.
+ *   menu:command  (main → MAIN WINDOW)  a command id the renderer runs
+ *   menu:state    (MAIN WINDOW → main)  ticks + greyed-out items, then rebuild
  *
- * File ▸ Open Folder… (#882) and View ▸ Board View sit where their platform
- * conventions put them, and carry the accelerators that make them reachable
- * without hunting for a button.
+ * Clicking any item calls one `onCommand(id)`. A command in `handlers` is a main
+ * process action (the updater, the Board View window) and runs here; anything
+ * else is relayed to the main window, where one dispatcher turns it into a store
+ * action or one of the window events the app already listens for. That is why
+ * adding a menu item is no longer six edits and another positional argument on
+ * `buildAppMenu`.
  *
- * The item invokes the same `checkForUpdatesManual` the clickable status-bar
- * version triggers via IPC — a user-initiated GitHub update check (see
- * `updater.ts`). It works the same way everywhere: in packaged builds it checks
- * GitHub Releases and prompts to download; unpackaged it shows a friendly note.
- *
- * @param onCheckForUpdates handler for the "Check for Updates…" item.
- * @param onOpenBoard handler for the Board View item.
- * @param onOpenFolder handler for the File ▸ Open Folder… item.
+ * The state comes back the other way because the menu is built HERE and every
+ * fact it reflects — which workspace is showing, whether a board is connected,
+ * whether a file is open — lives THERE. A published state rebuilds the menu, so
+ * the View ▸ Workspace radio follows the in-app switcher (#916).
  */
-export function buildAppMenu(
-  onCheckForUpdates: () => void,
-  onOpenBoard: () => void,
-  onOpenFolder: () => void
-): Menu {
-  const isMac = process.platform === 'darwin'
-  const appName = app.name
 
-  const checkForUpdatesItem: MenuItemConstructorOptions = {
-    label: 'Check for Updates…',
-    click: () => onCheckForUpdates()
+/** The renderer's latest published state (ticks + greyed items). */
+let menuState: MenuState = EMPTY_MENU_STATE
+/** Serialised `menuState`, so a republish that changes nothing doesn't rebuild
+ *  the menu — the renderer publishes on every relevant state change, and on
+ *  macOS a needless `setApplicationMenu` visibly closes an open menu. */
+let menuStateKey = JSON.stringify(EMPTY_MENU_STATE)
+/** Resolver for the main editor window — the renderer that runs the relayed
+ *  commands. Captured at setup, so registration order doesn't matter. */
+let resolveMainWindow: () => BrowserWindow | null = () => null
+/** Main-process commands and what they do. `Record<MainMenuCommand, …>` makes a
+ *  command with no handler a COMPILE error, the same guarantee the renderer's
+ *  dispatcher gets from its own exhaustive table. */
+let mainHandlers: Record<MainMenuCommand, () => void> | null = null
+
+/** Route one clicked command: main-process commands run here, everything else
+ *  goes to the main window. A command sent while no main window exists is
+ *  dropped — there is nothing to run it. */
+function dispatch(id: MenuCommand): void {
+  const local = mainHandlers?.[id as MainMenuCommand]
+  if (local) {
+    local()
+    return
   }
-
-  // Opener for the Board View window (#185). The open windows themselves are
-  // listed automatically by the `role: 'windowMenu'` Window menu (now that the
-  // window has native chrome); this item just opens/focuses it from the keyboard.
-  const boardViewItem: MenuItemConstructorOptions = {
-    label: 'Board View',
-    accelerator: 'CmdOrCtrl+Shift+B',
-    click: () => onOpenBoard()
-  }
-
-  // Open Folder (#882). The main toolbar's folder icon was a duplicate of the
-  // Local Files panel's own, so it went — but that button was ALSO the only
-  // Open Folder reachable when the Files panel is collapsed, or in Electronics /
-  // Build where there is no files panel at all. The action lives here now, with
-  // the accelerator every editor uses for it, so removing the icon removed a
-  // duplicate rather than the ability.
-  const openFolderItem: MenuItemConstructorOptions = {
-    label: 'Open Folder…',
-    accelerator: 'CmdOrCtrl+O',
-    click: () => onOpenFolder()
-  }
-
-  const template: MenuItemConstructorOptions[] = [
-    // macOS app menu (omitted on Windows/Linux). About → Check for Updates → …
-    ...(isMac
-      ? ([
-          {
-            label: appName,
-            submenu: [
-              { role: 'about' },
-              checkForUpdatesItem,
-              { type: 'separator' },
-              { role: 'services' },
-              { type: 'separator' },
-              { role: 'hide' },
-              { role: 'hideOthers' },
-              { role: 'unhide' },
-              { type: 'separator' },
-              { role: 'quit' }
-            ]
-          }
-        ] as MenuItemConstructorOptions[])
-      : []),
-    {
-      label: 'File',
-      submenu: [openFolderItem, { type: 'separator' }, isMac ? { role: 'close' } : { role: 'quit' }]
-    },
-    {
-      label: 'Edit',
-      submenu: [
-        { role: 'undo' },
-        { role: 'redo' },
-        { type: 'separator' },
-        { role: 'cut' },
-        { role: 'copy' },
-        { role: 'paste' },
-        ...(isMac
-          ? ([
-              { role: 'pasteAndMatchStyle' },
-              { role: 'delete' },
-              { role: 'selectAll' }
-            ] as MenuItemConstructorOptions[])
-          : ([
-              { role: 'delete' },
-              { type: 'separator' },
-              { role: 'selectAll' }
-            ] as MenuItemConstructorOptions[]))
-      ]
-    },
-    {
-      label: 'View',
-      submenu: [
-        { role: 'reload' },
-        { role: 'forceReload' },
-        { role: 'toggleDevTools' },
-        { type: 'separator' },
-        boardViewItem,
-        { type: 'separator' },
-        { role: 'resetZoom' },
-        { role: 'zoomIn' },
-        { role: 'zoomOut' },
-        { type: 'separator' },
-        { role: 'togglefullscreen' }
-      ]
-    },
-    // The Window menu uses the standard `windowMenu` role so the OS manages it —
-    // on macOS that AUTO-LISTS every open window (the main editor, the Board View
-    // and Find & Replace), which is what #185 wanted; this works now that those
-    // windows have native chrome (frameless windows were skipped by the OS list).
-    { role: 'windowMenu' },
-    {
-      role: 'help',
-      submenu: [
-        // On macOS "Check for Updates…" lives in the app menu, so the Help menu
-        // only needs the About item on Windows/Linux (macOS already has About in
-        // its app menu). Keep a Help menu everywhere for a consistent home.
-        ...(isMac ? [] : ([{ role: 'about' }, checkForUpdatesItem] as MenuItemConstructorOptions[]))
-      ]
-    }
-  ]
-
-  return Menu.buildFromTemplate(template)
+  const mw = resolveMainWindow()
+  if (mw && !mw.isDestroyed()) mw.webContents.send('menu:command', id)
 }
 
 /**
- * Build the application menu and install it as the global menu. Called once at
- * startup from `app.whenReady`.
+ * Build the application menu for the current app name, platform and state.
+ *
+ * @param onCommand handler for every command item in the menu.
+ * @param state the renderer's ticks + greyed-out items (defaults to none).
+ */
+export function buildAppMenu(
+  onCommand: (id: MenuCommand) => void,
+  state: MenuState = EMPTY_MENU_STATE
+): Menu {
+  return Menu.buildFromTemplate(
+    appMenuTemplate({
+      appName: app.name,
+      isMac: process.platform === 'darwin',
+      state,
+      onCommand
+    })
+  )
+}
+
+/** Rebuild the menu from the current state and install it. */
+function install(): void {
+  Menu.setApplicationMenu(buildAppMenu(dispatch, menuState))
+}
+
+/**
+ * Build the application menu, install it as the global menu, and register the
+ * command channel. Called once at startup from `app.whenReady`.
+ *
+ * @param handlers the main-process commands (updater, Board View window).
+ * @param getMainWindow resolves the live editor window, for relayed commands.
  */
 export function setupAppMenu(
-  onCheckForUpdates: () => void,
-  onOpenBoard: () => void,
-  onOpenFolder: () => void
+  handlers: Record<MainMenuCommand, () => void>,
+  getMainWindow: () => BrowserWindow | null
 ): void {
-  Menu.setApplicationMenu(buildAppMenu(onCheckForUpdates, onOpenBoard, onOpenFolder))
+  mainHandlers = handlers
+  resolveMainWindow = getMainWindow
+
+  // The renderer publishes what the menu should reflect whenever it changes.
+  // Sanitised here: it crosses a process boundary, so an unknown id or a
+  // non-boolean would otherwise reach the template as an item nobody can explain.
+  ipcMain.on('menu:state', (_e, raw: unknown) => {
+    const next = coerceMenuState(raw)
+    const key = JSON.stringify(next)
+    if (key === menuStateKey) return
+    menuState = next
+    menuStateKey = key
+    install()
+  })
+
+  install()
+}
+
+/** Forget the menu's wiring (used on quit / in tests). */
+export function disposeAppMenu(): void {
+  menuState = EMPTY_MENU_STATE
+  menuStateKey = JSON.stringify(EMPTY_MENU_STATE)
+  mainHandlers = null
+  resolveMainWindow = () => null
 }

--- a/src/main/workspace.ts
+++ b/src/main/workspace.ts
@@ -9,7 +9,10 @@ import { BrowserWindow, ipcMain } from 'electron'
  *   workspace:show       (any window → main → MAIN window)  switch workspace
  *   workspace:setFolder  (main window → main, send)         publish the folder
  *   workspace:folder     (any window → main, invoke)        read it back
- *   workspace:openFolder (app menu → MAIN window)           run Open Folder
+ *
+ * (File ▸ Open Folder… used to have a fourth channel of its own here. It moved
+ * onto the app menu's one `menu:command` channel in #914 — see `menu.ts` — so
+ * the next menu item doesn't add a fifth.)
  *
  * WHY A RELAY. The workspace switcher lives inside `AppShell`, in the main
  * window. A detached instrument (`instrumentWindows.ts`) or the board window has
@@ -33,28 +36,9 @@ import { BrowserWindow, ipcMain } from 'electron'
  *  `undefined` = no folder open (the userData fallback, same as before). */
 let projectFolder: string | undefined
 
-/** Resolver for the main editor window, captured at IPC registration so the app
- *  menu can reach the renderer that owns the folder picker (#882). */
-let resolveMainWindow: () => BrowserWindow | null = () => null
-
-/**
- * Ask the main window to run its Open Folder action — the File menu item and its
- * Cmd/Ctrl-O accelerator (#882).
- *
- * The picker itself belongs to the renderer: `fs.openFolderDialog` is what turns
- * a chosen directory into the workspace's `currentFolder` (and remembers it for
- * the next launch), so raising a dialog from here would open a folder nothing was
- * listening for. The menu only pulls the trigger.
- */
-export function requestOpenFolder(): void {
-  const mw = resolveMainWindow()
-  if (mw && !mw.isDestroyed()) mw.webContents.send('workspace:openFolder')
-}
-
 /** Register the workspace IPC. `getMainWindow` resolves the live editor window —
  *  the one that owns the workspace switcher. */
 export function registerWorkspaceIpc(getMainWindow: () => BrowserWindow | null): void {
-  resolveMainWindow = getMainWindow
   // Any window asks the MAIN window to show a workspace. Fire-and-forget: the
   // sender doesn't wait, and a request made while no main window exists is
   // simply dropped (there is nothing to switch).
@@ -74,5 +58,4 @@ export function registerWorkspaceIpc(getMainWindow: () => BrowserWindow | null):
 /** Forget the published folder (used on quit / in tests). */
 export function disposeWorkspace(): void {
   projectFolder = undefined
-  resolveMainWindow = () => null
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -12,6 +12,7 @@ ipcRenderer.setMaxListeners(40)
 import type { FlashMethod } from '../shared/board-profiles'
 import type { FirmwareRuntime } from '../shared/firmware-runtime'
 import type { BoardIdentity } from '../shared/esptool-identify'
+import type { MenuState, RendererMenuCommand } from '../shared/menu-commands'
 import type {
   CircuitPyDrive,
   ConnectOptions,
@@ -1339,18 +1340,34 @@ const workspace = {
     ipcRenderer.on('workspace:show', listener)
     return () => ipcRenderer.removeListener('workspace:show', listener)
   },
-  /** Subscribe to the app menu's File ▸ Open Folder… request (#882). The main
-   *  window listens and raises the picker; returns an unsubscribe function. */
-  onOpenFolder: (cb: () => void): (() => void) => {
-    const listener = (): void => cb()
-    ipcRenderer.on('workspace:openFolder', listener)
-    return () => ipcRenderer.removeListener('workspace:openFolder', listener)
-  },
   /** Publish the open project folder (the main window, when it changes). */
   setFolder: (folder?: string): void => ipcRenderer.send('workspace:setFolder', folder),
   /** The open project folder, or null when no folder is open. Readable from any
    *  window, with nothing opened to fetch it. */
   folder: (): Promise<string | null> => ipcRenderer.invoke('workspace:folder')
+}
+
+/**
+ * The application menu's one command channel (#914).
+ *
+ * Every menu item that the RENDERER performs arrives here as a single typed id
+ * (`file.openFolder`, `workspace.show.board`, …) instead of getting a channel,
+ * a relay, a subscription and a stub of its own — which is what adding
+ * File ▸ Open Folder… cost before this. And because a menu item is not only an
+ * action, state goes back the other way: the ticks and the greyed-out items are
+ * facts only the renderer knows, so it publishes them and the menu rebuilds.
+ */
+const menu = {
+  /** Subscribe to app-menu commands (the MAIN window listens). Returns an
+   *  unsubscribe function. */
+  onCommand: (cb: (id: RendererMenuCommand) => void): (() => void) => {
+    const listener = (_e: IpcRendererEvent, id: RendererMenuCommand): void => cb(id)
+    ipcRenderer.on('menu:command', listener)
+    return () => ipcRenderer.removeListener('menu:command', listener)
+  },
+  /** Publish what the menu should reflect — the workspace radio tick, and later
+   *  the items that grey out. Fire-and-forget; the menu rebuilds if it changed. */
+  setState: (state: MenuState): void => ipcRenderer.send('menu:state', state)
 }
 
 /**
@@ -1409,6 +1426,8 @@ const api = {
   board,
   /** Workspace relay + the session's project folder (#775). */
   workspace,
+  /** The application menu's command channel + the state it reflects (#914). */
+  menu,
   /** Instrument launch relay: board window → main window scope/meter hosting. */
   instruments,
   /** Find & Replace window: native window ↔ main editor find/replace relay. */

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -52,6 +52,8 @@ import { type UsedPins } from './parse-pins'
 import { runFindCommand } from './findController'
 import { ShellPanel } from './ShellPanel'
 import { RightPanel } from './RightPanel'
+import { runMenuCommand } from '../lib/menuCommands'
+import { menuStateFrom } from '../../../shared/menu-commands'
 import { IS_WEB } from '../lib/env'
 import { StatusBar } from './StatusBar'
 import { SettingsDialog, type SettingsTab } from './SettingsDialog'
@@ -593,6 +595,13 @@ export function AppShell(): JSX.Element {
     })
     return off
   }, [])
+  // …and the app menu is told which workspace is showing, so View ▸ Workspace's
+  // radio tick follows the switcher however the switch was made — the switcher
+  // itself, the menu, or another window's `workspace.show` (#914/#916). The menu
+  // is built in the main process; this is the only place that knows the answer.
+  useEffect(() => {
+    window.api.menu.setState(menuStateFrom({ workspace: layout.active }))
+  }, [layout.active])
   useEffect(() => {
     const off = window.api.board.onClosed(() => {
       if (poppedFromBoardRef.current) {
@@ -1088,20 +1097,30 @@ export function AppShell(): JSX.Element {
     return () => window.removeEventListener(HELP_EVENT, handler)
   }, [setActivityView, setLeftCollapsed])
 
-  // File ▸ Open Folder… from the app menu, or its Cmd/Ctrl-O accelerator (#882).
-  // The main toolbar's folder icon was a duplicate of the Local Files panel's,
-  // so it went — but the panel can be COLLAPSED (and Electronics/Build have no
-  // files panel at all), which would have left no way in. The menu is always
-  // there, so this is the reachable path; revealing the Files view first means
-  // the folder lands somewhere the user can see, rather than silently behind a
-  // collapsed panel. Both reveal calls are the ones the Help deep-link above
-  // uses, for the same solo-workspace reason.
+  // THE APP MENU'S COMMANDS (#914) — one subscription for the whole menu.
+  //
+  // File ▸ Open Folder… (#882): the main toolbar's folder icon was a duplicate of
+  // the Local Files panel's, so it went — but the panel can be COLLAPSED (and
+  // Electronics/Build have no files panel at all), which would have left no way
+  // in. The menu is always there, so this is the reachable path; revealing the
+  // Files view first means the folder lands somewhere the user can see, rather
+  // than silently behind a collapsed panel. Both reveal calls are the ones the
+  // Help deep-link above uses, for the same solo-workspace reason.
+  //
+  // View ▸ Workspace (#916) goes through the LAYOUT STORE's own switch — the very
+  // call the in-app switcher makes — so Electronics/Build get their sidebar gating
+  // right and Monaco stays mounted.
   useEffect(() => {
-    const off = window.api.workspace.onOpenFolder(() => {
-      setActivityView('files')
-      setLeftCollapsed('files', false)
-      filesRef.current?.expand()
-      void openFolder().catch(reporter('open folder', { notify: "Couldn't open the folder." }))
+    const off = window.api.menu.onCommand((id) => {
+      runMenuCommand(id, {
+        switchWorkspace: (target) => switchWorkspaceRef.current(target),
+        openFolder: () => {
+          setActivityView('files')
+          setLeftCollapsed('files', false)
+          filesRef.current?.expand()
+          void openFolder().catch(reporter('open folder', { notify: "Couldn't open the folder." }))
+        }
+      })
     })
     return off
   }, [openFolder, setActivityView, setLeftCollapsed])

--- a/src/renderer/src/lib/menuCommands.ts
+++ b/src/renderer/src/lib/menuCommands.ts
@@ -1,0 +1,72 @@
+import {
+  isRendererMenuCommand,
+  workspaceMenuCommand,
+  type RendererMenuCommand
+} from '../../../shared/menu-commands'
+import { WORKSPACE_IDS, type WorkspaceId } from '../../../shared/workspaces'
+
+/**
+ * THE RENDERER HALF OF THE MENU COMMAND CHANNEL (#914).
+ *
+ * One table: command id → what it does. AppShell subscribes once, and a new
+ * menu item is an id in `RENDERER_MENU_COMMANDS` plus a line here — not a
+ * channel, a relay, a subscription, a web stub and another argument on
+ * `buildAppMenu`.
+ *
+ * The table is a `Record<RendererMenuCommand, …>`, so an id with no handler is a
+ * COMPILE error, and `test/menuCommands.test.ts` checks the reverse at runtime:
+ * every id has a handler, every handler an id. A menu item that silently does
+ * nothing is the failure this whole seam exists to prevent.
+ *
+ * Handlers take no arguments and reach the app through {@link MenuCommandDeps},
+ * so this module is pure and testable in a node environment — no React, no
+ * `window`. A command that maps to one of the window events live components
+ * already listen for (`snakie:open-find`, `snakie:open-help`,
+ * `snakie:open-settings`, `snakie:open-part-editor`, `snakie:open-sprite-editor`)
+ * is one line: `() => window.dispatchEvent(new CustomEvent(HELP_EVENT))`, with
+ * no new listener anywhere.
+ */
+
+export interface MenuCommandDeps {
+  /**
+   * Show a workspace (#916).
+   *
+   * MUST be the layout store's `switchWorkspace` — the same call the in-app
+   * switcher makes. Electronics and Build are SOLO workspaces whose sidebar is
+   * gated on the store's `filesCollapsed` flag (#775), so a switch that rebuilt
+   * the layout instead would land the user in a workspace whose sidebar will not
+   * open — and would remount Monaco, which the store goes out of its way to
+   * avoid by keeping the editor mounted behind a zero-width panel.
+   */
+  switchWorkspace: (id: WorkspaceId) => void
+  /** Raise the folder picker and open what it returns (#882). The picker belongs
+   *  to the renderer — `fs.openFolderDialog` is what turns a chosen directory
+   *  into the workspace's `currentFolder` — so the menu only pulls the trigger. */
+  openFolder: () => void
+}
+
+/** Every renderer menu command and what it does. */
+export function menuCommandHandlers(deps: MenuCommandDeps): Record<RendererMenuCommand, () => void> {
+  const handlers = {
+    'file.openFolder': () => deps.openFolder()
+  } as Record<RendererMenuCommand, () => void>
+  // Derived from WORKSPACE_IDS, like the menu itself: a fourth workspace gets
+  // its menu item AND its handler with no edit here.
+  for (const id of WORKSPACE_IDS) {
+    handlers[workspaceMenuCommand(id)] = () => deps.switchWorkspace(id)
+  }
+  return handlers
+}
+
+/**
+ * Run the command `id` names. Returns whether anything ran.
+ *
+ * The id crosses a process boundary, so it is validated rather than trusted: a
+ * command from a newer main process (or a stale window) is dropped, the same way
+ * `coerceWorkspaceId` drops a workspace this build doesn't have.
+ */
+export function runMenuCommand(id: unknown, deps: MenuCommandDeps): boolean {
+  if (!isRendererMenuCommand(id)) return false
+  menuCommandHandlers(deps)[id]()
+  return true
+}

--- a/src/renderer/src/lib/preloadFallback.ts
+++ b/src/renderer/src/lib/preloadFallback.ts
@@ -203,14 +203,18 @@ if (!w.api) {
         workspaceListeners.add(cb)
         return () => workspaceListeners.delete(cb)
       },
-      // The Open Folder request comes from the DESKTOP app menu (#882); a browser
-      // has no menu bar to fire it, and the web build keeps its own Open Folder
-      // in the Local Files panel.
-      onOpenFolder: unsub,
       setFolder: (folder?: string): void => {
         workspaceFolder = folder && folder.trim() ? folder : undefined
       },
       folder: (): Promise<string | null> => Promise.resolve(workspaceFolder ?? null)
+    },
+    // The application menu (#914). A browser has no menu bar: nothing will ever
+    // fire a command, and there is no menu to tell about the workspace tick. So
+    // both halves are honest no-ops — the web build keeps its own Open Folder in
+    // the Local Files panel, and its own workspace switcher.
+    menu: {
+      onCommand: unsub,
+      setState: noop
     },
     /** The published board index (#893). Null outside Electron — the renderer
      *  has a complete BUNDLED seed served as a static asset, so a missing fetch

--- a/src/renderer/src/store/layout.ts
+++ b/src/renderer/src/store/layout.ts
@@ -38,38 +38,20 @@ import {
 } from 'react'
 import type { ActivityView } from '../components/ActivityBar'
 
-/** The named workspaces. Order = the switcher's display order (Code · Electronics
- *  · Build). Soft Shell (#581, epic #573) retired the never-surfaced Data Lab —
- *  its instrument bench lives on in the Code/Build docks. Stale `lab`/`data`/
- *  `datalab` persisted state coerces to `code` in {@link loadLayoutState}. */
-export const WORKSPACE_IDS = ['code', 'board', 'robot'] as const
-export type WorkspaceId = (typeof WORKSPACE_IDS)[number]
-
 /**
- * A workspace id from OUTSIDE this window, or null (#775).
- *
- * Since any window — a detached instrument, the board window — can ask the main
- * window to show a workspace, the id arrives as an unvalidated string across a
- * process boundary. A retired id (`lab`/`data`) or a typo would otherwise apply
- * geometry that doesn't exist and strand the user on a workspace with no
- * switcher segment. Null means "don't switch", which is the only safe answer to
- * a name this build doesn't have.
+ * The named workspaces, their labels and the id validator now live in
+ * `src/shared/workspaces.ts` — the application menu builds View ▸ Workspace
+ * from them (#916) and the main process cannot import this React store. They
+ * are re-exported here so every existing `from '../store/layout'` import keeps
+ * working, and so there is still only ONE list of workspaces.
  */
-export function coerceWorkspaceId(id: unknown): WorkspaceId | null {
-  return typeof id === 'string' && (WORKSPACE_IDS as readonly string[]).includes(id)
-    ? (id as WorkspaceId)
-    : null
-}
-
-/** Display labels + a one-line description for the switcher tooltips. */
-// Soft Shell (#575, epic #573) renamed the switcher's three workspaces to
-// Code / Electronics / Build. "Electronics" surfaces the Board View; "Build"
-// (was "Robot") won't collide with the upcoming electronics simulator.
-export const WORKSPACE_INFO: Record<WorkspaceId, { label: string; hint: string }> = {
-  code: { label: 'Code', hint: 'Editor-first: files, editor and console' },
-  board: { label: 'Electronics', hint: 'Wire components to your board — the Board View beside your code' },
-  robot: { label: 'Build', hint: 'Assemble the robot in 3D — joints, IK chains and poses' }
-}
+export {
+  WORKSPACE_IDS,
+  WORKSPACE_INFO,
+  coerceWorkspaceId,
+  type WorkspaceId
+} from '../../../shared/workspaces'
+import { WORKSPACE_IDS, type WorkspaceId } from '../../../shared/workspaces'
 
 /** One workspace's remembered geometry. */
 export interface WorkspaceLayout {

--- a/src/shared/menu-commands.ts
+++ b/src/shared/menu-commands.ts
@@ -1,0 +1,133 @@
+/**
+ * ONE TYPED COMMAND CHANNEL FOR THE APPLICATION MENU (#914, epic #913).
+ *
+ * Before this, every menu item that had to reach the renderer was wired by
+ * hand. `File ▸ Open Folder…` (#882) took six edits: its own IPC channel, a
+ * relay to the main window, a preload subscription, a no-op stub for the web
+ * build, a listener in `AppShell`, and another positional argument on
+ * `buildAppMenu(onCheckForUpdates, onOpenBoard, onOpenFolder)`. Epic #913 adds a
+ * dozen more items; done that way, the menu ends up half-wired — items that
+ * quietly do nothing on one platform or in one window, with nothing to catch it.
+ *
+ * So there is one channel (`menu:command`) carrying one id from the union
+ * below, and one dispatcher in the renderer. Both sides import THIS module, so
+ * main, preload and renderer cannot disagree about what exists, and a new menu
+ * item is an id plus a handler.
+ *
+ * TWO FAMILIES, because a menu item's action lives on one side or the other:
+ *
+ *   MAIN_MENU_COMMANDS      handled in the main process (it owns the updater and
+ *                           the Board View window) — never crosses to a renderer.
+ *   RENDERER_MENU_COMMANDS  relayed to the MAIN WINDOW over `menu:command`, where
+ *                           the dispatcher turns them into a store action or one
+ *                           of the window events live components already listen
+ *                           for (`snakie:open-find`, `snakie:open-help`, …).
+ *
+ * STATE TRAVELS BACK. Menu items are not only actions: View ▸ Workspace wants a
+ * radio tick that follows the in-app switcher, Disconnect should grey out with
+ * no board connected, Save with no file open. The menu is built in main and
+ * every one of those facts lives in the renderer, so {@link MenuState} goes the
+ * other way over `menu:state` — one map of ids to grey out, one of ids to tick.
+ * It is deliberately keyed by COMMAND ID rather than by feature, so #915–#918
+ * add an item's state the same way they add the item, and cannot each invent a
+ * different return path.
+ */
+import { WORKSPACE_IDS, type WorkspaceId } from './workspaces'
+
+/** Commands the MAIN process performs itself. */
+export const MAIN_MENU_COMMANDS = ['app.checkForUpdates', 'view.boardWindow'] as const
+export type MainMenuCommand = (typeof MAIN_MENU_COMMANDS)[number]
+
+/** `View ▸ Workspace ▸ …` — one command per workspace (#916). */
+export type WorkspaceMenuCommand = `workspace.show.${WorkspaceId}`
+
+/** The command that shows workspace `id`. */
+export function workspaceMenuCommand(id: WorkspaceId): WorkspaceMenuCommand {
+  return `workspace.show.${id}`
+}
+
+/** Commands the RENDERER performs, relayed to the main window. */
+export type RendererMenuCommand = 'file.openFolder' | WorkspaceMenuCommand
+
+/** Every renderer command, in menu order. The workspace entries are DERIVED
+ *  from `WORKSPACE_IDS`, so a fourth workspace gets its command, its menu item
+ *  and its handler without anyone editing a list. */
+export const RENDERER_MENU_COMMANDS: readonly RendererMenuCommand[] = [
+  'file.openFolder',
+  ...WORKSPACE_IDS.map(workspaceMenuCommand)
+]
+
+/** Any application-menu command. */
+export type MenuCommand = MainMenuCommand | RendererMenuCommand
+
+/** Is `v` a command this build's renderer knows how to run? Guards the IPC
+ *  boundary: an id from an older/newer main process is dropped rather than
+ *  dispatched into nothing. */
+export function isRendererMenuCommand(v: unknown): v is RendererMenuCommand {
+  return typeof v === 'string' && (RENDERER_MENU_COMMANDS as readonly string[]).includes(v)
+}
+
+/**
+ * What the renderer tells the menu about itself.
+ *
+ * Both maps are SPARSE and keyed by command id: absent means "nothing to say".
+ * An item is enabled unless `enabled[id] === false`, and unticked unless
+ * `checked[id] === true` — so a menu built before the renderer has ever
+ * published (at startup, or in a build with no renderer at all) is the normal
+ * menu rather than a dead one.
+ */
+export interface MenuState {
+  /** Ids to grey out (`false` = disabled). */
+  enabled: Partial<Record<MenuCommand, boolean>>
+  /** Ids to tick — radio items and checkboxes (`true` = checked). */
+  checked: Partial<Record<MenuCommand, boolean>>
+}
+
+/** The state a menu built before the renderer has spoken uses: everything
+ *  enabled, nothing ticked. */
+export const EMPTY_MENU_STATE: MenuState = { enabled: {}, checked: {} }
+
+/** The renderer facts the menu reflects. #915–#918 add their fields here
+ *  (`connected`, `hasFile`, …) and extend {@link menuStateFrom} to match. */
+export interface MenuContext {
+  /** The workspace showing in the main window — the radio tick in
+   *  View ▸ Workspace, so switching in-app moves the tick too (#916). */
+  workspace: WorkspaceId
+}
+
+/** Derive the menu's state from the renderer's. Pure, so what the menu shows is
+ *  testable without a menu. */
+export function menuStateFrom(ctx: MenuContext): MenuState {
+  const checked: Partial<Record<MenuCommand, boolean>> = {}
+  for (const id of WORKSPACE_IDS) checked[workspaceMenuCommand(id)] = id === ctx.workspace
+  return { enabled: {}, checked }
+}
+
+/** Every known command id (main + renderer) — the whitelist
+ *  {@link coerceMenuState} filters against. */
+const ALL_MENU_COMMANDS: readonly string[] = [...MAIN_MENU_COMMANDS, ...RENDERER_MENU_COMMANDS]
+
+/** One sparse map, keeping only known ids with boolean values. */
+function coerceFlags(raw: unknown): Partial<Record<MenuCommand, boolean>> {
+  const out: Partial<Record<MenuCommand, boolean>> = {}
+  if (!raw || typeof raw !== 'object') return out
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof value === 'boolean' && ALL_MENU_COMMANDS.includes(key)) {
+      out[key as MenuCommand] = value
+    }
+  }
+  return out
+}
+
+/**
+ * Validate a `MenuState` that arrived over IPC.
+ *
+ * The state comes from a renderer, so it is untrusted shape: a stale window
+ * could publish an id this build retired, or a garbled payload. Unknown ids and
+ * non-boolean values are dropped rather than fed into the menu template, where
+ * they would show as items the user cannot explain.
+ */
+export function coerceMenuState(raw: unknown): MenuState {
+  const r = (raw ?? {}) as Record<string, unknown>
+  return { enabled: coerceFlags(r.enabled), checked: coerceFlags(r.checked) }
+}

--- a/src/shared/workspaces.ts
+++ b/src/shared/workspaces.ts
@@ -1,0 +1,48 @@
+/**
+ * THE NAMED WORKSPACES — shared between the renderer and the main process.
+ *
+ * These three facts (the ids, their display labels, and how to validate an id
+ * that arrived from somewhere else) used to live inside the renderer's layout
+ * store. The application menu needs them too — View ▸ Workspace is built from
+ * `WORKSPACE_IDS` and labelled from `WORKSPACE_INFO` (#916), so a fourth
+ * workspace appears on the menu without anyone editing the menu — and the main
+ * process cannot import a React store. So they live here, and
+ * `src/renderer/src/store/layout.ts` re-exports them: one list, two processes,
+ * no chance of the menu and the switcher disagreeing about what exists.
+ */
+
+/** The named workspaces. Order = the switcher's display order (Code · Electronics
+ *  · Build). Soft Shell (#581, epic #573) retired the never-surfaced Data Lab —
+ *  its instrument bench lives on in the Code/Build docks. Stale `lab`/`data`/
+ *  `datalab` persisted state coerces to `code` in `loadLayoutState`. */
+export const WORKSPACE_IDS = ['code', 'board', 'robot'] as const
+export type WorkspaceId = (typeof WORKSPACE_IDS)[number]
+
+/** Display labels + a one-line description for the switcher tooltips. */
+// Soft Shell (#575, epic #573) renamed the switcher's three workspaces to
+// Code / Electronics / Build. "Electronics" surfaces the Board View; "Build"
+// (was "Robot") won't collide with the upcoming electronics simulator.
+export const WORKSPACE_INFO: Record<WorkspaceId, { label: string; hint: string }> = {
+  code: { label: 'Code', hint: 'Editor-first: files, editor and console' },
+  board: {
+    label: 'Electronics',
+    hint: 'Wire components to your board — the Board View beside your code'
+  },
+  robot: { label: 'Build', hint: 'Assemble the robot in 3D — joints, IK chains and poses' }
+}
+
+/**
+ * A workspace id from OUTSIDE this window, or null (#775).
+ *
+ * Since any window — a detached instrument, the board window — can ask the main
+ * window to show a workspace, the id arrives as an unvalidated string across a
+ * process boundary. A retired id (`lab`/`data`) or a typo would otherwise apply
+ * geometry that doesn't exist and strand the user on a workspace with no
+ * switcher segment. Null means "don't switch", which is the only safe answer to
+ * a name this build doesn't have.
+ */
+export function coerceWorkspaceId(id: unknown): WorkspaceId | null {
+  return typeof id === 'string' && (WORKSPACE_IDS as readonly string[]).includes(id)
+    ? (id as WorkspaceId)
+    : null
+}

--- a/test/appMenuTemplate.test.ts
+++ b/test/appMenuTemplate.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest'
+import type { MenuItemConstructorOptions } from 'electron'
+import { appMenuTemplate, workspaceSubmenu } from '../src/main/menu-template'
+import {
+  MAIN_MENU_COMMANDS,
+  RENDERER_MENU_COMMANDS,
+  menuStateFrom,
+  workspaceMenuCommand,
+  type MenuCommand,
+  type MenuState
+} from '../src/shared/menu-commands'
+import { WORKSPACE_IDS, WORKSPACE_INFO } from '../src/shared/workspaces'
+
+/**
+ * The application menu as data (#914 / #916).
+ *
+ * `menu-template.ts` type-imports Electron and nothing else, so what the menu
+ * contains — which items fire which command, what is ticked, what is greyed —
+ * is checked here directly, with no app running and no component rendered.
+ */
+
+/** Build the template, recording every command a click fires. */
+function build(opts: { isMac: boolean; state?: MenuState }): {
+  template: MenuItemConstructorOptions[]
+  fired: MenuCommand[]
+} {
+  const fired: MenuCommand[] = []
+  const template = appMenuTemplate({
+    appName: 'Snakie',
+    isMac: opts.isMac,
+    state: opts.state,
+    onCommand: (id) => fired.push(id)
+  })
+  return { template, fired }
+}
+
+/** Every item in the tree that DOES something (i.e. has a click handler). */
+function commandItems(items: MenuItemConstructorOptions[]): MenuItemConstructorOptions[] {
+  const out: MenuItemConstructorOptions[] = []
+  for (const item of items) {
+    if (item.click) out.push(item)
+    if (Array.isArray(item.submenu)) out.push(...commandItems(item.submenu))
+  }
+  return out
+}
+
+/** Click an item (the real signature takes three args we don't have here). */
+function click(item: MenuItemConstructorOptions): void {
+  ;(item.click as unknown as () => void)()
+}
+
+/** The submenu of the View item labelled `label`. */
+function viewSubmenu(template: MenuItemConstructorOptions[], label: string): MenuItemConstructorOptions[] {
+  const view = template.find((m) => m.label === 'View')
+  const items = Array.isArray(view?.submenu) ? view.submenu : []
+  const found = items.find((m) => m.label === label)
+  return Array.isArray(found?.submenu) ? found.submenu : []
+}
+
+describe.each([
+  { platform: 'macOS', isMac: true },
+  { platform: 'Windows/Linux', isMac: false }
+])('the app menu on $platform (#914)', ({ isMac }) => {
+  it('gives every command exactly one menu item, and every item a live command', () => {
+    const { template, fired } = build({ isMac })
+    const items = commandItems(template)
+    for (const item of items) click(item)
+    // Every id in the union reached the menu…
+    expect([...fired].sort()).toEqual([...MAIN_MENU_COMMANDS, ...RENDERER_MENU_COMMANDS].sort())
+    // …and no item fired nothing, or the same command twice.
+    expect(fired).toHaveLength(items.length)
+    expect(new Set(fired).size).toBe(fired.length)
+  })
+
+  it('carries the accelerators the shortcuts epic asks for (#920)', () => {
+    const { template } = build({ isMac })
+    const byLabel = new Map(commandItems(template).map((m) => [String(m.label), m]))
+    expect(byLabel.get('Open Folder…')?.accelerator).toBe('CmdOrCtrl+O')
+    expect(byLabel.get('Board View')?.accelerator).toBe('CmdOrCtrl+Shift+B')
+    // Cmd/Ctrl 1-2-3 for Code / Electronics / Build. Monaco binds Cmd+S, Cmd+F,
+    // Cmd+H and Cmd+Shift+1 — nothing plain-modifier-plus-digit — so these are free.
+    expect(byLabel.get('Code')?.accelerator).toBe('CmdOrCtrl+1')
+    expect(byLabel.get('Electronics')?.accelerator).toBe('CmdOrCtrl+2')
+    expect(byLabel.get('Build')?.accelerator).toBe('CmdOrCtrl+3')
+  })
+})
+
+describe('View ▸ Workspace (#916)', () => {
+  it('is built from WORKSPACE_IDS and labelled from WORKSPACE_INFO', () => {
+    const { template } = build({ isMac: true })
+    const submenu = viewSubmenu(template, 'Workspace')
+    expect(submenu.map((m) => m.label)).toEqual(WORKSPACE_IDS.map((id) => WORKSPACE_INFO[id].label))
+    for (const item of submenu) expect(item.type).toBe('radio')
+  })
+
+  it('each item switches to its OWN workspace', () => {
+    for (const id of WORKSPACE_IDS) {
+      const { template, fired } = build({ isMac: false })
+      const submenu = viewSubmenu(template, 'Workspace')
+      const item = submenu.find((m) => m.label === WORKSPACE_INFO[id].label)
+      click(item as MenuItemConstructorOptions)
+      expect(fired).toEqual([workspaceMenuCommand(id)])
+    }
+  })
+
+  it('ticks the workspace the renderer says is showing', () => {
+    for (const active of WORKSPACE_IDS) {
+      const { template } = build({ isMac: true, state: menuStateFrom({ workspace: active }) })
+      const submenu = viewSubmenu(template, 'Workspace')
+      const ticked = submenu.filter((m) => m.checked).map((m) => m.label)
+      expect(ticked).toEqual([WORKSPACE_INFO[active].label])
+    }
+  })
+
+  it('ticks nothing before the renderer has published (no state)', () => {
+    const submenu = workspaceSubmenu({ appName: 'Snakie', isMac: true, onCommand: () => {} })
+    expect(submenu.every((m) => m.checked === false)).toBe(true)
+    // …and every item is still usable: an unpublished state must not grey the menu.
+    expect(submenu.every((m) => m.enabled === true)).toBe(true)
+  })
+
+  it('only the radio items carry a tick at all', () => {
+    // Electron reads `checked` on checkbox/radio items only, so a plain item
+    // claiming one would be a tick that can never appear.
+    const { template } = build({ isMac: true, state: menuStateFrom({ workspace: 'code' }) })
+    for (const item of commandItems(template)) {
+      if (item.type === 'radio' || item.type === 'checkbox') {
+        expect(typeof item.checked, String(item.label)).toBe('boolean')
+      } else {
+        expect(item, String(item.label)).not.toHaveProperty('checked')
+      }
+    }
+  })
+})
+
+describe('menu state greys items out (#914, for #915–#918)', () => {
+  it('an item is enabled unless the renderer explicitly disabled it', () => {
+    const { template } = build({
+      isMac: false,
+      state: { enabled: { 'file.openFolder': false }, checked: {} }
+    })
+    const items = commandItems(template)
+    const openFolder = items.find((m) => m.label === 'Open Folder…')
+    expect(openFolder?.enabled).toBe(false)
+    // Everything the state says nothing about stays usable.
+    for (const item of items) {
+      if (item.label !== 'Open Folder…') expect(item.enabled, String(item.label)).toBe(true)
+    }
+  })
+})

--- a/test/menuChannel.test.ts
+++ b/test/menuChannel.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { MenuItemConstructorOptions } from 'electron'
+import { menuStateFrom, workspaceMenuCommand } from '../src/shared/menu-commands'
+
+/**
+ * The main-process half of the menu command channel (#914).
+ *
+ * Two things have to hold for the follow-on menu work (#915–#918) to be one line
+ * each: a clicked item reaches the right side of the process boundary, and the
+ * state the renderer publishes reaches the menu. Both are exercised here against
+ * the real `menu.ts`, with only Electron's own surface mocked.
+ */
+
+const installed = vi.hoisted(() => [] as { template: MenuItemConstructorOptions[] }[])
+const channels = vi.hoisted(() => new Map<string, (e: unknown, ...args: unknown[]) => void>())
+const sent = vi.hoisted(() => [] as { channel: string; args: unknown[] }[])
+const win = vi.hoisted(() => ({
+  destroyed: false,
+  isDestroyed(): boolean {
+    return this.destroyed
+  },
+  webContents: {
+    send: (channel: string, ...args: unknown[]): void => {
+      sent.push({ channel, args })
+    }
+  }
+}))
+
+vi.mock('electron', () => ({
+  app: { name: 'Snakie' },
+  BrowserWindow: class {},
+  ipcMain: {
+    on: (channel: string, fn: (e: unknown, ...args: unknown[]) => void): void => {
+      channels.set(channel, fn)
+    }
+  },
+  Menu: {
+    buildFromTemplate: (template: MenuItemConstructorOptions[]) => ({ template }),
+    setApplicationMenu: (menu: { template: MenuItemConstructorOptions[] }): void => {
+      installed.push(menu)
+    }
+  }
+}))
+
+const { setupAppMenu, disposeAppMenu } = await import('../src/main/menu')
+
+/** Every item with a click, from the most recently installed menu. */
+function items(): MenuItemConstructorOptions[] {
+  const walk = (list: MenuItemConstructorOptions[]): MenuItemConstructorOptions[] => {
+    const out: MenuItemConstructorOptions[] = []
+    for (const item of list) {
+      if (item.click) out.push(item)
+      if (Array.isArray(item.submenu)) out.push(...walk(item.submenu))
+    }
+    return out
+  }
+  return walk(installed[installed.length - 1].template)
+}
+
+/** Click the item labelled `label` in the installed menu. */
+function click(label: string): void {
+  const item = items().find((m) => m.label === label)
+  expect(item, label).toBeTruthy()
+  ;(item?.click as unknown as () => void)()
+}
+
+/** Publish a `menu:state` payload the way the renderer would. */
+function publish(state: unknown): void {
+  channels.get('menu:state')?.(null, state)
+}
+
+describe('the app menu command channel (#914)', () => {
+  let checks = 0
+  let boards = 0
+
+  beforeEach(() => {
+    installed.length = 0
+    sent.length = 0
+    channels.clear()
+    win.destroyed = false
+    checks = 0
+    boards = 0
+    disposeAppMenu()
+    setupAppMenu(
+      {
+        'app.checkForUpdates': () => {
+          checks += 1
+        },
+        'view.boardWindow': () => {
+          boards += 1
+        }
+      },
+      () => win as never
+    )
+  })
+
+  it('installs a menu at startup', () => {
+    expect(installed).toHaveLength(1)
+    expect(items().length).toBeGreaterThan(0)
+  })
+
+  it('runs a MAIN-process command here, without troubling the renderer', () => {
+    click('Check for Updates…')
+    click('Board View')
+    expect([checks, boards]).toEqual([1, 1])
+    expect(sent).toEqual([])
+  })
+
+  it('relays a RENDERER command to the main window on one channel', () => {
+    click('Open Folder…')
+    click('Electronics')
+    expect(sent).toEqual([
+      { channel: 'menu:command', args: ['file.openFolder'] },
+      { channel: 'menu:command', args: [workspaceMenuCommand('board')] }
+    ])
+  })
+
+  it('drops a command when the window has gone, rather than throwing', () => {
+    win.destroyed = true
+    expect(() => click('Open Folder…')).not.toThrow()
+    expect(sent).toEqual([])
+  })
+
+  it('rebuilds the menu when the renderer publishes its state', () => {
+    publish(menuStateFrom({ workspace: 'robot' }))
+    expect(installed).toHaveLength(2)
+    const ticked = items().filter((m) => m.checked)
+    expect(ticked.map((m) => m.label)).toEqual(['Build'])
+  })
+
+  it('does not rebuild when the state has not actually changed', () => {
+    publish(menuStateFrom({ workspace: 'board' }))
+    publish(menuStateFrom({ workspace: 'board' }))
+    // A rebuild closes an open menu on macOS, and the renderer republishes on
+    // every mount — so an unchanged state must be a no-op.
+    expect(installed).toHaveLength(2)
+    publish(menuStateFrom({ workspace: 'code' }))
+    expect(installed).toHaveLength(3)
+  })
+
+  it('ignores a garbled state instead of feeding it to the menu', () => {
+    publish({ enabled: { 'not.a.command': false }, checked: 'nonsense' })
+    // Nothing known changed, so nothing is rebuilt…
+    expect(installed).toHaveLength(1)
+    // …and every item is still usable.
+    expect(items().every((m) => m.enabled)).toBe(true)
+  })
+})

--- a/test/menuCommands.test.ts
+++ b/test/menuCommands.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import {
+  EMPTY_MENU_STATE,
+  MAIN_MENU_COMMANDS,
+  RENDERER_MENU_COMMANDS,
+  coerceMenuState,
+  isRendererMenuCommand,
+  menuStateFrom,
+  workspaceMenuCommand
+} from '../src/shared/menu-commands'
+import { menuCommandHandlers, runMenuCommand } from '../src/renderer/src/lib/menuCommands'
+import { WORKSPACE_IDS, type WorkspaceId } from '../src/shared/workspaces'
+
+/**
+ * The menu command channel's two halves must agree (#914).
+ *
+ * A menu item that silently does nothing is the failure this seam exists to
+ * prevent, so the contract is checked from both directions: every id in the
+ * union has a handler, and every handler has an id.
+ */
+
+/** Recording deps for the dispatcher. */
+function deps(): {
+  switched: WorkspaceId[]
+  folders: number
+  d: Parameters<typeof menuCommandHandlers>[0]
+} {
+  const rec = {
+    switched: [] as WorkspaceId[],
+    folders: 0,
+    d: {} as Parameters<typeof menuCommandHandlers>[0]
+  }
+  rec.d = {
+    switchWorkspace: (id: WorkspaceId) => rec.switched.push(id),
+    openFolder: () => {
+      rec.folders += 1
+    }
+  }
+  return rec
+}
+
+describe('menu command union ↔ renderer dispatcher (#914)', () => {
+  it('every id in the union has a handler, and every handler an id', () => {
+    const handlers = menuCommandHandlers(deps().d)
+    expect(Object.keys(handlers).sort()).toEqual([...RENDERER_MENU_COMMANDS].sort())
+  })
+
+  it('the workspace commands are derived from WORKSPACE_IDS, not hand-typed', () => {
+    // A fourth workspace must reach the menu, the union and the dispatcher with
+    // no list edited anywhere (#916).
+    for (const id of WORKSPACE_IDS) {
+      expect(RENDERER_MENU_COMMANDS).toContain(workspaceMenuCommand(id))
+    }
+    expect(RENDERER_MENU_COMMANDS).toHaveLength(WORKSPACE_IDS.length + 1)
+  })
+
+  it('main-process commands are NOT in the renderer union (they never cross)', () => {
+    for (const id of MAIN_MENU_COMMANDS) {
+      expect(RENDERER_MENU_COMMANDS as readonly string[]).not.toContain(id)
+      expect(isRendererMenuCommand(id)).toBe(false)
+    }
+  })
+
+  it('each workspace command switches to ITS OWN workspace', () => {
+    for (const id of WORKSPACE_IDS) {
+      const rec = deps()
+      menuCommandHandlers(rec.d)[workspaceMenuCommand(id)]()
+      expect(rec.switched).toEqual([id])
+    }
+  })
+
+  it('file.openFolder raises the picker', () => {
+    const rec = deps()
+    menuCommandHandlers(rec.d)['file.openFolder']()
+    expect(rec.folders).toBe(1)
+  })
+
+  it('runMenuCommand dispatches a known id and drops anything else', () => {
+    const rec = deps()
+    expect(runMenuCommand(workspaceMenuCommand('board'), rec.d)).toBe(true)
+    expect(rec.switched).toEqual(['board'])
+    // An id from a newer main process, a retired one, or junk: dropped, not run.
+    for (const bad of ['workspace.show.datalab', 'file.saveAs', '', 42, null, undefined, {}]) {
+      expect(runMenuCommand(bad, rec.d), JSON.stringify(bad)).toBe(false)
+    }
+    expect(rec.switched).toEqual(['board'])
+  })
+})
+
+describe('menu state travelling back to the menu (#914)', () => {
+  it('ticks exactly the active workspace', () => {
+    for (const active of WORKSPACE_IDS) {
+      const state = menuStateFrom({ workspace: active })
+      for (const id of WORKSPACE_IDS) {
+        expect(state.checked[workspaceMenuCommand(id)], `${active}/${id}`).toBe(id === active)
+      }
+      // Nothing is greyed out by the workspace alone.
+      expect(state.enabled).toEqual({})
+    }
+  })
+
+  it('an unpublished state greys nothing out and ticks nothing', () => {
+    expect(EMPTY_MENU_STATE).toEqual({ enabled: {}, checked: {} })
+  })
+
+  it('coerceMenuState keeps known ids with boolean values and drops the rest', () => {
+    const state = coerceMenuState({
+      enabled: { 'file.openFolder': false, 'device.disconnect': false, 'view.boardWindow': 'yes' },
+      checked: { [workspaceMenuCommand('robot')]: true, 'workspace.show.datalab': true }
+    })
+    expect(state).toEqual({
+      enabled: { 'file.openFolder': false },
+      checked: { 'workspace.show.robot': true }
+    })
+  })
+
+  it('coerceMenuState survives a garbled payload', () => {
+    for (const bad of [null, undefined, 42, 'nope', [], { enabled: 3, checked: null }]) {
+      expect(coerceMenuState(bad), JSON.stringify(bad)).toEqual({ enabled: {}, checked: {} })
+    }
+  })
+
+  // The last link in the chain: the state is only useful if the renderer sends
+  // it. There is no DOM here (the suite runs in `environment: 'node'`), so this
+  // reads the source — the same way `openFolderReachable.test.ts` checks a wire
+  // whose break would be silent.
+  it('AppShell publishes the active workspace whenever it changes', () => {
+    const shell = readFileSync('src/renderer/src/components/AppShell.tsx', 'utf8')
+    expect(shell).toMatch(/menu\.setState\(\s*menuStateFrom\(\{\s*workspace:\s*layout\.active/)
+    const at = shell.search(/menu\.setState\(/)
+    // Re-published on every workspace change, or the tick freezes on the first one.
+    expect(shell.slice(at, at + 200)).toContain('[layout.active]')
+  })
+})

--- a/test/openFolderReachable.test.ts
+++ b/test/openFolderReachable.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
+import type { MenuItemConstructorOptions } from 'electron'
+import { appMenuTemplate } from '../src/main/menu-template'
+import type { MenuCommand } from '../src/shared/menu-commands'
 
 /**
  * Open Folder stays reachable (#882).
@@ -27,12 +30,23 @@ const PRELOAD = readFileSync('src/preload/index.ts', 'utf8')
 const FALLBACK = readFileSync('src/renderer/src/lib/preloadFallback.ts', 'utf8')
 const APP_SHELL = readFileSync('src/renderer/src/components/AppShell.tsx', 'utf8')
 
-/** The body of the `onOpenFolder` subscription in AppShell — what actually runs
- *  when the menu item fires. */
+/** The body of the app-menu command subscription in AppShell — what actually
+ *  runs when the Open Folder item fires. */
 function openFolderHandler(): string {
-  const start = APP_SHELL.indexOf('window.api.workspace.onOpenFolder(')
-  expect(start, 'AppShell subscribes to the menu request').toBeGreaterThan(-1)
+  const start = APP_SHELL.indexOf('window.api.menu.onCommand(')
+  expect(start, 'AppShell subscribes to the menu commands').toBeGreaterThan(-1)
   return APP_SHELL.slice(start, APP_SHELL.indexOf('return off', start))
+}
+
+/** The File submenu, as the menu template actually builds it. */
+function fileSubmenu(fired: MenuCommand[]): MenuItemConstructorOptions[] {
+  const template = appMenuTemplate({
+    appName: 'Snakie',
+    isMac: true,
+    onCommand: (id) => fired.push(id)
+  })
+  const file = template.find((m) => m.label === 'File')
+  return Array.isArray(file?.submenu) ? file.submenu : []
 }
 
 describe('the duplicate is gone', () => {
@@ -68,37 +82,48 @@ describe('the Local Files panel keeps it', () => {
 
 describe('the app menu covers a collapsed or absent panel', () => {
   it('offers File ▸ Open Folder… with the standard accelerator', () => {
-    expect(MENU).toContain("label: 'Open Folder…'")
-    expect(MENU).toContain("accelerator: 'CmdOrCtrl+O'")
-    // It has to be IN the File submenu, not merely declared: a menu item nothing
-    // lists is exactly as unreachable as the button that was removed.
-    const file = MENU.slice(MENU.indexOf("label: 'File'"))
-    expect(file.slice(0, file.indexOf(']'))).toContain('openFolderItem')
+    // Built from the real template, so this checks the item the user gets rather
+    // than a line of source: it has to be IN the File submenu, not merely
+    // declared — a menu item nothing lists is exactly as unreachable as the
+    // button that was removed.
+    const item = fileSubmenu([]).find((m) => m.label === 'Open Folder…')
+    expect(item, 'File ▸ Open Folder…').toBeTruthy()
+    expect(item?.accelerator).toBe('CmdOrCtrl+O')
+    expect(item?.enabled).toBe(true)
   })
 
   it('is wired to a real handler at startup', () => {
-    expect(MENU).toContain('click: () => onOpenFolder()')
-    expect(MAIN).toContain('requestOpenFolder')
+    // Clicking it fires the command; the menu routes commands to the main window
+    // and `setupAppMenu` is installed with the resolver that finds it (#914).
+    const fired: MenuCommand[] = []
+    const item = fileSubmenu(fired).find((m) => m.label === 'Open Folder…')
+    ;(item?.click as unknown as () => void)()
+    expect(fired).toEqual(['file.openFolder'])
+    expect(MAIN).toContain('setupAppMenu(')
   })
 })
 
 describe('the wire from the menu to the picker', () => {
-  const CHANNEL = 'workspace:openFolder'
+  // Open Folder had a hand-built channel of its own until #914; it now travels
+  // the ONE command channel every menu item uses.
+  const CHANNEL = 'menu:command'
 
   it('carries the request from main to the main window', () => {
-    expect(MAIN_WORKSPACE).toContain(`webContents.send('${CHANNEL}')`)
+    expect(MENU).toContain(`webContents.send('${CHANNEL}', id)`)
     // A destroyed window would throw and take the menu click with it.
-    expect(MAIN_WORKSPACE).toContain('isDestroyed()')
+    expect(MENU).toContain('isDestroyed()')
+    // The channel it replaced is gone, not left behind half-wired.
+    expect(MAIN_WORKSPACE).not.toContain('workspace:openFolder')
   })
 
   it('is exposed over the bridge on the SAME channel, and unsubscribes', () => {
     expect(PRELOAD).toContain(`ipcRenderer.on('${CHANNEL}'`)
     expect(PRELOAD).toContain(`ipcRenderer.removeListener('${CHANNEL}'`)
-    expect(PRELOAD).toContain('onOpenFolder:')
+    expect(PRELOAD).toContain('onCommand:')
   })
 
   it('is inert outside Electron, where there is no menu bar', () => {
-    expect(FALLBACK).toContain('onOpenFolder: unsub')
+    expect(FALLBACK).toContain('onCommand: unsub')
   })
 
   it('ends in the renderer actually opening a folder', () => {


### PR DESCRIPTION
Closes #914
Closes #916

Part of #913, and it settles the overlap with #920 for the workspace shortcuts.

## The problem

The menu could reach the renderer, but only through a channel built by hand for one item. `File ▸ Open Folder…` (#882) took six edits: a `workspace:openFolder` channel, a relay, a preload subscription, a fallback stub, a listener in `AppShell`, and another positional argument on `buildAppMenu(onCheckForUpdates, onOpenBoard, onOpenFolder)`. #913 adds a dozen more items.

## One channel

- **`src/shared/menu-commands.ts`** — the id union, imported by main, preload and renderer, so they cannot disagree about what exists. Split into the two families a menu item can belong to: `MAIN_MENU_COMMANDS` (the updater, the Board View window — they never cross the boundary) and `RENDERER_MENU_COMMANDS` (relayed). That split is why `buildAppMenu` can take **one** `onCommand(id)` instead of one argument per item.
- **`menu:command`** — main → main window, one channel, one preload subscription, one honest no-op in `preloadFallback` (a browser has no menu bar).
- **`src/renderer/src/lib/menuCommands.ts`** — one dispatcher, `Record<RendererMenuCommand, () => void>`, so an id with no handler is a *compile* error. A command that maps to an existing window event (`snakie:open-find`, `snakie:open-help`, …) is one line there, with no new listener.
- **`src/main/menu-template.ts`** — the menu as plain data, type-importing Electron and nothing else, so what the menu contains is testable without an app. `menu.ts` keeps `app.name` and `Menu.buildFromTemplate`.
- `workspace:openFolder` is **migrated**, not kept: its channel, its preload method and its fallback stub are gone.

## How state travels back

The requirement that is easy to miss. The menu is built in main; every fact it reflects lives in the renderer. So `MenuState` goes the other way over **`menu:state`**:

```ts
interface MenuState {
  enabled: Partial<Record<MenuCommand, boolean>>  // `false` greys the item out
  checked: Partial<Record<MenuCommand, boolean>>  // `true` ticks it
}
```

Both maps are **sparse and keyed by command id**, so #915–#918 publish an item's state the same way they add the item — `enabled['device.disconnect'] = connected` — instead of each inventing a return path. Absent means "nothing to say", so the menu built before any renderer has spoken is a working menu, not a dead one. The renderer derives it with a pure `menuStateFrom(ctx)` (extend `MenuContext` with `connected`/`hasFile` and the follow-ons are done); main sanitises it on arrival like any other cross-process payload, and rebuilds **only when it actually changed** — a needless `setApplicationMenu` closes an open menu on macOS.

## The slice: View ▸ Workspace (#916)

Built from `WORKSPACE_IDS`, labelled from `WORKSPACE_INFO` — both moved to `src/shared/workspaces.ts` and re-exported from the layout store, so main can read them, the menu and the switcher can never disagree, and a fourth workspace would appear correctly labelled with nothing edited. `type: 'radio'`, ticking the workspace the renderer says is showing, so switching in the app moves the tick.

**⌘1 / ⌘2 / ⌘3** for Code / Electronics / Build — exactly what #920 asks for. **No collision**: Monaco binds ⌘S, ⌘F, ⌘H and ⌘⇧1, but nothing that is a plain modifier plus a digit (checked in `monaco-editor`'s own keybinding registrations), and the app's own handlers are ⌘W, ⌘Tab, ⌘F/⌘H, ⌘Z/⌘Y. A menu accelerator is handled before the renderer sees the key in any case.

The trap in the issue is handled: the switch goes through the layout store's **`switchWorkspace`** — the same call the in-app switcher makes — so Electronics/Build get their `filesCollapsed` sidebar gating (#775) and Monaco is never remounted.

## Tests

`test/menuCommands.test.ts`, `test/appMenuTemplate.test.ts`, `test/menuChannel.test.ts`, plus `test/openFolderReachable.test.ts` updated to follow the wire to its new home (and to assert the old channel is gone rather than left half-wired). All pure, `environment: 'node'`, no component source-text assertions except the one link a source read is the only way to see (AppShell publishing its workspace) — which is the existing precedent in `openFolderReachable`.

The contract test is the point: **every id in the union has a handler, every handler an id, and every command exactly one menu item that fires it.**

**Verified by breaking each fix and confirming the right test — and only that test — failed, then restoring:**

| break | test that failed |
|---|---|
| drop a handler from the dispatcher | *every id in the union has a handler…* |
| tick a fixed workspace instead of the active one | *ticks exactly the active workspace* + *ticks the workspace the renderer says is showing* |
| a workspace item with no `click` and no accelerator | *gives every command exactly one menu item…* + the accelerator and radio tests |
| don't rebuild the menu when state arrives | *rebuilds the menu when the renderer publishes its state* |

## Gates

`npm run lint` (only the pre-existing `DriverInstallBanner.tsx` warning) · `npm run typecheck` · `npm test` (6304 passed, 307 files) · `npm run build` — all green. Also `npm run build:web`, and a smoke run of the built app to confirm the menu installs without an Electron exception.

## Scope

Channel + workspace slice only. No File, Tools or Device menus — those are #915, #917 and #918, and their ids are not in the union yet.

`CHANGELOG.md` updated under `[Unreleased]`; `package.json` not bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe
