### PR TITLE
A File menu that does what a File menu does (#915)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,45 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **A File menu that does what a File menu does** (#915, epic #913). It was two
+  items — `Open Folder…` and Quit. It is now New File (⌘N), Open File… (⌘O),
+  Open Folder… (⇧⌘O), Open Recent ▸, Save (⌘S), Save As… (⇧⌘S) and Close Tab
+  (⌘W). Save, Save As and Close Tab grey out with nothing open, because a menu
+  that offers Save with nothing to save teaches people not to trust the rest of
+  it.
+
+  ⌘S is the one worth calling out. It already worked — but only inside the
+  editor, because the binding lived in Monaco. Anywhere else in the app, with the
+  Files tree or the shell or the board focused, it did nothing. As a menu
+  accelerator it works wherever you are.
+
+  Two accelerators moved, deliberately. **Open Folder is now ⇧⌘O**, because Open
+  File took the plain ⌘O that it means in every editor people arrive from. And on
+  macOS **Close Window is ⇧⌘W**, because Close Tab took the ⌘W that the window
+  role would otherwise own — the two now sit next to each other, named, so they
+  cannot be confused.
+
+  Open Recent is a list of folders with fixed slot ids: the labels change every
+  time you open something, the command ids do not, so the channel can still tell
+  a real command from a stale one. Close Tab goes through the tabs' own close,
+  which asks before discarding unsaved edits — a menu item that went round it
+  would discard your work while the × beside it asks.
+
+  The cheatsheet from #920 picked up all seven bindings with no edit, which is
+  the property it was built for.
+
+### Fixed
+
+- **Save As no longer leaves two tabs on one file** (#515). After Save As the
+  buffer keeps its `untitled:` id — deliberately, so the tab and its editor stay
+  mounted — while gaining a real path. Opening that same file from the Files tree
+  then matched no id and made a *second* tab for one file, whose saves silently
+  overwrote each other. Opening a file now matches an already-open one by path as
+  well as by id. It was a corner before; #915 put Save As on the menu with a
+  shortcut, which turns it into a normal Tuesday.
+
 ### Fixed
 
 - **The boards upstream has no photo of now have one on their card** (#942). The

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snakie",
-  "version": "0.48.3",
+  "version": "0.49.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "snakie",
-      "version": "0.48.3",
+      "version": "0.49.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snakie",
-  "version": "0.48.3",
+  "version": "0.49.0",
   "description": "A modern, cross-platform MicroPython editor.",
   "productName": "Snakie",
   "main": "./out/main/index.js",

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -23,9 +23,7 @@ const BoardPane = lazy(() => import('./BoardPane'))
 const RobotDockPanel = lazy(() => import('./RobotDockPanel'))
 // The Sprite editor overlay (launched from the Display instrument's SPRITES
 // key) — lazy so the canvas editor + codecs load only when opened.
-const SpriteEditor = lazy(() =>
-  import('./SpriteEditor').then((m) => ({ default: m.SpriteEditor }))
-)
+const SpriteEditor = lazy(() => import('./SpriteEditor').then((m) => ({ default: m.SpriteEditor })))
 import { MiniViewer } from './MiniViewer'
 import { useTheme } from '../hooks/useTheme'
 import { Toolbar } from './Toolbar'
@@ -53,6 +51,7 @@ import { runFindCommand } from './findController'
 import { ShellPanel } from './ShellPanel'
 import { RightPanel } from './RightPanel'
 import { runMenuCommand } from '../lib/menuCommands'
+import { readRecentFolders } from '../store/workspace'
 import { menuStateFrom } from '../../../shared/menu-commands'
 import { ShortcutSheet } from './ShortcutSheet'
 import { IS_WEB } from '../lib/env'
@@ -60,7 +59,7 @@ import { StatusBar } from './StatusBar'
 import { SettingsDialog, type SettingsTab } from './SettingsDialog'
 import { OPEN_SETTINGS_EVENT } from './settingsBus'
 import { OPEN_SPRITE_EDITOR_EVENT, type OpenSpriteEditorDetail } from './sprite-editor-bus'
-import { HELP_EVENT, type HelpEventDetail } from './editorBridge'
+import { dispatchCloseTab, HELP_EVENT, type HelpEventDetail } from './editorBridge'
 import { InstrumentLibBanner } from './InstrumentLibBanner'
 import { NoticeStack } from './Notice'
 import { PartsImportBanner } from './PartsImportBanner'
@@ -152,8 +151,8 @@ function LeftView({
     return (
       <LeftRegion title={title}>
         <p className="region__empty">
-          {title} needs a real filesystem and local processes (git / the Python
-          plugin host), so it&apos;s only available in the Snakie desktop app.
+          {title} needs a real filesystem and local processes (git / the Python plugin host), so
+          it&apos;s only available in the Snakie desktop app.
         </p>
       </LeftRegion>
     )
@@ -232,7 +231,18 @@ export function AppShell(): JSX.Element {
   // us stream every edit / theme change to that window over IPC so it updates
   // live. `boardOpened` tracks whether the window has been opened this session
   // (so we only stream while it's open); it resets when the user closes it.
-  const { openFiles, activeId, currentFolder, reloadContent, openFolder } = useWorkspace()
+  const {
+    openFiles,
+    activeId,
+    currentFolder,
+    reloadContent,
+    openFolder,
+    openFolderPath,
+    openFileDialog,
+    newFile,
+    saveFile,
+    saveFileAs
+  } = useWorkspace()
   const activeFile = openFiles.find((f) => f.id === activeId) ?? null
   const [boardOpened, setBoardOpened] = useState(false)
 
@@ -462,10 +472,7 @@ export function AppShell(): JSX.Element {
   // markers in the dock header AND the default-visible singletons below, so a
   // file using an OLED lights the I²C-display instrument without the user
   // hunting for it. Recomputed only when the source/python-ness changes.
-  const inUse = useMemo(
-    () => deriveInUse(boardSource, boardIsPython),
-    [boardSource, boardIsPython]
-  )
+  const inUse = useMemo(() => deriveInUse(boardSource, boardIsPython), [boardSource, boardIsPython])
 
   // SCOPE/METER start hidden (nothing is open until you summon one — so the dock
   // button isn't lit with no instrument behind it); both open paths (the dock
@@ -522,7 +529,10 @@ export function AppShell(): JSX.Element {
     (): void => setInstrumentsLive(!instrumentsLive),
     [instrumentsLive, setInstrumentsLive]
   )
-  const stopInstrumentsLive = useCallback((): void => setInstrumentsLive(false), [setInstrumentsLive])
+  const stopInstrumentsLive = useCallback(
+    (): void => setInstrumentsLive(false),
+    [setInstrumentsLive]
+  )
 
   const instruments = useInstruments({
     source: boardSource,
@@ -602,9 +612,27 @@ export function AppShell(): JSX.Element {
   // radio tick follows the switcher however the switch was made — the switcher
   // itself, the menu, or another window's `workspace.show` (#914/#916). The menu
   // is built in the main process; this is the only place that knows the answer.
+  // The recent folders behind File ▸ Open Recent (#915). In STATE so that
+  // publishing them to the menu re-runs when a folder opens, and in a ref so the
+  // menu subscription — set up once — reads the current list rather than the one
+  // that existed when it subscribed.
+  const [recentFolders, setRecentFolders] = useState<string[]>(() => readRecentFolders())
+  const recentFoldersRef = useRef(recentFolders)
+  recentFoldersRef.current = recentFolders
   useEffect(() => {
-    window.api.menu.setState(menuStateFrom({ workspace: layout.active }))
-  }, [layout.active])
+    setRecentFolders(readRecentFolders())
+  }, [currentFolder])
+
+  useEffect(() => {
+    window.api.menu.setState(
+      menuStateFrom({
+        workspace: layout.active,
+        // Save / Save As / Close Tab grey out with nothing open (#915).
+        hasActiveFile: activeId !== null,
+        recentFolders
+      })
+    )
+  }, [layout.active, activeId, recentFolders])
   useEffect(() => {
     const off = window.api.board.onClosed(() => {
       if (poppedFromBoardRef.current) {
@@ -763,9 +791,7 @@ export function AppShell(): JSX.Element {
               { path: INSTRUMENTS_LIB_PATH, contents: source },
               ...(rootShadow ? [{ path: INSTRUMENTS_ROOT_PATH, contents: source }] : []),
               ...(umbrella ? [{ path: SNAKIE_LIB_PATH, contents: umbrella }] : []),
-              ...(umbrella && rootShadow
-                ? [{ path: SNAKIE_ROOT_PATH, contents: umbrella }]
-                : [])
+              ...(umbrella && rootShadow ? [{ path: SNAKIE_ROOT_PATH, contents: umbrella }] : [])
             ]
             ctx.setSteps(writes.map((w) => installStepLabel(w.path)))
             await window.api.device.mkdir(INSTRUMENTS_LIB_DIR).catch(() => undefined)
@@ -944,9 +970,9 @@ export function AppShell(): JSX.Element {
     // module name the import mentions), so that nag — and its one-click
     // install — must stand.
     const imported = boardIsPython ? parsePyImports(boardSource) : new Set<string>()
-    return (installedModules ? computeMissingOnBoard(requiredModules, installedModules) : []).filter(
-      (m) => imported.has(m.module) || !moduleCoveredByInstrument(m.module, inUse)
-    )
+    return (
+      installedModules ? computeMissingOnBoard(requiredModules, installedModules) : []
+    ).filter((m) => imported.has(m.module) || !moduleCoveredByInstrument(m.module, inUse))
   }, [installedModules, requiredModules, inUse, boardIsPython, boardSource])
   // #621: this is a notice ABOUT THE OPEN FILE ("this file doesn't import servo"),
   // so it belongs to the Code workspace only. It used to render above all three,
@@ -981,11 +1007,7 @@ export function AppShell(): JSX.Element {
               // Per-file steps (#895) — a `mip` spec can bring dependencies, and
               // this banner is one of the places an install looked like a hang.
               run: (ctx) =>
-                window.api.packages.install(
-                  t.url as string,
-                  undefined,
-                  installStepReporter(ctx)
-                )
+                window.api.packages.install(t.url as string, undefined, installStepReporter(ctx))
             })
             if (!res.ok) throw new Error(res.log || `Failed to install ${t.module}`)
           }
@@ -996,9 +1018,7 @@ export function AppShell(): JSX.Element {
         // and leave the "Install servo" button stuck on screen.) The ref keeps
         // them present across any later re-probe this connection.
         for (const t of targets) selfInstalledRef.current.add(t.module)
-        setInstalledModules(
-          (prev) => new Set([...(prev ?? []), ...targets.map((t) => t.module)])
-        )
+        setInstalledModules((prev) => new Set([...(prev ?? []), ...targets.map((t) => t.module)]))
         // Tell the OTHER windows too (the Board View's driver banner re-probes,
         // the device file tree re-lists).
         window.api.modules.notifyChanged()
@@ -1134,21 +1154,74 @@ export function AppShell(): JSX.Element {
   // whether the sheet is showing.
   const [shortcutsOpen, setShortcutsOpen] = useState(false)
 
+  // --- what File ▸ … needs to know (#915) ------------------------------------
+  //
+  // Refs, not the values, because the menu subscription is set up once: reading
+  // `activeId` from the closure would save whichever file was open when the
+  // listener was created, which is the wrong file forever after the first tab
+  // switch.
+  const activeIdRef = useRef(activeId)
+  activeIdRef.current = activeId
+
+  /** Put the Files view in front — an Open that left the tree hidden would look
+   *  like it had done nothing (#775: Electronics and Build gate on the store). */
+  const revealFiles = useCallback((): void => {
+    setActivityView('files')
+    setLeftCollapsed('files', false)
+    filesRef.current?.expand()
+  }, [setActivityView, setLeftCollapsed])
+
   useEffect(() => {
     const off = window.api.menu.onCommand((id) => {
       runMenuCommand(id, {
         switchWorkspace: (target) => switchWorkspaceRef.current(target),
         showShortcuts: () => setShortcutsOpen(true),
         openFolder: () => {
-          setActivityView('files')
-          setLeftCollapsed('files', false)
-          filesRef.current?.expand()
+          revealFiles()
           void openFolder().catch(reporter('open folder', { notify: "Couldn't open the folder." }))
-        }
+        },
+        // --- File (#915) -------------------------------------------------
+        newFile: () => newFile(),
+        openFile: () =>
+          void openFileDialog().catch(
+            reporter('open file', { notify: "Couldn't open that file." })
+          ),
+        openRecent: (i) => {
+          // The list the MENU was built from, so slot i means the folder the
+          // user actually read there — not whatever the list says now.
+          const folder = recentFoldersRef.current[i]
+          if (!folder) return
+          revealFiles()
+          openFolderPath(folder)
+        },
+        save: () => {
+          if (!activeIdRef.current) return
+          void saveFile(activeIdRef.current).catch(
+            reporter('save', { notify: "Couldn't save the file." })
+          )
+        },
+        saveAs: () => {
+          if (!activeIdRef.current) return
+          void saveFileAs(activeIdRef.current).catch(
+            reporter('save as', { notify: "Couldn't save the file." })
+          )
+        },
+        // Through the tabs' own close, which prompts on a dirty buffer (#915).
+        closeTab: () => dispatchCloseTab()
       })
     })
     return off
-  }, [openFolder, setActivityView, setLeftCollapsed])
+  }, [
+    openFolder,
+    openFolderPath,
+    openFileDialog,
+    newFile,
+    saveFile,
+    saveFileAs,
+    setActivityView,
+    setLeftCollapsed,
+    revealFiles
+  ])
 
   // The Parts Library + Part Editor live in the Board Viewer window now (it's the
   // only place that uses parts), so the main window no longer hosts them.
@@ -1253,163 +1326,169 @@ export function AppShell(): JSX.Element {
             group makes the code panels structurally absent (no persisted flag can
             resurface them) and avoids RRP collapse races. */}
         <div className="shell__workarea">
-        {/* Code's panel group is ALWAYS mounted (#…) so the console terminal + editor
+          {/* Code's panel group is ALWAYS mounted (#…) so the console terminal + editor
             keep their state across a workspace switch, instead of remounting blank.
             The solo overlay (below) covers it for Electronics/Build. Sizes are
             recorded per-workspace via onLayout and applied imperatively on switch. */}
-        <PanelGroup
-          direction="horizontal"
-          ref={hGroupRef}
-          onLayout={(sizes) => layout.recordSizes('horizontal', sizes)}
-          className="shell__panels"
-        >
-          <Panel
-            ref={filesRef}
-            order={1}
-            collapsible
-            collapsedSize={0}
-            defaultSize={initialSizes.current.h[0]}
-            minSize={16}
-            onCollapse={() => layout.setCollapsed('files', true)}
-            onExpand={() => layout.setCollapsed('files', false)}
+          <PanelGroup
+            direction="horizontal"
+            ref={hGroupRef}
+            onLayout={(sizes) => layout.recordSizes('horizontal', sizes)}
+            className="shell__panels"
           >
-            <LeftView view={activityView} helpTarget={helpTarget} />
-          </Panel>
+            <Panel
+              ref={filesRef}
+              order={1}
+              collapsible
+              collapsedSize={0}
+              defaultSize={initialSizes.current.h[0]}
+              minSize={16}
+              onCollapse={() => layout.setCollapsed('files', true)}
+              onExpand={() => layout.setCollapsed('files', false)}
+            >
+              <LeftView view={activityView} helpTarget={helpTarget} />
+            </Panel>
 
-          {/* Hide the stitch when Files is collapsed — the panel isn't reopened by
+            {/* Hide the stitch when Files is collapsed — the panel isn't reopened by
               dragging this divider (any activity-bar button opens it for a purpose),
               so a visible resize thread there would be misleading (#…). */}
-          <PanelResizeHandle
-            className={`resize-handle resize-handle--vertical resize-handle--files${filesCollapsed ? ' is-collapsed' : ''}`}
-          />
+            <PanelResizeHandle
+              className={`resize-handle resize-handle--vertical resize-handle--files${filesCollapsed ? ' is-collapsed' : ''}`}
+            />
 
-          <Panel
-            ref={centreRef}
-            order={2}
-            collapsible
-            collapsedSize={0}
-            defaultSize={initialSizes.current.h[1]}
-            minSize={30}
-            onCollapse={() => layout.setCollapsed('centre', true)}
-            onExpand={() => layout.setCollapsed('centre', false)}
-          >
-            <div className="shell__center-col">
-              <PanelGroup
-                direction="vertical"
-                ref={vGroupRef}
-                className="shell__vgroup"
-                onLayout={(sizes) => layout.recordSizes('vertical', sizes)}
-              >
-                <Panel order={1} minSize={20}>
-                  <div className="shell__editor-region">
-                    <EditorArea
-                      chatOpen={!rightCollapsed}
-                      onToggleChat={IS_WEB ? undefined : () => toggle(rightRef)}
-                    />
-                  </div>
-                </Panel>
-
-                <PanelResizeHandle className="resize-handle resize-handle--horizontal" />
-
-                <Panel
-                  ref={shellRef}
-                  order={2}
-                  collapsible
-                  collapsedSize={0}
-                  defaultSize={initialSizes.current.v[1]}
-                  minSize={22}
-                  onCollapse={() => layout.setCollapsed('shell', true)}
-                  onExpand={() => layout.setCollapsed('shell', false)}
+            <Panel
+              ref={centreRef}
+              order={2}
+              collapsible
+              collapsedSize={0}
+              defaultSize={initialSizes.current.h[1]}
+              minSize={30}
+              onCollapse={() => layout.setCollapsed('centre', true)}
+              onExpand={() => layout.setCollapsed('centre', false)}
+            >
+              <div className="shell__center-col">
+                <PanelGroup
+                  direction="vertical"
+                  ref={vGroupRef}
+                  className="shell__vgroup"
+                  onLayout={(sizes) => layout.recordSizes('vertical', sizes)}
                 >
-                  <ShellPanel
-                    chatOpen={!rightCollapsed}
-                    onCollapse={() => {
-                      if (!exitFocus()) toggle(shellRef)
-                    }}
-                  />
-                </Panel>
-              </PanelGroup>
-              {/* Reopen rail (#592): when the console is collapsed to nothing, a
+                  <Panel order={1} minSize={20}>
+                    <div className="shell__editor-region">
+                      <EditorArea
+                        chatOpen={!rightCollapsed}
+                        onToggleChat={IS_WEB ? undefined : () => toggle(rightRef)}
+                      />
+                    </div>
+                  </Panel>
+
+                  <PanelResizeHandle className="resize-handle resize-handle--horizontal" />
+
+                  <Panel
+                    ref={shellRef}
+                    order={2}
+                    collapsible
+                    collapsedSize={0}
+                    defaultSize={initialSizes.current.v[1]}
+                    minSize={22}
+                    onCollapse={() => layout.setCollapsed('shell', true)}
+                    onExpand={() => layout.setCollapsed('shell', false)}
+                  >
+                    <ShellPanel
+                      chatOpen={!rightCollapsed}
+                      onCollapse={() => {
+                        if (!exitFocus()) toggle(shellRef)
+                      }}
+                    />
+                  </Panel>
+                </PanelGroup>
+                {/* Reopen rail (#592): when the console is collapsed to nothing, a
                   slim clickable bar is its own reopen affordance (the global
                   toolbar toggle is gone). */}
-              {shellCollapsed && !focus && (
-                <button
-                  type="button"
-                  className="shell__reopen shell__reopen--bottom"
-                  onClick={() => openPanel(shellRef)}
-                  title="Show the console"
-                >
-                  {/* Collapsed → UP chevron (the console expands upward). */}
-                  <svg width="12" height="12" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
-                    <path
-                      d="M4 10l4-4 4 4"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="1.8"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                  <span>Console</span>
-                </button>
-              )}
-            </div>
-          </Panel>
+                {shellCollapsed && !focus && (
+                  <button
+                    type="button"
+                    className="shell__reopen shell__reopen--bottom"
+                    onClick={() => openPanel(shellRef)}
+                    title="Show the console"
+                  >
+                    {/* Collapsed → UP chevron (the console expands upward). */}
+                    <svg
+                      width="12"
+                      height="12"
+                      viewBox="0 0 16 16"
+                      aria-hidden="true"
+                      focusable="false"
+                    >
+                      <path
+                        d="M4 10l4-4 4 4"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.8"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                    <span>Console</span>
+                  </button>
+                )}
+              </div>
+            </Panel>
 
-          {/* (The Board View is NOT a panel here anymore — Electronics renders it in
+            {/* (The Board View is NOT a panel here anymore — Electronics renders it in
               the solo overlay below, so the group stays a stable Code layout.) */}
 
-          {/* The Chat right-pane is desktop-only — hidden on the web build. */}
-          {!IS_WEB && (
-            <>
-              <PanelResizeHandle className="resize-handle resize-handle--vertical" />
+            {/* The Chat right-pane is desktop-only — hidden on the web build. */}
+            {!IS_WEB && (
+              <>
+                <PanelResizeHandle className="resize-handle resize-handle--vertical" />
 
-              <Panel
-                ref={rightRef}
-                order={4}
-                collapsible
-                collapsedSize={0}
-                defaultSize={initialSizes.current.h[3]}
-                minSize={14}
-                onCollapse={() => layout.setCollapsed('right', true)}
-                onExpand={() => layout.setCollapsed('right', false)}
-              >
-                <RightPanel />
-              </Panel>
-            </>
-          )}
-        </PanelGroup>
-        {/* Electronics + Build overlay the Code panel group (which stays mounted
+                <Panel
+                  ref={rightRef}
+                  order={4}
+                  collapsible
+                  collapsedSize={0}
+                  defaultSize={initialSizes.current.h[3]}
+                  minSize={14}
+                  onCollapse={() => layout.setCollapsed('right', true)}
+                  onExpand={() => layout.setCollapsed('right', false)}
+                >
+                  <RightPanel />
+                </Panel>
+              </>
+            )}
+          </PanelGroup>
+          {/* Electronics + Build overlay the Code panel group (which stays mounted
             underneath). A lesson — opened here, deep-linked, or carried in by a
             tutorial that asked for this workspace — shows in a left panel. */}
-        {soloWorkspace && (
-          <div className="shell__solo shell__solo--overlay">
-            {soloLessonOpen && (
-              <aside className="shell__solo-lesson" aria-label="Lesson">
-                <LeftView view={activityView} helpTarget={helpTarget} />
-              </aside>
-            )}
-            {robotMain ? (
-              <div className="shell__robot-main">
-                <Suspense fallback={<div className="shell__robot3d-loading">Loading 3D…</div>}>
-                  <RobotDockPanel full />
-                </Suspense>
-              </div>
-            ) : (
-              <div className="shell__solo-board">
-                <Suspense
-                  fallback={
-                    <div className="board-pane__loading" role="status">
-                      Loading Board View…
-                    </div>
-                  }
-                >
-                  <BoardPane />
-                </Suspense>
-              </div>
-            )}
-          </div>
-        )}
+          {soloWorkspace && (
+            <div className="shell__solo shell__solo--overlay">
+              {soloLessonOpen && (
+                <aside className="shell__solo-lesson" aria-label="Lesson">
+                  <LeftView view={activityView} helpTarget={helpTarget} />
+                </aside>
+              )}
+              {robotMain ? (
+                <div className="shell__robot-main">
+                  <Suspense fallback={<div className="shell__robot3d-loading">Loading 3D…</div>}>
+                    <RobotDockPanel full />
+                  </Suspense>
+                </div>
+              ) : (
+                <div className="shell__solo-board">
+                  <Suspense
+                    fallback={
+                      <div className="board-pane__loading" role="status">
+                        Loading Board View…
+                      </div>
+                    }
+                  >
+                    <BoardPane />
+                  </Suspense>
+                </div>
+              )}
+            </div>
+          )}
         </div>
 
         {/* The INSTRUMENT DOCK lives OUTSIDE the PanelGroup — a fixed-width region
@@ -1418,10 +1497,7 @@ export function AppShell(): JSX.Element {
             redistribute each other's freed space). Shown by the toolbar
             Instruments button or an incoming `instruments:open`. */}
         {instrumentsVisible && dockWorkspace && (
-          <aside
-            className="shell__dock shell__dock--mini"
-            aria-label="Instrument dock"
-          >
+          <aside className="shell__dock shell__dock--mini" aria-label="Instrument dock">
             {/* Per-panel collapse (#592) — the dock hides itself; the toolbar
                 Instruments toggle is gone, so the reopen rail below takes over. */}
             <button
@@ -1524,7 +1600,6 @@ export function AppShell(): JSX.Element {
       )}
 
       {shortcutsOpen && <ShortcutSheet onClose={() => setShortcutsOpen(false)} />}
-
     </div>
   )
 }

--- a/src/renderer/src/components/EditorTabs.tsx
+++ b/src/renderer/src/components/EditorTabs.tsx
@@ -1,3 +1,4 @@
+import { CLOSE_TAB_EVENT } from './editorBridge'
 import { useEffect } from 'react'
 import { useWorkspace } from '../store/workspace'
 import './EditorTabs.css'
@@ -53,8 +54,20 @@ export function EditorTabs(): JSX.Element | null {
       }
     }
 
+    // File ▸ Close Tab (#915) reaches the SAME close as the × and ⌘W, so it
+    // prompts on a dirty buffer like they do. On the desktop this is the only
+    // path that runs: ⌘W is a menu accelerator now, and Electron takes the key
+    // before `keydown` ever reaches here.
+    function onCloseTab(): void {
+      if (activeId) requestClose(activeId)
+    }
+
     window.addEventListener('keydown', onKeyDown)
-    return () => window.removeEventListener('keydown', onKeyDown)
+    window.addEventListener(CLOSE_TAB_EVENT, onCloseTab)
+    return () => {
+      window.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener(CLOSE_TAB_EVENT, onCloseTab)
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [openFiles, activeId, setActive, closeFile])
 

--- a/src/renderer/src/components/editorBridge.ts
+++ b/src/renderer/src/components/editorBridge.ts
@@ -33,9 +33,7 @@ export interface FindEventDetail {
 
 /** Dispatch the open-find event (used by the editor's keybinding commands). */
 export function dispatchOpenFind(withReplace: boolean): void {
-  window.dispatchEvent(
-    new CustomEvent<FindEventDetail>(FIND_EVENT, { detail: { withReplace } })
-  )
+  window.dispatchEvent(new CustomEvent<FindEventDetail>(FIND_EVENT, { detail: { withReplace } }))
 }
 
 /** Cross-panel "open help" event: switch the left sidebar to the Help view and
@@ -50,6 +48,27 @@ export interface HelpEventDetail {
 /** Dispatch the open-help event: reveal the Help view + open `articleId`. */
 export function dispatchOpenHelp(articleId: string): void {
   window.dispatchEvent(new CustomEvent<HelpEventDetail>(HELP_EVENT, { detail: { articleId } }))
+}
+
+/**
+ * "Close the active tab" (#915), fired by File ▸ Close Tab.
+ *
+ * An EVENT rather than a store call, because closing a tab is not just removing
+ * it: `EditorTabs` asks first when the buffer is dirty, and a menu item that
+ * went straight to the store would discard unsaved work while the × beside it
+ * asks — the sort of inconsistency nobody reports and everybody gets bitten by
+ * once. This routes the menu through the one implementation that prompts.
+ *
+ * It matters on the desktop specifically: ⌘W is now a menu ACCELERATOR, so
+ * Electron takes the key before the renderer sees a `keydown`, and the tabs'
+ * own shortcut handler never fires. That handler stays for the web build, which
+ * has no menu at all.
+ */
+export const CLOSE_TAB_EVENT = 'snakie:close-tab'
+
+/** Ask the editor tabs to close the active tab, prompting if it is dirty. */
+export function dispatchCloseTab(): void {
+  window.dispatchEvent(new CustomEvent(CLOSE_TAB_EVENT))
 }
 
 let current: Editor | null = null

--- a/src/renderer/src/lib/menuCommands.ts
+++ b/src/renderer/src/lib/menuCommands.ts
@@ -1,5 +1,7 @@
 import {
   isRendererMenuCommand,
+  RECENT_FOLDER_SLOTS,
+  recentFolderMenuCommand,
   workspaceMenuCommand,
   type RendererMenuCommand
 } from '../../../shared/menu-commands'
@@ -46,14 +48,52 @@ export interface MenuCommandDeps {
   /** Show the keyboard-shortcut cheatsheet (#920). The sheet is generated from
    *  the menu template, so this only has to raise it. */
   showShortcuts: () => void
+
+  // --- File (#915) ---------------------------------------------------------
+
+  /** A new untitled buffer — the store's `newFile`, which is what the toolbar's
+   *  + does. NOT the Files panel's "new file here", which needs a folder. */
+  newFile: () => void
+  /** Raise the file picker and open what it returns. */
+  openFile: () => void
+  /** Open the folder in recent slot `i`. Out-of-range slots do nothing: the
+   *  menu only shows the slots it has folders for, but the id survives a state
+   *  update that shortened the list. */
+  openRecent: (index: number) => void
+  /** Save the active file. Greyed out with none, so this is not reached then. */
+  save: () => void
+  /** Save the active file somewhere new, and follow it there. */
+  saveAs: () => void
+  /**
+   * Close the active TAB — not the window.
+   *
+   * MUST go through the tabs' own close, which prompts when the buffer is
+   * dirty. A menu item that discarded unsaved work while the × beside it asks
+   * first is the kind of inconsistency nobody reports and everybody gets bitten
+   * by once.
+   */
+  closeTab: () => void
 }
 
 /** Every renderer menu command and what it does. */
-export function menuCommandHandlers(deps: MenuCommandDeps): Record<RendererMenuCommand, () => void> {
+export function menuCommandHandlers(
+  deps: MenuCommandDeps
+): Record<RendererMenuCommand, () => void> {
   const handlers = {
+    'file.new': () => deps.newFile(),
+    'file.openFile': () => deps.openFile(),
     'file.openFolder': () => deps.openFolder(),
+    'file.save': () => deps.save(),
+    'file.saveAs': () => deps.saveAs(),
+    'file.closeTab': () => deps.closeTab(),
     'help.shortcuts': () => deps.showShortcuts()
   } as Record<RendererMenuCommand, () => void>
+  // Derived from the slot list, like the workspaces below: the submenu's ids are
+  // fixed and its labels come from the renderer's state, so a ninth slot is one
+  // number in `RECENT_FOLDER_SLOTS`.
+  for (const i of RECENT_FOLDER_SLOTS) {
+    handlers[recentFolderMenuCommand(i)] = () => deps.openRecent(i)
+  }
   // Derived from WORKSPACE_IDS, like the menu itself: a fourth workspace gets
   // its menu item AND its handler with no edit here.
   for (const id of WORKSPACE_IDS) {

--- a/src/renderer/src/store/workspace.ts
+++ b/src/renderer/src/store/workspace.ts
@@ -88,11 +88,51 @@ export function announceSaved(source: FileSource, path: string, content: string)
 /** localStorage key for the last opened working folder (#177), restored on launch. */
 const LAST_FOLDER_KEY = 'snakie.lastFolder'
 
-/** Persist (or clear) the last opened folder. Best-effort — storage may be off. */
+/** localStorage key for the recent-folder list behind `File ▸ Open Recent` (#915). */
+const RECENT_FOLDERS_KEY = 'snakie.recentFolders'
+
+/** How many the list keeps. Matches the menu's slot count — a longer list would
+ *  only ever be truncated on the way to the menu. */
+export const RECENT_FOLDERS_MAX = 8
+
+/** The recent folders, newest first. Never throws: storage may be off, and the
+ *  value may be anything a previous version or another tab left there. */
+export function readRecentFolders(): string[] {
+  try {
+    const raw = JSON.parse(window.localStorage.getItem(RECENT_FOLDERS_KEY) ?? '[]')
+    return Array.isArray(raw)
+      ? raw
+          .filter((f): f is string => typeof f === 'string' && f.length > 0)
+          .slice(0, RECENT_FOLDERS_MAX)
+      : []
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Move `folder` to the front of the recent list.
+ *
+ * Pure, so the MRU rule is testable: reopening a folder promotes it rather than
+ * adding a duplicate, which is the difference between a useful list and eight
+ * copies of the folder someone is working in.
+ */
+export function promoteRecentFolder(list: readonly string[], folder: string): string[] {
+  if (!folder) return [...list]
+  return [folder, ...list.filter((f) => f !== folder)].slice(0, RECENT_FOLDERS_MAX)
+}
+
+/** Persist (or clear) the last opened folder, and keep the recent list. */
 function rememberFolder(folder: string | null): void {
   try {
     if (folder) window.localStorage.setItem(LAST_FOLDER_KEY, folder)
     else window.localStorage.removeItem(LAST_FOLDER_KEY)
+    if (folder) {
+      window.localStorage.setItem(
+        RECENT_FOLDERS_KEY,
+        JSON.stringify(promoteRecentFolder(readRecentFolders(), folder))
+      )
+    }
   } catch {
     // ignore storage failures
   }
@@ -143,6 +183,12 @@ export interface WorkspaceStore {
    */
   reloadContent: (id: string, content: string) => void
   saveFile: (id: string) => Promise<void>
+  /** Write `id` to a NEW path, chosen from a dialog, and follow the buffer
+   *  there (#915). Distinct from {@link saveFile}, which only raises a dialog
+   *  for a buffer that has never had a path. */
+  saveFileAs: (id: string) => Promise<void>
+  /** Raise the file picker and open what it returns (#915). */
+  openFileDialog: () => Promise<void>
   newFile: () => void
   /**
    * Open a NEW untitled tab pre-filled with `content` (named `name`) and make it
@@ -197,8 +243,23 @@ export function baseName(path: string): string {
 function reducer(state: State, action: Action): State {
   switch (action.type) {
     case 'open': {
-      // Dedupe by id: if already open, just re-activate (don't clobber edits).
-      const existing = state.openFiles.find((f) => f.id === action.file.id)
+      // Dedupe by id, and then by PATH (#515).
+      //
+      // The id is normally `${source}:${path}`, so the two agree — except after
+      // a Save As, which deliberately keeps the buffer's `untitled:` id to hold
+      // the tab and its editor mounted, while giving it a real path. Opening
+      // that same file from the Files tree then matched no id and made a SECOND
+      // tab for one file, whose saves silently overwrote each other's.
+      //
+      // #915 put Save As on the menu with a shortcut, which turns that from a
+      // corner into a normal Tuesday.
+      const existing =
+        state.openFiles.find((f) => f.id === action.file.id) ??
+        (action.file.path
+          ? state.openFiles.find(
+              (f) => f.path === action.file.path && f.source === action.file.source
+            )
+          : undefined)
       if (existing) return { ...state, activeId: existing.id }
       return {
         ...state,
@@ -295,25 +356,22 @@ export function WorkspaceProvider({ children }: { children: ReactNode }): JSX.El
     currentFolder: null
   })
 
-  const openFile = useCallback(
-    async (source: FileSource, path: string): Promise<void> => {
-      const id = makeId(source, path)
-      // A `.mpy` is compiled bytecode, and both `readFile` channels decode UTF-8
-      // (#875) — so reading one here would produce a bufferful of replacement
-      // characters, and saving that back would destroy the file. The Bytecode
-      // view fetches the real bytes itself, so the tab opens with no text.
-      const content = isMpyFile(path)
-        ? ''
-        : source === 'local'
-          ? await window.api.fs.readFile(path)
-          : await window.api.device.readFile(path)
-      dispatch({
-        type: 'open',
-        file: { id, source, path, name: baseName(path), content, dirty: false }
-      })
-    },
-    []
-  )
+  const openFile = useCallback(async (source: FileSource, path: string): Promise<void> => {
+    const id = makeId(source, path)
+    // A `.mpy` is compiled bytecode, and both `readFile` channels decode UTF-8
+    // (#875) — so reading one here would produce a bufferful of replacement
+    // characters, and saving that back would destroy the file. The Bytecode
+    // view fetches the real bytes itself, so the tab opens with no text.
+    const content = isMpyFile(path)
+      ? ''
+      : source === 'local'
+        ? await window.api.fs.readFile(path)
+        : await window.api.device.readFile(path)
+    dispatch({
+      type: 'open',
+      file: { id, source, path, name: baseName(path), content, dirty: false }
+    })
+  }, [])
 
   const setActive = useCallback((id: string): void => {
     dispatch({ type: 'setActive', id })
@@ -344,7 +402,13 @@ export function WorkspaceProvider({ children }: { children: ReactNode }): JSX.El
         const chosen = await window.api.fs.saveFileDialog(file.name)
         if (!chosen) return
         await window.api.fs.writeFile(chosen, file.content)
-        dispatch({ type: 'savedAs', id, path: chosen, name: baseName(chosen), content: file.content })
+        dispatch({
+          type: 'savedAs',
+          id,
+          path: chosen,
+          name: baseName(chosen),
+          content: file.content
+        })
         announceSaved('local', chosen, file.content)
         return
       }
@@ -359,6 +423,42 @@ export function WorkspaceProvider({ children }: { children: ReactNode }): JSX.El
     },
     [state.openFiles]
   )
+
+  /**
+   * Save As on a file that already has one (#915).
+   *
+   * `saveFile` raises a dialog only for a buffer with no path at all, which was
+   * the only Save As the app had. The menu item means the other thing: take this
+   * file, write it somewhere else, and carry on editing THERE — so the buffer
+   * follows the new path rather than the old file quietly staying open.
+   *
+   * DEVICE files save to the LOCAL disk. A "save a copy" that could only put the
+   * copy back on the board would be the less useful half of the two, and the
+   * dialog is the local one either way.
+   */
+  const saveFileAs = useCallback(
+    async (id: string): Promise<void> => {
+      const file = state.openFiles.find((f) => f.id === id)
+      if (!file) return
+      const chosen = await window.api.fs.saveFileDialog(file.name)
+      if (!chosen) return
+      await window.api.fs.writeFile(chosen, file.content)
+      dispatch({
+        type: 'savedAs',
+        id,
+        path: chosen,
+        name: baseName(chosen),
+        content: file.content
+      })
+      announceSaved('local', chosen, file.content)
+    },
+    [state.openFiles]
+  )
+
+  const openFileDialog = useCallback(async (): Promise<void> => {
+    const chosen = await window.api.fs.openFileDialog()
+    if (chosen) await openFile('local', chosen)
+  }, [openFile])
 
   const openFolder = useCallback(async (): Promise<void> => {
     const folder = await window.api.fs.openFolderDialog()
@@ -489,9 +589,7 @@ export function WorkspaceProvider({ children }: { children: ReactNode }): JSX.El
       // immediately, so a quick relaunch / dev HMR reload can't strand it (the
       // old 4 s window did, which wiped the session).
       hydrated.current = true
-      requestAnimationFrame(() =>
-        requestAnimationFrame(() => markRestoreDone(storage))
-      )
+      requestAnimationFrame(() => requestAnimationFrame(() => markRestoreDone(storage)))
     })()
     // NB: deliberately no cleanup that cancels the restore or the guard-clear —
     // a StrictMode unmount/remount (or any remount) must not strand the marker.
@@ -539,6 +637,8 @@ export function WorkspaceProvider({ children }: { children: ReactNode }): JSX.El
       updateContent,
       reloadContent,
       saveFile,
+      saveFileAs,
+      openFileDialog,
       newFile,
       openBuffer,
       openFolder,
@@ -556,6 +656,8 @@ export function WorkspaceProvider({ children }: { children: ReactNode }): JSX.El
       updateContent,
       reloadContent,
       saveFile,
+      saveFileAs,
+      openFileDialog,
       newFile,
       openBuffer,
       openFolder,

--- a/src/shared/menu-commands.ts
+++ b/src/shared/menu-commands.ts
@@ -46,14 +46,49 @@ export function workspaceMenuCommand(id: WorkspaceId): WorkspaceMenuCommand {
   return `workspace.show.${id}`
 }
 
-/** Commands the RENDERER performs, relayed to the main window. */
-export type RendererMenuCommand = 'file.openFolder' | 'help.shortcuts' | WorkspaceMenuCommand
+/**
+ * How many folders `File ▸ Open Recent` remembers (#915).
+ *
+ * The ids are FIXED — `file.openRecent.0` … `.7` — and the labels arrive with
+ * the rest of the renderer's state. A dynamic id per folder would mean a command
+ * union that changes at runtime, which is exactly what {@link
+ * isRendererMenuCommand} exists to make impossible.
+ */
+export const RECENT_FOLDER_SLOTS = [0, 1, 2, 3, 4, 5, 6, 7] as const
+export type RecentFolderSlot = (typeof RECENT_FOLDER_SLOTS)[number]
 
-/** Every renderer command, in menu order. The workspace entries are DERIVED
- *  from `WORKSPACE_IDS`, so a fourth workspace gets its command, its menu item
- *  and its handler without anyone editing a list. */
+/** `File ▸ Open Recent ▸ …` — one command per slot, not per folder. */
+export type RecentFolderMenuCommand = `file.openRecent.${RecentFolderSlot}`
+
+/** The command that opens the folder in slot `i`. */
+export function recentFolderMenuCommand(i: RecentFolderSlot): RecentFolderMenuCommand {
+  return `file.openRecent.${i}`
+}
+
+/** Commands the RENDERER performs, relayed to the main window. */
+export type RendererMenuCommand =
+  | 'file.new'
+  | 'file.openFile'
+  | 'file.openFolder'
+  | 'file.save'
+  | 'file.saveAs'
+  | 'file.closeTab'
+  | 'help.shortcuts'
+  | WorkspaceMenuCommand
+  | RecentFolderMenuCommand
+
+/** Every renderer command, in menu order. The workspace and recent-folder
+ *  entries are DERIVED from their own lists, so a fourth workspace or a ninth
+ *  recent slot gets its command, its menu item and its handler without anyone
+ *  editing a list. */
 export const RENDERER_MENU_COMMANDS: readonly RendererMenuCommand[] = [
+  'file.new',
+  'file.openFile',
   'file.openFolder',
+  ...RECENT_FOLDER_SLOTS.map(recentFolderMenuCommand),
+  'file.save',
+  'file.saveAs',
+  'file.closeTab',
   ...WORKSPACE_IDS.map(workspaceMenuCommand),
   'help.shortcuts'
 ]
@@ -82,11 +117,20 @@ export interface MenuState {
   enabled: Partial<Record<MenuCommand, boolean>>
   /** Ids to tick — radio items and checkboxes (`true` = checked). */
   checked: Partial<Record<MenuCommand, boolean>>
+  /**
+   * Recently opened folders, newest first, for `File ▸ Open Recent` (#915).
+   *
+   * The one piece of menu state that is not a flag, because this submenu's
+   * LABELS are renderer data — the folders themselves. Slot `i` is opened by
+   * {@link recentFolderMenuCommand}, so the ids stay fixed while the text
+   * changes, and an empty list simply means a greyed-out submenu.
+   */
+  recentFolders: string[]
 }
 
 /** The state a menu built before the renderer has spoken uses: everything
  *  enabled, nothing ticked. */
-export const EMPTY_MENU_STATE: MenuState = { enabled: {}, checked: {} }
+export const EMPTY_MENU_STATE: MenuState = { enabled: {}, checked: {}, recentFolders: [] }
 
 /** The renderer facts the menu reflects. #915–#918 add their fields here
  *  (`connected`, `hasFile`, …) and extend {@link menuStateFrom} to match. */
@@ -94,6 +138,15 @@ export interface MenuContext {
   /** The workspace showing in the main window — the radio tick in
    *  View ▸ Workspace, so switching in-app moves the tick too (#916). */
   workspace: WorkspaceId
+  /**
+   * Whether a file is open and focused (#915).
+   *
+   * Greys out Save, Save As and Close Tab. Offering Save with nothing to save is
+   * how a menu teaches people not to trust it.
+   */
+  hasActiveFile: boolean
+  /** Recently opened folders, newest first. */
+  recentFolders: string[]
 }
 
 /** Derive the menu's state from the renderer's. Pure, so what the menu shows is
@@ -101,7 +154,12 @@ export interface MenuContext {
 export function menuStateFrom(ctx: MenuContext): MenuState {
   const checked: Partial<Record<MenuCommand, boolean>> = {}
   for (const id of WORKSPACE_IDS) checked[workspaceMenuCommand(id)] = id === ctx.workspace
-  return { enabled: {}, checked }
+  const enabled: Partial<Record<MenuCommand, boolean>> = {
+    'file.save': ctx.hasActiveFile,
+    'file.saveAs': ctx.hasActiveFile,
+    'file.closeTab': ctx.hasActiveFile
+  }
+  return { enabled, checked, recentFolders: ctx.recentFolders.slice(0, RECENT_FOLDER_SLOTS.length) }
 }
 
 /** Every known command id (main + renderer) — the whitelist
@@ -130,5 +188,16 @@ function coerceFlags(raw: unknown): Partial<Record<MenuCommand, boolean>> {
  */
 export function coerceMenuState(raw: unknown): MenuState {
   const r = (raw ?? {}) as Record<string, unknown>
-  return { enabled: coerceFlags(r.enabled), checked: coerceFlags(r.checked) }
+  return {
+    enabled: coerceFlags(r.enabled),
+    checked: coerceFlags(r.checked),
+    // Same untrusted-shape rule as the flags: strings only, capped at the number
+    // of slots the menu actually has, so a garbled payload cannot grow the
+    // submenu past the ids that exist to open its entries.
+    recentFolders: Array.isArray(r.recentFolders)
+      ? r.recentFolders
+          .filter((f): f is string => typeof f === 'string' && f.length > 0)
+          .slice(0, RECENT_FOLDER_SLOTS.length)
+      : []
+  }
 }

--- a/src/shared/menu-template.ts
+++ b/src/shared/menu-template.ts
@@ -1,6 +1,8 @@
 import type { MenuItemConstructorOptions } from 'electron'
 import {
   EMPTY_MENU_STATE,
+  RECENT_FOLDER_SLOTS,
+  recentFolderMenuCommand,
   workspaceMenuCommand,
   type MenuCommand,
   type MenuState
@@ -124,8 +126,32 @@ export function appMenuTemplate(o: MenuTemplateOptions): MenuItemConstructorOpti
   // the accelerator every editor uses for it, so removing the icon removed a
   // duplicate rather than the ability.
   const openFolderItem = commandItem('file.openFolder', 'Open Folder…', o, {
-    accelerator: 'CmdOrCtrl+O'
+    // ⇧⌘O, not ⌘O, since #915. Open FILE took the plain accelerator, because
+    // that is what it means in every editor people arrive from, and a folder is
+    // the rarer of the two once a project is open.
+    accelerator: 'CmdOrCtrl+Shift+O'
   })
+
+  /**
+   * File ▸ Open Recent (#915).
+   *
+   * Built from the renderer's list, so the labels are folders and the ids are
+   * slots. An empty list still shows the submenu, greyed and saying so, rather
+   * than vanishing — a menu whose items come and go is one people stop scanning.
+   */
+  const recents = (o.state ?? EMPTY_MENU_STATE).recentFolders
+  const openRecentItem: MenuItemConstructorOptions = {
+    label: 'Open Recent',
+    enabled: recents.length > 0,
+    submenu:
+      recents.length === 0
+        ? [{ label: 'No recent folders', enabled: false }]
+        : recents
+            .slice(0, RECENT_FOLDER_SLOTS.length)
+            .map((folder, i) =>
+              commandItem(recentFolderMenuCommand(RECENT_FOLDER_SLOTS[i]), folder, o)
+            )
+  }
 
   // Help ▸ Keyboard Shortcuts (#920) — the popup that lists every binding,
   // generated from THIS template (see `shared/shortcuts.ts`). It sits in Help on
@@ -169,7 +195,34 @@ export function appMenuTemplate(o: MenuTemplateOptions): MenuItemConstructorOpti
       : []),
     {
       label: 'File',
-      submenu: [openFolderItem, { type: 'separator' }, isMac ? { role: 'close' } : { role: 'quit' }]
+      submenu: [
+        // New means an UNTITLED BUFFER, which is what ⌘N means in an editor —
+        // not the Files panel's "new file in this folder", which needs a folder
+        // and a name first. The label says "File" so the two read as different
+        // things rather than as one item in two places.
+        commandItem('file.new', 'New File', o, { accelerator: 'CmdOrCtrl+N' }),
+        { type: 'separator' },
+        commandItem('file.openFile', 'Open File…', o, { accelerator: 'CmdOrCtrl+O' }),
+        openFolderItem,
+        openRecentItem,
+        { type: 'separator' },
+        commandItem('file.save', 'Save', o, { accelerator: 'CmdOrCtrl+S' }),
+        commandItem('file.saveAs', 'Save As…', o, { accelerator: 'CmdOrCtrl+Shift+S' }),
+        { type: 'separator' },
+        // Distinct from closing the WINDOW, which is macOS's ⇧⌘W role below.
+        // It goes through the tabs' own dirty prompt rather than around it.
+        commandItem('file.closeTab', 'Close Tab', o, { accelerator: 'CmdOrCtrl+W' }),
+        { type: 'separator' },
+        // macOS keeps Close Window here rather than Quit. It is LABELLED and
+        // re-bound, both deliberately: the role's own key is ⌘W, which Close Tab
+        // now takes, and the role's own label ("Close Window") is invisible to
+        // the cheatsheet, which lists items by label. Naming it costs the
+        // platform's localised string and buys two adjacent items that cannot be
+        // confused for each other.
+        isMac
+          ? { role: 'close', label: 'Close Window', accelerator: 'CmdOrCtrl+Shift+W' }
+          : { role: 'quit' }
+      ]
     },
     {
       label: 'Edit',

--- a/test/appMenuTemplate.test.ts
+++ b/test/appMenuTemplate.test.ts
@@ -9,7 +9,25 @@ import {
   type MenuCommand,
   type MenuState
 } from '../src/shared/menu-commands'
+import { RECENT_FOLDER_SLOTS } from '../src/shared/menu-commands'
 import { WORKSPACE_IDS, WORKSPACE_INFO } from '../src/shared/workspaces'
+
+/**
+ * A state with every recent slot filled (#915).
+ *
+ * `File ▸ Open Recent` builds one item per FOLDER, so the completeness check
+ * below — every command in the union has exactly one item — only holds when the
+ * renderer has published enough folders to fill the slots. That is the honest
+ * form of the invariant: a slot with no folder has no item ON PURPOSE, and a
+ * menu of eight greyed "empty" rows would be worse than a submenu that says so
+ * once.
+ */
+const fullRecents = (): MenuState =>
+  menuStateFrom({
+    workspace: 'code',
+    hasActiveFile: true,
+    recentFolders: RECENT_FOLDER_SLOTS.map((i) => `/projects/folder-${i}`)
+  })
 
 /**
  * The application menu as data (#914 / #916).
@@ -50,7 +68,10 @@ function click(item: MenuItemConstructorOptions): void {
 }
 
 /** The submenu of the View item labelled `label`. */
-function viewSubmenu(template: MenuItemConstructorOptions[], label: string): MenuItemConstructorOptions[] {
+function viewSubmenu(
+  template: MenuItemConstructorOptions[],
+  label: string
+): MenuItemConstructorOptions[] {
   const view = template.find((m) => m.label === 'View')
   const items = Array.isArray(view?.submenu) ? view.submenu : []
   const found = items.find((m) => m.label === label)
@@ -62,7 +83,7 @@ describe.each([
   { platform: 'Windows/Linux', isMac: false }
 ])('the app menu on $platform (#914)', ({ isMac }) => {
   it('gives every command exactly one menu item, and every item a live command', () => {
-    const { template, fired } = build({ isMac })
+    const { template, fired } = build({ isMac, state: fullRecents() })
     const items = commandItems(template)
     for (const item of items) click(item)
     // Every id in the union reached the menu…
@@ -75,7 +96,14 @@ describe.each([
   it('carries the accelerators the shortcuts epic asks for (#920)', () => {
     const { template } = build({ isMac })
     const byLabel = new Map(commandItems(template).map((m) => [String(m.label), m]))
-    expect(byLabel.get('Open Folder…')?.accelerator).toBe('CmdOrCtrl+O')
+    // File (#915). Open FILE took the plain ⌘O that every editor uses for it,
+    // so Open Folder moved to ⇧⌘O — a deliberate swap, not a drift.
+    expect(byLabel.get('New File')?.accelerator).toBe('CmdOrCtrl+N')
+    expect(byLabel.get('Open File…')?.accelerator).toBe('CmdOrCtrl+O')
+    expect(byLabel.get('Open Folder…')?.accelerator).toBe('CmdOrCtrl+Shift+O')
+    expect(byLabel.get('Save')?.accelerator).toBe('CmdOrCtrl+S')
+    expect(byLabel.get('Save As…')?.accelerator).toBe('CmdOrCtrl+Shift+S')
+    expect(byLabel.get('Close Tab')?.accelerator).toBe('CmdOrCtrl+W')
     expect(byLabel.get('Board View')?.accelerator).toBe('CmdOrCtrl+Shift+B')
     // Cmd/Ctrl 1-2-3 for Code / Electronics / Build. Monaco binds Cmd+S, Cmd+F,
     // Cmd+H and Cmd+Shift+1 — nothing plain-modifier-plus-digit — so these are free.
@@ -105,7 +133,10 @@ describe('View ▸ Workspace (#916)', () => {
 
   it('ticks the workspace the renderer says is showing', () => {
     for (const active of WORKSPACE_IDS) {
-      const { template } = build({ isMac: true, state: menuStateFrom({ workspace: active }) })
+      const { template } = build({
+        isMac: true,
+        state: menuStateFrom({ workspace: active, hasActiveFile: true, recentFolders: [] })
+      })
       const submenu = viewSubmenu(template, 'Workspace')
       const ticked = submenu.filter((m) => m.checked).map((m) => m.label)
       expect(ticked).toEqual([WORKSPACE_INFO[active].label])
@@ -122,7 +153,10 @@ describe('View ▸ Workspace (#916)', () => {
   it('only the radio items carry a tick at all', () => {
     // Electron reads `checked` on checkbox/radio items only, so a plain item
     // claiming one would be a tick that can never appear.
-    const { template } = build({ isMac: true, state: menuStateFrom({ workspace: 'code' }) })
+    const { template } = build({
+      isMac: true,
+      state: menuStateFrom({ workspace: 'code', hasActiveFile: true, recentFolders: [] })
+    })
     for (const item of commandItems(template)) {
       if (item.type === 'radio' || item.type === 'checkbox') {
         expect(typeof item.checked, String(item.label)).toBe('boolean')
@@ -137,7 +171,7 @@ describe('menu state greys items out (#914, for #915–#918)', () => {
   it('an item is enabled unless the renderer explicitly disabled it', () => {
     const { template } = build({
       isMac: false,
-      state: { enabled: { 'file.openFolder': false }, checked: {} }
+      state: { enabled: { 'file.openFolder': false }, checked: {}, recentFolders: [] }
     })
     const items = commandItems(template)
     const openFolder = items.find((m) => m.label === 'Open Folder…')

--- a/test/fileMenu.test.ts
+++ b/test/fileMenu.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import {
+  RECENT_FOLDER_SLOTS,
+  coerceMenuState,
+  isRendererMenuCommand,
+  menuStateFrom,
+  recentFolderMenuCommand
+} from '../src/shared/menu-commands'
+import { promoteRecentFolder, RECENT_FOLDERS_MAX } from '../src/renderer/src/store/workspace'
+
+/**
+ * The File menu (#915, epic #913).
+ *
+ * Before this the File menu was two items — Open Folder and Quit — and the only
+ * way to save was the toolbar button or ⌘S with the editor focused, since that
+ * binding lives inside Monaco. Anywhere else in the app, ⌘S did nothing.
+ *
+ * The parts worth testing are the ones a menu cannot show you it got wrong: the
+ * recent list's MRU rule, the items that must grey out, and the slot ids that
+ * have to stay fixed while their labels change.
+ */
+
+describe('Open Recent remembers folders in the right order', () => {
+  it('puts the newest first', () => {
+    expect(promoteRecentFolder([], '/a')).toEqual(['/a'])
+    expect(promoteRecentFolder(['/a'], '/b')).toEqual(['/b', '/a'])
+  })
+
+  it('promotes rather than duplicates', () => {
+    // Reopening a folder you already have is the common case, and the difference
+    // between a useful list and eight copies of the folder you work in.
+    expect(promoteRecentFolder(['/a', '/b', '/c'], '/c')).toEqual(['/c', '/a', '/b'])
+    expect(promoteRecentFolder(['/a'], '/a')).toEqual(['/a'])
+  })
+
+  it('keeps only as many as the menu has slots for', () => {
+    const many = Array.from({ length: 20 }, (_, i) => `/f${i}`)
+    expect(promoteRecentFolder(many, '/new')).toHaveLength(RECENT_FOLDERS_MAX)
+    expect(promoteRecentFolder(many, '/new')[0]).toBe('/new')
+    expect(RECENT_FOLDERS_MAX).toBe(RECENT_FOLDER_SLOTS.length)
+  })
+
+  it('ignores an empty folder rather than storing a blank row', () => {
+    expect(promoteRecentFolder(['/a'], '')).toEqual(['/a'])
+  })
+
+  it('does not mutate the list it was given', () => {
+    const before = ['/a', '/b']
+    promoteRecentFolder(before, '/c')
+    expect(before).toEqual(['/a', '/b'])
+  })
+})
+
+describe('the recent slots are ids, not folders', () => {
+  it('names a fixed command per slot', () => {
+    // The labels change every time someone opens a folder; the ids must not, or
+    // `isRendererMenuCommand` could not tell a real command from a stale one.
+    for (const i of RECENT_FOLDER_SLOTS) {
+      expect(isRendererMenuCommand(recentFolderMenuCommand(i))).toBe(true)
+    }
+  })
+
+  it('rejects a slot the menu does not have', () => {
+    expect(isRendererMenuCommand('file.openRecent.8')).toBe(false)
+    expect(isRendererMenuCommand('file.openRecent.99')).toBe(false)
+    expect(isRendererMenuCommand('file.openRecent.')).toBe(false)
+  })
+})
+
+describe('items grey out when they cannot act', () => {
+  const state = (hasActiveFile: boolean) =>
+    menuStateFrom({ workspace: 'code', hasActiveFile, recentFolders: [] })
+
+  it('greys Save, Save As and Close Tab with nothing open', () => {
+    // A menu that offers Save with nothing to save teaches people not to trust
+    // the rest of it.
+    for (const id of ['file.save', 'file.saveAs', 'file.closeTab'] as const) {
+      expect(state(false).enabled[id], id).toBe(false)
+      expect(state(true).enabled[id], id).toBe(true)
+    }
+  })
+
+  it('never greys the ones that always work', () => {
+    // New and the two Opens do not need a file — greying them with an empty
+    // window would leave no way to get one.
+    for (const id of ['file.new', 'file.openFile', 'file.openFolder'] as const) {
+      expect(state(false).enabled[id], id).toBeUndefined()
+    }
+  })
+})
+
+describe('the recent list crosses IPC as untrusted data', () => {
+  it('drops anything that is not a non-empty string', () => {
+    const s = coerceMenuState({ recentFolders: ['/a', 42, null, '', { x: 1 }, '/b'] })
+    expect(s.recentFolders).toEqual(['/a', '/b'])
+  })
+
+  it('caps it at the number of slots that exist', () => {
+    const many = Array.from({ length: 40 }, (_, i) => `/f${i}`)
+    expect(coerceMenuState({ recentFolders: many }).recentFolders).toHaveLength(
+      RECENT_FOLDER_SLOTS.length
+    )
+  })
+
+  it('treats a missing or wrong-typed list as empty', () => {
+    expect(coerceMenuState({}).recentFolders).toEqual([])
+    expect(coerceMenuState({ recentFolders: 'nope' }).recentFolders).toEqual([])
+  })
+})
+
+describe('Save As no longer leaves two tabs on one file (#515)', () => {
+  const store = readFileSync('src/renderer/src/store/workspace.ts', 'utf8')
+
+  it('matches an already-open file by path, not only by id', () => {
+    // After Save As the buffer keeps its `untitled:` id so the tab stays
+    // mounted, but now has a real path. Opening that file from the tree used to
+    // make a SECOND tab whose saves silently overwrote the first's — and #915
+    // put Save As on the menu with a shortcut, which turns that from a corner
+    // into a normal Tuesday.
+    const open = store.slice(store.indexOf("case 'open':"), store.indexOf("case 'add':"))
+    expect(open).toContain('f.path === action.file.path')
+    expect(open).toContain('f.source === action.file.source')
+  })
+
+  it('still matches by id first, so an untitled buffer is not merged into another', () => {
+    // Two untitled buffers both have an empty path. Matching those by path would
+    // fold every new file into the first one.
+    const open = store.slice(store.indexOf("case 'open':"), store.indexOf("case 'add':"))
+    expect(open).toContain('f.id === action.file.id')
+    expect(open).toContain('action.file.path')
+  })
+})
+
+describe('Close Tab goes through the prompt, not around it', () => {
+  const shell = readFileSync('src/renderer/src/components/AppShell.tsx', 'utf8')
+  const tabs = readFileSync('src/renderer/src/components/EditorTabs.tsx', 'utf8')
+
+  it('asks the tabs to close, rather than calling the store', () => {
+    // The × and ⌘W confirm before discarding unsaved edits. A menu item that
+    // went straight to `closeFile` would not.
+    expect(shell).toContain('closeTab: () => dispatchCloseTab()')
+    expect(shell).not.toMatch(/closeTab: \(\) => closeFile/)
+  })
+
+  it('is handled by the same close the × uses', () => {
+    expect(tabs).toContain('CLOSE_TAB_EVENT')
+    expect(tabs).toContain('if (activeId) requestClose(activeId)')
+  })
+
+  it('keeps the renderer shortcut, which is all the web build has', () => {
+    // On the desktop ⌘W is a menu accelerator and Electron takes the key first.
+    // The web build has no menu at all, so the keydown handler stays.
+    expect(tabs).toContain("e.key === 'w'")
+  })
+})

--- a/test/menuChannel.test.ts
+++ b/test/menuChannel.test.ts
@@ -122,19 +122,19 @@ describe('the app menu command channel (#914)', () => {
   })
 
   it('rebuilds the menu when the renderer publishes its state', () => {
-    publish(menuStateFrom({ workspace: 'robot' }))
+    publish(menuStateFrom({ workspace: 'robot', hasActiveFile: true, recentFolders: [] }))
     expect(installed).toHaveLength(2)
     const ticked = items().filter((m) => m.checked)
     expect(ticked.map((m) => m.label)).toEqual(['Build'])
   })
 
   it('does not rebuild when the state has not actually changed', () => {
-    publish(menuStateFrom({ workspace: 'board' }))
-    publish(menuStateFrom({ workspace: 'board' }))
+    publish(menuStateFrom({ workspace: 'board', hasActiveFile: true, recentFolders: [] }))
+    publish(menuStateFrom({ workspace: 'board', hasActiveFile: true, recentFolders: [] }))
     // A rebuild closes an open menu on macOS, and the renderer republishes on
     // every mount — so an unchanged state must be a no-op.
     expect(installed).toHaveLength(2)
-    publish(menuStateFrom({ workspace: 'code' }))
+    publish(menuStateFrom({ workspace: 'code', hasActiveFile: true, recentFolders: [] }))
     expect(installed).toHaveLength(3)
   })
 

--- a/test/menuCommands.test.ts
+++ b/test/menuCommands.test.ts
@@ -25,22 +25,38 @@ function deps(): {
   switched: WorkspaceId[]
   folders: number
   sheets: number
+  /** Every File command that fired, in order (#915). */
+  fired: string[]
+  /** Which recent slots were asked for. */
+  recents: number[]
   d: Parameters<typeof menuCommandHandlers>[0]
 } {
   const rec = {
     switched: [] as WorkspaceId[],
     folders: 0,
     sheets: 0,
+    fired: [] as string[],
+    recents: [] as number[],
     d: {} as Parameters<typeof menuCommandHandlers>[0]
   }
   rec.d = {
     switchWorkspace: (id: WorkspaceId) => rec.switched.push(id),
     openFolder: () => {
       rec.folders += 1
+      rec.fired.push('openFolder')
     },
     showShortcuts: () => {
       rec.sheets += 1
-    }
+    },
+    newFile: () => rec.fired.push('newFile'),
+    openFile: () => rec.fired.push('openFile'),
+    openRecent: (i: number) => {
+      rec.fired.push('openRecent')
+      rec.recents.push(i)
+    },
+    save: () => rec.fired.push('save'),
+    saveAs: () => rec.fired.push('saveAs'),
+    closeTab: () => rec.fired.push('closeTab')
   }
   return rec
 }
@@ -98,7 +114,18 @@ describe('menu command union ↔ renderer dispatcher (#914)', () => {
     expect(runMenuCommand(workspaceMenuCommand('board'), rec.d)).toBe(true)
     expect(rec.switched).toEqual(['board'])
     // An id from a newer main process, a retired one, or junk: dropped, not run.
-    for (const bad of ['workspace.show.datalab', 'file.saveAs', '', 42, null, undefined, {}]) {
+    // (`file.saveAs` is a real command since #915, so the stand-in for "an id
+    // this build does not have" is a slot past the end of the recent list.)
+    for (const bad of [
+      'workspace.show.datalab',
+      'file.openRecent.99',
+      'device.disconnect',
+      '',
+      42,
+      null,
+      undefined,
+      {}
+    ]) {
       expect(runMenuCommand(bad, rec.d), JSON.stringify(bad)).toBe(false)
     }
     expect(rec.switched).toEqual(['board'])
@@ -108,17 +135,22 @@ describe('menu command union ↔ renderer dispatcher (#914)', () => {
 describe('menu state travelling back to the menu (#914)', () => {
   it('ticks exactly the active workspace', () => {
     for (const active of WORKSPACE_IDS) {
-      const state = menuStateFrom({ workspace: active })
+      const state = menuStateFrom({ workspace: active, hasActiveFile: true, recentFolders: [] })
       for (const id of WORKSPACE_IDS) {
         expect(state.checked[workspaceMenuCommand(id)], `${active}/${id}`).toBe(id === active)
       }
-      // Nothing is greyed out by the workspace alone.
-      expect(state.enabled).toEqual({})
+      // The workspace itself greys nothing out — only the File items carry
+      // enablement, and with a file open they are all usable.
+      expect(state.enabled).toEqual({
+        'file.save': true,
+        'file.saveAs': true,
+        'file.closeTab': true
+      })
     }
   })
 
   it('an unpublished state greys nothing out and ticks nothing', () => {
-    expect(EMPTY_MENU_STATE).toEqual({ enabled: {}, checked: {} })
+    expect(EMPTY_MENU_STATE).toEqual({ enabled: {}, checked: {}, recentFolders: [] })
   })
 
   it('coerceMenuState keeps known ids with boolean values and drops the rest', () => {
@@ -128,13 +160,18 @@ describe('menu state travelling back to the menu (#914)', () => {
     })
     expect(state).toEqual({
       enabled: { 'file.openFolder': false },
-      checked: { 'workspace.show.robot': true }
+      checked: { 'workspace.show.robot': true },
+      recentFolders: []
     })
   })
 
   it('coerceMenuState survives a garbled payload', () => {
     for (const bad of [null, undefined, 42, 'nope', [], { enabled: 3, checked: null }]) {
-      expect(coerceMenuState(bad), JSON.stringify(bad)).toEqual({ enabled: {}, checked: {} })
+      expect(coerceMenuState(bad), JSON.stringify(bad)).toEqual({
+        enabled: {},
+        checked: {},
+        recentFolders: []
+      })
     }
   })
 
@@ -142,11 +179,16 @@ describe('menu state travelling back to the menu (#914)', () => {
   // it. There is no DOM here (the suite runs in `environment: 'node'`), so this
   // reads the source — the same way `openFolderReachable.test.ts` checks a wire
   // whose break would be silent.
-  it('AppShell publishes the active workspace whenever it changes', () => {
+  it('AppShell publishes the menu state whenever any of it changes', () => {
     const shell = readFileSync('src/renderer/src/components/AppShell.tsx', 'utf8')
     expect(shell).toMatch(/menu\.setState\(\s*menuStateFrom\(\{\s*workspace:\s*layout\.active/)
     const at = shell.search(/menu\.setState\(/)
-    // Re-published on every workspace change, or the tick freezes on the first one.
-    expect(shell.slice(at, at + 200)).toContain('[layout.active]')
+    const effect = shell.slice(at, shell.indexOf('])', at) + 2)
+    // Every input re-publishes, or that part of the menu freezes at whatever it
+    // was on first render: the workspace tick (#916), and since #915 the file
+    // that greys Save out and the folders Open Recent lists.
+    for (const dep of ['layout.active', 'activeId', 'recentFolders']) {
+      expect(effect, dep).toContain(dep)
+    }
   })
 })

--- a/test/openFolderReachable.test.ts
+++ b/test/openFolderReachable.test.ts
@@ -88,7 +88,12 @@ describe('the app menu covers a collapsed or absent panel', () => {
     // button that was removed.
     const item = fileSubmenu([]).find((m) => m.label === 'Open Folder…')
     expect(item, 'File ▸ Open Folder…').toBeTruthy()
-    expect(item?.accelerator).toBe('CmdOrCtrl+O')
+    // ⇧⌘O since #915, not ⌘O. Open FILE took the plain accelerator, because
+    // that is what it means in every editor people arrive from, and a folder is
+    // the rarer of the two once a project is open. Deliberate, and asserted
+    // alongside its partner so the pair cannot drift.
+    expect(item?.accelerator).toBe('CmdOrCtrl+Shift+O')
+    expect(fileSubmenu([]).find((m) => m.label === 'Open File…')?.accelerator).toBe('CmdOrCtrl+O')
     expect(item?.enabled).toBe(true)
   })
 
@@ -133,11 +138,29 @@ describe('the wire from the menu to the picker', () => {
 
 describe('the folder lands somewhere the user can see it', () => {
   it('reveals the Files view before raising the picker', () => {
-    const body = openFolderHandler()
-    expect(body).toContain("setActivityView('files')")
+    // The three calls moved into `revealFiles` when #915 gave Open Recent the
+    // same job, so the handler names it and the guarantee is checked where it
+    // now lives — below.
+    expect(openFolderHandler()).toContain('revealFiles()')
+  })
+
+  it('revealing the Files view does all three things it has to', () => {
+    const shell = readFileSync('src/renderer/src/components/AppShell.tsx', 'utf8')
+    const fn = shell.slice(
+      shell.indexOf('const revealFiles = useCallback'),
+      shell.indexOf('const revealFiles = useCallback') + 400
+    )
+    expect(fn).toContain("setActivityView('files')")
     // The solo workspaces gate their sidebar on the STORE flag, so an imperative
     // `expand()` alone is a no-op there (the bug that hid Help deep-links).
-    expect(body).toContain("setLeftCollapsed('files', false)")
-    expect(body).toContain('filesRef.current?.expand()')
+    expect(fn).toContain("setLeftCollapsed('files', false)")
+    expect(fn).toContain('filesRef.current?.expand()')
+  })
+
+  it('Open Recent reveals it too, or the folder opens behind a hidden tree', () => {
+    const shell = readFileSync('src/renderer/src/components/AppShell.tsx', 'utf8')
+    const handler = shell.slice(shell.indexOf('openRecent: (i)'), shell.indexOf('save: () =>'))
+    expect(handler).toContain('revealFiles()')
+    expect(handler).toContain('openFolderPath(folder)')
   })
 })

--- a/test/shortcutSheet.test.ts
+++ b/test/shortcutSheet.test.ts
@@ -71,8 +71,19 @@ describe.each([
       `Workspace ▸ ${WORKSPACE_INFO.code.label}`
     )
     expect(view?.shortcuts.map((s) => s.label)).toContain('Board View')
+    // The File menu's own bindings, in menu order (#915). The sheet picked all
+    // six up with no edit to `shortcuts.ts` — which is the property #920 was
+    // built for, so it is worth asserting the whole list rather than a sample.
     expect(sections.find((s) => s.title === 'File')?.shortcuts.map((s) => s.label)).toEqual([
-      'Open Folder…'
+      'New File',
+      'Open File…',
+      'Open Folder…',
+      'Save',
+      'Save As…',
+      'Close Tab',
+      // macOS only: the window close, re-bound to ⇧⌘W because Close Tab took
+      // the role's own ⌘W, and labelled so the sheet can name it.
+      ...(isMac ? ['Close Window'] : [])
     ])
     // Every row belongs to a section — nothing is orphaned by the grouping.
     const grouped = sections.flatMap((s) => s.shortcuts).length


### PR DESCRIPTION
Closes #915, and #515 with it. Part of epic #913.

## Before / after

The File menu was **two items**: `Open Folder…` and Quit.

| | |
|---|---|
| New File | ⌘N |
| Open File… | ⌘O |
| Open Folder… | ⇧⌘O |
| Open Recent ▸ | — |
| Save | ⌘S |
| Save As… | ⇧⌘S |
| Close Tab | ⌘W |

Save, Save As and Close Tab grey out with nothing open. A menu that offers Save with nothing to save teaches people not to trust the rest of it.

## One correction to the issue's premise

#915 says *"⌘S does nothing"*. It already worked — **inside the editor**, because the binding lives in Monaco (`MonacoEditor.tsx:374`). Anywhere else in the app — Files tree, shell, board view focused — it did nothing. As a menu accelerator it now works wherever you are, and Electron takes the key before Monaco, so the two can't disagree.

I also checked the neighbouring claim in the existing tests that *"Monaco binds Cmd+S"*: it has **no** default ⌘S binding. The app's own binding is what was there.

## Two accelerators moved, deliberately

- **Open Folder → ⇧⌘O**, because Open File took the plain ⌘O it means in every editor people arrive from.
- **Close Window → ⇧⌘W** (macOS), because Close Tab took the ⌘W the `close` role would otherwise own. That role is now labelled too, which costs its localised string and buys two adjacent items nobody can confuse.

## Open Recent is slots, not folders

The ids are fixed (`file.openRecent.0`…`.7`); the labels arrive with the renderer's state. So the command union stays static and `isRendererMenuCommand` can still tell a real command from a stale one — which is the whole point of that guard. The MRU rule is pure and tested: reopening a folder promotes it rather than adding a ninth copy of the one you work in.

## Close Tab goes through the prompt, not around it

The tabs' own close asks before discarding unsaved edits. The menu routes to that, not to the store.

This matters more than it looks: ⌘W is now an accelerator, so **Electron takes the key before `keydown` reaches the renderer** and EditorTabs' own handler never fires on desktop. That handler stays for the web build, which has no menu at all.

## Also fixes #515

After Save As the buffer keeps its `untitled:` id so the tab stays mounted, while gaining a real path. Opening that same file from the tree matched no id and made a **second tab for one file**, whose saves silently overwrote each other.

`open` now matches by path as well as id — **id first**, so two untitled buffers (both path-less) aren't folded into one. It was a corner before; putting Save As on the menu with a shortcut makes it a normal Tuesday, which is why it's fixed here rather than referenced.

Mutation-checked: reverting to id-only matching fails two tests.

## Deliberately not in scope

- **Quitting with unsaved work is still silent.** `before-quit` disposes without asking, while closing a *tab* prompts. #915 flags it; it belongs to #852 (Resilience) because the fix is in main's shutdown path, not the menu.
- **The web build gets no new shortcuts.** These are Electron accelerators, and the web has no menu. ⌘W still works there via EditorTabs; ⌘S still only inside the editor. Deriving renderer keybindings from the same template is a real follow-on, and its own piece of work.

## Gates

lint (pre-existing `DriverInstallBanner.tsx` warning only) · typecheck · **6,574 tests in 315 files** · build — green.

The #920 cheatsheet picked up all seven bindings with **no edit to `shortcuts.ts`** — the property it was built for — so its test now asserts the whole File section rather than a sample.

**Not verified on screen.** The menu is data and heavily tested as data, but I haven't clicked through it in a running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe