### PR TITLE
feat(boards): fill the rows, and tint each maker's run (#927)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **The Board Finder fills its rows, and marks each manufacturer with a tint**
+  (#927). Every maker had its own shelf — its own heading, its own grid, its own
+  fresh row. With 54 makers and a median of two boards each, that was 54 headings
+  and 54 rows left mostly empty, so a catalogue of 225 boards took far more
+  scrolling than 225 boards should. They now go into one continuous grid, so a
+  row can hold the last two Arduinos and the first five Espressifs, and a maker
+  is marked instead by a soft tint on the ground **between** its cards — a band
+  that runs on across row ends for as long as the maker does and stops mid-row
+  where the next one starts. There are six tints for 54 makers, which is the
+  honest ratio: a tint says *the maker changed here* and is never asked to say
+  *which maker this is*. Every card still prints its manufacturer, so the
+  grouping is never carried by colour alone. A maker's tint comes from its name
+  rather than its position, so adding a board next release does not repaint the
+  gallery; it shifts only where it would otherwise land too close to itself.
+- **A board card at rest shows its photo, its maker and its name, and nothing
+  else** (#927). It also carried the chip, three feature chips with an overflow
+  count, and two firmware notes — a wall of specification that nobody reads while
+  scanning and that made every one of the 225 cards taller than it needed to be.
+  All of it is a beat away on the hover preview (#919), which states the firmware
+  **first**, and on the details page behind a click. Nothing that warns you about
+  a board has been lost on the way to flashing one: a card does not flash
+  anything, and every route from it to the flash button passes a screen that says
+  so. The manufacturer line also got brighter, because it is now the accessible
+  half of the new tints rather than a caption.
+
 ### Fixed
 
 - **The Board Finder opened behind the flash dialog** (#893). It was given the

--- a/src/renderer/src/components/BoardFinder.css
+++ b/src/renderer/src/components/BoardFinder.css
@@ -324,40 +324,30 @@
 
 /* --- the grid ------------------------------------------------------------- */
 
-.bfind__shelves {
+.bfind__gallery {
   flex: 1 1 auto;
   overflow-y: auto;
   padding: 16px 18px 28px;
 }
 
-.bfind__shelf {
-  margin-bottom: 22px;
-}
-
-.bfind__shelf-name {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin: 0 0 10px;
-  font-size: 13px;
-  font-weight: 800;
-  color: var(--bf-ink);
-}
-
-.bfind__shelf-count {
-  font-size: 11px;
-  font-weight: 700;
-  color: var(--bf-ink3);
-  background: var(--bf-card);
-  border: 1px solid var(--bf-line);
-  border-radius: 999px;
-  padding: 1px 8px;
-}
-
+/*
+ * ONE GRID, WITH NO GAP (#927).
+ *
+ * The gap moved into the cells as padding, and that is the whole trick behind
+ * the maker tints. A maker's tint is painted on its CELLS, not on its cards, so
+ * with the cells butted against each other the tinted areas of consecutive cards
+ * join into one continuous ground — a band with card-shaped holes in it, running
+ * on across row ends for as long as the maker does, and stopping mid-row where
+ * the next maker starts. Restore `gap` here and every band breaks into separate
+ * patches, which is the thing the tint exists to avoid.
+ *
+ * The cards keep exactly the 12px between them they had before: 6px of padding
+ * on each of two neighbouring cells.
+ */
 .bfind__grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(178px, 1fr));
-  gap: 12px;
+  gap: 0;
 }
 
 .bfind__empty,
@@ -372,14 +362,88 @@
 
 /* The card's cell. It exists so the hover preview can be the card's SIBLING
    rather than its child: the card is a button, and a button inside a button is
-   not markup a browser will honour. */
+   not markup a browser will honour. Since #927 it is also what carries the
+   maker tint — see the palette below. */
 .bfind__cell {
   position: relative;
   display: flex;
+  padding: var(--bf-cell-pad);
+  background: var(--bf-tint);
 }
 /* A preview covers its neighbours, never the other way round. */
 .bfind__cell.is-peeking {
   z-index: 3;
+}
+
+/*
+ * THE MAKER TINTS (#927) — six of them, for 54 makers.
+ * ---------------------------------------------------------------------------
+ * A tint says "the maker changed here", and that is all it is asked to say.
+ * Six colours cannot name 54 makers and are not trying to; every card prints
+ * its manufacturer, which is what actually identifies the group and what keeps
+ * this from being a distinction carried by colour alone. `board-finder.ts`
+ * argues the ratio; this file only has to make six grounds tellable apart.
+ *
+ * They are FLAT, not gradients. A run wraps across rows, and a gradient defined
+ * per cell would restart at every card — a run of eight boards would read as
+ * eight stripes, which says the opposite of what the band is for.
+ *
+ * They sit BESIDE the cards and never under them. The card is opaque
+ * `--bf-card` and the photo well opaque `--bf-sunk`, so a tint reaches neither
+ * the photographs — which are the content here, and which a wash over them
+ * would flatten — nor a single character of text. That is what lets these be
+ * strong enough to actually see: the first cut was ~10% alpha, faint enough
+ * that the bands it drew could not be made out, and there was no contrast
+ * budget being spent to justify the caution. Nothing readable moves if you take
+ * them further still.
+ *
+ * The alphas differ per hue rather than being one number, because they are
+ * matched by eye and not by arithmetic: lime and teal carry further at the same
+ * alpha than blue and violet do, and six tints that read as equally present
+ * matter more than six that share a formula.
+ *
+ * The ORDER matters too. A run whose hash lands on a tint too near itself steps
+ * forward through this list until it is clear (`vendorRuns`), so the entries
+ * are arranged with each a long way round the hue wheel from the next — ≥85°,
+ * never adjacent shades. A run stepping away from a clash must not land on a
+ * near-miss of the very tint it was stepping away from.
+ */
+.bfind {
+  /* Half the space between two cards; the other half is the next cell's. */
+  --bf-cell-pad: 6px;
+  --bf-tint: transparent;
+}
+.bfind__cell.is-tint0 {
+  --bf-tint: hsl(180 45% 48% / 0.22); /* teal */
+  --bf-tint-edge: hsl(180 55% 62% / 0.85);
+}
+.bfind__cell.is-tint1 {
+  --bf-tint: hsl(325 45% 55% / 0.28); /* rose */
+  --bf-tint-edge: hsl(325 60% 68% / 0.85);
+}
+.bfind__cell.is-tint2 {
+  --bf-tint: hsl(75 40% 48% / 0.2); /* lime */
+  --bf-tint-edge: hsl(75 50% 60% / 0.85);
+}
+.bfind__cell.is-tint3 {
+  --bf-tint: hsl(215 55% 58% / 0.32); /* blue */
+  --bf-tint-edge: hsl(215 70% 68% / 0.9);
+}
+.bfind__cell.is-tint4 {
+  --bf-tint: hsl(10 50% 55% / 0.28); /* terracotta */
+  --bf-tint-edge: hsl(10 65% 64% / 0.85);
+}
+.bfind__cell.is-tint5 {
+  --bf-tint: hsl(265 50% 62% / 0.34); /* violet */
+  --bf-tint-edge: hsl(265 65% 74% / 0.9);
+}
+
+/* Where a maker's run begins. The tint change already marks it, but a run that
+   happens to start at the left edge of a row has its boundary hidden in the
+   row break — this puts a tick on it either way. It is the last trace of the
+   vendor headings, and deliberately not a heading: the name is on the card. */
+.bfind__cell.is-run-start {
+  box-shadow: inset 2px 0 0 var(--bf-tint-edge);
 }
 
 .bfind__card {
@@ -443,12 +507,18 @@
   min-width: 0;
 }
 
+/* `--bf-ink2`, not the `--bf-ink3` this was, and the tints are why (#927). This
+   line is the only thing that NAMES the group a tint is drawing, so it stopped
+   being a caption the moment the shelf headings went. At 10px on `--bf-card`
+   ink3 came to 4.39:1, which is under AA for text this size — close enough to
+   ignore while it was a detail, not while it is the accessible half of the
+   grouping. ink2 is 5.3:1. */
 .bfind__card-vendor {
   font-size: 10px;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--bf-ink3);
+  color: var(--bf-ink2);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -461,12 +531,7 @@
   color: var(--bf-ink);
 }
 
-.bfind__card-mcu {
-  font-family: var(--font-mono), monospace;
-  font-size: 11px;
-  color: var(--bf-ink2);
-}
-
+/* Only the preview carries these now (#927) — see `BoardCard`. */
 .bfind__card-feats {
   display: flex;
   flex-wrap: wrap;
@@ -485,22 +550,20 @@
   padding: 1px 5px;
 }
 
-/* Says at a glance that this one cannot be flashed from here. */
-.bfind__card-nofw {
-  font-size: 10px;
-  font-weight: 700;
-  color: var(--bf-gold);
-}
-
 /* --- the hover preview (#919) --------------------------------------------- */
 
 /* Grows out of the card it covers, 10px proud on each side so it reads as the
-   same card enlarged rather than as a tooltip that happens to be near one. */
+   same card enlarged rather than as a tooltip that happens to be near one.
+   Measured from the CARD, not the cell — the cell gained the grid's gap as
+   padding in #927, so the two are no longer the same box and a raw -10px here
+   would stand the preview 16px proud instead. */
 .bfind__peek {
+  --bf-peek-proud: 10px;
+  --bf-peek-off: calc(var(--bf-cell-pad) - var(--bf-peek-proud));
   position: absolute;
-  left: -10px;
-  right: -10px;
-  top: -10px;
+  left: var(--bf-peek-off);
+  right: var(--bf-peek-off);
+  top: var(--bf-peek-off);
   display: flex;
   flex-direction: column;
   background: var(--bf-card);
@@ -515,7 +578,7 @@
 /* The bottom row grows UP instead, or it would open into the scroller's edge. */
 .bfind__peek.is-up {
   top: auto;
-  bottom: -10px;
+  bottom: var(--bf-peek-off);
   transform-origin: 50% 100%;
 }
 @keyframes bfind-peek {

--- a/src/renderer/src/components/BoardFinder.tsx
+++ b/src/renderer/src/components/BoardFinder.tsx
@@ -38,11 +38,11 @@ import {
   isFiltering,
   memoryThresholdLabel,
   peekFacts,
-  shelvesByVendor,
   toggleChip,
   toggleRuntime,
   unsizedNotice,
-  variantList
+  variantList,
+  vendorRuns
 } from './board-finder'
 import { requestFlash } from './board-finder-bus'
 import './BoardFinder.css'
@@ -53,9 +53,17 @@ import './BoardFinder.css'
  * Every board MicroPython builds for — 225 of them, 54 vendors — as a gallery
  * with the filters that actually narrow it: manufacturer, processor, features,
  * and a search box. A sibling of the Parts Catalog (#613): same pop-out
- * affordance, same shelves-then-flat-grid behaviour, same details-over-the-grid
- * detour. Unlike the rest of the app's chrome it is DARK in both skins — see
- * `BoardFinder.css`, which says why, and why that is not an oversight to tidy up.
+ * affordance, same details-over-the-grid detour. Unlike the rest of the app's
+ * chrome it is DARK in both skins — see `BoardFinder.css`, which says why, and
+ * why that is not an oversight to tidy up.
+ *
+ * ONE GRID, TINTED IN RUNS (#927). Each maker used to get its own shelf, which
+ * with 54 makers and a median of two boards apiece meant 54 headings and 54
+ * rows left part-empty — a lot of scrolling to see a small catalogue. Now every
+ * board goes into one continuous grid, so a row can hold the tail of one maker
+ * and the head of the next, and a maker is marked by a tint on the ground behind
+ * its cards instead. `vendorRuns` in `board-finder.ts` decides both the order
+ * and the tints, and argues why a tint can only ever be a separator here.
  *
  * Clicking a board asks the firmware flasher to open on it with the newest build
  * already chosen — see `board-finder-bus.ts`, which is the whole of that seam.
@@ -63,7 +71,9 @@ import './BoardFinder.css'
  * RESTING on a board opens a preview instead (#919): the same card, grown, with
  * the facts that decide whether it is the one — see {@link BoardCell} for the
  * three things that keep that from pouncing, and for how it is reached without a
- * pointer at all.
+ * pointer at all. The resting card is down to the photo, the maker and the name
+ * (#927), which makes that preview load-bearing rather than a bonus — {@link
+ * BoardCard} says what moved onto it and why that is safe.
  *
  * ON THE FILTERS. MEMORY is a filter now (#897): 226 of the 230 boards have a
  * sourced RAM figure, up from 86, and it is one comparable quantity. The four
@@ -211,11 +221,14 @@ export function BoardFinder({ onClose, origin, closing, onClosed }: BoardFinderP
     return FIRMWARE_RUNTIMES.map((r) => ({ value: r, count: counts[r] }))
   }, [all])
 
-  // Shelves are for BROWSING. Once anything is narrowing the catalogue the
-  // result set IS the answer, and re-sectioning it by vendor fights the vendor
-  // filter that is already on screen.
+  // ONE grid, filtered or not (#927). This used to fork: vendor shelves while
+  // browsing, a flat grid once anything narrowed the catalogue, on the reasoning
+  // that re-SECTIONING a result set fights the vendor filter beside it. That
+  // reasoning was about sections, and there are no sections any more — a run is
+  // an ordering plus a tint inside a single grid, which narrows to a subset
+  // without leaving holes in it. `filtering` still gates the Clear button.
   const filtering = isFiltering(filter)
-  const shelves = useMemo(() => (filtering ? [] : shelvesByVendor(matched)), [filtering, matched])
+  const runs = useMemo(() => vendorRuns(matched), [matched])
 
   const clearFilters = useCallback((): void => {
     setText('')
@@ -358,7 +371,7 @@ export function BoardFinder({ onClose, origin, closing, onClosed }: BoardFinderP
             )}
           </aside>
 
-          <div className="bfind__shelves">
+          <div className="bfind__gallery">
             {boards === null && <div className="bfind__loading">Loading boards…</div>}
             {boards !== null && matched.length === 0 && (
               <div className="bfind__empty">
@@ -368,30 +381,26 @@ export function BoardFinder({ onClose, origin, closing, onClosed }: BoardFinderP
               </div>
             )}
 
-            {/* Filtered ⇒ ONE grid; the card carries the vendor the shelf
-                heading used to supply, so collapsing loses nothing. */}
-            {filtering && matched.length > 0 && (
+            {matched.length > 0 && (
               <div className="bfind__grid">
-                {matched.map((b) => (
-                  <BoardCell key={b.id} board={b} onOpen={() => setSelected(b)} />
-                ))}
+                {/* Runs are flattened straight into the grid rather than wrapped
+                    — a wrapper per run would be a grid item per run, which is
+                    the row-per-maker this issue removes. What survives the
+                    flattening is the tint on each cell, and a marker on the
+                    card the run starts at. */}
+                {runs.map((run) =>
+                  run.boards.map((b, i) => (
+                    <BoardCell
+                      key={b.id}
+                      board={b}
+                      tint={run.tint}
+                      runStart={i === 0}
+                      onOpen={() => setSelected(b)}
+                    />
+                  ))
+                )}
               </div>
             )}
-
-            {!filtering &&
-              shelves.map((shelf) => (
-                <section className="bfind__shelf" key={shelf.vendor}>
-                  <h3 className="bfind__shelf-name">
-                    {shelf.vendor}
-                    <span className="bfind__shelf-count">{shelf.boards.length}</span>
-                  </h3>
-                  <div className="bfind__grid">
-                    {shelf.boards.map((b) => (
-                      <BoardCell key={b.id} board={b} onOpen={() => setSelected(b)} />
-                    ))}
-                  </div>
-                </section>
-              ))}
           </div>
         </div>
 
@@ -477,10 +486,8 @@ function ChipFacet({
   )
 }
 
-/** How many feature chips fit on a card before it starts to look like a list. */
-const CARD_FEATURE_LIMIT = 3
-
-/** And on the preview, which has room for more but still a height to keep. */
+/** How many feature chips the preview shows before it stops being a preview.
+ *  The resting card shows none at all since #927 — see {@link BoardCard}. */
 const PEEK_FEATURE_LIMIT = 6
 
 /**
@@ -515,7 +522,19 @@ const PEEK_OVERHANG_PX = 180
  * itself doing exactly what that button does. Nothing here is reachable only by
  * hovering.
  */
-function BoardCell({ board, onOpen }: { board: IndexedBoard; onOpen: () => void }): JSX.Element {
+function BoardCell({
+  board,
+  tint,
+  runStart,
+  onOpen
+}: {
+  board: IndexedBoard
+  /** Which of the maker tints this card's ground is painted in (#927). */
+  tint: number
+  /** First card of its maker's run — the one that gets the edge marker. */
+  runStart: boolean
+  onOpen: () => void
+}): JSX.Element {
   const [peeking, setPeeking] = useState(false)
   // Grow UPWARD when there is no room below inside the scroller: the bottom row
   // is otherwise a preview clipped to the two lines that were already visible.
@@ -539,7 +558,7 @@ function BoardCell({ board, onOpen }: { board: IndexedBoard; onOpen: () => void 
 
   const open = useCallback((): void => {
     const el = cell.current
-    const scroller = el?.closest('.bfind__shelves')
+    const scroller = el?.closest('.bfind__gallery')
     if (el && scroller) {
       const room = scroller.getBoundingClientRect().bottom - el.getBoundingClientRect().bottom
       setUp(room < PEEK_OVERHANG_PX)
@@ -554,7 +573,7 @@ function BoardCell({ board, onOpen }: { board: IndexedBoard; onOpen: () => void 
 
   return (
     <div
-      className={`bfind__cell${peeking ? ' is-peeking' : ''}`}
+      className={`bfind__cell is-tint${tint}${runStart ? ' is-run-start' : ''}${peeking ? ' is-peeking' : ''}`}
       ref={cell}
       onPointerEnter={(e) => {
         if (e.pointerType !== 'mouse') return
@@ -654,7 +673,32 @@ function BoardPeek({
   )
 }
 
-/** One board in the grid. */
+/**
+ * One board in the grid, at rest: the photo, the maker, the name (#927).
+ *
+ * It used to carry the chip, three feature chips with an overflow count, the
+ * substitute-firmware line and the no-firmware line as well. Multiplied by 225
+ * cards that is a wall of specification nobody reads while scanning, and it is
+ * what made every card tall enough to need the scrolling this issue is about.
+ * The preview states all of it a beat later, which is the arrangement #919 built
+ * and this finishes: the resting card is for FINDING a board and the preview is
+ * for deciding on it.
+ *
+ * TWO OF THE DROPPED LINES WERE WARNINGS, and dropping them is safe for a reason
+ * worth writing down rather than assuming. #893 put "Flashes ⟨other board⟩" on
+ * the face of the card because flashing a board with another board's firmware is
+ * the mistake epic #884 exists to prevent. But a card does not flash anything —
+ * clicking one opens the details, and the flash button is there, under the
+ * substitute's own section explaining it. The same goes for "No published
+ * firmware", which the preview states FIRST and the details state instead of a
+ * flash button. There is no route from this card to a flash that does not pass a
+ * screen saying so. Put them back if that ever stops being true.
+ *
+ * The manufacturer line stays, and not only because the issue asked for it:
+ * it is the only thing that names the group the tint is drawing (see
+ * `TINT_COUNT`), so removing it would leave 54 makers distinguished by six
+ * colours and nothing else.
+ */
 function BoardCard({
   board,
   onOpen
@@ -663,7 +707,6 @@ function BoardCard({
   onOpen: () => void
 }): JSX.Element {
   const src = thumbUrl(board.thumb)
-  const extra = board.features.length - CARD_FEATURE_LIMIT
   return (
     <button type="button" className="bfind__card" onClick={onOpen}>
       <span className="bfind__card-img">
@@ -681,26 +724,6 @@ function BoardCard({
       <span className="bfind__card-body">
         <span className="bfind__card-vendor">{board.vendor || 'Unknown'}</span>
         <span className="bfind__card-name">{board.product}</span>
-        <span className="bfind__card-mcu">{board.mcu}</span>
-        {board.features.length > 0 && (
-          <span className="bfind__card-feats">
-            {board.features.slice(0, CARD_FEATURE_LIMIT).map((f) => (
-              <span className="bfind__feat" key={f}>
-                {f}
-              </span>
-            ))}
-            {extra > 0 && <span className="bfind__feat">+{extra}</span>}
-          </span>
-        )}
-        {/* Said on the FACE of the card, not buried in the details: picking a
-            board whose firmware is really another board's is the exact mistake
-            this epic exists to stop someone making by accident. */}
-        {board.substitute?.build && (
-          <span className="bfind__card-sub">Flashes {board.substitute.build}</span>
-        )}
-        {board.builds.length === 0 && (
-          <span className="bfind__card-nofw">No published firmware</span>
-        )}
       </span>
     </button>
   )

--- a/src/renderer/src/components/board-finder.ts
+++ b/src/renderer/src/components/board-finder.ts
@@ -3,10 +3,11 @@
  * =============================================================================
  *
  * `shared/board-index.ts` owns the index: parsing, filtering, and picking a
- * build. This module owns what the GALLERY does with it — how boards are shelved,
- * what a card shows when it has no photo, and which of upstream's fields are
- * stated as facts. The request that reaches the firmware flasher is next door in
- * `board-finder-bus.ts`, so a listener can import it without the gallery.
+ * build. This module owns what the GALLERY does with it — how boards are grouped
+ * and tinted, what a card shows when it has no photo, and which of upstream's
+ * fields are stated as facts. The request that reaches the firmware flasher is
+ * next door in `board-finder-bus.ts`, so a listener can import it without the
+ * gallery.
  *
  * Separate from the component, and DOM-free, so every one of those decisions is
  * a unit test in node rather than an assertion about JSX.
@@ -54,33 +55,121 @@ import {
 import type { FirmwareRuntime } from '../../../shared/firmware-runtime'
 
 // ---------------------------------------------------------------------------
-// Shelving
+// Runs (#927) — what replaced the shelves
 // ---------------------------------------------------------------------------
 
-/** One vendor's boards, the gallery's browsing unit. */
-export interface VendorShelf {
+/**
+ * One maker's boards, in the order they are laid out.
+ *
+ * This used to be a SHELF: its own section, its own heading, its own grid that
+ * started on a fresh row. With 54 makers and a median of two boards each, that
+ * was 54 headings and 54 part-empty rows — a page you scroll past rather than
+ * read, and the reason #927 exists. A RUN is the same group with no section
+ * around it: the boards go into one continuous grid, so a row can hold the end
+ * of one maker and the start of the next, and the group is marked by the
+ * {@link VendorRun.tint} behind its cards instead of by a heading above them.
+ *
+ * Losing the headings is only affordable because manufacturer became a filter
+ * facet in #919. The shelves were one way to find a maker; the facet is the
+ * other, and it is the better one — it says how many boards each maker has,
+ * and it composes with the other filters, which a heading never did.
+ */
+export interface VendorRun {
   vendor: string
   boards: IndexedBoard[]
+  /** Which of the {@link TINT_COUNT} tints this run's cards sit on. */
+  tint: number
 }
 
-/** Shelf heading for a board whose vendor upstream left blank. */
+/** Heading for a board whose vendor upstream left blank. */
 export const UNKNOWN_VENDOR = 'Other'
 
 /**
- * Group boards into vendor shelves — the Parts Catalog's category shelves, for a
- * catalogue whose natural sections are makers.
+ * How many tints the gallery has to separate its makers with.
  *
- * Vendors alphabetically, `Other` last; boards within a shelf by product name so
- * a vendor's range reads in order rather than in upstream's file order.
+ * There are 54 makers and six tints, and that ratio is the honest one: 54
+ * background tints that a person could tell apart do not exist — not at the
+ * strength that survives sitting behind product photography on a dark ground,
+ * and not in a quantity anyone could hold in their head. So the tint is a
+ * SEPARATOR, never a name. It answers "did the maker change here?" and it is
+ * not asked to answer "which maker is this?" — the card's own manufacturer line
+ * answers that, on every card, which is what keeps colour from being the only
+ * carrier of a distinction (WCAG 1.4.1, and plain sense besides).
+ *
+ * If a later tidy-up removes the manufacturer from the card, it removes the
+ * only thing that names a group, and the tint is left doing a job it cannot do.
+ *
+ * Six rather than eight because six can be told apart. Six tints over the
+ * alphabetical maker order collide about one boundary in six, which {@link
+ * vendorRuns} then resolves; eight would collide less often and read as noise.
  */
-export function shelvesByVendor(boards: readonly IndexedBoard[]): VendorShelf[] {
+export const TINT_COUNT = 6
+
+/**
+ * How many runs back a tint has to stay clear of.
+ *
+ * One is not enough, and the catalogue says so: `Arduino`, `BBC`, `Cytron` run
+ * consecutively and `BBC` has a single board. Give Arduino and Cytron the same
+ * tint — legal, if a tint need only differ from the one immediately before it —
+ * and their bands are separated by one card in a row of seven, which the eye
+ * joins into a single Arduino band with an odd card in the middle of it.
+ *
+ * Two is what breaks that, and two is affordable: it forbids two of six tints,
+ * so four remain to choose from. Three would forbid half the palette to buy
+ * separation between bands that already have two other bands between them.
+ */
+const TINT_LOOKBACK = 2
+
+/**
+ * FNV-1a, 32-bit — the tint is keyed on the maker's NAME, not its position.
+ *
+ * Position would be simpler and would still guarantee that neighbours differ,
+ * but it would re-colour half the catalogue every time upstream adds a maker:
+ * insert one name near the top of the alphabet and everything below it shifts a
+ * tint. Hashing the name means Adafruit's boards sit on the same tint next
+ * release as this one, which is the difference between a grouping and a
+ * flicker.
+ */
+function vendorHash(vendor: string): number {
+  let h = 0x811c9dc5
+  for (let i = 0; i < vendor.length; i += 1) {
+    h ^= vendor.charCodeAt(i)
+    h = Math.imul(h, 0x01000193)
+  }
+  return h >>> 0
+}
+
+/**
+ * Group boards into vendor runs and give each run a tint.
+ *
+ * Makers stay in alphabetical order, `Other` last, boards by product name
+ * within a maker — the shelves' ordering, kept deliberately. The tint only
+ * separates ADJACENT groups, so the boards of one maker have to be adjacent for
+ * it to separate anything; scattering the catalogue and tinting per card would
+ * turn 225 cards into 225 unrelated colour patches. Runs also keep the one
+ * thing the shelves were genuinely good at: a maker's range reads together.
+ *
+ * The tint is the maker's hash, EXCEPT where that lands on one of the last
+ * {@link TINT_LOOKBACK} runs' tints — then it steps forward until it does not,
+ * which always terminates because the palette is bigger than the lookback. The
+ * step is by one, and the palette is ordered so that "one on" is a long way
+ * round the hue wheel rather than a neighbouring shade (see `BoardFinder.css`)
+ * — a run stepping away from a clash must not land on a near-miss of it.
+ *
+ * The step is the one place a maker's tint depends on its neighbours rather
+ * than on its name, and that trade is the right way round: a tint that repeats
+ * near itself fails at the only job it has, while a tint that shifts when the
+ * catalogue changes merely disappoints a memory nobody was invited to form.
+ */
+export function vendorRuns(boards: readonly IndexedBoard[]): VendorRun[] {
   const byVendor = new Map<string, IndexedBoard[]>()
   for (const b of boards) {
     const vendor = b.vendor.trim() || UNKNOWN_VENDOR
-    const shelf = byVendor.get(vendor)
-    if (shelf) shelf.push(b)
+    const run = byVendor.get(vendor)
+    if (run) run.push(b)
     else byVendor.set(vendor, [b])
   }
+  const recent: number[] = []
   return [...byVendor.entries()]
     .sort(([a], [b]) => {
       // `Other` is a bucket, not a maker, so it sorts below the real ones
@@ -89,10 +178,20 @@ export function shelvesByVendor(boards: readonly IndexedBoard[]): VendorShelf[] 
       if (b === UNKNOWN_VENDOR) return -1
       return a.localeCompare(b)
     })
-    .map(([vendor, list]) => ({
-      vendor,
-      boards: [...list].sort((x, y) => x.product.localeCompare(y.product))
-    }))
+    .map(([vendor, list]) => {
+      const hashed = vendorHash(vendor) % TINT_COUNT
+      let tint = hashed
+      for (let step = 1; recent.includes(tint); step += 1) {
+        tint = (hashed + step) % TINT_COUNT
+      }
+      recent.push(tint)
+      if (recent.length > TINT_LOOKBACK) recent.shift()
+      return {
+        vendor,
+        tint,
+        boards: [...list].sort((x, y) => x.product.localeCompare(y.product))
+      }
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/test/boardFinder.test.ts
+++ b/test/boardFinder.test.ts
@@ -4,6 +4,7 @@ import {
   MEMORY_THRESHOLDS,
   NO_SIZE_PUBLISHED,
   PLAIN_BUILD_LABEL,
+  TINT_COUNT,
   UNKNOWN_VENDOR,
   activeFilterChips,
   boardFacts,
@@ -13,10 +14,10 @@ import {
   isFiltering,
   memoryThresholdLabel,
   peekFacts,
-  shelvesByVendor,
   toggleChip,
   unsizedNotice,
-  variantList
+  variantList,
+  vendorRuns
 } from '../src/renderer/src/components/board-finder'
 import {
   FLASH_BOARD_EVENT,
@@ -74,30 +75,123 @@ const board = (over: Partial<IndexedBoard> = {}): IndexedBoard => ({
   ...over
 })
 
+/**
+ * The 54 manufacturers the shipped board index actually carries.
+ *
+ * A snapshot, not a fixture invented to suit the test: the tint rules only have
+ * to hold for the catalogue people browse, and the names are what the hash sees.
+ * A handful of them clash on the way past — `Silicognition` and `Silicognition
+ * LLC` sit next to each other, as do `WeAct` and `WeAct Studio` — which is a
+ * fair sample of the awkwardness the real list contains.
+ */
+const VENDOR_SPREAD = [
+  'Actinius', 'Adafruit', 'Alif Semiconductor', 'Arduino', 'BBC', 'Cytron',
+  'Espressif', 'Espruino', 'Ezurio', 'Fez', 'George Robotics', 'HydraBus',
+  'I-SYST', 'Infineon Technologies', 'LEGO', 'LILYGO', 'LimiFrog', 'M5Stack',
+  'Machdyne', 'Makerdiary', 'McHobby', 'Microchip', 'MikroElektronika',
+  'MiniFig Boards', 'Netduino', 'Nordic Semiconductor', 'nullbits', 'NXP',
+  'Olimex', 'Particle', 'PHYTEC', 'Pimoroni', 'PJRC', 'Pololu', 'Pycom',
+  'PyMateIO', 'Raspberry Pi', 'Renesas Electronics', 'Seeed Studio',
+  'Silicognition', 'Silicognition LLC', 'Soldered Electronics', 'SparkFun',
+  'ST Microelectronics', 'u-blox', 'Unexpected Maker', 'VCC-GND Studio',
+  'Vekatech', 'Waveshare', 'WeAct', 'WeAct Studio', 'Wemos', 'Wireless-Tag',
+  'WIZnet'
+]
+
 afterEach(() => {
   vi.unstubAllGlobals()
 })
 
-describe('shelvesByVendor', () => {
-  it('groups by vendor, alphabetically, products sorted within a shelf', () => {
-    const shelves = shelvesByVendor([
+describe('vendorRuns (#927)', () => {
+  it('groups by vendor, alphabetically, products sorted within a run', () => {
+    const runs = vendorRuns([
       board({ id: 'B', vendor: 'Pimoroni', product: 'Tiny 2040' }),
       board({ id: 'A', vendor: 'Adafruit', product: 'QT Py' }),
       board({ id: 'C', vendor: 'Pimoroni', product: 'Badger 2040' })
     ])
-    expect(shelves.map((s) => s.vendor)).toEqual(['Adafruit', 'Pimoroni'])
-    expect(shelves[1].boards.map((b) => b.product)).toEqual(['Badger 2040', 'Tiny 2040'])
+    expect(runs.map((r) => r.vendor)).toEqual(['Adafruit', 'Pimoroni'])
+    expect(runs[1].boards.map((b) => b.product)).toEqual(['Badger 2040', 'Tiny 2040'])
   })
 
   it('buckets a blank vendor under Other, and puts it last despite the alphabet', () => {
     // 'Other' would sort between Adafruit and Pimoroni on name alone — it is a
     // bucket, not a maker, so it belongs below both.
-    const shelves = shelvesByVendor([
+    const runs = vendorRuns([
       board({ id: 'P', vendor: 'Pimoroni' }),
       board({ id: 'X', vendor: '   ' }),
       board({ id: 'A', vendor: 'Adafruit' })
     ])
-    expect(shelves.map((s) => s.vendor)).toEqual(['Adafruit', 'Pimoroni', UNKNOWN_VENDOR])
+    expect(runs.map((r) => r.vendor)).toEqual(['Adafruit', 'Pimoroni', UNKNOWN_VENDOR])
+  })
+
+  it('gives a maker exactly one run, so every one of its boards shares a tint', () => {
+    // The tint is painted per CELL, so "a maker's boards share a tint" is only
+    // true while a maker's boards share a run. Two runs for one maker would put
+    // the same colour on two bands with somebody else's boards between them.
+    const runs = vendorRuns([
+      board({ id: 'A1', vendor: 'Adafruit', product: 'QT Py' }),
+      board({ id: 'P1', vendor: 'Pimoroni', product: 'Tiny 2040' }),
+      board({ id: 'A2', vendor: 'Adafruit', product: 'Feather' })
+    ])
+    expect(runs.filter((r) => r.vendor === 'Adafruit')).toHaveLength(1)
+    expect(runs[0].boards.map((b) => b.id)).toEqual(['A2', 'A1'])
+  })
+
+  it('gives every maker a tint from the palette', () => {
+    const runs = vendorRuns(VENDOR_SPREAD.map((v, i) => board({ id: `b${i}`, vendor: v })))
+    for (const run of runs) {
+      expect(Number.isInteger(run.tint)).toBe(true)
+      expect(run.tint).toBeGreaterThanOrEqual(0)
+      expect(run.tint).toBeLessThan(TINT_COUNT)
+    }
+  })
+
+  it('keeps a tint clear of the two runs before it', () => {
+    // The one job a tint has. Six tints over 54 makers collide by chance often
+    // enough that a build without the step-on rule fails this many times over —
+    // hashing alone is not enough, which is exactly why the rule is there.
+    //
+    // TWO back, not one: `Arduino`, `BBC`, `Cytron` are consecutive here and
+    // BBC has a single board, so an Arduino and a Cytron on the same tint would
+    // draw one band with a stranger's card sitting inside it.
+    const runs = vendorRuns(VENDOR_SPREAD.map((v, i) => board({ id: `b${i}`, vendor: v })))
+    expect(runs.length).toBeGreaterThan(TINT_COUNT * 6)
+    for (let i = 1; i < runs.length; i += 1) {
+      const before = runs.slice(Math.max(0, i - 2), i)
+      expect(
+        before.map((r) => r.tint),
+        `${before.map((r) => r.vendor).join(', ')} → ${runs[i].vendor}`
+      ).not.toContain(runs[i].tint)
+    }
+  })
+
+  it('is the same assignment every time, whatever order the boards arrive in', () => {
+    // The grouping is only worth anything if it holds still: a tint that
+    // depended on upstream's file order would repaint the gallery whenever the
+    // index was refetched.
+    const boards = VENDOR_SPREAD.map((v, i) => board({ id: `b${i}`, vendor: v }))
+    const forwards = vendorRuns(boards)
+    const backwards = vendorRuns([...boards].reverse())
+    const tints = (runs: ReturnType<typeof vendorRuns>): string[] =>
+      runs.map((r) => `${r.vendor}=${r.tint}`)
+    expect(tints(backwards)).toEqual(tints(forwards))
+    expect(tints(vendorRuns(boards))).toEqual(tints(forwards))
+  })
+
+  it('keys a tint on the maker’s name, not on where it lands in the list', () => {
+    // Adding a maker at the top of the alphabet must not repaint the ones below
+    // it — the whole reason the tint is hashed rather than counted off. Only
+    // makers that end up touching a clash are allowed to move.
+    const names = ['Cytron', 'Espressif', 'Pimoroni', 'SparkFun', 'Waveshare']
+    const before = vendorRuns(names.map((v, i) => board({ id: `b${i}`, vendor: v })))
+    const after = vendorRuns([
+      ...names.map((v, i) => board({ id: `b${i}`, vendor: v })),
+      board({ id: 'new', vendor: 'Actinius' })
+    ])
+    const tintOf = (runs: ReturnType<typeof vendorRuns>, vendor: string): number =>
+      runs.find((r) => r.vendor === vendor)!.tint
+    expect(after[0].vendor).toBe('Actinius')
+    for (const name of names) expect(tintOf(after, name)).toBe(tintOf(before, name))
   })
 })
 


### PR DESCRIPTION
Closes #927.

Each manufacturer had its own shelf — heading, grid, fresh row. With 54 makers
and a median of **two boards each**, that is 54 headings and 54 rows left mostly
empty, so browsing 225 boards cost far more scrolling than 225 boards should.
The shelves also could not put two makers on one row, which is exactly the space
they were wasting.

## One grid, banded by maker

Every board now goes into one continuous grid, so a row holds the tail of one
maker and the head of the next. A maker is marked by a soft tint on the ground
**between** its cards instead of by a heading above them — a band that runs on
across row ends for as long as the maker does, and stops mid-row where the next
one starts.

The grid's `gap` moved into the cells as padding to make that work: with the
cells butted together, their tinted areas join into one field with card-shaped
holes in it. That is a band, rather than coloured grout around separate patches.
Cards keep exactly the 12px between them they had.

Losing the headings is only affordable because **#919 made manufacturer a filter
facet**. The shelves were one way to find a maker; the facet is the other, and
the better one — it carries board counts and it composes with the other filters,
which a heading never did. The code says so where a future reader will look.

## Six tints for 54 makers

54 background tints that a person could tell apart do not exist, so the design
does not pretend otherwise. A tint answers **"did the maker change here?"** and
is never asked to answer "which maker is this?" — the card's manufacturer line
answers that, on every card, which is what keeps the grouping from being carried
by colour alone. That connection is stated in `TINT_COUNT` and again in the CSS,
so a later tidy-up that removes the name can see what it would be breaking.

- **Deterministic, and keyed on the name.** The tint is `FNV-1a(vendor) % 6`, not
  the maker's position — position would repaint half the catalogue every time
  upstream inserted a name near the top of the alphabet.
- **Adjacent runs always differ.** A hashed tint steps forward until it clears
  the last **two** runs. Two back rather than one because the real catalogue has
  `Arduino, BBC, Cytron` consecutive with BBC holding a single board: give
  Arduino and Cytron the same tint and their bands read as one band with a
  stranger's card sitting inside it. This actually happened — the first render
  showed it, and it is why the rule widened.
- **The palette order is load-bearing.** A stepping run moves one entry along, so
  the six are arranged ≥85° apart round the hue wheel — a run stepping away from
  a clash must not land on a near-miss of it.

**Runs, not scattered tints.** A tint only separates *adjacent* groups, so a
maker's boards have to be adjacent for it to separate anything; sorting some
other way and tinting per card would turn 225 cards into 225 unrelated colour
patches. Alphabetical maker order also keeps the one thing shelves were good at
— a maker's range reads together.

**The tints cannot touch anything readable.** They sit beside the cards, never
under them: the card is opaque `--bf-card` and the photo well opaque
`--bf-sunk`, so a tint reaches neither the 217 product photographs nor a single
character of text. That is what lets them be strong enough to actually see — a
first cut at ~10% alpha drew bands that could not be made out, while spending no
contrast budget to justify the caution.

## The resting card

Photo, manufacturer, name. It also carried the chip, three feature chips with an
overflow count, and two firmware warnings — a wall of specification nobody reads
while scanning, and what made all 225 cards taller than they needed to be.

The two warnings were on the face of the card *deliberately* (#893: flashing a
board with another board's firmware is the mistake epic #884 exists to prevent),
so moving them needed checking rather than assuming. **A card does not flash
anything** — clicking one opens the details, where the substitute has its own
section above the specification and the flash button sits beside it, and the
hover preview states firmware *first*. There is no route from a card to a flash
that does not pass a screen saying so. The comment records that, and says to put
them back if it ever stops being true.

The manufacturer line went `--bf-ink3` → `--bf-ink2`. At 10px on the card it was
4.39:1, under AA — ignorable while it was a caption, not while it is the
accessible half of the new grouping. It is 5.3:1 now.

#919's hover preview is untouched, including all three anti-pounce guards and
the `:focus-visible` check that keeps a preview from swallowing a click. Its
offsets are now derived from the cell padding rather than hardcoded, so the
preview still stands 10px proud of the *card* now that cell and card are no
longer the same box.

## Testing

`vendorRuns` is pure and DOM-free, so it is tested directly in node against a
snapshot of the catalogue's real 54 manufacturer names: grouping and ordering,
one run per maker, the palette bound, the two-back rule, order-independence, and
that a tint follows the name rather than the index.

**Both discriminating tests were verified by breaking the code:**

- removing the step-on rule → *"keeps a tint clear of the two runs before it"*
  fails, and only that test;
- swapping the hash for a positional counter → *"keys a tint on the maker's name"*
  fails, and only that test.

Rendered the real 225-board grid headlessly to check the bands read as bands
against the actual product photography, that different makers share rows, and
that the tint never reaches a photo.

`loading="lazy"` and the placeholder initials for the 8 photo-less boards are
unchanged; `prefers-reduced-motion` still suppresses both animations; the
gallery stays dark in both skins and keeps `z-index: 1150` with its comment.

## Gates

`npm run lint` (only the pre-existing `DriverInstallBanner.tsx` warning) ·
`npm run typecheck` · `npm test` (310 files, 6386 tests) · `npm run build` — all
green.

## Not fixed here

`boards.json` lists `ra6m5` and `RA6M5` as separate chip families, one board
each, so the Processor facet shows two entries where there should be one. That
is generator/data territory and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe
