### PR TITLE
The Board Finder: a preview on hover, chip filters, and a gallery that stops following the skin (#919)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,28 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **The Board Finder is dark on both skins, and its manufacturers are chips**
+  (#919). Two of its filters were dropdowns, which hold one value at a time and
+  keep the other 53 out of sight: you could look for an Adafruit board or a
+  Pimoroni one, never both, and nothing on screen said what the catalogue was
+  actually made of. Manufacturer and Processor are now chip rows like Features,
+  each chip carrying its own board count, ordered commonest-first with the tail
+  behind **Show more** / **Show less** — ten chips collapsed, which is 135 of the
+  225 boards by maker and 155 by chip family, so most people's board is named
+  before they open anything. Ticking two makers means **either**, not both, which
+  is the opposite of what ticking two features means and deliberately so: a board
+  has exactly one manufacturer, so an "Adafruit AND Pimoroni" filter could only
+  ever return nothing. A board's features are a set, so "WiFi and BLE" is a real
+  question. The gallery also stops following the theme: it is dark now on the
+  parchment skin too. It opens from a button inside the flash dialog, which has
+  been deliberately dark in both skins since #14 — a parchment sheet unrolling
+  out of a dark modal was the odd one out inside its own container — and 217
+  product photographs shot on white read as one beige field on parchment and as
+  217 lit objects on a dark ground.
+- **The full board page closes with an X, in the corner** (#919). It had a
+  "← All boards" button in the top left, which said the same thing as the
+  gallery's own close in a different idiom and a different place. It is now the
+  same control, in the same corner, and Esc still backs out one step.
 - **The flash dialog reads as fewer decisions** (#896). Detect board and Board
   Finder have moved to sit beside the Board dropdown rather than floating above
   the label they fill in — the dropdown is the answer, and those two buttons are
@@ -46,7 +68,18 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   every id has a handler and every handler an id. Open Folder moved onto it and
   its own channel is gone. State travels back the same way, so an item that
   should grey out has somewhere to learn that it should.
-
+- **A preview of the board you are resting on** (#919). Deciding between two
+  boards used to mean opening one, reading it, coming back, and opening the
+  other. Rest the pointer on a card and it grows into the same card with the rest
+  of the answer on it — what there is to flash and how many builds, the MCU and
+  port, the flash and RAM figures where they are sourced, the features it
+  carries, and a **Details** button into the full page. It waits 400 ms first, so a pointer
+  crossing the grid on its way to the sidebar opens nothing behind it, and it
+  flips above the card on the bottom row rather than opening into the edge of the
+  scroller. A touch is a tap, not a hover, so touch keeps the plain card and the
+  tap that already opened the full page; a keyboard gets the preview on focus,
+  with its Details button as the next stop and Enter on the card doing the same
+  thing. Nothing in it is reachable only by hovering.
 - **The boards MicroPython does not build for, and where the numbers come from**
   (#902, #897). The Board Finder had 15 Adafruit boards and not one Adafruit
   ESP32 board, because MicroPython publishes no firmware under any of those

--- a/src/renderer/src/components/BoardFinder.css
+++ b/src/renderer/src/components/BoardFinder.css
@@ -1,14 +1,62 @@
 /*
  * Board Finder (#893, epic #884) — the full-screen board gallery.
  *
- * A sibling of the Parts Catalog (`pcat__`), with one deliberate difference: the
- * catalog paints itself a fixed light "shop" surface, while this is ordinary
- * panel chrome and takes every colour from the theme tokens, so it reads
- * correctly on the parchment skin and the dark one alike. Unique `bfind__` BEM
+ * A sibling of the Parts Catalog (`pcat__`), with its own unique `bfind__` BEM
  * prefix — this CSS is global, so a shared prefix would collide.
- */
+ *
+ * ---------------------------------------------------------------------------
+ * THIS GALLERY IS DARK IN BOTH THEMES, AND THAT IS DELIBERATE (#919).
+ *
+ * It shipped taking every colour from the theme tokens, on the reasoning that
+ * panel chrome follows the skin. That was the wrong call for this one panel, for
+ * a reason visible only from inside its container: the Board Finder opens from a
+ * button in the FLASH DIALOG, and that dialog is already dark in both skins on
+ * purpose — see the note at the top of `FirmwareFlasher.css`, where taking `--text`
+ * from the parchment skin put near-black body copy on a near-black panel. So the
+ * gallery following the skin made it the odd one out inside the very thing that
+ * launches it: a parchment sheet unrolling out of a dark modal.
+ *
+ * It is also what the gallery is FOR. This is 217 product photographs, nearly all
+ * of them shot on white; on parchment they wash together into one beige field,
+ * and on a dark ground each board is its own lit object. The catalogue is the
+ * content here, not the chrome.
+ *
+ * So the colours below are the gallery's OWN — no `var(--panel)`, no `var(--text)`
+ * — and they are literally the Soft Shell DARK skin's values, copied rather than
+ * referenced so the skeuomorph skin cannot repaint them. Structural tokens stay
+ * as tokens (`--radius`, the fonts): those are theme intent, not foreground colour,
+ * and they should follow the app.
+ *
+ * If you are here to "fix" these back to tokens: that is the change this comment
+ * exists to stop. Restyle the palette by all means — but keep it self-contained,
+ * and check it against the flash dialog it opens out of.
+ * ------------------------------------------------------------------------- */
 
 .bfind {
+  /* surfaces — Soft Shell dark (`index.css`, :root[data-theme='dark']) */
+  --bf-shell: #1d201a;
+  --bf-panel: #21251f;
+  --bf-sunk: #171a14;
+  --bf-card: #262a21;
+  --bf-line: #31352b;
+  --bf-line-hi: #4d5245;
+  /* ink */
+  --bf-ink: #eef1ea;
+  --bf-ink2: #9a9d8f;
+  --bf-ink3: #8b8e80;
+  --bf-ink4: #73766a;
+  /* accents */
+  --bf-green: #26a269;
+  --bf-green-ink: #8fe6b6;
+  --bf-green-pill: linear-gradient(145deg, #203f2d, #183324);
+  --bf-gold: #d9a441;
+  --bf-gold-grad: linear-gradient(180deg, #f0dca6, #e7bf62);
+  /* The ink ON the gold gradient is the DARK brass, not `--goldink`: the
+     gradient is identical in both skins, so the dark skin's pale-gold ink would
+     be pale on pale. */
+  --bf-gold-ink: #5a3d0e;
+  --bf-inset: rgba(255, 255, 255, 0.08);
+
   position: fixed;
   inset: 0;
   /* ABOVE the flash dialog's overlay (1100), which is the only thing that opens
@@ -21,14 +69,13 @@
   align-items: stretch;
   justify-content: stretch;
   font-family: var(--font-ui), system-ui, sans-serif;
-  color: var(--head, var(--text));
+  color: var(--bf-ink);
 }
 
 .bfind__backdrop {
   position: absolute;
   inset: 0;
-  /* Theme-neutral: a dim over whatever is behind, in either skin. */
-  background: rgba(15, 20, 18, 0.55);
+  background: rgba(8, 10, 7, 0.62);
   backdrop-filter: blur(2px);
 }
 
@@ -39,10 +86,10 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
-  background: var(--panel, var(--bg-elevated));
-  border: 1px solid var(--shellbd, var(--border));
+  background: var(--bf-panel);
+  border: 1px solid var(--bf-line);
   border-radius: 16px;
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
   overflow: hidden;
 }
 
@@ -90,22 +137,22 @@
   align-items: center;
   gap: 14px;
   padding: 12px 16px;
-  background: var(--shell, var(--bg-sunken));
-  border-bottom: 1px solid var(--shellbd, var(--border));
+  background: var(--bf-shell);
+  border-bottom: 1px solid var(--bf-line);
 }
 
 .bfind__title {
   font-size: 16px;
   font-weight: 800;
   letter-spacing: 0.01em;
-  color: var(--head, var(--text));
+  color: var(--bf-ink);
 }
 
 /* What the catalogue is and how old it is — quiet, but it answers "is this
    stale?" without a click. */
 .bfind__meta {
   font-size: 11px;
-  color: var(--txt3, var(--text-muted));
+  color: var(--bf-ink3);
   font-family: var(--font-mono), monospace;
 }
 
@@ -116,18 +163,18 @@
   padding: 0 10px;
   font-family: var(--font-ui), sans-serif;
   font-size: 13px;
-  color: var(--head, var(--text));
-  background: var(--card, var(--bg-elevated));
-  border: 1px solid var(--shellbd, var(--border));
+  color: var(--bf-ink);
+  background: var(--bf-sunk);
+  border: 1px solid var(--bf-line);
   border-radius: var(--radius);
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.08);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.3);
   outline: none;
 }
 .bfind__search:focus {
-  border-color: var(--green, var(--accent));
+  border-color: var(--bf-green);
 }
 .bfind__search::placeholder {
-  color: var(--txt4, var(--text-muted));
+  color: var(--bf-ink4);
 }
 
 .bfind__spacer {
@@ -137,23 +184,29 @@
 .bfind__count {
   font-size: 12px;
   font-weight: 600;
-  color: var(--txt2, var(--text-muted));
+  color: var(--bf-ink2);
 }
 
+/* The gallery's close, and — since #919 — the details view's too, so the same
+   control means the same thing in the same corner. */
 .bfind__close {
   width: 30px;
   height: 30px;
   display: grid;
   place-items: center;
   font-size: 15px;
-  color: var(--head, var(--text));
-  background: var(--card, var(--bg-elevated));
-  border: 1px solid var(--shellbd, var(--border));
+  color: var(--bf-ink);
+  background: var(--bf-card);
+  border: 1px solid var(--bf-line);
   border-radius: var(--radius);
   cursor: pointer;
 }
 .bfind__close:hover {
-  border-color: var(--txt4, var(--text-muted));
+  border-color: var(--bf-line-hi);
+}
+.bfind__close:focus-visible {
+  outline: 2px solid var(--bf-green);
+  outline-offset: 2px;
 }
 
 /* --- body ----------------------------------------------------------------- */
@@ -169,8 +222,8 @@
   flex: 0 0 auto;
   overflow-y: auto;
   padding: 14px;
-  background: var(--shell, var(--bg-sunken));
-  border-right: 1px solid var(--shellbd, var(--border));
+  background: var(--bf-shell);
+  border-right: 1px solid var(--bf-line);
 }
 
 .bfind__facet {
@@ -183,24 +236,7 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--txt3, var(--text-muted));
-}
-
-.bfind__select {
-  width: 100%;
-  height: 30px;
-  padding: 0 8px;
-  font-family: var(--font-ui), sans-serif;
-  font-size: 12px;
-  color: var(--head, var(--text));
-  background: var(--card, var(--bg-elevated));
-  border: 1px solid var(--shellbd, var(--border));
-  border-radius: var(--radius);
-  cursor: pointer;
-  outline: none;
-}
-.bfind__select:focus {
-  border-color: var(--green, var(--accent));
+  color: var(--bf-ink3);
 }
 
 .bfind__chips {
@@ -213,20 +249,48 @@
   font-family: var(--font-ui), sans-serif;
   font-size: 11px;
   font-weight: 600;
-  color: var(--txt2, var(--text-muted));
-  background: var(--card, var(--bg-elevated));
-  border: 1px solid var(--shellbd, var(--border));
+  color: var(--bf-ink2);
+  background: var(--bf-card);
+  border: 1px solid var(--bf-line);
   border-radius: 999px;
   padding: 3px 9px;
   cursor: pointer;
+  text-align: left;
 }
 .bfind__chip:hover {
-  border-color: var(--txt4, var(--text-muted));
+  border-color: var(--bf-line-hi);
+  color: var(--bf-ink);
 }
 .bfind__chip.is-on {
-  color: var(--greentext, var(--accent-ink));
-  background: var(--greenpill, var(--bg-sunken));
-  border-color: var(--green, var(--accent));
+  color: var(--bf-green-ink);
+  background: var(--bf-green-pill);
+  border-color: var(--bf-green);
+}
+.bfind__chip:focus-visible {
+  outline: 2px solid var(--bf-green);
+  outline-offset: 1px;
+}
+
+/* Show more / show less, under the section it belongs to (#919) — a link, not a
+   chip, because it selects nothing and must not look like something you can
+   tick. */
+.bfind__more {
+  margin-top: 7px;
+  padding: 0;
+  font-family: var(--font-ui), sans-serif;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--bf-green-ink);
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+.bfind__more:hover {
+  text-decoration: underline;
+}
+.bfind__more:focus-visible {
+  outline: 2px solid var(--bf-green);
+  outline-offset: 2px;
 }
 
 /* The "only boards with published firmware" switch — 3 of the 225 have none. */
@@ -235,11 +299,11 @@
   align-items: center;
   gap: 7px;
   font-size: 12px;
-  color: var(--txt2, var(--text-muted));
+  color: var(--bf-ink2);
   cursor: pointer;
 }
 .bfind__toggle input {
-  accent-color: var(--green, var(--accent));
+  accent-color: var(--bf-green);
 }
 
 .bfind__clear {
@@ -247,15 +311,15 @@
   font-family: var(--font-ui), sans-serif;
   font-size: 11px;
   font-weight: 600;
-  color: var(--head, var(--text));
-  background: var(--card, var(--bg-elevated));
-  border: 1px solid var(--shellbd, var(--border));
+  color: var(--bf-ink);
+  background: var(--bf-card);
+  border: 1px solid var(--bf-line);
   border-radius: var(--radius);
   padding: 5px 8px;
   cursor: pointer;
 }
 .bfind__clear:hover {
-  border-color: var(--txt4, var(--text-muted));
+  border-color: var(--bf-line-hi);
 }
 
 /* --- the grid ------------------------------------------------------------- */
@@ -277,15 +341,15 @@
   margin: 0 0 10px;
   font-size: 13px;
   font-weight: 800;
-  color: var(--head, var(--text));
+  color: var(--bf-ink);
 }
 
 .bfind__shelf-count {
   font-size: 11px;
   font-weight: 700;
-  color: var(--txt3, var(--text-muted));
-  background: var(--card, var(--bg-elevated));
-  border: 1px solid var(--shellbd, var(--border));
+  color: var(--bf-ink3);
+  background: var(--bf-card);
+  border: 1px solid var(--bf-line);
   border-radius: 999px;
   padding: 1px 8px;
 }
@@ -301,20 +365,34 @@
   padding: 40px 8px;
   text-align: center;
   font-size: 13px;
-  color: var(--txt3, var(--text-muted));
+  color: var(--bf-ink3);
 }
 
 /* --- a board card --------------------------------------------------------- */
 
+/* The card's cell. It exists so the hover preview can be the card's SIBLING
+   rather than its child: the card is a button, and a button inside a button is
+   not markup a browser will honour. */
+.bfind__cell {
+  position: relative;
+  display: flex;
+}
+/* A preview covers its neighbours, never the other way round. */
+.bfind__cell.is-peeking {
+  z-index: 3;
+}
+
 .bfind__card {
+  flex: 1 1 auto;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   text-align: left;
   padding: 0;
   font: inherit;
-  color: var(--head, var(--text));
-  background: var(--card, var(--bg-elevated));
-  border: 1px solid var(--shellbd, var(--border));
+  color: var(--bf-ink);
+  background: var(--bf-card);
+  border: 1px solid var(--bf-line);
   border-radius: 12px;
   overflow: hidden;
   cursor: pointer;
@@ -323,13 +401,13 @@
     transform 0.08s ease;
 }
 .bfind__card:hover {
-  border-color: var(--green, var(--accent));
+  border-color: var(--bf-green);
 }
 .bfind__card:active {
   transform: translateY(1px);
 }
 .bfind__card:focus-visible {
-  outline: 2px solid var(--accent, var(--green));
+  outline: 2px solid var(--bf-green);
   outline-offset: 2px;
 }
 
@@ -338,8 +416,8 @@
   display: grid;
   place-items: center;
   overflow: hidden;
-  background: var(--bg-sunken, var(--shell));
-  border-bottom: 1px solid var(--shellbd, var(--border));
+  background: var(--bf-sunk);
+  border-bottom: 1px solid var(--bf-line);
 }
 .bfind__card-img img {
   width: 100%;
@@ -354,7 +432,7 @@
   font-size: 22px;
   font-weight: 700;
   letter-spacing: 0.04em;
-  color: var(--txt4, var(--text-muted));
+  color: var(--bf-ink4);
 }
 
 .bfind__card-body {
@@ -370,7 +448,7 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--txt3, var(--text-muted));
+  color: var(--bf-ink3);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -380,13 +458,13 @@
   font-size: 13px;
   font-weight: 700;
   line-height: 1.25;
-  color: var(--head, var(--text));
+  color: var(--bf-ink);
 }
 
 .bfind__card-mcu {
   font-family: var(--font-mono), monospace;
   font-size: 11px;
-  color: var(--txt2, var(--text-muted));
+  color: var(--bf-ink2);
 }
 
 .bfind__card-feats {
@@ -400,9 +478,9 @@
   font-size: 9.5px;
   font-weight: 700;
   letter-spacing: 0.03em;
-  color: var(--txt2, var(--text-muted));
-  background: var(--bg-sunken, var(--shell));
-  border: 1px solid var(--shellbd, var(--border));
+  color: var(--bf-ink2);
+  background: var(--bf-sunk);
+  border: 1px solid var(--bf-line);
   border-radius: 4px;
   padding: 1px 5px;
 }
@@ -411,7 +489,132 @@
 .bfind__card-nofw {
   font-size: 10px;
   font-weight: 700;
-  color: var(--warn, var(--accent-ink));
+  color: var(--bf-gold);
+}
+
+/* --- the hover preview (#919) --------------------------------------------- */
+
+/* Grows out of the card it covers, 10px proud on each side so it reads as the
+   same card enlarged rather than as a tooltip that happens to be near one. */
+.bfind__peek {
+  position: absolute;
+  left: -10px;
+  right: -10px;
+  top: -10px;
+  display: flex;
+  flex-direction: column;
+  background: var(--bf-card);
+  border: 1px solid var(--bf-green);
+  border-radius: 12px;
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.6);
+  overflow: hidden;
+  transform-origin: 50% 0;
+  animation: bfind-peek 0.16s ease-out both;
+  cursor: pointer;
+}
+/* The bottom row grows UP instead, or it would open into the scroller's edge. */
+.bfind__peek.is-up {
+  top: auto;
+  bottom: -10px;
+  transform-origin: 50% 100%;
+}
+@keyframes bfind-peek {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .bfind__peek {
+    animation: none;
+  }
+}
+
+.bfind__peek-img {
+  aspect-ratio: 4 / 3;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  background: var(--bf-sunk);
+  border-bottom: 1px solid var(--bf-line);
+}
+.bfind__peek-img img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.bfind__peek-body {
+  padding: 9px 11px 11px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.bfind__peek-name {
+  font-size: 13.5px;
+  font-weight: 800;
+  line-height: 1.25;
+  color: var(--bf-ink);
+}
+
+/* What there is to flash, or that there is nothing — the first thing that
+   settles whether this board is worth opening. */
+.bfind__peek-fw {
+  font-family: var(--font-mono), monospace;
+  font-size: 10.5px;
+  font-weight: 700;
+  color: var(--bf-green-ink);
+}
+.bfind__peek-fw.is-none {
+  color: var(--bf-gold);
+}
+
+.bfind__peek-facts {
+  margin: 2px 0 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 2px 10px;
+  font-size: 10.5px;
+}
+.bfind__peek-facts dt {
+  font-weight: 700;
+  color: var(--bf-ink3);
+}
+.bfind__peek-facts dd {
+  margin: 0;
+  font-family: var(--font-mono), monospace;
+  color: var(--bf-ink);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* The disclosure into the full page. A pointer's route to what Enter on the card
+   already does, so it is a convenience and never the only way through. */
+.bfind__peek-open {
+  margin-top: 7px;
+  font-family: var(--font-ui), sans-serif;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--bf-ink);
+  background: var(--bf-sunk);
+  border: 1px solid var(--bf-line);
+  border-radius: var(--radius);
+  padding: 5px 8px;
+  cursor: pointer;
+}
+.bfind__peek-open:hover {
+  border-color: var(--bf-green);
+  color: var(--bf-green-ink);
+}
+.bfind__peek-open:focus-visible {
+  outline: 2px solid var(--bf-green);
+  outline-offset: 2px;
 }
 
 /* --- a board's details, over the grid ------------------------------------- */
@@ -421,7 +624,7 @@
   inset: 0;
   display: flex;
   flex-direction: column;
-  background: var(--panel, var(--bg-elevated));
+  background: var(--bf-panel);
   animation: bfind-grow 0.18s ease-out both;
 }
 @media (prefers-reduced-motion: reduce) {
@@ -435,23 +638,8 @@
   align-items: center;
   gap: 12px;
   padding: 12px 16px;
-  background: var(--shell, var(--bg-sunken));
-  border-bottom: 1px solid var(--shellbd, var(--border));
-}
-
-.bfind__back {
-  font-family: var(--font-ui), sans-serif;
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--head, var(--text));
-  background: var(--card, var(--bg-elevated));
-  border: 1px solid var(--shellbd, var(--border));
-  border-radius: var(--radius);
-  padding: 5px 11px;
-  cursor: pointer;
-}
-.bfind__back:hover {
-  border-color: var(--txt4, var(--text-muted));
+  background: var(--bf-shell);
+  border-bottom: 1px solid var(--bf-line);
 }
 
 .bfind__det-title {
@@ -465,12 +653,12 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--txt3, var(--text-muted));
+  color: var(--bf-ink3);
 }
 .bfind__det-name {
   font-size: 16px;
   font-weight: 800;
-  color: var(--head, var(--text));
+  color: var(--bf-ink);
 }
 
 /* The primary action — the Soft Shell gold button, as elsewhere in the app. */
@@ -478,11 +666,11 @@
   font-family: var(--font-ui), sans-serif;
   font-size: 13px;
   font-weight: 700;
-  color: var(--goldink, var(--accent-contrast));
-  background: var(--grad-gold, var(--accent));
+  color: var(--bf-gold-ink);
+  background: var(--bf-gold-grad);
   border: none;
   border-radius: var(--radius);
-  box-shadow: inset 0 1px 0 var(--pillinset, transparent);
+  box-shadow: inset 0 1px 0 var(--bf-inset);
   padding: 9px 16px;
   cursor: pointer;
 }
@@ -490,9 +678,9 @@
   filter: brightness(1.05);
 }
 .bfind__flash:disabled {
-  color: var(--txt4, var(--text-muted));
-  background: var(--card, var(--bg-elevated));
-  border: 1px solid var(--shellbd, var(--border));
+  color: var(--bf-ink4);
+  background: var(--bf-card);
+  border: 1px solid var(--bf-line);
   box-shadow: none;
   cursor: not-allowed;
 }
@@ -517,8 +705,8 @@
   display: grid;
   place-items: center;
   overflow: hidden;
-  background: var(--bg-sunken, var(--shell));
-  border: 1px solid var(--shellbd, var(--border));
+  background: var(--bf-sunk);
+  border: 1px solid var(--bf-line);
   border-radius: 12px;
 }
 .bfind__det-img img {
@@ -537,7 +725,7 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--txt3, var(--text-muted));
+  color: var(--bf-ink3);
 }
 
 /* A dt/dd pair needs a wrapper to carry React's key, and that wrapper must not
@@ -556,12 +744,12 @@
 }
 .bfind__facts dt {
   font-weight: 700;
-  color: var(--txt2, var(--text-muted));
+  color: var(--bf-ink2);
 }
 .bfind__facts dd {
   margin: 0;
   font-family: var(--font-mono), monospace;
-  color: var(--head, var(--text));
+  color: var(--bf-ink);
 }
 
 /* The honest footnote about what upstream does not publish. */
@@ -569,7 +757,7 @@
   margin: 8px 0 0;
   font-size: 11.5px;
   line-height: 1.5;
-  color: var(--txt3, var(--text-muted));
+  color: var(--bf-ink3);
 }
 
 .bfind__variants {
@@ -582,11 +770,11 @@
 .bfind__variants dt {
   font-family: var(--font-mono), monospace;
   font-weight: 700;
-  color: var(--accent-ink, var(--accent));
+  color: var(--bf-gold);
 }
 .bfind__variants dd {
   margin: 0;
-  color: var(--txt2, var(--text-muted));
+  color: var(--bf-ink2);
 }
 
 .bfind__builds {
@@ -604,19 +792,19 @@
   gap: 9px;
   font-size: 12px;
   padding: 6px 10px;
-  background: var(--card, var(--bg-elevated));
-  border: 1px solid var(--shellbd, var(--border));
+  background: var(--bf-card);
+  border: 1px solid var(--bf-line);
   border-radius: var(--radius);
 }
 
 .bfind__build-name {
   font-family: var(--font-mono), monospace;
   font-weight: 700;
-  color: var(--head, var(--text));
+  color: var(--bf-ink);
 }
 .bfind__build-ver {
   font-family: var(--font-mono), monospace;
-  color: var(--txt2, var(--text-muted));
+  color: var(--bf-ink2);
 }
 
 /* The one that a click on the board would actually flash. */
@@ -626,17 +814,17 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--greentext, var(--accent-ink));
+  color: var(--bf-green-ink);
 }
 
 .bfind__link {
   font-size: 12.5px;
-  color: var(--accent-ink, var(--accent));
+  color: var(--bf-gold);
   text-decoration: none;
-  border-bottom: 1px solid var(--shellbd, var(--border));
+  border-bottom: 1px solid var(--bf-line);
 }
 .bfind__link:hover {
-  border-bottom-color: var(--accent, var(--accent-ink));
+  border-bottom-color: var(--bf-gold);
 }
 
 .bfind__feats-big {
@@ -649,10 +837,12 @@
   padding: 3px 8px;
 }
 
-/* --- the runtime facet (#902) --------------------------------------------- */
+/* --- counts and caveats on a facet ---------------------------------------- */
 
-/* The confirmed count, on the chip. Without it a bare "CircuitPython" chip reads
-   as the whole answer rather than as the subset it is. */
+/* The count, on the chip. Without it a bare "CircuitPython" chip reads as the
+   whole answer rather than as the subset it is — and, since #919, it is also
+   what makes the commonest-first order of the manufacturer and processor chips
+   read as an order rather than as a shuffle. */
 .bfind__chip-n {
   margin-left: 5px;
   font-size: 10px;
@@ -666,7 +856,7 @@
   margin: 7px 0 0;
   font-size: 10.5px;
   line-height: 1.45;
-  color: var(--txt3, var(--text-muted));
+  color: var(--bf-ink3);
 }
 
 /* --- boards Snakie carries and upstream does not (#902) ------------------- */
@@ -676,21 +866,21 @@
   font-family: var(--font-mono), monospace;
   font-size: 9.5px;
   font-weight: 700;
-  color: var(--accent-ink, var(--accent));
+  color: var(--bf-gold);
 }
 
 /* The same thing on the details, given its own tinted block so it is read
    before the specification rather than after it. */
 .bfind__sub {
   padding: 10px 12px;
-  background: var(--shell, var(--bg-sunken));
-  border: 1px solid var(--shellbd, var(--border));
-  border-left: 3px solid var(--accent, var(--accent-ink));
+  background: var(--bf-shell);
+  border: 1px solid var(--bf-line);
+  border-left: 3px solid var(--bf-gold);
   border-radius: var(--radius);
 }
 .bfind__sub .bfind__section-name {
   font-family: var(--font-mono), monospace;
-  color: var(--accent-ink, var(--accent));
+  color: var(--bf-gold);
 }
 .bfind__sub .bfind__note {
   margin-top: 4px;
@@ -706,15 +896,15 @@
   font-family: var(--font-ui), sans-serif;
   font-size: 10px;
   font-weight: 600;
-  color: var(--txt3, var(--text-muted));
+  color: var(--bf-ink3);
 }
 
 .bfind__code {
   font-family: var(--font-mono), monospace;
   font-size: 11px;
-  color: var(--head, var(--text));
-  background: var(--shell, var(--bg-sunken));
-  border: 1px solid var(--shellbd, var(--border));
+  color: var(--bf-ink);
+  background: var(--bf-shell);
+  border: 1px solid var(--bf-line);
   border-radius: 4px;
   padding: 1px 5px;
 }

--- a/src/renderer/src/components/BoardFinder.tsx
+++ b/src/renderer/src/components/BoardFinder.tsx
@@ -8,14 +8,15 @@ import {
   type JSX
 } from 'react'
 import {
-  featuresOf,
+  featureOptions,
   filterBoards,
-  mcusOf,
+  mcuOptions,
   newestBuilds,
   runtimeCounts,
-  vendorsOf,
+  vendorOptions,
   defaultBuild,
   type BoardFilter,
+  type FacetOption,
   type IndexedBoard
 } from '../../../shared/board-index'
 import { withOverlay } from '../../../shared/board-overlay'
@@ -30,9 +31,11 @@ import {
   boardFacts,
   boardInitials,
   buildLabel,
+  firmwareSummary,
   isFiltering,
+  peekFacts,
   shelvesByVendor,
-  toggleFeature,
+  toggleChip,
   toggleRuntime,
   variantList
 } from './board-finder'
@@ -43,14 +46,19 @@ import './BoardFinder.css'
  * BOARD FINDER (#893, epic #884) — the full-screen board gallery.
  * =============================================================================
  * Every board MicroPython builds for — 225 of them, 54 vendors — as a gallery
- * with the filters that actually narrow it: vendor, MCU, features, and a search
- * box. A sibling of the Parts Catalog (#613): same pop-out affordance, same
- * shelves-then-flat-grid behaviour, same details-over-the-grid detour. It differs
- * in taking its colours from the theme tokens rather than painting itself a fixed
- * light surface, because this is panel chrome and follows the skin.
+ * with the filters that actually narrow it: manufacturer, processor, features,
+ * and a search box. A sibling of the Parts Catalog (#613): same pop-out
+ * affordance, same shelves-then-flat-grid behaviour, same details-over-the-grid
+ * detour. Unlike the rest of the app's chrome it is DARK in both skins — see
+ * `BoardFinder.css`, which says why, and why that is not an oversight to tidy up.
  *
  * Clicking a board asks the firmware flasher to open on it with the newest build
  * already chosen — see `board-finder-bus.ts`, which is the whole of that seam.
+ *
+ * RESTING on a board opens a preview instead (#919): the same card, grown, with
+ * the facts that decide whether it is the one — see {@link BoardCell} for the
+ * three things that keep that from pouncing, and for how it is reached without a
+ * pointer at all.
  *
  * ON THE FILTERS. Storage and memory are still not filters (#897): there are
  * sourced sizes now, but 5 boards of 225 have a flash figure, and a size control
@@ -77,10 +85,23 @@ export interface BoardFinderProps {
   onClosed?: () => void
 }
 
-/** How many feature chips the sidebar shows before "Show all". `featuresOf`
- *  orders commonest-first, so the eight that lead are the ones worth offering;
- *  the remaining nineteen tail off into single-board curiosities. */
+/** How many feature chips the sidebar shows before the disclosure.
+ *  `featureOptions` orders commonest-first, so the eight that lead are the ones
+ *  worth offering; the remaining nineteen tail off into single-board curiosities. */
 const FEATURE_CHIP_LIMIT = 8
+
+/**
+ * The same, for the two long facets — 54 manufacturers and 41 chip families
+ * (#919).
+ *
+ * Ten, because ten is where the collapsed list stops being a sample and starts
+ * being an answer: the ten commonest makers are 135 of the 225 boards and the ten
+ * commonest chip families 155, so most people's board is named before they open
+ * anything. Twice that would fill the sidebar to no purpose — the tail is makers
+ * of one or two boards each, which is a list to search, not to scan, and the
+ * search box already matches on manufacturer.
+ */
+const LONG_FACET_LIMIT = 10
 
 export function BoardFinder({ onClose, origin, closing, onClosed }: BoardFinderProps): JSX.Element {
   // The panel is inset from the viewport, so the button's viewport position has
@@ -120,12 +141,20 @@ export function BoardFinder({ onClose, origin, closing, onClosed }: BoardFinderP
   }, [])
 
   const [text, setText] = useState('')
-  const [vendor, setVendor] = useState('')
-  const [mcu, setMcu] = useState('')
+  // Manufacturer and processor are SETS now (#919), and ticking two of either
+  // means "or" — see `BoardFilter`, which is where that rule is stated and
+  // tested, because it is the opposite of what ticking two features means.
+  const [vendors, setVendors] = useState<string[]>([])
+  const [mcus, setMcus] = useState<string[]>([])
   const [features, setFeatures] = useState<string[]>([])
   const [runtimes, setRuntimes] = useState<FirmwareRuntime[]>([])
   const [flashableOnly, setFlashableOnly] = useState(false)
-  const [showAllFeatures, setShowAllFeatures] = useState(false)
+  // Which facets are showing their whole list, by facet name — so a fifth facet
+  // needs no fifth flag.
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({})
+  const toggleExpanded = useCallback((name: string): void => {
+    setExpanded((prev) => ({ ...prev, [name]: !prev[name] }))
+  }, [])
   // The board whose details are open, or null for the grid. A DETOUR, as in the
   // Parts Catalog: the details render OVER the grid, which stays mounted, so
   // closing them restores the filters and the scroll position by never having
@@ -148,20 +177,22 @@ export function BoardFinder({ onClose, origin, closing, onClosed }: BoardFinderP
   // a board the overlay is standing in for, which `withOverlay` then drops.
   const all = useMemo(() => (boards ? withOverlay(boards) : []), [boards])
   const filter: BoardFilter = useMemo(
-    () => ({ text, vendor, mcu, features, runtimes, flashableOnly }),
-    [text, vendor, mcu, features, runtimes, flashableOnly]
+    () => ({ text, vendors, mcus, features, runtimes, flashableOnly }),
+    [text, vendors, mcus, features, runtimes, flashableOnly]
   )
   const matched = useMemo(() => filterBoards(all, filter), [all, filter])
 
   // The options come from the WHOLE catalogue, not the current result set: a
   // vendor list that shrinks as you filter cannot be used to change your mind.
-  const vendors = useMemo(() => vendorsOf(all), [all])
-  const mcus = useMemo(() => mcusOf(all), [all])
-  const allFeatures = useMemo(() => featuresOf(all), [all])
-  const shownFeatures = showAllFeatures ? allFeatures : allFeatures.slice(0, FEATURE_CHIP_LIMIT)
+  const vendorChips = useMemo(() => vendorOptions(all), [all])
+  const mcuChips = useMemo(() => mcuOptions(all), [all])
+  const featureChips = useMemo(() => featureOptions(all), [all])
   // Printed on the runtime chips. The number is the point: "CircuitPython 49"
   // reads as a confirmed subset, where a bare chip would read as the answer.
-  const runtimeTotals = useMemo(() => runtimeCounts(all), [all])
+  const runtimeChips = useMemo<FacetOption[]>(() => {
+    const counts = runtimeCounts(all)
+    return FIRMWARE_RUNTIMES.map((r) => ({ value: r, count: counts[r] }))
+  }, [all])
 
   // Shelves are for BROWSING. Once anything is narrowing the catalogue the
   // result set IS the answer, and re-sectioning it by vendor fights the vendor
@@ -171,8 +202,8 @@ export function BoardFinder({ onClose, origin, closing, onClosed }: BoardFinderP
 
   const clearFilters = useCallback((): void => {
     setText('')
-    setVendor('')
-    setMcu('')
+    setVendors([])
+    setMcus([])
     setFeatures([])
     setRuntimes([])
     setFlashableOnly(false)
@@ -229,93 +260,46 @@ export function BoardFinder({ onClose, origin, closing, onClosed }: BoardFinderP
 
         <div className="bfind__body">
           <aside className="bfind__sidebar">
-            <div className="bfind__facet">
-              <h3 className="bfind__facet-name">Manufacturer</h3>
-              <select
-                className="bfind__select"
-                value={vendor}
-                onChange={(e) => setVendor(e.target.value)}
-                aria-label="Filter by manufacturer"
-              >
-                <option value="">All manufacturers</option>
-                {vendors.map((v) => (
-                  <option key={v} value={v}>
-                    {v}
-                  </option>
-                ))}
-              </select>
-            </div>
+            {/* Four facets, one control. They differ only in what a tick means,
+                and that lives in `matchesFilter` where it is tested. */}
+            <ChipFacet
+              name="Manufacturer"
+              options={vendorChips}
+              selected={vendors}
+              limit={LONG_FACET_LIMIT}
+              expanded={expanded.vendor === true}
+              onToggleExpand={() => toggleExpanded('vendor')}
+              onToggle={(v) => setVendors((prev) => toggleChip(prev, v))}
+            />
 
-            <div className="bfind__facet">
-              <h3 className="bfind__facet-name">Processor</h3>
-              <select
-                className="bfind__select"
-                value={mcu}
-                onChange={(e) => setMcu(e.target.value)}
-                aria-label="Filter by processor"
-              >
-                <option value="">All processors</option>
-                {mcus.map((m) => (
-                  <option key={m} value={m}>
-                    {m}
-                  </option>
-                ))}
-              </select>
-            </div>
+            <ChipFacet
+              name="Processor"
+              options={mcuChips}
+              selected={mcus}
+              limit={LONG_FACET_LIMIT}
+              expanded={expanded.mcu === true}
+              onToggleExpand={() => toggleExpanded('mcu')}
+              onToggle={(m) => setMcus((prev) => toggleChip(prev, m))}
+            />
 
-            <div className="bfind__facet">
-              <h3 className="bfind__facet-name">Runtime</h3>
-              <div className="bfind__chips">
-                {FIRMWARE_RUNTIMES.map((r) => {
-                  const on = runtimes.includes(r)
-                  return (
-                    <button
-                      key={r}
-                      type="button"
-                      className={`bfind__chip${on ? ' is-on' : ''}`}
-                      aria-pressed={on}
-                      onClick={() => setRuntimes((prev) => toggleRuntime(prev, r))}
-                    >
-                      {FIRMWARE_RUNTIME_LABEL[r]}
-                      <span className="bfind__chip-n">{runtimeTotals[r]}</span>
-                    </button>
-                  )
-                })}
-              </div>
-              {/* The two things a bare "CircuitPython" chip would imply and
-                  cannot support, printed where the chip is rather than in a
-                  tooltip nobody opens. */}
-              <p className="bfind__facet-note">{RUNTIME_CAVEAT}</p>
-            </div>
+            <ChipFacet
+              name="Runtime"
+              options={runtimeChips}
+              selected={runtimes}
+              label={(r) => FIRMWARE_RUNTIME_LABEL[r as FirmwareRuntime]}
+              onToggle={(r) => setRuntimes((prev) => toggleRuntime(prev, r as FirmwareRuntime))}
+              note={RUNTIME_CAVEAT}
+            />
 
-            <div className="bfind__facet">
-              <h3 className="bfind__facet-name">Features</h3>
-              <div className="bfind__chips">
-                {shownFeatures.map((f) => {
-                  const on = features.includes(f)
-                  return (
-                    <button
-                      key={f}
-                      type="button"
-                      className={`bfind__chip${on ? ' is-on' : ''}`}
-                      aria-pressed={on}
-                      onClick={() => setFeatures((prev) => toggleFeature(prev, f))}
-                    >
-                      {f}
-                    </button>
-                  )
-                })}
-                {allFeatures.length > FEATURE_CHIP_LIMIT && (
-                  <button
-                    type="button"
-                    className="bfind__chip"
-                    onClick={() => setShowAllFeatures((v) => !v)}
-                  >
-                    {showAllFeatures ? 'Show fewer' : `+${allFeatures.length - FEATURE_CHIP_LIMIT} more`}
-                  </button>
-                )}
-              </div>
-            </div>
+            <ChipFacet
+              name="Features"
+              options={featureChips}
+              selected={features}
+              limit={FEATURE_CHIP_LIMIT}
+              expanded={expanded.feature === true}
+              onToggleExpand={() => toggleExpanded('feature')}
+              onToggle={(f) => setFeatures((prev) => toggleChip(prev, f))}
+            />
 
             <div className="bfind__facet">
               <label className="bfind__toggle">
@@ -350,7 +334,7 @@ export function BoardFinder({ onClose, origin, closing, onClosed }: BoardFinderP
             {filtering && matched.length > 0 && (
               <div className="bfind__grid">
                 {matched.map((b) => (
-                  <BoardCard key={b.id} board={b} onOpen={() => setSelected(b)} />
+                  <BoardCell key={b.id} board={b} onOpen={() => setSelected(b)} />
                 ))}
               </div>
             )}
@@ -364,7 +348,7 @@ export function BoardFinder({ onClose, origin, closing, onClosed }: BoardFinderP
                   </h3>
                   <div className="bfind__grid">
                     {shelf.boards.map((b) => (
-                      <BoardCard key={b.id} board={b} onOpen={() => setSelected(b)} />
+                      <BoardCell key={b.id} board={b} onOpen={() => setSelected(b)} />
                     ))}
                   </div>
                 </section>
@@ -376,7 +360,7 @@ export function BoardFinder({ onClose, origin, closing, onClosed }: BoardFinderP
           <BoardDetails
             key={selected.id}
             board={selected}
-            onBack={() => setSelected(null)}
+            onClose={() => setSelected(null)}
             onFlash={() => flash(selected)}
           />
         )}
@@ -385,8 +369,251 @@ export function BoardFinder({ onClose, origin, closing, onClosed }: BoardFinderP
   )
 }
 
+/**
+ * One filter facet: a ranked row of chips, with the long tail behind a
+ * disclosure (#919).
+ *
+ * Every facet in the sidebar is this control. Manufacturer and processor used to
+ * be dropdowns, which hold one value and hide the other 53 behind a click — a
+ * chip row says what the catalogue is made of before anything is chosen, and the
+ * count on each chip is what makes the commonest-first order legible rather than
+ * arbitrary.
+ *
+ * `limit` absent means no disclosure: the runtime facet has two options and
+ * nothing to hide.
+ */
+function ChipFacet({
+  name,
+  options,
+  selected,
+  onToggle,
+  limit,
+  expanded,
+  onToggleExpand,
+  label,
+  note
+}: {
+  name: string
+  options: readonly FacetOption[]
+  selected: readonly string[]
+  onToggle: (value: string) => void
+  limit?: number
+  expanded?: boolean
+  onToggleExpand?: () => void
+  /** What the chip says, where that is not the value itself. */
+  label?: (value: string) => string
+  /** What this facet cannot claim, printed under it. */
+  note?: string
+}): JSX.Element | null {
+  if (options.length === 0) return null
+  const hidden = limit === undefined || expanded ? 0 : Math.max(0, options.length - limit)
+  const shown = hidden > 0 ? options.slice(0, limit) : options
+  return (
+    <div className="bfind__facet">
+      <h3 className="bfind__facet-name">{name}</h3>
+      <div className="bfind__chips">
+        {shown.map((o) => {
+          const on = selected.includes(o.value)
+          return (
+            <button
+              key={o.value}
+              type="button"
+              className={`bfind__chip${on ? ' is-on' : ''}`}
+              aria-pressed={on}
+              onClick={() => onToggle(o.value)}
+            >
+              {label ? label(o.value) : o.value}
+              <span className="bfind__chip-n">{o.count}</span>
+            </button>
+          )
+        })}
+      </div>
+      {limit !== undefined && onToggleExpand && options.length > limit && (
+        <button type="button" className="bfind__more" onClick={onToggleExpand}>
+          {expanded ? 'Show less' : `Show ${options.length - limit} more`}
+        </button>
+      )}
+      {note && <p className="bfind__facet-note">{note}</p>}
+    </div>
+  )
+}
+
 /** How many feature chips fit on a card before it starts to look like a list. */
 const CARD_FEATURE_LIMIT = 3
+
+/** And on the preview, which has room for more but still a height to keep. */
+const PEEK_FEATURE_LIMIT = 6
+
+/**
+ * How long a pointer must REST on a card before its preview opens.
+ *
+ * Long enough that crossing the grid on the way to the sidebar opens nothing —
+ * the timer is per-card and dies on the way out — and short enough that resting
+ * on a board feels like an answer rather than a wait.
+ */
+const PEEK_DELAY_MS = 400
+
+/** Roughly how far the preview grows past the card. Only the flip decision reads
+ *  it, and only to choose a direction, so an estimate is the right precision. */
+const PEEK_OVERHANG_PX = 180
+
+/**
+ * One board in the grid, and its hover preview (#919).
+ *
+ * The preview is the Netflix move: rest on a card and it grows into a bigger one
+ * carrying the facts that decide whether this is your board, with a disclosure
+ * into the full page. Three things stop it pouncing:
+ *
+ *   - the DELAY. A pointer crossing the grid on its way somewhere else leaves
+ *     before the timer fires, so nothing opens behind it.
+ *   - MOUSE only. A touch that "hovers" is really a tap, and a tap already opens
+ *     the full page — so `pointerType` gates it and touch keeps the plain card.
+ *   - FOCUS opens it at once, with no timer, because focus is deliberate in a way
+ *     that a pointer passing over is not.
+ *
+ * That last one is also the whole keyboard story: tab to a card and the preview
+ * is there, its Details button the next stop after it, and Enter on the card
+ * itself doing exactly what that button does. Nothing here is reachable only by
+ * hovering.
+ */
+function BoardCell({ board, onOpen }: { board: IndexedBoard; onOpen: () => void }): JSX.Element {
+  const [peeking, setPeeking] = useState(false)
+  // Grow UPWARD when there is no room below inside the scroller: the bottom row
+  // is otherwise a preview clipped to the two lines that were already visible.
+  const [up, setUp] = useState(false)
+  const cell = useRef<HTMLDivElement>(null)
+  const timer = useRef<number | null>(null)
+
+  const cancel = useCallback((): void => {
+    if (timer.current !== null) window.clearTimeout(timer.current)
+    timer.current = null
+    setPeeking(false)
+  }, [])
+  // A card scrolled or filtered away mid-wait must not open a preview onto
+  // whatever took its place.
+  useEffect(
+    () => () => {
+      if (timer.current !== null) window.clearTimeout(timer.current)
+    },
+    []
+  )
+
+  const open = useCallback((): void => {
+    const el = cell.current
+    const scroller = el?.closest('.bfind__shelves')
+    if (el && scroller) {
+      const room = scroller.getBoundingClientRect().bottom - el.getBoundingClientRect().bottom
+      setUp(room < PEEK_OVERHANG_PX)
+    }
+    setPeeking(true)
+  }, [])
+
+  const openDetails = useCallback((): void => {
+    cancel()
+    onOpen()
+  }, [cancel, onOpen])
+
+  return (
+    <div
+      className={`bfind__cell${peeking ? ' is-peeking' : ''}`}
+      ref={cell}
+      onPointerEnter={(e) => {
+        if (e.pointerType !== 'mouse') return
+        timer.current = window.setTimeout(open, PEEK_DELAY_MS)
+      }}
+      onPointerLeave={cancel}
+      onFocus={(e) => {
+        // KEYBOARD focus only, and `:focus-visible` is the browser's own answer
+        // to which is which. A click focuses the card too — and a preview that
+        // appeared between pointerdown and pointerup would take the pointerup
+        // for itself, leaving the click to land on the cell instead of the card
+        // and the board never opening at all.
+        if (e.target instanceof HTMLElement && e.target.matches(':focus-visible')) open()
+      }}
+      onBlur={(e) => {
+        // Tabbing from the card to its own Details button must not close the
+        // thing that button sits on.
+        if (!e.currentTarget.contains(e.relatedTarget as Node | null)) cancel()
+      }}
+    >
+      <BoardCard board={board} onOpen={openDetails} />
+      {peeking && <BoardPeek board={board} up={up} onOpen={openDetails} />}
+    </div>
+  )
+}
+
+/**
+ * The preview's contents: what the card shows, plus what it could not fit.
+ *
+ * It repeats the photo and the name because it covers the card it grew out of —
+ * a preview that dropped them would read as some other board's.
+ */
+function BoardPeek({
+  board,
+  up,
+  onOpen
+}: {
+  board: IndexedBoard
+  up: boolean
+  onOpen: () => void
+}): JSX.Element {
+  const src = thumbUrl(board.thumb)
+  const facts = peekFacts(board)
+  const extra = board.features.length - PEEK_FEATURE_LIMIT
+  return (
+    <div
+      className={`bfind__peek${up ? ' is-up' : ''}`}
+      role="group"
+      aria-label={`More about ${board.vendor} ${board.product}`}
+      // The preview covers the card it grew out of, so it has to accept the
+      // click the card would have taken. Its Details button is the same action
+      // said out loud, for the keyboard and for anyone who wants a target.
+      onClick={onOpen}
+    >
+      <div className="bfind__peek-img">
+        {src ? (
+          <img src={src} alt="" loading="lazy" draggable={false} />
+        ) : (
+          <span className="bfind__noimg" aria-hidden="true">
+            {boardInitials(board)}
+          </span>
+        )}
+      </div>
+      <div className="bfind__peek-body">
+        <div className="bfind__card-vendor">{board.vendor || 'Unknown'}</div>
+        <div className="bfind__peek-name">{board.product}</div>
+        {/* First, because having nothing to flash is what disqualifies a board. */}
+        <div className={`bfind__peek-fw${board.builds.length === 0 ? ' is-none' : ''}`}>
+          {firmwareSummary(board)}
+        </div>
+        <dl className="bfind__peek-facts">
+          {facts.map((f) => (
+            <div className="bfind__row" key={f.label}>
+              <dt>{f.label}</dt>
+              <dd>{f.value}</dd>
+            </div>
+          ))}
+        </dl>
+        {board.features.length > 0 && (
+          <div className="bfind__card-feats">
+            {board.features.slice(0, PEEK_FEATURE_LIMIT).map((f) => (
+              <span className="bfind__feat" key={f}>
+                {f}
+              </span>
+            ))}
+            {extra > 0 && <span className="bfind__feat">+{extra}</span>}
+          </div>
+        )}
+        {board.substitute?.build && (
+          <div className="bfind__card-sub">Flashes {board.substitute.build}</div>
+        )}
+        <button type="button" className="bfind__peek-open" onClick={onOpen}>
+          Details
+        </button>
+      </div>
+    </div>
+  )
+}
 
 /** One board in the grid. */
 function BoardCard({
@@ -443,11 +670,11 @@ function BoardCard({
 /** A board's full details, over the grid rather than instead of it. */
 function BoardDetails({
   board,
-  onBack,
+  onClose,
   onFlash
 }: {
   board: IndexedBoard
-  onBack: () => void
+  onClose: () => void
   onFlash: () => void
 }): JSX.Element {
   const src = thumbUrl(board.thumb)
@@ -459,9 +686,6 @@ function BoardDetails({
   return (
     <div className="bfind__details" role="group" aria-label={`${board.vendor} ${board.product}`}>
       <header className="bfind__det-head">
-        <button type="button" className="bfind__back" onClick={onBack}>
-          ← All boards
-        </button>
         <span className="bfind__det-title">
           <span className="bfind__det-vendor">{board.vendor || 'Unknown'}</span>
           <span className="bfind__det-name">{board.product}</span>
@@ -479,6 +703,20 @@ function BoardDetails({
           }
         >
           {chosen ? `⚡ Flash MicroPython ${chosen.version}` : 'No firmware published'}
+        </button>
+        {/* The way out is an X in the top-right corner (#919), where a
+            full-screen view's close always is — and it is the same control, in
+            the same place, as the gallery's own. The "← All boards" button it
+            replaces sat in the top LEFT, which gave one view two exits in two
+            different idioms. Esc still does it too. */}
+        <button
+          type="button"
+          className="bfind__close"
+          onClick={onClose}
+          aria-label="Close board details"
+          title="Back to the boards (Esc)"
+        >
+          ✕
         </button>
       </header>
 

--- a/src/renderer/src/components/board-finder.ts
+++ b/src/renderer/src/components/board-finder.ts
@@ -22,7 +22,13 @@
  * THE RUNTIME FILTER (#902) does ship, because its data supports it and the one
  * thing it cannot say is sayable out loud. See {@link RUNTIME_CAVEAT}.
  */
-import type { BoardBuild, BoardFilter, IndexedBoard } from '../../../shared/board-index'
+import {
+  defaultBuild,
+  newestBuilds,
+  type BoardBuild,
+  type BoardFilter,
+  type IndexedBoard
+} from '../../../shared/board-index'
 import type { FirmwareRuntime } from '../../../shared/firmware-runtime'
 
 // ---------------------------------------------------------------------------
@@ -154,7 +160,7 @@ export function formatBytes(bytes: number): string {
 export function boardFacts(board: IndexedBoard): BoardFact[] {
   const facts: BoardFact[] = [{ label: 'MCU', value: board.mcu || 'unknown' }]
   if (board.port) facts.push({ label: 'Port', value: board.port })
-  if (board.flashOffset) facts.push({ label: 'Flash offset', value: board.flashOffset })
+  if (board.flashOffset) facts.push({ label: FLASH_OFFSET_LABEL, value: board.flashOffset })
   if (board.flash) {
     facts.push({ label: 'Flash', value: formatBytes(board.flash.bytes), source: board.flash.source })
   }
@@ -199,8 +205,8 @@ export function activeFilterChips(
   filter: BoardFilter
 ): { axis: 'vendor' | 'mcu' | 'feature' | 'runtime'; value: string }[] {
   const out: { axis: 'vendor' | 'mcu' | 'feature' | 'runtime'; value: string }[] = []
-  if (filter.vendor) out.push({ axis: 'vendor', value: filter.vendor })
-  if (filter.mcu) out.push({ axis: 'mcu', value: filter.mcu })
+  for (const v of filter.vendors ?? []) out.push({ axis: 'vendor', value: v })
+  for (const m of filter.mcus ?? []) out.push({ axis: 'mcu', value: m })
   for (const f of filter.features ?? []) out.push({ axis: 'feature', value: f })
   for (const r of filter.runtimes ?? []) out.push({ axis: 'runtime', value: r })
   return out
@@ -215,11 +221,16 @@ export function isFiltering(filter: BoardFilter): boolean {
   )
 }
 
-/** Add or remove one feature, so the chips toggle rather than only accumulate. */
-export function toggleFeature(features: readonly string[], feature: string): string[] {
-  return features.includes(feature)
-    ? features.filter((f) => f !== feature)
-    : [...features, feature]
+/**
+ * Add or remove one value, so the chips toggle rather than only accumulate.
+ *
+ * One toggle for all three string facets — manufacturer, processor and feature
+ * (#919). What differs between them is what a SET of ticked values means, and
+ * that lives in `matchesFilter`, not here: OR for the single-valued facets,
+ * AND for features.
+ */
+export function toggleChip(values: readonly string[], value: string): string[] {
+  return values.includes(value) ? values.filter((v) => v !== value) : [...values, value]
 }
 
 /** Same toggle, typed for the runtime chips. */
@@ -230,6 +241,55 @@ export function toggleRuntime(
   return runtimes.includes(runtime)
     ? runtimes.filter((r) => r !== runtime)
     : [...runtimes, runtime]
+}
+
+// ---------------------------------------------------------------------------
+// The hover preview (#919)
+// ---------------------------------------------------------------------------
+
+/** The label {@link boardFacts} gives the address a board's firmware is written
+ *  at — named once, because the preview drops that row by name. */
+const FLASH_OFFSET_LABEL = 'Flash offset'
+
+/** How many rows the preview states before it stops being a preview. */
+export const PEEK_FACT_LIMIT = 4
+
+/**
+ * The facts the hover preview states, out of everything the details page does.
+ *
+ * The same list minus the flash offset, capped. The offset is an address, and
+ * the only question it answers — where does this binary go — is one the flasher
+ * answers for you; on a preview it is four hex digits in the way of the MCU and
+ * the memory, which are what tell two boards apart at a glance. The cap is what
+ * keeps the preview's height roughly known, which is what lets the gallery decide
+ * to open it upward or downward without measuring it first.
+ *
+ * Provenance is deliberately dropped too — a source is for a figure you are about
+ * to rely on, and this is a glance. The details page keeps every one of them.
+ */
+export function peekFacts(board: IndexedBoard): BoardFact[] {
+  return boardFacts(board)
+    .filter((f) => f.label !== FLASH_OFFSET_LABEL)
+    .slice(0, PEEK_FACT_LIMIT)
+    .map(({ label, value }) => ({ label, value }))
+}
+
+/**
+ * The firmware line the hover preview prints, in one string.
+ *
+ * The preview exists to answer "is this the board I want?" without a click, and
+ * the first thing that disqualifies a board is having nothing to flash — so it
+ * is said here rather than left to the details page. Variants are COUNTED rather
+ * than listed: that a board has a choice to make is the useful signal at a
+ * glance, and which one to make is exactly the judgement the details page (and
+ * upstream's own descriptions) exist for.
+ */
+export function firmwareSummary(board: IndexedBoard): string {
+  const chosen = defaultBuild(board)
+  if (!chosen) return 'No published firmware'
+  const variants = newestBuilds(board).length
+  const version = `MicroPython ${chosen.version}`
+  return variants > 1 ? `${version} · ${variants} builds` : version
 }
 
 /**

--- a/src/shared/board-index.ts
+++ b/src/shared/board-index.ts
@@ -311,8 +311,21 @@ export function newerIndex(a: BoardIndex | null, b: BoardIndex | null): BoardInd
 export interface BoardFilter {
   /** Free text over vendor, product, id and mcu. */
   text?: string
-  vendor?: string
-  mcu?: string
+  /**
+   * Makers to keep — ANY of them, not all (#919).
+   *
+   * This is the opposite of {@link features}, and deliberately so. A board has
+   * exactly ONE vendor, so intersecting two of them is empty by construction: an
+   * "Adafruit AND Pimoroni" chip pair could only ever return nothing, which is
+   * not a filter but a trap. A board's features are a SET, so "WiFi and BLE" is
+   * a question with answers. Same rule for {@link mcus}.
+   *
+   * So: OR within a facet whose value is single, AND across facets — ticking
+   * Adafruit and Pimoroni shows both makers, and adding WiFi then narrows that.
+   */
+  vendors?: string[]
+  /** Chip families to keep — ANY of them, for the same reason as {@link vendors}. */
+  mcus?: string[]
   /** Every one of these must be present — filters narrow, they do not widen. */
   features?: string[]
   /**
@@ -333,8 +346,10 @@ function norm(s: string): string {
 
 export function matchesFilter(board: IndexedBoard, filter: BoardFilter): boolean {
   if (filter.flashableOnly && board.builds.length === 0) return false
-  if (filter.vendor && board.vendor !== filter.vendor) return false
-  if (filter.mcu && board.mcu !== filter.mcu) return false
+  // Empty means "no opinion", not "match nothing" — a facet with nothing ticked
+  // must not hide the catalogue.
+  if (filter.vendors?.length && !filter.vendors.includes(board.vendor)) return false
+  if (filter.mcus?.length && !filter.mcus.includes(board.mcu)) return false
   for (const f of filter.features ?? []) {
     if (!board.features.includes(f)) return false
   }
@@ -356,28 +371,46 @@ export function filterBoards(boards: readonly IndexedBoard[], filter: BoardFilte
   return boards.filter((b) => matchesFilter(b, filter))
 }
 
-/** Distinct vendors present, sorted — the vendor filter's options. */
-export function vendorsOf(boards: readonly IndexedBoard[]): string[] {
-  return [...new Set(boards.map((b) => b.vendor).filter(Boolean))].sort((a, b) => a.localeCompare(b))
-}
-
-/** Distinct chip families present, sorted. */
-export function mcusOf(boards: readonly IndexedBoard[]): string[] {
-  return [...new Set(boards.map((b) => b.mcu).filter(Boolean))].sort((a, b) => a.localeCompare(b))
+/** One choice on a chip facet: the value, and how many boards carry it. */
+export interface FacetOption {
+  value: string
+  count: number
 }
 
 /**
- * Feature chips, commonest first.
+ * Distinct values, COMMONEST FIRST, ties alphabetical.
  *
- * Ordered by how many boards have them so the useful filters — WiFi, BLE — lead,
- * rather than an alphabetical list headed by `Audio Codec`.
+ * One order for every chip facet, because every one of them is now shown a few
+ * at a time with the rest behind a disclosure (#919) — and a collapsed head that
+ * is the first ten alphabetically is a list of curiosities, where a collapsed
+ * head that is the ten commonest is most people's board. It is the same argument
+ * that already ordered the feature chips: alphabetical would lead with `Audio
+ * Codec` and bury WiFi.
+ *
+ * The count travels with the value because it is what makes that order legible:
+ * without "43" beside ST Microelectronics, leading the list is arbitrary.
  */
-export function featuresOf(boards: readonly IndexedBoard[]): string[] {
+function rankOptions(values: Iterable<string>): FacetOption[] {
   const count = new Map<string, number>()
-  for (const b of boards) for (const f of b.features) count.set(f, (count.get(f) ?? 0) + 1)
+  for (const v of values) if (v) count.set(v, (count.get(v) ?? 0) + 1)
   return [...count.entries()]
     .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
-    .map(([f]) => f)
+    .map(([value, n]) => ({ value, count: n }))
+}
+
+/** The manufacturer chips — 54 of them, so most are behind "show more". */
+export function vendorOptions(boards: readonly IndexedBoard[]): FacetOption[] {
+  return rankOptions(boards.map((b) => b.vendor))
+}
+
+/** The processor chips. 41 chip families, and the top ten are two thirds of them. */
+export function mcuOptions(boards: readonly IndexedBoard[]): FacetOption[] {
+  return rankOptions(boards.map((b) => b.mcu))
+}
+
+/** The feature chips. */
+export function featureOptions(boards: readonly IndexedBoard[]): FacetOption[] {
+  return rankOptions(boards.flatMap((b) => b.features))
 }
 
 /**

--- a/test/boardFinder.test.ts
+++ b/test/boardFinder.test.ts
@@ -7,9 +7,11 @@ import {
   boardFacts,
   boardInitials,
   buildLabel,
+  firmwareSummary,
   isFiltering,
+  peekFacts,
   shelvesByVendor,
-  toggleFeature,
+  toggleChip,
   variantList
 } from '../src/renderer/src/components/board-finder'
 import {
@@ -153,17 +155,20 @@ describe('variantList', () => {
 })
 
 describe('the filter chips', () => {
-  it('lists vendor, mcu and every feature — but never the search text', () => {
+  it('lists every vendor, mcu and feature ticked — but never the search text', () => {
     // Free text has its own input with its own clear; a second control for the
     // same value is a control that can disagree with it.
     const chips = activeFilterChips({
-      vendor: 'Adafruit',
-      mcu: 'esp32s3',
+      vendors: ['Adafruit', 'Pimoroni'],
+      mcus: ['esp32s3'],
       features: ['WiFi', 'BLE'],
       text: 'feather'
     })
     expect(chips).toEqual([
       { axis: 'vendor', value: 'Adafruit' },
+      // Both makers, because both are ticked — a chip row that showed only the
+      // first would leave a filter nobody can see or take off again (#919).
+      { axis: 'vendor', value: 'Pimoroni' },
       { axis: 'mcu', value: 'esp32s3' },
       { axis: 'feature', value: 'WiFi' },
       { axis: 'feature', value: 'BLE' }
@@ -172,6 +177,8 @@ describe('the filter chips', () => {
 
   it('counts search text and the flashable toggle as filtering, though neither is a chip', () => {
     expect(isFiltering({})).toBe(false)
+    expect(isFiltering({ vendors: [], mcus: [] })).toBe(false)
+    expect(isFiltering({ vendors: ['Adafruit'] })).toBe(true)
     expect(isFiltering({ text: '  ' })).toBe(false)
     expect(isFiltering({ text: 'pico' })).toBe(true)
     expect(isFiltering({ flashableOnly: true })).toBe(true)
@@ -179,10 +186,65 @@ describe('the filter chips', () => {
   })
 })
 
-describe('toggleFeature', () => {
-  it('adds a feature that is off and removes one that is on', () => {
-    expect(toggleFeature([], 'WiFi')).toEqual(['WiFi'])
-    expect(toggleFeature(['WiFi', 'BLE'], 'WiFi')).toEqual(['BLE'])
+describe('toggleChip', () => {
+  it('adds a value that is off and removes one that is on', () => {
+    expect(toggleChip([], 'WiFi')).toEqual(['WiFi'])
+    expect(toggleChip(['WiFi', 'BLE'], 'WiFi')).toEqual(['BLE'])
+  })
+
+  it('is the same toggle for a manufacturer, since only the MEANING differs', () => {
+    expect(toggleChip(['Adafruit'], 'Pimoroni')).toEqual(['Adafruit', 'Pimoroni'])
+    expect(toggleChip(['Adafruit', 'Pimoroni'], 'Adafruit')).toEqual(['Pimoroni'])
+  })
+})
+
+describe('the hover preview (#919)', () => {
+  it('says what there is to flash, and counts variants rather than listing them', () => {
+    expect(firmwareSummary(board())).toBe('MicroPython 1.29.0')
+    expect(
+      firmwareSummary(
+        board({
+          builds: [
+            build(),
+            build({ build: 'RPI_PICO-RISCV', variant: 'RISCV', version: '1.29.0' })
+          ]
+        })
+      )
+    ).toBe('MicroPython 1.29.0 · 2 builds')
+  })
+
+  it('says so plainly when there is nothing to flash', () => {
+    // The one fact that disqualifies a board, and the reason the preview leads
+    // with this line rather than burying it.
+    expect(firmwareSummary(board({ builds: [] }))).toBe('No published firmware')
+  })
+
+  it('counts only the NEWEST version, not every build ever published', () => {
+    const b = board({
+      builds: [
+        build({ date: '20250101', version: '1.28.0' }),
+        build({ date: '20260824', version: '1.29.0' })
+      ]
+    })
+    expect(firmwareSummary(b)).toBe('MicroPython 1.29.0')
+  })
+
+  it('drops the flash offset, which is an address rather than a fact about the board', () => {
+    const facts = peekFacts(board({ flashOffset: '0x1000', port: 'esp32' }))
+    expect(facts.map((f) => f.label)).toEqual(['MCU', 'Port'])
+  })
+
+  it('states at most four rows, so the preview has a height the gallery can predict', () => {
+    const b = board({
+      port: 'esp32',
+      flashOffset: '0x1000',
+      flash: { bytes: 8 * 1024 * 1024, source: 'Adafruit', scope: 'board' },
+      ram: { bytes: 520 * 1024, source: 'Espressif datasheet', scope: 'chip' },
+      psram: { bytes: 2 * 1024 * 1024, source: 'Adafruit', scope: 'board' }
+    })
+    expect(peekFacts(b)).toHaveLength(4)
+    // And no provenance: a source is for a figure you are about to rely on.
+    expect(peekFacts(b).every((f) => f.source === undefined)).toBe(true)
   })
 })
 

--- a/test/boardIndex.test.ts
+++ b/test/boardIndex.test.ts
@@ -3,14 +3,14 @@ import { readFileSync } from 'node:fs'
 import {
   BOARD_INDEX_SCHEMA,
   defaultBuild,
-  featuresOf,
+  featureOptions,
   filterBoards,
   matchesFilter,
-  mcusOf,
+  mcuOptions,
   newerIndex,
   newestBuilds,
   parseBoardIndex,
-  vendorsOf,
+  vendorOptions,
   type BoardIndex,
   type IndexedBoard
 } from '../src/shared/board-index'
@@ -178,6 +178,39 @@ describe('filtering', () => {
     expect(filterBoards(boards, { features: ['WiFi', 'BLE'] }).map((b) => b.id)).toEqual(['B'])
   })
 
+  it('widens on manufacturer, because a board has only one (#919)', () => {
+    // The opposite of features, and the whole reason the two facets are not the
+    // same control underneath. Intersecting two makers is empty by
+    // construction, so "Adafruit AND LILYGO" could only ever return nothing —
+    // a chip pair that can only disappoint. Ticking both means both.
+    expect(filterBoards(boards, { vendors: ['Adafruit', 'LILYGO'] }).map((b) => b.id)).toEqual([
+      'A',
+      'D'
+    ])
+    expect(filterBoards(boards, { vendors: ['Adafruit'] }).map((b) => b.id)).toEqual(['A'])
+  })
+
+  it('widens on processor for the same reason', () => {
+    expect(filterBoards(boards, { mcus: ['rp2040', 'esp32s3'] }).map((b) => b.id)).toEqual([
+      'A',
+      'C'
+    ])
+  })
+
+  it('still narrows ACROSS facets, so a maker and a feature compound', () => {
+    // OR inside a facet, AND between them: LILYGO or Espressif, and of those
+    // only the ones with LoRa.
+    expect(
+      filterBoards(boards, { vendors: ['LILYGO', 'Espressif'], features: ['LoRa'] }).map(
+        (b) => b.id
+      )
+    ).toEqual(['D'])
+  })
+
+  it('treats an empty facet as no opinion rather than as no boards', () => {
+    expect(filterBoards(boards, { vendors: [], mcus: [] })).toHaveLength(4)
+  })
+
   it('matches text across vendor, product, id and mcu', () => {
     expect(filterBoards(boards, { text: 'lilygo' }).map((b) => b.id)).toEqual(['D'])
     expect(filterBoards(boards, { text: 'esp32s3' }).map((b) => b.id)).toEqual(['C'])
@@ -222,14 +255,32 @@ describe('the filter options', () => {
     board({ vendor: 'Espressif', mcu: 'esp32', features: ['WiFi', 'Camera'] })
   ]
 
-  it('lists each vendor and chip once, sorted', () => {
-    expect(vendorsOf(boards)).toEqual(['Adafruit', 'Espressif'])
-    expect(mcusOf(boards)).toEqual(['esp32', 'rp2040'])
+  it('lists each vendor and chip once, commonest first with its count (#919)', () => {
+    // Commonest-first is what makes a collapsed list of ten useful: the head is
+    // most people's board, where the first ten alphabetically are curiosities.
+    // The count travels with it because it is what makes that order legible.
+    expect(vendorOptions(boards)).toEqual([
+      { value: 'Espressif', count: 2 },
+      { value: 'Adafruit', count: 1 }
+    ])
+    expect(mcuOptions(boards)).toEqual([
+      { value: 'esp32', count: 2 },
+      { value: 'rp2040', count: 1 }
+    ])
+  })
+
+  it('breaks a tie alphabetically, so the order is stable between renders', () => {
+    const tied = [board({ vendor: 'Pimoroni' }), board({ vendor: 'Arduino' })]
+    expect(vendorOptions(tied).map((o) => o.value)).toEqual(['Arduino', 'Pimoroni'])
   })
 
   it('orders features commonest first, so the useful ones lead', () => {
     // Alphabetical would head the list with `Audio Codec` and bury WiFi.
-    expect(featuresOf(boards)).toEqual(['WiFi', 'BLE', 'Camera'])
+    expect(featureOptions(boards)).toEqual([
+      { value: 'WiFi', count: 3 },
+      { value: 'BLE', count: 1 },
+      { value: 'Camera', count: 1 }
+    ])
   })
 })
 
@@ -279,7 +330,7 @@ describe('the generated seed that actually ships', () => {
   })
 
   it('carries the boards Thonny’s catalogue does not', () => {
-    const vendors = vendorsOf(doc!.boards)
+    const vendors = vendorOptions(doc!.boards).map((o) => o.value)
     expect(vendors).toContain('Adafruit')
     expect(vendors.length).toBeGreaterThan(40)
   })


### PR DESCRIPTION
Five things the Board Finder was asked for in #919, and the reasoning each one turned on.

## A preview on the board you are resting on

Choosing between two boards meant opening one, reading it, going back, opening the other. Rest a pointer on a card and it grows, after 400 ms, into the same card with the rest of the answer on it: what there is to flash and how many builds, the MCU and port, the sourced flash/RAM figures, the features, and a **Details** button into the full page.

Three things keep it from pouncing:

- **the delay** — the timer is per card and dies on the way out, so a pointer crossing the grid on its way to the sidebar opens nothing behind it;
- **mouse only** — `pointerType` gates it, because a touch that "hovers" is a tap, and a tap already opens the full page;
- **`:focus-visible`, not focus** — a click focuses the card too, and a preview appearing between pointerdown and pointerup would take the pointerup for itself, leaving the click to land on the cell instead of the card. The board would simply never open. This one is worth knowing about before anyone simplifies it back to `onFocus={open}`.

It flips **above** the card on the bottom row rather than opening into the edge of the scroller, and it is the card's **sibling**, not its child — the card is a `<button>`, and a button inside a button is not markup a browser honours.

### Without a pointer

Keyboard focus opens the preview immediately (no timer — focus is deliberate in a way that a pointer passing over is not). Its **Details** button is the next tab stop after the card, and `Enter` on the card itself does exactly what that button does, so nothing in the preview is reachable only by hovering. Touch keeps the plain card and the tap that already worked. The preview animation respects `prefers-reduced-motion`; thumbnails keep `loading="lazy"`, and a board with `thumb: null` keeps its initials placeholder in the preview as well as on the card.

## An X, in the corner

The full board page had **← All boards** in the top left, which said what the gallery's own close says, in a different idiom and a different place. It is now the same control in the same corner. `Esc` still backs out one step (details first, then the gallery).

## Manufacturer and processor as chips, with show more / show less

They were dropdowns: one value at a time, the other 53 out of sight, and nothing on screen saying what the catalogue is made of. Both are now chip rows like Features, each chip carrying its board count, ordered commonest-first, with the tail behind a disclosure.

**Collapsed at ten**, because ten is where the head stops being a sample: the ten commonest makers are **135 of the 225** boards and the ten commonest chip families **155**, so most people's board is named before they open anything. The tail is makers of one or two boards each — a list to search rather than to scan, and the search box already matches on manufacturer. Features stay at eight, which is the count #893 already argued for.

The count on each chip is not decoration: it is what makes a non-alphabetical order legible. Without "43" beside ST Microelectronics, leading the list looks arbitrary.

## OR, not AND — the interesting half

Features narrow with **AND**, because a board's features are a *set*: "WiFi and BLE" is a question with answers.

A board has exactly **one** vendor and **one** mcu. Intersecting two of them is empty by construction — an "Adafruit AND Pimoroni" chip pair could only ever return nothing, which is not a filter but a trap. So:

> **OR within a single-valued facet, AND across facets.** Adafruit + Pimoroni shows both makers; adding WiFi then narrows that.

The rule lives in `matchesFilter` with its tests, not in the component, because on screen it is the same control either way — only the meaning differs, and the meaning is the part that can be wrong.

## Dark in both skins — a reversal, and the right one

The gallery was deliberately built to take every colour from the theme tokens, unlike `PartCatalog.css`. That was wrong for this one panel, for a reason visible only from inside its container: **it opens from a button in the flash dialog**, and that dialog has been deliberately dark in both skins since #14, precisely because the parchment skin's `--text` is near-black on a near-black panel. Following the skin made the gallery the odd one out inside the very thing that launches it — a parchment sheet unrolling out of a dark modal.

It is also what the gallery is *for*: 217 product photographs, nearly all shot on white, are one beige field on parchment and 217 lit objects on a dark ground.

So the palette is now the gallery's own `--bf-*` tokens, holding literally the Soft Shell **dark** skin's values (copied, not referenced, so the skeuomorph skin cannot repaint them), and `BoardFinder.css` opens with a note in the style of `FirmwareFlasher.css` saying why — so the next tidy-up does not "fix" it back to tokens. Structural tokens (`--radius`, `--font-ui`, `--font-mono`) stay as tokens: theme intent, not foreground colour. `z-index: 1150` and its comment are untouched — above the flash dialog's overlay (1100), below the transfer dialog (1250).

One thing fixed on the way: the Flash button no longer takes `--goldink` on `--grad-gold`. That pairing is the app's convention, but the gradient is identical in both skins while `--goldink` is *pale gold* in the dark one — pale text on a pale button. The gallery's ink is the dark brass instead.

## Tests

`board-index.ts` gains the multi-select shape and ranked `{value, count}` facet options; the gallery's own decisions — which facts the preview states, and its firmware line — live in `board-finder.ts`. Both are pure, so all of it is node unit tests rather than assertions about JSX.

**Each new test was checked by breaking the thing it covers, and restored:**

| broken | fails |
| --- | --- |
| `vendors` intersected instead of unioned | *widens on manufacturer* + *narrows ACROSS facets* |
| facet options sorted alphabetically | *commonest first with its count* + *orders features commonest first* |
| preview keeps the flash offset | *drops the flash offset* |
| firmware line counts every build ever published | *counts only the NEWEST version* |

Also verified by rendering the real CSS in headless Chromium — the gallery with a preview open, and the full board page with its new X.

## The shared seam

I did have to touch `src/shared/board-index.ts`, which the board-index agent is also in: `BoardFilter.vendor`/`mcu` (strings) became `vendors`/`mcus` (arrays), `matchesFilter` gained the OR clauses, and `vendorsOf`/`mcusOf`/`featuresOf` became `vendorOptions`/`mcuOptions`/`featureOptions` returning `{value, count}` ranked commonest-first. That is the whole of my diff in that file — nothing near parsing, sizes or provenance. `BoardFinder.tsx` is heavily changed, so a storage/RAM filter landing there will want a careful merge.

## Found, not fixed

- The `--goldink` on `--grad-gold` pairing is pale-on-pale in the dark theme wherever else it is used — `WorkspaceSwitcher.css` (active workspace tab), `RobotDockPanel.css` (CTA), `PartsPanel.css` (update badge). Fixed locally in the gallery only; the app-wide version is somebody's issue to file.
- The board index has duplicate chip families differing by case — `ra6m5` and `RA6M5` are both in `boards.json`, so they appear as two processor chips of one board each. That is generator/data territory (`scripts/build-board-index.mjs`), which another agent is in, so I left it alone.

## Gates

`npm run lint` (only the pre-existing `DriverInstallBanner.tsx` warning) · `npm run typecheck` · `npm test` (305 files, 6294 tests) · `npm run build` — all green. `CHANGELOG.md` updated under `[Unreleased]`; `package.json` untouched.

Closes #919.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe
