### PR TITLE
The hover preview is twice as wide, so the photo is worth looking at (#938)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **The hover preview is twice as wide, so the photo is worth looking at**
+  (#938). The Board Finder's preview grew a card into a slightly bigger card,
+  and the picture — the fastest way to recognise a board — stayed small. It is
+  now 2x the width, centred on the cell it grew from, and the photo roughly
+  doubles with it.
+
+  The image box keeps its 4/3 ratio rather than just getting wider, and that is
+  the part that matters: every bundled thumbnail is 320px wide with a median
+  aspect of 1.20, so in a 4/3 box most of them are already *height*-constrained
+  and have width going spare. Widening the box alone would have shown no more
+  image at all. `object-fit: contain` keeps each photo's own ratio whatever the
+  box does.
+
+  Two things had to move with it. The first and last columns have nowhere to put
+  half a card, so they anchor to their own edge and grow inward — measured
+  against the gallery's scroller, which is the box the preview must not hang out
+  of, rather than the window, which knows nothing about the panel's margin. And
+  the estimate that decides whether the bottom row grows *upward* had to grow
+  too: left where it was, a taller preview would have flipped a row too late and
+  opened into the scroller's bottom edge.
+
 ### Added
 
 - **Seven more boards MicroPython builds nothing for** (#936, epic #884). #902

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snakie",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "snakie",
-      "version": "0.48.0",
+      "version": "0.48.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snakie",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "description": "A modern, cross-platform MicroPython editor.",
   "productName": "Snakie",
   "main": "./out/main/index.js",

--- a/src/renderer/src/components/BoardFinder.css
+++ b/src/renderer/src/components/BoardFinder.css
@@ -636,8 +636,19 @@
   --bf-peek-proud: 10px;
   --bf-peek-off: calc(var(--bf-cell-pad) - var(--bf-peek-proud));
   position: absolute;
-  left: var(--bf-peek-off);
-  right: var(--bf-peek-off);
+  /* TWICE the card's width (#938), centred on the cell.
+     It used to span the cell (`left`/`right` at `--bf-peek-off`), which is
+     `100% - 2*pad + 2*proud`. Twice that is the width below, and half of it is
+     the margin that pulls the card back over its own cell.
+     Percentages resolve against the CELL, which is the containing block, so the
+     card stays exactly 2x whatever the grid's `1fr` columns work out to.
+     The offset is a negative MARGIN rather than a translate on purpose:
+     `transform` belongs to the open animation, and sharing it would mean
+     restating the centring inside the keyframes and in every variant below. */
+  width: calc(200% - 4 * var(--bf-cell-pad) + 4 * var(--bf-peek-proud));
+  left: 50%;
+  margin-left: calc(-100% + 2 * var(--bf-cell-pad) - 2 * var(--bf-peek-proud));
+  right: auto;
   top: var(--bf-peek-off);
   display: flex;
   flex-direction: column;
@@ -650,6 +661,19 @@
   animation: bfind-peek 0.16s ease-out both;
   cursor: pointer;
 }
+/* The first and last columns have nowhere to put half a card, so they grow
+   INWARD from their own edge rather than centring (#938). Same width; only the
+   anchor changes, so a preview never hangs outside the panel. */
+.bfind__peek.is-wide-left {
+  left: var(--bf-peek-off);
+  margin-left: 0;
+}
+.bfind__peek.is-wide-right {
+  left: auto;
+  right: var(--bf-peek-off);
+  margin-left: 0;
+}
+
 /* The bottom row grows UP instead, or it would open into the scroller's edge. */
 .bfind__peek.is-up {
   top: auto;
@@ -672,6 +696,12 @@
   }
 }
 
+/* The ratio is deliberately UNCHANGED at twice the width (#938), so the box
+   grows in both directions and the photo roughly doubles.
+   Widening it alone would have shown no more image at all: every bundled
+   thumbnail is 320px wide with a median aspect of 1.20, so in a 4/3 box most of
+   them are HEIGHT-constrained already and have width to spare. `contain` keeps
+   the photo's own ratio, whatever the box does. */
 .bfind__peek-img {
   aspect-ratio: 4 / 3;
   display: grid;

--- a/src/renderer/src/components/BoardFinder.tsx
+++ b/src/renderer/src/components/BoardFinder.tsx
@@ -34,6 +34,7 @@ import {
   buildLabel,
   chipSilkscreen,
   firmwareSummary,
+  peekSide,
   isFiltering,
   memoryThresholdLabel,
   noPhotoLabel,
@@ -500,8 +501,13 @@ const PEEK_FEATURE_LIMIT = 6
 const PEEK_DELAY_MS = 400
 
 /** Roughly how far the preview grows past the card. Only the flip decision reads
- *  it, and only to choose a direction, so an estimate is the right precision. */
-const PEEK_OVERHANG_PX = 180
+ *  it, and only to choose a direction, so an estimate is the right precision.
+ *
+ *  It grew with the card (#938): at twice the width the image box is twice as
+ *  tall too, which is most of what hangs below the cell. An estimate that had
+ *  not moved would flip a row too late and open the preview into the scroller's
+ *  bottom edge. */
+const PEEK_OVERHANG_PX = 320
 
 /**
  * One board in the grid, and its hover preview (#919).
@@ -539,6 +545,10 @@ function BoardCell({
   // Grow UPWARD when there is no room below inside the scroller: the bottom row
   // is otherwise a preview clipped to the two lines that were already visible.
   const [up, setUp] = useState(false)
+  // And which way the extra WIDTH goes (#938) — centred on the cell unless the
+  // cell is in the first or last column, where half a card would hang outside
+  // the panel.
+  const [side, setSide] = useState<'centre' | 'left' | 'right'>('centre')
   const cell = useRef<HTMLDivElement>(null)
   const timer = useRef<number | null>(null)
 
@@ -560,8 +570,15 @@ function BoardCell({
     const el = cell.current
     const scroller = el?.closest('.bfind__gallery')
     if (el && scroller) {
-      const room = scroller.getBoundingClientRect().bottom - el.getBoundingClientRect().bottom
-      setUp(room < PEEK_OVERHANG_PX)
+      const cellBox = el.getBoundingClientRect()
+      const view = scroller.getBoundingClientRect()
+      setUp(view.bottom - cellBox.bottom < PEEK_OVERHANG_PX)
+      // Which way the extra width goes (#938). Centred is the default and the
+      // one that looks deliberate; the columns at either end of the grid have
+      // nowhere to put half a card, so they grow inward from their own edge
+      // instead. Measured against the SCROLLER rather than the window, because
+      // that is the box the preview must not hang out of.
+      setSide(peekSide(cellBox, view))
     }
     setPeeking(true)
   }, [])
@@ -595,7 +612,7 @@ function BoardCell({
       }}
     >
       <BoardCard board={board} onOpen={openDetails} />
-      {peeking && <BoardPeek board={board} up={up} onOpen={openDetails} />}
+      {peeking && <BoardPeek board={board} up={up} side={side} onOpen={openDetails} />}
     </div>
   )
 }
@@ -609,10 +626,13 @@ function BoardCell({
 function BoardPeek({
   board,
   up,
+  side,
   onOpen
 }: {
   board: IndexedBoard
   up: boolean
+  /** Which way the extra width goes (#938) — see {@link BoardCell}. */
+  side: 'centre' | 'left' | 'right'
   onOpen: () => void
 }): JSX.Element {
   const src = thumbUrl(board.thumb)
@@ -620,7 +640,9 @@ function BoardPeek({
   const extra = board.features.length - PEEK_FEATURE_LIMIT
   return (
     <div
-      className={`bfind__peek${up ? ' is-up' : ''}`}
+      className={`bfind__peek${up ? ' is-up' : ''}${
+        side === 'centre' ? '' : side === 'left' ? ' is-wide-left' : ' is-wide-right'
+      }`}
       role="group"
       aria-label={`More about ${board.vendor} ${board.product}`}
       // The preview covers the card it grew out of, so it has to accept the

--- a/src/renderer/src/components/board-finder.ts
+++ b/src/renderer/src/components/board-finder.ts
@@ -520,9 +520,7 @@ export function unsizedNotice(count: number): string | null {
 
 /** Add or remove one feature, so the chips toggle rather than only accumulate. */
 export function toggleFeature(features: readonly string[], feature: string): string[] {
-  return features.includes(feature)
-    ? features.filter((f) => f !== feature)
-    : [...features, feature]
+  return features.includes(feature) ? features.filter((f) => f !== feature) : [...features, feature]
 }
 
 /** Same toggle, typed for the runtime chips. */
@@ -530,9 +528,7 @@ export function toggleRuntime(
   runtimes: readonly FirmwareRuntime[],
   runtime: FirmwareRuntime
 ): FirmwareRuntime[] {
-  return runtimes.includes(runtime)
-    ? runtimes.filter((r) => r !== runtime)
-    : [...runtimes, runtime]
+  return runtimes.includes(runtime) ? runtimes.filter((r) => r !== runtime) : [...runtimes, runtime]
 }
 
 // ---------------------------------------------------------------------------
@@ -601,3 +597,36 @@ export const RUNTIME_CAVEAT =
   'This is MicroPython’s catalogue, so CircuitPython-only boards are not in it. ' +
   'CircuitPython is marked only where the board id was confirmed — the rest are ' +
   'unconfirmed, not unsupported.'
+
+// --- where the hover preview grows (#938) ------------------------------------
+
+/** The edges of a box, as `getBoundingClientRect` gives them. */
+export interface Span {
+  left: number
+  right: number
+}
+
+/** Which way the preview's extra width goes. */
+export type PeekSide = 'centre' | 'left' | 'right'
+
+/**
+ * Where to put a preview twice the width of the cell it grew from.
+ *
+ * Centred is the default and the one that reads as deliberate — the card grows
+ * evenly out of the thing you are pointing at. The first and last columns have
+ * nowhere to put half a card, so they anchor to their own edge and grow inward.
+ *
+ * Measured against the SCROLLER, not the window: the scroller is the box the
+ * preview must not hang out of, and the gallery has a margin around it that the
+ * window knows nothing about.
+ *
+ * Left wins a tie. A viewport too narrow to hold the doubled card at all is the
+ * only case where both tests pass, and pinning it to the left edge at least
+ * keeps the start of the card — including the photo — on screen.
+ */
+export function peekSide(cell: Span, view: Span): PeekSide {
+  const grow = (cell.right - cell.left) / 2
+  if (cell.left - grow < view.left) return 'left'
+  if (cell.right + grow > view.right) return 'right'
+  return 'centre'
+}

--- a/test/boardPeekWidth.test.ts
+++ b/test/boardPeekWidth.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { peekSide } from '../src/renderer/src/components/board-finder'
+
+/**
+ * The hover preview at twice the width (#938).
+ *
+ * The preview grew a card into a slightly bigger card, and the photo — the
+ * fastest way to recognise a board — stayed small. Doubling the width is the
+ * whole change; the two things that can go wrong are the arithmetic (a card
+ * that is not actually 2x, or is not centred on what you are pointing at) and
+ * the edges (half a card hanging outside the panel). Both are covered here.
+ */
+
+const css = readFileSync('src/renderer/src/components/BoardFinder.css', 'utf8')
+
+/**
+ * Evaluate one of the peek's `calc()` expressions in pixels.
+ *
+ * The real rule is CSS, so the test reads the CSS rather than restating the
+ * formula — a rule edited to something that is no longer 2x has to fail here,
+ * which a hard-coded expectation could not do.
+ */
+const evalCalc = (expr: string, cellW: number, pad: number, proud: number): number => {
+  const js = expr
+    .replace(/calc\(/g, '(')
+    .replace(/var\(--bf-cell-pad\)/g, String(pad))
+    .replace(/var\(--bf-peek-proud\)/g, String(proud))
+    .replace(/([\d.]+)px/g, '$1')
+    .replace(/([\d.]+)%/g, (_m, n) => String((Number(n) / 100) * cellW))
+  if (!/^[\d\s+\-*/().]+$/.test(js)) throw new Error(`unsafe calc: ${expr} → ${js}`)
+  return Function(`"use strict";return (${js})`)() as number
+}
+
+const ruleFor = (selector: string): string => {
+  const at = css.indexOf(`${selector} {`)
+  expect(at, `${selector} is missing`).toBeGreaterThan(-1)
+  return css.slice(at, css.indexOf('}', at))
+}
+
+const declaration = (rule: string, prop: string): string => {
+  const m = rule.match(new RegExp(`\\n\\s*${prop}:\\s*([^;]+);`))
+  expect(m, `no ${prop} in rule`).toBeTruthy()
+  return m![1].trim()
+}
+
+const PAD = 6
+const PROUD = 10
+/** The grid is `minmax(178px, 1fr)`, so a cell is never narrower than this and
+ *  is usually a little wider. Both ends are checked. */
+const CELL_WIDTHS = [178, 200, 240, 320]
+
+describe('the preview is twice the card', () => {
+  const rule = ruleFor('.bfind__peek')
+  const width = declaration(rule, 'width')
+  const marginLeft = declaration(rule, 'margin-left')
+
+  it.each(CELL_WIDTHS)('is exactly 2x the old width in a %ipx cell', (cellW) => {
+    // What it used to be: inset by `--bf-peek-off` on both sides, which is
+    // `pad - proud` each — so it stood `proud` beyond the cell on each side.
+    const before = cellW - 2 * (PAD - PROUD)
+    expect(evalCalc(width, cellW, PAD, PROUD)).toBeCloseTo(2 * before, 6)
+  })
+
+  it.each(CELL_WIDTHS)('stays centred on the cell it grew from (%ipx)', (cellW) => {
+    // `left: 50%` then pulled back by the margin. The card's centre must land on
+    // the cell's centre, or the preview drifts off the thing under the pointer.
+    const w = evalCalc(width, cellW, PAD, PROUD)
+    const left = cellW / 2 + evalCalc(marginLeft, cellW, PAD, PROUD)
+    expect(left + w / 2).toBeCloseTo(cellW / 2, 6)
+  })
+
+  it('leaves `transform` to the open animation', () => {
+    // The offset is a negative margin on purpose: `transform` carries the scale
+    // keyframes, and sharing it would mean restating the centring inside them
+    // and in both edge variants.
+    expect(rule).not.toMatch(/\n\s*transform:\s*translate/)
+    expect(css).toContain('@keyframes bfind-peek')
+  })
+
+  it('keeps the image box ratio, so the photo grows both ways', () => {
+    // Every bundled thumbnail is 320px wide with a median aspect of 1.20, so in
+    // a 4/3 box most are HEIGHT-constrained and have width to spare. Widening
+    // the box alone would have shown no more image at all.
+    expect(ruleFor('.bfind__peek-img')).toContain('aspect-ratio: 4 / 3')
+    expect(ruleFor('.bfind__peek-img img')).toContain('object-fit: contain')
+  })
+})
+
+describe('a doubled card still fits the panel', () => {
+  // A 200px cell in a 1000px-wide scroller.
+  const view = { left: 0, right: 1000 }
+  const cell = (left: number, w = 200): { left: number; right: number } => ({
+    left,
+    right: left + w
+  })
+
+  it('centres a card with room on both sides', () => {
+    expect(peekSide(cell(400), view)).toBe('centre')
+  })
+
+  it('grows inward from the first column', () => {
+    expect(peekSide(cell(0), view)).toBe('left')
+  })
+
+  it('grows inward from the last column', () => {
+    expect(peekSide(cell(800), view)).toBe('right')
+  })
+
+  it('measures against the scroller, not the window', () => {
+    // The gallery is inset by its panel's margin, so a cell flush against the
+    // window's edge is not flush against the scroller's.
+    const inset = { left: 100, right: 900 }
+    expect(peekSide(cell(100), inset)).toBe('left')
+    expect(peekSide(cell(120), inset)).toBe('left')
+    expect(peekSide(cell(400), inset)).toBe('centre')
+  })
+
+  it('holds at the exact boundary rather than one pixel past it', () => {
+    // A 200px cell needs 100px of room each side. At exactly 100 it fits.
+    expect(peekSide(cell(100), view)).toBe('centre')
+    expect(peekSide(cell(99), view)).toBe('left')
+    expect(peekSide(cell(700), view)).toBe('centre')
+    expect(peekSide(cell(701), view)).toBe('right')
+  })
+
+  it('keeps the photo on screen when nothing can fit', () => {
+    // A viewport too narrow for the doubled card at all: both tests pass, and
+    // anchoring left keeps the start of the card — the picture — visible.
+    expect(peekSide(cell(0, 300), { left: 0, right: 320 })).toBe('left')
+  })
+})
+
+describe('the flip estimate moved with the card', () => {
+  const tsx = readFileSync('src/renderer/src/components/BoardFinder.tsx', 'utf8')
+
+  it('allows for a preview that is now twice as tall in its image', () => {
+    // The estimate decides whether the bottom row grows up. Left at its old
+    // value it would flip a row too late and open into the scroller's edge.
+    const m = tsx.match(/const PEEK_OVERHANG_PX = (\d+)/)
+    expect(m).toBeTruthy()
+    expect(Number(m![1])).toBeGreaterThanOrEqual(300)
+  })
+})


### PR DESCRIPTION
Closes #938.

The Board Finder's preview grew a card into a slightly bigger card, and the picture — the fastest way to recognise a board — stayed small. It's now **2x the width**, centred on the cell it grew from, and the photo roughly doubles with it.

## Why the box keeps its 4/3 ratio

This is the part that decides whether the change does anything. Every bundled thumbnail is **320px wide with a median aspect of 1.20**, against an image box of `aspect-ratio: 4/3` — so most photos are already *height*-constrained and have width going spare.

**Widening the box alone would have shown no more image at all.** Keeping the ratio grows it in both directions, which is what actually doubles the picture. `object-fit: contain` keeps each photo's own ratio whatever the box does.

## The arithmetic is tested from the CSS, not restated

The test reads the `calc()` expressions out of the stylesheet and evaluates them at four cell widths, asserting the result is exactly 2x the old width and that the card's centre lands on the cell's centre. A rule edited to something that's no longer 2x has to fail — which a hard-coded expectation couldn't do.

Mutation-checked against two plausible wrong answers: a width that doubles the percentage but forgets the pad/proud terms, and the naive `margin-left: -50%`. Both fail it.

The offset is a negative **margin** rather than a translate on purpose — `transform` carries the open animation's scale keyframes, and sharing it would mean restating the centring inside them and in both edge variants.

## Two things had to move with it

**The edges.** The first and last columns have nowhere to put half a card, so they anchor to their own edge and grow inward. `peekSide` is pure, so the boundary cases are node tests — including that it measures against the **scroller**, not the window, since the gallery sits inside a panel with a margin the window knows nothing about.

**The flip estimate.** `PEEK_OVERHANG_PX` decides whether the bottom row grows upward. Left at 180, a preview twice as tall in its image would flip a row too late and open into the scroller's bottom edge. Now 320.

## Gates

lint (pre-existing `DriverInstallBanner.tsx` warning only) · typecheck · **6,540 tests in 314 files** · build — green.

**Not verified on screen.** The arithmetic and the edge logic are tested; how a doubled card feels in the grid is not something a node test can tell you.

One thing worth knowing: at 2x, a 320px thumbnail upscales by up to ~1.35x on wide cells, so photos may look slightly softer. Regenerating the thumbnails at a larger `THUMB_WIDTH` would fix that, but it's a full re-fetch of 217 images and a large data diff — worth doing separately if it bothers you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe