### PR TITLE
The compile message goes to the status bar, and goes away (#952)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **"Compiled foo.mpy" no longer sticks in the Files panel** (#952). #949's
+  success message was rendered inside the Files panel and stayed there until
+  something else replaced it. It goes to the status bar now, where syncing
+  already reports itself, and clears itself after a few seconds — a compile is a
+  momentary action whose only lasting trace is the new file in the tree.
+
+  The status bar's slot is *sticky*: whoever posts a message schedules its
+  removal. Two callers had already written that dance by hand with their own
+  timers, and this would have been the third, so it is one helper now and both
+  of them moved to it. The timer is deliberately **shared** — there is one slot,
+  so a newer message must cancel the older one's countdown, or the first
+  message's clear wipes the second off the screen partway through.
+
 ### Added
 
 - **Right-click a `.py` and compile it to `.mpy`** (#949). MicroPython's own

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snakie",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "snakie",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snakie",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "A modern, cross-platform MicroPython editor.",
   "productName": "Snakie",
   "main": "./out/main/index.js",

--- a/src/renderer/src/components/LocalFileTree.tsx
+++ b/src/renderer/src/components/LocalFileTree.tsx
@@ -4,6 +4,7 @@ import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { useWorkspace, FILE_SAVED_EVENT, type FileSavedDetail } from '../store/workspace'
 import { forgetTagsPrompt, useSync } from '../store/sync'
 import { useFileSelection } from '../store/file-selection'
+import { showStatus } from '../lib/status-bar'
 import { ContextMenu, type ContextMenuItem, type ContextMenuPosition } from './ContextMenu'
 import { usePrompt } from './PromptModal'
 import { iconProps, NewFileIcon, NewFolderIcon, RefreshIcon } from './file-tree-icons'
@@ -212,9 +213,6 @@ export function LocalFileTree(): JSX.Element {
     publishSelection(selectedPath ? { path: selectedPath, isDir: selectedIsDir } : null)
   }, [selectedPath, selectedIsDir, publishSelection])
   const [error, setError] = useState<string | null>(null)
-  /** A one-line "that worked" for an action with no other visible result (#949):
-   *  a compiled `.mpy` lands in the tree, but silently. */
-  const [notice, setNotice] = useState<string | null>(null)
   /** Whether this build ships the MicroPython compiler. False on the web, which
    *  has no main process to run it in — so the item says why instead of failing
    *  when pressed. */
@@ -453,13 +451,20 @@ export function LocalFileTree(): JSX.Element {
       if (entry.isDir) return
       void (async (): Promise<void> => {
         setError(null)
-        setNotice(null)
         const res = await window.api.mpy.compile(entry.path).catch((err: unknown) => ({
           ok: false as const,
           error: err instanceof Error ? err.message : String(err)
         }))
         if (res.ok) {
-          setNotice(`Compiled ${res.path.split(/[/\\]/).pop()} — ${res.bytes} bytes`)
+          // The STATUS BAR, not this panel (#952): a compile is a momentary
+          // action whose only lasting trace is the new file in the tree, and the
+          // bar is where syncing already reports itself, so the two read as the
+          // same kind of event. It also goes away on its own — the in-panel
+          // version sat there until something else replaced it.
+          showStatus(`Compiled ${res.path.split(/[/\\]/).pop()} — ${res.bytes} bytes`, {
+            priority: 4,
+            clearAfterMs: 6000
+          })
           void refresh()
         } else {
           // mpy-cross's own complaint, which names the line. Anything vaguer
@@ -663,7 +668,6 @@ export function LocalFileTree(): JSX.Element {
           </nav>
 
           {error && <div className="localtree__error">{error}</div>}
-          {!error && notice && <div className="localtree__notice">{notice}</div>}
 
           <div
             className="localtree__tree"
@@ -691,7 +695,6 @@ export function LocalFileTree(): JSX.Element {
       ) : (
         <div className="localtree__empty">
           {error && <div className="localtree__error">{error}</div>}
-          {!error && notice && <div className="localtree__notice">{notice}</div>}
           {reopenName && (
             <button
               className="btn btn--primary"

--- a/src/renderer/src/components/RobotDockPanel.tsx
+++ b/src/renderer/src/components/RobotDockPanel.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from 'react'
+import { showStatus } from '../lib/status-bar'
+import { useEffect, useState } from 'react'
 import { RobotView } from './RobotView'
 import { SyncControl } from './SyncControl'
 import { dirname } from './robot-mesh'
@@ -47,25 +48,11 @@ export function RobotDockPanel({
   // Bumped when another window rewrites the .urdf on disk (#716).
   const [urdfNonce, setUrdfNonce] = useState(0)
 
-  // Show a transient message in the status bar so linking/creating a robot — which
-  // is otherwise invisible — is clear to the user. Auto-clears after a few seconds
-  // (the shared `snakie:status` seam is sticky, so the caller schedules the clear).
-  const statusTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const notify = (text: string): void => {
-    window.dispatchEvent(new CustomEvent('snakie:status', { detail: { text, priority: 4 } }))
-    if (statusTimer.current) clearTimeout(statusTimer.current)
-    statusTimer.current = setTimeout(
-      () => window.dispatchEvent(new CustomEvent('snakie:status', { detail: { text: '' } })),
-      4000
-    )
-  }
-  useEffect(
-    () => () => {
-      if (statusTimer.current != null) clearTimeout(statusTimer.current)
-    },
-    []
-  )
-
+  // Show a transient message in the status bar so linking/creating a robot —
+  // otherwise invisible — is clear to the user. The scheduling lives in
+  // `showStatus` since #952; the slot is sticky, and three copies of that dance
+  // is how three of them end up disagreeing about how long a message lives.
+  const notify = (text: string): void => showStatus(text, { priority: 4, clearAfterMs: 4000 })
   useEffect(() => {
     let live = true
     void (async () => {
@@ -111,12 +98,19 @@ export function RobotDockPanel({
     setFocus(true)
   }
 
-  const nameOf = (p: string): string => p.replace(/[/\\]+$/, '').split(/[/\\]/).pop() ?? p
+  const nameOf = (p: string): string =>
+    p
+      .replace(/[/\\]+$/, '')
+      .split(/[/\\]/)
+      .pop() ?? p
   // Forward slashes, no trailing slash, and a lower-cased Windows drive letter (the
   // file dialog can return `C:\…` while the remembered folder is `c:\…`, which would
   // otherwise defeat the prefix test and silently skip linking).
   const normSlash = (p: string): string =>
-    p.replace(/\\/g, '/').replace(/\/$/, '').replace(/^([a-zA-Z]):/, (_m, d) => `${d.toLowerCase()}:`)
+    p
+      .replace(/\\/g, '/')
+      .replace(/\/$/, '')
+      .replace(/^([a-zA-Z]):/, (_m, d) => `${d.toLowerCase()}:`)
   // The path of `p` relative to project folder `dir`, or null when it's outside it.
   const relInside = (p: string, dir: string): string | null => {
     const np = normSlash(p)
@@ -309,32 +303,34 @@ export function RobotDockPanel({
       )}
       {/* Full-screen in Build: the full pose tool is the single control, so hide
           this row. */}
-      {!embedded && !full && <div className="robotdock__actions">
-        <button
-          type="button"
-          className={`robotdock__btn${hasProjectRobot ? '' : ' robotdock__btn--cta'}`}
-          title="Create a new blank robot (.urdf) and open it in the pose tool"
-          onClick={() => void newRobot()}
-        >
-          ＋ New robot
-        </button>
-        <button
-          type="button"
-          className="robotdock__btn"
-          title="Open an existing robot (.urdf) full-screen"
-          onClick={() => void openRobot()}
-        >
-          <FolderOpenIcon size={13} /> Open…
-        </button>
-        <button
-          type="button"
-          className="robotdock__btn"
-          title="Pop out full-screen (pose tool + assembly)"
-          onClick={popOut}
-        >
-          ⤢ Pop out
-        </button>
-      </div>}
+      {!embedded && !full && (
+        <div className="robotdock__actions">
+          <button
+            type="button"
+            className={`robotdock__btn${hasProjectRobot ? '' : ' robotdock__btn--cta'}`}
+            title="Create a new blank robot (.urdf) and open it in the pose tool"
+            onClick={() => void newRobot()}
+          >
+            ＋ New robot
+          </button>
+          <button
+            type="button"
+            className="robotdock__btn"
+            title="Open an existing robot (.urdf) full-screen"
+            onClick={() => void openRobot()}
+          >
+            <FolderOpenIcon size={13} /> Open…
+          </button>
+          <button
+            type="button"
+            className="robotdock__btn"
+            title="Pop out full-screen (pose tool + assembly)"
+            onClick={popOut}
+          >
+            ⤢ Pop out
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -2257,24 +2257,11 @@ body {
 }
 
 .localtree__error,
-.localtree__notice,
 .tree-error {
+  color: var(--danger);
   font-size: 0.75rem;
   padding: 0.25rem 0.6rem;
   word-break: break-word;
-}
-
-.localtree__error,
-.tree-error {
-  color: var(--danger);
-}
-
-/* The quiet counterpart (#949): an action worked and its only other trace is a
-   new file somewhere in the tree. It shares the error's slot, so the two can
-   never both be on screen arguing about what just happened — and takes the
-   accent rather than a hardcoded green, which the skeuomorph skin would lose. */
-.localtree__notice {
-  color: var(--accent);
 }
 
 /* Device filesystem browser (issue #7) — mirrors the local tree styling. */

--- a/src/renderer/src/lib/status-bar.ts
+++ b/src/renderer/src/lib/status-bar.ts
@@ -1,0 +1,82 @@
+/**
+ * THE STATUS BAR'S TRANSIENT SLOT (#952).
+ * =============================================================================
+ *
+ * One line at the bottom of the window for "that happened": a file synced, a
+ * robot linked, a module compiled. `StatusBar` listens for `snakie:status` and
+ * shows whatever arrives; an empty `text` clears it.
+ *
+ * THE SLOT IS STICKY, which is the part everybody has to remember: a message
+ * stays until something replaces it, so whoever posts a terminal message must
+ * also schedule its removal. Two callers had already written that dance by hand
+ * with their own timers — `emitSyncStatus` in `store/sync.ts` and `notify` in
+ * `RobotDockPanel` — and #949 was about to make it three, which is how three
+ * implementations end up disagreeing about how long a message lives.
+ *
+ * ONE TIMER, deliberately shared. There is one slot, so a second message
+ * genuinely does supersede the first, and its clear must supersede the first's
+ * clear too. Separate timers would let an older message's countdown wipe a newer
+ * message off the screen partway through.
+ *
+ * PRIORITY is passed through to the bar untouched; it decides what outranks what
+ * when several things want to speak. Existing callers: sync is 2, the robot dock
+ * is 4.
+ */
+
+/** The window event `StatusBar` listens on. */
+export const STATUS_EVENT = 'snakie:status'
+
+/** The one pending clear, shared because there is only one slot to clear. */
+let clearTimer: ReturnType<typeof setTimeout> | null = null
+
+export interface StatusOptions {
+  /** What outranks what when several sources want the slot. */
+  priority?: number
+  /**
+   * Remove it after this long.
+   *
+   * Omit for an IN-PROGRESS message ("Syncing…"), which should stay until the
+   * message that replaces it says how it ended.
+   */
+  clearAfterMs?: number
+}
+
+/**
+ * Put `text` in the status bar. Empty text clears it.
+ *
+ * Never throws: a status line is not worth failing an action over, and this runs
+ * in contexts (tests, a window mid-teardown) where `window` may not oblige.
+ */
+export function showStatus(text: string, opts: StatusOptions = {}): void {
+  try {
+    window.dispatchEvent(
+      new CustomEvent(STATUS_EVENT, { detail: { text, priority: opts.priority ?? 2 } })
+    )
+  } catch {
+    return
+  }
+  if (clearTimer) {
+    clearTimeout(clearTimer)
+    clearTimer = null
+  }
+  if (opts.clearAfterMs && text) {
+    clearTimer = setTimeout(() => {
+      try {
+        window.dispatchEvent(new CustomEvent(STATUS_EVENT, { detail: { text: '' } }))
+      } catch {
+        // The slot is overwritten by the next message anyway.
+      }
+    }, opts.clearAfterMs)
+  }
+}
+
+/** Clear the slot now. */
+export function clearStatus(): void {
+  showStatus('')
+}
+
+/** Test seam: drop any pending clear so one test's timer cannot fire in another. */
+export function resetStatusForTest(): void {
+  if (clearTimer) clearTimeout(clearTimer)
+  clearTimer = null
+}

--- a/src/renderer/src/store/sync.ts
+++ b/src/renderer/src/store/sync.ts
@@ -42,6 +42,7 @@ import {
   useState,
   type ReactNode
 } from 'react'
+import { showStatus } from '../lib/status-bar'
 import { baseName, FILE_SAVED_EVENT, useWorkspace, type FileSavedDetail } from './workspace'
 import { useFileSelection } from './file-selection'
 import { planUploadOf, runFolderUpload } from '../lib/folder-transfer'
@@ -81,28 +82,13 @@ const ERROR_LINGER_MS = 4000
  * In-progress messages (`Syncing …`) are dispatched with no linger so the next
  * message replaces them; terminal messages auto-clear after `lingerMs`.
  */
-const SYNC_STATUS_EVENT = 'snakie:status'
-let syncStatusClearTimer: ReturnType<typeof setTimeout> | null = null
-
+/**
+ * Surface a short, transient SYNC message in the status bar (see `showStatus`).
+ * In-progress messages (`Syncing …`) carry no linger so the next message
+ * replaces them; terminal ones auto-clear.
+ */
 function emitSyncStatus(text: string, lingerMs?: number): void {
-  try {
-    window.dispatchEvent(new CustomEvent(SYNC_STATUS_EVENT, { detail: { text, priority: 2 } }))
-  } catch {
-    return
-  }
-  if (syncStatusClearTimer) {
-    clearTimeout(syncStatusClearTimer)
-    syncStatusClearTimer = null
-  }
-  if (lingerMs && text) {
-    syncStatusClearTimer = setTimeout(() => {
-      try {
-        window.dispatchEvent(new CustomEvent(SYNC_STATUS_EVENT, { detail: { text: '' } }))
-      } catch {
-        // ignore — the slot will be overwritten by the next message anyway
-      }
-    }, lingerMs)
-  }
+  showStatus(text, { priority: 2, clearAfterMs: lingerMs })
 }
 
 /** Coarse status backing the toolbar indicator. */
@@ -486,8 +472,7 @@ export function SyncProvider({ children }: { children: ReactNode }): JSX.Element
   const pushPaths = useCallback(
     async (paths: string[]): Promise<void> => {
       if (paths.length === 0) return
-      const label =
-        paths.length === 1 ? baseName(paths[0]) : `${paths.length} files`
+      const label = paths.length === 1 ? baseName(paths[0]) : `${paths.length} files`
       if (lingerTimer.current) clearTimeout(lingerTimer.current)
       setStatus('syncing')
       setError(null)
@@ -599,7 +584,9 @@ export function SyncProvider({ children }: { children: ReactNode }): JSX.Element
         emitSyncStatus(`Syncing ${label}…`)
         // Only a FILE can be saved from an editor buffer, so this path knows the
         // kind without asking the disk (#863).
-        setFileStates((prev) => markFiles(markKind(prev, detail.path, false), [detail.path], 'syncing'))
+        setFileStates((prev) =>
+          markFiles(markKind(prev, detail.path, false), [detail.path], 'syncing')
+        )
         try {
           await window.api.device.writeFile(deviceDestForLocal(detail.path), detail.content)
           setFileStates((prev) => markFiles(prev, [detail.path], 'done'))

--- a/test/statusBar.test.ts
+++ b/test/statusBar.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { clearStatus, resetStatusForTest, showStatus, STATUS_EVENT } from '../src/renderer/src/lib/status-bar'
+
+/**
+ * The status bar's one transient slot (#952).
+ *
+ * `Compiled robot.mpy — 5157 bytes` was rendered inside the Files panel and
+ * never went away: it sat there until something else replaced it. The status bar
+ * is where a momentary action belongs — it is where syncing already reports
+ * itself — and the point of a transient message is that it goes.
+ *
+ * The slot is STICKY, so whoever posts a terminal message schedules its removal.
+ * Two callers had already written that by hand with their own timers, and #949
+ * was about to make it three; the tests below are mostly about the timer being
+ * shared, because that is the part separate implementations get wrong.
+ */
+
+/**
+ * The suite runs in `environment: 'node'`, so there is no `window` — and this
+ * module only needs the one thing a window is here: something to dispatch events
+ * on. Node's own `EventTarget` is that, exactly, so the stub is honest rather
+ * than a mock that could drift from what a browser does.
+ */
+beforeAll(() => {
+  ;(globalThis as { window?: unknown }).window = new EventTarget()
+})
+
+/** Collect what reaches the window, the way StatusBar would. */
+function listen(): { seen: { text: string; priority?: number }[]; stop: () => void } {
+  const seen: { text: string; priority?: number }[] = []
+  const on = (e: Event): void => {
+    seen.push((e as CustomEvent<{ text: string; priority?: number }>).detail)
+  }
+  window.addEventListener(STATUS_EVENT, on)
+  return { seen, stop: () => window.removeEventListener(STATUS_EVENT, on) }
+}
+
+afterEach(() => {
+  resetStatusForTest()
+  vi.useRealTimers()
+})
+
+describe('a message reaches the bar', () => {
+  it('carries its text and priority', () => {
+    const l = listen()
+    showStatus('Compiled robot.mpy — 5157 bytes', { priority: 4 })
+    l.stop()
+    expect(l.seen).toEqual([{ text: 'Compiled robot.mpy — 5157 bytes', priority: 4 }])
+  })
+
+  it('defaults to the priority sync already uses', () => {
+    const l = listen()
+    showStatus('hello')
+    l.stop()
+    expect(l.seen[0].priority).toBe(2)
+  })
+
+  it('clears with an empty text, which is how the bar empties the slot', () => {
+    const l = listen()
+    clearStatus()
+    l.stop()
+    expect(l.seen[0].text).toBe('')
+  })
+})
+
+describe('a terminal message goes away by itself', () => {
+  it('clears after the time it was given', () => {
+    vi.useFakeTimers()
+    const l = listen()
+    showStatus('done', { clearAfterMs: 5000 })
+    expect(l.seen).toHaveLength(1)
+    vi.advanceTimersByTime(4999)
+    expect(l.seen, 'not yet').toHaveLength(1)
+    vi.advanceTimersByTime(1)
+    l.stop()
+    expect(l.seen[1].text).toBe('')
+  })
+
+  it('stays put with no linger, which is what an in-progress message wants', () => {
+    // "Syncing…" should be replaced by the message that says how it ended, not
+    // wiped to an empty bar partway through.
+    vi.useFakeTimers()
+    const l = listen()
+    showStatus('Syncing…')
+    vi.advanceTimersByTime(60_000)
+    l.stop()
+    expect(l.seen).toHaveLength(1)
+  })
+})
+
+describe('one slot, one timer', () => {
+  it('a newer message cancels the older one’s clear', () => {
+    // The failure separate timers produce: the first message's countdown fires
+    // while the SECOND message is on screen, and wipes it mid-life.
+    vi.useFakeTimers()
+    const l = listen()
+    showStatus('first', { clearAfterMs: 1000 })
+    vi.advanceTimersByTime(900)
+    showStatus('second', { clearAfterMs: 5000 })
+    vi.advanceTimersByTime(200) // past when `first` would have cleared
+    expect(l.seen.map((s) => s.text), 'second must still be showing').toEqual(['first', 'second'])
+    vi.advanceTimersByTime(4800)
+    l.stop()
+    expect(l.seen[2].text).toBe('')
+  })
+
+  it('an explicit clear cancels a pending one too', () => {
+    vi.useFakeTimers()
+    const l = listen()
+    showStatus('a', { clearAfterMs: 1000 })
+    clearStatus()
+    vi.advanceTimersByTime(5000)
+    l.stop()
+    expect(l.seen.map((s) => s.text)).toEqual(['a', ''])
+  })
+})
+
+describe('nobody hand-rolls it any more', () => {
+  it('the compile message goes to the bar, not into the Files panel', () => {
+    const tree = readFileSync('src/renderer/src/components/LocalFileTree.tsx', 'utf8')
+    expect(tree).toContain('showStatus(`Compiled ')
+    expect(tree).toContain('clearAfterMs')
+    // The in-panel version had no way to go away.
+    expect(tree).not.toContain('localtree__notice')
+    expect(tree).not.toContain('setNotice')
+  })
+
+  it('the two earlier copies were migrated rather than left to drift', () => {
+    for (const f of ['src/renderer/src/store/sync.ts', 'src/renderer/src/components/RobotDockPanel.tsx']) {
+      const src = readFileSync(f, 'utf8')
+      expect(src, f).toContain('showStatus(')
+      // No local timer, and no raw event dispatch, in either.
+      expect(src, f).not.toMatch(/new CustomEvent\('snakie:status'/)
+    }
+  })
+})


### PR DESCRIPTION
Closes #952. Fixes the thing you hit with #949.

`Compiled robot.mpy — 5157 bytes` was rendered **inside the Files panel** and never left — it sat there until something else replaced it.

It goes to the **status bar** now, where syncing already reports itself so the two read as the same kind of event, and it clears after a few seconds. A compile is a momentary action whose only lasting trace is the new file in the tree.

## Why this touched three files

The status slot is **sticky**: whoever posts a message schedules its own removal. Two callers had already written that dance by hand —

- `store/sync.ts` → `emitSyncStatus`, priority 2, module-level timer
- `RobotDockPanel` → `notify`, priority 4, ref timer

— and this would have been the third. That's how three implementations end up disagreeing about how long a message lives, so it's one `showStatus` now and both moved to it.

**One timer, shared, deliberately.** There is one slot, so a newer message must cancel the older one's countdown — separate timers let the first message's clear fire while the *second* is on screen and wipe it mid-life. Mutation-checked: removing the shared cancel fails two tests.

## A note on the tests

They stub `window` with Node's own `EventTarget` rather than pulling in jsdom. The suite is `environment: 'node'` on purpose, and dispatching events is the only thing this module wants a window for — so the stub is the real class, not a mock that could drift from browser behaviour.

## Gates

lint (pre-existing `DriverInstallBanner.tsx` warning only) · typecheck · **6,634 tests in 320 files** · build — green.

The file-size column you asked for is next, on its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe