### PR TITLE
feat(boards): sizes for almost every board, and a memory filter (#897)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,43 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   tap that already opened the full page; a keyboard gets the preview on focus,
   with its Details button as the next stop and Enter on the card doing the same
   thing. Nothing in it is reachable only by hovering.
+- **Sizes for almost every board, and a memory filter that earns its place**
+  (#897). The board index could attribute a flash size for 10 boards of 230 and
+  a RAM size for 86, so both were shown as facts and neither was offered as a
+  filter. Now **187 boards have a flash figure and 226 have a RAM one**, and
+  every one still names its source.
+
+  Most of that came from reading what MicroPython already publishes NEXT to
+  `board.json` — the build configuration each board needs in order to compile at
+  all, which is a better citation than a product page because it is what the
+  firmware people flash was built against. A Teensy 4.1's `mpconfigboard.mk`
+  states its 8 MB QSPI part; an nRF52832 board's makefile names the memory map it
+  links against, which is the only thing that separates the 512 KB part from the
+  256 KB one; an RP2040 board's config names a pico-sdk board header — and that
+  is read at the revision MicroPython PINS, which is how the XIAO RP2350 gets
+  Seeed's 2 MB rather than a later SDK's 4 MB. Chip part numbers then go to the
+  silicon vendor's datasheet, and the rest is curation from the makers' own
+  pages, vendor by vendor.
+
+  A board that carries flash in TWO places now says so in both: a Feather M0
+  Express reads "Flash 256 KB (the chip's internal flash)" and "External flash
+  2 MB", where before a chip figure would have suppressed the note about the
+  SPI chip entirely.
+
+  **Memory** is a filter now — `≥ 32 KB` through `≥ 1 MB` — because 226 of 230
+  boards can answer it and it says something the processor dropdown cannot:
+  `stm32f4` runs from 96 KB to 384 KB, `mimxrt` from 128 KB to 2 MB. The four
+  boards with no published figure are **counted and named under the control**
+  rather than quietly dropped. **Storage is still not a filter**, and no longer
+  for want of numbers: 107 of those flash figures are the flash inside the
+  microcontroller and 80 are the chip on the module, which are not the same
+  quantity to rank boards by — and every `ESP32_GENERIC` entry is missing one,
+  because its size belongs to whichever module the buyer has.
+
+  Boards where the sources genuinely disagree say nothing and record why: the
+  Werkzeug's flash changed size in March 2025, the wESP32's changed at revision
+  7, and upstream's `FEATHER52` links one Adafruit product while building for
+  another.
 - **The boards MicroPython does not build for, and where the numbers come from**
   (#902, #897). The Board Finder had 15 Adafruit boards and not one Adafruit
   ESP32 board, because MicroPython publishes no firmware under any of those
@@ -103,13 +140,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
   And boards now state their **flash, RAM and PSRAM** — each naming where the
   figure came from, because upstream publishes none of them and a number nobody
-  can check is not worth showing. 86 boards have a RAM figure (their chip's
-  SRAM, marked as the chip's rather than the board's) and 10 have a flash figure,
-  from the maker's own documentation. The rest say nothing rather than guessing:
-  an `stm32f4` spans 96 KB to 256 KB of SRAM, and a wrong flash size sends
-  someone to a board that cannot hold their program. Storage and memory still are
-  not filters at that coverage — a size control would hide the catalogue rather
-  than narrow it.
+  can check is not worth showing. Anything that could not be attributed says
+  nothing rather than guessing: an `stm32f4` spans 96 KB to 256 KB of SRAM, and a
+  wrong flash size sends someone to a board that cannot hold their program.
 
 - **A Board Finder, and the firmware picker finally knows every board** (#893).
   The picker showed Thonny's catalogue, which lists no Adafruit boards at all

--- a/scripts/board-config.mjs
+++ b/scripts/board-config.mjs
@@ -1,0 +1,299 @@
+/**
+ * READING SIZES OUT OF MICROPYTHON'S OWN PER-BOARD BUILD CONFIGURATION (#897).
+ * =============================================================================
+ *
+ * `board.json` publishes no flash size and no RAM size — but the files BESIDE it
+ * often do, because the firmware cannot be built without them. `ports/mimxrt/
+ * boards/TEENSY41/mpconfigboard.mk` says `MICROPY_HW_FLASH_SIZE = 0x800000`
+ * because that is the QSPI part on the board; `ports/rp2/boards/SEEED_XIAO_RP2350
+ * /mpconfigboard.cmake` names a pico-sdk board whose header states the same thing.
+ * Those are better than a product page: they are what the firmware people
+ * actually flash was compiled against, and they cite a path anyone can open.
+ *
+ * SO THIS IS SEVERAL SMALL READERS, ONE PER PORT — NOT ONE PARSER.
+ * Each port answers a different question in a different file, and the ways they
+ * go wrong are different too. A single "find a number that looks like a size"
+ * pass over all of them would find plenty, and some of them would be lies:
+ *
+ *   - **rp2** — see {@link readRp2}. `MICROPY_HW_FLASH_STORAGE_BYTES` is the
+ *     FILESYSTEM partition, not the part (RPI_PICO reports 1441792 on a 2 MB
+ *     chip), and half these boards borrow another board's pico-sdk header.
+ *   - **stm32 / nrf / samd / renesas-ra** — the file names the CHIP, not a size.
+ *     The size then comes from the silicon vendor's datasheet, via
+ *     `MCU_MEMORY` in `board-specs.mjs`.
+ *   - **esp32** — almost nothing. Three boards of the 45 set a flash size; the
+ *     rest inherit shared `sdkconfig` fragments that do not mention one.
+ *   - **mimxrt** — the one port where the board file states the external flash
+ *     outright, because there is no internal flash to fall back on.
+ *
+ * Pure text-in, facts-out, so `test/boardSpecs.test.ts` feeds them the awkward
+ * real files rather than diffing generated output.
+ */
+
+/** Which files this port's reader wants, relative to the board's directory. */
+export const PORT_CONFIG_FILES = {
+  stm32: ['mpconfigboard.h', 'mpconfigboard.mk'],
+  nrf: ['mpconfigboard.mk'],
+  samd: ['mpconfigboard.mk'],
+  'renesas-ra': ['mpconfigboard.h'],
+  mimxrt: ['mpconfigboard.mk'],
+  esp32: ['sdkconfig.board'],
+  rp2: ['mpconfigboard.cmake']
+}
+
+/**
+ * A C/CMake/Make size expression as bytes: `(8 * 1024 * 1024)`, `0x800000`, `16`.
+ *
+ * Deliberately arithmetic-only and deliberately tiny. Anything with a symbol in
+ * it — `PICO_FLASH_SIZE_BYTES - (1024 * 1024)`, which several boards write —
+ * returns null rather than being resolved, because resolving it means knowing
+ * what the symbol was, and being wrong about that is how you publish a firmware
+ * reservation as a flash size.
+ */
+export function sizeExpression(text) {
+  const s = String(text ?? '')
+    .replace(/\/\*.*?\*\//g, '')
+    .replace(/\/\/.*$/, '')
+    .replace(/#.*$/, '')
+    .trim()
+  if (!s || !/^[-+*()\s\w]+$/.test(s)) return null
+  // A bare identifier, or any letter that is not part of a hex literal, means a
+  // symbol we cannot resolve here.
+  if (/[g-wyzG-WYZ]/.test(s.replace(/0[xX][0-9a-fA-F]+/g, ''))) return null
+  let total = 0
+  for (const term of s.replace(/[()]/g, '').split('+')) {
+    if (term.includes('-')) return null
+    let product = 1
+    for (const factor of term.split('*')) {
+      const n = Number(factor.trim())
+      if (!Number.isFinite(n)) return null
+      product *= n
+    }
+    total += product
+  }
+  return Number.isSafeInteger(total) && total > 0 ? total : null
+}
+
+const line = (text, re) => re.exec(text ?? '')?.[1]?.trim() ?? null
+
+/**
+ * The chip an stm32 board carries, said twice.
+ *
+ * `mpconfigboard.h`'s `MICROPY_HW_MCU_NAME` is the BOARD's statement and the
+ * `.mk`'s `CMSIS_MCU` is the BUILD's, and neither is reliably the better one:
+ *
+ *   - the Espruino Pico builds with `STM32F401xE` and names itself
+ *     `STM32F401CD`, which is the part it actually has — 384 KB of flash, not
+ *     the 512 KB the build's memory map allows for. The board wins.
+ *   - the HydraBus builds with `STM32F405xx` and names itself `STM32F4`, which
+ *     is not a part at all. The build wins.
+ *
+ * So both are reported and the caller tries them in order — a name that is too
+ * vague to be in the memory table simply falls through to the other one, which
+ * is the same "say nothing rather than guess" rule one level down.
+ */
+export function readStm32(files) {
+  return {
+    part: line(files['mpconfigboard.h'], /MICROPY_HW_MCU_NAME\s+"([^"]+)"/),
+    partAlso: line(files['mpconfigboard.mk'], /^CMSIS_MCU\s*=\s*(\S+)/m)
+  }
+}
+
+/** Renesas names the chip in the same place, and has no `CMSIS_MCU` fallback. */
+export function readRenesasRa(files) {
+  return { part: line(files['mpconfigboard.h'], /MICROPY_HW_MCU_NAME\s+"([^"]+)"/) }
+}
+
+/** SAM D names the exact part, ordering suffix and all: `SAMD51J19A`. */
+export function readSamd(files) {
+  return { part: line(files['mpconfigboard.mk'], /^CMSIS_MCU\s*=\s*(\S+)/m) }
+}
+
+/** A linker-script size: `512K`, `1M`, `0x80000`, `262144`. */
+export function linkerSize(text) {
+  const m = /^\s*(0[xX][0-9a-fA-F]+|\d+)\s*([KMG])?\s*$/.exec(String(text ?? ''))
+  if (!m) return null
+  const scale = { K: 1024, M: 1024 * 1024, G: 1024 * 1024 * 1024 }[m[2]] ?? 1
+  const n = Number(m[1]) * scale
+  return Number.isSafeInteger(n) && n > 0 ? n : null
+}
+
+/** The top-level `boards/*.ld` scripts an nrf board's makefile pulls in. */
+export function nrfMemoryScriptsFor(files) {
+  const out = []
+  for (const m of (files['mpconfigboard.mk'] ?? '').matchAll(/boards\/([A-Za-z0-9_.]+\.ld)\b/g)) {
+    if (!out.includes(m[1])) out.push(m[1])
+  }
+  return out
+}
+
+/**
+ * Nordic: the sub-variant, and the memory map the board is actually linked for.
+ *
+ * `MCU_SUB_VARIANT` alone is not a part. `nrf52832` is sold as the 512 KB/64 KB
+ * QFAA and the 256 KB/32 KB QFAB — a factor of two apart on both axes — and
+ * `nrf51822` has three configurations. On the strength of that name, 22 of the
+ * 23 nrf boards would have to say nothing at all.
+ *
+ * They do not have to, because each board's makefile names the memory map it
+ * links against: `LD_FILES += boards/nrf52832_512k_64k.ld`, whose first two
+ * lines are `_flash_size = 512K;` and `_ram_size = 64K;`. That is a statement
+ * about THIS board — a 512 KB image will not fit a QFAB, so a board built this
+ * way carries the QFAA — and it is one file away for anyone checking.
+ *
+ * Only a script defining BOTH sizes counts, which is what separates the memory
+ * map from the bootloader and softdevice scripts listed beside it; and only if
+ * exactly one does, so a board pulling in two never has one picked for it.
+ */
+export function readNrf(files, { boardId, nrfScripts = {} } = {}) {
+  const part = line(files['mpconfigboard.mk'], /^MCU_SUB_VARIANT\s*=\s*(\S+)/m)
+  const found = []
+  for (const [name, text] of Object.entries(nrfScripts)) {
+    const flash = linkerSize(line(text, /^\s*_flash_size\s*=\s*([^;]+);/m))
+    const sram = linkerSize(line(text, /^\s*_ram_size\s*=\s*([^;]+);/m))
+    if (flash && sram) found.push({ flash, sram, source: `MicroPython ports/nrf/boards/${name}` })
+  }
+  if (found.length !== 1) return { part }
+  return { part, chipMemory: found[0], nrfSubVariant: part, boardId }
+}
+
+/**
+ * i.MX RT: the one port that states its own sizes.
+ *
+ * These chips have no usable internal flash, so the board file has to name the
+ * QSPI part's size for the firmware to link at all — which makes
+ * `MICROPY_HW_FLASH_SIZE` a statement about THIS board's flash chip, not a
+ * partition and not a family default. `MICROPY_HW_SDRAM_SIZE` is the same for
+ * external SDRAM where the board has any.
+ */
+export function readMimxrt(files, { boardId } = {}) {
+  const mk = files['mpconfigboard.mk']
+  const at = `MicroPython ports/mimxrt/boards/${boardId}/mpconfigboard.mk`
+  const flash = sizeExpression(line(mk, /^MICROPY_HW_FLASH_SIZE\s*\??=\s*(.+)$/m))
+  const externalRam = sizeExpression(line(mk, /^MICROPY_HW_SDRAM_SIZE\s*\??=\s*(.+)$/m))
+  return {
+    part: line(mk, /^MCU_SERIES\s*=\s*(\S+)/m),
+    flash,
+    flashSource: flash ? `${at} (MICROPY_HW_FLASH_SIZE)` : null,
+    externalRam,
+    externalRamSource: externalRam ? `${at} (MICROPY_HW_SDRAM_SIZE)` : null
+  }
+}
+
+/**
+ * esp32: the little that `sdkconfig.board` says.
+ *
+ * Three of the 45 esp32 boards set `CONFIG_ESPTOOLPY_FLASHSIZE_<n>MB=y`; the
+ * rest inherit shared fragments that set no size, so there is nothing per-board
+ * to read and this returns null for them. That is the honest answer — the size
+ * for those comes from the maker's page or not at all.
+ *
+ * The `=y` matters: boards that list the other sizes commented out or empty
+ * (`CONFIG_ESPTOOLPY_FLASHSIZE_4MB=`) are saying which one is NOT selected.
+ */
+export function readEsp32(files, { boardId } = {}) {
+  const m = /^CONFIG_ESPTOOLPY_FLASHSIZE_(\d+)MB=y\s*$/m.exec(files['sdkconfig.board'] ?? '')
+  if (!m) return { flash: null, flashSource: null }
+  return {
+    flash: Number(m[1]) * 1024 * 1024,
+    flashSource: `MicroPython ports/esp32/boards/${boardId}/sdkconfig.board (CONFIG_ESPTOOLPY_FLASHSIZE)`
+  }
+}
+
+/** Case- and separator-insensitive, so `weact_studio_rp2350b_core` meets `WEACTSTUDIO_RP2350B_CORE`. */
+const norm = (s) => (s ?? '').toLowerCase().replace(/[^a-z0-9]+/g, '')
+
+/**
+ * What an rp2 board's `mpconfigboard.cmake` says about its flash — carefully.
+ *
+ * The RP2040 and RP2350 have no internal flash at all, so the size is entirely a
+ * property of the module, and pico-sdk's board headers state it as
+ * `PICO_FLASH_SIZE_BYTES`. That is Raspberry Pi publishing a figure about
+ * somebody's board, which is as good a source as the maker's own page.
+ *
+ * THE TRAP, and the reason this is fifty lines rather than five: MicroPython
+ * frequently points a board at ANOTHER board's header, because it only needs the
+ * pin definitions to be close enough. `CYTRON_MOTION_2350_PRO` sets
+ * `PICO_BOARD "pico2"`, and `W5500_EVB_PICO` sets the W5100S board's header.
+ * Reading the flash size out of those gives you Raspberry Pi's figure for a
+ * Raspberry Pi board, correctly, about the wrong board.
+ *
+ * So a header only counts when it is THIS board's:
+ *
+ *   1. the board's own `mpconfigboard.cmake` sets `PICO_FLASH_SIZE_BYTES`
+ *      outright — nobody writes that about someone else's board;
+ *   2. the header is shipped inside the board's own directory in MicroPython's
+ *      tree — same argument;
+ *   3. the pico-sdk header's name IS this board's name, ignoring case and
+ *      punctuation.
+ *
+ * Anything else returns null and falls through to curation. `RPI_PICO` → `pico`
+ * fails rule 3 and that is fine: the Picos are curated from raspberrypi.com,
+ * which is a better citation than a header anyway, and the two agree.
+ *
+ * Returns the claim plus WHERE it came from, because the caller has to print
+ * that beside the number.
+ */
+export function readRp2(files, { boardId, ownHeaders = {}, picoSdkHeaders = {} } = {}) {
+  const cmake = files['mpconfigboard.cmake'] ?? ''
+  const picoBoard = line(cmake, /set\(\s*PICO_BOARD\s+"?([A-Za-z0-9_]+)"?\s*\)/)
+  const storage = sizeExpression(line(cmake, /set\(\s*MICROPY_HW_FLASH_STORAGE_BYTES\s+(\d+)\s*\)/))
+
+  let flash = sizeExpression(line(cmake, /set\(\s*PICO_FLASH_SIZE_BYTES\s+([^)]+)\)/))
+  let from = flash ? `MicroPython ports/rp2/boards/${boardId}/mpconfigboard.cmake` : null
+
+  if (!flash) {
+    for (const [name, text] of Object.entries(ownHeaders)) {
+      const size = sizeExpression(line(text, /#define\s+PICO_FLASH_SIZE_BYTES\s+(.+)$/m))
+      if (size) {
+        flash = size
+        from = `MicroPython ports/rp2/boards/${boardId}/${name}`
+        break
+      }
+    }
+  }
+  if (!flash && picoBoard && norm(picoBoard) === norm(boardId)) {
+    const size = sizeExpression(
+      line(picoSdkHeaders[picoBoard], /#define\s+PICO_FLASH_SIZE_BYTES\s+(.+)$/m)
+    )
+    if (size) {
+      flash = size
+      from = `Raspberry Pi pico-sdk src/boards/include/boards/${picoBoard}.h`
+    }
+  }
+
+  // A last guard that costs nothing: the filesystem cannot be bigger than the
+  // flash it lives in. If it is, the header has been paired with the wrong
+  // board and the number is not about this one.
+  if (flash && storage && storage >= flash) return { flash: null, flashSource: null, picoBoard }
+
+  return { flash, flashSource: flash ? `${from} (PICO_FLASH_SIZE_BYTES)` : null, picoBoard }
+}
+
+/** The pico-sdk header this board would need fetching, or null. */
+export function picoSdkBoardFor(files, boardId) {
+  const picoBoard = line(files['mpconfigboard.cmake'] ?? '', /set\(\s*PICO_BOARD\s+"?([A-Za-z0-9_]+)"?\s*\)/)
+  return picoBoard && norm(picoBoard) === norm(boardId) ? picoBoard : null
+}
+
+/** Dispatch to the right reader. Ports with no reader simply say nothing. */
+export function readBoardConfig(port, files, options = {}) {
+  switch (port) {
+    case 'stm32':
+      return readStm32(files)
+    case 'renesas-ra':
+      return readRenesasRa(files)
+    case 'samd':
+      return readSamd(files)
+    case 'nrf':
+      return readNrf(files, options)
+    case 'mimxrt':
+      return readMimxrt(files, options)
+    case 'esp32':
+      return readEsp32(files, options)
+    case 'rp2':
+      return readRp2(files, options)
+    default:
+      return {}
+  }
+}

--- a/scripts/board-specs.mjs
+++ b/scripts/board-specs.mjs
@@ -8,7 +8,7 @@
  * have. This module is the answer to "then where did that number come from?",
  * and every figure it emits carries a `source` saying so.
  *
- * THREE SOURCES, IN DESCENDING ORDER OF COVERAGE AND ASCENDING ORDER OF EFFORT:
+ * FOUR SOURCES, IN DESCENDING ORDER OF COVERAGE AND ASCENDING ORDER OF EFFORT:
  *
  *  1. **The chip's own SRAM**, from `mcu`. Exact, free, and correct for every
  *     part in the family — but it is the CHIP's figure, so it is marked
@@ -21,14 +21,37 @@
  *     same story. Those are ABSENT rather than averaged — a plausible wrong
  *     number is worse than a blank, because a blank gets checked.
  *
- *  2. **Curated boards**, where a maker's page or upstream's own build
- *     configuration states it outright. Small on purpose.
+ *  2. **The exact chip, where upstream's build config names one** — {@link
+ *     CHIP_MEMORY}, read by `board-config.mjs`. This is what raised #897 from
+ *     "five boards have a flash size" to most of the catalogue: `ports/stm32/
+ *     boards/NUCLEO_F401RE/mpconfigboard.h` says `STM32F401xE`, and ST says that
+ *     part has 512 KB of flash and 96 KB of SRAM. On every port whose MCU has
+ *     internal flash — stm32, nrf, samd, renesas-ra — the flash IS the chip's,
+ *     so naming the chip names the flash.
  *
- *  3. **The manufacturer `url` each board already carries.** That is the
- *     authoritative source for the rest and it is per-vendor work with a review
- *     step, not one parser: those pages have no common structure, and guessing
- *     sends someone to a board that cannot hold their program. Left to a
- *     follow-up, with the count of boards still unknown reported by the run.
+ *     Same rule as (1) about ambiguity, one level finer: a key that does not pin
+ *     the memory down is absent rather than averaged. `nrf52832` ships in two
+ *     memory configurations, so it has an SRAM figure and no flash figure.
+ *
+ *  3. **Sizes upstream states outright**, also via `board-config.mjs` — i.MX RT's
+ *     `MICROPY_HW_FLASH_SIZE`, esp32's `CONFIG_ESPTOOLPY_FLASHSIZE`, rp2's
+ *     pico-sdk board headers. Only on the ports whose parts have no internal
+ *     flash, which is exactly why those ports have to say it.
+ *
+ *  4. **Curated boards** — {@link CURATED_BOARDS} — from the manufacturer `url`
+ *     each board already carries. Per-vendor work with a review step, not one
+ *     parser: those pages have no common structure, and guessing sends someone
+ *     to a board that cannot hold their program. This table holds what the first
+ *     three cannot reach: every ESP32 module's flash, the second flash chip so
+ *     many boards add beside the MCU, and PSRAM sizes.
+ *
+ * WHERE THEY DISAGREE. They mostly do not, and the agreement is worth having:
+ * upstream's pinned pico-sdk, SparkFun's product pages and SparkFun's own docs
+ * independently give the same 16 MB for six RP2350 boards. Where a curated
+ * figure and a derived one would collide, the DERIVED one wins and the curated
+ * entry is deleted rather than left to shadow it — a table that silently
+ * overrides a mechanically-refreshed figure is a table that goes stale in
+ * secret. What curation adds is the fields nothing else publishes.
  *
  * A NOTE ON WHAT LOOKS LIKE A SHORTCUT AND IS NOT. `ports/rp2/boards/<BOARD>/
  * mpconfigboard.cmake` carries `MICROPY_HW_FLASH_STORAGE_BYTES`, which is
@@ -37,7 +60,7 @@
  * one, with the arithmetic in a comment. Deriving flash from it means guessing
  * the firmware reservation, which varies. Likewise `ports/esp32/boards/<BOARD>/
  * sdkconfig.board` mostly does not set a flash size at all — the boards inherit
- * shared `sdkconfig` fragments — so there is no per-board figure to read.
+ * shared `sdkconfig` fragments — so 3 of the 45 esp32 boards have one to read.
  *
  * Kept as `.mjs` beside the generator that uses it, and pure, so `test/
  * boardSpecs.test.ts` exercises the tables directly rather than diffing output.
@@ -62,10 +85,297 @@ export const MCU_SRAM = {
   esp32c3: { bytes: 400 * KiB, source: 'Espressif ESP32-C3 datasheet' },
   esp32c5: { bytes: 384 * KiB, source: 'Espressif ESP32-C5 datasheet (HP SRAM)' },
   esp32c6: { bytes: 512 * KiB, source: 'Espressif ESP32-C6 datasheet (HP SRAM)' },
+  esp32h2: { bytes: 320 * KiB, source: 'Espressif ESP32-H2 datasheet (HP SRAM)' },
   esp32p4: { bytes: 768 * KiB, source: 'Espressif ESP32-P4 datasheet (HP SRAM)' }
-  // esp32h2 and esp8266 are deliberately absent: the published figures for both
-  // disagree with each other often enough that I could not name one and stand
-  // behind it. Two boards and one board respectively — not worth a wrong number.
+  // esp8266 is deliberately absent, and now for a reason rather than a doubt:
+  // Espressif's current datasheet states no total RAM figure at all. The only
+  // quantity it gives is software-dependent — "RAM size < 50 kB … according to
+  // our current version of SDK … under the Station mode" — and the 32K/80K split
+  // everyone quotes traces to a dead BBS wiki page, not to any Espressif
+  // document. One board, and no honest number to put on it.
+  //
+  // esp32h2 was absent for the same doubt and is now here: the datasheet and the
+  // technical reference manual agree at 320 KB HP SRAM, and differ only in
+  // whether they add the 4 KB of LP memory, which is listed on its own line.
+}
+
+/**
+ * Flash and SRAM for an exact chip, from the silicon vendor's own datasheet.
+ *
+ * Keyed by the string upstream's build configuration writes, so a reader can go
+ * from `ports/stm32/boards/NUCLEO_F401RE/mpconfigboard.h` to a row here without
+ * a translation step. Upstream writes the same part several ways — `STM32F405RG`
+ * in one board's header and `STM32F405xx` in another's makefile — so both appear
+ * as keys, and `board-config.mjs` hands over both for the lookup to try in turn.
+ *
+ * FLASH IS `chip` SCOPE HERE, and that is the point. On these parts it is on the
+ * die, so it is a fact about every board carrying one — and a board may well add
+ * a second flash chip beside it, which is `externalFlash` and is nothing to do
+ * with this table.
+ *
+ * A KEY THAT DOES NOT PIN THE MEMORY DOWN CARRIES NO `flash`:
+ *
+ *   - `nrf52832` is sold as the 512 KB/64 KB QFAA and the 256 KB/32 KB QFAB, so
+ *     it has an SRAM figure only — and `nrf51822`, worse, spans three.
+ *   - `STM32F407` names four parts between 512 KB and 1 MB; its SRAM is 192 KB
+ *     on all of them. Same for `STM32F413`, `STM32F429`, `STM32F746`.
+ *
+ * Those rows are the ones most likely to be "improved" by somebody filling in a
+ * plausible number. They are blank on purpose. Where the BOARD settles it,
+ * {@link BOARD_MCU_PART} names the exact part instead.
+ */
+export const CHIP_MEMORY = {
+  // --- ST, exact parts -----------------------------------------------------
+  // Figures from ST's own STM32CubeMX MCU database (STMicroelectronics/
+  // STM32_open_pin_data, which is what CubeMX ships), cross-checked region by
+  // region against Zephyr's device trees — the address-mapped breakdown is the
+  // only way to add these up safely, because CubeMX's own `<Ram>` field means
+  // different things in different families: on the F405 it EXCLUDES the 64 KB
+  // CCM, on the F746 it INCLUDES the 64 KB DTCM, and on the H723 it includes
+  // the TCM and the backup RAM both.
+  //
+  // TWO THINGS ARE EXCLUDED THROUGHOUT, and the same way every time:
+  //   - backup SRAM (4 KB on most F4/F7/H7, 2 KB on U5). It is a separate power
+  //     domain and nobody's program lives in it.
+  //   - the F7 family's 16 KB instruction TCM. ST's own headline leaves it out
+  //     ("320 Kbytes … + 16 Kbytes of instruction TCM RAM"), MicroPython puts
+  //     nothing in it, and counting it would make every F7 board look 16 KB
+  //     roomier than it is.
+  // The H7's TCM is NOT excluded, because ST counts it in its own headline
+  // ("up to 1 Mbyte of RAM … including 192 Kbytes of TCM RAM").
+  STM32F091RC: { flash: 256 * KiB, sram: 32 * KiB, source: 'ST STM32F091RC (CubeMX MCU database)' },
+  STM32F091xC: { flash: 256 * KiB, sram: 32 * KiB, source: 'ST STM32F091xC (CubeMX MCU database)' },
+  STM32F401CD: { flash: 384 * KiB, sram: 96 * KiB, source: 'ST STM32F401CD (CubeMX MCU database)' },
+  STM32F401RE: { flash: 512 * KiB, sram: 96 * KiB, source: 'ST STM32F401RE (CubeMX MCU database)' },
+  STM32F401xE: { flash: 512 * KiB, sram: 96 * KiB, source: 'ST STM32F401xE (CubeMX MCU database)' },
+  STM32F405RG: { flash: 1 * MiB, sram: 192 * KiB, source: 'ST STM32F405RG (CubeMX MCU database)' },
+  STM32F405xx: { flash: 1 * MiB, sram: 192 * KiB, source: 'ST STM32F405 (CubeMX MCU database)' },
+  STM32F407VE: { flash: 512 * KiB, sram: 192 * KiB, source: 'ST STM32F407VE (CubeMX MCU database)' },
+  STM32F407VG: { flash: 1 * MiB, sram: 192 * KiB, source: 'ST STM32F407VG (CubeMX MCU database)' },
+  STM32F407ZG: { flash: 1 * MiB, sram: 192 * KiB, source: 'ST STM32F407ZG (CubeMX MCU database)' },
+  STM32F411CE: { flash: 512 * KiB, sram: 128 * KiB, source: 'ST STM32F411CE (CubeMX MCU database)' },
+  STM32F411RE: { flash: 512 * KiB, sram: 128 * KiB, source: 'ST STM32F411RE (CubeMX MCU database)' },
+  STM32F411xE: { flash: 512 * KiB, sram: 128 * KiB, source: 'ST STM32F411xE (CubeMX MCU database)' },
+  STM32F412RE: { flash: 512 * KiB, sram: 256 * KiB, source: 'ST STM32F412RE (CubeMX MCU database)' },
+  STM32F412ZG: { flash: 1 * MiB, sram: 256 * KiB, source: 'ST STM32F412ZG (CubeMX MCU database)' },
+  STM32F413ZH: { flash: 1536 * KiB, sram: 320 * KiB, source: 'ST STM32F413ZH (CubeMX MCU database)' },
+  STM32F427VI: { flash: 2 * MiB, sram: 256 * KiB, source: 'ST STM32F427VI (CubeMX MCU database)' },
+  STM32F429ZG: { flash: 1 * MiB, sram: 256 * KiB, source: 'ST STM32F429ZG (CubeMX MCU database)' },
+  STM32F429ZI: { flash: 2 * MiB, sram: 256 * KiB, source: 'ST STM32F429ZI (CubeMX MCU database)' },
+  STM32F439ZI: { flash: 2 * MiB, sram: 256 * KiB, source: 'ST STM32F439ZI (CubeMX MCU database)' },
+  STM32F446RE: { flash: 512 * KiB, sram: 128 * KiB, source: 'ST STM32F446RE (CubeMX MCU database)' },
+  STM32F469NI: { flash: 2 * MiB, sram: 384 * KiB, source: 'ST STM32F469NI (CubeMX MCU database)' },
+  STM32F722IE: { flash: 512 * KiB, sram: 256 * KiB, source: 'ST STM32F722IE (CubeMX MCU database)' },
+  STM32F722ZE: { flash: 512 * KiB, sram: 256 * KiB, source: 'ST STM32F722ZE (CubeMX MCU database)' },
+  STM32F733IE: { flash: 512 * KiB, sram: 256 * KiB, source: 'ST STM32F733IE (CubeMX MCU database)' },
+  STM32F746NG: { flash: 1 * MiB, sram: 320 * KiB, source: 'ST STM32F746NG (CubeMX MCU database)' },
+  STM32F746ZG: { flash: 1 * MiB, sram: 320 * KiB, source: 'ST STM32F746ZG (CubeMX MCU database)' },
+  STM32F756ZG: { flash: 1 * MiB, sram: 320 * KiB, source: 'ST STM32F756ZG (CubeMX MCU database)' },
+  STM32F767II: { flash: 2 * MiB, sram: 512 * KiB, source: 'ST STM32F767II (CubeMX MCU database)' },
+  STM32F767ZI: { flash: 2 * MiB, sram: 512 * KiB, source: 'ST STM32F767ZI (CubeMX MCU database)' },
+  STM32F769NI: { flash: 2 * MiB, sram: 512 * KiB, source: 'ST STM32F769NI (CubeMX MCU database)' },
+  STM32G0B1xE: { flash: 512 * KiB, sram: 144 * KiB, source: 'ST STM32G0B1xE (CubeMX MCU database)' },
+  STM32G474RE: { flash: 512 * KiB, sram: 128 * KiB, source: 'ST STM32G474RE (CubeMX MCU database)' },
+  STM32H563ZI: { flash: 2 * MiB, sram: 640 * KiB, source: 'ST STM32H563ZI (CubeMX MCU database)' },
+  STM32H573II: { flash: 2 * MiB, sram: 640 * KiB, source: 'ST STM32H573II (CubeMX MCU database)' },
+  STM32H723VG: { flash: 1 * MiB, sram: 560 * KiB, source: 'ST STM32H723VG (CubeMX MCU database)' },
+  STM32H723ZG: { flash: 1 * MiB, sram: 560 * KiB, source: 'ST STM32H723ZG (CubeMX MCU database)' },
+  STM32H743VI: { flash: 2 * MiB, sram: 1056 * KiB, source: 'ST STM32H743VI (CubeMX MCU database)' },
+  STM32H743ZI: { flash: 2 * MiB, sram: 1056 * KiB, source: 'ST STM32H743ZI (CubeMX MCU database)' },
+  STM32H747XI: { flash: 2 * MiB, sram: 1056 * KiB, source: 'ST STM32H747XI (CubeMX MCU database)' },
+  STM32H753ZI: { flash: 2 * MiB, sram: 1056 * KiB, source: 'ST STM32H753ZI (CubeMX MCU database)' },
+  // 1376, not the 1424 in ST's own CubeMX database: ST's datasheet text says
+  // "approximately 1.4 Mbyte … including 192 Kbytes of TCM RAM, 1.18 Mbytes of
+  // user SRAM", which is 1376, and Zephyr's mapped regions sum to the same.
+  STM32H7A3ZI: { flash: 2 * MiB, sram: 1376 * KiB, source: 'ST STM32H7A3ZI datasheet (192 KB TCM + 1.18 MB user SRAM)' },
+  STM32H7B3LI: { flash: 2 * MiB, sram: 1376 * KiB, source: 'ST STM32H7B3LI datasheet (192 KB TCM + 1.18 MB user SRAM)' },
+  STM32L072CZ: { flash: 192 * KiB, sram: 20 * KiB, source: 'ST STM32L072CZ (CubeMX MCU database)' },
+  STM32L073RZ: { flash: 192 * KiB, sram: 20 * KiB, source: 'ST STM32L073RZ (CubeMX MCU database)' },
+  STM32L152xE: { flash: 512 * KiB, sram: 80 * KiB, source: 'ST STM32L152xE (CubeMX MCU database)' },
+  STM32L432KC: { flash: 256 * KiB, sram: 64 * KiB, source: 'ST STM32L432KC (CubeMX MCU database)' },
+  STM32L452RE: { flash: 512 * KiB, sram: 160 * KiB, source: 'ST STM32L452RE (CubeMX MCU database)' },
+  STM32L475VG: { flash: 1 * MiB, sram: 128 * KiB, source: 'ST STM32L475VG (CubeMX MCU database)' },
+  STM32L476RG: { flash: 1 * MiB, sram: 128 * KiB, source: 'ST STM32L476RG (CubeMX MCU database)' },
+  STM32L476VG: { flash: 1 * MiB, sram: 128 * KiB, source: 'ST STM32L476VG (CubeMX MCU database)' },
+  STM32L496ZG: { flash: 1 * MiB, sram: 320 * KiB, source: 'ST STM32L496ZG (CubeMX MCU database)' },
+  STM32L4A6ZG: { flash: 1 * MiB, sram: 320 * KiB, source: 'ST STM32L4A6ZG (CubeMX MCU database)' },
+  // The STM32N6 has no internal user flash at all — CubeMX says `<Flash>0`,
+  // Zephyr defines no flash node, and code runs from external XSPI.
+  STM32N657X0: { sram: 4200 * KiB, source: 'ST STM32N657X0 (CubeMX MCU database; no internal flash)' },
+  STM32N657xx: { sram: 4200 * KiB, source: 'ST STM32N657 (CubeMX MCU database; no internal flash)' },
+  STM32U585CI: { flash: 2 * MiB, sram: 784 * KiB, source: 'ST STM32U585CI (CubeMX MCU database)' },
+  STM32U5A5ZJ: { flash: 4 * MiB, sram: 2512 * KiB, source: 'ST STM32U5A5ZJ (CubeMX MCU database)' },
+  // Silicon figures. With the BLE coprocessor loaded, roughly 876 KB of the
+  // flash and 222 KB of the SRAM are left to the application — but that depends
+  // on which stack is flashed, so the chip's own numbers are what is published.
+  STM32WB55CG: { flash: 1 * MiB, sram: 256 * KiB, source: 'ST STM32WB55CG (CubeMX MCU database)' },
+  STM32WB55RG: { flash: 1 * MiB, sram: 256 * KiB, source: 'ST STM32WB55RG (CubeMX MCU database)' },
+  // Shared between the M4 and the M0+ radio stack; there is no second bank.
+  STM32WL55JC: { flash: 256 * KiB, sram: 64 * KiB, source: 'ST STM32WL55JC (CubeMX MCU database)' },
+
+  // --- ST, names that stop short of a part ---------------------------------
+  // SRAM is constant across each of these lines and the flash is not, so they
+  // carry one figure and not the other. `STM32F407` is four parts between
+  // 512 KB and 1 MB; `STM32F413` is 1 MB and 1.5 MB; and so on.
+  STM32F407: { sram: 192 * KiB, source: 'ST STM32F407 line (CubeMX MCU database)' },
+  STM32F407xx: { sram: 192 * KiB, source: 'ST STM32F407 line (CubeMX MCU database)' },
+  STM32F411: { sram: 128 * KiB, source: 'ST STM32F411 line (CubeMX MCU database)' },
+  STM32F412Rx: { sram: 256 * KiB, source: 'ST STM32F412 line (CubeMX MCU database)' },
+  STM32F412Zx: { sram: 256 * KiB, source: 'ST STM32F412 line (CubeMX MCU database)' },
+  STM32F413: { sram: 320 * KiB, source: 'ST STM32F413 line (CubeMX MCU database)' },
+  STM32F413xx: { sram: 320 * KiB, source: 'ST STM32F413 line (CubeMX MCU database)' },
+  STM32F427xx: { sram: 256 * KiB, source: 'ST STM32F427 line (CubeMX MCU database)' },
+  STM32F429: { sram: 256 * KiB, source: 'ST STM32F429 line (CubeMX MCU database)' },
+  STM32F429xx: { sram: 256 * KiB, source: 'ST STM32F429 line (CubeMX MCU database)' },
+  STM32F439: { sram: 256 * KiB, source: 'ST STM32F439 line (CubeMX MCU database)' },
+  STM32F439xx: { sram: 256 * KiB, source: 'ST STM32F439 line (CubeMX MCU database)' },
+  STM32F446xx: { sram: 128 * KiB, source: 'ST STM32F446 line (CubeMX MCU database)' },
+  STM32F469: { sram: 384 * KiB, source: 'ST STM32F469 line (CubeMX MCU database)' },
+  STM32F469xx: { sram: 384 * KiB, source: 'ST STM32F469 line (CubeMX MCU database)' },
+  STM32F722: { sram: 256 * KiB, source: 'ST STM32F722 line (CubeMX MCU database)' },
+  STM32F722xx: { sram: 256 * KiB, source: 'ST STM32F722 line (CubeMX MCU database)' },
+  STM32F733xx: { sram: 256 * KiB, source: 'ST STM32F733 line (CubeMX MCU database)' },
+  STM32F746: { sram: 320 * KiB, source: 'ST STM32F746 line (CubeMX MCU database)' },
+  STM32F746xx: { sram: 320 * KiB, source: 'ST STM32F746 line (CubeMX MCU database)' },
+  STM32F756: { sram: 320 * KiB, source: 'ST STM32F756 line (CubeMX MCU database)' },
+  STM32F756xx: { sram: 320 * KiB, source: 'ST STM32F756 line (CubeMX MCU database)' },
+  STM32F767: { sram: 512 * KiB, source: 'ST STM32F767 line (CubeMX MCU database)' },
+  STM32F767xx: { sram: 512 * KiB, source: 'ST STM32F767 line (CubeMX MCU database)' },
+  STM32F769: { sram: 512 * KiB, source: 'ST STM32F769 line (CubeMX MCU database)' },
+  STM32F769xx: { sram: 512 * KiB, source: 'ST STM32F769 line (CubeMX MCU database)' },
+  STM32G474: { sram: 128 * KiB, source: 'ST STM32G474 line (CubeMX MCU database)' },
+  STM32G474xx: { sram: 128 * KiB, source: 'ST STM32G474 line (CubeMX MCU database)' },
+  STM32H573xx: { sram: 640 * KiB, source: 'ST STM32H573 line (CubeMX MCU database)' },
+  STM32H723xx: { sram: 560 * KiB, source: 'ST STM32H723 line (CubeMX MCU database)' },
+  STM32H743: { sram: 1056 * KiB, source: 'ST STM32H743 line (CubeMX MCU database)' },
+  STM32H743xx: { sram: 1056 * KiB, source: 'ST STM32H743 line (CubeMX MCU database)' },
+  STM32H747: { sram: 1056 * KiB, source: 'ST STM32H747 line (CubeMX MCU database)' },
+  STM32H747xx: { sram: 1056 * KiB, source: 'ST STM32H747 line (CubeMX MCU database)' },
+  STM32H753: { sram: 1056 * KiB, source: 'ST STM32H753 line (CubeMX MCU database)' },
+  STM32H753xx: { sram: 1056 * KiB, source: 'ST STM32H753 line (CubeMX MCU database)' },
+  STM32H7A3xx: { sram: 1376 * KiB, source: 'ST STM32H7A3 line datasheet' },
+  STM32H7B3xx: { sram: 1376 * KiB, source: 'ST STM32H7B3 line datasheet' },
+  STM32L072xx: { sram: 20 * KiB, source: 'ST STM32L072 line (CubeMX MCU database)' },
+  STM32L073xx: { sram: 20 * KiB, source: 'ST STM32L073 line (CubeMX MCU database)' },
+  STM32L432xx: { sram: 64 * KiB, source: 'ST STM32L432 line (CubeMX MCU database)' },
+  STM32L452xx: { sram: 160 * KiB, source: 'ST STM32L452 line (CubeMX MCU database)' },
+  STM32L475: { sram: 128 * KiB, source: 'ST STM32L475 line (CubeMX MCU database)' },
+  STM32L475xx: { sram: 128 * KiB, source: 'ST STM32L475 line (CubeMX MCU database)' },
+  STM32L476: { sram: 128 * KiB, source: 'ST STM32L476 line (CubeMX MCU database)' },
+  STM32L476xx: { sram: 128 * KiB, source: 'ST STM32L476 line (CubeMX MCU database)' },
+  STM32L496: { sram: 320 * KiB, source: 'ST STM32L496 line (CubeMX MCU database)' },
+  STM32L496xx: { sram: 320 * KiB, source: 'ST STM32L496 line (CubeMX MCU database)' },
+  STM32L4A6xx: { sram: 320 * KiB, source: 'ST STM32L4A6 line (CubeMX MCU database)' },
+  STM32U585xx: { sram: 784 * KiB, source: 'ST STM32U585 line (CubeMX MCU database)' },
+  STM32U5A5xx: { sram: 2512 * KiB, source: 'ST STM32U5A5 line (CubeMX MCU database)' },
+  STM32WB55xx: { sram: 256 * KiB, source: 'ST STM32WB55 line (CubeMX MCU database)' },
+  STM32WL55xx: { sram: 64 * KiB, source: 'ST STM32WL55 line (CubeMX MCU database)' },
+
+  // --- Nordic --------------------------------------------------------------
+  // The -F / -B ordering suffixes on these change access-port protection, not
+  // memory, so the bare name settles both figures.
+  nrf52840: { flash: 1 * MiB, sram: 256 * KiB, source: 'Nordic nRF52840 product specification' },
+  nrf52833: { flash: 512 * KiB, sram: 128 * KiB, source: 'Nordic nRF52833 product specification' },
+  nrf9160: { flash: 1 * MiB, sram: 256 * KiB, source: 'Nordic nRF9160 product specification' },
+  // nrf52832 and nrf51822 are absent, and it costs 14 boards. Nordic's own
+  // page prints the nRF52832 as "512/256 KB Flash, 64/32 KB RAM" — the QFAA and
+  // the QFAB, a factor of two apart on BOTH axes — and the nRF51822 is worse at
+  // three variants, one of which exists only on IC revision 3. Upstream's
+  // `MCU_SUB_VARIANT` stops at the sub-variant, so there is nothing here that
+  // knows which one is on the board.
+
+  // --- Microchip SAM D -----------------------------------------------------
+  // The ordering code carries the size: 18 = 256 KB, 19 = 512 KB, 20 = 1 MB.
+  SAMD21E18A: { flash: 256 * KiB, sram: 32 * KiB, source: 'Microchip SAM D21/DA1 datasheet DS40001882G' },
+  SAMD21G18A: { flash: 256 * KiB, sram: 32 * KiB, source: 'Microchip SAM D21/DA1 datasheet DS40001882G' },
+  SAMD21J18A: { flash: 256 * KiB, sram: 32 * KiB, source: 'Microchip SAM D21/DA1 datasheet DS40001882G' },
+  // 192 KB and 256 KB, NOT 200 and 264: Microchip prints these as "192/8", and
+  // the 8 KB is backup RAM in its own power domain, not contiguous system SRAM.
+  SAMD51G19A: { flash: 512 * KiB, sram: 192 * KiB, source: 'Microchip SAM D5x/E5x datasheet DS60001507' },
+  SAMD51J19A: { flash: 512 * KiB, sram: 192 * KiB, source: 'Microchip SAM D5x/E5x datasheet DS60001507' },
+  SAMD51P19A: { flash: 512 * KiB, sram: 192 * KiB, source: 'Microchip SAM D5x/E5x datasheet DS60001507' },
+  SAMD51J20A: { flash: 1 * MiB, sram: 256 * KiB, source: 'Microchip SAM D5x/E5x datasheet DS60001507' },
+  SAMD51P20A: { flash: 1 * MiB, sram: 256 * KiB, source: 'Microchip SAM D5x/E5x datasheet DS60001507' },
+
+  // --- Renesas RA ----------------------------------------------------------
+  // Upstream names the GROUP (`RA6M2`), not the part, and for the RA6 groups the
+  // group spans several flash sizes — RA6M2 is 512 KB to 1 MB, RA6M5 is 1 MB to
+  // 2 MB — while the SRAM is constant across each. So those two carry SRAM only.
+  RA4M1: { flash: 256 * KiB, sram: 32 * KiB, source: 'Renesas RA4M1 group datasheet' },
+  RA4W1: { flash: 512 * KiB, sram: 96 * KiB, source: 'Renesas RA4W1 group datasheet' },
+  RA6M1: { flash: 512 * KiB, sram: 256 * KiB, source: 'Renesas RA6M1 group datasheet' },
+  RA6M2: { sram: 384 * KiB, source: 'Renesas RA6M2 group datasheet' },
+  RA6M5: { sram: 512 * KiB, source: 'Renesas RA6M5 group datasheet' },
+
+  // --- NXP i.MX RT ---------------------------------------------------------
+  // No internal flash on any of these but the RT1064, whose 4 MB is a
+  // co-packaged QSPI die rather than on-die — and which upstream's
+  // `MICROPY_HW_FLASH_SIZE` states anyway, so it is not repeated here. SRAM
+  // totals come from each datasheet's "On-chip RAM (…)" line, not from the
+  // "up to 512 kB TCM" marketing line, which is half the total on the RT1062.
+  MIMXRT1011: { sram: 128 * KiB, source: 'NXP i.MX RT1010 datasheet IMXRT1010CEC' },
+  MIMXRT1021: { sram: 256 * KiB, source: 'NXP i.MX RT1020 datasheet IMXRT1020CEC' },
+  MIMXRT1052: { sram: 512 * KiB, source: 'NXP i.MX RT1050 datasheet IMXRT1050CEC' },
+  MIMXRT1062: { sram: 1 * MiB, source: 'NXP i.MX RT1060 datasheet IMXRT1060CEC' },
+  MIMXRT1064: { sram: 1 * MiB, source: 'NXP i.MX RT1064 datasheet IMXRT1064CEC' },
+  MIMXRT1176: { sram: 2 * MiB, source: 'NXP i.MX RT1170 datasheet IMXRT1170CEC' },
+  // MIMXRT1015 is absent: I did not find NXP's own on-chip RAM figure for it.
+
+  // --- One-off parts, reached through BOARD_MCU_PART ------------------------
+  AE722F80F55D5: {
+    flash: 5.5 * MiB,
+    sram: 13.5 * MiB,
+    source: 'Alif Ensemble E7 datasheet ADTS0005 (MRAM / SRAM)'
+  },
+  PSE846GPS2DBZC4: {
+    flash: 512 * KiB,
+    // 6 MB total, not the 5120 KB in the ordering table: that column is System
+    // SRAM alone and omits the 1 MB in the low-power CPU subsystem.
+    sram: 6 * MiB,
+    source: 'Infineon PSOC Edge E8x datasheet 002-37630 (RRAM / total SRAM)'
+  }
+}
+
+/**
+ * The exact part a board carries, where upstream's own name is too vague.
+ *
+ * `ports/stm32/boards/OLIMEX_E407/mpconfigboard.h` says `STM32F407`, which does
+ * not settle the flash; Olimex's page says `STM32F407ZGT6`, which does. Only
+ * boards where the maker names the full part are here, and the entry cites them.
+ */
+export const BOARD_MCU_PART = {
+  OLIMEX_E407: { part: 'STM32F407ZG', source: 'olimex.com STM32-E407 (STM32F407ZGT6)' },
+  OLIMEX_H407: { part: 'STM32F407ZG', source: 'olimex.com STM32-H407 (STM32F407ZGT6)' },
+
+  // ST names a Nucleo after the exact part on it — NUCLEO-F746ZG carries an
+  // STM32F746ZGT6 — so for these the board's own name is the missing suffix.
+  // Applied ONLY where the id carries a full pin-count-and-flash suffix, which
+  // is why the Discovery boards are not here: `STM32F7DISC` names no part.
+  NUCLEO_F412ZG: { part: 'STM32F412ZG', source: 'ST NUCLEO-F412ZG' },
+  NUCLEO_F413ZH: { part: 'STM32F413ZH', source: 'ST NUCLEO-F413ZH' },
+  NUCLEO_F429ZI: { part: 'STM32F429ZI', source: 'ST NUCLEO-F429ZI' },
+  NUCLEO_F446RE: { part: 'STM32F446RE', source: 'ST NUCLEO-F446RE' },
+  NUCLEO_F722ZE: { part: 'STM32F722ZE', source: 'ST NUCLEO-F722ZE' },
+  NUCLEO_F746ZG: { part: 'STM32F746ZG', source: 'ST NUCLEO-F746ZG' },
+  NUCLEO_F756ZG: { part: 'STM32F756ZG', source: 'ST NUCLEO-F756ZG' },
+  NUCLEO_F767ZI: { part: 'STM32F767ZI', source: 'ST NUCLEO-F767ZI' },
+  NUCLEO_G474RE: { part: 'STM32G474RE', source: 'ST NUCLEO-G474RE' },
+  NUCLEO_H743ZI: { part: 'STM32H743ZI', source: 'ST NUCLEO-H743ZI' },
+  NUCLEO_H743ZI2: { part: 'STM32H743ZI', source: 'ST NUCLEO-H743ZI2' },
+  NUCLEO_H753ZI: { part: 'STM32H753ZI', source: 'ST NUCLEO-H753ZI' },
+
+  // Arduino's four H7 boards, where upstream stops at "STM32H747" and Arduino
+  // names the part and its 2 MB outright.
+  ARDUINO_GIGA: { part: 'STM32H747XI', source: 'docs.arduino.cc/hardware/giga-r1-wifi' },
+  ARDUINO_NICLA_VISION: { part: 'STM32H747XI', source: 'docs.arduino.cc/hardware/nicla-vision' },
+  ARDUINO_OPTA: { part: 'STM32H747XI', source: 'docs.arduino.cc/hardware/opta' },
+  ARDUINO_PORTENTA_H7: { part: 'STM32H747XI', source: 'docs.arduino.cc/hardware/portenta-h7' },
+
+  // Two ports with a single board each and no reader of their own; upstream's
+  // `board.json` names the part in `mcu`, which is the whole configuration
+  // these ports would otherwise need one for.
+  ALIF_ENSEMBLE: { part: 'AE722F80F55D5', source: 'board.json mcu = AE722F80F55D5XX' },
+  KIT_PSE84_AI: { part: 'PSE846GPS2DBZC4', source: 'board.json mcu = PSE846GPS2DBZC4' }
 }
 
 /**
@@ -73,11 +383,25 @@ export const MCU_SRAM = {
  *
  * Seeded from `src/shared/board-profiles.ts`, which has carried some of these by
  * hand since #756 ("8 MB flash, 2 MB PSRAM" on the Feather V2), plus the makers'
- * own documentation for the rest. `flash` and `psram` are `board` scope; SRAM is
- * left to {@link MCU_SRAM} so one chip's figure lives in one place.
+ * own documentation for the rest.
+ *
+ * WHAT BELONGS HERE. Only what the derived sources cannot reach, because a
+ * curated figure that shadows a mechanically-refreshed one goes stale in secret:
+ *
+ *   - `flash` for the boards whose MCU has no internal flash and whose build
+ *     configuration does not state a size — which is most of the ESP32 catalogue;
+ *   - `externalFlash`, the second flash chip beside the MCU, which nothing but
+ *     the maker publishes;
+ *   - `psram`.
  *
  * `psram: null` is a CLAIM, not a gap — it says the board has none — and is set
  * only where the maker says so.
+ *
+ * WHAT DOES NOT BELONG HERE: a board sold in more than one memory size. The
+ * Pico LiPo is a 4 MB board and a 16 MB board under one name, and so are the
+ * Tiny 2040, the RP2040-Plus, the WeAct RP2040 CoreBoard and the ESP32-POE.
+ * Half those owners would be told the wrong thing, so they are told nothing —
+ * their `variants` already say "16 MiB Flash" where upstream models it.
  */
 export const CURATED_BOARDS = {
   RPI_PICO: {
@@ -108,21 +432,371 @@ export const CURATED_BOARDS = {
       bytes: 8 * MiB,
       source: 'MicroPython ports/esp32/boards/SEEED_XIAO_ESP32S3/mpconfigboard.cmake'
     }
+  },
+
+  // --- Adafruit ------------------------------------------------------------
+  // Every one of these adds an SPI flash chip beside a microcontroller that
+  // already has its own, and says both figures on the product page. Not on the
+  // list: the QT Py SAMD21, whose "Optional SOIC-8 SPI Flash chip on bottom" is
+  // a bare pad, and the Trinket M0 and NeoKey Trinkey, which have neither.
+  ADAFRUIT_F405_EXPRESS: { externalFlash: { bytes: 2 * MiB, source: 'adafruit.com/product/4382' } },
+  ADAFRUIT_FEATHER_M0_EXPRESS: {
+    externalFlash: { bytes: 2 * MiB, source: 'adafruit.com/product/3403' }
+  },
+  ADAFRUIT_FEATHER_M4_EXPRESS: {
+    externalFlash: { bytes: 2 * MiB, source: 'adafruit.com/product/3857' }
+  },
+  // FEATHER52 is deliberately absent — see WITHHELD. Upstream's `board.json`
+  // points at one Adafruit product and its build config describes another, so
+  // there is no page whose figures are safe to put under that name.
+  ADAFRUIT_FEATHER_RP2040: { flash: { bytes: 8 * MiB, source: 'adafruit.com/product/4884' } },
+  ADAFRUIT_ITSYBITSY_M0_EXPRESS: {
+    externalFlash: { bytes: 2 * MiB, source: 'adafruit.com/product/3727' }
+  },
+  ADAFRUIT_ITSYBITSY_M4_EXPRESS: {
+    externalFlash: { bytes: 2 * MiB, source: 'adafruit.com/product/3800' }
+  },
+  ADAFRUIT_ITSYBITSY_RP2040: { flash: { bytes: 8 * MiB, source: 'adafruit.com/product/4888' } },
+  ADAFRUIT_METRO_M4_EXPRESS: {
+    externalFlash: { bytes: 2 * MiB, source: 'adafruit.com/product/4000' }
+  },
+  ADAFRUIT_QTPY_RP2040: { flash: { bytes: 8 * MiB, source: 'adafruit.com/product/4900' } },
+  // The Feather RP2350 is sold as "No PSRAM" and "With 8MB PSRAM" on one page,
+  // so it gets its flash from upstream's header and no PSRAM figure at all.
+
+  // --- SparkFun ------------------------------------------------------------
+  SPARKFUN_IOTNODE_LORAWAN_RP2350: {
+    psram: { bytes: 8 * MiB, source: 'docs.sparkfun.com/SparkFun_IoT_Node_LoRaWAN' }
+  },
+  SPARKFUN_IOTREDBOARD_RP2350: {
+    psram: { bytes: 8 * MiB, source: 'sparkfun.com/sparkfun-iot-redboard-rp2350.html' }
+  },
+  SPARKFUN_MICROMOD_STM32: {
+    externalFlash: {
+      bytes: 16 * MiB,
+      source: 'learn.sparkfun.com micromod-stm32-processor-hookup-guide (128 Mbit)'
+    }
+  },
+  SPARKFUN_PROMICRO: { flash: { bytes: 16 * MiB, source: 'sparkfun.com/sparkfun-pro-micro-rp2040.html' } },
+  SPARKFUN_PROMICRO_RP2350: {
+    psram: { bytes: 8 * MiB, source: 'sparkfun.com/sparkfun-pro-micro-rp2350.html' }
+  },
+  SPARKFUN_REDBOARD_TURBO: {
+    externalFlash: { bytes: 4 * MiB, source: 'learn.sparkfun.com redboard-turbo-hookup-guide' }
+  },
+  SPARKFUN_SAMD51_THING_PLUS: {
+    // SparkFun writes "4Mb", lower-case b, and means it: the fitted part is an
+    // AT25SF041, four MEGABIT. Reading that as 4 MB overstates the board by 8×,
+    // which is the single worst mistake available anywhere in this file.
+    externalFlash: {
+      bytes: 512 * KiB,
+      source: 'learn.sparkfun.com samd51-thing-plus-hookup-guide (4 Mbit, AT25SF041)'
+    }
+  },
+  SPARKFUN_THINGPLUS: {
+    flash: { bytes: 16 * MiB, source: 'sparkfun.com/sparkfun-thing-plus-rp2040.html' }
+  },
+  SPARKFUN_THINGPLUS_ESP32C5: {
+    flash: { bytes: 8 * MiB, source: 'sparkfun.com/sparkfun-thing-plus-esp32-c5.html' },
+    psram: { bytes: 8 * MiB, source: 'sparkfun.com/sparkfun-thing-plus-esp32-c5.html' }
+  },
+  SPARKFUN_THINGPLUS_RP2350: {
+    psram: { bytes: 8 * MiB, source: 'sparkfun.com/sparkfun-thing-plus-rp2350.html' }
+  },
+  SPARKFUN_XRP_CONTROLLER: {
+    psram: { bytes: 8 * MiB, source: 'sparkfun.com/…xrp-controller.html' }
+  },
+  SPARKFUN_XRP_CONTROLLER_BETA: {
+    // A Pico W on a carrier board, and SparkFun lists the Pico W's own figure.
+    flash: { bytes: 2 * MiB, source: 'sparkfun.com/…xrp-controller-beta.html (it carries a Pico W)' }
+  },
+  // Not on the list: the IoT RedBoard ESP32, whose only published figure is the
+  // WROOM module family's "4/8/16 MB" range, which is not a statement about it.
+
+  // --- Unexpected Maker ----------------------------------------------------
+  // The one vendor here that publishes flash AND PSRAM for its whole range, on
+  // per-board microsites and again in a PSRAM table that agrees with them.
+  UM_FEATHERS2: {
+    flash: { bytes: 16 * MiB, source: 'feathers2.io' },
+    psram: { bytes: 8 * MiB, source: 'feathers2.io' }
+  },
+  // The FeatherS2 Neo is discontinued and no maker page states its flash; the
+  // PSRAM table still does, so it gets one figure and not the other.
+  UM_FEATHERS2NEO: { psram: { bytes: 2 * MiB, source: 'help.unexpectedmaker.com PSRAM table' } },
+  UM_FEATHERS3: {
+    flash: { bytes: 16 * MiB, source: 'esp32s3.com/feathers3.html' },
+    psram: { bytes: 8 * MiB, source: 'esp32s3.com/feathers3.html' }
+  },
+  UM_FEATHERS3NEO: {
+    flash: { bytes: 8 * MiB, source: 'esp32s3.com/feathers3neo.html' },
+    psram: { bytes: 2 * MiB, source: 'esp32s3.com/feathers3neo.html' }
+  },
+  UM_NANOS3: {
+    flash: { bytes: 8 * MiB, source: 'esp32s3.com/nanos3.html' },
+    psram: { bytes: 8 * MiB, source: 'esp32s3.com/nanos3.html' }
+  },
+  UM_OMGS3: {
+    flash: { bytes: 8 * MiB, source: 'esp32s3.com/omgs3.html' },
+    psram: { bytes: 2 * MiB, source: 'esp32s3.com/omgs3.html' }
+  },
+  UM_PROS3: {
+    flash: { bytes: 16 * MiB, source: 'esp32s3.com/pros3.html' },
+    psram: { bytes: 8 * MiB, source: 'esp32s3.com/pros3.html' }
+  },
+  UM_RGBTOUCH_MINI: {
+    flash: { bytes: 8 * MiB, source: 'unexpectedmaker.com shop, RGB Touch Mini' },
+    psram: { bytes: 2 * MiB, source: 'unexpectedmaker.com shop, RGB Touch Mini' }
+  },
+  UM_TINYC6: { flash: { bytes: 8 * MiB, source: 'unexpectedmaker.com shop, TinyC6' } },
+  UM_TINYPICO: {
+    flash: { bytes: 4 * MiB, source: 'unexpectedmaker.com shop, TinyPICO' },
+    psram: { bytes: 4 * MiB, source: 'unexpectedmaker.com shop, TinyPICO' }
+  },
+  UM_TINYS2: {
+    flash: { bytes: 4 * MiB, source: 'unexpectedmaker.com shop, TinyS2' },
+    psram: { bytes: 2 * MiB, source: 'unexpectedmaker.com shop, TinyS2' }
+  },
+  UM_TINYS3: {
+    flash: { bytes: 8 * MiB, source: 'esp32s3.com/tinys3.html' },
+    psram: { bytes: 8 * MiB, source: 'esp32s3.com/tinys3.html' }
+  },
+  UM_TINYWATCHS3: {
+    flash: { bytes: 8 * MiB, source: 'help.unexpectedmaker.com/docs/products/tinywatch-s3' },
+    psram: { bytes: 2 * MiB, source: 'help.unexpectedmaker.com/docs/products/tinywatch-s3' }
+  },
+
+  // --- Seeed Studio --------------------------------------------------------
+  SEEED_WIO_TERMINAL: {
+    externalFlash: { bytes: 4 * MiB, source: 'seeedstudio.com Wio-Terminal-p-4509' }
+  },
+  SEEED_XIAO_ESP32C3: { flash: { bytes: 4 * MiB, source: 'seeedstudio.com Seeed-XIAO-ESP32C3-p-5431' } },
+  SEEED_XIAO_ESP32C5: {
+    flash: { bytes: 8 * MiB, source: 'wiki.seeedstudio.com/xiao_esp32c5_getting_started' },
+    psram: { bytes: 8 * MiB, source: 'wiki.seeedstudio.com/xiao_esp32c5_getting_started' }
+  },
+  SEEED_XIAO_ESP32C6: {
+    flash: { bytes: 4 * MiB, source: 'seeedstudio.com Seeed-Studio-XIAO-ESP32C6-p-5884' }
+  },
+  SEEED_XIAO_NRF52: {
+    externalFlash: {
+      bytes: 2 * MiB,
+      source: 'seeedstudio.com Seeed-XIAO-BLE-Sense-nRF52840-p-5253'
+    }
+  },
+
+  // --- Waveshare -----------------------------------------------------------
+  WAVESHARE_RP2040_LCD_0_96: {
+    flash: { bytes: 2 * MiB, source: 'waveshare.com/product/rp2040-lcd-0.96.htm (W25Q16)' }
+  },
+  WAVESHARE_ESP32_S3_PICO: {
+    flash: { bytes: 16 * MiB, source: 'waveshare.com/ESP32-S3-Pico.htm (W25Q128)' },
+    psram: { bytes: 2 * MiB, source: 'waveshare.com/ESP32-S3-Pico.htm (in the ESP32-S3R2 package)' }
+  },
+  // The RP2040-Plus is a 4 MB board and a 16 MB board; the RP2350B Core's PSRAM
+  // is 0, 2 or 8 MB depending on the SKU. Both say nothing rather than half of it.
+
+  // --- Arduino -------------------------------------------------------------
+  ARDUINO_GIGA: {
+    externalFlash: { bytes: 16 * MiB, source: 'docs.arduino.cc/hardware/giga-r1-wifi (AT25SF128A)' },
+    psram: { bytes: 8 * MiB, source: 'docs.arduino.cc/hardware/giga-r1-wifi (AS4C4M16SA SDRAM)' }
+  },
+  ARDUINO_NANO_ESP32: {
+    psram: { bytes: 8 * MiB, source: 'docs.arduino.cc/hardware/nano-esp32 (in the NORA-W106 module)' }
+  },
+  ARDUINO_NANO_RP2040_CONNECT: {
+    flash: { bytes: 16 * MiB, source: 'docs.arduino.cc/hardware/nano-rp2040-connect (AT25SF128A)' }
+  },
+  ARDUINO_NICLA_VISION: {
+    externalFlash: { bytes: 16 * MiB, source: 'docs.arduino.cc/hardware/nicla-vision (AT25QL128A)' }
+  },
+  ARDUINO_OPTA: {
+    externalFlash: { bytes: 16 * MiB, source: 'docs.arduino.cc/hardware/opta' }
+    // Arduino's spec card calls the H747's own 1 MB of SRAM "SDRAM: 1 MB"; the
+    // datasheet table on the same page calls it "1 MB of RAM". No SDRAM figure.
+  },
+  ARDUINO_PORTENTA_C33: {
+    // The RA6M5 group spans 1 MB to 2 MB, so {@link CHIP_MEMORY} will not name a
+    // flash size for it; Arduino names this board's.
+    flash: { bytes: 2 * MiB, source: 'docs.arduino.cc/hardware/portenta-c33' },
+    externalFlash: { bytes: 16 * MiB, source: 'docs.arduino.cc/hardware/portenta-c33 (MX25L12833F)' }
+  },
+  ARDUINO_PORTENTA_H7: {
+    externalFlash: { bytes: 16 * MiB, source: 'docs.arduino.cc/hardware/portenta-h7' },
+    psram: { bytes: 8 * MiB, source: 'docs.arduino.cc/hardware/portenta-h7 (SDRAM)' }
+  },
+
+  // --- M5Stack -------------------------------------------------------------
+  M5STACK_ATOM: { flash: { bytes: 4 * MiB, source: 'docs.m5stack.com/en/core/ATOM Matrix' } },
+  M5STACK_ATOMS3_LITE: { flash: { bytes: 8 * MiB, source: 'docs.m5stack.com/en/core/AtomS3 Lite' } },
+  M5STACK_NANOC6: { flash: { bytes: 4 * MiB, source: 'docs.m5stack.com/en/core/M5NanoC6' } },
+  M5STACK_NANOH2: { flash: { bytes: 4 * MiB, source: 'docs.m5stack.com/en/core/NanoH2' } },
+
+  // --- Wemos / LOLIN -------------------------------------------------------
+  LOLIN_C3_MINI: { flash: { bytes: 4 * MiB, source: 'wemos.cc/en/latest/c3/c3_mini.html' } },
+  LOLIN_S2_MINI: {
+    flash: { bytes: 4 * MiB, source: 'wemos.cc/en/latest/s2/s2_mini.html' },
+    psram: { bytes: 2 * MiB, source: 'wemos.cc/en/latest/s2/s2_mini.html' }
+  },
+  LOLIN_S2_PICO: {
+    flash: { bytes: 4 * MiB, source: 'wemos.cc/en/latest/s2/s2_pico.html' },
+    psram: { bytes: 2 * MiB, source: 'wemos.cc/en/latest/s2/s2_pico.html' }
+  },
+
+  // --- Everyone else -------------------------------------------------------
+  CYTRON_MOTION_2350_PRO: {
+    flash: { bytes: 2 * MiB, source: 'cytron.io/p-motion-2350-pro' }
+  },
+  LILYGO_TTGO_LORA32: { flash: { bytes: 4 * MiB, source: 'lilygo.cc/products/lora3 (V1.6.1)' } },
+  OLIMEX_ESP32_POE: {
+    flash: { bytes: 4 * MiB, source: 'olimex.com ESP32-POE user manual (WROOM-32E)' }
+  },
+  POLOLU_3PI_2040_ROBOT: { flash: { bytes: 16 * MiB, source: 'pololu.com/docs/0J86/6.1' } },
+  POLOLU_ZUMO_2040_ROBOT: { flash: { bytes: 16 * MiB, source: 'pololu.com/docs/0J87/1' } },
+  PYBD_SF2: {
+    externalFlash: {
+      bytes: 4 * MiB,
+      source: 'store.micropython.org PYBD-SF2 (2 MiB XIP + 2 MiB filesystem)'
+    }
+  },
+  PYBD_SF3: {
+    externalFlash: {
+      bytes: 4 * MiB,
+      source: 'store.micropython.org PYBD-SF3 (2 MiB XIP + 2 MiB filesystem)'
+    }
+  },
+  PYBD_SF6: {
+    externalFlash: {
+      bytes: 4 * MiB,
+      source: 'store.micropython.org PYBD-SF6 (2 MiB XIP + 2 MiB filesystem)'
+    }
+  },
+  SOLDERED_NULA_MINI: { flash: { bytes: 4 * MiB, source: 'soldered.com/product/nula-mini-esp32-c6' } },
+  W5100S_EVB_PICO: { flash: { bytes: 2 * MiB, source: 'docs.wiznet.io W5100S-EVB-Pico' } },
+  W5500_EVB_PICO: { flash: { bytes: 2 * MiB, source: 'docs.wiznet.io W5500-EVB-Pico' } },
+  WEACTSTUDIO_MINI_STM32H723: {
+    externalFlash: {
+      bytes: 16 * MiB,
+      source: 'github.com/WeActStudio/WeActStudio.MiniSTM32H723 (8 MB SPI + 8 MB OSPI)'
+    }
+  },
+  WEACTSTUDIO_MINI_STM32H743: {
+    externalFlash: {
+      bytes: 16 * MiB,
+      source: 'github.com/WeActStudio/MiniSTM32H7xx (8 MB SPI + 8 MB QSPI)'
+    }
   }
 }
 
 /**
- * The flash / RAM / PSRAM to publish for one board, or nulls where nothing is
- * known. `board` beats `chip`, and nothing is invented.
+ * Figures a derived source offers and this module refuses to publish.
+ *
+ * Rare, and each one is a real disagreement rather than a doubt. The Werkzeug is
+ * the clearest: Machdyne's page says "Update March 2025: Werkzeug now has 4MB
+ * flash instead of 1MB", and upstream still builds it against the 1 MB header —
+ * so both numbers are right, for different boards with the same name, and either
+ * one alone is wrong for half the people reading it.
+ *
+ * Withholding is deliberately noisy in the diff: `why` has to be written down.
  */
-export function specsForBoard(board) {
-  const curated = CURATED_BOARDS[board.id]
-  const sram = MCU_SRAM[board.mcu]
-  return {
-    flash: curated?.flash ? { ...curated.flash, scope: 'board' } : null,
-    ram: sram ? { ...sram, scope: 'chip' } : null,
-    psram: curated?.psram ? { ...curated.psram, scope: 'board' } : null
+export const WITHHELD = {
+  MACHDYNE_WERKZEUG: {
+    fields: ['flash'],
+    why:
+      'Machdyne: "Update March 2025: Werkzeug now has 4MB flash instead of 1MB". Upstream ' +
+      'still builds against the 1 MB pico-sdk header. Both numbers are right, for different ' +
+      'boards sold under one name.'
+  },
+  SIL_WESP32: {
+    fields: ['flash'],
+    why:
+      'wesp32.com states 16 MB from revision 7 and 4 MB before it; upstream builds against ' +
+      '8 MB. Three figures, one board name, and no way to tell which one is in the hand.'
+  },
+  FEATHER52: {
+    fields: ['flash', 'ram'],
+    why:
+      'Upstream’s own entry disagrees with itself: `board.json` calls this the "Feather ' +
+      'nRF52840 Express" and links adafruit.com/product/4062, while the build beside it is ' +
+      '`MCU_SUB_VARIANT = nrf52832`, `-DNRF52832_XXAA` and "Bluefruit nRF52 Feather" — which ' +
+      'is product 3406, a different board with half the flash and a quarter of the RAM. ' +
+      'Publishing either figure puts it under the other board’s name.'
   }
+}
+
+/** A curated size, or null. Curated figures are always about the board. */
+const boardSize = (size) => (size ? { ...size, scope: 'board' } : null)
+
+/** A datasheet figure for the chip, which is a fact about every board using it. */
+const chipSize = (bytes, source) => (bytes ? { bytes, source, scope: 'chip' } : null)
+
+/**
+ * A chip name reduced to what identifies its memory.
+ *
+ * ST's ordering code is fixed-width up to and including the flash-size letter:
+ * `STM32` + family + line + pin-count letter + flash letter is eleven
+ * characters, and everything after it — `T6`, `H6Q`, `VT6` — is package,
+ * temperature range and options, none of which changes a byte of memory. So
+ * `STM32H7B3LIH6Q` and `STM32H723ZGT6` are looked up as `STM32H7B3LI` and
+ * `STM32H723ZG`, and the table does not have to carry a row per package.
+ *
+ * Names SHORTER than that — `STM32F407`, `STM32F4` — are left alone, and are
+ * exactly the ones the table answers with SRAM and no flash.
+ */
+export function chipKey(name) {
+  const s = String(name ?? '')
+  return s.startsWith('STM32') && s.length > 11 ? s.slice(0, 11) : s
+}
+
+/**
+ * The chip row for this board.
+ *
+ * The board's own name first, then the build's, then whatever the port's reader
+ * worked out directly — which on nrf is the memory map the board is linked
+ * against, and is the only thing that tells an nRF52832 QFAA from a QFAB.
+ */
+function chipMemoryFor(board, config) {
+  for (const key of [BOARD_MCU_PART[board.id]?.part, config.part, config.partAlso]) {
+    if (key && CHIP_MEMORY[chipKey(key)]) return CHIP_MEMORY[chipKey(key)]
+  }
+  return config.chipMemory ?? null
+}
+
+/**
+ * The sizes to publish for one board, or nulls where nothing is known.
+ *
+ * `config` is what `board-config.mjs` read out of upstream's tree for this board.
+ * The order below is the precedence argued for at the top of this file: what
+ * upstream states outright, then what the chip settles, then curation — and
+ * nothing is invented at any step.
+ */
+export function specsForBoard(board, config = {}) {
+  const curated = CURATED_BOARDS[board.id] ?? {}
+  const withheld = WITHHELD[board.id]?.fields ?? []
+  const chip = chipMemoryFor(board, config)
+  const family = MCU_SRAM[board.mcu]
+
+  // Flash the board states, then flash the chip has, then flash a maker states.
+  let flash = null
+  if (config.flash && config.flashSource) {
+    flash = { bytes: config.flash, source: config.flashSource, scope: 'board' }
+  } else if (chip?.flash) {
+    flash = chipSize(chip.flash, chip.source)
+  } else {
+    flash = boardSize(curated.flash)
+  }
+
+  const psram = config.externalRam && config.externalRamSource
+    ? { bytes: config.externalRam, source: config.externalRamSource, scope: 'board' }
+    : boardSize(curated.psram)
+
+  const out = {
+    flash,
+    externalFlash: boardSize(curated.externalFlash),
+    ram: chip?.sram ? chipSize(chip.sram, chip.source) : family ? { ...family, scope: 'chip' } : null,
+    psram
+  }
+  for (const field of withheld) out[field] = null
+  return out
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/build-board-index.mjs
+++ b/scripts/build-board-index.mjs
@@ -19,11 +19,17 @@
  * committed here as the bundled seed, so a fresh install and the offline
  * classroom build (#267) work with no network at all.
  *
- * WHAT UPSTREAM DOES NOT PUBLISH: flash size, RAM size, and whether the board
- * also runs CircuitPython. `features` carries `External Flash` and `External
- * RAM` as booleans and nothing more. Those come from `board-specs.mjs` instead,
- * which is where every figure's provenance lives — see #897 for why a number
- * with no `source` is not published at all.
+ * WHAT UPSTREAM DOES NOT PUBLISH IN `board.json`: flash size, RAM size, and
+ * whether the board also runs CircuitPython. `features` carries `External Flash`
+ * and `External RAM` as booleans and nothing more.
+ *
+ * It does, though, publish sizes NEXT to `board.json`, in the build
+ * configuration each board needs to compile at all — which is a better citation
+ * than a product page, because it is what the firmware people flash was built
+ * against. `board-config.mjs` reads those, one small reader per port;
+ * `board-specs.mjs` turns a chip name into a datasheet figure and holds the
+ * curation for everything neither can reach. Every number ends up with a
+ * `source` — see #897 for why one without is not published at all.
  *
  * Run:  node scripts/build-board-index.mjs [--tag v1.29.0] [--no-images]
  *       node scripts/build-board-index.mjs --specs-only
@@ -32,7 +38,8 @@
  * derived fields — sizes, runtimes, CircuitPython ids. It exists because the
  * curation in `board-specs.mjs` changes far more often than upstream's tree
  * does, and a full run re-encodes 217 thumbnails into an unreviewable binary
- * diff to say nothing about them.
+ * diff to say nothing about them. It still needs the network: the sizes are
+ * read from upstream's tree, not remembered.
  */
 import { mkdir, readFile, writeFile, rm } from 'node:fs/promises'
 import { join, dirname } from 'node:path'
@@ -46,6 +53,12 @@ import {
   runtimesForBoard,
   specsForBoard
 } from './board-specs.mjs'
+import {
+  PORT_CONFIG_FILES,
+  nrfMemoryScriptsFor,
+  picoSdkBoardFor,
+  readBoardConfig
+} from './board-config.mjs'
 
 const run = promisify(execFile)
 const HERE = dirname(fileURLToPath(import.meta.url))
@@ -149,11 +162,23 @@ async function newestReleaseTag() {
   return stable[0]
 }
 
-/** Every `board.json` path in the tree, one API call. */
-async function boardPaths(tag) {
+/**
+ * Upstream's whole file listing at `tag`, one API call.
+ *
+ * Worth keeping whole rather than filtering to `board.json` on the way past: the
+ * same response says which per-board config files exist (so #897's readers ask
+ * for nothing that would 404) and pins the pico-sdk revision, which is a
+ * submodule and therefore a `commit` entry carrying its sha.
+ */
+async function repoTree(tag) {
   const tree = await getJson(`${GH}/git/trees/${tag}?recursive=1`, ghHeaders())
   if (tree.truncated) throw new Error('tree response was truncated — cannot enumerate boards')
   return tree.tree
+}
+
+/** Every `board.json` path in the tree. */
+function boardPaths(tree) {
+  return tree
     .filter((e) => e.path.endsWith('/board.json'))
     .map((e) => ({ path: e.path, port: e.path.split('/')[1], board: e.path.split('/')[3] }))
 }
@@ -223,20 +248,128 @@ async function thumbnail(srcBytes, destPath) {
 }
 
 /**
+ * What MicroPython's own tree says about each board's hardware (#897).
+ *
+ * Two passes, because rp2's answer may live in a pico-sdk header whose NAME is
+ * only known once the board's `mpconfigboard.cmake` has been read. `tree` is
+ * consulted first so nothing is requested that does not exist — a 404 per board
+ * is both rude and slow against someone else's hosting.
+ *
+ * A board whose files cannot be fetched yields `{}`, which reads downstream as
+ * "nothing known", not as an error: this enriches the index, it does not gate it.
+ */
+async function gatherConfigs(tag, boards, tree) {
+  const present = new Set(tree.map((e) => e.path))
+  const picoSdkSha = tree.find((e) => e.path === 'lib/pico-sdk' && e.type === 'commit')?.sha ?? null
+
+  const fetched = await pooled(boards, CONCURRENCY, async (b) => {
+    const dir = `ports/${b.port}/boards/${b.id}`
+    const files = {}
+    for (const name of PORT_CONFIG_FILES[b.port] ?? []) {
+      if (present.has(`${dir}/${name}`)) files[name] = await getText(`${RAW}/${tag}/${dir}/${name}`)
+    }
+    // A pico-sdk board header the board ships itself — the strongest rp2 source,
+    // because nobody writes one of these about somebody else's board.
+    const ownHeaders = {}
+    if (b.port === 'rp2') {
+      for (const e of tree) {
+        if (!e.path.startsWith(`${dir}/`) || !e.path.endsWith('.h')) continue
+        const name = e.path.slice(dir.length + 1)
+        if (name === 'mpconfigboard.h' || name.includes('/')) continue
+        ownHeaders[name] = await getText(`${RAW}/${tag}/${e.path}`)
+      }
+    }
+    return { files, ownHeaders }
+  })
+
+  // Second pass: the files those configs turned out to name — pico-sdk board
+  // headers, and the nrf memory maps that are the only thing separating an
+  // nRF52832 QFAA from a QFAB. Both are shared between boards, so they are
+  // gathered once by name rather than per board.
+  //
+  // The pico-sdk is fetched at the revision MicroPython PINS, not at whatever is
+  // newest, so the figure is the one this firmware was built against. That is
+  // not a formality: the pinned revision gives the XIAO RP2350 2 MB, agreeing
+  // with Seeed, where a later pico-sdk gives 4 MB.
+  const picoHeaders = new Map()
+  const nrfScripts = new Map()
+  boards.forEach((b, i) => {
+    const got = fetched[i]
+    if (!got?.files) return
+    if (b.port === 'rp2' && picoSdkSha) {
+      const name = picoSdkBoardFor(got.files, b.id)
+      if (name) picoHeaders.set(name, null)
+    }
+    if (b.port === 'nrf') {
+      for (const name of nrfMemoryScriptsFor(got.files)) {
+        if (present.has(`ports/nrf/boards/${name}`)) nrfScripts.set(name, null)
+      }
+    }
+  })
+  await Promise.all([
+    fetchInto(picoHeaders, (name) =>
+      getText(
+        `https://raw.githubusercontent.com/raspberrypi/pico-sdk/${picoSdkSha}/src/boards/include/boards/${name}.h`
+      )
+    ),
+    fetchInto(nrfScripts, (name) => getText(`${RAW}/${tag}/ports/nrf/boards/${name}`))
+  ])
+
+  const out = new Map()
+  boards.forEach((b, i) => {
+    const got = fetched[i]
+    if (!got?.files) return out.set(b.id, {})
+    out.set(
+      b.id,
+      readBoardConfig(b.port, got.files, {
+        boardId: b.id,
+        ownHeaders: got.ownHeaders,
+        picoSdkHeaders: Object.fromEntries(picoHeaders),
+        // Only the scripts THIS board names, so a board never sees another's.
+        nrfScripts: Object.fromEntries(
+          nrfMemoryScriptsFor(got.files)
+            .map((name) => [name, nrfScripts.get(name)])
+            .filter(([, text]) => typeof text === 'string')
+        )
+      })
+    )
+  })
+  return out
+}
+
+/** Fill a `name → null` map with `fetch(name)`, dropping whatever fails. */
+async function fetchInto(map, fetchOne) {
+  const names = [...map.keys()]
+  const got = await pooled(names, CONCURRENCY, fetchOne)
+  names.forEach((name, i) => {
+    if (typeof got[i] === 'string') map.set(name, got[i])
+  })
+}
+
+/**
  * Attach the derived fields to every board, in place.
  *
  * Shared by the full run and `--specs-only` so the two cannot drift: a seed
  * enriched by the quick path has to be byte-identical to one the slow path would
  * have produced, or the quick path is just a second, worse generator.
  */
-function addSpecs(boards, cpIndex) {
+function addSpecs(boards, cpIndex, configs) {
+  const derived = ['flash', 'externalFlash', 'ram', 'psram', 'circuitPythonBoardId', 'runtimes']
   for (const b of boards) {
-    const { flash, ram, psram } = specsForBoard(b)
+    const { flash, externalFlash, ram, psram } = specsForBoard(b, configs?.get(b.id) ?? {})
+    const circuitPythonBoardId = cpIndex ? circuitPythonIdFor(b, cpIndex) : null
+    // Cleared and re-set in one order, so a seed enriched by `--specs-only`
+    // matches one the full run wrote KEY FOR KEY. Assigning over the existing
+    // fields instead would leave a field added since the seed was last built
+    // sitting at the end of the object, and the two paths would differ in a diff
+    // while agreeing on every value.
+    for (const key of derived) delete b[key]
     b.flash = flash
+    b.externalFlash = externalFlash
     b.ram = ram
     b.psram = psram
-    b.circuitPythonBoardId = cpIndex ? circuitPythonIdFor(b, cpIndex) : null
-    b.runtimes = runtimesForBoard(b, b.circuitPythonBoardId)
+    b.circuitPythonBoardId = circuitPythonBoardId
+    b.runtimes = runtimesForBoard(b, circuitPythonBoardId)
   }
   return boards
 }
@@ -254,22 +387,45 @@ async function loadCircuitPython() {
   }
 }
 
-/** Report what is known and what is not, because the gaps are the point (#897). */
+/**
+ * Report what is known and what is not, because the gaps are the point (#897).
+ *
+ * Broken down by vendor as well as in total: "flash on 195 of 225" hides that a
+ * whole maker's range is missing, and which maker it is decides whether the
+ * gallery can offer a size filter without quietly dropping them.
+ */
 function reportCoverage(boards) {
   const n = (f) => boards.filter(f).length
   process.stderr.write(
     `  flash size on ${n((b) => b.flash)}/${boards.length}, ` +
-      `RAM on ${n((b) => b.ram)}, PSRAM on ${n((b) => b.psram)}, ` +
+      `external flash on ${n((b) => b.externalFlash)}, ` +
+      `RAM on ${n((b) => b.ram)}, external RAM on ${n((b) => b.psram)}, ` +
       `CircuitPython confirmed on ${n((b) => b.circuitPythonBoardId)}\n`
   )
+  const byVendor = new Map()
+  for (const b of boards) {
+    const row = byVendor.get(b.vendor) ?? { total: 0, flash: 0, ram: 0 }
+    row.total += 1
+    if (b.flash) row.flash += 1
+    if (b.ram) row.ram += 1
+    byVendor.set(b.vendor, row)
+  }
+  for (const [vendor, row] of [...byVendor].sort((a, b) => b[1].total - a[1].total)) {
+    if (row.flash === row.total && row.ram === row.total) continue
+    process.stderr.write(
+      `    ${vendor}: flash ${row.flash}/${row.total}, RAM ${row.ram}/${row.total}\n`
+    )
+  }
 }
 
 /** Rewrite the committed seed's derived fields without touching anything else. */
 async function specsOnly() {
   const path = join(OUT_DIR, 'boards.json')
   const doc = JSON.parse(await readFile(path, 'utf8'))
-  process.stderr.write(`Re-deriving specs for ${doc.boards.length} boards in ${path}\n`)
-  addSpecs(doc.boards, await loadCircuitPython())
+  const tag = value('--tag', null) ?? doc.micropython
+  process.stderr.write(`Re-deriving specs for ${doc.boards.length} boards in ${path} (${tag})\n`)
+  const configs = await gatherConfigs(tag, doc.boards, await repoTree(tag))
+  addSpecs(doc.boards, await loadCircuitPython(), configs)
   doc.generated = new Date().toISOString().slice(0, 10)
   await writeFile(path, `${JSON.stringify(doc, null, 2)}\n`)
   reportCoverage(doc.boards)
@@ -281,7 +437,8 @@ async function main() {
   const withImages = !flag('--no-images')
   process.stderr.write(`Building board index from MicroPython ${tag}\n`)
 
-  const paths = await boardPaths(tag)
+  const tree = await repoTree(tag)
+  const paths = boardPaths(tree)
   process.stderr.write(`  ${paths.length} boards in the tree\n`)
 
   await mkdir(join(OUT_DIR, 'thumbs'), { recursive: true })
@@ -330,7 +487,7 @@ async function main() {
   const ok = boards.filter((b) => b && !b.error)
   const failed = boards.length - ok.length
   ok.sort((a, b) => a.vendor.localeCompare(b.vendor) || a.product.localeCompare(b.product))
-  addSpecs(ok, await loadCircuitPython())
+  addSpecs(ok, await loadCircuitPython(), await gatherConfigs(tag, ok, tree))
 
   const doc = {
     schema: SCHEMA,

--- a/src/renderer/public/boards/boards.json
+++ b/src/renderer/public/boards/boards.json
@@ -32,8 +32,17 @@
           "url": "https://micropython.org/resources/firmware/ACTINIUS_ICARUS-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "Nordic nRF9160 product specification",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 262144,
+        "source": "Nordic nRF9160 product specification",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -69,8 +78,21 @@
           "url": "https://micropython.org/resources/firmware/ADAFRUIT_F405_EXPRESS-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "ST STM32F405RG (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": {
+        "bytes": 2097152,
+        "source": "adafruit.com/product/4382",
+        "scope": "board"
+      },
+      "ram": {
+        "bytes": 196608,
+        "source": "ST STM32F405RG (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -112,8 +134,21 @@
           "url": "https://micropython.org/resources/firmware/ADAFRUIT_FEATHER_M0_EXPRESS-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 262144,
+        "source": "Microchip SAM D21/DA1 datasheet DS40001882G",
+        "scope": "chip"
+      },
+      "externalFlash": {
+        "bytes": 2097152,
+        "source": "adafruit.com/product/3403",
+        "scope": "board"
+      },
+      "ram": {
+        "bytes": 32768,
+        "source": "Microchip SAM D21/DA1 datasheet DS40001882G",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": "feather_m0_express",
       "runtimes": [
@@ -156,8 +191,21 @@
           "url": "https://micropython.org/resources/firmware/ADAFRUIT_FEATHER_M4_EXPRESS-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "Microchip SAM D5x/E5x datasheet DS60001507",
+        "scope": "chip"
+      },
+      "externalFlash": {
+        "bytes": 2097152,
+        "source": "adafruit.com/product/3857",
+        "scope": "board"
+      },
+      "ram": {
+        "bytes": 196608,
+        "source": "Microchip SAM D5x/E5x datasheet DS60001507",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": "feather_m4_express",
       "runtimes": [
@@ -195,6 +243,7 @@
         }
       ],
       "flash": null,
+      "externalFlash": null,
       "ram": null,
       "psram": null,
       "circuitPythonBoardId": "feather_nrf52840_express",
@@ -240,7 +289,12 @@
           "url": "https://micropython.org/resources/firmware/ADAFRUIT_FEATHER_RP2040-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 8388608,
+        "source": "adafruit.com/product/4884",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 270336,
         "source": "Raspberry Pi RP2040 datasheet",
@@ -293,6 +347,7 @@
         }
       ],
       "flash": null,
+      "externalFlash": null,
       "ram": {
         "bytes": 532480,
         "source": "Raspberry Pi RP2350 datasheet",
@@ -338,8 +393,21 @@
           "url": "https://micropython.org/resources/firmware/ADAFRUIT_ITSYBITSY_M0_EXPRESS-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 262144,
+        "source": "Microchip SAM D21/DA1 datasheet DS40001882G",
+        "scope": "chip"
+      },
+      "externalFlash": {
+        "bytes": 2097152,
+        "source": "adafruit.com/product/3727",
+        "scope": "board"
+      },
+      "ram": {
+        "bytes": 32768,
+        "source": "Microchip SAM D21/DA1 datasheet DS40001882G",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": "itsybitsy_m0_express",
       "runtimes": [
@@ -380,8 +448,21 @@
           "url": "https://micropython.org/resources/firmware/ADAFRUIT_ITSYBITSY_M4_EXPRESS-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "Microchip SAM D5x/E5x datasheet DS60001507",
+        "scope": "chip"
+      },
+      "externalFlash": {
+        "bytes": 2097152,
+        "source": "adafruit.com/product/3800",
+        "scope": "board"
+      },
+      "ram": {
+        "bytes": 196608,
+        "source": "Microchip SAM D5x/E5x datasheet DS60001507",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": "itsybitsy_m4_express",
       "runtimes": [
@@ -423,7 +504,12 @@
           "url": "https://micropython.org/resources/firmware/ADAFRUIT_ITSYBITSY_RP2040-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 8388608,
+        "source": "adafruit.com/product/4888",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 270336,
         "source": "Raspberry Pi RP2040 datasheet",
@@ -472,8 +558,21 @@
           "url": "https://micropython.org/resources/firmware/ADAFRUIT_METRO_M4_EXPRESS-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "Microchip SAM D5x/E5x datasheet DS60001507",
+        "scope": "chip"
+      },
+      "externalFlash": {
+        "bytes": 2097152,
+        "source": "adafruit.com/product/4000",
+        "scope": "board"
+      },
+      "ram": {
+        "bytes": 196608,
+        "source": "Microchip SAM D5x/E5x datasheet DS60001507",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -516,8 +615,17 @@
           "url": "https://micropython.org/resources/firmware/ADAFRUIT_METRO_M7-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 8388608,
+        "source": "MicroPython ports/mimxrt/boards/ADAFRUIT_METRO_M7/mpconfigboard.mk (MICROPY_HW_FLASH_SIZE)",
+        "scope": "board"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 131072,
+        "source": "NXP i.MX RT1010 datasheet IMXRT1010CEC",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -556,8 +664,17 @@
           "url": "https://micropython.org/resources/firmware/ADAFRUIT_NEOKEY_TRINKEY-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 262144,
+        "source": "Microchip SAM D21/DA1 datasheet DS40001882G",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 32768,
+        "source": "Microchip SAM D21/DA1 datasheet DS40001882G",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -611,8 +728,17 @@
           "url": "https://micropython.org/resources/firmware/ADAFRUIT_QTPY_SAMD21-SPIFLASH-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 262144,
+        "source": "Microchip SAM D21/DA1 datasheet DS40001882G",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 32768,
+        "source": "Microchip SAM D21/DA1 datasheet DS40001882G",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -654,7 +780,12 @@
           "url": "https://micropython.org/resources/firmware/ADAFRUIT_QTPY_RP2040-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 8388608,
+        "source": "adafruit.com/product/4900",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 270336,
         "source": "Raspberry Pi RP2040 datasheet",
@@ -699,8 +830,17 @@
           "url": "https://micropython.org/resources/firmware/ADAFRUIT_TRINKET_M0-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 262144,
+        "source": "Microchip SAM D21/DA1 datasheet DS40001882G",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 32768,
+        "source": "Microchip SAM D21/DA1 datasheet DS40001882G",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": "trinket_m0",
       "runtimes": [
@@ -724,8 +864,17 @@
       "image": "https://micropython.org/resources/micropython-media/boards/ALIF_ENSEMBLE/ensemble-devkit-gen-2.jpg",
       "thumb": "ALIF_ENSEMBLE.jpg",
       "builds": [],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 5767168,
+        "source": "Alif Ensemble E7 datasheet ADTS0005 (MRAM / SRAM)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 14155776,
+        "source": "Alif Ensemble E7 datasheet ADTS0005 (MRAM / SRAM)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": []
@@ -766,9 +915,26 @@
           "url": "https://micropython.org/resources/firmware/ARDUINO_GIGA-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
-      "psram": null,
+      "flash": {
+        "bytes": 2097152,
+        "source": "ST STM32H747XI (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": {
+        "bytes": 16777216,
+        "source": "docs.arduino.cc/hardware/giga-r1-wifi (AT25SF128A)",
+        "scope": "board"
+      },
+      "ram": {
+        "bytes": 1081344,
+        "source": "ST STM32H747XI (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "psram": {
+        "bytes": 8388608,
+        "source": "docs.arduino.cc/hardware/giga-r1-wifi (AS4C4M16SA SDRAM)",
+        "scope": "board"
+      },
       "circuitPythonBoardId": null,
       "runtimes": [
         "micropython"
@@ -810,8 +976,17 @@
           "url": "https://micropython.org/resources/firmware/ARDUINO_NANO_33_BLE_SENSE-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "Nordic nRF52840 product specification",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 262144,
+        "source": "Nordic nRF52840 product specification",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -853,13 +1028,22 @@
           "url": "https://micropython.org/resources/firmware/ARDUINO_NANO_ESP32-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 16777216,
+        "source": "MicroPython ports/esp32/boards/ARDUINO_NANO_ESP32/sdkconfig.board (CONFIG_ESPTOOLPY_FLASHSIZE)",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 524288,
         "source": "Espressif ESP32-S3 datasheet",
         "scope": "chip"
       },
-      "psram": null,
+      "psram": {
+        "bytes": 8388608,
+        "source": "docs.arduino.cc/hardware/nano-esp32 (in the NORA-W106 module)",
+        "scope": "board"
+      },
       "circuitPythonBoardId": "arduino_nano_esp32s3",
       "runtimes": [
         "micropython",
@@ -904,7 +1088,12 @@
           "url": "https://micropython.org/resources/firmware/ARDUINO_NANO_RP2040_CONNECT-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 16777216,
+        "source": "docs.arduino.cc/hardware/nano-rp2040-connect (AT25SF128A)",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 270336,
         "source": "Raspberry Pi RP2040 datasheet",
@@ -953,8 +1142,21 @@
           "url": "https://micropython.org/resources/firmware/ARDUINO_NICLA_VISION-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 2097152,
+        "source": "ST STM32H747XI (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": {
+        "bytes": 16777216,
+        "source": "docs.arduino.cc/hardware/nicla-vision (AT25QL128A)",
+        "scope": "board"
+      },
+      "ram": {
+        "bytes": 1081344,
+        "source": "ST STM32H747XI (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -996,8 +1198,21 @@
           "url": "https://micropython.org/resources/firmware/ARDUINO_OPTA-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 2097152,
+        "source": "ST STM32H747XI (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": {
+        "bytes": 16777216,
+        "source": "docs.arduino.cc/hardware/opta",
+        "scope": "board"
+      },
+      "ram": {
+        "bytes": 1081344,
+        "source": "ST STM32H747XI (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -1040,8 +1255,21 @@
           "url": "https://micropython.org/resources/firmware/ARDUINO_PORTENTA_C33-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 2097152,
+        "source": "docs.arduino.cc/hardware/portenta-c33",
+        "scope": "board"
+      },
+      "externalFlash": {
+        "bytes": 16777216,
+        "source": "docs.arduino.cc/hardware/portenta-c33 (MX25L12833F)",
+        "scope": "board"
+      },
+      "ram": {
+        "bytes": 524288,
+        "source": "Renesas RA6M5 group datasheet",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -1085,9 +1313,26 @@
           "url": "https://micropython.org/resources/firmware/ARDUINO_PORTENTA_H7-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
-      "psram": null,
+      "flash": {
+        "bytes": 2097152,
+        "source": "ST STM32H747XI (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": {
+        "bytes": 16777216,
+        "source": "docs.arduino.cc/hardware/portenta-h7",
+        "scope": "board"
+      },
+      "ram": {
+        "bytes": 1081344,
+        "source": "ST STM32H747XI (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "psram": {
+        "bytes": 8388608,
+        "source": "docs.arduino.cc/hardware/portenta-h7 (SDRAM)",
+        "scope": "board"
+      },
       "circuitPythonBoardId": null,
       "runtimes": [
         "micropython"
@@ -1122,8 +1367,17 @@
           "url": "https://micropython.org/resources/firmware/ARDUINO_PRIMO-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "MicroPython ports/nrf/boards/nrf52832_512k_64k.ld",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 65536,
+        "source": "MicroPython ports/nrf/boards/nrf52832_512k_64k.ld",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -1159,8 +1413,17 @@
           "url": "https://micropython.org/resources/firmware/MICROBIT-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 262144,
+        "source": "MicroPython ports/nrf/boards/nrf51x22_256k_16k.ld",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 16384,
+        "source": "MicroPython ports/nrf/boards/nrf51x22_256k_16k.ld",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -1217,7 +1480,12 @@
           "url": "https://micropython.org/resources/firmware/CYTRON_MOTION_2350_PRO-RISCV-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 2097152,
+        "source": "cytron.io/p-motion-2350-pro",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 532480,
         "source": "Raspberry Pi RP2350 datasheet",
@@ -1268,6 +1536,7 @@
         }
       ],
       "flash": null,
+      "externalFlash": null,
       "ram": {
         "bytes": 270336,
         "source": "Raspberry Pi RP2040 datasheet",
@@ -1374,6 +1643,7 @@
         }
       ],
       "flash": null,
+      "externalFlash": null,
       "ram": {
         "bytes": 532480,
         "source": "Espressif ESP32 datasheet",
@@ -1435,6 +1705,7 @@
         }
       ],
       "flash": null,
+      "externalFlash": null,
       "ram": {
         "bytes": 278528,
         "source": "Espressif ESP32-C2 datasheet",
@@ -1480,6 +1751,7 @@
         }
       ],
       "flash": null,
+      "externalFlash": null,
       "ram": {
         "bytes": 409600,
         "source": "Espressif ESP32-C3 datasheet",
@@ -1525,6 +1797,7 @@
         }
       ],
       "flash": null,
+      "externalFlash": null,
       "ram": {
         "bytes": 393216,
         "source": "Espressif ESP32-C5 datasheet (HP SRAM)",
@@ -1569,6 +1842,7 @@
         }
       ],
       "flash": null,
+      "externalFlash": null,
       "ram": {
         "bytes": 524288,
         "source": "Espressif ESP32-C6 datasheet (HP SRAM)",
@@ -1605,7 +1879,12 @@
         }
       ],
       "flash": null,
-      "ram": null,
+      "externalFlash": null,
+      "ram": {
+        "bytes": 327680,
+        "source": "Espressif ESP32-H2 datasheet (HP SRAM)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -1700,6 +1979,7 @@
         }
       ],
       "flash": null,
+      "externalFlash": null,
       "ram": {
         "bytes": 786432,
         "source": "Espressif ESP32-P4 datasheet (HP SRAM)",
@@ -1745,6 +2025,7 @@
         }
       ],
       "flash": null,
+      "externalFlash": null,
       "ram": {
         "bytes": 327680,
         "source": "Espressif ESP32-S2 datasheet",
@@ -1807,6 +2088,7 @@
         }
       ],
       "flash": null,
+      "externalFlash": null,
       "ram": {
         "bytes": 524288,
         "source": "Espressif ESP32-S3 datasheet",
@@ -1897,6 +2179,7 @@
         }
       ],
       "flash": null,
+      "externalFlash": null,
       "ram": null,
       "psram": null,
       "circuitPythonBoardId": null,
@@ -1933,8 +2216,17 @@
           "url": "https://micropython.org/resources/firmware/ESPRUINO_PICO-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 393216,
+        "source": "ST STM32F401CD (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 98304,
+        "source": "ST STM32F401CD (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -1970,8 +2262,17 @@
           "url": "https://micropython.org/resources/firmware/DVK_BL652-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "MicroPython ports/nrf/boards/nrf52832_512k_64k.ld",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 65536,
+        "source": "MicroPython ports/nrf/boards/nrf52832_512k_64k.ld",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -2007,8 +2308,17 @@
           "url": "https://micropython.org/resources/firmware/CERB40-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "ST STM32F405RG (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 196608,
+        "source": "ST STM32F405RG (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -2044,8 +2354,21 @@
           "url": "https://micropython.org/resources/firmware/PYBD_SF2-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "ST STM32F722IE (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": {
+        "bytes": 4194304,
+        "source": "store.micropython.org PYBD-SF2 (2 MiB XIP + 2 MiB filesystem)",
+        "scope": "board"
+      },
+      "ram": {
+        "bytes": 262144,
+        "source": "ST STM32F722IE (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -2081,8 +2404,21 @@
           "url": "https://micropython.org/resources/firmware/PYBD_SF3-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "ST STM32F733IE (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": {
+        "bytes": 4194304,
+        "source": "store.micropython.org PYBD-SF3 (2 MiB XIP + 2 MiB filesystem)",
+        "scope": "board"
+      },
+      "ram": {
+        "bytes": 262144,
+        "source": "ST STM32F733IE (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -2121,8 +2457,21 @@
           "url": "https://micropython.org/resources/firmware/PYBD_SF6-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 2097152,
+        "source": "ST STM32F767II (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": {
+        "bytes": 4194304,
+        "source": "store.micropython.org PYBD-SF6 (2 MiB XIP + 2 MiB filesystem)",
+        "scope": "board"
+      },
+      "ram": {
+        "bytes": 524288,
+        "source": "ST STM32F767II (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -2219,8 +2568,17 @@
           "url": "https://micropython.org/resources/firmware/PYBLITEV10-NETWORK-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "ST STM32F411RE (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 131072,
+        "source": "ST STM32F411RE (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -2317,8 +2675,17 @@
           "url": "https://micropython.org/resources/firmware/PYBV10-NETWORK-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "ST STM32F405RG (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 196608,
+        "source": "ST STM32F405RG (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -2415,8 +2782,17 @@
           "url": "https://micropython.org/resources/firmware/PYBV11-NETWORK-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "ST STM32F405RG (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 196608,
+        "source": "ST STM32F405RG (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -2452,8 +2828,17 @@
           "url": "https://micropython.org/resources/firmware/HYDRABUS-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "ST STM32F405 (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 196608,
+        "source": "ST STM32F405 (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -2489,8 +2874,17 @@
           "url": "https://micropython.org/resources/firmware/BLUEIO_TAG_EVIM-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "MicroPython ports/nrf/boards/nrf52832_512k_64k.ld",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 65536,
+        "source": "MicroPython ports/nrf/boards/nrf52832_512k_64k.ld",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -2526,8 +2920,17 @@
           "url": "https://micropython.org/resources/firmware/IBK_BLYST_NANO-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "MicroPython ports/nrf/boards/nrf52832_512k_64k.ld",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 65536,
+        "source": "MicroPython ports/nrf/boards/nrf52832_512k_64k.ld",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -2563,8 +2966,17 @@
           "url": "https://micropython.org/resources/firmware/IDK_BLYST_NANO-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "MicroPython ports/nrf/boards/nrf52832_512k_64k.ld",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 65536,
+        "source": "MicroPython ports/nrf/boards/nrf52832_512k_64k.ld",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -2594,8 +3006,17 @@
       "image": "https://micropython.org/resources/micropython-media/boards/KIT_PSE84_AI/kit_pse84_ai.jpg",
       "thumb": null,
       "builds": [],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "Infineon PSOC Edge E8x datasheet 002-37630 (RRAM / total SRAM)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 6291456,
+        "source": "Infineon PSOC Edge E8x datasheet 002-37630 (RRAM / total SRAM)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": []
@@ -2630,7 +3051,12 @@
         }
       ],
       "flash": null,
-      "ram": null,
+      "externalFlash": null,
+      "ram": {
+        "bytes": 327680,
+        "source": "ST STM32F413 line (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -2667,7 +3093,12 @@
         }
       ],
       "flash": null,
-      "ram": null,
+      "externalFlash": null,
+      "ram": {
+        "bytes": 327680,
+        "source": "ST STM32F413 line (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -2706,6 +3137,7 @@
         }
       ],
       "flash": null,
+      "externalFlash": null,
       "ram": {
         "bytes": 524288,
         "source": "Espressif ESP32-S3 datasheet",
@@ -2754,7 +3186,12 @@
           "url": "https://micropython.org/resources/firmware/LILYGO_TTGO_LORA32-20260406-v1.28.0.bin"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 4194304,
+        "source": "lilygo.cc/products/lora3 (V1.6.1)",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 532480,
         "source": "Espressif ESP32 datasheet",
@@ -2796,7 +3233,12 @@
         }
       ],
       "flash": null,
-      "ram": null,
+      "externalFlash": null,
+      "ram": {
+        "bytes": 131072,
+        "source": "ST STM32L476 line (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -2839,7 +3281,12 @@
           "url": "https://micropython.org/resources/firmware/M5STACK_ATOM-20260406-v1.28.0.bin"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 4194304,
+        "source": "docs.m5stack.com/en/core/ATOM Matrix",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 532480,
         "source": "Espressif ESP32 datasheet",
@@ -2886,7 +3333,12 @@
           "url": "https://micropython.org/resources/firmware/M5STACK_ATOMS3_LITE-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 8388608,
+        "source": "docs.m5stack.com/en/core/AtomS3 Lite",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 524288,
         "source": "Espressif ESP32-S3 datasheet",
@@ -2935,7 +3387,12 @@
           "url": "https://micropython.org/resources/firmware/M5STACK_NANOC6-20260406-v1.28.0.bin"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 4194304,
+        "source": "docs.m5stack.com/en/core/M5NanoC6",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 524288,
         "source": "Espressif ESP32-C6 datasheet (HP SRAM)",
@@ -2975,8 +3432,17 @@
           "url": "https://micropython.org/resources/firmware/M5STACK_NANOH2-20260824-v1.29.0.bin"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 4194304,
+        "source": "docs.m5stack.com/en/core/NanoH2",
+        "scope": "board"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 327680,
+        "source": "Espressif ESP32-H2 datasheet (HP SRAM)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -3017,6 +3483,7 @@
         }
       ],
       "flash": null,
+      "externalFlash": null,
       "ram": {
         "bytes": 270336,
         "source": "Raspberry Pi RP2040 datasheet",
@@ -3061,8 +3528,17 @@
           "url": "https://micropython.org/resources/firmware/MAKERDIARY_RT1011_NANO_KIT-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 16777216,
+        "source": "MicroPython ports/mimxrt/boards/MAKERDIARY_RT1011_NANO_KIT/mpconfigboard.mk (MICROPY_HW_FLASH_SIZE)",
+        "scope": "board"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 131072,
+        "source": "NXP i.MX RT1010 datasheet IMXRT1010CEC",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": "makerdiary_imxrt1011_nanokit",
       "runtimes": [
@@ -3099,8 +3575,17 @@
           "url": "https://micropython.org/resources/firmware/NRF52840_MDK_USB_DONGLE-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "Nordic nRF52840 product specification",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 262144,
+        "source": "Nordic nRF52840 product specification",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -3136,8 +3621,17 @@
           "url": "https://micropython.org/resources/firmware/GARATRONIC_NADHAT_F405-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "ST STM32F405RG (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 196608,
+        "source": "ST STM32F405RG (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -3173,8 +3667,17 @@
           "url": "https://micropython.org/resources/firmware/GARATRONIC_PYBSTICK26_F411-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "ST STM32F411RE (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 131072,
+        "source": "ST STM32F411RE (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -3216,6 +3719,7 @@
         }
       ],
       "flash": null,
+      "externalFlash": null,
       "ram": {
         "bytes": 409600,
         "source": "Espressif ESP32-C3 datasheet",
@@ -3262,6 +3766,7 @@
         }
       ],
       "flash": null,
+      "externalFlash": null,
       "ram": {
         "bytes": 270336,
         "source": "Raspberry Pi RP2040 datasheet",
@@ -3304,8 +3809,17 @@
           "url": "https://micropython.org/resources/firmware/SAMD_GENERIC_D21X18-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 262144,
+        "source": "Microchip SAM D21/DA1 datasheet DS40001882G",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 32768,
+        "source": "Microchip SAM D21/DA1 datasheet DS40001882G",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -3343,8 +3857,17 @@
           "url": "https://micropython.org/resources/firmware/SAMD_GENERIC_D51X19-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "Microchip SAM D5x/E5x datasheet DS60001507",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 196608,
+        "source": "Microchip SAM D5x/E5x datasheet DS60001507",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -3382,8 +3905,17 @@
           "url": "https://micropython.org/resources/firmware/SAMD_GENERIC_D51X20-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "Microchip SAM D5x/E5x datasheet DS60001507",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 262144,
+        "source": "Microchip SAM D5x/E5x datasheet DS60001507",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -3422,8 +3954,17 @@
           "url": "https://micropython.org/resources/firmware/SAMD21_XPLAINED_PRO-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 262144,
+        "source": "Microchip SAM D21/DA1 datasheet DS40001882G",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 32768,
+        "source": "Microchip SAM D21/DA1 datasheet DS40001882G",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -3462,7 +4003,12 @@
         }
       ],
       "flash": null,
-      "ram": null,
+      "externalFlash": null,
+      "ram": {
+        "bytes": 196608,
+        "source": "ST STM32F407 line (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -3500,8 +4046,17 @@
           "url": "https://micropython.org/resources/firmware/MIKROE_QUAIL-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 2097152,
+        "source": "ST STM32F427VI (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 262144,
+        "source": "ST STM32F427VI (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -3537,8 +4092,17 @@
           "url": "https://micropython.org/resources/firmware/RA4M1_CLICKER-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 262144,
+        "source": "Renesas RA4M1 group datasheet",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 32768,
+        "source": "Renesas RA4M1 group datasheet",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -3578,8 +4142,17 @@
           "url": "https://micropython.org/resources/firmware/MINISAM_M4-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "Microchip SAM D5x/E5x datasheet DS60001507",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 196608,
+        "source": "Microchip SAM D5x/E5x datasheet DS60001507",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -3615,8 +4188,17 @@
           "url": "https://micropython.org/resources/firmware/NETDUINO_PLUS_2-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "ST STM32F405RG (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 196608,
+        "source": "ST STM32F405RG (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -3652,8 +4234,17 @@
           "url": "https://micropython.org/resources/firmware/PCA10000-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 262144,
+        "source": "MicroPython ports/nrf/boards/nrf51x22_256k_16k.ld",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 16384,
+        "source": "MicroPython ports/nrf/boards/nrf51x22_256k_16k.ld",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -3689,8 +4280,17 @@
           "url": "https://micropython.org/resources/firmware/PCA10001-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 262144,
+        "source": "MicroPython ports/nrf/boards/nrf51x22_256k_16k.ld",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 16384,
+        "source": "MicroPython ports/nrf/boards/nrf51x22_256k_16k.ld",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -3726,8 +4326,17 @@
           "url": "https://micropython.org/resources/firmware/PCA10028-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 262144,
+        "source": "MicroPython ports/nrf/boards/nrf51x22_256k_32k.ld",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 32768,
+        "source": "MicroPython ports/nrf/boards/nrf51x22_256k_32k.ld",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -3763,8 +4372,17 @@
           "url": "https://micropython.org/resources/firmware/PCA10031-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 262144,
+        "source": "MicroPython ports/nrf/boards/nrf51x22_256k_32k.ld",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 32768,
+        "source": "MicroPython ports/nrf/boards/nrf51x22_256k_32k.ld",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -3800,8 +4418,17 @@
           "url": "https://micropython.org/resources/firmware/PCA10040-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "MicroPython ports/nrf/boards/nrf52832_512k_64k.ld",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 65536,
+        "source": "MicroPython ports/nrf/boards/nrf52832_512k_64k.ld",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -3837,8 +4464,17 @@
           "url": "https://micropython.org/resources/firmware/PCA10056-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "Nordic nRF52840 product specification",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 262144,
+        "source": "Nordic nRF52840 product specification",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": "pca10056",
       "runtimes": [
@@ -3875,8 +4511,17 @@
           "url": "https://micropython.org/resources/firmware/PCA10059-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "Nordic nRF52840 product specification",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 262144,
+        "source": "Nordic nRF52840 product specification",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": "pca10059",
       "runtimes": [
@@ -3913,8 +4558,17 @@
           "url": "https://micropython.org/resources/firmware/PCA10090-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "Nordic nRF9160 product specification",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 262144,
+        "source": "Nordic nRF9160 product specification",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -3955,7 +4609,12 @@
           "url": "https://micropython.org/resources/firmware/NULLBITS_BIT_C_PRO-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 4194304,
+        "source": "Raspberry Pi pico-sdk src/boards/include/boards/nullbits_bit_c_pro.h (PICO_FLASH_SIZE_BYTES)",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 270336,
         "source": "Raspberry Pi RP2040 datasheet",
@@ -4002,8 +4661,17 @@
           "url": "https://micropython.org/resources/firmware/MIMXRT1010_EVK-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 16777216,
+        "source": "MicroPython ports/mimxrt/boards/MIMXRT1010_EVK/mpconfigboard.mk (MICROPY_HW_FLASH_SIZE)",
+        "scope": "board"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 131072,
+        "source": "NXP i.MX RT1010 datasheet IMXRT1010CEC",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -4044,7 +4712,12 @@
           "url": "https://micropython.org/resources/firmware/MIMXRT1015_EVK-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 16777216,
+        "source": "MicroPython ports/mimxrt/boards/MIMXRT1015_EVK/mpconfigboard.mk (MICROPY_HW_FLASH_SIZE)",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": null,
       "psram": null,
       "circuitPythonBoardId": null,
@@ -4090,9 +4763,22 @@
           "url": "https://micropython.org/resources/firmware/MIMXRT1020_EVK-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
-      "ram": null,
-      "psram": null,
+      "flash": {
+        "bytes": 8388608,
+        "source": "MicroPython ports/mimxrt/boards/MIMXRT1020_EVK/mpconfigboard.mk (MICROPY_HW_FLASH_SIZE)",
+        "scope": "board"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 262144,
+        "source": "NXP i.MX RT1020 datasheet IMXRT1020CEC",
+        "scope": "chip"
+      },
+      "psram": {
+        "bytes": 33554432,
+        "source": "MicroPython ports/mimxrt/boards/MIMXRT1020_EVK/mpconfigboard.mk (MICROPY_HW_SDRAM_SIZE)",
+        "scope": "board"
+      },
       "circuitPythonBoardId": null,
       "runtimes": [
         "micropython"
@@ -4136,9 +4822,22 @@
           "url": "https://micropython.org/resources/firmware/MIMXRT1050_EVK-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
-      "psram": null,
+      "flash": {
+        "bytes": 67108864,
+        "source": "MicroPython ports/mimxrt/boards/MIMXRT1050_EVK/mpconfigboard.mk (MICROPY_HW_FLASH_SIZE)",
+        "scope": "board"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 524288,
+        "source": "NXP i.MX RT1050 datasheet IMXRT1050CEC",
+        "scope": "chip"
+      },
+      "psram": {
+        "bytes": 33554432,
+        "source": "MicroPython ports/mimxrt/boards/MIMXRT1050_EVK/mpconfigboard.mk (MICROPY_HW_SDRAM_SIZE)",
+        "scope": "board"
+      },
       "circuitPythonBoardId": null,
       "runtimes": [
         "micropython"
@@ -4183,9 +4882,22 @@
           "url": "https://micropython.org/resources/firmware/MIMXRT1060_EVK-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
-      "ram": null,
-      "psram": null,
+      "flash": {
+        "bytes": 8388608,
+        "source": "MicroPython ports/mimxrt/boards/MIMXRT1060_EVK/mpconfigboard.mk (MICROPY_HW_FLASH_SIZE)",
+        "scope": "board"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 1048576,
+        "source": "NXP i.MX RT1060 datasheet IMXRT1060CEC",
+        "scope": "chip"
+      },
+      "psram": {
+        "bytes": 33554432,
+        "source": "MicroPython ports/mimxrt/boards/MIMXRT1060_EVK/mpconfigboard.mk (MICROPY_HW_SDRAM_SIZE)",
+        "scope": "board"
+      },
       "circuitPythonBoardId": null,
       "runtimes": [
         "micropython"
@@ -4230,9 +4942,22 @@
           "url": "https://micropython.org/resources/firmware/MIMXRT1064_EVK-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
-      "ram": null,
-      "psram": null,
+      "flash": {
+        "bytes": 4194304,
+        "source": "MicroPython ports/mimxrt/boards/MIMXRT1064_EVK/mpconfigboard.mk (MICROPY_HW_FLASH_SIZE)",
+        "scope": "board"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 1048576,
+        "source": "NXP i.MX RT1064 datasheet IMXRT1064CEC",
+        "scope": "chip"
+      },
+      "psram": {
+        "bytes": 33554432,
+        "source": "MicroPython ports/mimxrt/boards/MIMXRT1064_EVK/mpconfigboard.mk (MICROPY_HW_SDRAM_SIZE)",
+        "scope": "board"
+      },
       "circuitPythonBoardId": null,
       "runtimes": [
         "micropython"
@@ -4277,9 +5002,22 @@
           "url": "https://micropython.org/resources/firmware/MIMXRT1170_EVK-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
-      "psram": null,
+      "flash": {
+        "bytes": 16777216,
+        "source": "MicroPython ports/mimxrt/boards/MIMXRT1170_EVK/mpconfigboard.mk (MICROPY_HW_FLASH_SIZE)",
+        "scope": "board"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 2097152,
+        "source": "NXP i.MX RT1170 datasheet IMXRT1170CEC",
+        "scope": "chip"
+      },
+      "psram": {
+        "bytes": 67108864,
+        "source": "MicroPython ports/mimxrt/boards/MIMXRT1170_EVK/mpconfigboard.mk (MICROPY_HW_SDRAM_SIZE)",
+        "scope": "board"
+      },
       "circuitPythonBoardId": null,
       "runtimes": [
         "micropython"
@@ -4322,6 +5060,7 @@
         }
       ],
       "flash": null,
+      "externalFlash": null,
       "ram": {
         "bytes": 532480,
         "source": "Espressif ESP32 datasheet",
@@ -4370,7 +5109,12 @@
           "url": "https://micropython.org/resources/firmware/OLIMEX_ESP32_POE-20260406-v1.28.0.bin"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 4194304,
+        "source": "olimex.com ESP32-POE user manual (WROOM-32E)",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 532480,
         "source": "Espressif ESP32 datasheet",
@@ -4415,8 +5159,17 @@
           "url": "https://micropython.org/resources/firmware/OLIMEX_RT1010-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 2097152,
+        "source": "MicroPython ports/mimxrt/boards/OLIMEX_RT1010/mpconfigboard.mk (MICROPY_HW_FLASH_SIZE)",
+        "scope": "board"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 131072,
+        "source": "NXP i.MX RT1010 datasheet IMXRT1010CEC",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -4452,8 +5205,17 @@
           "url": "https://micropython.org/resources/firmware/OLIMEX_E407-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "ST STM32F407ZG (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 196608,
+        "source": "ST STM32F407ZG (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -4489,8 +5251,17 @@
           "url": "https://micropython.org/resources/firmware/OLIMEX_H407-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "ST STM32F407ZG (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 196608,
+        "source": "ST STM32F407ZG (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -4526,8 +5297,17 @@
           "url": "https://micropython.org/resources/firmware/PARTICLE_XENON-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "Nordic nRF52840 product specification",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 262144,
+        "source": "Nordic nRF52840 product specification",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": "particle_xenon",
       "runtimes": [
@@ -4577,9 +5357,22 @@
           "url": "https://micropython.org/resources/firmware/PHYBOARD_RT1170-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
-      "psram": null,
+      "flash": {
+        "bytes": 16777216,
+        "source": "MicroPython ports/mimxrt/boards/PHYBOARD_RT1170/mpconfigboard.mk (MICROPY_HW_FLASH_SIZE)",
+        "scope": "board"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 2097152,
+        "source": "NXP i.MX RT1170 datasheet IMXRT1170CEC",
+        "scope": "chip"
+      },
+      "psram": {
+        "bytes": 67108864,
+        "source": "MicroPython ports/mimxrt/boards/PHYBOARD_RT1170/mpconfigboard.mk (MICROPY_HW_SDRAM_SIZE)",
+        "scope": "board"
+      },
       "circuitPythonBoardId": null,
       "runtimes": [
         "micropython"
@@ -4637,6 +5430,7 @@
         }
       ],
       "flash": null,
+      "externalFlash": null,
       "ram": {
         "bytes": 270336,
         "source": "Raspberry Pi RP2040 datasheet",
@@ -4699,6 +5493,7 @@
         }
       ],
       "flash": null,
+      "externalFlash": null,
       "ram": {
         "bytes": 270336,
         "source": "Raspberry Pi RP2040 datasheet",
@@ -4743,8 +5538,17 @@
           "url": "https://micropython.org/resources/firmware/TEENSY40-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 2097152,
+        "source": "MicroPython ports/mimxrt/boards/TEENSY40/mpconfigboard.mk (MICROPY_HW_FLASH_SIZE)",
+        "scope": "board"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 1048576,
+        "source": "NXP i.MX RT1060 datasheet IMXRT1060CEC",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": "teensy40",
       "runtimes": [
@@ -4786,8 +5590,17 @@
           "url": "https://micropython.org/resources/firmware/TEENSY41-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 8388608,
+        "source": "MicroPython ports/mimxrt/boards/TEENSY41/mpconfigboard.mk (MICROPY_HW_FLASH_SIZE)",
+        "scope": "board"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 1048576,
+        "source": "NXP i.MX RT1060 datasheet IMXRT1060CEC",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": "teensy41",
       "runtimes": [
@@ -4831,7 +5644,12 @@
           "url": "https://micropython.org/resources/firmware/POLOLU_3PI_2040_ROBOT-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 16777216,
+        "source": "pololu.com/docs/0J86/6.1",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 270336,
         "source": "Raspberry Pi RP2040 datasheet",
@@ -4880,7 +5698,12 @@
           "url": "https://micropython.org/resources/firmware/POLOLU_ZUMO_2040_ROBOT-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 16777216,
+        "source": "pololu.com/docs/0J87/1",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 270336,
         "source": "Raspberry Pi RP2040 datasheet",
@@ -4913,6 +5736,7 @@
       "thumb": "WIPY.jpg",
       "builds": [],
       "flash": null,
+      "externalFlash": null,
       "ram": null,
       "psram": null,
       "circuitPythonBoardId": null,
@@ -4940,8 +5764,17 @@
           "url": "https://micropython.org/resources/firmware/GARATRONIC_PYMATE_CORE8ADI8DOSC-20260824-v1.29.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "ST STM32F412RE (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 262144,
+        "source": "ST STM32F412RE (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -4986,6 +5819,7 @@
         "source": "raspberrypi.com Pico series documentation",
         "scope": "board"
       },
+      "externalFlash": null,
       "ram": {
         "bytes": 270336,
         "source": "Raspberry Pi RP2040 datasheet",
@@ -5052,6 +5886,7 @@
         "source": "raspberrypi.com Pico series documentation",
         "scope": "board"
       },
+      "externalFlash": null,
       "ram": {
         "bytes": 532480,
         "source": "Raspberry Pi RP2350 datasheet",
@@ -5120,6 +5955,7 @@
         "source": "raspberrypi.com Pico series documentation",
         "scope": "board"
       },
+      "externalFlash": null,
       "ram": {
         "bytes": 532480,
         "source": "Raspberry Pi RP2350 datasheet",
@@ -5172,6 +6008,7 @@
         "source": "raspberrypi.com Pico series documentation",
         "scope": "board"
       },
+      "externalFlash": null,
       "ram": {
         "bytes": 270336,
         "source": "Raspberry Pi RP2040 datasheet",
@@ -5213,8 +6050,17 @@
           "url": "https://micropython.org/resources/firmware/EK_RA4M1-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 262144,
+        "source": "Renesas RA4M1 group datasheet",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 32768,
+        "source": "Renesas RA4M1 group datasheet",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -5250,8 +6096,17 @@
           "url": "https://micropython.org/resources/firmware/EK_RA4W1-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "Renesas RA4W1 group datasheet",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 98304,
+        "source": "Renesas RA4W1 group datasheet",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -5287,8 +6142,17 @@
           "url": "https://micropython.org/resources/firmware/EK_RA6M1-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "Renesas RA6M1 group datasheet",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 262144,
+        "source": "Renesas RA6M1 group datasheet",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -5325,7 +6189,12 @@
         }
       ],
       "flash": null,
-      "ram": null,
+      "externalFlash": null,
+      "ram": {
+        "bytes": 393216,
+        "source": "Renesas RA6M2 group datasheet",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -5367,9 +6236,22 @@
           "url": "https://micropython.org/resources/firmware/SEEED_ARCH_MIX-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
-      "ram": null,
-      "psram": null,
+      "flash": {
+        "bytes": 8388608,
+        "source": "MicroPython ports/mimxrt/boards/SEEED_ARCH_MIX/mpconfigboard.mk (MICROPY_HW_FLASH_SIZE)",
+        "scope": "board"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 524288,
+        "source": "NXP i.MX RT1050 datasheet IMXRT1050CEC",
+        "scope": "chip"
+      },
+      "psram": {
+        "bytes": 33554432,
+        "source": "MicroPython ports/mimxrt/boards/SEEED_ARCH_MIX/mpconfigboard.mk (MICROPY_HW_SDRAM_SIZE)",
+        "scope": "board"
+      },
       "circuitPythonBoardId": null,
       "runtimes": [
         "micropython"
@@ -5412,8 +6294,21 @@
           "url": "https://micropython.org/resources/firmware/SEEED_WIO_TERMINAL-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "Microchip SAM D5x/E5x datasheet DS60001507",
+        "scope": "chip"
+      },
+      "externalFlash": {
+        "bytes": 4194304,
+        "source": "seeedstudio.com Wio-Terminal-p-4509",
+        "scope": "board"
+      },
+      "ram": {
+        "bytes": 196608,
+        "source": "Microchip SAM D5x/E5x datasheet DS60001507",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -5448,7 +6343,12 @@
           "url": "https://micropython.org/resources/firmware/SEEED_XIAO_ESP32C3-20260824-v1.29.0.bin"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 4194304,
+        "source": "seeedstudio.com Seeed-XIAO-ESP32C3-p-5431",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 409600,
         "source": "Espressif ESP32-C3 datasheet",
@@ -5491,13 +6391,22 @@
           "url": "https://micropython.org/resources/firmware/SEEED_XIAO_ESP32C5-20260824-v1.29.0.bin"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 8388608,
+        "source": "wiki.seeedstudio.com/xiao_esp32c5_getting_started",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 393216,
         "source": "Espressif ESP32-C5 datasheet (HP SRAM)",
         "scope": "chip"
       },
-      "psram": null,
+      "psram": {
+        "bytes": 8388608,
+        "source": "wiki.seeedstudio.com/xiao_esp32c5_getting_started",
+        "scope": "board"
+      },
       "circuitPythonBoardId": null,
       "runtimes": [
         "micropython"
@@ -5539,7 +6448,12 @@
           "url": "https://micropython.org/resources/firmware/SEEED_XIAO_ESP32C6-20260406-v1.28.0.bin"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 4194304,
+        "source": "seeedstudio.com Seeed-Studio-XIAO-ESP32C6-p-5884",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 524288,
         "source": "Espressif ESP32-C6 datasheet (HP SRAM)",
@@ -5587,6 +6501,7 @@
         "source": "MicroPython ports/esp32/boards/SEEED_XIAO_ESP32S3/mpconfigboard.cmake",
         "scope": "board"
       },
+      "externalFlash": null,
       "ram": {
         "bytes": 524288,
         "source": "Espressif ESP32-S3 datasheet",
@@ -5640,8 +6555,21 @@
           "url": "https://micropython.org/resources/firmware/SEEED_XIAO_NRF52-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "Nordic nRF52840 product specification",
+        "scope": "chip"
+      },
+      "externalFlash": {
+        "bytes": 2097152,
+        "source": "seeedstudio.com Seeed-XIAO-BLE-Sense-nRF52840-p-5253",
+        "scope": "board"
+      },
+      "ram": {
+        "bytes": 262144,
+        "source": "Nordic nRF52840 product specification",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -5683,7 +6611,12 @@
           "url": "https://micropython.org/resources/firmware/SEEED_XIAO_RP2040-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 2097152,
+        "source": "Raspberry Pi pico-sdk src/boards/include/boards/seeed_xiao_rp2040.h (PICO_FLASH_SIZE_BYTES)",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 270336,
         "source": "Raspberry Pi RP2040 datasheet",
@@ -5746,7 +6679,12 @@
           "url": "https://micropython.org/resources/firmware/SEEED_XIAO_RP2350-RISCV-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 2097152,
+        "source": "Raspberry Pi pico-sdk src/boards/include/boards/seeed_xiao_rp2350.h (PICO_FLASH_SIZE_BYTES)",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 532480,
         "source": "Raspberry Pi RP2350 datasheet",
@@ -5789,8 +6727,17 @@
           "url": "https://micropython.org/resources/firmware/SEEED_XIAO_SAMD21-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 262144,
+        "source": "Microchip SAM D21/DA1 datasheet DS40001882G",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 32768,
+        "source": "Microchip SAM D21/DA1 datasheet DS40001882G",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -5833,6 +6780,7 @@
         }
       ],
       "flash": null,
+      "externalFlash": null,
       "ram": {
         "bytes": 532480,
         "source": "Espressif ESP32 datasheet",
@@ -5881,7 +6829,12 @@
           "url": "https://micropython.org/resources/firmware/SIL_MANT1S-20260406-v1.28.0.bin"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 8388608,
+        "source": "MicroPython ports/esp32/boards/SIL_MANT1S/sdkconfig.board (CONFIG_ESPTOOLPY_FLASHSIZE)",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 532480,
         "source": "Espressif ESP32 datasheet",
@@ -5927,7 +6880,12 @@
           "url": "https://micropython.org/resources/firmware/SIL_RP2040_SHIM-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 4194304,
+        "source": "MicroPython ports/rp2/boards/SIL_RP2040_SHIM/mpconfigboard.cmake (PICO_FLASH_SIZE_BYTES)",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 270336,
         "source": "Raspberry Pi RP2040 datasheet",
@@ -5974,7 +6932,12 @@
           "url": "https://micropython.org/resources/firmware/SOLDERED_NULA_MINI-20260406-v1.28.0.bin"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 4194304,
+        "source": "soldered.com/product/nula-mini-esp32-c6",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 524288,
         "source": "Espressif ESP32-C6 datasheet (HP SRAM)",
@@ -6018,7 +6981,12 @@
           "url": "https://micropython.org/resources/firmware/SOLDERED_NULA_MAX_RP2350-20260824-v1.29.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 16777216,
+        "source": "MicroPython ports/rp2/boards/SOLDERED_NULA_MAX_RP2350/soldered_nula_max_rp2350.h (PICO_FLASH_SIZE_BYTES)",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 532480,
         "source": "Raspberry Pi RP2350 datasheet",
@@ -6065,6 +7033,7 @@
         }
       ],
       "flash": null,
+      "externalFlash": null,
       "ram": {
         "bytes": 532480,
         "source": "Espressif ESP32 datasheet",
@@ -6131,13 +7100,22 @@
           "url": "https://micropython.org/resources/firmware/SPARKFUN_IOTNODE_LORAWAN_RP2350-RISCV-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 16777216,
+        "source": "MicroPython ports/rp2/boards/SPARKFUN_IOTNODE_LORAWAN_RP2350/sparkfun_iotnode_lorawan_rp2350.h (PICO_FLASH_SIZE_BYTES)",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 532480,
         "source": "Raspberry Pi RP2350 datasheet",
         "scope": "chip"
       },
-      "psram": null,
+      "psram": {
+        "bytes": 8388608,
+        "source": "docs.sparkfun.com/SparkFun_IoT_Node_LoRaWAN",
+        "scope": "board"
+      },
       "circuitPythonBoardId": null,
       "runtimes": [
         "micropython"
@@ -6172,8 +7150,21 @@
           "url": "https://micropython.org/resources/firmware/SPARKFUN_MICROMOD_STM32-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "ST STM32F405RG (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": {
+        "bytes": 16777216,
+        "source": "learn.sparkfun.com micromod-stm32-processor-hookup-guide (128 Mbit)",
+        "scope": "board"
+      },
+      "ram": {
+        "bytes": 196608,
+        "source": "ST STM32F405RG (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -6215,7 +7206,12 @@
           "url": "https://micropython.org/resources/firmware/SPARKFUN_PROMICRO-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 16777216,
+        "source": "sparkfun.com/sparkfun-pro-micro-rp2040.html",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 270336,
         "source": "Raspberry Pi RP2040 datasheet",
@@ -6280,13 +7276,22 @@
           "url": "https://micropython.org/resources/firmware/SPARKFUN_PROMICRO_RP2350-RISCV-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 16777216,
+        "source": "Raspberry Pi pico-sdk src/boards/include/boards/sparkfun_promicro_rp2350.h (PICO_FLASH_SIZE_BYTES)",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 532480,
         "source": "Raspberry Pi RP2350 datasheet",
         "scope": "chip"
       },
-      "psram": null,
+      "psram": {
+        "bytes": 8388608,
+        "source": "sparkfun.com/sparkfun-pro-micro-rp2350.html",
+        "scope": "board"
+      },
       "circuitPythonBoardId": "sparkfun_pro_micro_rp2350",
       "runtimes": [
         "micropython",
@@ -6327,8 +7332,21 @@
           "url": "https://micropython.org/resources/firmware/SPARKFUN_SAMD51_THING_PLUS-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "Microchip SAM D5x/E5x datasheet DS60001507",
+        "scope": "chip"
+      },
+      "externalFlash": {
+        "bytes": 524288,
+        "source": "learn.sparkfun.com samd51-thing-plus-hookup-guide (4 Mbit, AT25SF041)",
+        "scope": "board"
+      },
+      "ram": {
+        "bytes": 262144,
+        "source": "Microchip SAM D5x/E5x datasheet DS60001507",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": "sparkfun_samd51_thing_plus",
       "runtimes": [
@@ -6392,13 +7410,22 @@
           "url": "https://micropython.org/resources/firmware/SPARKFUN_IOTREDBOARD_RP2350-RISCV-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 16777216,
+        "source": "MicroPython ports/rp2/boards/SPARKFUN_IOTREDBOARD_RP2350/sparkfun_iotredboard_rp2350.h (PICO_FLASH_SIZE_BYTES)",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 532480,
         "source": "Raspberry Pi RP2350 datasheet",
         "scope": "chip"
       },
-      "psram": null,
+      "psram": {
+        "bytes": 8388608,
+        "source": "sparkfun.com/sparkfun-iot-redboard-rp2350.html",
+        "scope": "board"
+      },
       "circuitPythonBoardId": null,
       "runtimes": [
         "micropython"
@@ -6439,8 +7466,21 @@
           "url": "https://micropython.org/resources/firmware/SPARKFUN_REDBOARD_TURBO-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 262144,
+        "source": "Microchip SAM D21/DA1 datasheet DS40001882G",
+        "scope": "chip"
+      },
+      "externalFlash": {
+        "bytes": 4194304,
+        "source": "learn.sparkfun.com redboard-turbo-hookup-guide",
+        "scope": "board"
+      },
+      "ram": {
+        "bytes": 32768,
+        "source": "Microchip SAM D21/DA1 datasheet DS40001882G",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": "sparkfun_redboard_turbo",
       "runtimes": [
@@ -6481,8 +7521,17 @@
           "url": "https://micropython.org/resources/firmware/SPARKFUN_SAMD21_DEV_BREAKOUT-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 262144,
+        "source": "Microchip SAM D21/DA1 datasheet DS40001882G",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 32768,
+        "source": "Microchip SAM D21/DA1 datasheet DS40001882G",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -6527,7 +7576,12 @@
           "url": "https://micropython.org/resources/firmware/SPARKFUN_THINGPLUS-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 16777216,
+        "source": "sparkfun.com/sparkfun-thing-plus-rp2040.html",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 270336,
         "source": "Raspberry Pi RP2040 datasheet",
@@ -6580,13 +7634,22 @@
           "url": "https://micropython.org/resources/firmware/SPARKFUN_THINGPLUS_ESP32C5-20260406-v1.28.0.bin"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 8388608,
+        "source": "sparkfun.com/sparkfun-thing-plus-esp32-c5.html",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 393216,
         "source": "Espressif ESP32-C5 datasheet (HP SRAM)",
         "scope": "chip"
       },
-      "psram": null,
+      "psram": {
+        "bytes": 8388608,
+        "source": "sparkfun.com/sparkfun-thing-plus-esp32-c5.html",
+        "scope": "board"
+      },
       "circuitPythonBoardId": null,
       "runtimes": [
         "micropython"
@@ -6649,13 +7712,22 @@
           "url": "https://micropython.org/resources/firmware/SPARKFUN_THINGPLUS_RP2350-RISCV-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 16777216,
+        "source": "Raspberry Pi pico-sdk src/boards/include/boards/sparkfun_thingplus_rp2350.h (PICO_FLASH_SIZE_BYTES)",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 532480,
         "source": "Raspberry Pi RP2350 datasheet",
         "scope": "chip"
       },
-      "psram": null,
+      "psram": {
+        "bytes": 8388608,
+        "source": "sparkfun.com/sparkfun-thing-plus-rp2350.html",
+        "scope": "board"
+      },
       "circuitPythonBoardId": "sparkfun_thing_plus_rp2350",
       "runtimes": [
         "micropython",
@@ -6717,13 +7789,22 @@
           "url": "https://micropython.org/resources/firmware/SPARKFUN_XRP_CONTROLLER-RISCV-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 16777216,
+        "source": "MicroPython ports/rp2/boards/SPARKFUN_XRP_CONTROLLER/sparkfun_xrp_controller.h (PICO_FLASH_SIZE_BYTES)",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 532480,
         "source": "Raspberry Pi RP2350 datasheet",
         "scope": "chip"
       },
-      "psram": null,
+      "psram": {
+        "bytes": 8388608,
+        "source": "sparkfun.com/…xrp-controller.html",
+        "scope": "board"
+      },
       "circuitPythonBoardId": null,
       "runtimes": [
         "micropython"
@@ -6766,7 +7847,12 @@
           "url": "https://micropython.org/resources/firmware/SPARKFUN_XRP_CONTROLLER_BETA-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 2097152,
+        "source": "sparkfun.com/…xrp-controller-beta.html (it carries a Pico W)",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 270336,
         "source": "Raspberry Pi RP2040 datasheet",
@@ -6807,8 +7893,17 @@
           "url": "https://micropython.org/resources/firmware/B_L072Z_LRWAN1-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 196608,
+        "source": "ST STM32L072CZ (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 20480,
+        "source": "ST STM32L072CZ (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -6845,7 +7940,12 @@
         }
       ],
       "flash": null,
-      "ram": null,
+      "externalFlash": null,
+      "ram": {
+        "bytes": 131072,
+        "source": "ST STM32L475 line (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -6882,7 +7982,12 @@
         }
       ],
       "flash": null,
-      "ram": null,
+      "externalFlash": null,
+      "ram": {
+        "bytes": 196608,
+        "source": "ST STM32F407 line (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -6919,7 +8024,12 @@
         }
       ],
       "flash": null,
-      "ram": null,
+      "externalFlash": null,
+      "ram": {
+        "bytes": 131072,
+        "source": "ST STM32F411 line (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -6956,7 +8066,12 @@
         }
       ],
       "flash": null,
-      "ram": null,
+      "externalFlash": null,
+      "ram": {
+        "bytes": 262144,
+        "source": "ST STM32F429 line (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -6993,7 +8108,12 @@
         }
       ],
       "flash": null,
-      "ram": null,
+      "externalFlash": null,
+      "ram": {
+        "bytes": 393216,
+        "source": "ST STM32F469 line (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -7030,7 +8150,12 @@
         }
       ],
       "flash": null,
-      "ram": null,
+      "externalFlash": null,
+      "ram": {
+        "bytes": 327680,
+        "source": "ST STM32F746 line (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -7067,7 +8192,12 @@
         }
       ],
       "flash": null,
-      "ram": null,
+      "externalFlash": null,
+      "ram": {
+        "bytes": 524288,
+        "source": "ST STM32F769 line (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -7103,8 +8233,17 @@
           "url": "https://micropython.org/resources/firmware/STM32H7B3I_DK-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 2097152,
+        "source": "ST STM32H7B3LI datasheet (192 KB TCM + 1.18 MB user SRAM)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 1409024,
+        "source": "ST STM32H7B3LI datasheet (192 KB TCM + 1.18 MB user SRAM)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -7142,7 +8281,12 @@
         }
       ],
       "flash": null,
-      "ram": null,
+      "externalFlash": null,
+      "ram": {
+        "bytes": 1081344,
+        "source": "ST STM32H747 line (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -7179,7 +8323,12 @@
         }
       ],
       "flash": null,
-      "ram": null,
+      "externalFlash": null,
+      "ram": {
+        "bytes": 131072,
+        "source": "ST STM32L476 line (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -7216,7 +8365,12 @@
         }
       ],
       "flash": null,
-      "ram": null,
+      "externalFlash": null,
+      "ram": {
+        "bytes": 327680,
+        "source": "ST STM32L496 line (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -7252,8 +8406,17 @@
           "url": "https://micropython.org/resources/firmware/NUCLEO_F091RC-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 262144,
+        "source": "ST STM32F091RC (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 32768,
+        "source": "ST STM32F091RC (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -7289,8 +8452,17 @@
           "url": "https://micropython.org/resources/firmware/NUCLEO_F401RE-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "ST STM32F401xE (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 98304,
+        "source": "ST STM32F401xE (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -7326,8 +8498,17 @@
           "url": "https://micropython.org/resources/firmware/NUCLEO_F411RE-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "ST STM32F411xE (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 131072,
+        "source": "ST STM32F411xE (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -7363,8 +8544,17 @@
           "url": "https://micropython.org/resources/firmware/NUCLEO_F412ZG-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "ST STM32F412ZG (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 262144,
+        "source": "ST STM32F412ZG (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -7400,8 +8590,17 @@
           "url": "https://micropython.org/resources/firmware/NUCLEO_F413ZH-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1572864,
+        "source": "ST STM32F413ZH (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 327680,
+        "source": "ST STM32F413ZH (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -7437,8 +8636,17 @@
           "url": "https://micropython.org/resources/firmware/NUCLEO_F429ZI-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 2097152,
+        "source": "ST STM32F429ZI (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 262144,
+        "source": "ST STM32F429ZI (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -7474,8 +8682,17 @@
           "url": "https://micropython.org/resources/firmware/NUCLEO_F439ZI-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 2097152,
+        "source": "ST STM32F439ZI (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 262144,
+        "source": "ST STM32F439ZI (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -7511,8 +8728,17 @@
           "url": "https://micropython.org/resources/firmware/NUCLEO_F446RE-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "ST STM32F446RE (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 131072,
+        "source": "ST STM32F446RE (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -7548,8 +8774,17 @@
           "url": "https://micropython.org/resources/firmware/NUCLEO_F722ZE-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "ST STM32F722ZE (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 262144,
+        "source": "ST STM32F722ZE (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -7585,8 +8820,17 @@
           "url": "https://micropython.org/resources/firmware/NUCLEO_F746ZG-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "ST STM32F746ZG (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 327680,
+        "source": "ST STM32F746ZG (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -7622,8 +8866,17 @@
           "url": "https://micropython.org/resources/firmware/NUCLEO_F756ZG-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "ST STM32F756ZG (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 327680,
+        "source": "ST STM32F756ZG (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -7659,8 +8912,17 @@
           "url": "https://micropython.org/resources/firmware/NUCLEO_F767ZI-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 2097152,
+        "source": "ST STM32F767ZI (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 524288,
+        "source": "ST STM32F767ZI (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -7696,8 +8958,17 @@
           "url": "https://micropython.org/resources/firmware/NUCLEO_G0B1RE-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "ST STM32G0B1xE (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 147456,
+        "source": "ST STM32G0B1xE (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -7733,8 +9004,17 @@
           "url": "https://micropython.org/resources/firmware/NUCLEO_G474RE-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "ST STM32G474RE (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 131072,
+        "source": "ST STM32G474RE (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -7770,8 +9050,17 @@
           "url": "https://micropython.org/resources/firmware/NUCLEO_H563ZI-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 2097152,
+        "source": "ST STM32H563ZI (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 655360,
+        "source": "ST STM32H563ZI (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -7807,8 +9096,17 @@
           "url": "https://micropython.org/resources/firmware/NUCLEO_H723ZG-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "ST STM32H723ZG (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 573440,
+        "source": "ST STM32H723ZG (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -7844,8 +9142,17 @@
           "url": "https://micropython.org/resources/firmware/NUCLEO_H743ZI-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 2097152,
+        "source": "ST STM32H743ZI (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 1081344,
+        "source": "ST STM32H743ZI (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -7881,8 +9188,17 @@
           "url": "https://micropython.org/resources/firmware/NUCLEO_H743ZI2-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 2097152,
+        "source": "ST STM32H743ZI (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 1081344,
+        "source": "ST STM32H743ZI (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -7918,8 +9234,17 @@
           "url": "https://micropython.org/resources/firmware/NUCLEO_H753ZI-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 2097152,
+        "source": "ST STM32H753ZI (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 1081344,
+        "source": "ST STM32H753ZI (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -7955,8 +9280,17 @@
           "url": "https://micropython.org/resources/firmware/NUCLEO_H7A3ZI_Q-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 2097152,
+        "source": "ST STM32H7A3ZI datasheet (192 KB TCM + 1.18 MB user SRAM)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 1409024,
+        "source": "ST STM32H7A3ZI datasheet (192 KB TCM + 1.18 MB user SRAM)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -7992,8 +9326,17 @@
           "url": "https://micropython.org/resources/firmware/NUCLEO_L073RZ-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 196608,
+        "source": "ST STM32L073RZ (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 20480,
+        "source": "ST STM32L073RZ (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -8029,8 +9372,17 @@
           "url": "https://micropython.org/resources/firmware/NUCLEO_L152RE-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "ST STM32L152xE (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 81920,
+        "source": "ST STM32L152xE (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -8066,8 +9418,17 @@
           "url": "https://micropython.org/resources/firmware/NUCLEO_L432KC-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 262144,
+        "source": "ST STM32L432KC (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 65536,
+        "source": "ST STM32L432KC (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -8103,8 +9464,17 @@
           "url": "https://micropython.org/resources/firmware/NUCLEO_L452RE-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "ST STM32L452RE (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 163840,
+        "source": "ST STM32L452RE (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -8140,8 +9510,17 @@
           "url": "https://micropython.org/resources/firmware/NUCLEO_L476RG-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "ST STM32L476RG (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 131072,
+        "source": "ST STM32L476RG (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -8177,8 +9556,17 @@
           "url": "https://micropython.org/resources/firmware/NUCLEO_L4A6ZG-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "ST STM32L4A6ZG (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 327680,
+        "source": "ST STM32L4A6ZG (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -8214,8 +9602,17 @@
           "url": "https://micropython.org/resources/firmware/NUCLEO_U5A5ZJ_Q-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 4194304,
+        "source": "ST STM32U5A5ZJ (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 2572288,
+        "source": "ST STM32U5A5ZJ (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -8251,8 +9648,17 @@
           "url": "https://micropython.org/resources/firmware/NUCLEO_WB55-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "ST STM32WB55RG (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 262144,
+        "source": "ST STM32WB55RG (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -8288,8 +9694,17 @@
           "url": "https://micropython.org/resources/firmware/NUCLEO_WL55-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 262144,
+        "source": "ST STM32WL55JC (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 65536,
+        "source": "ST STM32WL55JC (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -8326,7 +9741,12 @@
         }
       ],
       "flash": null,
-      "ram": null,
+      "externalFlash": null,
+      "ram": {
+        "bytes": 262144,
+        "source": "ST STM32F439 line (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -8362,8 +9782,17 @@
           "url": "https://micropython.org/resources/firmware/USBDONGLE_WB55-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "ST STM32WB55CG (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 262144,
+        "source": "ST STM32WB55CG (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -8399,8 +9828,17 @@
           "url": "https://micropython.org/resources/firmware/EVK_NINA_B1-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "MicroPython ports/nrf/boards/nrf52832_512k_64k.ld",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 65536,
+        "source": "MicroPython ports/nrf/boards/nrf52832_512k_64k.ld",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -8436,8 +9874,17 @@
           "url": "https://micropython.org/resources/firmware/EVK_NINA_B3-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "Nordic nRF52840 product specification",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 262144,
+        "source": "Nordic nRF52840 product specification",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -8484,13 +9931,22 @@
           "url": "https://micropython.org/resources/firmware/UM_FEATHERS2-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 16777216,
+        "source": "feathers2.io",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 327680,
         "source": "Espressif ESP32-S2 datasheet",
         "scope": "chip"
       },
-      "psram": null,
+      "psram": {
+        "bytes": 8388608,
+        "source": "feathers2.io",
+        "scope": "board"
+      },
       "circuitPythonBoardId": null,
       "runtimes": [
         "micropython"
@@ -8537,12 +9993,17 @@
         }
       ],
       "flash": null,
+      "externalFlash": null,
       "ram": {
         "bytes": 327680,
         "source": "Espressif ESP32-S2 datasheet",
         "scope": "chip"
       },
-      "psram": null,
+      "psram": {
+        "bytes": 2097152,
+        "source": "help.unexpectedmaker.com PSRAM table",
+        "scope": "board"
+      },
       "circuitPythonBoardId": null,
       "runtimes": [
         "micropython"
@@ -8587,13 +10048,22 @@
           "url": "https://micropython.org/resources/firmware/UM_FEATHERS3-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 16777216,
+        "source": "esp32s3.com/feathers3.html",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 524288,
         "source": "Espressif ESP32-S3 datasheet",
         "scope": "chip"
       },
-      "psram": null,
+      "psram": {
+        "bytes": 8388608,
+        "source": "esp32s3.com/feathers3.html",
+        "scope": "board"
+      },
       "circuitPythonBoardId": null,
       "runtimes": [
         "micropython"
@@ -8638,13 +10108,22 @@
           "url": "https://micropython.org/resources/firmware/UM_FEATHERS3NEO-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 8388608,
+        "source": "esp32s3.com/feathers3neo.html",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 524288,
         "source": "Espressif ESP32-S3 datasheet",
         "scope": "chip"
       },
-      "psram": null,
+      "psram": {
+        "bytes": 2097152,
+        "source": "esp32s3.com/feathers3neo.html",
+        "scope": "board"
+      },
       "circuitPythonBoardId": null,
       "runtimes": [
         "micropython"
@@ -8687,13 +10166,22 @@
           "url": "https://micropython.org/resources/firmware/UM_NANOS3-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 8388608,
+        "source": "esp32s3.com/nanos3.html",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 524288,
         "source": "Espressif ESP32-S3 datasheet",
         "scope": "chip"
       },
-      "psram": null,
+      "psram": {
+        "bytes": 8388608,
+        "source": "esp32s3.com/nanos3.html",
+        "scope": "board"
+      },
       "circuitPythonBoardId": null,
       "runtimes": [
         "micropython"
@@ -8736,13 +10224,22 @@
           "url": "https://micropython.org/resources/firmware/UM_OMGS3-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 8388608,
+        "source": "esp32s3.com/omgs3.html",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 524288,
         "source": "Espressif ESP32-S3 datasheet",
         "scope": "chip"
       },
-      "psram": null,
+      "psram": {
+        "bytes": 2097152,
+        "source": "esp32s3.com/omgs3.html",
+        "scope": "board"
+      },
       "circuitPythonBoardId": null,
       "runtimes": [
         "micropython"
@@ -8787,13 +10284,22 @@
           "url": "https://micropython.org/resources/firmware/UM_PROS3-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 16777216,
+        "source": "esp32s3.com/pros3.html",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 524288,
         "source": "Espressif ESP32-S3 datasheet",
         "scope": "chip"
       },
-      "psram": null,
+      "psram": {
+        "bytes": 8388608,
+        "source": "esp32s3.com/pros3.html",
+        "scope": "board"
+      },
       "circuitPythonBoardId": null,
       "runtimes": [
         "micropython"
@@ -8841,13 +10347,22 @@
           "url": "https://micropython.org/resources/firmware/UM_RGBTOUCH_MINI-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 8388608,
+        "source": "unexpectedmaker.com shop, RGB Touch Mini",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 524288,
         "source": "Espressif ESP32-S3 datasheet",
         "scope": "chip"
       },
-      "psram": null,
+      "psram": {
+        "bytes": 2097152,
+        "source": "unexpectedmaker.com shop, RGB Touch Mini",
+        "scope": "board"
+      },
       "circuitPythonBoardId": null,
       "runtimes": [
         "micropython"
@@ -8890,7 +10405,12 @@
           "url": "https://micropython.org/resources/firmware/UM_TINYC6-20260406-v1.28.0.bin"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 8388608,
+        "source": "unexpectedmaker.com shop, TinyC6",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 524288,
         "source": "Espressif ESP32-C6 datasheet (HP SRAM)",
@@ -8941,13 +10461,22 @@
           "url": "https://micropython.org/resources/firmware/UM_TINYPICO-20260406-v1.28.0.bin"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 4194304,
+        "source": "unexpectedmaker.com shop, TinyPICO",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 532480,
         "source": "Espressif ESP32 datasheet",
         "scope": "chip"
       },
-      "psram": null,
+      "psram": {
+        "bytes": 4194304,
+        "source": "unexpectedmaker.com shop, TinyPICO",
+        "scope": "board"
+      },
       "circuitPythonBoardId": null,
       "runtimes": [
         "micropython"
@@ -8992,13 +10521,22 @@
           "url": "https://micropython.org/resources/firmware/UM_TINYS2-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 4194304,
+        "source": "unexpectedmaker.com shop, TinyS2",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 327680,
         "source": "Espressif ESP32-S2 datasheet",
         "scope": "chip"
       },
-      "psram": null,
+      "psram": {
+        "bytes": 2097152,
+        "source": "unexpectedmaker.com shop, TinyS2",
+        "scope": "board"
+      },
       "circuitPythonBoardId": null,
       "runtimes": [
         "micropython"
@@ -9043,13 +10581,22 @@
           "url": "https://micropython.org/resources/firmware/UM_TINYS3-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 8388608,
+        "source": "esp32s3.com/tinys3.html",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 524288,
         "source": "Espressif ESP32-S3 datasheet",
         "scope": "chip"
       },
-      "psram": null,
+      "psram": {
+        "bytes": 8388608,
+        "source": "esp32s3.com/tinys3.html",
+        "scope": "board"
+      },
       "circuitPythonBoardId": null,
       "runtimes": [
         "micropython"
@@ -9093,13 +10640,22 @@
           "url": "https://micropython.org/resources/firmware/UM_TINYWATCHS3-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 8388608,
+        "source": "help.unexpectedmaker.com/docs/products/tinywatch-s3",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 524288,
         "source": "Espressif ESP32-S3 datasheet",
         "scope": "chip"
       },
-      "psram": null,
+      "psram": {
+        "bytes": 2097152,
+        "source": "help.unexpectedmaker.com/docs/products/tinywatch-s3",
+        "scope": "board"
+      },
       "circuitPythonBoardId": null,
       "runtimes": [
         "micropython"
@@ -9134,8 +10690,17 @@
           "url": "https://micropython.org/resources/firmware/VCC_GND_F407VE-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "ST STM32F407VE (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 196608,
+        "source": "ST STM32F407VE (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -9171,8 +10736,17 @@
           "url": "https://micropython.org/resources/firmware/VCC_GND_F407ZG-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "ST STM32F407ZG (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 196608,
+        "source": "ST STM32F407ZG (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -9208,8 +10782,17 @@
           "url": "https://micropython.org/resources/firmware/VCC_GND_H743VI-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 2097152,
+        "source": "ST STM32H743VI (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 1081344,
+        "source": "ST STM32H743VI (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -9248,7 +10831,12 @@
         }
       ],
       "flash": null,
-      "ram": null,
+      "externalFlash": null,
+      "ram": {
+        "bytes": 524288,
+        "source": "Renesas RA6M5 group datasheet",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -9290,7 +10878,12 @@
           "url": "https://micropython.org/resources/firmware/WAVESHARE_RP2040_LCD_0_96-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 2097152,
+        "source": "waveshare.com/product/rp2040-lcd-0.96.htm (W25Q16)",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 270336,
         "source": "Raspberry Pi RP2040 datasheet",
@@ -9354,6 +10947,7 @@
         }
       ],
       "flash": null,
+      "externalFlash": null,
       "ram": {
         "bytes": 270336,
         "source": "Raspberry Pi RP2040 datasheet",
@@ -9399,7 +10993,12 @@
           "url": "https://micropython.org/resources/firmware/WAVESHARE_RP2040_ZERO-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 2097152,
+        "source": "Raspberry Pi pico-sdk src/boards/include/boards/waveshare_rp2040_zero.h (PICO_FLASH_SIZE_BYTES)",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 270336,
         "source": "Raspberry Pi RP2040 datasheet",
@@ -9462,7 +11061,12 @@
           "url": "https://micropython.org/resources/firmware/WAVESHARE_RP2350B_CORE-RISCV-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 16777216,
+        "source": "MicroPython ports/rp2/boards/WAVESHARE_RP2350B_CORE/mpconfigboard.cmake (PICO_FLASH_SIZE_BYTES)",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 532480,
         "source": "Raspberry Pi RP2350 datasheet",
@@ -9501,13 +11105,22 @@
           "url": "https://micropython.org/resources/firmware/WAVESHARE_ESP32_S3_PICO-20260824-v1.29.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 16777216,
+        "source": "waveshare.com/ESP32-S3-Pico.htm (W25Q128)",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 524288,
         "source": "Espressif ESP32-S3 datasheet",
         "scope": "chip"
       },
-      "psram": null,
+      "psram": {
+        "bytes": 2097152,
+        "source": "waveshare.com/ESP32-S3-Pico.htm (in the ESP32-S3R2 package)",
+        "scope": "board"
+      },
       "circuitPythonBoardId": "waveshare_esp32_s3_pico",
       "runtimes": [
         "micropython",
@@ -9594,6 +11207,7 @@
         }
       ],
       "flash": null,
+      "externalFlash": null,
       "ram": {
         "bytes": 270336,
         "source": "Raspberry Pi RP2040 datasheet",
@@ -9634,8 +11248,21 @@
           "url": "https://micropython.org/resources/firmware/WEACTSTUDIO_MINI_STM32H723-20260824-v1.29.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 1048576,
+        "source": "ST STM32H723VG (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": {
+        "bytes": 16777216,
+        "source": "github.com/WeActStudio/WeActStudio.MiniSTM32H723 (8 MB SPI + 8 MB OSPI)",
+        "scope": "board"
+      },
+      "ram": {
+        "bytes": 573440,
+        "source": "ST STM32H723VG (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -9678,8 +11305,21 @@
           "url": "https://micropython.org/resources/firmware/WEACTSTUDIO_MINI_STM32H743-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 2097152,
+        "source": "ST STM32H743VI (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": {
+        "bytes": 16777216,
+        "source": "github.com/WeActStudio/MiniSTM32H7xx (8 MB SPI + 8 MB QSPI)",
+        "scope": "board"
+      },
+      "ram": {
+        "bytes": 1081344,
+        "source": "ST STM32H743VI (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -9715,8 +11355,17 @@
           "url": "https://micropython.org/resources/firmware/WEACTSTUDIO_MINI_STM32U585-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 2097152,
+        "source": "ST STM32U585CI (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 802816,
+        "source": "ST STM32U585CI (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -9773,7 +11422,12 @@
           "url": "https://micropython.org/resources/firmware/WEACTSTUDIO_RP2350B_CORE-RISCV-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 16777216,
+        "source": "Raspberry Pi pico-sdk src/boards/include/boards/weact_studio_rp2350b_core.h (PICO_FLASH_SIZE_BYTES)",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 532480,
         "source": "Raspberry Pi RP2350 datasheet",
@@ -9890,8 +11544,17 @@
           "url": "https://micropython.org/resources/firmware/WEACT_F411_BLACKPILL-V31_XTAL_8M-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 524288,
+        "source": "ST STM32F411CE (CubeMX MCU database)",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 131072,
+        "source": "ST STM32F411CE (CubeMX MCU database)",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -9932,7 +11595,12 @@
           "url": "https://micropython.org/resources/firmware/LOLIN_C3_MINI-20260406-v1.28.0.bin"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 4194304,
+        "source": "wemos.cc/en/latest/c3/c3_mini.html",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 409600,
         "source": "Espressif ESP32-C3 datasheet",
@@ -9979,13 +11647,22 @@
           "url": "https://micropython.org/resources/firmware/LOLIN_S2_MINI-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 4194304,
+        "source": "wemos.cc/en/latest/s2/s2_mini.html",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 327680,
         "source": "Espressif ESP32-S2 datasheet",
         "scope": "chip"
       },
-      "psram": null,
+      "psram": {
+        "bytes": 2097152,
+        "source": "wemos.cc/en/latest/s2/s2_mini.html",
+        "scope": "board"
+      },
       "circuitPythonBoardId": "lolin_s2_mini",
       "runtimes": [
         "micropython",
@@ -10028,13 +11705,22 @@
           "url": "https://micropython.org/resources/firmware/LOLIN_S2_PICO-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 4194304,
+        "source": "wemos.cc/en/latest/s2/s2_pico.html",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 327680,
         "source": "Espressif ESP32-S2 datasheet",
         "scope": "chip"
       },
-      "psram": null,
+      "psram": {
+        "bytes": 2097152,
+        "source": "wemos.cc/en/latest/s2/s2_pico.html",
+        "scope": "board"
+      },
       "circuitPythonBoardId": "lolin_s2_pico",
       "runtimes": [
         "micropython",
@@ -10070,8 +11756,17 @@
           "url": "https://micropython.org/resources/firmware/WT51822_S4AT-20260406-v1.28.0.hex"
         }
       ],
-      "flash": null,
-      "ram": null,
+      "flash": {
+        "bytes": 262144,
+        "source": "MicroPython ports/nrf/boards/nrf51x22_256k_16k.ld",
+        "scope": "chip"
+      },
+      "externalFlash": null,
+      "ram": {
+        "bytes": 16384,
+        "source": "MicroPython ports/nrf/boards/nrf51x22_256k_16k.ld",
+        "scope": "chip"
+      },
       "psram": null,
       "circuitPythonBoardId": null,
       "runtimes": [
@@ -10112,7 +11807,12 @@
           "url": "https://micropython.org/resources/firmware/W5100S_EVB_PICO-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 2097152,
+        "source": "docs.wiznet.io W5100S-EVB-Pico",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 270336,
         "source": "Raspberry Pi RP2040 datasheet",
@@ -10159,7 +11859,12 @@
           "url": "https://micropython.org/resources/firmware/W5500_EVB_PICO-20260406-v1.28.0.uf2"
         }
       ],
-      "flash": null,
+      "flash": {
+        "bytes": 2097152,
+        "source": "docs.wiznet.io W5500-EVB-Pico",
+        "scope": "board"
+      },
+      "externalFlash": null,
       "ram": {
         "bytes": 270336,
         "source": "Raspberry Pi RP2040 datasheet",

--- a/src/renderer/src/components/BoardFinder.css
+++ b/src/renderer/src/components/BoardFinder.css
@@ -859,6 +859,13 @@
   color: var(--bf-ink3);
 }
 
+/* The count of boards a size filter dropped for want of a figure (#897). It has
+   to read as a caveat about the RESULT rather than more small print about the
+   control, so it takes the warning token — which both skins define. */
+.bfind__facet-note.is-warn {
+  color: var(--warn, var(--accent));
+}
+
 /* --- boards Snakie carries and upstream does not (#902) ------------------- */
 
 /* On the card face: this board flashes another board's build. */

--- a/src/renderer/src/components/BoardFinder.tsx
+++ b/src/renderer/src/components/BoardFinder.tsx
@@ -8,6 +8,7 @@ import {
   type JSX
 } from 'react'
 import {
+  boardsWithoutRam,
   featureOptions,
   filterBoards,
   mcuOptions,
@@ -27,16 +28,20 @@ import {
 } from '../../../shared/firmware-runtime'
 import { loadBoardIndex, thumbUrl } from '../lib/board-index-source'
 import {
+  MEMORY_CAVEAT,
+  MEMORY_THRESHOLDS,
   RUNTIME_CAVEAT,
   boardFacts,
   boardInitials,
   buildLabel,
   firmwareSummary,
   isFiltering,
+  memoryThresholdLabel,
   peekFacts,
   shelvesByVendor,
   toggleChip,
   toggleRuntime,
+  unsizedNotice,
   variantList
 } from './board-finder'
 import { requestFlash } from './board-finder-bus'
@@ -60,12 +65,14 @@ import './BoardFinder.css'
  * three things that keep that from pouncing, and for how it is reached without a
  * pointer at all.
  *
- * ON THE FILTERS. Storage and memory are still not filters (#897): there are
- * sourced sizes now, but 5 boards of 225 have a flash figure, and a size control
- * at that coverage hides the catalogue rather than narrowing it. They are stated
- * as facts on the board instead, each naming where it came from. The RUNTIME
- * filter (#902) does ship — see `RUNTIME_CAVEAT` for the limits it prints under
- * itself, which are what make it honest enough to offer.
+ * ON THE FILTERS. MEMORY is a filter now (#897): 226 of the 230 boards have a
+ * sourced RAM figure, up from 86, and it is one comparable quantity. The four
+ * without one are COUNTED and named under the control rather than quietly
+ * dropped — see `boardsWithoutRam`. STORAGE still is not, and no longer for want
+ * of numbers: the flash figures are 107 chip-internal and 80 on-module, which
+ * are different quantities to rank against each other. `board-finder.ts` argues
+ * both at length. The RUNTIME filter (#902) ships on the same terms — see
+ * `RUNTIME_CAVEAT` for the limits it prints under itself.
  *
  * ON THE BOARDS. The list is upstream's plus `board-overlay.ts` — boards
  * MicroPython builds no firmware for under any name, which is why the Adafruit
@@ -146,6 +153,9 @@ export function BoardFinder({ onClose, origin, closing, onClosed }: BoardFinderP
   // tested, because it is the opposite of what ticking two features means.
   const [vendors, setVendors] = useState<string[]>([])
   const [mcus, setMcus] = useState<string[]>([])
+  // A size threshold, not a facet: one comparable number rather than a set
+  // of values, so it gets its own control and its own clause (#897).
+  const [minRam, setMinRam] = useState(0)
   const [features, setFeatures] = useState<string[]>([])
   const [runtimes, setRuntimes] = useState<FirmwareRuntime[]>([])
   const [flashableOnly, setFlashableOnly] = useState(false)
@@ -177,10 +187,17 @@ export function BoardFinder({ onClose, origin, closing, onClosed }: BoardFinderP
   // a board the overlay is standing in for, which `withOverlay` then drops.
   const all = useMemo(() => (boards ? withOverlay(boards) : []), [boards])
   const filter: BoardFilter = useMemo(
-    () => ({ text, vendors, mcus, features, runtimes, flashableOnly }),
-    [text, vendors, mcus, features, runtimes, flashableOnly]
+    () => ({ text, vendors, mcus, minRam: minRam || undefined, features, runtimes, flashableOnly }),
+    [text, vendors, mcus, minRam, features, runtimes, flashableOnly]
   )
   const matched = useMemo(() => filterBoards(all, filter), [all, filter])
+  // Boards the memory filter drops for having no figure rather than too small a
+  // one. Counted so the gallery can SAY so — a size control that quietly loses
+  // the undocumented boards is the one thing #897 set out not to build.
+  const unsized = useMemo(
+    () => (minRam ? unsizedNotice(boardsWithoutRam(all, filter).length) : null),
+    [all, filter, minRam]
+  )
 
   // The options come from the WHOLE catalogue, not the current result set: a
   // vendor list that shrinks as you filter cannot be used to change your mind.
@@ -204,6 +221,7 @@ export function BoardFinder({ onClose, origin, closing, onClosed }: BoardFinderP
     setText('')
     setVendors([])
     setMcus([])
+    setMinRam(0)
     setFeatures([])
     setRuntimes([])
     setFlashableOnly(false)
@@ -290,6 +308,27 @@ export function BoardFinder({ onClose, origin, closing, onClosed }: BoardFinderP
               onToggle={(r) => setRuntimes((prev) => toggleRuntime(prev, r as FirmwareRuntime))}
               note={RUNTIME_CAVEAT}
             />
+            <div className="bfind__facet">
+              <h3 className="bfind__facet-name">Memory</h3>
+              <select
+                className="bfind__select"
+                value={minRam || ''}
+                onChange={(e) => setMinRam(Number(e.target.value) || 0)}
+                aria-label="Filter by on-chip RAM"
+              >
+                <option value="">Any amount of RAM</option>
+                {MEMORY_THRESHOLDS.map((bytes) => (
+                  <option key={bytes} value={bytes}>
+                    {memoryThresholdLabel(bytes)}
+                  </option>
+                ))}
+              </select>
+              {/* What the control filters on is the chip's SRAM, which is not
+                  the whole story on a board with PSRAM. Said here rather than
+                  left to be discovered. */}
+              <p className="bfind__facet-note">{MEMORY_CAVEAT}</p>
+              {unsized && <p className="bfind__facet-note is-warn">{unsized}</p>}
+            </div>
 
             <ChipFacet
               name="Features"

--- a/src/renderer/src/components/board-finder.ts
+++ b/src/renderer/src/components/board-finder.ts
@@ -11,16 +11,38 @@
  * Separate from the component, and DOM-free, so every one of those decisions is
  * a unit test in node rather than an assertion about JSX.
  *
- * WHY THERE IS STILL NO STORAGE OR MEMORY FILTER (#897). There are sourced sizes
- * now, and they are stated on the board — but 5 of 225 boards have a flash
- * figure and 81 have a RAM one, and 81 of those are the CHIP's SRAM rather than
- * the module's. A "≥ 4 MB" control at that coverage is not a filter, it is a way
- * of hiding 220 boards for being undocumented. It becomes one when the coverage
- * does; until then the sizes are facts, each naming its source, and the missing
- * ones say they are missing instead of quietly vanishing from a filtered list.
+ * THE MEMORY FILTER SHIPS AND THE STORAGE FILTER DOES NOT (#897). They were
+ * held back together while the sizes were unsourced; they part company now that
+ * they are not, and for different reasons than coverage.
  *
- * THE RUNTIME FILTER (#902) does ship, because its data supports it and the one
- * thing it cannot say is sayable out loud. See {@link RUNTIME_CAVEAT}.
+ * MEMORY: 226 of the 230 boards have a sourced RAM figure, up from 86, and
+ * every one of them means the same thing — the chip's own SRAM. It is also
+ * worth filtering on, which was not obvious: RAM is NOT a restatement of the
+ * processor facet, because over a hundred of those boards sit in a family whose
+ * members differ. `stm32f4` alone runs from the F401's 96 KB to the F469's
+ * 384 KB, and `mimxrt` from 128 KB to 2 MB. So the control says something the
+ * `Processor` dropdown cannot, about all but four boards. See {@link
+ * MEMORY_CAVEAT} for the one thing it has to say out loud, and
+ * `boardsWithoutRam` for what becomes of those four.
+ *
+ * STORAGE: no. Not for want of numbers any more — 187 of 230 have a flash
+ * figure, up from 10 — but because they are not all the same quantity. 107 are
+ * the flash INSIDE the microcontroller, on parts where that is where a program
+ * goes; 80 are the flash chip on the module, on parts with none inside. Ranking
+ * an STM32H743's 2 MB of internal flash against a Pico's 2 MB of QSPI compares a
+ * program's ROM with a filesystem's disk. Narrow it to the one a filesystem can
+ * actually use — module flash, or a second flash chip beside the MCU — and it
+ * covers 100 of 230, which is thinner than the coverage that stopped this being
+ * offered in the first place. And every one of the ten `ESP32_GENERIC*` entries
+ * is missing from it, which are the most-flashed boards in the catalogue: their
+ * size is a property of whichever module the buyer happens to have.
+ *
+ * So storage stays a fact. What would change that is not more scraping — it is
+ * deciding, per port, which flash a MicroPython filesystem actually lands in,
+ * which is knowledge the index does not carry.
+ *
+ * THE RUNTIME FILTER (#902) ships on the same terms: its data supports it and
+ * the one thing it cannot say is sayable out loud. See {@link RUNTIME_CAVEAT}.
  */
 import {
   defaultBuild,
@@ -122,10 +144,20 @@ export interface BoardFact {
   source?: string
 }
 
-/** Features that are a yes/no upstream publishes but no figure to go with it. */
+/**
+ * Features that are a yes/no upstream publishes, paired with the field that
+ * would give the figure.
+ *
+ * `External Flash` pairs with `externalFlash` and NOT with `flash` — the
+ * distinction #897 turned on once boards started carrying both. An Adafruit
+ * Feather M0 Express has 256 KB inside the SAMD21 and a 2 MB SPI flash chip
+ * beside it; letting the first suppress the note about the second would say the
+ * board has 256 KB of flash and nothing else, which is the misreading the whole
+ * epic exists to stop.
+ */
 const SIZELESS_FEATURES: readonly { feature: string; label: string; sized: keyof IndexedBoard }[] =
   [
-    { feature: 'External Flash', label: 'External flash', sized: 'flash' },
+    { feature: 'External Flash', label: 'External flash', sized: 'externalFlash' },
     { feature: 'External RAM', label: 'External RAM', sized: 'psram' }
   ]
 
@@ -133,25 +165,46 @@ const SIZELESS_FEATURES: readonly { feature: string; label: string; sized: keyof
 export const NO_SIZE_PUBLISHED = 'present — size not published'
 
 /**
- * A byte count as people say it: `264 KB`, `8 MB`, `1.5 MB`.
+ * A byte count as people say it: `264 KB`, `8 MB`, `1.5 MB`, `1056 KB`.
  *
  * Binary units, because that is what these parts are sold in — a "2 MB" flash
- * chip is 2 × 1024 × 1024 bytes — and no trailing `.0`, so the common sizes read
- * as round numbers rather than as measurements.
+ * chip is 2 × 1024 × 1024 bytes.
+ *
+ * MB only where it lands on a whole or a half, and KB otherwise. Rounding to one
+ * decimal instead would print an STM32H743's 1056 KB as "1.0 MB" — the same
+ * string as a part with 1024 KB, and 32 KB adrift, which on a board with 1 MB of
+ * RAM is a real amount of somebody's heap. Sizes like that are common enough in
+ * this catalogue (1056, 1376, 2512, 4200 KB) that the awkward-looking number is
+ * the accurate one.
  */
 export function formatBytes(bytes: number): string {
-  const [unit, size] = bytes >= 1024 * 1024 ? ['MB', 1024 * 1024] : ['KB', 1024]
-  const n = bytes / size
-  return `${Number.isInteger(n) ? n : n.toFixed(1)} ${unit}`
+  const mb = bytes / (1024 * 1024)
+  if (mb >= 1 && Number.isInteger(mb * 2)) {
+    return `${Number.isInteger(mb) ? mb : mb.toFixed(1)} MB`
+  }
+  const kb = bytes / 1024
+  return `${Number.isInteger(kb) ? kb : kb.toFixed(1)} KB`
+}
+
+/**
+ * How a figure that is really the CHIP's is said out loud.
+ *
+ * "The ESP32 has 520 KB" is a fact about every ESP32 board and therefore not
+ * much of a fact about this one — and for flash it is the difference between the
+ * megabyte on an STM32F405's die and the eight megabytes of SPI flash sitting
+ * next to it. The scope goes in the value rather than a tooltip so it is read at
+ * the same moment as the number.
+ */
+const CHIP_SCOPE_NOTE: Record<'flash' | 'ram', string> = {
+  flash: ' (the chip’s internal flash)',
+  ram: ' (the chip’s SRAM)'
 }
 
 /**
  * The facts a board's detail states, in display order.
  *
  * Sizes come first-hand or not at all: each one carries the source that makes it
- * publishable, and a RAM figure that is really the CHIP's says so, because "the
- * ESP32 has 520 KB" is a fact about every ESP32 board and therefore not much of
- * a fact about this one.
+ * publishable.
  *
  * `External flash` / `External RAM` still appear as the booleans upstream
  * publishes, but only where no sourced size has replaced them — otherwise a
@@ -162,17 +215,35 @@ export function boardFacts(board: IndexedBoard): BoardFact[] {
   if (board.port) facts.push({ label: 'Port', value: board.port })
   if (board.flashOffset) facts.push({ label: FLASH_OFFSET_LABEL, value: board.flashOffset })
   if (board.flash) {
-    facts.push({ label: 'Flash', value: formatBytes(board.flash.bytes), source: board.flash.source })
+    facts.push({
+      label: 'Flash',
+      value: `${formatBytes(board.flash.bytes)}${board.flash.scope === 'chip' ? CHIP_SCOPE_NOTE.flash : ''}`,
+      source: board.flash.source
+    })
+  }
+  if (board.externalFlash) {
+    facts.push({
+      label: 'External flash',
+      value: formatBytes(board.externalFlash.bytes),
+      source: board.externalFlash.source
+    })
   }
   if (board.ram) {
     facts.push({
       label: 'RAM',
-      value: `${formatBytes(board.ram.bytes)}${board.ram.scope === 'chip' ? ' (the chip’s SRAM)' : ''}`,
+      value: `${formatBytes(board.ram.bytes)}${board.ram.scope === 'chip' ? CHIP_SCOPE_NOTE.ram : ''}`,
       source: board.ram.source
     })
   }
   if (board.psram) {
-    facts.push({ label: 'PSRAM', value: formatBytes(board.psram.bytes), source: board.psram.source })
+    // "External RAM" rather than "PSRAM": upstream's own word for the feature
+    // this row replaces, and the right one for the boards whose external RAM is
+    // SDRAM rather than SPI PSRAM.
+    facts.push({
+      label: 'External RAM',
+      value: formatBytes(board.psram.bytes),
+      source: board.psram.source
+    })
   }
   for (const { feature, label, sized } of SIZELESS_FEATURES) {
     if (board.features.includes(feature) && !board[sized]) {
@@ -203,10 +274,11 @@ export function variantList(board: IndexedBoard): { variant: string; description
  */
 export function activeFilterChips(
   filter: BoardFilter
-): { axis: 'vendor' | 'mcu' | 'feature' | 'runtime'; value: string }[] {
-  const out: { axis: 'vendor' | 'mcu' | 'feature' | 'runtime'; value: string }[] = []
+): { axis: 'vendor' | 'mcu' | 'feature' | 'runtime' | 'memory'; value: string }[] {
+  const out: { axis: 'vendor' | 'mcu' | 'feature' | 'runtime' | 'memory'; value: string }[] = []
   for (const v of filter.vendors ?? []) out.push({ axis: 'vendor', value: v })
   for (const m of filter.mcus ?? []) out.push({ axis: 'mcu', value: m })
+  if (filter.minRam) out.push({ axis: 'memory', value: memoryThresholdLabel(filter.minRam) })
   for (const f of filter.features ?? []) out.push({ axis: 'feature', value: f })
   for (const r of filter.runtimes ?? []) out.push({ axis: 'runtime', value: r })
   return out
@@ -231,6 +303,59 @@ export function isFiltering(filter: BoardFilter): boolean {
  */
 export function toggleChip(values: readonly string[], value: string): string[] {
   return values.includes(value) ? values.filter((v) => v !== value) : [...values, value]
+}
+
+// ---------------------------------------------------------------------------
+// The memory filter (#897)
+// ---------------------------------------------------------------------------
+
+/**
+ * The steps the memory control offers, in bytes.
+ *
+ * Chosen where the catalogue actually divides rather than at round powers for
+ * their own sake: 32 KB separates the SAMD21 class from everything else, 64 KB
+ * is where the smaller nRF52 sits, 264 KB is an RP2040 and 520 KB an ESP32 or
+ * an RP2350, so 256 KB and 512 KB are the two thresholds people are really
+ * asking about. 1 MB picks out the i.MX RT and STM32H7 boards.
+ */
+export const MEMORY_THRESHOLDS = [
+  32 * 1024,
+  64 * 1024,
+  128 * 1024,
+  256 * 1024,
+  512 * 1024,
+  1024 * 1024
+] as const
+
+/** "≥ 256 KB", for the dropdown and for the removable chip. */
+export function memoryThresholdLabel(bytes: number): string {
+  return `≥ ${formatBytes(bytes)}`
+}
+
+/**
+ * The one thing the memory filter cannot say, said on screen.
+ *
+ * Every figure it filters on is the CHIP's SRAM, so the control is silent about
+ * the external PSRAM that is the whole point of several of these boards — an
+ * ESP32 Feather V2 has 520 KB of SRAM and 2 MB of PSRAM, and this control sees
+ * the first number. Saying so under the control is what makes it honest to
+ * offer, exactly as {@link RUNTIME_CAVEAT} is for the runtime chips.
+ */
+export const MEMORY_CAVEAT =
+  'This is the chip’s own SRAM. Boards with external PSRAM have far more than ' +
+  'this figure shows — it is listed separately on the board.'
+
+/** "3 boards have no published RAM figure and are not shown." */
+export function unsizedNotice(count: number): string | null {
+  if (count <= 0) return null
+  return `${count} board${count === 1 ? '' : 's'} ${count === 1 ? 'has' : 'have'} no published RAM figure and ${count === 1 ? 'is' : 'are'} not shown.`
+}
+
+/** Add or remove one feature, so the chips toggle rather than only accumulate. */
+export function toggleFeature(features: readonly string[], feature: string): string[] {
+  return features.includes(feature)
+    ? features.filter((f) => f !== feature)
+    : [...features, feature]
 }
 
 /** Same toggle, typed for the runtime chips. */

--- a/src/shared/board-index.ts
+++ b/src/shared/board-index.ts
@@ -33,8 +33,8 @@
  * comes from somewhere else, and every figure therefore carries a {@link
  * BoardSize.source} naming it. A number with no provenance is not worth
  * publishing: a wrong flash size sends someone to a board that cannot hold their
- * program. They are still NOT offered as filters — see `board-finder.ts` for the
- * coverage that decision turns on.
+ * program. Whether they are offered as FILTERS is a separate question, decided
+ * on coverage — see `board-finder.ts`.
  *
  * Pure — parsing, filtering and picking, no IO — so all of it unit-tests in node.
  */
@@ -144,11 +144,33 @@ export interface IndexedBoard {
   /** Bundled thumbnail filename, or null where none could be made. */
   thumb: string | null
   builds: BoardBuild[]
-  /** On-board flash, when a sourced figure exists (#897). Usually `board` scope. */
+  /**
+   * The flash a program is written into (#897).
+   *
+   * `chip` scope where the microcontroller has its own — an STM32F405's 1 MB is
+   * on the die and true of every board carrying one. `board` scope on the parts
+   * with NO internal flash at all, where it is entirely a property of the
+   * module: RP2040, RP2350, ESP32 and i.MX RT.
+   */
   flash: BoardSize | null
+  /**
+   * A SEPARATE flash chip the board adds, when its size is sourced (#897).
+   *
+   * Distinct from {@link flash} because on half the catalogue they are both real
+   * and different: the Feather M0 Express has 256 KB inside the SAMD21 and 2 MB
+   * of SPI flash beside it, and answering "how much flash?" with either number
+   * alone is answering a different question from the one that was asked. Null on
+   * boards with no second chip AND on boards that have one whose size nobody
+   * publishes — `features` still carries `External Flash` for the latter, and the
+   * card says the size is unknown rather than implying there is none.
+   */
+  externalFlash: BoardSize | null
   /** Built-in SRAM (#897). Usually `chip` scope — it follows from `mcu`. */
   ram: BoardSize | null
-  /** External PSRAM/SPIRAM, when the board has any and the size is sourced. */
+  /**
+   * External RAM — SPI PSRAM on the ESP32 and RP2350 boards, SDRAM on the bigger
+   * i.MX RT and STM32H7 ones. One field, because it answers one question.
+   */
   psram: BoardSize | null
   /**
    * The runtimes with a published, flashable build for THIS board (#902).
@@ -270,6 +292,7 @@ export function parseBoardIndex(raw: unknown): BoardIndex | null {
       thumb: strOrNull(b.thumb),
       builds,
       flash: parseSize(b.flash),
+      externalFlash: parseSize(b.externalFlash),
       ram: parseSize(b.ram),
       psram: parseSize(b.psram),
       // DERIVED, not read, when the document does not say — which is what a
@@ -335,6 +358,16 @@ export interface BoardFilter {
    * question someone switching a class from one to the other actually has.
    */
   runtimes?: FirmwareRuntime[]
+  /**
+   * Keep only boards with at least this much on-chip RAM, in bytes (#897).
+   *
+   * A board with NO published RAM figure does not match — there is no honest
+   * way to include it — so the gallery counts those separately and says how
+   * many it dropped for want of a figure. See {@link boardsWithoutRam}.
+   *
+   * There is deliberately no `minFlash` beside this. See `board-finder.ts`.
+   */
+  minRam?: number
   /** Hide boards with no published firmware. */
   flashableOnly?: boolean
 }
@@ -350,6 +383,9 @@ export function matchesFilter(board: IndexedBoard, filter: BoardFilter): boolean
   // must not hide the catalogue.
   if (filter.vendors?.length && !filter.vendors.includes(board.vendor)) return false
   if (filter.mcus?.length && !filter.mcus.includes(board.mcu)) return false
+  // A size threshold is a different shape from a facet: one comparable number,
+  // not a set of values, so it narrows on its own terms (#897).
+  if (filter.minRam && (board.ram === null || board.ram.bytes < filter.minRam)) return false
   for (const f of filter.features ?? []) {
     if (!board.features.includes(f)) return false
   }
@@ -369,6 +405,26 @@ export function matchesFilter(board: IndexedBoard, filter: BoardFilter): boolean
 
 export function filterBoards(boards: readonly IndexedBoard[], filter: BoardFilter): IndexedBoard[] {
   return boards.filter((b) => matchesFilter(b, filter))
+}
+
+/**
+ * Boards with no published RAM figure, among those the OTHER filters keep.
+ *
+ * The whole design of #897 is that a missing figure is stated rather than
+ * hidden, and a size filter is the one place that promise is easy to break: a
+ * board with no number silently drops out of the list and nobody is told. This
+ * is what the gallery prints instead — "4 boards have no published RAM figure
+ * and are not shown" — so the gap stays visible at the moment it bites.
+ *
+ * `minRam` is ignored when counting, on purpose: the answer must not depend on
+ * where the threshold happens to sit.
+ */
+export function boardsWithoutRam(
+  boards: readonly IndexedBoard[],
+  filter: BoardFilter
+): IndexedBoard[] {
+  const rest = { ...filter, minRam: undefined }
+  return boards.filter((b) => b.ram === null && matchesFilter(b, rest))
 }
 
 /** One choice on a chip facet: the value, and how many boards carry it. */

--- a/src/shared/board-overlay.ts
+++ b/src/shared/board-overlay.ts
@@ -59,6 +59,8 @@ export interface OverlayBoard {
   /** esptool write offset, or null where the board is not flashed that way. */
   flashOffset: string | null
   flash: BoardSize | null
+  /** A second flash chip beside the MCU, where the maker states its size (#897). */
+  externalFlash?: BoardSize | null
   ram: BoardSize | null
   psram: BoardSize | null
   /** Confirmed against circuitpython.org's published catalogue, or null. */
@@ -230,6 +232,7 @@ function toIndexedBoard(entry: OverlayBoard, upstream: readonly IndexedBoard[]):
     thumb: null,
     builds: borrowed,
     flash: entry.flash,
+    externalFlash: entry.externalFlash ?? null,
     ram: entry.ram,
     psram: entry.psram,
     runtimes,

--- a/test/boardConfig.test.ts
+++ b/test/boardConfig.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it } from 'vitest'
+// @ts-ignore — plain .mjs beside the generator that uses it; the readers are the
+// thing under test, so they are imported rather than re-typed.
+import {
+  linkerSize,
+  nrfMemoryScriptsFor,
+  picoSdkBoardFor,
+  readBoardConfig,
+  readEsp32,
+  readMimxrt,
+  readNrf,
+  readRp2,
+  readStm32,
+  sizeExpression
+} from '../scripts/board-config.mjs'
+
+/**
+ * Reading sizes out of MicroPython's own per-board build configuration (#897).
+ *
+ * The fixtures below are real fragments of upstream's tree, kept verbatim
+ * including the comments, because the comments are where several of these go
+ * wrong. Every test here is about the same question: is this number about THIS
+ * board, or about a board whose configuration it happens to borrow?
+ */
+
+describe('size expressions', () => {
+  it('reads the forms upstream actually writes', () => {
+    expect(sizeExpression('(8 * 1024 * 1024)')).toBe(8 * 1024 * 1024)
+    expect(sizeExpression('0x800000  # 8MB')).toBe(8 * 1024 * 1024)
+    expect(sizeExpression('16777216')).toBe(16 * 1024 * 1024)
+    expect(sizeExpression('(1 * 1024 * 1024) /* entire flash */')).toBe(1024 * 1024)
+  })
+
+  it('refuses anything with a symbol in it', () => {
+    // Several boards write their storage size as arithmetic ON the flash size.
+    // Resolving that means knowing what the symbol was, and being wrong about it
+    // is how a firmware reservation gets published as a flash size.
+    expect(sizeExpression('PICO_FLASH_SIZE_BYTES - (1024 * 1024)')).toBeNull()
+    expect(sizeExpression('MICROPY_HW_FLASH_SIZE')).toBeNull()
+    expect(sizeExpression('')).toBeNull()
+    expect(sizeExpression(null)).toBeNull()
+  })
+})
+
+describe('which chip an stm32 board carries', () => {
+  it('reports the board’s name and the build’s, because neither always wins', () => {
+    // The Espruino Pico BUILDS as an F401xE and IS an F401CD — 384 KB of flash,
+    // not the 512 KB the build's memory map allows for. The board is right.
+    const pico = readStm32({
+      'mpconfigboard.h': '#define MICROPY_HW_MCU_NAME "STM32F401CD"',
+      'mpconfigboard.mk': 'CMSIS_MCU = STM32F401xE\n'
+    })
+    expect(pico.part).toBe('STM32F401CD')
+    expect(pico.partAlso).toBe('STM32F401xE')
+
+    // The HydraBus calls itself "STM32F4", which is not a part. The build is.
+    const hydra = readStm32({
+      'mpconfigboard.h': '#define MICROPY_HW_MCU_NAME "STM32F4"',
+      'mpconfigboard.mk': 'CMSIS_MCU = STM32F405xx\n'
+    })
+    expect(hydra.part).toBe('STM32F4')
+    expect(hydra.partAlso).toBe('STM32F405xx')
+  })
+})
+
+describe('i.MX RT, the port that states its own sizes', () => {
+  // Verbatim from ports/mimxrt/boards/MIMXRT1060_EVK/mpconfigboard.mk.
+  const evk = {
+    'mpconfigboard.mk': [
+      'MCU_SERIES = MIMXRT1062',
+      'MCU_VARIANT = MIMXRT1062DVL6A',
+      '',
+      'MICROPY_HW_FLASH_TYPE = qspi_nor_flash',
+      'MICROPY_HW_FLASH_SIZE = 0x800000  # 8MB',
+      'MICROPY_HW_FLASH_RESERVED ?= 0x1000  # 4KB',
+      '',
+      'MICROPY_HW_SDRAM_AVAIL = 1',
+      'MICROPY_HW_SDRAM_SIZE  = 0x2000000  # 32MB'
+    ].join('\n')
+  }
+
+  it('reads the flash chip and the SDRAM, and says where from', () => {
+    const got = readMimxrt(evk, { boardId: 'MIMXRT1060_EVK' })
+    expect(got.part).toBe('MIMXRT1062')
+    expect(got.flash).toBe(8 * 1024 * 1024)
+    expect(got.externalRam).toBe(32 * 1024 * 1024)
+    expect(got.flashSource).toContain('MIMXRT1060_EVK/mpconfigboard.mk')
+    expect(got.flashSource).toContain('MICROPY_HW_FLASH_SIZE')
+  })
+
+  it('offers no external RAM for a board that declares none', () => {
+    const teensy = readMimxrt(
+      { 'mpconfigboard.mk': 'MCU_SERIES = MIMXRT1062\nMICROPY_HW_FLASH_SIZE = 0x200000  # 2MB\n' },
+      { boardId: 'TEENSY40' }
+    )
+    expect(teensy.flash).toBe(2 * 1024 * 1024)
+    expect(teensy.externalRam).toBeNull()
+    expect(teensy.externalRamSource).toBeNull()
+  })
+})
+
+describe('esp32, which almost never says', () => {
+  it('takes only the size that is selected', () => {
+    // SIL_MANT1S lists the sizes it is NOT using with an empty value. Matching
+    // the name without the `=y` would read the first one and get 4 MB.
+    const sdk = [
+      'CONFIG_ESPTOOLPY_FLASHSIZE_4MB=',
+      'CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y',
+      'CONFIG_ESPTOOLPY_FLASHSIZE_16MB=',
+      'CONFIG_ESPTOOLPY_FLASHSIZE="8MB"'
+    ].join('\n')
+    expect(readEsp32({ 'sdkconfig.board': sdk }, { boardId: 'SIL_MANT1S' }).flash).toBe(
+      8 * 1024 * 1024
+    )
+  })
+
+  it('says nothing for the 42 boards that set no size at all', () => {
+    expect(readEsp32({ 'sdkconfig.board': 'CONFIG_SPIRAM_MEMTEST=\n' }, {}).flash).toBeNull()
+    expect(readEsp32({}, {}).flash).toBeNull()
+  })
+})
+
+describe('nrf, where the sub-variant is not a part', () => {
+  // Verbatim from ports/nrf/boards/nrf52832_512k_64k.ld and its siblings.
+  const map = (flash: string, ram: string) =>
+    `/*\n    GNU linker script\n*/\n\n_flash_size = ${flash};\n_ram_size   = ${ram};\n` +
+    `_micropy_hw_romfs_part0_size = 128K;\n_stack_size = 8K;\n`
+
+  it('reads the memory map the board is actually linked against', () => {
+    // `nrf52832` alone spans the 512 KB/64 KB QFAA and the 256 KB/32 KB QFAB.
+    // The makefile picks one, and a 512 KB image will not fit a QFAB.
+    const got = readNrf(
+      {
+        'mpconfigboard.mk':
+          'MCU_VARIANT = nrf52\nMCU_SUB_VARIANT = nrf52832\nSOFTDEV_VERSION = 6.1.1\n' +
+          'LD_FILES += boards/nrf52832_512k_64k.ld\n'
+      },
+      { boardId: 'PCA10040', nrfScripts: { 'nrf52832_512k_64k.ld': map('512K', '64K') } }
+    )
+    expect(got.part).toBe('nrf52832')
+    expect(got.chipMemory).toEqual({
+      flash: 512 * 1024,
+      sram: 64 * 1024,
+      source: 'MicroPython ports/nrf/boards/nrf52832_512k_64k.ld'
+    })
+  })
+
+  it('ignores the bootloader and softdevice scripts listed beside it', () => {
+    // The micro:bit v1 and the XIAO nRF52840 both pull in a second script; only
+    // the memory map defines both sizes, which is what picks it out.
+    const got = readNrf(
+      {
+        'mpconfigboard.mk':
+          'MCU_SUB_VARIANT = nrf51822\n' +
+          'LD_FILES += boards/MICROBIT/custom_nrf51822_s110_microbit.ld boards/nrf51x22_256k_16k.ld\n'
+      },
+      {
+        boardId: 'MICROBIT',
+        nrfScripts: {
+          'nrf51x22_256k_16k.ld': map('256K', '16K'),
+          'custom_nrf51822_s110_microbit.ld': '_sd_size = 88K;\n_sd_ram = 8K;\n'
+        }
+      }
+    )
+    expect(got.chipMemory?.flash).toBe(256 * 1024)
+    expect(got.chipMemory?.sram).toBe(16 * 1024)
+  })
+
+  it('says nothing when two scripts would both answer', () => {
+    const got = readNrf(
+      { 'mpconfigboard.mk': 'MCU_SUB_VARIANT = nrf52832\n' },
+      {
+        boardId: 'X',
+        nrfScripts: { 'a.ld': map('512K', '64K'), 'b.ld': map('256K', '32K') }
+      }
+    )
+    expect(got.chipMemory).toBeUndefined()
+  })
+
+  it('says nothing at all when no script was found', () => {
+    const got = readNrf({ 'mpconfigboard.mk': 'MCU_SUB_VARIANT = nrf52832\n' }, { boardId: 'X' })
+    expect(got.part).toBe('nrf52832')
+    expect(got.chipMemory).toBeUndefined()
+  })
+
+  it('asks only for the top-level scripts a board names', () => {
+    expect(
+      nrfMemoryScriptsFor({
+        'mpconfigboard.mk':
+          'LD_FILES += boards/SEEED_XIAO_NRF52/XIAO_bootloader.ld boards/nrf52840_1M_256k.ld\n'
+      })
+    ).toEqual(['nrf52840_1M_256k.ld'])
+  })
+
+  it('reads the sizes the way a linker script writes them', () => {
+    expect(linkerSize('512K')).toBe(512 * 1024)
+    expect(linkerSize('1M')).toBe(1024 * 1024)
+    expect(linkerSize('0x40000')).toBe(0x40000)
+    expect(linkerSize('_flash_size')).toBeNull()
+  })
+})
+
+describe('rp2, where the header may be another board’s', () => {
+  const header = (mb: number) =>
+    `// pico_cmake_set_default PICO_FLASH_SIZE_BYTES = (${mb} * 1024 * 1024)\n` +
+    `#ifndef PICO_FLASH_SIZE_BYTES\n#define PICO_FLASH_SIZE_BYTES (${mb} * 1024 * 1024)\n#endif\n`
+
+  it('takes a pico-sdk header whose name IS this board', () => {
+    const got = readRp2(
+      { 'mpconfigboard.cmake': 'set(PICO_BOARD "seeed_xiao_rp2040")\n' },
+      { boardId: 'SEEED_XIAO_RP2040', picoSdkHeaders: { seeed_xiao_rp2040: header(2) } }
+    )
+    expect(got.flash).toBe(2 * 1024 * 1024)
+    expect(got.flashSource).toContain('pico-sdk')
+  })
+
+  it('matches across naming styles, so punctuation does not lose a board', () => {
+    const got = readRp2(
+      { 'mpconfigboard.cmake': 'set(PICO_BOARD "weact_studio_rp2350b_core")\n' },
+      {
+        boardId: 'WEACTSTUDIO_RP2350B_CORE',
+        picoSdkHeaders: { weact_studio_rp2350b_core: header(16) }
+      }
+    )
+    expect(got.flash).toBe(16 * 1024 * 1024)
+  })
+
+  it('REFUSES a header belonging to a different board', () => {
+    // The heart of it. `W5500_EVB_PICO` points at the W5100S board's header, and
+    // `CYTRON_MOTION_2350_PRO` at a Raspberry Pi Pico 2's. Reading the flash out
+    // of those gives a correct figure about the wrong board.
+    expect(
+      readRp2(
+        { 'mpconfigboard.cmake': 'set(PICO_BOARD "wiznet_w5100s_evb_pico")\n' },
+        { boardId: 'W5500_EVB_PICO', picoSdkHeaders: { wiznet_w5100s_evb_pico: header(2) } }
+      ).flash
+    ).toBeNull()
+    expect(
+      readRp2(
+        { 'mpconfigboard.cmake': 'set(PICO_BOARD "pico2")\n' },
+        { boardId: 'CYTRON_MOTION_2350_PRO', picoSdkHeaders: { pico2: header(4) } }
+      ).flash
+    ).toBeNull()
+  })
+
+  it('takes a header the board ships in its own directory', () => {
+    const got = readRp2(
+      { 'mpconfigboard.cmake': 'set(PICO_BOARD "sparkfun_xrp_controller")\n' },
+      { boardId: 'SPARKFUN_XRP_CONTROLLER', ownHeaders: { 'sparkfun_xrp_controller.h': header(16) } }
+    )
+    expect(got.flash).toBe(16 * 1024 * 1024)
+    expect(got.flashSource).toContain('ports/rp2/boards/SPARKFUN_XRP_CONTROLLER')
+  })
+
+  it('takes a size the board sets outright', () => {
+    const got = readRp2(
+      {
+        'mpconfigboard.cmake':
+          'set(PICO_BOARD none)\nset(PICO_FLASH_SIZE_BYTES 4194304)\n' +
+          'set(MICROPY_HW_FLASH_STORAGE_BYTES 3145728)\n'
+      },
+      { boardId: 'SIL_RP2040_SHIM' }
+    )
+    expect(got.flash).toBe(4 * 1024 * 1024)
+    expect(got.flashSource).toContain('SIL_RP2040_SHIM/mpconfigboard.cmake')
+  })
+
+  it('never reads the filesystem partition as the flash size', () => {
+    // `MICROPY_HW_FLASH_STORAGE_BYTES` is 1408 KB on a 2 MB Pico. It is the
+    // tempting field and it is the wrong one, so nothing may come of it alone.
+    const got = readRp2(
+      { 'mpconfigboard.cmake': 'set(MICROPY_HW_FLASH_STORAGE_BYTES 1441792)  # 1408 * 1024\n' },
+      { boardId: 'SOME_BOARD' }
+    )
+    expect(got.flash).toBeNull()
+  })
+
+  it('throws out a pairing where the filesystem would not fit in the flash', () => {
+    const got = readRp2(
+      {
+        'mpconfigboard.cmake':
+          'set(PICO_BOARD "tiny_board")\nset(MICROPY_HW_FLASH_STORAGE_BYTES 15728640)\n'
+      },
+      { boardId: 'TINY_BOARD', picoSdkHeaders: { tiny_board: header(2) } }
+    )
+    expect(got.flash).toBeNull()
+  })
+
+  it('names only the pico-sdk headers worth fetching', () => {
+    expect(
+      picoSdkBoardFor({ 'mpconfigboard.cmake': 'set(PICO_BOARD "seeed_xiao_rp2040")' }, 'SEEED_XIAO_RP2040')
+    ).toBe('seeed_xiao_rp2040')
+    expect(
+      picoSdkBoardFor({ 'mpconfigboard.cmake': 'set(PICO_BOARD "pico_w")' }, 'CYTRON_NANOXRP_CONTROLLER')
+    ).toBeNull()
+  })
+})
+
+describe('dispatch', () => {
+  it('says nothing for a port with no reader, rather than throwing', () => {
+    expect(readBoardConfig('cc3200', {}, { boardId: 'WIPY' })).toEqual({})
+    expect(readBoardConfig('esp8266', {}, { boardId: 'ESP8266_GENERIC' })).toEqual({})
+  })
+})

--- a/test/boardFinder.test.ts
+++ b/test/boardFinder.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, afterEach, vi } from 'vitest'
 import {
+  MEMORY_CAVEAT,
+  MEMORY_THRESHOLDS,
   NO_SIZE_PUBLISHED,
   PLAIN_BUILD_LABEL,
   UNKNOWN_VENDOR,
@@ -9,9 +11,11 @@ import {
   buildLabel,
   firmwareSummary,
   isFiltering,
+  memoryThresholdLabel,
   peekFacts,
   shelvesByVendor,
   toggleChip,
+  unsizedNotice,
   variantList
 } from '../src/renderer/src/components/board-finder'
 import {
@@ -19,7 +23,13 @@ import {
   flashRequestFor,
   requestFlash
 } from '../src/renderer/src/components/board-finder-bus'
-import type { BoardBuild, IndexedBoard } from '../src/shared/board-index'
+import {
+  boardsWithoutRam,
+  filterBoards,
+  type BoardBuild,
+  type BoardSize,
+  type IndexedBoard
+} from '../src/shared/board-index'
 
 /**
  * The Board Finder gallery's own decisions (#893) — shelving, the photo-less
@@ -54,6 +64,7 @@ const board = (over: Partial<IndexedBoard> = {}): IndexedBoard => ({
   thumb: null,
   builds: [build()],
   flash: null,
+  externalFlash: null,
   ram: null,
   psram: null,
   runtimes: ['micropython'],
@@ -294,5 +305,86 @@ describe('the flasher hand-off', () => {
     expect(events).toHaveLength(1)
     expect(events[0].type).toBe(FLASH_BOARD_EVENT)
     expect((events[0].detail as { boardId: string }).boardId).toBe('RPI_PICO')
+  })
+})
+
+describe('the memory filter (#897)', () => {
+  const sram = (kb: number): BoardSize => ({
+    bytes: kb * 1024,
+    source: 'a datasheet',
+    scope: 'chip'
+  })
+  const catalogue = [
+    board({ id: 'TRINKET_M0', ram: sram(32) }),
+    board({ id: 'RPI_PICO', ram: sram(264) }),
+    board({ id: 'ESP32_GENERIC', ram: sram(520) }),
+    board({ id: 'TEENSY41', ram: sram(1024) }),
+    // The boards in the real catalogue with no sourced RAM figure at all.
+    board({ id: 'ESP8266_GENERIC', ram: null }),
+    board({ id: 'WIPY', ram: null })
+  ]
+
+  it('keeps the boards at or above the threshold', () => {
+    expect(filterBoards(catalogue, { minRam: 256 * 1024 }).map((b) => b.id)).toEqual([
+      'RPI_PICO',
+      'ESP32_GENERIC',
+      'TEENSY41'
+    ])
+  })
+
+  it('does not quietly keep a board whose RAM nobody published', () => {
+    // Including them would be the more generous answer and the dishonest one:
+    // the filter would be saying "this board has at least 32 KB" about a board
+    // it knows nothing about.
+    expect(filterBoards(catalogue, { minRam: 32 * 1024 }).map((b) => b.id)).not.toContain(
+      'ESP8266_GENERIC'
+    )
+  })
+
+  it('counts the boards it dropped for having no figure, so they can be named', () => {
+    // The trap the whole design exists to avoid: a size control that silently
+    // loses the undocumented boards. The gallery prints this count.
+    const dropped = boardsWithoutRam(catalogue, { minRam: 512 * 1024 })
+    expect(dropped.map((b) => b.id)).toEqual(['ESP8266_GENERIC', 'WIPY'])
+    expect(unsizedNotice(dropped.length)).toBe(
+      '2 boards have no published RAM figure and are not shown.'
+    )
+  })
+
+  it('counts the same boards whatever the threshold is', () => {
+    // The answer is about what is unknown, not about where the threshold sits.
+    for (const bytes of MEMORY_THRESHOLDS) {
+      expect(boardsWithoutRam(catalogue, { minRam: bytes }).length, String(bytes)).toBe(2)
+    }
+  })
+
+  it('still respects the other filters when counting them', () => {
+    expect(
+      boardsWithoutRam(catalogue, { minRam: 512 * 1024, text: 'wipy' }).map((b) => b.id)
+    ).toEqual(['WIPY'])
+  })
+
+  it('says nothing when nothing was dropped', () => {
+    expect(unsizedNotice(0)).toBeNull()
+    expect(unsizedNotice(1)).toBe('1 board has no published RAM figure and is not shown.')
+  })
+
+  it('shows as a removable chip, and counts as filtering', () => {
+    expect(activeFilterChips({ minRam: 256 * 1024 })).toEqual([
+      { axis: 'memory', value: '≥ 256 KB' }
+    ])
+    expect(isFiltering({ minRam: 256 * 1024 })).toBe(true)
+    expect(activeFilterChips({})).toEqual([])
+  })
+
+  it('labels its thresholds the way sizes are written elsewhere', () => {
+    expect(memoryThresholdLabel(256 * 1024)).toBe('≥ 256 KB')
+    expect(memoryThresholdLabel(1024 * 1024)).toBe('≥ 1 MB')
+  })
+
+  it('says out loud that PSRAM is not in the figure', () => {
+    // Without this the control would quietly rank an ESP32 Feather V2 - 520 KB
+    // of SRAM and 2 MB of PSRAM - below a board with a megabyte of plain SRAM.
+    expect(MEMORY_CAVEAT).toMatch(/PSRAM/)
   })
 })

--- a/test/boardFlashHandoff.test.ts
+++ b/test/boardFlashHandoff.test.ts
@@ -39,6 +39,7 @@ const board = (over: Partial<IndexedBoard> = {}): IndexedBoard => ({
     }
   ],
   flash: null,
+  externalFlash: null,
   ram: null,
   psram: null,
   runtimes: ['micropython'],

--- a/test/boardIndex.test.ts
+++ b/test/boardIndex.test.ts
@@ -46,6 +46,7 @@ const board = (over: Partial<IndexedBoard> = {}): IndexedBoard => ({
   thumb: null,
   builds: [],
   flash: null,
+  externalFlash: null,
   ram: null,
   psram: null,
   runtimes: ['micropython'],
@@ -104,12 +105,14 @@ describe('parsing a document', () => {
         {
           id: 'X',
           flash: { bytes: 8388608 },
+          externalFlash: { bytes: 2097152, source: '   ' },
           ram: { bytes: 264 * 1024, source: 'RP2040 datasheet', scope: 'chip' },
           psram: { bytes: 0, source: 'somewhere' }
         }
       ]
     })
     expect(doc?.boards[0].flash).toBeNull()
+    expect(doc?.boards[0].externalFlash).toBeNull()
     expect(doc?.boards[0].psram).toBeNull()
     expect(doc?.boards[0].ram).toEqual({ bytes: 270336, source: 'RP2040 datasheet', scope: 'chip' })
   })
@@ -370,7 +373,7 @@ describe('the generated seed that actually ships', () => {
     it('names a source for every figure, and never publishes a bare number', () => {
       const raw = JSON.parse(readFileSync('src/renderer/public/boards/boards.json', 'utf8'))
       for (const b of raw.boards) {
-        for (const key of ['flash', 'ram', 'psram'] as const) {
+        for (const key of ['flash', 'externalFlash', 'ram', 'psram'] as const) {
           const size = b[key]
           if (size === null || size === undefined) continue
           expect(typeof size.bytes, `${b.id}.${key}`).toBe('number')
@@ -393,12 +396,32 @@ describe('the generated seed that actually ships', () => {
       expect(pico.flash?.bytes).toBe(2 * 1024 * 1024)
     })
 
-    it('says nothing about chip families whose SRAM is not fixed', () => {
-      // stm32f4 spans 96 KB to 256 KB; nrf52 spans 64 KB to 256 KB. A plausible
-      // average would never get checked, which is what makes it dangerous.
+    it('takes RAM from the exact chip, never from the chip family', () => {
+      // This used to be "say nothing about a family whose SRAM varies", which
+      // cost 140 boards a figure. #897's coverage pass resolved the exact part
+      // instead — but the original hazard is unchanged, so the tripwire moves
+      // rather than goes: within a family that varies, the seed must show that
+      // variation. A figure derived from `mcu` alone would be uniform, and this
+      // is what would catch it.
+      for (const mcu of ['stm32f4', 'stm32l4', 'mimxrt']) {
+        const values = new Set(
+          doc!.boards.filter((b) => b.mcu === mcu && b.ram).map((b) => b.ram!.bytes)
+        )
+        expect(values.size, `${mcu} RAM values`).toBeGreaterThan(1)
+      }
+    })
+
+    it('still says nothing where even the exact chip does not settle it', () => {
+      // Espressif publishes no total RAM figure for the ESP8266 at all — the
+      // only quantity in its datasheet is an SDK-dependent "< 50 kB". A number
+      // here would be somebody's guess wearing a source.
+      const esp8266 = doc!.boards.find((b) => b.id === 'ESP8266_GENERIC')!
+      expect(esp8266.ram).toBeNull()
+      // …and no board anywhere carries a size without a source, which is the
+      // rule all of this hangs from.
       for (const b of doc!.boards) {
-        if (['stm32f4', 'nrf52', 'samd21', 'samd51', 'mimxrt'].includes(b.mcu)) {
-          expect(b.ram, `${b.id} (${b.mcu})`).toBeNull()
+        for (const key of ['flash', 'externalFlash', 'ram', 'psram'] as const) {
+          if (b[key]) expect(String(b[key]!.source).trim(), `${b.id}.${key}`).not.toBe('')
         }
       }
     })

--- a/test/boardOverlay.test.ts
+++ b/test/boardOverlay.test.ts
@@ -41,6 +41,7 @@ const board = (over: Partial<IndexedBoard> = {}): IndexedBoard => ({
   thumb: null,
   builds: [],
   flash: null,
+  externalFlash: null,
   ram: null,
   psram: null,
   runtimes: [],
@@ -96,7 +97,7 @@ describe('the board that started the epic', () => {
     expect(feather!.psram?.bytes).toBe(2 * 1024 * 1024)
     const facts = boardFacts(feather!)
     expect(facts.find((f) => f.label === 'Flash')?.value).toBe('8 MB')
-    expect(facts.find((f) => f.label === 'PSRAM')?.value).toBe('2 MB')
+    expect(facts.find((f) => f.label === 'External RAM')?.value).toBe('2 MB')
   })
 })
 
@@ -203,8 +204,20 @@ describe('formatting a size', () => {
     expect(formatBytes(8 * 1024 * 1024)).toBe('8 MB')
   })
 
-  it('keeps one decimal for a size that is not round', () => {
+  it('keeps one decimal for a size that is half a megabyte off', () => {
     expect(formatBytes(1.5 * 1024 * 1024)).toBe('1.5 MB')
+    expect(formatBytes(5.5 * 1024 * 1024)).toBe('5.5 MB')
+  })
+
+  it('stays in KB rather than rounding a real difference away', () => {
+    // An STM32H743 has 1056 KB. Printed as "1.0 MB" it would be indistinguishable
+    // from a part with 1024 KB, and 32 KB short — which on a board with a
+    // megabyte of RAM is a noticeable piece of somebody's heap. These sizes are
+    // not rare here: 1056, 1376, 2512 and 4200 KB all occur.
+    expect(formatBytes(1056 * 1024)).toBe('1056 KB')
+    expect(formatBytes(1376 * 1024)).toBe('1376 KB')
+    expect(formatBytes(4200 * 1024)).toBe('4200 KB')
+    expect(formatBytes(1024 * 1024)).toBe('1 MB')
   })
 })
 
@@ -232,8 +245,45 @@ describe('what a board’s details say about its sizes', () => {
         psram: { bytes: 2 * 1024 * 1024, source: 'a page', scope: 'board' }
       })
     )
-    expect(withSize.map((f) => f.label)).not.toContain('External RAM')
+    expect(withSize.find((f) => f.label === 'External RAM')?.value).toBe('2 MB')
     const without = boardFacts(board({ features: ['External RAM'] }))
     expect(without.find((f) => f.label === 'External RAM')?.value).toMatch(/not published/)
+  })
+
+  it('marks a chip-derived FLASH figure as the chip’s, and states the board’s beside it', () => {
+    // An Adafruit Feather M0 Express: 256 KB inside the SAMD21, 2 MB next to it.
+    // Both, labelled, because either alone answers a different question from the
+    // one the reader asked.
+    const facts = boardFacts(
+      board({
+        features: ['External Flash'],
+        flash: { bytes: 256 * 1024, source: 'Microchip SAM D21 datasheet', scope: 'chip' },
+        externalFlash: { bytes: 2 * 1024 * 1024, source: 'adafruit.com/product/3403', scope: 'board' }
+      })
+    )
+    expect(facts.find((f) => f.label === 'Flash')?.value).toBe('256 KB (the chip’s internal flash)')
+    expect(facts.find((f) => f.label === 'External flash')?.value).toBe('2 MB')
+    expect(facts.find((f) => f.label === 'External flash')?.source).toBe('adafruit.com/product/3403')
+  })
+
+  it('still says the external flash size is unknown when only the chip’s is known', () => {
+    // The bug this pairing exists to stop: before `externalFlash`, a chip-scope
+    // flash figure suppressed the note about a SEPARATE flash chip, so a board
+    // with 2 MB of SPI flash beside a 256 KB SAMD21 said "256 KB" and no more.
+    const facts = boardFacts(
+      board({
+        features: ['External Flash'],
+        flash: { bytes: 256 * 1024, source: 'Microchip SAM D21 datasheet', scope: 'chip' }
+      })
+    )
+    expect(facts.find((f) => f.label === 'External flash')?.value).toMatch(/not published/)
+  })
+
+  it('does not claim an external flash chip on a board that has no such feature', () => {
+    const facts = boardFacts(
+      board({ flash: { bytes: 2 * 1024 * 1024, source: 'raspberrypi.com', scope: 'board' } })
+    )
+    expect(facts.find((f) => f.label === 'Flash')?.value).toBe('2 MB')
+    expect(facts.map((f) => f.label)).not.toContain('External flash')
   })
 })

--- a/test/boardSpecs.test.ts
+++ b/test/boardSpecs.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from 'vitest'
 // @ts-ignore — a plain .mjs beside the generator that uses it; the tables
 // are the thing under test, so they are imported rather than re-typed.
 import {
+  BOARD_MCU_PART,
+  CHIP_MEMORY,
   CURATED_BOARDS,
   MCU_SRAM,
+  WITHHELD,
   circuitPythonIdFor,
   circuitPythonIndex,
   runtimesForBoard,
@@ -45,9 +48,10 @@ describe('SRAM derived from the chip', () => {
     }
   })
 
-  it('never derives flash from the chip, because flash is not on the chip', () => {
+  it('never derives flash from the chip FAMILY, because flash is not in the family', () => {
     // The distinction #897 turns on: RP2040 boards ship with 2 MB to 16 MB of
-    // flash and all of them have exactly 264 KB of SRAM.
+    // flash and all of them have exactly 264 KB of SRAM. An exact PART may well
+    // settle the flash — see the CHIP_MEMORY tests below — but `mcu` never does.
     for (const mcu of Object.keys(MCU_SRAM)) {
       const { flash } = specsForBoard(board({ id: 'NOT_CURATED', mcu }))
       expect(flash, mcu).toBeNull()
@@ -81,6 +85,131 @@ describe('curated boards', () => {
         expect(size.source.trim(), `${id}.${key}`).not.toBe('')
       }
     }
+  })
+})
+
+describe('memory the exact chip settles', () => {
+  it('gives a SAMD51 Feather its 512 KB, as the chip’s figure and not the board’s', () => {
+    const { flash, ram } = specsForBoard(board({ mcu: 'samd51' }), { part: 'SAMD51J19A' })
+    expect(flash.bytes).toBe(512 * 1024)
+    expect(flash.scope).toBe('chip')
+    expect(flash.source).toMatch(/Microchip/)
+    // 192, not 200: Microchip prints "192/8" and the 8 KB is backup RAM in its
+    // own power domain. Adding it would be the easiest wrong number in the file.
+    expect(ram.bytes).toBe(192 * 1024)
+  })
+
+  it('falls back to the build’s name when the board’s is too vague to be a part', () => {
+    // The HydraBus calls itself "STM32F4"; its makefile says `STM32F405xx`.
+    const { flash } = specsForBoard(board({ mcu: 'stm32f4' }), {
+      part: 'STM32F4',
+      partAlso: 'STM32F405xx'
+    })
+    expect(flash?.bytes).toBe(1024 * 1024)
+  })
+
+  it('says nothing for a chip name that does not pin the memory down', () => {
+    // nRF52832 is the 512 KB/64 KB QFAA and the 256 KB/32 KB QFAB — a factor of
+    // two apart on both axes — and nRF51822 is worse at three variants. These
+    // are the rows most likely to be "improved" by a plausible number.
+    for (const part of ['nrf52832', 'nrf51822']) {
+      const { flash, ram } = specsForBoard(board({ mcu: 'nrf52' }), { part })
+      expect(flash, part).toBeNull()
+      expect(ram, part).toBeNull()
+    }
+  })
+
+  it('states SRAM alone for a Renesas group that spans several flash sizes', () => {
+    // RA6M5 is 1 MB to 2 MB of flash and 512 KB of SRAM throughout, and upstream
+    // names the group rather than the part.
+    const { flash, ram } = specsForBoard(board({ mcu: 'ra6m5' }), { part: 'RA6M5' })
+    expect(flash).toBeNull()
+    expect(ram.bytes).toBe(512 * 1024)
+  })
+
+  it('lets the board name a part where upstream’s name is too vague', () => {
+    // "STM32F407" spans 512 KB and 1 MB; Olimex says STM32F407ZGT6.
+    expect(BOARD_MCU_PART.OLIMEX_E407.part).toBe('STM32F407ZG')
+    const { flash } = specsForBoard(board({ id: 'OLIMEX_E407', mcu: 'stm32f4' }), {
+      part: 'STM32F407'
+    })
+    expect(flash?.bytes).toBe(1024 * 1024)
+  })
+
+  it('names a source for every figure it states', () => {
+    for (const [part, entry] of Object.entries(CHIP_MEMORY) as [
+      string,
+      { flash?: number; sram?: number; source: string }
+    ][]) {
+      expect(entry.source?.trim(), part).not.toBe('')
+      expect(entry.flash ?? entry.sram, part).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('what upstream states outright', () => {
+  it('prefers the board’s own build configuration to the chip’s datasheet', () => {
+    // An i.MX RT has no internal flash, so the only true figure is the one the
+    // board file gives, and it must not be shadowed by anything.
+    const { flash } = specsForBoard(board({ mcu: 'mimxrt' }), {
+      part: 'MIMXRT1062',
+      flash: 8 * 1024 * 1024,
+      flashSource: 'MicroPython ports/mimxrt/boards/TEENSY41/mpconfigboard.mk'
+    })
+    expect(flash.bytes).toBe(8 * 1024 * 1024)
+    expect(flash.scope).toBe('board')
+    expect(flash.source).toMatch(/TEENSY41/)
+  })
+
+  it('refuses a size with no source, even when it has a number', () => {
+    // The rule the whole issue turns on, enforced one layer before the parser.
+    const { flash, psram } = specsForBoard(board(), {
+      flash: 4 * 1024 * 1024,
+      externalRam: 2 * 1024 * 1024
+    })
+    expect(flash).toBeNull()
+    expect(psram).toBeNull()
+  })
+})
+
+describe('figures deliberately withheld', () => {
+  it('blanks a figure two sources disagree about, and says why', () => {
+    const spec = specsForBoard(board({ id: 'MACHDYNE_WERKZEUG', mcu: 'rp2040' }), {
+      flash: 1024 * 1024,
+      flashSource: 'Raspberry Pi pico-sdk src/boards/include/boards/machdyne_werkzeug.h'
+    })
+    expect(spec.flash).toBeNull()
+    expect(WITHHELD.MACHDYNE_WERKZEUG.why).toMatch(/4MB/)
+  })
+
+  it('writes down a reason for every one of them', () => {
+    for (const [id, entry] of Object.entries(WITHHELD) as [
+      string,
+      { fields: string[]; why: string }
+    ][]) {
+      expect(entry.fields.length, id).toBeGreaterThan(0)
+      expect(entry.why.trim(), id).not.toBe('')
+    }
+  })
+})
+
+describe('a second flash chip beside the microcontroller', () => {
+  it('is published separately from the chip’s own', () => {
+    // The Feather M0 Express has 256 KB inside the SAMD21 and 2 MB next to it.
+    // Answering "how much flash?" with either alone answers a different question.
+    const spec = specsForBoard(board({ id: 'ADAFRUIT_FEATHER_M0_EXPRESS', mcu: 'samd21' }), {
+      part: 'SAMD21G18A'
+    })
+    expect(spec.flash.bytes).toBe(256 * 1024)
+    expect(spec.flash.scope).toBe('chip')
+    expect(spec.externalFlash.bytes).toBe(2 * 1024 * 1024)
+    expect(spec.externalFlash.scope).toBe('board')
+  })
+
+  it('reads SparkFun’s "4Mb" as four megaBITs, which is what SparkFun fitted', () => {
+    // An AT25SF041. Reading the lower-case b as bytes overstates the board by
+    // eight times, which is the worst mistake available anywhere in this file.
+    expect(CURATED_BOARDS.SPARKFUN_SAMD51_THING_PLUS.externalFlash.bytes).toBe(512 * 1024)
   })
 })
 


### PR DESCRIPTION
Continues #897. PR #911 built the machinery and the silence rule; this is the coverage pass, plus the filter decision that coverage was blocking.

**220 of 230 boards had no flash figure and 144 had no RAM figure.** Now **43 have no flash figure and 4 have no RAM figure** — and every number still names its source, which is the rule that has not moved.

## Coverage, by vendor

| vendor | boards | flash | RAM | ext. flash | ext. RAM |
|---|---|---|---|---|---|
| **all** | **230** | **187** (was 10) | **226** (was 86) | **21** | **34** |
| ST Microelectronics | 43 | 32 | 43 | 0 | 0 |
| Adafruit | 19 | 17 | 18 | 6 | 1 |
| SparkFun | 14 | 13 | 14 | 3 | 6 |
| Unexpected Maker | 13 | 12 | 13 | 0 | 12 |
| Espressif | 10 | **0** | 9 | 0 | 0 |
| Seeed Studio | 10 | 10 | 10 | 2 | 3 |
| Arduino | 9 | 9 | 9 | 5 | 3 |
| Nordic Semiconductor | 8 | 8 | 8 | 0 | 0 |
| NXP | 7 | 7 | 6 | 0 | 5 |
| George Robotics | 6 | 6 | 6 | 3 | 0 |
| Olimex / Waveshare / WeAct Studio | 15 | 13 | 15 | 2 | 1 |
| M5Stack / Microchip / Raspberry Pi | 12 | 12 | 12 | 0 | 0 |
| McHobby / Renesas | 8 | 5 | 8 | 0 | 0 |
| _29 vendors of 3 or fewer_ | 56 | 43 | 55 | 0 | 3 |

Espressif's ten are `ESP32_GENERIC*`. They are **correctly** empty: their flash is a property of whichever module the buyer has, and the only figure anyone publishes is the WROOM family's "4/8/16 MB" range, which is not a statement about a board.

## Where the numbers came from

Mostly from what MicroPython **already publishes next to `board.json`** — the build configuration each board needs in order to compile at all. That is a better citation than a product page, because it is what the firmware people flash was compiled against, and it is a path anyone can open. New `scripts/board-config.mjs` is a small reader **per port**, not one parser, because the ways they go wrong differ:

- **mimxrt** states `MICROPY_HW_FLASH_SIZE` outright — those parts have no internal flash to fall back on. 14 boards, and it agrees with Adafruit's and PJRC's own pages where they say.
- **nrf** names the memory map it links against (`boards/nrf52832_512k_64k.ld`, whose first two lines are the two sizes). That is the only thing separating an nRF52832 QFAA from a QFAB, and it is worth **22 boards** that could otherwise say nothing at all.
- **rp2** names a pico-sdk board header — read at the revision MicroPython **pins**, not at whatever is newest. That is not a formality: the pinned revision gives the XIAO RP2350 2 MB, agreeing with Seeed; pico-sdk 2.2.0 says 4 MB.
- **stm32 / samd / renesas-ra** name a *chip*, and the silicon vendor's datasheet gives the rest.

The negative finding from before **stands and stays documented**: rp2's `MICROPY_HW_FLASH_STORAGE_BYTES` is the filesystem partition and not the part, and esp32's `sdkconfig.board` sets a size on 3 boards of 45.

`CHIP_MEMORY` then holds datasheet figures keyed on the string upstream writes. **A key that does not pin the memory down carries no flash** — `nrf52832` is two configurations a factor of two apart, `STM32F407` is four parts between 512 KB and 1 MB. The remainder is curation from the makers' own pages, vendor by vendor, deliberately **disjoint** from what the readers derive: a curated figure that shadows a mechanically-refreshed one goes stale in secret.

### The pico-sdk rule, because it is the one most likely to be wrong

Half the rp2 boards point at *another* board's header, because MicroPython only needs the pin definitions to be close enough. `W5500_EVB_PICO` points at the W5100S's; `CYTRON_MOTION_2350_PRO` at a Pico 2's. Reading flash out of those gives a correct figure about the wrong board. A header counts only when it is **this** board's — set outright, shipped in the board's own directory, or named identically — plus a guard that the filesystem cannot be larger than the flash it lives in. Six RP2350 boards where SparkFun's docs, SparkFun's product pages and the pinned pico-sdk all say 16 MB were the check that this produces right answers.

## A new field: `externalFlash`

Half the catalogue has flash in two places, and answering "how much flash?" with either alone answers a different question. A Feather M0 Express has 256 KB inside the SAMD21 and 2 MB of SPI flash beside it, and now says both.

This also **fixes a real misreading**: before, a chip-scope flash figure suppressed the `External flash: present — size not published` note, so that board would have said "256 KB" and nothing more. Optional and additive, so the **schema is not bumped** — a bump makes older builds refuse the document.

## The filter call: memory ships, storage does not

**Memory does clear the bar.** 226 of 230 boards can answer it, and it is one comparable quantity — the chip's own SRAM, every time. The thing worth checking was whether it says anything the `Processor` dropdown does not, and it does: **over a hundred boards sit in a family whose members differ** — `stm32f4` runs 96 KB → 384 KB, `mimxrt` 128 KB → 2 MB. So there is a `Memory` facet (`≥ 32 KB` … `≥ 1 MB`), with `MEMORY_CAVEAT` under it saying plainly that PSRAM is not in the figure.

The four boards with no figure are **counted and named under the control** — "4 boards have no published RAM figure and are not shown" — rather than quietly vanishing. That is the trap the whole design has been avoiding, so `boardsWithoutRam` is pure and directly tested, including that its answer does not depend on where the threshold sits.

**Storage does not, and no longer for want of numbers.** Its 187 figures are *two* quantities: 107 are the flash **inside** the microcontroller, on parts where that is where a program goes, and 80 are the chip **on the module**, on parts with none inside. Ranking an STM32H743's 2 MB of internal flash against a Pico's 2 MB of QSPI compares a program's ROM with a filesystem's disk. Narrow it to what a filesystem can actually use and it covers **100 of 230** — thinner than the coverage that stopped this being offered in the first place — and every `ESP32_GENERIC` entry is missing from it.

So storage stays a fact. What would change that is not more scraping; it is deciding, per port, which flash a MicroPython filesystem lands in, which is knowledge the index does not carry. That is the follow-up, and it is a design question rather than a data-gathering one.

## Where sources genuinely disagree, nothing is published

Each with its reason written into `WITHHELD`:

- **Werkzeug** — Machdyne: "Update March 2025: Werkzeug now has 4MB flash instead of 1MB". Upstream still builds against the 1 MB header. Both are right, for different boards under one name.
- **wESP32** — wesp32.com says 16 MB from revision 7 and 4 MB before it; upstream builds against 8 MB.
- **`FEATHER52`** — upstream's own entry disagrees with itself: `board.json` calls it the "Feather nRF52840 Express" and links adafruit.com/product/4062, while the build beside it is `MCU_SUB_VARIANT = nrf52832`, `-DNRF52832_XXAA` and "Bluefruit nRF52 Feather", which is product **3406** — a different board with half the flash and a quarter of the RAM. Worth reporting upstream.

Boards sold in more than one memory size are left blank for the same reason — Pico LiPo, Tiny 2040, RP2040-Plus, the WeAct RP2040 CoreBoard, the Feather RP2350's optional PSRAM, the RP2350B Core's 0/2/8 MB.

Two traps caught and not published wrong: SparkFun's SAMD51 Thing Plus says "4Mb" and means four **megabits** (an AT25SF041 — 512 KB, an 8× overstatement if misread), and Adafruit's QT Py SAMD21 "optional SOIC-8 SPI Flash" is a bare pad.

## Display

`formatBytes` now stays in KB unless the size lands on a whole or half megabyte. Rounding to one decimal printed an STM32H743's 1056 KB as "1.0 MB" — the same string as a part with 1024 KB, 32 KB adrift. 1056, 1376, 2512 and 4200 KB all occur here.

## Tests

`test/boardConfig.test.ts` is new and feeds the readers **real fragments of upstream's tree**, including the borrowed pico-sdk header, the two-linker-scripts case, and `CONFIG_ESPTOOLPY_FLASHSIZE_4MB=` sitting above the `=y` line.

**Verified that the two load-bearing tests fail without the change** — temporarily reverting `sized: 'externalFlash'` → `'flash'` fails "still says the external flash size is unknown when only the chip's is known"; dropping the pico-sdk name check fails "REFUSES a header belonging to a different board".

One existing assertion — *"say nothing about a chip family whose SRAM varies"* — is **replaced rather than deleted**. The hazard is unchanged, so the tripwire moves: the seed must now show that variation *within* such a family, which a figure derived from `mcu` alone could not do.

## Gates

`lint` ✅ (only the pre-existing `DriverInstallBanner.tsx` warning) · `typecheck` ✅ · `test` ✅ 6324 passing · `build` ✅

Seed regenerated with `--specs-only`. `addSpecs` now clears and re-sets the derived keys in one order, so a seed enriched by the quick path matches one the full run wrote key for key.

## Found but not fixed

- `FEATHER52`'s upstream metadata mismatch (above) — worth a MicroPython issue.
- `MIMXRT1015_EVK` has no RAM figure: I did not find NXP's own on-chip RAM line for the RT1015.
- `CYTRON_NANOXRP_CONTROLLER`'s `url` points at an education-programme site with no product page at all; no manufacturer figure exists to find.
- `LILYGO_T3_S3`: LilyGO states 4 MB / 2 MB on its wiki for **V1.2/V1.3**, but upstream's `url` is the V1.0 product page, which states nothing. Left blank.
- ST's 11 remaining gaps are Discovery boards whose ids name no part (`STM32F7DISC`, `STM32F4DISC`, …); st.com was unreachable, so these want a pass with the datasheets open.
- `scripts/*.mjs` are outside eslint's `--ext` list, so the two generator modules are unlinted. Pre-existing.

Does not close #897 — storage remains a fact, deliberately, and the reasoning is in `board-finder.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe
