### PR TITLE
Seven more boards MicroPython builds nothing for (#936)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,44 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Seven more boards MicroPython builds nothing for** (#936, epic #884). #902
+  built the overlay and curated five entries, deliberately leaving the rest —
+  every entry is a claim about somebody's hardware that Snakie acts on, so the
+  bar is the maker's own page open in front of you. #934 then linked 11 of the
+  22 microcontroller parts to a board; the other 11 had nowhere to link because
+  the board was not in the catalogue at all. Seven now are: Pimoroni's **Tiny
+  2350**, **Servo 2040**, **Motor 2040**, **Pico LiPo 2** and **Pico LiPo 2 XL
+  W**, Cytron's **Maker Pi RP2040**, and Adafruit's **Feather ESP32-S3** (the
+  8 MB / no-PSRAM one). Each carries its flash, RAM and PSRAM with the page they
+  were read from, and a CircuitPython id checked against the published catalogue
+  or none at all. All seven are linked to their parts, so each one now opens with
+  its own pinout — and the Maker Pi RP2040 brings the first 3-D model to a board
+  in the finder.
+
+  **This batch had a hazard the first did not.** The Adafruit ESP32 entries
+  borrow a generic build because there is a right one to borrow. These are mostly
+  RP2040/RP2350, where a generic Pico build *runs* on nearly every board — and
+  running is not the same as being right. "It booted, so it was the correct
+  firmware" is exactly the reasoning that cost a week on the Feather V2. So a
+  donor build is offered only where the maker's own page says the board is
+  spec-identical to the donor: Cytron's does, and it is the only one here that
+  does. Where the maker publishes its own build, the entry says so and points
+  there, as the micro:bit v2 entry already did.
+
+  The Pico LiPo 2 is the case that settles it. It is an RP2350**B** with 16 MB of
+  flash and 8 MB of PSRAM; upstream's Pico 2 build is an RP2350**A** with 4 MB
+  and no PSRAM. Flashing it would boot, and quietly leave most of the board
+  switched off — the Feather V2 story one chip family across. It gets no donor
+  and a card that says why.
+
+### Changed
+
+- **Overlay boards can no longer invent a filter chip** (#936). A board's
+  `features` feed the gallery's facets, so `USB C` where upstream writes `USB-C`
+  fails nothing and silently splits one filter into two — #928 by another route.
+  Every feature string an overlay states is now held to upstream's own
+  vocabulary by a test.
+
 - **A board in the finder shows the board itself: front, back, model and
   pinout** (#934). The Board Finder knew 225 boards the way MicroPython
   describes them — a vendor, a chip, and a list of firmware to write. The parts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snakie",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "snakie",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snakie",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "A modern, cross-platform MicroPython editor.",
   "productName": "Snakie",
   "main": "./out/main/index.js",

--- a/src/shared/board-overlay.ts
+++ b/src/shared/board-overlay.ts
@@ -45,6 +45,14 @@ const espressifSram = (bytes: number, chip: string): BoardSize => ({
   scope: 'chip'
 })
 
+/** An RP2040/RP2350's on-die SRAM. The flash beside it is always `board` scope:
+ *  these chips have none of their own, so every byte is the module's. */
+const rpSram = (bytes: number, chip: string): BoardSize => ({
+  bytes,
+  source: `Raspberry Pi ${chip} datasheet`,
+  scope: 'chip'
+})
+
 /** One board Snakie knows about and upstream does not. */
 export interface OverlayBoard {
   /** Upstream's id if it ever adds this board — so the step-aside can match. */
@@ -82,6 +90,26 @@ export interface OverlayBoard {
  * Snakie will act on, so the bar is a maker's own page open in front of me, not
  * a plausible-looking slug. The candidates that did not clear that bar are in
  * the issue rather than here.
+ *
+ * THE SECOND BATCH (#936) BROUGHT A HAZARD THE FIRST DID NOT. The Adafruit ESP32
+ * entries above borrow a generic build because there is a right one to borrow.
+ * Most of what follows is RP2040/RP2350, where a generic Pico build runs on
+ * nearly every board — and running is not the same as being right. "It booted,
+ * so it was the correct firmware" is exactly the reasoning that cost a week on
+ * the Feather V2.
+ *
+ * So a donor is offered only where the MAKER'S OWN PAGE says the board is
+ * spec-identical to the donor — Cytron's does, and is the only one here that
+ * does. Where the maker publishes its own build, the entry says so and points
+ * there, the way the micro:bit v2 entry does. `PIMORONI_PICOLIPO2` is the case
+ * that settles it: an RP2350B with 16 MB of flash and 8 MB of PSRAM, against a
+ * Pico 2 build that is an RP2350A with 4 MB and none. It would boot, and leave
+ * most of the board switched off.
+ *
+ * One more rule, quieter but easy to break: `features` feed the gallery's filter
+ * facets. `USB C` where upstream writes `USB-C` fails nothing and silently
+ * splits one facet in two, so the tests hold every string here to upstream's own
+ * vocabulary.
  */
 export const OVERLAY_BOARDS: OverlayBoard[] = [
   {
@@ -106,6 +134,42 @@ export const OVERLAY_BOARDS: OverlayBoard[] = [
       'initialised by the SPIRAM variant of the generic ESP32 build, so that is the one ' +
       'to flash — the plain build runs and leaves the PSRAM switched off.',
     profileId: 'adafruit-feather-esp32-v2'
+  },
+  {
+    // Adafruit 5323 — the 8 MB / NO PSRAM one. Adafruit sells three ESP32-S3
+    // Feathers and they do not take the same build; this entry is only the one
+    // whose page says "8MB Flash No PSRAM".
+    id: 'ADAFRUIT_FEATHER_ESP32S3',
+    vendor: 'Adafruit',
+    product: 'Feather ESP32-S3 (8 MB, no PSRAM)',
+    port: 'esp32',
+    mcu: 'esp32s3',
+    features: [
+      'BLE',
+      'WiFi',
+      'External Flash',
+      'USB-C',
+      'Feather',
+      'JST-SH',
+      'RGB LED',
+      'Battery Charging',
+      'Dual-core'
+    ],
+    url: 'https://www.adafruit.com/product/5323',
+    flashOffset: '0x0',
+    flash: { bytes: 8 * MiB, source: 'adafruit.com/product/5323', scope: 'board' },
+    ram: espressifSram(512 * KiB, 'ESP32-S3'),
+    // Stated absent on the product page, not merely unlisted — which is what
+    // decides the build below.
+    psram: null,
+    circuitPythonBoardId: 'adafruit_feather_esp32s3_nopsram',
+    donorBoardId: 'ESP32_GENERIC_S3',
+    donorBuild: 'ESP32_GENERIC_S3',
+    why:
+      'MicroPython publishes no build under this board’s name. This model has no PSRAM, so ' +
+      'the STANDARD generic ESP32-S3 build is the right one — the SPIRAM_OCT variant would ' +
+      'print a PSRAM initialisation error at every boot. The 4 MB / 2 MB PSRAM Feather is a ' +
+      'different board and takes a different build.'
   },
   {
     id: 'ADAFRUIT_HUZZAH32_FEATHER',
@@ -191,6 +255,179 @@ export const OVERLAY_BOARDS: OverlayBoard[] = [
       'MicroPython for the micro:bit v2 is published by the micro:bit Foundation, not by ' +
       'micropython.org, so there is no build here to flash. Get it from python.microbit.org.',
     profileId: 'microbit-v2'
+  },
+  {
+    // Cytron's own page states the board is spec-identical to a Pico — same
+    // RP2040, same 264 KB, same 2 MB — and that MicroPython for the Pico/RP2040
+    // is a supported way to use it. That is a maker's endorsement of the generic
+    // build, which is the bar for offering one here.
+    id: 'CYTRON_MAKER_PI_RP2040',
+    vendor: 'Cytron',
+    product: 'Maker Pi RP2040',
+    port: 'rp2',
+    mcu: 'rp2040',
+    features: ['External Flash', 'RGB LED', 'Dual-core', 'Battery Charging'],
+    url: 'https://www.cytron.io/p-maker-pi-rp2040-simplifying-robotics-with-raspberry-pi-rp2040',
+    // An RP2 board is flashed by dragging a .uf2 onto its bootloader drive, so
+    // there is no esptool offset to write at.
+    flashOffset: null,
+    flash: { bytes: 2 * MiB, source: 'cytron.io Maker Pi RP2040 specifications', scope: 'board' },
+    ram: rpSram(264 * KiB, 'RP2040'),
+    psram: null,
+    circuitPythonBoardId: 'cytron_maker_pi_rp2040',
+    donorBoardId: 'RPI_PICO',
+    donorBuild: 'RPI_PICO',
+    why:
+      'MicroPython publishes no build under this board’s name. Cytron states it carries the ' +
+      'same RP2040, the same 264 KB of RAM and the same 2 MB of flash as a Pico, so the Pico ' +
+      'build is the one to flash. The board ships with CircuitPython on it, so flashing ' +
+      'MicroPython replaces what is already there.'
+  },
+  {
+    // Pimoroni publishes a MicroPython build for each of the four boards below,
+    // with that board's own library baked in — `servo`, `motor`, `picographics`.
+    // Their pages send you there, so that is what these entries say, and none of
+    // them borrows a Pico build: a Servo 2040 running stock MicroPython is a
+    // board with no `servo` module, which is the entire reason someone bought it.
+    id: 'PIMORONI_TINY2350',
+    vendor: 'Pimoroni',
+    product: 'Tiny 2350',
+    port: 'rp2',
+    mcu: 'rp2350',
+    features: ['External Flash', 'USB-C', 'RGB LED', 'Dual-core', 'JST-SH'],
+    url: 'https://shop.pimoroni.com/products/tiny-2350',
+    flashOffset: null,
+    flash: { bytes: 4 * MiB, source: 'shop.pimoroni.com/products/tiny-2350', scope: 'board' },
+    ram: rpSram(520 * KiB, 'RP2350'),
+    psram: null,
+    circuitPythonBoardId: 'pimoroni_tiny2350',
+    donorBoardId: null,
+    donorBuild: null,
+    why:
+      'MicroPython publishes no build under this board’s name. Pimoroni publishes its own, ' +
+      'with the board’s RGB LED and Qw/ST libraries included — get it from ' +
+      'github.com/pimoroni/pimoroni-pico/releases.'
+  },
+  {
+    id: 'PIMORONI_SERVO2040',
+    vendor: 'Pimoroni',
+    product: 'Servo 2040',
+    port: 'rp2',
+    mcu: 'rp2040',
+    features: ['External Flash', 'USB-C', 'RGB LED', 'Dual-core', 'JST-SH'],
+    url: 'https://shop.pimoroni.com/products/servo-2040',
+    flashOffset: null,
+    flash: { bytes: 2 * MiB, source: 'shop.pimoroni.com/products/servo-2040', scope: 'board' },
+    ram: rpSram(264 * KiB, 'RP2040'),
+    psram: null,
+    circuitPythonBoardId: 'pimoroni_servo2040',
+    donorBoardId: null,
+    donorBuild: null,
+    why:
+      'MicroPython publishes no build under this board’s name. Pimoroni publishes its own, ' +
+      'and it is the one that carries the `servo` module this board exists to run — get it ' +
+      'from github.com/pimoroni/pimoroni-pico/releases.'
+  },
+  {
+    id: 'PIMORONI_MOTOR2040',
+    vendor: 'Pimoroni',
+    product: 'Motor 2040',
+    port: 'rp2',
+    mcu: 'rp2040',
+    features: ['External Flash', 'USB-C', 'RGB LED', 'Dual-core', 'JST-SH'],
+    url: 'https://shop.pimoroni.com/products/motor-2040',
+    flashOffset: null,
+    flash: { bytes: 2 * MiB, source: 'shop.pimoroni.com/products/motor-2040', scope: 'board' },
+    ram: rpSram(264 * KiB, 'RP2040'),
+    psram: null,
+    circuitPythonBoardId: 'pimoroni_motor2040',
+    donorBoardId: null,
+    donorBuild: null,
+    why:
+      'MicroPython publishes no build under this board’s name. Pimoroni publishes its own, ' +
+      'and it is the one that carries the `motor` and encoder modules this board exists to ' +
+      'run — get it from github.com/pimoroni/pimoroni-pico/releases.'
+  },
+  {
+    // The PSRAM board, and the reason none of the RP2350 entries borrows a Pico
+    // 2 build: this is an RP2350B with 16 MB of flash and 8 MB of PSRAM, and the
+    // Pico 2 build is an RP2350A with 4 MB and no PSRAM support. Flashing it
+    // would run, and quietly leave 12 MB of flash and all 8 MB of PSRAM switched
+    // off — which is, exactly, the Feather V2 story this file was opened for.
+    id: 'PIMORONI_PICOLIPO2',
+    vendor: 'Pimoroni',
+    product: 'Pico LiPo 2',
+    port: 'rp2',
+    mcu: 'rp2350',
+    features: [
+      'External Flash',
+      'External RAM',
+      'USB-C',
+      'Battery Charging',
+      'Dual-core',
+      'JST-SH'
+    ],
+    url: 'https://shop.pimoroni.com/en-us/products/pimoroni-pico-lipo-2',
+    flashOffset: null,
+    flash: {
+      bytes: 16 * MiB,
+      source: 'shop.pimoroni.com/products/pimoroni-pico-lipo-2',
+      scope: 'board'
+    },
+    ram: rpSram(520 * KiB, 'RP2350'),
+    psram: {
+      bytes: 8 * MiB,
+      source: 'shop.pimoroni.com/products/pimoroni-pico-lipo-2',
+      scope: 'board'
+    },
+    // circuitpython.org lists the original Pico LiPo (4 MB and 16 MB RP2040
+    // builds) and no Pico LiPo 2 at all — checked, not inferred from the slug.
+    circuitPythonBoardId: null,
+    donorBoardId: null,
+    donorBuild: null,
+    why:
+      'MicroPython publishes no build under this board’s name, and no upstream build fits it: ' +
+      'this is an RP2350B with 16 MB of flash and 8 MB of PSRAM, where the Pico 2 build is an ' +
+      'RP2350A with 4 MB and no PSRAM. Flashing that would run and leave most of the board ' +
+      'switched off. Pimoroni’s own build is at github.com/pimoroni/pico-lipo.'
+  },
+  {
+    id: 'PIMORONI_PICOLIPO2_XL_W',
+    vendor: 'Pimoroni',
+    product: 'Pico LiPo 2 XL W',
+    port: 'rp2',
+    mcu: 'rp2350',
+    features: [
+      'External Flash',
+      'External RAM',
+      'USB-C',
+      'Battery Charging',
+      'Dual-core',
+      'JST-SH',
+      'WiFi',
+      'BLE'
+    ],
+    url: 'https://shop.pimoroni.com/en-us/products/pimoroni-pico-lipo-2-xl-w',
+    flashOffset: null,
+    flash: {
+      bytes: 16 * MiB,
+      source: 'shop.pimoroni.com/products/pimoroni-pico-lipo-2-xl-w',
+      scope: 'board'
+    },
+    ram: rpSram(520 * KiB, 'RP2350'),
+    psram: {
+      bytes: 8 * MiB,
+      source: 'shop.pimoroni.com/products/pimoroni-pico-lipo-2-xl-w',
+      scope: 'board'
+    },
+    circuitPythonBoardId: null,
+    donorBoardId: null,
+    donorBuild: null,
+    why:
+      'MicroPython publishes no build under this board’s name, and no upstream build fits it: ' +
+      'an RP2350B with 16 MB of flash, 8 MB of PSRAM and a Raspberry Pi RM2 radio, none of ' +
+      'which the Pico 2 build knows about. Pimoroni’s own build is at ' +
+      'github.com/pimoroni/pico-lipo.'
   }
 ]
 
@@ -203,12 +440,8 @@ export const OVERLAY_BOARDS: OverlayBoard[] = [
  * the plain build, which is the original bug.
  */
 function toIndexedBoard(entry: OverlayBoard, upstream: readonly IndexedBoard[]): IndexedBoard {
-  const donor = entry.donorBoardId
-    ? upstream.find((b) => b.id === entry.donorBoardId)
-    : undefined
-  const borrowed = donor
-    ? newestBuilds(donor).filter((b) => b.build === entry.donorBuild)
-    : []
+  const donor = entry.donorBoardId ? upstream.find((b) => b.id === entry.donorBoardId) : undefined
+  const borrowed = donor ? newestBuilds(donor).filter((b) => b.build === entry.donorBuild) : []
   const runtimes: IndexedBoard['runtimes'] = []
   if (borrowed.length > 0) runtimes.push('micropython')
   if (entry.circuitPythonBoardId) runtimes.push('circuitpython')

--- a/src/shared/board-part-link.ts
+++ b/src/shared/board-part-link.ts
@@ -59,6 +59,12 @@ export const BOARD_PART_LINKS: readonly BoardPartLink[] = [
     why: 'The overlay board from #902 and the part are the same Feather V2 — the board upstream builds nothing for.'
   },
   {
+    boardId: 'ADAFRUIT_FEATHER_ESP32S3',
+    libraryId: STD,
+    partId: 'adafruit-feather-esp32s3',
+    why: 'Adafruit product 5323 on both sides — the 8 MB / no-PSRAM Feather, not the 4 MB / 2 MB one.'
+  },
+  {
     boardId: 'ADAFRUIT_FEATHER_RP2040',
     libraryId: STD,
     partId: 'adafruit-feather-rp2040',
@@ -87,6 +93,42 @@ export const BOARD_PART_LINKS: readonly BoardPartLink[] = [
     libraryId: STD,
     partId: 'arduino-nano-esp32',
     why: 'Arduino ABX00083; ESP32-S3 on both sides. The part carries a back photo.'
+  },
+  {
+    boardId: 'CYTRON_MAKER_PI_RP2040',
+    libraryId: STD,
+    partId: 'cytron-maker-pi-rp2040',
+    why: 'Cytron MAKER-PI-RP2040 on both sides. The part carries a 3-D model.'
+  },
+  {
+    boardId: 'PIMORONI_MOTOR2040',
+    libraryId: STD,
+    partId: 'motor2040',
+    why: 'Pimoroni PIM618; RP2040 on both sides.'
+  },
+  {
+    boardId: 'PIMORONI_PICOLIPO2',
+    libraryId: STD,
+    partId: 'pimoroni-pico-lipo-2',
+    why: 'Pimoroni PIM775; RP2350B on both sides. NOT upstream’s `PIMORONI_PICOLIPO`, which is the RP2040 original.'
+  },
+  {
+    boardId: 'PIMORONI_PICOLIPO2_XL_W',
+    libraryId: STD,
+    partId: 'pimoroni-pico-lipo-2-xl-w',
+    why: 'Pimoroni PIM776; RP2350B with the RM2 radio on both sides — a different board from the plain Pico LiPo 2.'
+  },
+  {
+    boardId: 'PIMORONI_SERVO2040',
+    libraryId: STD,
+    partId: 'servo2040',
+    why: 'Pimoroni PIM613; RP2040 on both sides.'
+  },
+  {
+    boardId: 'PIMORONI_TINY2350',
+    libraryId: STD,
+    partId: 'tiny2350',
+    why: 'Pimoroni PIM721; RP2350A on both sides. NOT upstream’s `PIMORONI_TINY2040`, which is the RP2040 board.'
   },
   {
     boardId: 'RPI_PICO',

--- a/test/boardOverlay.test.ts
+++ b/test/boardOverlay.test.ts
@@ -287,3 +287,94 @@ describe('what a board’s details say about its sizes', () => {
     expect(facts.map((f) => f.label)).not.toContain('External flash')
   })
 })
+
+/**
+ * The second batch (#936) — the boards upstream builds nothing for, beyond the
+ * Adafruit ESP32 family that #902 curated first.
+ *
+ * These are mostly RP2040/RP2350 boards, and they bring a hazard the first batch
+ * did not have: a generic Pico build RUNS on nearly all of them. Running is not
+ * the same as being right, and "it booted, so it was the correct firmware" is
+ * precisely the reasoning that cost a week on the Feather V2.
+ */
+describe('the RP2 boards upstream does not build for', () => {
+  const all = withOverlay(seed.boards)
+  const find = (id: string): IndexedBoard => all.find((b) => b.id === id)!
+
+  it('does not hand a Pico 2 build to a board with PSRAM', () => {
+    // The Feather V2 story, one chip family across. A Pico LiPo 2 is an RP2350B
+    // with 16 MB of flash and 8 MB of PSRAM; the Pico 2 build is an RP2350A with
+    // 4 MB and no PSRAM. It would boot, and leave most of the board switched off.
+    const lipo = find('PIMORONI_PICOLIPO2')
+    expect(lipo.substitute?.boardId).toBeNull()
+    expect(lipo.builds).toEqual([])
+    expect(lipo.psram?.bytes).toBe(8 * 1024 * 1024)
+    expect(lipo.substitute?.why).toMatch(/RP2350B/)
+  })
+
+  it('says where the firmware actually is, when it is not here', () => {
+    // A board with no build must still leave the reader somewhere to go, or the
+    // entry is just a dead end with a photograph.
+    for (const id of [
+      'PIMORONI_TINY2350',
+      'PIMORONI_SERVO2040',
+      'PIMORONI_MOTOR2040',
+      'PIMORONI_PICOLIPO2',
+      'PIMORONI_PICOLIPO2_XL_W'
+    ]) {
+      const b = find(id)
+      expect(b.builds, id).toEqual([])
+      expect(b.substitute?.why, id).toMatch(/github\.com\/pimoroni/)
+    }
+  })
+
+  it('borrows a Pico build only where the maker says the board IS a Pico', () => {
+    // Cytron's own page states the same RP2040, RAM and flash as a Pico. That is
+    // the endorsement; without one, an entry gets no donor.
+    const cytron = find('CYTRON_MAKER_PI_RP2040')
+    expect(cytron.substitute?.build).toBe('RPI_PICO')
+    expect(cytron.builds.length).toBeGreaterThan(0)
+  })
+
+  it('writes no esptool offset for a board that is flashed by drag-and-drop', () => {
+    // An RP2 board takes a .uf2 onto its bootloader drive. An offset here would
+    // be a number the flasher could act on for a board that has no such step.
+    for (const id of [
+      'PIMORONI_TINY2350',
+      'PIMORONI_SERVO2040',
+      'PIMORONI_MOTOR2040',
+      'PIMORONI_PICOLIPO2',
+      'PIMORONI_PICOLIPO2_XL_W',
+      'CYTRON_MAKER_PI_RP2040'
+    ]) {
+      expect(find(id).flashOffset, id).toBeNull()
+    }
+  })
+
+  it('keeps the ESP32-S3 Feather off the PSRAM build it has no PSRAM for', () => {
+    // Adafruit sells three ESP32-S3 Feathers and they do not take the same
+    // build. This entry is the 8 MB / no-PSRAM one, so the SPIRAM_OCT variant
+    // would print an initialisation error at every boot.
+    const f = find('ADAFRUIT_FEATHER_ESP32S3')
+    expect(f.substitute?.build).toBe('ESP32_GENERIC_S3')
+    expect(f.psram).toBeNull()
+    expect(f.builds.every((b) => !b.build.includes('SPIRAM'))).toBe(true)
+  })
+})
+
+describe('an overlay entry does not invent a filter chip', () => {
+  /**
+   * The facets are built from these strings. A near-miss — `USB C`, `Dual Core`,
+   * `RGB Led` — does not fail anything; it quietly splits one filter into two,
+   * which is #928 by another route. So every feature an overlay states must be
+   * one upstream already uses.
+   */
+  it('uses only feature names upstream already publishes', () => {
+    const known = new Set(seed.boards.flatMap((b) => [...b.features, ...b.notes]))
+    for (const e of OVERLAY_BOARDS) {
+      for (const f of e.features) {
+        expect(known.has(f), `${e.id} states a feature upstream never uses: ${f}`).toBe(true)
+      }
+    }
+  })
+})

--- a/test/boardPartLink.test.ts
+++ b/test/boardPartLink.test.ts
@@ -80,11 +80,22 @@ describe('a link is the SAME board, not a near relative', () => {
   )
 
   it('refuses the pairing that started this', () => {
-    // Pimoroni's Pico LiPo 2 is RP2350; upstream's Pico LiPo is RP2040. Name
-    // matching put them together, so the table must not.
+    // Pimoroni's Pico LiPo 2 is RP2350B; upstream's `PIMORONI_PICOLIPO` is the
+    // RP2040 original. Name matching put them together, so the table must not —
+    // and now that the Pico LiPo 2 HAS a board of its own (the overlay entry),
+    // the check is sharper than "linked to nothing": it is linked to the right
+    // one, and upstream's RP2040 board is still linked to no part at all.
     expect(partLinkForBoard('PIMORONI_PICOLIPO')).toBeNull()
-    expect(boardLinkForPart('snakie-standard', 'pimoroni-pico-lipo-2')).toBeNull()
+    expect(boardLinkForPart('snakie-standard', 'pimoroni-pico-lipo-2')?.boardId).toBe(
+      'PIMORONI_PICOLIPO2'
+    )
     expect(chipsAgree('RP2350', 'rp2040')).toBe(false)
+  })
+
+  it('keeps the Tiny 2350 off upstream’s Tiny2040, for the same reason', () => {
+    // Two Pimoroni boards one digit apart, RP2350A against RP2040.
+    expect(partLinkForBoard('PIMORONI_TINY2040')).toBeNull()
+    expect(boardLinkForPart('snakie-standard', 'tiny2350')?.boardId).toBe('PIMORONI_TINY2350')
   })
 
   it('keeps the wireless and non-wireless Picos apart', () => {


### PR DESCRIPTION
Closes #936. Finishes the half of #902 that was deliberately deferred.

## What's new

Pimoroni **Tiny 2350**, **Servo 2040**, **Motor 2040**, **Pico LiPo 2**, **Pico LiPo 2 XL W**; Cytron **Maker Pi RP2040**; Adafruit **Feather ESP32-S3** (8MB / no PSRAM).

These are the boards the other half of #934's parts had nowhere to link to — not because the link was missing, but because the board wasn't in the catalogue at all. All seven now link to their parts, so each opens with its own pinout, and the **Maker Pi RP2040 brings the first 3-D model to a board in the finder**.

Every size names the page it was read from. Every CircuitPython id was checked against circuitpython.org rather than inferred from the slug — which is how the Pico LiPo 2 ends up with **none**: the catalogue lists `pimoroni_picolipo_4mb` and `_16mb`, both the RP2040 original, and no Pico LiPo 2 at all.

## The hazard this batch has and the first didn't

The Adafruit ESP32 entries in #902 borrow a generic build because there *is* a right one to borrow. These are mostly RP2 boards, where **a generic Pico build runs on nearly all of them** — and running is not the same as being right. "It booted, so it was the correct firmware" is precisely the reasoning that cost a week on the Feather V2.

So a donor build is offered **only where the maker's own page says the board is spec-identical to the donor**. Cytron's states the same RP2040, the same 264KB and the same 2MB as a Pico — and it's the only one here that does. Where the maker publishes its own build, the entry says so and points there, exactly as the micro:bit v2 entry already did.

**`PIMORONI_PICOLIPO2` is the case that settles it.** An RP2350**B** with 16MB flash and 8MB PSRAM, against a Pico 2 build that's an RP2350**A** with 4MB and none. It would boot, and quietly leave most of the board switched off — the Feather V2 story one chip family across. No donor, and a card that says why.

I mutation-checked that: handing it the Pico 2 build fails two tests.

## One quieter guard

Overlay `features` feed the gallery's filter facets. `USB C` where upstream writes `USB-C` fails nothing and silently splits one facet into two — #928 by another route. Every overlay feature string is now held to upstream's vocabulary, and that test bites on exactly that near-miss.

## Sources

Each spec came from the maker's page, not from memory:

- [Tiny 2350](https://shop.pimoroni.com/products/tiny-2350) — 4MB, 520KB, RP2350A
- [Servo 2040](https://shop.pimoroni.com/products/servo-2040) · [Motor 2040](https://shop.pimoroni.com/products/motor-2040) — 2MB, 264KB, RP2040
- [Pico LiPo 2](https://shop.pimoroni.com/en-us/products/pimoroni-pico-lipo-2) · [XL W](https://shop.pimoroni.com/en-us/products/pimoroni-pico-lipo-2-xl-w) — 16MB, 8MB PSRAM, RP2350B
- [Maker Pi RP2040](https://www.cytron.io/p-maker-pi-rp2040-simplifying-robotics-with-raspberry-pi-rp2040) — "exact same specifications as Raspberry Pi Pico"
- [Feather ESP32-S3 5323](https://www.adafruit.com/product/5323) — 8MB, no PSRAM, 512KB SRAM
- CircuitPython ids verified at circuitpython.org/board/&lt;id&gt;/

## Gates

lint (pre-existing `DriverInstallBanner.tsx` warning only) · typecheck · **6,523 tests** · build — green.

**Not verified on screen** — these are data entries; how their cards look is the finder's existing rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe