### PR TITLE
A Device menu — Run, Stop, Connect, Soft Reset, Sync (#918)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **A Device menu** (#918, epic #913). Everything you do *to the board* was
+  reachable only from the toolbar or the console panel — including Run and Stop,
+  the two most-used actions in the app, which had no keyboard route at all.
+  There is now Device ▸ Connect / Disconnect · Run (⌘R) · Stop (⌘.) · Soft Reset
+  · Sync Now.
+
+  Every item greys out when it cannot act, which is the strongest case for the
+  menu carrying renderer state at all: device state changes constantly, a cable
+  gets knocked, and a Run item that looks available with nothing plugged in makes
+  the *app* look broken rather than the board look absent. Connect and Disconnect
+  are opposites, so exactly one is ever offered. **Run is the exception** — it
+  stays available with no board, because it auto-connects, and that is what makes
+  it work for someone who has just opened the app. What Run needs is a file.
+
+  **⌘R came from somewhere.** `role: 'reload'` owned it. In an editor for running
+  MicroPython, ⌘R meaning "run my program" is worth more than reloading the
+  renderer, so the plain reload stands down — Force Reload still does the
+  stronger version of the same thing on ⇧⌘R, and is the one that helps when a
+  renderer is actually stuck. A test now asserts no binding in the whole menu is
+  claimed twice, on either platform, which is what would have caught this.
+
+  Run and Stop reach the **toolbar's own handlers**, and Connect/Disconnect the
+  connection control's. That matters most for Run: it auto-connects, prefers a
+  real board over the simulator, says so out loud when the board it was using has
+  vanished, and does the soft reboot #871 turns on. A second Run would have been
+  a different Run wearing the same word.
+
+- **Help ▸ Snakie Help** (#918). Snakie has a whole help system — the Help panel,
+  the "Why?" article behind every refactoring — reachable until now only from
+  inside the panels that use it. On macOS the Help menu held nothing of Snakie's
+  at all.
+
+### Added
+
 - **A File menu that does what a File menu does** (#915, epic #913). It was two
   items — `Open Folder…` and Quit. It is now New File (⌘N), Open File… (⌘O),
   Open Folder… (⇧⌘O), Open Recent ▸, Save (⌘S), Save As… (⇧⌘S) and Close Tab

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snakie",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "snakie",
-      "version": "0.49.0",
+      "version": "0.50.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snakie",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "A modern, cross-platform MicroPython editor.",
   "productName": "Snakie",
   "main": "./out/main/index.js",

--- a/src/renderer/src/components/AppShell.tsx
+++ b/src/renderer/src/components/AppShell.tsx
@@ -51,6 +51,7 @@ import { runFindCommand } from './findController'
 import { ShellPanel } from './ShellPanel'
 import { RightPanel } from './RightPanel'
 import { runMenuCommand } from '../lib/menuCommands'
+import { dispatchDeviceAction } from './device-bus'
 import { readRecentFolders } from '../store/workspace'
 import { menuStateFrom } from '../../../shared/menu-commands'
 import { ShortcutSheet } from './ShortcutSheet'
@@ -59,7 +60,12 @@ import { StatusBar } from './StatusBar'
 import { SettingsDialog, type SettingsTab } from './SettingsDialog'
 import { OPEN_SETTINGS_EVENT } from './settingsBus'
 import { OPEN_SPRITE_EDITOR_EVENT, type OpenSpriteEditorDetail } from './sprite-editor-bus'
-import { dispatchCloseTab, HELP_EVENT, type HelpEventDetail } from './editorBridge'
+import {
+  dispatchCloseTab,
+  dispatchOpenHelp,
+  HELP_EVENT,
+  type HelpEventDetail
+} from './editorBridge'
 import { InstrumentLibBanner } from './InstrumentLibBanner'
 import { NoticeStack } from './Notice'
 import { PartsImportBanner } from './PartsImportBanner'
@@ -78,6 +84,7 @@ import { enqueueDeviceTask } from '../lib/device-queue'
 import { installStepReporter } from '../lib/install-steps'
 import { installStepLabel } from '../../../shared/install-file-progress'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
+import { useSync } from '../store/sync'
 import { useSkeletonSync } from '../hooks/useSkeletonSync'
 import {
   INSTRUMENTS_LIB_PATH,
@@ -616,6 +623,16 @@ export function AppShell(): JSX.Element {
   // publishing them to the menu re-runs when a folder opens, and in a ref so the
   // menu subscription — set up once — reads the current list rather than the one
   // that existed when it subscribed.
+  // Device state for the menu (#918). `deviceStatus` is read further down for
+  // other reasons; the menu needs only the one fact.
+  const menuSync = useSync()
+  // Read where the menu state is published, not where `deviceStatus` is read
+  // further down — that one is declared later and this effect runs first.
+  const menuConnected = useDeviceStatus().state === 'connected'
+  // The subscription is set up once, so the handler must read the CURRENT
+  // `syncNow` rather than the one that existed when it subscribed.
+  const syncNowRef = useRef(menuSync.syncNow)
+  syncNowRef.current = menuSync.syncNow
   const [recentFolders, setRecentFolders] = useState<string[]>(() => readRecentFolders())
   const recentFoldersRef = useRef(recentFolders)
   recentFoldersRef.current = recentFolders
@@ -629,10 +646,13 @@ export function AppShell(): JSX.Element {
         workspace: layout.active,
         // Save / Save As / Close Tab grey out with nothing open (#915).
         hasActiveFile: activeId !== null,
-        recentFolders
+        recentFolders,
+        // Connect/Disconnect, Stop, Soft Reset and Sync follow the board (#918).
+        connected: menuConnected,
+        hasSyncedFiles: menuSync.syncedPaths.length > 0
       })
     )
-  }, [layout.active, activeId, recentFolders])
+  }, [layout.active, activeId, recentFolders, menuConnected, menuSync.syncedPaths.length])
   useEffect(() => {
     const off = window.api.board.onClosed(() => {
       if (poppedFromBoardRef.current) {
@@ -1207,7 +1227,27 @@ export function AppShell(): JSX.Element {
           )
         },
         // Through the tabs' own close, which prompts on a dirty buffer (#915).
-        closeTab: () => dispatchCloseTab()
+        closeTab: () => dispatchCloseTab(),
+        // --- Device (#918) -------------------------------------------------
+        // Run and Stop reach the TOOLBAR's handlers; Connect and Disconnect
+        // reach ConnectionControl's. Reimplementing Run here would drop the
+        // auto-connect and the soft reboot #871 turns on.
+        connect: () => dispatchDeviceAction('connect'),
+        disconnect: () => dispatchDeviceAction('disconnect'),
+        run: () => dispatchDeviceAction('run'),
+        stop: () => dispatchDeviceAction('stop'),
+        // These two have no component state behind them — one API call and one
+        // store call — so routing a message to somebody who would do the same
+        // would only add a place for it to go missing.
+        softReset: () =>
+          void window.api.device
+            .softReset()
+            .catch(reporter('soft reset', { notify: "Couldn't reset the board." })),
+        syncNow: () =>
+          void syncNowRef
+            .current()
+            .catch(reporter('sync now', { notify: "Couldn't sync to the board." })),
+        showHelp: () => dispatchOpenHelp('')
       })
     })
     return off

--- a/src/renderer/src/components/ConnectionControl.tsx
+++ b/src/renderer/src/components/ConnectionControl.tsx
@@ -1,5 +1,10 @@
 import { useCallback, useEffect, useState } from 'react'
-import { isVirtualPort, VIRTUAL_PORT_LABEL, VIRTUAL_PORT_PATH } from '../../../shared/virtual-device'
+import {
+  isVirtualPort,
+  VIRTUAL_PORT_LABEL,
+  VIRTUAL_PORT_PATH
+} from '../../../shared/virtual-device'
+import { onDeviceAction } from './device-bus'
 import { SimMemoryDialog } from './SimMemoryDialog'
 import { pushSimHeapBytes, readSimHeapBytes, writeSimHeapBytes } from '../store/sim-memory'
 import type { DeviceStatus, PortCircuitPy, PortInfo } from '../../../preload/index.d'
@@ -117,6 +122,32 @@ export function ConnectionControl({ status }: ConnectionControlProps): JSX.Eleme
     }
   }, [connected, selected])
 
+  // Device ▸ Connect / Disconnect (#918). Addressed separately rather than as
+  // the toggle above, because a menu says what it will do before you choose it:
+  // "Disconnect" has to mean disconnect, not "toggle whatever the state is now".
+  useEffect(
+    () =>
+      onDeviceAction('connect', () => {
+        if (connected || !selected) return
+        setError(null)
+        window.api.device
+          .connect(selected)
+          .catch((err) => setError(err instanceof Error ? err.message : String(err)))
+      }),
+    [connected, selected]
+  )
+  useEffect(
+    () =>
+      onDeviceAction('disconnect', () => {
+        if (!connected) return
+        setError(null)
+        window.api.device
+          .disconnect()
+          .catch((err) => setError(err instanceof Error ? err.message : String(err)))
+      }),
+    [connected]
+  )
+
   /** Persist a new simulated heap and hand it to the device layer. */
   const saveHeap = useCallback(async (bytes: number): Promise<number> => {
     const stored = writeSimHeapBytes(bytes)
@@ -191,7 +222,11 @@ export function ConnectionControl({ status }: ConnectionControlProps): JSX.Eleme
           // real device node — show just its USB name. OS serial paths (e.g.
           // /dev/ttyACM0) DO identify the port, so keep those.
           const isWebSerial = p.path.startsWith('webserial://')
-          const base = isWebSerial ? detail || 'USB board' : detail ? `${p.path} — ${detail}` : p.path
+          const base = isWebSerial
+            ? detail || 'USB board'
+            : detail
+              ? `${p.path} — ${detail}`
+              : p.path
           // A board whose CIRCUITPY drive we found says what it's running before
           // you connect to it (#753). Only shown when the drive was tied to THIS
           // port, so a second board can't borrow the first one's identity.

--- a/src/renderer/src/components/Toolbar.tsx
+++ b/src/renderer/src/components/Toolbar.tsx
@@ -4,6 +4,7 @@ import { WorkspaceSwitcher } from './WorkspaceSwitcher'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { useWorkspace } from '../store/workspace'
 import { useConsole } from '../store/console'
+import { onDeviceAction } from './device-bus'
 import { isVirtualPort } from '../../../shared/virtual-device'
 import { runTitle, stopTitle } from './run-controls'
 import './RunControls.css'
@@ -26,7 +27,6 @@ const ToolIcon = (children: ReactNode): JSX.Element => (
   </svg>
 )
 
-
 // page with a `+` (new file)
 const NEW_FILE_ICON = ToolIcon(
   <g fill="currentColor">
@@ -44,7 +44,6 @@ const SAVE_ICON = ToolIcon(
     <rect x="3.5" y="9" width="9" height="5" fill="var(--bg-elevated)" />
   </g>
 )
-
 
 /**
  * Glossy green snake brand mark from the Skeuomorph concept: a green
@@ -77,7 +76,6 @@ const SNAKE_LOGO = (
     <path d="M24.4 8l3 .7m-3-.7l3-.9" stroke="#e23b2b" strokeWidth="1.1" strokeLinecap="round" />
   </svg>
 )
-
 
 /**
  * TOP TOOLBAR.
@@ -194,12 +192,22 @@ export function Toolbar(): JSX.Element {
       window.api.device.interrupt().catch(reporter('stop', { notify: "Couldn't stop the board." }))
       setRunning(false)
     } else {
-      window.api.device.softReset().catch(reporter('reset', { notify: "Couldn't reset the board." }))
+      window.api.device
+        .softReset()
+        .catch(reporter('reset', { notify: "Couldn't reset the board." }))
     }
   }, [running])
 
+  // Device ▸ Run / Stop (#918) reach the SAME handlers as the toolbar buttons.
+  // Run in particular carries the auto-connect, the real-board preference and
+  // the soft reboot that #871 turns on — a menu item that reimplemented any of
+  // that would be a different Run wearing the same word.
+  useEffect(() => onDeviceAction('run', () => void handleRun()), [handleRun])
+  useEffect(() => onDeviceAction('stop', handleStop), [handleStop])
+
   const handleSave = useCallback(() => {
-    if (activeId) void saveFile(activeId).catch(reporter('save file', { notify: "Couldn't save the file." }))
+    if (activeId)
+      void saveFile(activeId).catch(reporter('save file', { notify: "Couldn't save the file." }))
   }, [activeId, saveFile])
 
   return (
@@ -208,71 +216,70 @@ export function Toolbar(): JSX.Element {
           that's balanced by an empty side on the right, so the workspace
           switcher sits CENTRED at the top of the toolbar (not shoved right). */}
       <div className="toolbar__side">
-      <div className="toolbar__brand">
-        {SNAKE_LOGO}
-        <span className="toolbar__wordmark">Snakie</span>
-      </div>
+        <div className="toolbar__brand">
+          {SNAKE_LOGO}
+          <span className="toolbar__wordmark">Snakie</span>
+        </div>
 
-      <div className="toolbar__group">
-        <div className="toolbar__seg" role="group" aria-label="File actions">
+        <div className="toolbar__group">
+          <div className="toolbar__seg" role="group" aria-label="File actions">
+            <button
+              type="button"
+              className="btn btn--ghost btn--icon toolbar__seg-btn"
+              onClick={newFile}
+              title="New file"
+              aria-label="New file"
+            >
+              {NEW_FILE_ICON}
+            </button>
+            <button
+              type="button"
+              className="btn btn--ghost btn--icon toolbar__seg-btn"
+              onClick={handleSave}
+              disabled={!activeFile}
+              title={activeFile ? `Save ${activeFile.name}` : 'Open a file to save'}
+              aria-label="Save active file"
+            >
+              {SAVE_ICON}
+            </button>
+          </div>
+        </div>
+
+        <span className="toolbar__divider" aria-hidden="true" />
+
+        <div className="toolbar__group">
           <button
             type="button"
-            className="btn btn--ghost btn--icon toolbar__seg-btn"
-            onClick={newFile}
-            title="New file"
-            aria-label="New file"
+            className="btn btn--primary"
+            onClick={() => void handleRun()}
+            disabled={!canRun}
+            title={runTitle({
+              activeFileName: activeFile?.name,
+              connected,
+              connecting,
+              dialect: status.runtime?.dialect
+            })}
+            aria-label="Run active file on device"
           >
-            {NEW_FILE_ICON}
+            <span className="btn__glyph" aria-hidden="true">
+              ▶
+            </span>
+            <span>Run</span>
           </button>
           <button
             type="button"
-            className="btn btn--ghost btn--icon toolbar__seg-btn"
-            onClick={handleSave}
-            disabled={!activeFile}
-            title={activeFile ? `Save ${activeFile.name}` : 'Open a file to save'}
-            aria-label="Save active file"
+            className="btn btn--danger"
+            onClick={handleStop}
+            disabled={!connected}
+            title={stopTitle({ connected, running, dialect: status.runtime?.dialect })}
+            aria-label={running ? 'Stop / interrupt running program' : 'Reset the board'}
           >
-            {SAVE_ICON}
+            <span className="btn__glyph" aria-hidden="true">
+              {running ? '■' : '⟳'}
+            </span>
+            <span>{running ? 'Stop' : 'Reset'}</span>
           </button>
         </div>
-      </div>
-
-      <span className="toolbar__divider" aria-hidden="true" />
-
-      <div className="toolbar__group">
-        <button
-          type="button"
-          className="btn btn--primary"
-          onClick={() => void handleRun()}
-          disabled={!canRun}
-          title={runTitle({
-            activeFileName: activeFile?.name,
-            connected,
-            connecting,
-            dialect: status.runtime?.dialect
-          })}
-          aria-label="Run active file on device"
-        >
-          <span className="btn__glyph" aria-hidden="true">
-            ▶
-          </span>
-          <span>Run</span>
-        </button>
-        <button
-          type="button"
-          className="btn btn--danger"
-          onClick={handleStop}
-          disabled={!connected}
-          title={stopTitle({ connected, running, dialect: status.runtime?.dialect })}
-          aria-label={running ? 'Stop / interrupt running program' : 'Reset the board'}
-        >
-          <span className="btn__glyph" aria-hidden="true">
-            {running ? '■' : '⟳'}
-          </span>
-          <span>{running ? 'Stop' : 'Reset'}</span>
-        </button>
-      </div>
-
       </div>
 
       {/* Workspace layouts (epic #259): Code · Electronics · Build + reset.

--- a/src/renderer/src/components/device-bus.ts
+++ b/src/renderer/src/components/device-bus.ts
@@ -1,0 +1,55 @@
+/**
+ * THE DEVICE ACTIONS, ADDRESSED BY NAME (#918, epic #913).
+ * =============================================================================
+ *
+ * Run, Stop, Connect and Disconnect are on the Device menu now, and every one of
+ * them already had an owner: `Toolbar` runs and stops, `ConnectionControl`
+ * connects and disconnects. The menu has to reach THOSE, not reimplement them.
+ *
+ * Run is the reason this is a bus rather than four calls. `Toolbar.handleRun` is
+ * forty lines of decisions — is a board already connected, was one connected
+ * before, is the port that vanished the one we were on, should this fall back to
+ * the simulator or say so out loud — and #871 turns on it doing a soft reboot so
+ * `boot.py` runs again. A second Run that skipped any of that would be a
+ * different Run wearing the same word, and the difference would only show up on
+ * someone's desk with a board that had browned out.
+ *
+ * Connect and Disconnect are addressed SEPARATELY rather than as a toggle, even
+ * though `ConnectionControl` implements them as one: a menu says what it will do
+ * before you choose it, so "Disconnect" has to mean disconnect even if the state
+ * changed between the menu opening and the click.
+ *
+ * Soft reset and Sync now are NOT here — they are one API call and one store
+ * call respectively, with no component state behind them, so the menu makes them
+ * directly rather than routing a message to somebody who would do the same.
+ */
+
+/** A device action a menu item can ask for. */
+export type DeviceAction = 'run' | 'stop' | 'connect' | 'disconnect'
+
+export const DEVICE_ACTION_EVENT = 'snakie:device-action'
+
+export interface DeviceActionDetail {
+  action: DeviceAction
+}
+
+/** Ask whoever owns `action` to perform it. */
+export function dispatchDeviceAction(action: DeviceAction): void {
+  window.dispatchEvent(
+    new CustomEvent<DeviceActionDetail>(DEVICE_ACTION_EVENT, { detail: { action } })
+  )
+}
+
+/**
+ * Listen for one action. Returns the unsubscribe.
+ *
+ * Per-action rather than one listener with a switch, so a component subscribes
+ * to exactly what it owns and two components cannot quietly both answer for Run.
+ */
+export function onDeviceAction(action: DeviceAction, run: () => void): () => void {
+  const handler = (e: Event): void => {
+    if ((e as CustomEvent<DeviceActionDetail>).detail?.action === action) run()
+  }
+  window.addEventListener(DEVICE_ACTION_EVENT, handler)
+  return () => window.removeEventListener(DEVICE_ACTION_EVENT, handler)
+}

--- a/src/renderer/src/lib/menuCommands.ts
+++ b/src/renderer/src/lib/menuCommands.ts
@@ -73,6 +73,33 @@ export interface MenuCommandDeps {
    * by once.
    */
   closeTab: () => void
+
+  // --- Device (#918) -------------------------------------------------------
+
+  /** Connect to the selected port — `ConnectionControl`'s own connect. */
+  connect: () => void
+  /** Disconnect, freeing the serial port (#845 — this is how the flasher gets
+   *  at the board, and the documented escape from an install that looks stuck). */
+  disconnect: () => void
+  /**
+   * Run the active file.
+   *
+   * MUST be the toolbar's own Run. It auto-connects, prefers a real board over
+   * the simulator, says so when the board it was using has vanished, and does a
+   * soft reboot so `boot.py` runs again (#871). A second Run that skipped any of
+   * that would be a different Run wearing the same word.
+   */
+  run: () => void
+  /** Interrupt the running program, or soft-reset when nothing is running —
+   *  the toolbar's Stop, which decides between the two. */
+  stop: () => void
+  /** Soft reset the board. One API call, so the menu makes it. */
+  softReset: () => void
+  /** Push the tagged files to the board now. */
+  syncNow: () => void
+
+  /** Open the Help panel (#918). */
+  showHelp: () => void
 }
 
 /** Every renderer menu command and what it does. */
@@ -86,6 +113,13 @@ export function menuCommandHandlers(
     'file.save': () => deps.save(),
     'file.saveAs': () => deps.saveAs(),
     'file.closeTab': () => deps.closeTab(),
+    'device.connect': () => deps.connect(),
+    'device.disconnect': () => deps.disconnect(),
+    'device.run': () => deps.run(),
+    'device.stop': () => deps.stop(),
+    'device.softReset': () => deps.softReset(),
+    'device.syncNow': () => deps.syncNow(),
+    'help.snakieHelp': () => deps.showHelp(),
     'help.shortcuts': () => deps.showShortcuts()
   } as Record<RendererMenuCommand, () => void>
   // Derived from the slot list, like the workspaces below: the submenu's ids are

--- a/src/shared/menu-commands.ts
+++ b/src/shared/menu-commands.ts
@@ -73,7 +73,14 @@ export type RendererMenuCommand =
   | 'file.save'
   | 'file.saveAs'
   | 'file.closeTab'
+  | 'device.connect'
+  | 'device.disconnect'
+  | 'device.run'
+  | 'device.stop'
+  | 'device.softReset'
+  | 'device.syncNow'
   | 'help.shortcuts'
+  | 'help.snakieHelp'
   | WorkspaceMenuCommand
   | RecentFolderMenuCommand
 
@@ -89,7 +96,14 @@ export const RENDERER_MENU_COMMANDS: readonly RendererMenuCommand[] = [
   'file.save',
   'file.saveAs',
   'file.closeTab',
+  'device.connect',
+  'device.disconnect',
+  'device.run',
+  'device.stop',
+  'device.softReset',
+  'device.syncNow',
   ...WORKSPACE_IDS.map(workspaceMenuCommand),
+  'help.snakieHelp',
   'help.shortcuts'
 ]
 
@@ -147,6 +161,18 @@ export interface MenuContext {
   hasActiveFile: boolean
   /** Recently opened folders, newest first. */
   recentFolders: string[]
+  /**
+   * Whether a board is connected (#918).
+   *
+   * The strongest case for state travelling back to the menu at all: device
+   * state changes constantly — a board is unplugged, a cable is knocked — and a
+   * Run item that looks available with nothing plugged in is worse than no menu,
+   * because it makes the app look broken rather than the board look absent.
+   */
+  connected: boolean
+  /** Whether anything is tagged for sync in the current folder — Sync now with
+   *  nothing tagged would do nothing, loudly. */
+  hasSyncedFiles: boolean
 }
 
 /** Derive the menu's state from the renderer's. Pure, so what the menu shows is
@@ -157,7 +183,19 @@ export function menuStateFrom(ctx: MenuContext): MenuState {
   const enabled: Partial<Record<MenuCommand, boolean>> = {
     'file.save': ctx.hasActiveFile,
     'file.saveAs': ctx.hasActiveFile,
-    'file.closeTab': ctx.hasActiveFile
+    'file.closeTab': ctx.hasActiveFile,
+    // Connect and Disconnect are opposites, so exactly one is ever available —
+    // an enabled Disconnect with nothing connected is a menu describing a state
+    // the app is not in.
+    'device.connect': !ctx.connected,
+    'device.disconnect': ctx.connected,
+    // RUN stays available with no board: it auto-connects, and that is the whole
+    // reason a first-time user with nothing plugged in still gets the simulator
+    // rather than a dead button. It needs a FILE, though.
+    'device.run': ctx.hasActiveFile,
+    'device.stop': ctx.connected,
+    'device.softReset': ctx.connected,
+    'device.syncNow': ctx.connected && ctx.hasSyncedFiles
   }
   return { enabled, checked, recentFolders: ctx.recentFolders.slice(0, RECENT_FOLDER_SLOTS.length) }
 }

--- a/src/shared/menu-template.ts
+++ b/src/shared/menu-template.ts
@@ -249,7 +249,12 @@ export function appMenuTemplate(o: MenuTemplateOptions): MenuItemConstructorOpti
     {
       label: 'View',
       submenu: [
-        { role: 'reload' },
+        // `role: 'reload'` IS ⌘R, and #918 wants that key for Run — which in an
+        // editor for running MicroPython is worth far more than reloading the
+        // renderer. Reloading is not lost: `forceReload` is ⇧⌘R, does the
+        // stronger version of the same thing, and is the one that helps when a
+        // renderer is actually stuck. So the plain one stands down rather than
+        // being given a third accelerator nobody would guess.
         { role: 'forceReload' },
         { role: 'toggleDevTools' },
         { type: 'separator' },
@@ -261,6 +266,27 @@ export function appMenuTemplate(o: MenuTemplateOptions): MenuItemConstructorOpti
         { role: 'zoomOut' },
         { type: 'separator' },
         { role: 'togglefullscreen' }
+      ]
+    },
+    {
+      label: 'Device',
+      submenu: [
+        // Exactly one of these is ever enabled (see `menuStateFrom`), so the
+        // pair reads as a state rather than as two buttons.
+        commandItem('device.connect', 'Connect', o),
+        commandItem('device.disconnect', 'Disconnect', o),
+        { type: 'separator' },
+        // ⌘R, freed above. Run stays enabled with no board connected because it
+        // AUTO-CONNECTS — that is what makes it work for someone who has just
+        // opened the app — so what it needs is a file, not a board.
+        commandItem('device.run', 'Run', o, { accelerator: 'CmdOrCtrl+R' }),
+        // ⌘. is the platform's own "stop what you are doing", and the nearest
+        // thing to the Ctrl-C this sends. Monaco binds none of ⌘R, ⌘. or ⌘Enter,
+        // so neither of these is taken out of the editor's hands.
+        commandItem('device.stop', 'Stop', o, { accelerator: 'CmdOrCtrl+.' }),
+        commandItem('device.softReset', 'Soft Reset', o),
+        { type: 'separator' },
+        commandItem('device.syncNow', 'Sync Now', o)
       ]
     },
     // The Window menu uses the standard `windowMenu` role so the OS manages it —
@@ -281,6 +307,11 @@ export function appMenuTemplate(o: MenuTemplateOptions): MenuItemConstructorOpti
               checkForUpdatesItem,
               { type: 'separator' }
             ] as MenuItemConstructorOptions[])),
+        // Snakie has a whole help system — the Help panel, the "Why?" article
+        // behind every refactoring — reachable until now only from inside the
+        // panels that use it. On macOS the Help menu held nothing of Snakie's at
+        // all (#918).
+        commandItem('help.snakieHelp', 'Snakie Help', o),
         shortcutsItem
       ]
     }

--- a/test/appMenuTemplate.test.ts
+++ b/test/appMenuTemplate.test.ts
@@ -26,7 +26,9 @@ const fullRecents = (): MenuState =>
   menuStateFrom({
     workspace: 'code',
     hasActiveFile: true,
-    recentFolders: RECENT_FOLDER_SLOTS.map((i) => `/projects/folder-${i}`)
+    recentFolders: RECENT_FOLDER_SLOTS.map((i) => `/projects/folder-${i}`),
+    connected: true,
+    hasSyncedFiles: true
   })
 
 /**
@@ -135,7 +137,7 @@ describe('View ▸ Workspace (#916)', () => {
     for (const active of WORKSPACE_IDS) {
       const { template } = build({
         isMac: true,
-        state: menuStateFrom({ workspace: active, hasActiveFile: true, recentFolders: [] })
+        state: menuStateFrom({ workspace: active, hasActiveFile: true, recentFolders: [], connected: true, hasSyncedFiles: true })
       })
       const submenu = viewSubmenu(template, 'Workspace')
       const ticked = submenu.filter((m) => m.checked).map((m) => m.label)
@@ -155,7 +157,7 @@ describe('View ▸ Workspace (#916)', () => {
     // claiming one would be a tick that can never appear.
     const { template } = build({
       isMac: true,
-      state: menuStateFrom({ workspace: 'code', hasActiveFile: true, recentFolders: [] })
+      state: menuStateFrom({ workspace: 'code', hasActiveFile: true, recentFolders: [], connected: true, hasSyncedFiles: true })
     })
     for (const item of commandItems(template)) {
       if (item.type === 'radio' || item.type === 'checkbox') {

--- a/test/deviceMenu.test.ts
+++ b/test/deviceMenu.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import type { MenuItemConstructorOptions } from 'electron'
+import { appMenuTemplate } from '../src/shared/menu-template'
+import { menuStateFrom, type MenuCommand } from '../src/shared/menu-commands'
+import { allShortcuts } from '../src/shared/shortcuts'
+
+/**
+ * The Device menu (#918, epic #913).
+ *
+ * Everything a user does TO THE BOARD was reachable only from the toolbar or the
+ * console panel, with no menu entry and no keyboard route — including the two
+ * most-used actions in the app.
+ *
+ * The strongest reason this menu needed #914's state channel: device state
+ * changes constantly, a cable gets knocked, and a Run item that looks available
+ * with nothing plugged in makes the APP look broken rather than the board look
+ * absent. So most of this file is about what greys out, and when.
+ */
+
+const ctx = (over: Partial<Parameters<typeof menuStateFrom>[0]> = {}) =>
+  menuStateFrom({
+    workspace: 'code',
+    hasActiveFile: true,
+    recentFolders: [],
+    connected: true,
+    hasSyncedFiles: true,
+    ...over
+  })
+
+const deviceSubmenu = (isMac: boolean): MenuItemConstructorOptions[] => {
+  const template = appMenuTemplate({
+    appName: 'Snakie',
+    isMac,
+    state: ctx(),
+    onCommand: () => {}
+  })
+  const menu = template.find((m) => m.label === 'Device')
+  return Array.isArray(menu?.submenu) ? menu.submenu : []
+}
+
+describe('the Device menu exists on both platforms', () => {
+  it.each([true, false])('lists the board actions (isMac=%s)', (isMac) => {
+    const labels = deviceSubmenu(isMac)
+      .filter((m) => m.label)
+      .map((m) => String(m.label))
+    expect(labels).toEqual([
+      'Connect',
+      'Disconnect',
+      'Run',
+      'Stop',
+      'Soft Reset',
+      'Sync Now'
+    ])
+  })
+})
+
+describe('items grey out when the board cannot act', () => {
+  const on = (id: MenuCommand, over: Parameters<typeof ctx>[0]): boolean | undefined =>
+    ctx(over).enabled[id]
+
+  it('offers exactly one of Connect and Disconnect', () => {
+    // Two enabled items describing opposite states is a menu describing a state
+    // the app is not in.
+    expect(on('device.connect', { connected: false })).toBe(true)
+    expect(on('device.disconnect', { connected: false })).toBe(false)
+    expect(on('device.connect', { connected: true })).toBe(false)
+    expect(on('device.disconnect', { connected: true })).toBe(true)
+  })
+
+  it('greys Stop and Soft Reset with no board', () => {
+    for (const id of ['device.stop', 'device.softReset'] as const) {
+      expect(on(id, { connected: false }), id).toBe(false)
+      expect(on(id, { connected: true }), id).toBe(true)
+    }
+  })
+
+  it('keeps RUN available with no board, because Run connects one', () => {
+    // The auto-connect is what makes Run work for someone who has just opened
+    // the app; greying it would leave a first-time user with a dead item and no
+    // way to discover the simulator. What Run needs is a FILE.
+    expect(on('device.run', { connected: false })).toBe(true)
+    expect(on('device.run', { hasActiveFile: false })).toBe(false)
+  })
+
+  it('greys Sync Now unless there is a board AND something tagged', () => {
+    expect(on('device.syncNow', { connected: true, hasSyncedFiles: true })).toBe(true)
+    expect(on('device.syncNow', { connected: false, hasSyncedFiles: true })).toBe(false)
+    expect(on('device.syncNow', { connected: true, hasSyncedFiles: false })).toBe(false)
+  })
+})
+
+describe('the accelerators do not collide with what already owns them', () => {
+  it('gives Run ⌘R, which the View menu had to give up', () => {
+    const run = deviceSubmenu(true).find((m) => m.label === 'Run')
+    expect(run?.accelerator).toBe('CmdOrCtrl+R')
+  })
+
+  it('leaves no reload role still holding ⌘R', () => {
+    // `role: 'reload'` IS ⌘R. Two menu items claiming one key is a coin toss
+    // resolved by menu order, which is not a design.
+    const src = readFileSync('src/shared/menu-template.ts', 'utf8')
+    expect(src).not.toContain("{ role: 'reload' }")
+    // Reloading is not lost — the force variant does the stronger version of the
+    // same thing on ⇧⌘R, and is the one that helps a stuck renderer.
+    expect(src).toContain("{ role: 'forceReload' }")
+  })
+
+  it('gives Stop ⌘., the platform’s own "stop that"', () => {
+    expect(deviceSubmenu(true).find((m) => m.label === 'Stop')?.accelerator).toBe('CmdOrCtrl+.')
+  })
+
+  it('claims no key twice across the whole menu', () => {
+    // The real guard. Every binding Snakie declares, on both platforms, has to
+    // be unique — this is what would have caught ⌘R being taken twice.
+    for (const isMac of [true, false]) {
+      const keys = allShortcuts({ appName: 'Snakie', isMac }).map((s) => s.accelerator)
+      expect(new Set(keys).size, `${isMac ? 'macOS' : 'Windows/Linux'}: ${keys.join(', ')}`).toBe(
+        keys.length
+      )
+    }
+  })
+})
+
+describe('the menu reaches the actions that already exist', () => {
+  const shell = readFileSync('src/renderer/src/components/AppShell.tsx', 'utf8')
+  const toolbar = readFileSync('src/renderer/src/components/Toolbar.tsx', 'utf8')
+  const conn = readFileSync('src/renderer/src/components/ConnectionControl.tsx', 'utf8')
+
+  it('routes Run and Stop to the toolbar’s own handlers', () => {
+    // `handleRun` auto-connects, prefers a real board over the simulator, says so
+    // when the board it was using has vanished, and does the soft reboot #871
+    // turns on. A second Run would be a different Run wearing the same word.
+    expect(shell).toContain("run: () => dispatchDeviceAction('run')")
+    expect(toolbar).toContain("onDeviceAction('run'")
+    expect(toolbar).toContain("onDeviceAction('stop'")
+  })
+
+  it('routes Connect and Disconnect to the connection control', () => {
+    expect(conn).toContain("onDeviceAction('connect'")
+    expect(conn).toContain("onDeviceAction('disconnect'")
+  })
+
+  it('says disconnect, not toggle', () => {
+    // A menu says what it will do before you choose it, so Disconnect has to
+    // mean disconnect even if the state moved between opening and clicking.
+    const off = conn.slice(conn.indexOf("onDeviceAction('disconnect'"))
+    expect(off.slice(0, 500)).toContain('if (!connected) return')
+    expect(off.slice(0, 500)).toContain('.disconnect()')
+  })
+
+  it('makes the two stateless calls directly rather than via the bus', () => {
+    // Soft reset is one API call and Sync now one store call. Routing a message
+    // to somebody who would make the same call only adds a place to lose it.
+    expect(shell).toContain('window.api.device')
+    expect(shell).toContain('.softReset()')
+    expect(shell).toContain('syncNowRef')
+  })
+})
+
+describe('Help finally holds something of Snakie’s', () => {
+  it('offers Snakie Help on both platforms', () => {
+    for (const isMac of [true, false]) {
+      const template = appMenuTemplate({
+        appName: 'Snakie',
+        isMac,
+        state: ctx(),
+        onCommand: () => {}
+      })
+      const help = template.find((m) => m.role === 'help')
+      const labels = Array.isArray(help?.submenu)
+        ? help.submenu.filter((m) => m.label).map((m) => String(m.label))
+        : []
+      // On macOS this menu held nothing of Snakie's at all before (#918).
+      expect(labels, isMac ? 'macOS' : 'Windows/Linux').toContain('Snakie Help')
+    }
+  })
+})

--- a/test/fileMenu.test.ts
+++ b/test/fileMenu.test.ts
@@ -70,7 +70,13 @@ describe('the recent slots are ids, not folders', () => {
 
 describe('items grey out when they cannot act', () => {
   const state = (hasActiveFile: boolean) =>
-    menuStateFrom({ workspace: 'code', hasActiveFile, recentFolders: [] })
+    menuStateFrom({
+      workspace: 'code',
+      hasActiveFile,
+      recentFolders: [],
+      connected: true,
+      hasSyncedFiles: true
+    })
 
   it('greys Save, Save As and Close Tab with nothing open', () => {
     // A menu that offers Save with nothing to save teaches people not to trust

--- a/test/menuChannel.test.ts
+++ b/test/menuChannel.test.ts
@@ -122,19 +122,19 @@ describe('the app menu command channel (#914)', () => {
   })
 
   it('rebuilds the menu when the renderer publishes its state', () => {
-    publish(menuStateFrom({ workspace: 'robot', hasActiveFile: true, recentFolders: [] }))
+    publish(menuStateFrom({ workspace: 'robot', hasActiveFile: true, recentFolders: [], connected: true, hasSyncedFiles: true }))
     expect(installed).toHaveLength(2)
     const ticked = items().filter((m) => m.checked)
     expect(ticked.map((m) => m.label)).toEqual(['Build'])
   })
 
   it('does not rebuild when the state has not actually changed', () => {
-    publish(menuStateFrom({ workspace: 'board', hasActiveFile: true, recentFolders: [] }))
-    publish(menuStateFrom({ workspace: 'board', hasActiveFile: true, recentFolders: [] }))
+    publish(menuStateFrom({ workspace: 'board', hasActiveFile: true, recentFolders: [], connected: true, hasSyncedFiles: true }))
+    publish(menuStateFrom({ workspace: 'board', hasActiveFile: true, recentFolders: [], connected: true, hasSyncedFiles: true }))
     // A rebuild closes an open menu on macOS, and the renderer republishes on
     // every mount — so an unchanged state must be a no-op.
     expect(installed).toHaveLength(2)
-    publish(menuStateFrom({ workspace: 'code', hasActiveFile: true, recentFolders: [] }))
+    publish(menuStateFrom({ workspace: 'code', hasActiveFile: true, recentFolders: [], connected: true, hasSyncedFiles: true }))
     expect(installed).toHaveLength(3)
   })
 

--- a/test/menuCommands.test.ts
+++ b/test/menuCommands.test.ts
@@ -56,7 +56,14 @@ function deps(): {
     },
     save: () => rec.fired.push('save'),
     saveAs: () => rec.fired.push('saveAs'),
-    closeTab: () => rec.fired.push('closeTab')
+    closeTab: () => rec.fired.push('closeTab'),
+    connect: () => rec.fired.push('connect'),
+    disconnect: () => rec.fired.push('disconnect'),
+    run: () => rec.fired.push('run'),
+    stop: () => rec.fired.push('stop'),
+    softReset: () => rec.fired.push('softReset'),
+    syncNow: () => rec.fired.push('syncNow'),
+    showHelp: () => rec.fired.push('showHelp')
   }
   return rec
 }
@@ -119,7 +126,7 @@ describe('menu command union ↔ renderer dispatcher (#914)', () => {
     for (const bad of [
       'workspace.show.datalab',
       'file.openRecent.99',
-      'device.disconnect',
+      'device.reboot',
       '',
       42,
       null,
@@ -135,16 +142,30 @@ describe('menu command union ↔ renderer dispatcher (#914)', () => {
 describe('menu state travelling back to the menu (#914)', () => {
   it('ticks exactly the active workspace', () => {
     for (const active of WORKSPACE_IDS) {
-      const state = menuStateFrom({ workspace: active, hasActiveFile: true, recentFolders: [] })
+      const state = menuStateFrom({
+        workspace: active,
+        hasActiveFile: true,
+        recentFolders: [],
+        connected: true,
+        hasSyncedFiles: true
+      })
       for (const id of WORKSPACE_IDS) {
         expect(state.checked[workspaceMenuCommand(id)], `${active}/${id}`).toBe(id === active)
       }
-      // The workspace itself greys nothing out — only the File items carry
-      // enablement, and with a file open they are all usable.
+      // The workspace itself greys nothing out. Everything listed here is a
+      // FILE or DEVICE item, and with a file open and a board connected they are
+      // all usable except Connect, whose whole job is to be the other half of
+      // Disconnect (#918).
       expect(state.enabled).toEqual({
         'file.save': true,
         'file.saveAs': true,
-        'file.closeTab': true
+        'file.closeTab': true,
+        'device.connect': false,
+        'device.disconnect': true,
+        'device.run': true,
+        'device.stop': true,
+        'device.softReset': true,
+        'device.syncNow': true
       })
     }
   })
@@ -155,7 +176,7 @@ describe('menu state travelling back to the menu (#914)', () => {
 
   it('coerceMenuState keeps known ids with boolean values and drops the rest', () => {
     const state = coerceMenuState({
-      enabled: { 'file.openFolder': false, 'device.disconnect': false, 'view.boardWindow': 'yes' },
+      enabled: { 'file.openFolder': false, 'device.reboot': false, 'view.boardWindow': 'yes' },
       checked: { [workspaceMenuCommand('robot')]: true, 'workspace.show.datalab': true }
     })
     expect(state).toEqual({


### PR DESCRIPTION
Closes #918. Part of epic #913.

Everything you do *to the board* was reachable only from the toolbar or the console panel — including **Run and Stop, the two most-used actions in the app**, which had no keyboard route at all.

Device ▸ Connect / Disconnect · **Run (⌘R)** · **Stop (⌘.)** · Soft Reset · Sync Now.

## Greying out is the point

This is the strongest case for #914 carrying renderer state back to the menu. Device state changes constantly — a cable gets knocked — and a Run item that looks available with nothing plugged in makes the *app* look broken rather than the board look absent.

Connect and Disconnect are opposites, so exactly one is ever offered. Stop, Soft Reset and Sync Now need a board. Sync Now also needs something tagged.

**Run is the deliberate exception.** It stays available with no board, because it auto-connects — that's what makes it work for someone who just opened the app and would otherwise meet a dead item and never discover the simulator. What Run needs is a *file*.

## ⌘R came from somewhere

`role: 'reload'` owned it. In an editor for running MicroPython, ⌘R meaning "run my program" is worth more than reloading the renderer, so the plain reload stands down. Reloading isn't lost — **Force Reload is ⇧⌘R**, does the stronger version of the same thing, and is the one that helps when a renderer is actually stuck.

A test now asserts **no binding in the whole menu is claimed twice**, on either platform. That's the guard that would have caught this, and the mutation check confirms it fails when two items claim one key.

Stop takes ⌘., the platform's own "stop that" and the nearest thing to the Ctrl-C it sends. I checked the Monaco bundle rather than assuming: it binds **none** of ⌘R, ⌘. or ⌘Enter by default, so neither key is taken out of the editor's hands.

## Run reaches the toolbar's own handler

`handleRun` is forty lines of decisions — is a board already connected, was one connected before, is the port that vanished the one we were on, fall back to the simulator or say so out loud — and **#871 turns on it doing a soft reboot so `boot.py` runs again**.

A second Run that skipped any of that would be a different Run wearing the same word, and the difference would only show up on someone's desk with a board that had browned out. So Run, Stop, Connect and Disconnect go over a small typed bus to the components that already own them.

Connect and Disconnect are addressed **separately** rather than as the toggle `ConnectionControl` implements: a menu says what it will do before you choose it, so Disconnect must mean disconnect even if the state moved between the menu opening and the click.

Soft Reset and Sync Now are deliberately *not* on the bus — one API call and one store call, no component state behind either, so routing a message to somebody who'd make the same call only adds a place to lose it.

## Also: Help ▸ Snakie Help

Snakie has a whole help system — the Help panel, the "Why?" article behind every refactoring — reachable until now only from inside the panels that use it. On macOS the Help menu held nothing of Snakie's at all.

## One thing the issue asked for that isn't here

**"Upload to device"** isn't a distinct action in this codebase — `Sync Now` is how files reach the board. Adding a separate upload would be inventing a feature under cover of a menu item, so I implemented Sync Now and left it at that.

## Gates

lint (pre-existing `DriverInstallBanner.tsx` warning only) · typecheck · **6,589 tests in 316 files** · build — green.

**Not verified on screen.** The menu is data and heavily tested as data, but I haven't driven it against a real board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe