### PR TITLE
The packaged app could not reach the bundled board index (#947)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The packaged app showed twelve boards instead of 237** (#947). 0.51.0's
+  Board Finder listed only the twelve curated overlay boards. Those are compiled
+  into JavaScript; the 225 from upstream live in `boards.json`, fetched at
+  runtime from an *absolute* path — and the packaged app loads its renderer with
+  `loadFile`, so the document is a `file://` URL, where an absolute path resolves
+  against the **filesystem root** rather than the app bundle. The file was
+  packaged correctly all along; it simply could not be reached by that URL. The
+  thumbnails had the same leading slash, so the twelve boards that did show had
+  no photographs either.
+
+  Both are relative now, which resolves correctly under `file://`, under the dev
+  server, and on the web — including a web build served from a subpath, which the
+  absolute form never handled.
+
+  It failed *quietly*: `loadBundledIndex` catches a miss and returns an empty
+  index by design, so the gallery looked small rather than broken. And it could
+  not be seen in `npm run dev`, which serves from `/`. The new test resolves both
+  URLs against a packaged `file://` base and asserts they land inside the
+  renderer directory — reproducing the failure rather than asserting the shape of
+  a string, since the string is only wrong in the one context that ships.
+
 ## [0.51.0] - 2026-09-05
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snakie",
-  "version": "0.51.0",
+  "version": "0.51.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "snakie",
-      "version": "0.51.0",
+      "version": "0.51.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snakie",
-  "version": "0.51.0",
+  "version": "0.51.1",
   "description": "A modern, cross-platform MicroPython editor.",
   "productName": "Snakie",
   "main": "./out/main/index.js",

--- a/src/renderer/src/lib/board-index-source.ts
+++ b/src/renderer/src/lib/board-index-source.ts
@@ -29,12 +29,32 @@ import {
   type BoardIndex
 } from '../../../shared/board-index'
 
-/** Where the bundled seed is served from, in both builds. */
-export const BUNDLED_INDEX_URL = '/boards/boards.json'
+/**
+ * Where the bundled seed is served from, in both builds.
+ *
+ * RELATIVE, and it has to stay relative (#947). The packaged app loads its
+ * renderer with `loadFile`, so the document is a `file://` URL — and an absolute
+ * path under `file://` resolves against the FILESYSTEM ROOT, not the app:
+ *
+ *     '/boards/boards.json'  →  file:///boards/boards.json          ✗
+ *     'boards/boards.json'   →  file:///…/out/renderer/boards/…     ✓
+ *
+ * Shipped absolute in 0.51.0, where it cost the gallery every one of the 225
+ * upstream boards. It failed quietly rather than loudly: `loadBundledIndex`
+ * catches the miss and returns an empty index, so the finder simply showed the
+ * twelve overlay boards — which are compiled into JS and therefore fine — and
+ * looked like a much smaller catalogue rather than a broken one.
+ *
+ * It cannot be caught by running `npm run dev`, which serves from `/`, so
+ * `boardAssetPaths.test.ts` resolves these against a packaged `file://` base
+ * instead of trusting the shape of the string.
+ */
+export const BUNDLED_INDEX_URL = 'boards/boards.json'
 
-/** A board's bundled thumbnail, or null when it has none. */
+/** A board's bundled thumbnail, or null when it has none. Relative, for the
+ *  reason above — every thumbnail was unreachable in the packaged 0.51.0 too. */
 export function thumbUrl(thumb: string | null): string | null {
-  return thumb ? `/boards/thumbs/${thumb}` : null
+  return thumb ? `boards/thumbs/${thumb}` : null
 }
 
 /** Read the seed. Never throws — a broken seed means an empty gallery, not a crash. */

--- a/test/boardAssetPaths.test.ts
+++ b/test/boardAssetPaths.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import { existsSync, readFileSync } from 'node:fs'
+import { BUNDLED_INDEX_URL, thumbUrl } from '../src/renderer/src/lib/board-index-source'
+
+/**
+ * The bundled board assets have to be reachable from the PACKAGED app (#947).
+ *
+ * 0.51.0 shipped a Board Finder that showed twelve boards instead of 237. The
+ * twelve were the overlay, which is compiled into JavaScript; the 225 upstream
+ * ones live in `boards.json`, fetched at runtime from `/boards/boards.json`.
+ *
+ * That leading slash is the whole bug. The packaged app loads its renderer with
+ * `loadFile`, so the document is a `file://` URL, and an absolute path under
+ * `file://` resolves against the FILESYSTEM ROOT rather than the app bundle. The
+ * fetch missed, `loadBundledIndex` returned an empty index by design, and the
+ * gallery quietly looked small instead of broken.
+ *
+ * It could not be seen in `npm run dev`, which serves from `/`, and no test
+ * caught it because none of them resolved a URL against a `file://` base. So
+ * this file does exactly that, rather than asserting the shape of a string:
+ * the string is only wrong in one context, and that context is the one that
+ * ships.
+ */
+
+/** Where the renderer's HTML actually sits in a packaged macOS build. */
+const PACKAGED = 'file:///Applications/Snakie.app/Contents/Resources/app.asar/out/renderer/index.html'
+const RENDERER_DIR = 'file:///Applications/Snakie.app/Contents/Resources/app.asar/out/renderer/'
+/** The dev server, and the web build served from a domain root. */
+const DEV = 'http://localhost:5173/index.html'
+const WEB = 'https://app.snakie.org/index.html'
+/** The web build can also be served from a subpath (`base: '/app/'`). */
+const WEB_SUBPATH = 'https://snakie.org/app/index.html'
+
+const resolve = (path: string, base: string): string => new URL(path, base).href
+
+describe('the board index is reachable wherever the app is loaded from', () => {
+  it('lands inside the renderer directory in a packaged build', () => {
+    // The bug, directly: absolute gave `file:///boards/boards.json`.
+    expect(resolve(BUNDLED_INDEX_URL, PACKAGED)).toBe(`${RENDERER_DIR}boards/boards.json`)
+  })
+
+  it('still resolves under the dev server and on the web', () => {
+    expect(resolve(BUNDLED_INDEX_URL, DEV)).toBe('http://localhost:5173/boards/boards.json')
+    expect(resolve(BUNDLED_INDEX_URL, WEB)).toBe('https://app.snakie.org/boards/boards.json')
+  })
+
+  it('follows the web build to a subpath, which absolute never did', () => {
+    expect(resolve(BUNDLED_INDEX_URL, WEB_SUBPATH)).toBe('https://snakie.org/app/boards/boards.json')
+  })
+
+  it('never escapes to the filesystem root', () => {
+    // The one shape that is always wrong under `file://`.
+    expect(BUNDLED_INDEX_URL.startsWith('/')).toBe(false)
+    expect(resolve(BUNDLED_INDEX_URL, PACKAGED).startsWith(RENDERER_DIR)).toBe(true)
+  })
+})
+
+describe('so are the thumbnails', () => {
+  // They had the same leading slash, so every photo in the packaged 0.51.0 was
+  // unreachable too — including on the twelve boards that did show.
+  it('lands inside the renderer directory in a packaged build', () => {
+    expect(resolve(thumbUrl('RPI_PICO.jpg')!, PACKAGED)).toBe(
+      `${RENDERER_DIR}boards/thumbs/RPI_PICO.jpg`
+    )
+  })
+
+  it('is null for a board with no thumbnail, rather than a path to nothing', () => {
+    expect(thumbUrl(null)).toBeNull()
+  })
+
+  it('never escapes to the filesystem root', () => {
+    expect(thumbUrl('X.jpg')!.startsWith('/')).toBe(false)
+  })
+})
+
+describe('the file it points at is actually shipped', () => {
+  /**
+   * The other half of the failure: a correct URL to a missing file looks
+   * identical from the renderer. `boards.json` IS packaged — it was reachable
+   * all along, just not by that URL — and this keeps both halves true together.
+   */
+  it('is in the public folder the build copies', () => {
+    expect(existsSync('src/renderer/public/boards/boards.json')).toBe(true)
+  })
+
+  it('holds the full catalogue, not a stub', () => {
+    const index = JSON.parse(readFileSync('src/renderer/public/boards/boards.json', 'utf8'))
+    // If this ever collapses to a handful, the gallery would look exactly as it
+    // did in 0.51.0 — small rather than broken — so the count is worth pinning.
+    expect(index.boards.length).toBeGreaterThan(200)
+  })
+
+  it('reaches the packaged output', () => {
+    // Present only after a build; skipped rather than failing a clean checkout.
+    if (!existsSync('out/renderer')) return
+    expect(existsSync('out/renderer/boards/boards.json')).toBe(true)
+  })
+})


### PR DESCRIPTION
Closes #947. Fixes the 0.51.0 regression you hit: **twelve boards instead of 237**.

## What was happening

Twelve is exactly the overlay count — and the overlay is compiled into JavaScript. The 225 upstream boards live in `boards.json`, fetched at runtime from an **absolute** path.

The packaged app loads its renderer with `loadFile`, so the document is a `file://` URL, where an absolute path resolves against the **filesystem root**:

| | `/boards/boards.json` | `boards/boards.json` |
|---|---|---|
| dev (vite) | `http://localhost:5173/boards/boards.json` ✅ | ✅ |
| **packaged (`file://`)** | **`file:///boards/boards.json`** ❌ | `file:///…/out/renderer/boards/boards.json` ✅ |
| web root | ✅ | ✅ |
| web subpath | ❌ wrong | ✅ |

The file was packaged correctly all along — 353 KB, sitting in `out/renderer/boards/` — it just couldn't be reached by that URL. `thumbUrl` had the same leading slash, so **the twelve boards that did show had no photographs either**.

Both are relative now.

## Why nothing caught it

Three things lined up:

- It **failed quietly by design** — `loadBundledIndex` catches a miss and returns an empty index, so a broken seed is a small gallery rather than a crash. That's right, and here it meant the finder looked like a smaller catalogue instead of a broken one.
- It **cannot appear in `npm run dev`**, which serves from `/`.
- **No test resolved a URL against a `file://` base** — the only context where absolute and relative differ.

The Board Finder shipped packaged for the first time in 0.51.0, so this was its first exposure.

## The test

It resolves both URLs against a packaged `file://` document base and asserts they land inside the renderer directory — reproducing the failure rather than asserting the shape of a string, since the string is only wrong in the one context that ships.

Reverting either path fails five assertions, naming `file:///boards/boards.json` in the message. It also pins that `boards.json` still holds the full catalogue: a correct URL to a stubbed file would look identical from the renderer.

I verified the fix against the **real built output**, not just a hypothetical path — resolving `boards/boards.json` from the actual `out/renderer/index.html` finds the file; the 0.51.0 form doesn't.

## Swept the rest

This was the only runtime fetch of a bundled asset. Vite rewrites the HTML's own references to `./` itself, and the two remaining absolute paths (`/lib/instruments.py`, `/lib/snakie.py`) are paths **on the board**, not browser URLs.

## Gates

lint (pre-existing `DriverInstallBanner.tsx` warning only) · typecheck · **6,612 tests in 318 files** · desktop build · web build — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe