### PR TITLE
Draw a board for the eight without a photograph (#931)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **A board with no photograph gets a drawn board, not its initials** (#931).
+  Eight of the 225 have no picture — seven of them name one upstream, and those
+  URLs 404, because MicroPython's media repository never published a file at
+  that path. So there is nothing to fetch, and the tile has to draw something.
+  It used to draw the product name's two initials, in a well beside the product
+  name, at three different sizes in three different places. It now draws a
+  board: an outline with headers, mounting holes and a chip in the middle, with
+  the chip marked with the board's MCU. That marking is the point — since #927
+  the resting card names only the maker and the board, so on these eight the
+  chip was stated nowhere until the preview opened, and a chip is exactly where
+  a chip's name belongs. It is line art rather than a plausible green PCB, so
+  that among 217 real product photographs it can only be read as a stand-in; and
+  it is one drawing scaling across the card, the preview and the details rather
+  than three that can drift apart. Screen readers get it as "No photo published"
+  plus the chip, where the initials were hidden from them entirely — rightly,
+  since they said nothing the card did not already print.
+
 - **The Board Finder fills its rows, and marks each manufacturer with a tint**
   (#927). Every maker had its own shelf — its own heading, its own grid, its own
   fresh row. With 54 makers and a median of two boards each, that was 54 headings
@@ -53,6 +70,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   code editor.
 
 ### Fixed
+
+- **The board index recorded picture URLs that 404** (#931). When upstream names
+  an image its media repository does not publish, the generator noticed — that
+  is why those boards have no thumbnail — but wrote the dead URL into the index
+  anyway, waiting for whatever renders it next. It now drops the URL when the
+  fetch comes back "not found", and keeps it when the failure was the network or
+  a machine with no image resizer, where the picture is presumably still there.
+  Seven boards in the shipped index lose a link to nowhere.
 
 - **The Board Finder opened behind the flash dialog** (#893). It was given the
   Parts Catalog's stacking order, which is right for a gallery opened from a

--- a/scripts/build-board-index.mjs
+++ b/scripts/build-board-index.mjs
@@ -453,16 +453,31 @@ async function main() {
       // the gallery — it is real, someone owns one — it just cannot be flashed
       // from here, and the UI says so rather than pretending.
     }
-    const image = (meta.images ?? [])[0] ?? null
+    const named = (meta.images ?? [])[0] ?? null
+    // What the board's `board.json` SAYS its picture is. Whether that file
+    // exists is a separate question, answered just below.
+    let image = named ? `${MPY}/resources/micropython-media/boards/${p.board}/${named}` : null
     let thumb = null
     if (withImages && image) {
-      const url = `${MPY}/resources/micropython-media/boards/${p.board}/${image}`
       try {
-        const bytes = Buffer.from(await (await fetch(url)).arrayBuffer())
-        const name = `${p.board}.jpg`
-        if (await thumbnail(bytes, join(OUT_DIR, 'thumbs', name))) thumb = name
+        const res = await fetch(image)
+        if (res.ok) {
+          const bytes = Buffer.from(await res.arrayBuffer())
+          const name = `${p.board}.jpg`
+          if (await thumbnail(bytes, join(OUT_DIR, 'thumbs', name))) thumb = name
+        } else {
+          // Upstream names a file its media repo does not publish at that path,
+          // and seven boards do (#931). Recording the URL anyway would hand the
+          // details page a link to a 404 — so the board has no picture, which
+          // is the truth and what the gallery's placeholder is for. NOT the
+          // same as the two failures either side of this: a `catch` here is the
+          // network, and a `thumbnail` that returns false is this machine
+          // having no resizer. Both leave the URL alone, because in both the
+          // picture is presumed to be there.
+          image = null
+        }
       } catch {
-        /* no picture; the tile falls back to a placeholder */
+        /* no picture this run; the tile falls back to a placeholder */
       }
     }
     return {
@@ -478,7 +493,7 @@ async function main() {
       url: meta.url || null,
       variants: meta.variants ?? {},
       flashOffset: meta.deploy_options?.flash_offset ?? null,
-      image: image ? `${MPY}/resources/micropython-media/boards/${p.board}/${image}` : null,
+      image,
       thumb,
       builds
     }

--- a/src/renderer/public/boards/boards.json
+++ b/src/renderer/public/boards/boards.json
@@ -1517,7 +1517,7 @@
       "url": "https://www.experiential.bot/",
       "variants": {},
       "flashOffset": null,
-      "image": "https://micropython.org/resources/micropython-media/boards/CYTRON_NANOXRP_CONTROLLER/nanoxrp-board.jpg",
+      "image": null,
       "thumb": null,
       "builds": [
         {
@@ -3003,7 +3003,7 @@
       "url": "https://www.infineon.com/evaluation-board/kit-pse84-ai",
       "variants": {},
       "flashOffset": null,
-      "image": "https://micropython.org/resources/micropython-media/boards/KIT_PSE84_AI/kit_pse84_ai.jpg",
+      "image": null,
       "thumb": null,
       "builds": [],
       "flash": {
@@ -8089,7 +8089,7 @@
       "url": "https://www.st.com/en/evaluation-tools/32f469idiscovery.html",
       "variants": {},
       "flashOffset": null,
-      "image": "https://micropython.org/resources/micropython-media/boards/STM32F469DISC/stm32f469disc.jpg",
+      "image": null,
       "thumb": null,
       "builds": [
         {
@@ -11029,7 +11029,7 @@
         "RISCV": "RISC V"
       },
       "flashOffset": null,
-      "image": "https://micropython.org/resources/micropython-media/boards/WAVESHARE_RP2350B_CORE/waveshare_rp2350b_core.png",
+      "image": null,
       "thumb": null,
       "builds": [
         {
@@ -11237,7 +11237,7 @@
       "url": "https://github.com/WeActStudio/WeActStudio.MiniSTM32H723",
       "variants": {},
       "flashOffset": null,
-      "image": "https://micropython.org/resources/micropython-media/boards/WEACTSTUDIO_MINI_STM32H723/weact_stm32h723.jpg",
+      "image": null,
       "thumb": null,
       "builds": [
         {
@@ -11287,7 +11287,7 @@
       "url": "https://github.com/WeActStudio/MiniSTM32H7xx",
       "variants": {},
       "flashOffset": null,
-      "image": "https://micropython.org/resources/micropython-media/boards/WEACTSTUDIO_MINI_STM32H743/weact_stm32h743.jpg",
+      "image": null,
       "thumb": null,
       "builds": [
         {
@@ -11337,7 +11337,7 @@
       "url": "https://github.com/WeActStudio/WeActStudio.STM32U585Cx_CoreBoard",
       "variants": {},
       "flashOffset": null,
-      "image": "https://micropython.org/resources/micropython-media/boards/WEACTSTUDIO_MINI_STM32U585/weact_u585ci.jpg",
+      "image": null,
       "thumb": null,
       "builds": [
         {

--- a/src/renderer/src/components/BoardFinder.css
+++ b/src/renderer/src/components/BoardFinder.css
@@ -489,14 +489,89 @@
   object-fit: contain;
 }
 
-/* A board with no thumbnail (8 of the 225) gets its initials, not a broken
-   image icon. */
+/*
+ * A BOARD WITH NO PHOTOGRAPH (#931) — 8 of the 225.
+ * ---------------------------------------------------------------------------
+ * A drawn board, where this used to print the product name's two initials next
+ * to the product name. `board-finder.ts` argues the choice; this file only has
+ * to make one SVG work in the three wells it lands in — the card, the preview
+ * and the details — which differ in nothing but size.
+ *
+ * CAPPED, because they differ in size by a lot. The details well is 320px wide
+ * against the card's 166, and a drawing filling it would set the chip's marking
+ * at 19px: a diagram enlarged, where the card's is a board at the size a board
+ * is looked at. Capped, the same drawing sits centred in the big well with the
+ * weight it has in the small one.
+ *
+ * IT DEPENDS ON ITS WELL STAYING OPAQUE. All three are `--bf-sunk`, which is
+ * what keeps a maker's tint off the photographs (see THE MAKER TINTS above),
+ * and these lines are drawn dim on the assumption of that ground. Let a tint
+ * reach in here and six different colours get to decide whether the drawing is
+ * visible at all.
+ */
 .bfind__noimg {
-  font-family: var(--font-mono), monospace;
-  font-size: 22px;
-  font-weight: 700;
-  letter-spacing: 0.04em;
+  display: block;
+  width: 100%;
+  height: auto;
+  max-width: 240px;
   color: var(--bf-ink4);
+}
+
+/* The board itself, raised off the well the way a card is. */
+.bfind__noimg-pcb {
+  fill: var(--bf-card);
+  stroke: currentColor;
+  stroke-width: 1.5;
+}
+
+.bfind__noimg-hole {
+  fill: var(--bf-sunk);
+  stroke: currentColor;
+  stroke-width: 1.2;
+}
+
+/* Headers and the edge connector — solid, because at tile size none of them is
+   two pixels across and an outline would disappear. */
+.bfind__noimg-pad,
+.bfind__noimg-port {
+  fill: currentColor;
+  opacity: 0.7;
+}
+
+.bfind__noimg-leg line {
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+}
+
+/* The package, sunk back to the well's own colour so the marking on it can have
+   the contrast the rest of the drawing deliberately does not. */
+.bfind__noimg-chip {
+  fill: var(--bf-sunk);
+  stroke: currentColor;
+  stroke-width: 1.5;
+}
+
+.bfind__noimg-pin1 {
+  fill: currentColor;
+}
+
+/* The MCU, marked on the package. `--bf-ink2` — 6.4:1 on `--bf-sunk` — because
+   it is the one thing here meant to be READ rather than recognised, and on a
+   resting card it is a fact stated nowhere else since #927 took the chip line
+   off. The drawing around it is `--bf-ink4` and meant to recede.
+   Lengths are viewBox user units, not screen pixels: the viewBox is 160 wide,
+   so 10 here is 10px in a 160px-wide card well and scales from there. */
+.bfind__noimg-mark {
+  font-family: var(--font-mono), monospace;
+  font-size: 10px;
+  font-weight: 700;
+  fill: var(--bf-ink2);
+}
+/* An order code too long for one line gets two, and both have to fit between
+   the package's edges — see `chipSilkscreen` for the wrap. */
+.bfind__noimg-mark.is-two {
+  font-size: 8px;
 }
 
 .bfind__card-body {

--- a/src/renderer/src/components/BoardFinder.tsx
+++ b/src/renderer/src/components/BoardFinder.tsx
@@ -32,11 +32,12 @@ import {
   MEMORY_THRESHOLDS,
   RUNTIME_CAVEAT,
   boardFacts,
-  boardInitials,
   buildLabel,
+  chipSilkscreen,
   firmwareSummary,
   isFiltering,
   memoryThresholdLabel,
+  noPhotoLabel,
   peekFacts,
   toggleChip,
   toggleRuntime,
@@ -632,9 +633,7 @@ function BoardPeek({
         {src ? (
           <img src={src} alt="" loading="lazy" draggable={false} />
         ) : (
-          <span className="bfind__noimg" aria-hidden="true">
-            {boardInitials(board)}
-          </span>
+          <BoardNoPhoto board={board} />
         )}
       </div>
       <div className="bfind__peek-body">
@@ -670,6 +669,79 @@ function BoardPeek({
         </button>
       </div>
     </div>
+  )
+}
+
+/**
+ * What stands in for the photograph on the eight boards that have none (#931).
+ *
+ * A drawn board — outline, headers, mounting holes, and a chip marked with the
+ * board's MCU. `board-finder.ts` argues the choice at length: why not a broken
+ * frame, why not the initials this replaces, and why the marking is the one
+ * thing here worth reading. This function is only how it is drawn.
+ *
+ * ONE COMPONENT, THREE WELLS. It goes in the card, the hover preview and the
+ * details, which are 166, 186 and up to 320 CSS pixels wide. It is one SVG on
+ * one `0 0 160 120` grid rather than three drawings, because the placeholder it
+ * replaces was three copies of an idea and they had already drifted — the
+ * details page inherited a 22px monogram sized for a tile. Everything here
+ * scales with the box; `BoardFinder.css` caps how far, and says why.
+ *
+ * It is LINE ART, not a rendered board. These sit in a grid of real product
+ * photographs, and a plausible green PCB among them would be read as a
+ * photograph of some board — which is worse than an obvious stand-in. Drawn in
+ * the gallery's own dim ink, it is unmistakably a diagram.
+ */
+function BoardNoPhoto({ board }: { board: IndexedBoard }): JSX.Element {
+  const lines = chipSilkscreen(board)
+  const two = lines.length > 1
+  return (
+    <svg className="bfind__noimg" viewBox="0 0 160 120" role="img" aria-label={noPhotoLabel(board)}>
+      {/* The connector, off the left edge — the cue that says "development
+          board" before any of the detail is legible at tile size. */}
+      <rect className="bfind__noimg-port" x="1" y="51" width="17" height="18" rx="3" />
+      <rect className="bfind__noimg-pcb" x="10" y="16" width="140" height="88" rx="8" />
+      {[21, 139].map((x) =>
+        [27, 93].map((y) => (
+          <circle className="bfind__noimg-hole" key={`${x}-${y}`} cx={x} cy={y} r="3.2" />
+        ))
+      )}
+      {/* Two header rows. Ten a side rather than a real pin count: this is not
+          any particular board, and a countable row would invite counting. */}
+      {[19.5, 95.5].map((y) =>
+        Array.from({ length: 10 }, (_, i) => (
+          <rect
+            className="bfind__noimg-pad"
+            key={`${y}-${i}`}
+            x={31 + i * 10}
+            y={y}
+            width="5"
+            height="5"
+            rx="1.2"
+          />
+        ))
+      )}
+      {[48, 55, 62, 69].map((y) => (
+        <g className="bfind__noimg-leg" key={y}>
+          <line x1="44" y1={y} x2="49" y2={y} />
+          <line x1="111" y1={y} x2="116" y2={y} />
+        </g>
+      ))}
+      <rect className="bfind__noimg-chip" x="49" y="42" width="62" height="36" rx="3" />
+      {/* Pin 1, in the corner it is always in. */}
+      <circle className="bfind__noimg-pin1" cx="54.5" cy="47.5" r="2.2" />
+      {lines.map((line, i) => (
+        <text
+          className={`bfind__noimg-mark${two ? ' is-two' : ''}`}
+          key={line}
+          x="80"
+          y={two ? 57 + i * 10 : 63.6}
+          textAnchor="middle"
+        >
+          {line}
+        </text>
+      ))}
+    </svg>
   )
 }
 
@@ -716,9 +788,7 @@ function BoardCard({
           // board — announcing it twice is noise, not access.
           <img src={src} alt="" loading="lazy" draggable={false} />
         ) : (
-          <span className="bfind__noimg" aria-hidden="true">
-            {boardInitials(board)}
-          </span>
+          <BoardNoPhoto board={board} />
         )}
       </span>
       <span className="bfind__card-body">
@@ -787,9 +857,7 @@ function BoardDetails({
           {src ? (
             <img src={src} alt={`${board.vendor} ${board.product}`} loading="lazy" />
           ) : (
-            <span className="bfind__noimg" aria-hidden="true">
-              {boardInitials(board)}
-            </span>
+            <BoardNoPhoto board={board} />
           )}
         </div>
 

--- a/src/renderer/src/components/board-finder.ts
+++ b/src/renderer/src/components/board-finder.ts
@@ -199,17 +199,85 @@ export function vendorRuns(boards: readonly IndexedBoard[]): VendorRun[] {
 // ---------------------------------------------------------------------------
 
 /**
- * The two letters a photo-less board shows instead (8 of the 225 have no thumb).
+ * A BOARD WITH NO PHOTOGRAPH (#931) — 8 of the 225.
+ * ---------------------------------------------------------------------------
+ * Seven of the eight DO name a picture upstream; those URLs 404, because
+ * `board.json` names a file micropython.org's media repo never published at
+ * that path. So this is not a fetch to fix — there is no photograph, and the
+ * gallery has to draw something in its place.
  *
- * Initials of the first two words, so `Feather RP2350` reads `FR` rather than
- * `FE` — a vendor's range is mostly one-word-apart, and the second word is what
- * tells two of them apart. Falls back to the board id, which is never empty.
+ * What it draws is a board: a PCB outline with headers, mounting holes and a
+ * chip in the middle, with the chip MARKED with the board's MCU. Three things
+ * that ruled out the alternatives:
+ *
+ *   - it must not read as a BROKEN IMAGE or a spinner. Both say something went
+ *     wrong here, and nothing did — nobody published a photo, which is a fact
+ *     about the catalogue and not a fault in the app;
+ *   - it must not REPEAT THE CARD. This replaces the board's initials, which
+ *     were the product name abbreviated and printed next to the product name;
+ *     the card already prints the maker and the name (#927) and nothing else,
+ *     so a placeholder saying either spends the space twice;
+ *   - it must say something the card cannot. #927 took the chip line OFF the
+ *     resting card, so on the eight that land here the MCU is stated nowhere
+ *     until the preview opens. A drawn chip is exactly where a chip's name
+ *     goes, so the one fact worth recovering has a place to sit.
+ *
+ * That last point is also why the drawing is LABELLED rather than
+ * `aria-hidden`, which is what the initials were — see {@link noPhotoLabel}.
  */
-export function boardInitials(board: IndexedBoard): string {
-  const words = board.product.trim().split(/\s+/).filter(Boolean)
-  if (words.length >= 2) return (words[0][0] + words[1][0]).toUpperCase()
-  const source = words[0] || board.id
-  return source.slice(0, 2).toUpperCase()
+
+/**
+ * How many characters fit on one line of the drawn chip.
+ *
+ * Nine, because `stm32f411` is the longest MCU in the catalogue that names a
+ * chip FAMILY, and a family is what 223 of the 225 boards carry. The two that
+ * do not carry a full order code (`PSE846GPS2DBZC4`, `AE722F80F55D5XX`), and
+ * one of them — Infineon's KIT_PSE84_AI — is a board with no photograph.
+ */
+const SILKSCREEN_COLUMNS = 9
+
+/**
+ * What is printed on the drawn chip: the board's MCU, in one line or two.
+ *
+ * UPPERCASE, because a package is marked in uppercase and because the
+ * lowercase `rp2040` upstream publishes is the exact string the Specification
+ * list prints. This has to read as a marking on a chip; a data field in a
+ * picture frame would just be the initials problem again in longer words.
+ *
+ * TWO LINES for an order code too long to fit, which is what the marking on a
+ * real package does with one — and the split is by character count rather than
+ * at some meaningful boundary because a part number has none. Two lines hold
+ * 22 characters at the size they are drawn, against a longest-in-catalogue of
+ * 15, so nothing overflows the package.
+ *
+ * EMPTY when upstream names no MCU. A blank package is honest about knowing
+ * nothing; the word "unknown" silkscreened on a chip is a caption for a fault,
+ * which is the reading this whole placeholder exists to avoid.
+ */
+export function chipSilkscreen(board: IndexedBoard): string[] {
+  const mcu = board.mcu.trim().toUpperCase()
+  if (!mcu) return []
+  if (mcu.length <= SILKSCREEN_COLUMNS) return [mcu]
+  const split = Math.ceil(mcu.length / 2)
+  return [mcu.slice(0, split), mcu.slice(split)]
+}
+
+/**
+ * What a screen reader hears where the photograph would be.
+ *
+ * The initials this replaces were `aria-hidden`, and rightly: they were the
+ * product name shortened, sitting beside the product name. The drawing is not,
+ * because it carries the MCU, and on a resting card that is a fact stated
+ * nowhere else. It also says the thing a sighted reader gets from the drawing
+ * being a drawing — that there is no photograph of this board — which no text
+ * on the card says either.
+ *
+ * The MCU goes in as upstream spells it, not as the chip is marked: the
+ * uppercasing is a drawing decision, and `RP2040` risks being spelt out.
+ */
+export function noPhotoLabel(board: IndexedBoard): string {
+  const mcu = board.mcu.trim()
+  return mcu ? `No photo published, ${mcu}` : 'No photo published'
 }
 
 /**

--- a/test/boardFinder.test.ts
+++ b/test/boardFinder.test.ts
@@ -8,11 +8,12 @@ import {
   UNKNOWN_VENDOR,
   activeFilterChips,
   boardFacts,
-  boardInitials,
   buildLabel,
+  chipSilkscreen,
   firmwareSummary,
   isFiltering,
   memoryThresholdLabel,
+  noPhotoLabel,
   peekFacts,
   toggleChip,
   unsizedNotice,
@@ -195,19 +196,56 @@ describe('vendorRuns (#927)', () => {
   })
 })
 
-describe('boardInitials', () => {
-  it('takes one letter from each of the first two words', () => {
-    // Not the first two letters: an Adafruit range is mostly "Feather …", so
-    // 'FE' would be identical across a dozen boards.
-    expect(boardInitials(board({ product: 'Feather RP2350' }))).toBe('FR')
+describe('the boards with no photograph (#931)', () => {
+  describe('chipSilkscreen', () => {
+    it('marks the drawn chip with the MCU, as a package is marked', () => {
+      // Uppercase, because this has to read as a marking rather than as the
+      // Specification list's `rp2040` shown twice.
+      expect(chipSilkscreen(board({ mcu: 'rp2040' }))).toEqual(['RP2040'])
+    })
+
+    it('keeps the longest chip FAMILY on one line', () => {
+      // `stm32f411` is nine characters, which is the width the package is drawn
+      // to hold. Wrapping this one would wrap most of the STM32 catalogue.
+      expect(chipSilkscreen(board({ mcu: 'stm32f411' }))).toEqual(['STM32F411'])
+    })
+
+    it('wraps a full order code onto a second line', () => {
+      // Infineon's KIT_PSE84_AI, which is both one of the two boards carrying an
+      // order code instead of a family AND one of the eight with no photo — so
+      // this is the case that actually renders, not a hypothetical.
+      expect(chipSilkscreen(board({ mcu: 'PSE846GPS2DBZC4' }))).toEqual(['PSE846GP', 'S2DBZC4'])
+      // Alif's, the other one. Two lines, neither wider than the package.
+      const alif = chipSilkscreen(board({ mcu: 'AE722F80F55D5XX' }))
+      expect(alif).toHaveLength(2)
+      for (const line of alif) expect(line.length).toBeLessThanOrEqual(9)
+    })
+
+    it('leaves the package blank rather than marking it "unknown"', () => {
+      // A caption where a part number goes is how a placeholder starts reading
+      // as a fault, which is the whole thing this drawing exists to avoid.
+      expect(chipSilkscreen(board({ mcu: '' }))).toEqual([])
+      expect(chipSilkscreen(board({ mcu: '   ' }))).toEqual([])
+    })
   })
 
-  it('falls back to the first two letters of a single-word product', () => {
-    expect(boardInitials(board({ product: 'Pico' }))).toBe('PI')
-  })
+  describe('noPhotoLabel', () => {
+    it('says there is no photograph, and names the chip', () => {
+      // The drawing is NOT `aria-hidden`, unlike the initials it replaces: it
+      // carries the MCU, and a resting card has said nothing about the chip
+      // since #927.
+      expect(noPhotoLabel(board({ mcu: 'rp2350' }))).toBe('No photo published, rp2350')
+    })
 
-  it('falls back to the board id when the product name is empty', () => {
-    expect(boardInitials(board({ product: '', id: 'ESP32_GENERIC' }))).toBe('ES')
+    it('spells the chip as upstream does, not as the package is marked', () => {
+      // The uppercasing is a drawing decision; `RP2040` read aloud risks being
+      // spelt out letter by letter.
+      expect(noPhotoLabel(board({ mcu: 'esp32s3' }))).not.toContain('ESP32S3')
+    })
+
+    it('still says why there is no picture when upstream names no chip', () => {
+      expect(noPhotoLabel(board({ mcu: '' }))).toBe('No photo published')
+    })
   })
 })
 

--- a/test/boardIndex.test.ts
+++ b/test/boardIndex.test.ts
@@ -362,6 +362,22 @@ describe('the generated seed that actually ships', () => {
     expect(previews).toEqual([])
   })
 
+  it('names no picture for a board whose picture could not be fetched (#931)', () => {
+    // Seven boards name an image in upstream's `board.json` whose URL 404s —
+    // the media repo never published a file at that path. The generator used to
+    // record the URL regardless, which is a dead link waiting for whatever
+    // renders `image` next; it drops it now, and this is what notices if that
+    // regresses.
+    //
+    // It would also trip on a transport blip during a refresh, and that is the
+    // safe side to fail on: the workflow runs this BEFORE it commits, so a run
+    // that could not reach a board's photo leaves yesterday's good index in
+    // place rather than shipping one that quietly lost a picture.
+    const raw = JSON.parse(readFileSync('src/renderer/public/boards/boards.json', 'utf8'))
+    const dead = raw.boards.filter((b) => !b.thumb && b.image).map((b) => b.id)
+    expect(dead).toEqual([])
+  })
+
   /**
    * This used to assert that NO flash or RAM figure appeared at all, on the
    * grounds that upstream publishes none and anything that showed up must have


### PR DESCRIPTION
Closes #931.

## Why it looked wrong

Eight of the 225 boards have no picture. The tile drew the product name's **two initials**, in a well, directly beside the product name — spending the space to repeat what was already next to it, at three different sizes in three different places.

## What it draws now

A board: an outline with headers, mounting holes and a chip in the middle, with the chip **marked with the board's MCU**.

That marking is the point, not decoration. Since #927 stripped the resting card back to the maker and the board name, on these eight the chip was stated nowhere until the preview opened — and a chip is exactly where a chip's name belongs.

It's line art rather than a plausible green PCB, deliberately: sitting among 217 real product photographs, it should only ever read as a stand-in, never as a board someone photographed badly.

## The seven dead URLs

Seven of the eight *do* name an image in their `board.json`, which looks at first like a generator bug rather than a case for a placeholder. It isn't — those URLs **404**. Upstream names a file its media repo doesn't publish at that path. I verified that before the work started, so it wasn't chased down blind.

The generator now clears `image` when the fetch comes back not-ok, because recording it hands the details page a link to a 404. It's deliberately **not** treated the same as the two failures either side of it: a thrown fetch is the network, and a `thumbnail()` returning false is this machine having no resizer. Both leave the URL alone, because in both the picture is presumed to be there. That distinction is written into the code.

The data diff is exactly those seven `image` fields going to `null` — checked, and no board is left claiming a picture it hasn't got.

## Provenance

The agent doing this was **interrupted by a session rate limit** with the work complete and the changelog written, but nothing committed. I recovered it from its worktree and **re-ran all four gates myself** rather than trust the interrupted "all four gates green" report.

lint (only the pre-existing `DriverInstallBanner.tsx` warning) · typecheck · **6,413 tests** · build — all green.

**Not verified on screen.** The placeholder's appearance against the real grid — including the six manufacturer tints from #927 — is reasoned, not observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe