### PR TITLE
A shortcut cheatsheet, generated from the bindings themselves (#920)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,25 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   anything, and every route from it to the flash button passes a screen that says
   so. The manufacturer line also got brighter, because it is now the accessible
   half of the new tints rather than a caption.
+### Added
+
+- **A keyboard shortcut cheatsheet, generated from the bindings themselves**
+  (#920). **Help ▸ Keyboard Shortcuts**, or `⌘⇧/` / `Ctrl+Shift+/`, lists every
+  key the app binds, grouped by the menu it lives in and printed the way the
+  platform prints it — `⌘⇧B` on macOS, `Ctrl+Shift+B` elsewhere. Nothing in it
+  is typed out: it walks the same menu template `Menu.buildFromTemplate` is
+  handed, because in Electron an item's accelerator **is** the binding, and a
+  hand-written list drifts from the real keys within a release or two. A
+  shortcut list that lies is worse than none — the reader trusts it, presses the
+  key, and concludes the app is broken. Six bindings today, which the sheet is
+  honest about; the File, Tools and Device menus (#915, #917, #918) aren't built
+  yet, and their keys will appear here on their own as they land, with a menu
+  that has commands but no keys yet saying so rather than showing a bare
+  heading. Not `⌘H`, which #920 originally asked for — that is Hide Application
+  on macOS — and not `⌘/` either, the usual editor choice: Monaco already binds
+  it to Toggle Line Comment, and a menu accelerator is caught before the editor
+  ever sees the key, so taking it would have silently broken commenting in a
+  code editor.
 
 ### Fixed
 

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,5 +1,5 @@
 import { app, BrowserWindow, ipcMain, Menu } from 'electron'
-import { appMenuTemplate } from './menu-template'
+import { appMenuTemplate } from '../shared/menu-template'
 import {
   EMPTY_MENU_STATE,
   coerceMenuState,

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -54,6 +54,7 @@ import { ShellPanel } from './ShellPanel'
 import { RightPanel } from './RightPanel'
 import { runMenuCommand } from '../lib/menuCommands'
 import { menuStateFrom } from '../../../shared/menu-commands'
+import { ShortcutSheet } from './ShortcutSheet'
 import { IS_WEB } from '../lib/env'
 import { StatusBar } from './StatusBar'
 import { SettingsDialog, type SettingsTab } from './SettingsDialog'
@@ -1128,10 +1129,16 @@ export function AppShell(): JSX.Element {
   // View ▸ Workspace (#916) goes through the LAYOUT STORE's own switch — the very
   // call the in-app switcher makes — so Electronics/Build get their sidebar gating
   // right and Monaco stays mounted.
+  // Help ▸ Keyboard Shortcuts / ⌘⇧/ (#920). The binding is the menu item's
+  // accelerator, so Electron catches it before Monaco does; this only holds
+  // whether the sheet is showing.
+  const [shortcutsOpen, setShortcutsOpen] = useState(false)
+
   useEffect(() => {
     const off = window.api.menu.onCommand((id) => {
       runMenuCommand(id, {
         switchWorkspace: (target) => switchWorkspaceRef.current(target),
+        showShortcuts: () => setShortcutsOpen(true),
         openFolder: () => {
           setActivityView('files')
           setLeftCollapsed('files', false)
@@ -1515,6 +1522,8 @@ export function AppShell(): JSX.Element {
           <SpriteEditor openPath={spriteOpen.path} onClose={() => setSpriteOpen(null)} />
         </Suspense>
       )}
+
+      {shortcutsOpen && <ShortcutSheet onClose={() => setShortcutsOpen(false)} />}
 
     </div>
   )

--- a/src/renderer/src/components/ShortcutSheet.css
+++ b/src/renderer/src/components/ShortcutSheet.css
@@ -1,0 +1,141 @@
+/*
+ * Keyboard shortcut cheatsheet (ShortcutSheet.tsx, #920).
+ *
+ * Ordinary renderer chrome, so every colour is a shared token — it must read
+ * correctly on the skeuomorph parchment AND the dark skin. (The flash dialog and
+ * the Board Finder are deliberately dark in both and document why; this is not
+ * one of those, so it takes no literals.)
+ */
+
+.shortcuts-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+  padding: 1rem;
+}
+
+.shortcuts {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  width: min(34rem, 100%);
+  max-height: calc(100vh - 2rem);
+  padding: 1rem 1.1rem;
+  background: var(--bg-elevated);
+  color: var(--text);
+  border: var(--border-w) solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--pixel-shadow);
+  font-family: var(--font-ui);
+}
+
+.shortcuts__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.shortcuts__title {
+  margin: 0;
+  font-family: var(--font-pixel);
+  font-size: 0.9rem;
+}
+
+.shortcuts__close {
+  flex: none;
+}
+
+/* The list scrolls, not the whole card — the title and the footnote stay put as
+   #915–#918 add enough bindings to overflow. */
+.shortcuts__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  overflow-y: auto;
+  padding-right: 0.2rem;
+}
+
+.shortcuts__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.shortcuts__section-title {
+  margin: 0;
+  font-family: var(--font-pixel);
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  border-bottom: var(--border-w) solid var(--border);
+  padding-bottom: 0.25rem;
+}
+
+.shortcuts__empty {
+  margin: 0.15rem 0 0;
+  font-size: 0.76rem;
+  font-style: italic;
+  color: var(--text-muted);
+}
+
+.shortcuts__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  margin: 0;
+}
+
+.shortcuts__row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.8rem;
+  padding: 0.28rem 0.35rem;
+  border-radius: var(--radius);
+}
+
+.shortcuts__row:nth-child(odd) {
+  background: var(--bg-sunken);
+}
+
+.shortcuts__label {
+  font-size: 0.82rem;
+}
+
+.shortcuts__keys {
+  margin: 0;
+  flex: none;
+}
+
+/* A physical-key look built from tokens: sunken face, metal edge, brass ink.
+   Both skins define all three, so it reads as a keycap in either. */
+.shortcuts__kbd {
+  display: inline-block;
+  min-width: 1.6rem;
+  padding: 0.12rem 0.4rem;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  line-height: 1.4;
+  text-align: center;
+  white-space: nowrap;
+  color: var(--accent-ink);
+  background: var(--bg);
+  border: var(--border-w) solid var(--border);
+  border-bottom-width: 2px;
+  border-radius: 4px;
+}
+
+.shortcuts__foot {
+  margin: 0;
+  padding-top: 0.5rem;
+  border-top: var(--border-w) solid var(--border);
+  font-size: 0.72rem;
+  line-height: 1.5;
+  color: var(--text-muted);
+}

--- a/src/renderer/src/components/ShortcutSheet.tsx
+++ b/src/renderer/src/components/ShortcutSheet.tsx
@@ -1,0 +1,110 @@
+import { useMemo } from 'react'
+import { useFocusTrap } from '../hooks/useFocusTrap'
+import { isMac } from '../lib/platform'
+import { shortcutSections } from '../../../shared/shortcuts'
+import './ShortcutSheet.css'
+
+/**
+ * THE KEYBOARD SHORTCUT CHEATSHEET (#920, epic #913).
+ * =============================================================================
+ *
+ * Opened by Help ▸ Keyboard Shortcuts, or its own ⌘⇧/ — which the sheet lists
+ * like any other binding, because it is one.
+ *
+ * NOTHING HERE KNOWS A SHORTCUT. Every row comes from `shortcutSections()`,
+ * which walks the same menu template `Menu.buildFromTemplate` is handed, so the
+ * sheet cannot advertise a key the menu doesn't bind (or miss one it does). Only
+ * a handful exist today — the File, Tools and Device menus of #915 / #917 / #918
+ * aren't built yet — and the sheet grows on its own as they land.
+ *
+ * The list is honestly incomplete in one way, said in the footnote rather than
+ * papered over: standard-role items (Undo, Copy, Zoom, Minimise) carry no
+ * accelerator in the template because Electron gives each role the platform's
+ * own key. Reprinting those would mean hand-writing the second table this whole
+ * design exists to avoid.
+ */
+
+interface ShortcutSheetProps {
+  /** `app.name` — the heading for the macOS app menu's section. */
+  appName?: string
+  onClose: () => void
+}
+
+export function ShortcutSheet({ appName = 'Snakie', onClose }: ShortcutSheetProps): JSX.Element {
+  const mac = isMac()
+  const sections = useMemo(() => shortcutSections({ appName, isMac: mac }), [appName, mac])
+  const dialogRef = useFocusTrap<HTMLDivElement>(true)
+
+  return (
+    <div
+      className="shortcuts-overlay"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div
+        className="shortcuts"
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="shortcuts-title"
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') {
+            e.preventDefault()
+            onClose()
+          }
+        }}
+      >
+        <div className="shortcuts__head">
+          <h2 className="shortcuts__title" id="shortcuts-title">
+            Keyboard shortcuts
+          </h2>
+          {/* The close button is the first focusable control, so the focus trap
+              lands here on open and Escape/Return/Space all dismiss the sheet
+              without a mouse — which a keyboard-shortcut sheet rather owes you. */}
+          <button
+            type="button"
+            className="btn btn--ghost shortcuts__close"
+            onClick={onClose}
+            aria-label="Close keyboard shortcuts"
+          >
+            Close
+          </button>
+        </div>
+
+        <div className="shortcuts__body">
+          {sections.map((section) => (
+            <section className="shortcuts__section" key={section.title}>
+              <h3 className="shortcuts__section-title">{section.title}</h3>
+              {section.shortcuts.length === 0 ? (
+                // An empty heading would read as a bug. Saying WHY it is empty
+                // is the useful thing, and it stops being shown the moment that
+                // menu gains its first accelerator.
+                <p className="shortcuts__empty">
+                  Nothing bound here yet &mdash; these items are click-only for now.
+                </p>
+              ) : (
+                <dl className="shortcuts__list">
+                  {section.shortcuts.map((s) => (
+                    <div className="shortcuts__row" key={s.accelerator + s.label}>
+                      <dt className="shortcuts__label">{s.label}</dt>
+                      <dd className="shortcuts__keys">
+                        <kbd className="shortcuts__kbd">{s.keys}</kbd>
+                      </dd>
+                    </div>
+                  ))}
+                </dl>
+              )}
+            </section>
+          ))}
+        </div>
+
+        <p className="shortcuts__foot">
+          Generated from the application menu, so it can&rsquo;t drift from the real bindings. Edit
+          and Window use your platform&rsquo;s standard keys, and the editor keeps its own &mdash;{' '}
+          {mac ? '⌘/' : 'Ctrl+/'} to comment a line, {mac ? '⌘F' : 'Ctrl+F'} to find.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/lib/menuCommands.ts
+++ b/src/renderer/src/lib/menuCommands.ts
@@ -43,12 +43,16 @@ export interface MenuCommandDeps {
    *  to the renderer — `fs.openFolderDialog` is what turns a chosen directory
    *  into the workspace's `currentFolder` — so the menu only pulls the trigger. */
   openFolder: () => void
+  /** Show the keyboard-shortcut cheatsheet (#920). The sheet is generated from
+   *  the menu template, so this only has to raise it. */
+  showShortcuts: () => void
 }
 
 /** Every renderer menu command and what it does. */
 export function menuCommandHandlers(deps: MenuCommandDeps): Record<RendererMenuCommand, () => void> {
   const handlers = {
-    'file.openFolder': () => deps.openFolder()
+    'file.openFolder': () => deps.openFolder(),
+    'help.shortcuts': () => deps.showShortcuts()
   } as Record<RendererMenuCommand, () => void>
   // Derived from WORKSPACE_IDS, like the menu itself: a fourth workspace gets
   // its menu item AND its handler with no edit here.

--- a/src/renderer/src/lib/platform.ts
+++ b/src/renderer/src/lib/platform.ts
@@ -25,6 +25,16 @@ export function isElectron(): boolean {
   return typeof navigator !== 'undefined' && /electron/i.test(navigator.userAgent)
 }
 
+/**
+ * True on macOS — which decides how a keyboard shortcut is PRINTED (⌘⇧B rather
+ * than Ctrl+Shift+B), not what it does. Electron resolves `CmdOrCtrl` itself in
+ * the main process; the renderer only has to render the same string the way the
+ * platform's own menu bar does (#920).
+ */
+export function isMac(): boolean {
+  return typeof navigator !== 'undefined' && /mac/i.test(navigator.userAgent)
+}
+
 /** Web Serial (`navigator.serial`) — used for ESP32/ESP8266 flashing via esptool-js. */
 export function hasWebSerial(): boolean {
   return typeof navigator !== 'undefined' && 'serial' in navigator

--- a/src/shared/menu-commands.ts
+++ b/src/shared/menu-commands.ts
@@ -47,14 +47,15 @@ export function workspaceMenuCommand(id: WorkspaceId): WorkspaceMenuCommand {
 }
 
 /** Commands the RENDERER performs, relayed to the main window. */
-export type RendererMenuCommand = 'file.openFolder' | WorkspaceMenuCommand
+export type RendererMenuCommand = 'file.openFolder' | 'help.shortcuts' | WorkspaceMenuCommand
 
 /** Every renderer command, in menu order. The workspace entries are DERIVED
  *  from `WORKSPACE_IDS`, so a fourth workspace gets its command, its menu item
  *  and its handler without anyone editing a list. */
 export const RENDERER_MENU_COMMANDS: readonly RendererMenuCommand[] = [
   'file.openFolder',
-  ...WORKSPACE_IDS.map(workspaceMenuCommand)
+  ...WORKSPACE_IDS.map(workspaceMenuCommand),
+  'help.shortcuts'
 ]
 
 /** Any application-menu command. */

--- a/src/shared/menu-template.ts
+++ b/src/shared/menu-template.ts
@@ -4,8 +4,8 @@ import {
   workspaceMenuCommand,
   type MenuCommand,
   type MenuState
-} from '../shared/menu-commands'
-import { WORKSPACE_IDS, WORKSPACE_INFO } from '../shared/workspaces'
+} from './menu-commands'
+import { WORKSPACE_IDS, WORKSPACE_INFO } from './workspaces'
 
 /**
  * The application menu as PLAIN DATA (#914).
@@ -15,6 +15,12 @@ import { WORKSPACE_IDS, WORKSPACE_INFO } from '../shared/workspaces'
  * name, the platform and the renderer's {@link MenuState}. `menu.ts` keeps the
  * two lines that need Electron (`app.name` and `Menu.buildFromTemplate`), and
  * the decisions are testable directly, without a running app.
+ *
+ * It lives in `src/shared/` rather than `src/main/` (where #914 first put it)
+ * because the RENDERER reads it too now: the shortcut cheatsheet (#920) is
+ * generated from these `accelerator` strings, so the sheet and the menu cannot
+ * drift apart. Nothing here needs a running Electron — the one Electron import
+ * is a type.
  *
  * Every item that DOES something goes through `onCommand(id)`: one callback for
  * the whole menu, rather than a positional argument per item (which is how
@@ -121,6 +127,25 @@ export function appMenuTemplate(o: MenuTemplateOptions): MenuItemConstructorOpti
     accelerator: 'CmdOrCtrl+O'
   })
 
+  // Help ▸ Keyboard Shortcuts (#920) — the popup that lists every binding,
+  // generated from THIS template (see `shared/shortcuts.ts`). It sits in Help on
+  // every platform so it is findable by someone who doesn't know the shortcut
+  // for finding shortcuts, and being a menu accelerator makes it self-listing:
+  // the sheet shows its own key without anyone typing it anywhere.
+  //
+  // NOT ⌘H, which #920 originally asked for: on macOS that is Hide Application,
+  // a system binding, and stealing it would annoy people far more often than the
+  // sheet helps. NOT ⌘/ either, the usual editor choice — Monaco already binds
+  // `CmdOrCtrl+Slash` to `editor.action.commentLine` (Toggle Line Comment) and,
+  // while the suggest widget is open, to `toggleExplainMode`. A menu accelerator
+  // is handled natively BEFORE the web contents sees it, so taking ⌘/ would have
+  // silently killed commenting in a code editor — which is this issue's own
+  // failure mode from the other direction. ⌘⇧/ (i.e. ⌘? on a US layout) is what
+  // Slack, GitHub and Gmail use for this, and Monaco binds no Shift+Slash at all.
+  const shortcutsItem = commandItem('help.shortcuts', 'Keyboard Shortcuts', o, {
+    accelerator: 'CmdOrCtrl+Shift+/'
+  })
+
   return [
     // macOS app menu (omitted on Windows/Linux). About → Check for Updates → …
     ...(isMac
@@ -196,7 +221,14 @@ export function appMenuTemplate(o: MenuTemplateOptions): MenuItemConstructorOpti
         // On macOS "Check for Updates…" lives in the app menu, so the Help menu
         // only needs the About item on Windows/Linux (macOS already has About in
         // its app menu). Keep a Help menu everywhere for a consistent home.
-        ...(isMac ? [] : ([{ role: 'about' }, checkForUpdatesItem] as MenuItemConstructorOptions[]))
+        ...(isMac
+          ? []
+          : ([
+              { role: 'about' },
+              checkForUpdatesItem,
+              { type: 'separator' }
+            ] as MenuItemConstructorOptions[])),
+        shortcutsItem
       ]
     }
   ]

--- a/src/shared/shortcuts.ts
+++ b/src/shared/shortcuts.ts
@@ -1,0 +1,226 @@
+import type { MenuItemConstructorOptions } from 'electron'
+import { appMenuTemplate } from './menu-template'
+
+/**
+ * THE KEYBOARD SHORTCUT CHEATSHEET, DERIVED FROM THE MENU (#920, epic #913).
+ * =============================================================================
+ *
+ * A list of shortcuts that is TYPED OUT drifts from the real bindings within a
+ * release or two, and a shortcut list that lies is worse than none — the reader
+ * trusts it, presses the key, and concludes the app is broken. So nothing here
+ * knows a single accelerator: {@link shortcutSections} walks the very template
+ * `menu.ts` hands to `Menu.buildFromTemplate` and reports what it finds. In
+ * Electron an item's `accelerator` IS the binding, so the menu and the sheet
+ * cannot disagree, and #915 / #917 / #918 fill the sheet in by adding their menu
+ * items — with no edit here.
+ *
+ * That is also why `menu-template.ts` moved from `src/main/` to `src/shared/`
+ * (it only ever type-imported Electron): the main process builds the menu from
+ * it and the renderer now builds the sheet from it, so it belongs to both.
+ *
+ * WHAT IS DELIBERATELY NOT LISTED. Standard-role items (Undo, Copy, Zoom In,
+ * Minimise) carry no `accelerator` in the template — Electron supplies the
+ * platform's own key for each role. Reproducing those would mean hand-writing
+ * exactly the second table this module exists to avoid, so the sheet shows what
+ * Snakie itself binds and the UI says so in one line.
+ */
+
+/** One binding, as the sheet shows it. */
+export interface Shortcut {
+  /** Where the item sits in its menu — a nested item keeps its path
+   *  ("Workspace ▸ Code"), since "Code" alone under View means nothing. */
+  label: string
+  /** The accelerator string EXACTLY as the menu declares it, e.g.
+   *  `CmdOrCtrl+Shift+B`. Kept so a test can compare the sheet against the
+   *  template without re-deriving the pretty form. */
+  accelerator: string
+  /** The same binding for THIS platform: `⌘⇧B` on macOS, `Ctrl+Shift+B` else. */
+  keys: string
+}
+
+/** One top-level menu's worth of bindings. */
+export interface ShortcutSection {
+  /** The menu's own title — "File", "View", "Help", or the app name on macOS. */
+  title: string
+  /** Bindings in menu order. MAY BE EMPTY: a menu can hold commands that have
+   *  no key yet, and the sheet says so rather than rendering a bare heading. */
+  shortcuts: Shortcut[]
+}
+
+/**
+ * Titles for the top-level menus built from a `role` rather than a label.
+ *
+ * The template hands those to the OS (`{ role: 'windowMenu' }`, `{ role: 'help'
+ * }`) precisely so the platform names and populates them, which means the title
+ * is the one thing about them that isn't in the data. Small, and only ever the
+ * menus the template actually uses at the top level.
+ */
+const ROLE_TITLES: Record<string, string> = {
+  help: 'Help',
+  windowMenu: 'Window',
+  fileMenu: 'File',
+  editMenu: 'Edit',
+  viewMenu: 'View'
+}
+
+/** macOS prints modifiers as glyphs. `CmdOrCtrl` resolves to ⌘ here for the same
+ *  reason Electron does: on a Mac that is the key it binds. */
+const MAC_MODIFIERS: Record<string, string> = {
+  command: '⌘',
+  cmd: '⌘',
+  commandorcontrol: '⌘',
+  cmdorctrl: '⌘',
+  control: '⌃',
+  ctrl: '⌃',
+  alt: '⌥',
+  option: '⌥',
+  altgr: '⌥',
+  shift: '⇧',
+  super: '⌘',
+  meta: '⌘'
+}
+
+/** Everywhere else they are words. `Cmd` stays "Cmd" rather than becoming Ctrl:
+ *  Electron only honours it on macOS, so calling it Ctrl would be a claim about
+ *  a key that does nothing. */
+const OTHER_MODIFIERS: Record<string, string> = {
+  command: 'Cmd',
+  cmd: 'Cmd',
+  commandorcontrol: 'Ctrl',
+  cmdorctrl: 'Ctrl',
+  control: 'Ctrl',
+  ctrl: 'Ctrl',
+  alt: 'Alt',
+  option: 'Alt',
+  altgr: 'AltGr',
+  shift: 'Shift',
+  super: 'Super',
+  meta: 'Meta'
+}
+
+/** Key names that don't read well raw. Anything absent is printed as written
+ *  (upper-cased), which is right for letters, digits and punctuation. */
+const MAC_KEYS: Record<string, string> = {
+  return: '↩',
+  enter: '↩',
+  tab: '⇥',
+  backspace: '⌫',
+  delete: '⌦',
+  escape: '⎋',
+  esc: '⎋',
+  up: '↑',
+  down: '↓',
+  left: '←',
+  right: '→',
+  pageup: '⇞',
+  pagedown: '⇟',
+  home: '↖',
+  end: '↘',
+  space: 'Space',
+  plus: '+'
+}
+
+const OTHER_KEYS: Record<string, string> = {
+  return: 'Enter',
+  enter: 'Enter',
+  escape: 'Esc',
+  esc: 'Esc',
+  pageup: 'Page Up',
+  pagedown: 'Page Down',
+  plus: '+'
+}
+
+/**
+ * Render one Electron accelerator for `isMac`.
+ *
+ * The accelerator string is the ONLY input: this is a substitution over the very
+ * text Electron parses, not a second table of bindings that could fall out of
+ * step with it. Electron joins parts with `+` and spells a literal plus `Plus`,
+ * so splitting on `+` is safe.
+ *
+ * Modifiers keep the order the accelerator declares them in (`CmdOrCtrl+Shift+B`
+ * → `⌘⇧B`), as #920 specifies. Worth knowing: macOS's own menu bar sorts them
+ * into Apple's ⌃⌥⇧⌘ order and would print `⇧⌘B` — the same keys, one glyph
+ * apart. Sorting here instead is a one-line change if that ever matters.
+ */
+export function formatAccelerator(accelerator: string, isMac: boolean): string {
+  const parts = accelerator.split('+').filter((p) => p.length > 0)
+  if (parts.length === 0) return ''
+  const modifiers = isMac ? MAC_MODIFIERS : OTHER_MODIFIERS
+  const keys = isMac ? MAC_KEYS : OTHER_KEYS
+  const rendered = parts.map((part, i) => {
+    const lower = part.toLowerCase()
+    // Only the LAST part is the key; everything before it is a modifier. A
+    // modifier name in key position (there is none today) still prints as
+    // written rather than silently vanishing.
+    if (i < parts.length - 1) return modifiers[lower] ?? part
+    return keys[lower] ?? (part.length === 1 ? part.toUpperCase() : part)
+  })
+  // Glyphs run together on macOS (⌘⇧B); words need a separator (Ctrl+Shift+B).
+  return rendered.join(isMac ? '' : '+')
+}
+
+/** Is this item something SNAKIE binds, rather than a standard role the OS
+ *  owns? Command items are exactly the ones with a click handler — the same
+ *  test `test/appMenuTemplate.test.ts` uses to enumerate the menu. */
+function isCommandItem(item: MenuItemConstructorOptions): boolean {
+  return typeof item.click === 'function'
+}
+
+/** Collect one menu's bindings, depth-first, keeping the path to nested items. */
+function collect(
+  items: MenuItemConstructorOptions[],
+  isMac: boolean,
+  path: string[],
+  out: { shortcuts: Shortcut[]; hasCommands: boolean }
+): void {
+  for (const item of items) {
+    if (isCommandItem(item)) out.hasCommands = true
+    const label = typeof item.label === 'string' ? item.label : ''
+    if (typeof item.accelerator === 'string' && label) {
+      out.shortcuts.push({
+        label: [...path, label].join(' ▸ '),
+        accelerator: item.accelerator,
+        keys: formatAccelerator(item.accelerator, isMac)
+      })
+    }
+    if (Array.isArray(item.submenu)) {
+      collect(item.submenu, isMac, label ? [...path, label] : path, out)
+    }
+  }
+}
+
+/**
+ * The cheatsheet for a platform: every accelerator in the application menu,
+ * grouped by the top-level menu it lives under.
+ *
+ * A menu appears only if it holds at least one of Snakie's OWN commands. That
+ * keeps Edit and Window — pure standard roles, whose keys belong to the platform
+ * and are nowhere in the template — out of a sheet that would otherwise have to
+ * invent them. A menu that has commands but no keys yet still gets its heading
+ * and an empty list, because "File has nothing bound" is a useful thing to read
+ * and the sheet fills itself in as #915–#918 land.
+ *
+ * @param appName `app.name` — the macOS app menu's title, and so its heading.
+ */
+export function shortcutSections(o: { appName: string; isMac: boolean }): ShortcutSection[] {
+  const template = appMenuTemplate({ appName: o.appName, isMac: o.isMac, onCommand: () => {} })
+  const sections: ShortcutSection[] = []
+  for (const menu of template) {
+    const title =
+      (typeof menu.label === 'string' && menu.label) ||
+      (typeof menu.role === 'string' && ROLE_TITLES[menu.role]) ||
+      ''
+    if (!title) continue
+    const found = { shortcuts: [] as Shortcut[], hasCommands: false }
+    if (Array.isArray(menu.submenu)) collect(menu.submenu, o.isMac, [], found)
+    if (found.hasCommands) sections.push({ title, shortcuts: found.shortcuts })
+  }
+  return sections
+}
+
+/** Every binding on `isMac`, flattened — what a test compares against the
+ *  template, and what the UI counts. */
+export function allShortcuts(o: { appName: string; isMac: boolean }): Shortcut[] {
+  return shortcutSections(o).flatMap((s) => s.shortcuts)
+}

--- a/test/appMenuTemplate.test.ts
+++ b/test/appMenuTemplate.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import type { MenuItemConstructorOptions } from 'electron'
-import { appMenuTemplate, workspaceSubmenu } from '../src/main/menu-template'
+import { appMenuTemplate, workspaceSubmenu } from '../src/shared/menu-template'
 import {
   MAIN_MENU_COMMANDS,
   RENDERER_MENU_COMMANDS,

--- a/test/menuCommands.test.ts
+++ b/test/menuCommands.test.ts
@@ -24,17 +24,22 @@ import { WORKSPACE_IDS, type WorkspaceId } from '../src/shared/workspaces'
 function deps(): {
   switched: WorkspaceId[]
   folders: number
+  sheets: number
   d: Parameters<typeof menuCommandHandlers>[0]
 } {
   const rec = {
     switched: [] as WorkspaceId[],
     folders: 0,
+    sheets: 0,
     d: {} as Parameters<typeof menuCommandHandlers>[0]
   }
   rec.d = {
     switchWorkspace: (id: WorkspaceId) => rec.switched.push(id),
     openFolder: () => {
       rec.folders += 1
+    },
+    showShortcuts: () => {
+      rec.sheets += 1
     }
   }
   return rec
@@ -52,7 +57,13 @@ describe('menu command union ↔ renderer dispatcher (#914)', () => {
     for (const id of WORKSPACE_IDS) {
       expect(RENDERER_MENU_COMMANDS).toContain(workspaceMenuCommand(id))
     }
-    expect(RENDERER_MENU_COMMANDS).toHaveLength(WORKSPACE_IDS.length + 1)
+    // Exactly one workspace command per workspace — no stragglers from a retired
+    // one. Counted rather than compared against a total, so adding an unrelated
+    // command (help.shortcuts, #920) doesn't need this number nudging.
+    const workspaceCommands = RENDERER_MENU_COMMANDS.filter((id) =>
+      id.startsWith('workspace.show.')
+    )
+    expect(workspaceCommands).toHaveLength(WORKSPACE_IDS.length)
   })
 
   it('main-process commands are NOT in the renderer union (they never cross)', () => {
@@ -74,6 +85,12 @@ describe('menu command union ↔ renderer dispatcher (#914)', () => {
     const rec = deps()
     menuCommandHandlers(rec.d)['file.openFolder']()
     expect(rec.folders).toBe(1)
+  })
+
+  it('help.shortcuts raises the cheatsheet (#920)', () => {
+    const rec = deps()
+    menuCommandHandlers(rec.d)['help.shortcuts']()
+    expect(rec.sheets).toBe(1)
   })
 
   it('runMenuCommand dispatches a known id and drops anything else', () => {

--- a/test/openFolderReachable.test.ts
+++ b/test/openFolderReachable.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import type { MenuItemConstructorOptions } from 'electron'
-import { appMenuTemplate } from '../src/main/menu-template'
+import { appMenuTemplate } from '../src/shared/menu-template'
 import type { MenuCommand } from '../src/shared/menu-commands'
 
 /**

--- a/test/shortcutSheet.test.ts
+++ b/test/shortcutSheet.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest'
+import type { MenuItemConstructorOptions } from 'electron'
+import { appMenuTemplate } from '../src/shared/menu-template'
+import { allShortcuts, formatAccelerator, shortcutSections } from '../src/shared/shortcuts'
+import { WORKSPACE_INFO } from '../src/shared/workspaces'
+
+/**
+ * THE CHEATSHEET CANNOT DISAGREE WITH THE MENU (#920).
+ * =============================================================================
+ *
+ * The whole point of generating the sheet is that it can't drift, so the test
+ * asserts the DERIVATION rather than a list of keys: every accelerator the menu
+ * template declares reaches the sheet, and nothing reaches the sheet that the
+ * template doesn't declare. A hardcoded count would be wrong the week #915 or
+ * #918 lands; this stays true as the menu grows.
+ *
+ * The walk below is deliberately naive — it takes EVERY `accelerator` in the
+ * tree, with no knowledge of how `shortcutSections` groups or filters them. So
+ * if the grouping ever drops one (an accelerator in a menu the sheet skips, say),
+ * this fails rather than the sheet quietly omitting a real binding.
+ */
+
+const OPTS = { appName: 'Snakie', isMac: true }
+
+/** Every accelerator in the template, however deeply nested. */
+function acceleratorsIn(items: MenuItemConstructorOptions[]): string[] {
+  const out: string[] = []
+  for (const item of items) {
+    if (typeof item.accelerator === 'string') out.push(item.accelerator)
+    if (Array.isArray(item.submenu)) out.push(...acceleratorsIn(item.submenu))
+  }
+  return out
+}
+
+function templateAccelerators(isMac: boolean): string[] {
+  return acceleratorsIn(appMenuTemplate({ appName: 'Snakie', isMac, onCommand: () => {} }))
+}
+
+describe.each([
+  { platform: 'macOS', isMac: true },
+  { platform: 'Windows/Linux', isMac: false }
+])('the cheatsheet is generated from the menu on $platform', ({ isMac }) => {
+  it('lists every accelerator the menu declares, and only those', () => {
+    const fromMenu = templateAccelerators(isMac).sort()
+    const fromSheet = allShortcuts({ appName: 'Snakie', isMac })
+      .map((s) => s.accelerator)
+      .sort()
+    // Both directions in one comparison: a missing binding and an invented one
+    // are the same failure, and both are the failure this issue exists to stop.
+    expect(fromSheet).toEqual(fromMenu)
+  })
+
+  it('binds each key exactly once — two items on one key is a bug, not a list', () => {
+    const accels = templateAccelerators(isMac)
+    expect(new Set(accels).size).toBe(accels.length)
+  })
+
+  it('gives every row a label and a rendered key', () => {
+    for (const s of allShortcuts({ appName: 'Snakie', isMac })) {
+      expect(s.label, s.accelerator).not.toBe('')
+      expect(s.keys, s.accelerator).toBe(formatAccelerator(s.accelerator, isMac))
+    }
+  })
+
+  it('groups rows under the menu they live in, keeping the path to nested items', () => {
+    const sections = shortcutSections({ appName: 'Snakie', isMac })
+    const view = sections.find((s) => s.title === 'View')
+    expect(view).toBeDefined()
+    // View ▸ Workspace ▸ Code: "Code" alone under View would say nothing.
+    expect(view?.shortcuts.map((s) => s.label)).toContain(
+      `Workspace ▸ ${WORKSPACE_INFO.code.label}`
+    )
+    expect(view?.shortcuts.map((s) => s.label)).toContain('Board View')
+    expect(sections.find((s) => s.title === 'File')?.shortcuts.map((s) => s.label)).toEqual([
+      'Open Folder…'
+    ])
+    // Every row belongs to a section — nothing is orphaned by the grouping.
+    const grouped = sections.flatMap((s) => s.shortcuts).length
+    expect(grouped).toBe(allShortcuts({ appName: 'Snakie', isMac }).length)
+  })
+
+  it('skips the menus that are pure platform roles', () => {
+    // Edit and Window are standard roles: Electron gives each its platform key,
+    // none of which is in the template. Listing them would mean hand-writing the
+    // second table the generation exists to avoid, so the UI says so instead.
+    const titles = shortcutSections({ appName: 'Snakie', isMac }).map((s) => s.title)
+    expect(titles).not.toContain('Edit')
+    expect(titles).not.toContain('Window')
+  })
+
+  it('lists its own shortcut, because that is a menu item like any other', () => {
+    const help = shortcutSections({ appName: 'Snakie', isMac })?.find((s) => s.title === 'Help')
+    expect(help?.shortcuts.map((s) => s.label)).toContain('Keyboard Shortcuts')
+  })
+})
+
+describe('sections with no bindings yet (#920)', () => {
+  it('keeps its heading and an empty list rather than vanishing', () => {
+    // macOS puts Check for Updates… in the app menu, and it has no key. The menu
+    // exists and holds a command, so the sheet shows the heading and says why it
+    // is empty — and fills in on its own when something there gains a key.
+    const app = shortcutSections(OPTS).find((s) => s.title === 'Snakie')
+    expect(app).toBeDefined()
+    expect(app?.shortcuts).toEqual([])
+  })
+
+  it('names the app menu after the app, not a hardcoded "Snakie"', () => {
+    const titles = shortcutSections({ appName: 'Renamed', isMac: true }).map((s) => s.title)
+    expect(titles).toContain('Renamed')
+    expect(titles).not.toContain('Snakie')
+  })
+})
+
+describe('accelerators render for the platform, from the same string Electron parses', () => {
+  it('spells the modifiers as macOS glyphs', () => {
+    expect(formatAccelerator('CmdOrCtrl+Shift+B', true)).toBe('⌘⇧B')
+    expect(formatAccelerator('CmdOrCtrl+O', true)).toBe('⌘O')
+    expect(formatAccelerator('CmdOrCtrl+1', true)).toBe('⌘1')
+    expect(formatAccelerator('CmdOrCtrl+Shift+/', true)).toBe('⌘⇧/')
+    expect(formatAccelerator('Ctrl+Alt+Delete', true)).toBe('⌃⌥⌦')
+  })
+
+  it('spells them as words everywhere else', () => {
+    expect(formatAccelerator('CmdOrCtrl+Shift+B', false)).toBe('Ctrl+Shift+B')
+    expect(formatAccelerator('CmdOrCtrl+O', false)).toBe('Ctrl+O')
+    expect(formatAccelerator('CmdOrCtrl+1', false)).toBe('Ctrl+1')
+    expect(formatAccelerator('CmdOrCtrl+Shift+/', false)).toBe('Ctrl+Shift+/')
+    expect(formatAccelerator('Ctrl+Alt+Delete', false)).toBe('Ctrl+Alt+Delete')
+  })
+
+  it('names the keys that do not read well raw', () => {
+    expect(formatAccelerator('CmdOrCtrl+Return', true)).toBe('⌘↩')
+    expect(formatAccelerator('CmdOrCtrl+Return', false)).toBe('Ctrl+Enter')
+    expect(formatAccelerator('Escape', true)).toBe('⎋')
+    expect(formatAccelerator('Escape', false)).toBe('Esc')
+    // Electron spells a literal plus `Plus`, which is why splitting on `+` is safe.
+    expect(formatAccelerator('CmdOrCtrl+Plus', false)).toBe('Ctrl++')
+  })
+
+  it('does not claim Cmd is Ctrl on Windows, where Electron ignores it', () => {
+    expect(formatAccelerator('Cmd+K', false)).toBe('Cmd+K')
+    expect(formatAccelerator('Cmd+K', true)).toBe('⌘K')
+  })
+
+  it('renders a lone letter as a key, not a modifier', () => {
+    expect(formatAccelerator('F5', true)).toBe('F5')
+    expect(formatAccelerator('b', false)).toBe('B')
+    expect(formatAccelerator('', false)).toBe('')
+  })
+})
+
+describe('the cheatsheet does not steal a key Monaco already owns', () => {
+  it('is not on CmdOrCtrl+/, which is Toggle Line Comment', () => {
+    // `monaco-editor/esm/vs/editor/contrib/comment/browser/comment.js` binds
+    // `KeyMod.CtrlCmd | KeyCode.Slash` to `editor.action.commentLine` (and
+    // `suggestController.js` to `toggleExplainMode` while the suggest widget is
+    // up). A MENU accelerator is handled natively before the web contents sees
+    // the key, so taking ⌘/ would silently kill commenting in a code editor —
+    // this issue's own failure mode, from the other direction. Monaco binds no
+    // Shift+Slash at all, so ⌘⇧/ (⌘? on a US layout) is free.
+    const help = shortcutSections(OPTS).find((s) => s.title === 'Help')
+    const sheet = help?.shortcuts.find((s) => s.label === 'Keyboard Shortcuts')
+    expect(sheet?.accelerator).toBe('CmdOrCtrl+Shift+/')
+    expect(templateAccelerators(true)).not.toContain('CmdOrCtrl+/')
+    expect(templateAccelerators(false)).not.toContain('CmdOrCtrl+/')
+  })
+
+  it('is not on CmdOrCtrl+H, which macOS keeps for Hide Application', () => {
+    expect(templateAccelerators(true)).not.toContain('CmdOrCtrl+H')
+    expect(templateAccelerators(true)).not.toContain('Cmd+H')
+  })
+})


### PR DESCRIPTION
Closes #920.

A popup listing every keyboard shortcut the app binds — **Help ▸ Keyboard Shortcuts**, or `⌘⇧/` / `Ctrl+Shift+/`.

## Generated, not typed

Nothing in `src/shared/shortcuts.ts` knows an accelerator. `shortcutSections()` walks the very template `Menu.buildFromTemplate` is handed, collects every `accelerator` it finds and groups them by the top-level menu the item lives in, keeping the path to nested items (`Workspace ▸ Code`, because "Code" alone under View says nothing).

In Electron an item's `accelerator` **is** the binding, so the sheet and the menu cannot disagree — and #915 / #917 / #918 fill the sheet in by adding their menu items, with no edit here.

That is why **`menu-template.ts` moves from `src/main/` to `src/shared/`**. It only ever type-imported Electron; the main process builds the menu from it and the renderer now builds the sheet from it, so it belongs to both. The alternative was copying the accelerator strings into a second place, which is the thing this issue exists to prevent.

Platform rendering is a substitution over the same string Electron parses — `CmdOrCtrl+Shift+B` → `⌘⇧B` on macOS, `Ctrl+Shift+B` elsewhere — not a second mapping. (One deliberate note, called out in the code: macOS's own menu bar sorts modifiers into Apple's `⌃⌥⇧⌘` order and would print `⇧⌘B`. This keeps the order the accelerator declares, as the issue specifies; it's a one-line sort if you'd rather match the menu bar exactly.)

## The binding: not ⌘H, and not ⌘/ either

`⌘H` is Hide Application on macOS, so it's out for the reason the issue gives.

`⌘/` — the requested replacement, and what most editors use — turns out **not to be free**. `monaco-editor/esm/vs/editor/contrib/comment/browser/comment.js:64` binds `KeyMod.CtrlCmd | KeyCode.Slash` to `editor.action.commentLine` (Toggle Line Comment), and `suggestController.js:872` binds the same chord to `toggleExplainMode` while the suggest widget is up. A **menu** accelerator is handled natively *before* the web contents sees the key, so taking `⌘/` would have silently killed commenting in a code editor — this issue's own failure mode, from the other direction.

Monaco binds no `Shift+Slash` anywhere (grep for `KeyCode.Slash` returns three hits, none with `KeyMod.Shift`), so **`CmdOrCtrl+Shift+/`** — `⌘?` on a US layout, which is what Slack, GitHub, Gmail and Jira use for exactly this — is what it's on. A test pins that reasoning down so nobody "restores" the requested key later.

Because the binding is a menu accelerator, the sheet is **self-listing**: it shows its own key without anyone typing it anywhere.

## Six bindings today, and honest about it

```
macOS                              Windows/Linux
[Snakie]                           [File]
  (nothing bound here yet)           Open Folder…            Ctrl+O
[File]                             [View]
  Open Folder…          ⌘O           Workspace ▸ Code        Ctrl+1
[View]                               Workspace ▸ Electronics Ctrl+2
  Workspace ▸ Code      ⌘1           Workspace ▸ Build       Ctrl+3
  Workspace ▸ Electronics ⌘2         Board View              Ctrl+Shift+B
  Workspace ▸ Build     ⌘3         [Help]
  Board View            ⌘⇧B          Keyboard Shortcuts      Ctrl+Shift+/
[Help]
  Keyboard Shortcuts    ⌘⇧/
```

A menu that holds commands but no keys yet (the macOS app menu, whose only command is Check for Updates…) keeps its heading and says *why* it's empty rather than rendering a bare one — and stops saying so the moment something there gains a key.

**Edit and Window are left out entirely.** They're standard roles whose keys belong to the platform and are nowhere in the template; reprinting them would mean hand-writing exactly the second table this design avoids. The footnote in the sheet says so, and points at the editor's own `⌘/` and `⌘F` while it's there.

## The test

`test/shortcutSheet.test.ts` asserts the **derivation**, in both directions, with a walk that knows nothing about the grouping: every accelerator in the template reaches the sheet, and nothing reaches the sheet that isn't in the template. Not a count — that would be wrong the week the next menu lands. It also checks each key is bound exactly once, the platform formatting on both sides, and the two "don't take this key" decisions above.

**Verified the tests fail without the change**, four ways, each reverted after:

| Break | Failing test |
|---|---|
| `collect()` stops descending into submenus (drops the workspace keys) | *lists every accelerator the menu declares, and only those* ×2, *groups rows under the menu they live in* ×2 |
| `allShortcuts()` appends an invented `CmdOrCtrl+S` row | same test, from the other direction (+ *gives every row a label and a rendered key*) |
| Sheet moved onto `CmdOrCtrl+/` | *is not on CmdOrCtrl+/, which is Toggle Line Comment* |
| macOS glyph joining replaced with `+` | *spells the modifiers as macOS glyphs*, and two more |

## Keyboard and themes

Escape closes it, it has a focus trap, and the Close button is the first focusable control so the trap lands there on open — reachable and dismissable by keyboard alone, which a keyboard-shortcut sheet rather owes you. This is ordinary renderer chrome, so every colour is a shared token and it reads on both the parchment and the dark skin (no copy of the flash dialog / Board Finder's deliberate dark-in-both exception).

## Not done, deliberately

The sheet is unreachable in the **web build** — `window.api.menu` is a no-op there, and the web build has no application menu, so none of these six keys exist in it either. Listing them would be the lie this issue is about. Same position #914 already left Open Folder and the workspace switch in.

## Gates

`npm run lint` (only the pre-existing `DriverInstallBanner.tsx` warning) · `npm run typecheck` · `npm test` (311 files, 6403 tests) · `npm run build` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe
