### PR TITLE
The status bar keeps a history (#953)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **The status bar keeps a history** (#953). It shows one line at a time and
+  every message wipes the one before it, so anything you were not looking at was
+  simply gone — including the ones that matter afterwards: which file failed to
+  sync, what the compile said, why an install stopped.
+
+  Click the message to see the recent ones; **Show all** opens the full log,
+  where it can be copied to the clipboard, saved as a text file, or cleared.
+  Settings ▸ Editor carries the three questions worth asking: keep a history at
+  all, how many lines, and clear what is there.
+
+  Newest first on screen, **oldest first in the file** — the thing you just
+  missed is the thing you clicked for, while a saved log is read by other tools
+  and by scrolling down, and those want time running forwards.
+
+  Messages are recorded from the `snakie:status` **event** rather than from
+  `showStatus`, so a plugin posting to the bar directly is kept too, and the
+  listener attaches at module load rather than from a component — the panel that
+  reads the history is opened *after* the message you wanted. The cap is a ring
+  buffer, applied to what is already stored as well as to what arrives, so
+  lowering it in Settings takes effect immediately rather than drifting until
+  enough new messages reconcile the two numbers. Turning history off discards
+  what was kept, because a switch that says "don't keep a history" and leaves the
+  old one on disk is not telling the truth.
+
 ### Fixed
 
 - **"Compiled foo.mpy" no longer sticks in the Files panel** (#952). #949's

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snakie",
-  "version": "0.52.1",
+  "version": "0.53.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "snakie",
-      "version": "0.52.1",
+      "version": "0.53.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snakie",
-  "version": "0.52.1",
+  "version": "0.53.0",
   "description": "A modern, cross-platform MicroPython editor.",
   "productName": "Snakie",
   "main": "./out/main/index.js",

--- a/src/renderer/src/components/SettingsDialog.css
+++ b/src/renderer/src/components/SettingsDialog.css
@@ -204,3 +204,52 @@
   color: var(--text-muted);
   text-align: right;
 }
+
+/* --- Status history (#953) ------------------------------------------------
+ * Three controls that no other section needed: a labelled number field and a
+ * destructive button. Their own `settings-shist__` names rather than generic
+ * ones, so a later section adding a "settings-number" cannot restyle these by
+ * accident.
+ * ---------------------------------------------------------------------- */
+
+.settings-shist__label {
+  font-size: 0.8rem;
+  color: var(--text);
+}
+
+.settings-shist__number {
+  width: 6rem;
+  padding: 0.2rem 0.4rem;
+  background: var(--bg-sunken);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font: inherit;
+  font-size: 0.8rem;
+  /* The value is a count; digits should line up if it ever sits in a column. */
+  font-variant-numeric: tabular-nums;
+}
+.settings-shist__number:disabled {
+  opacity: 0.5;
+}
+
+.settings-shist__clear {
+  align-self: flex-start;
+  margin-top: 0.4rem;
+  padding: 0.25rem 0.7rem;
+  background: var(--bg-sunken);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font: inherit;
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+.settings-shist__clear:hover:not(:disabled) {
+  border-color: var(--danger);
+  color: var(--danger);
+}
+.settings-shist__clear:disabled {
+  opacity: 0.5;
+  cursor: default;
+}

--- a/src/renderer/src/components/SettingsDialog.tsx
+++ b/src/renderer/src/components/SettingsDialog.tsx
@@ -1,3 +1,5 @@
+import { useStatusHistory } from '../store/status-history'
+import { HISTORY_LIMIT_MAX, HISTORY_LIMIT_MIN } from '../../../shared/status-history'
 import { useEffect, useState } from 'react'
 import {
   useEditorSettings,
@@ -48,7 +50,11 @@ const TABS: { id: SettingsTab; label: string }[] = [
 /** The app-wide skins (moved here from the toolbar toggle). "Light" is the
  *  textured default skin (id `skeuomorph`); the other is the dark theme. */
 const THEME_OPTIONS: { value: Theme; label: string; hint: string }[] = [
-  { value: 'skeuomorph', label: 'Light', hint: 'The bright default skin — brushed metal, felt and cream paper' },
+  {
+    value: 'skeuomorph',
+    label: 'Light',
+    hint: 'The bright default skin — brushed metal, felt and cream paper'
+  },
   { value: 'dark', label: 'Dark', hint: 'A dark, lights-out theme' }
 ]
 
@@ -143,7 +149,11 @@ export function SettingsDialog({
 const BREADBOARD_BG_OPTIONS: { value: BreadboardBg; label: string; hint: string }[] = [
   { value: 'dark', label: 'Dark', hint: 'The default dark workbench mat' },
   { value: 'blueprint', label: 'Blueprint', hint: 'A classic blue blueprint with a light grid' },
-  { value: 'white', label: 'White', hint: 'A plain white sheet — best for printing and screenshots' }
+  {
+    value: 'white',
+    label: 'White',
+    hint: 'A plain white sheet — best for printing and screenshots'
+  }
 ]
 
 /** The Appearance tab: the app-wide skin + the Board View breadboard background. */
@@ -181,9 +191,7 @@ function AppearanceTab({
 
       <section className="settings-section">
         <h3 className="settings-section__title">Breadboard background</h3>
-        <p className="settings-section__hint">
-          The backdrop behind the Board View wiring canvas.
-        </p>
+        <p className="settings-section__hint">The backdrop behind the Board View wiring canvas.</p>
         <div className="settings-segment" role="radiogroup" aria-label="Breadboard background">
           {BREADBOARD_BG_OPTIONS.map((opt) => (
             <button
@@ -326,9 +334,9 @@ function EditorTab(): JSX.Element {
         <h3 className="settings-section__title">Refactoring hints</h3>
         <p className="settings-section__hint">
           Snakie always points out the MicroPython ones — a tick counter that will wrap, an
-          interrupt handler that allocates — because those are bugs waiting to happen. Turn this
-          on to also see the style suggestions: guard clauses, simpler loops, names for magic
-          numbers. Right-click → Refactor… offers everything either way.
+          interrupt handler that allocates — because those are bugs waiting to happen. Turn this on
+          to also see the style suggestions: guard clauses, simpler loops, names for magic numbers.
+          Right-click → Refactor… offers everything either way.
         </p>
         <label className="settings-check">
           <input
@@ -354,8 +362,8 @@ function EditorTab(): JSX.Element {
       <section className="settings-section">
         <h3 className="settings-section__title">Firmware updates</h3>
         <p className="settings-section__hint">
-          Check whether a newer MicroPython is available for the connected device and prompt you from
-          the Flash-firmware button.
+          Check whether a newer MicroPython is available for the connected device and prompt you
+          from the Flash-firmware button.
         </p>
         <label className="settings-check">
           <input
@@ -366,6 +374,71 @@ function EditorTab(): JSX.Element {
           <span>Check for newer MicroPython firmware</span>
         </label>
       </section>
+
+      <StatusHistorySettings />
     </>
+  )
+}
+
+/**
+ * What the status bar keeps (#953).
+ *
+ * The bar shows one line and each message wipes the last, so the history is
+ * where a message goes to still exist. Three controls, because those are the
+ * three questions: keep any at all, how many, and get rid of what is there.
+ */
+function StatusHistorySettings(): JSX.Element {
+  const { entries, limit, enabled, clear, setLimit, setEnabled } = useStatusHistory()
+  return (
+    <section className="settings-section">
+      <div className="settings-section__row">
+        <h3 className="settings-section__title">Status history</h3>
+        <span className="settings-value">
+          {entries.length} {entries.length === 1 ? 'message' : 'messages'}
+        </span>
+      </div>
+      <p className="settings-section__hint">
+        The status bar shows one message at a time. Click it to see the ones before it.
+      </p>
+      <label className="settings-check">
+        <input type="checkbox" checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />
+        <span>Keep a history of status messages</span>
+      </label>
+      <div className="settings-section__row">
+        <label className="settings-shist__label" htmlFor="status-history-limit">
+          Keep the most recent
+        </label>
+        <input
+          id="status-history-limit"
+          // UNCONTROLLED, committed on blur or Enter. A controlled field would
+          // apply every keystroke, and typing "500" over "200" passes through
+          // "5" — which trims the log to its floor one character into an edit.
+          // `key` re-seeds the field if the limit changes from elsewhere.
+          key={limit}
+          type="number"
+          className="settings-shist__number"
+          min={HISTORY_LIMIT_MIN}
+          max={HISTORY_LIMIT_MAX}
+          step={10}
+          defaultValue={limit}
+          disabled={!enabled}
+          onBlur={(e) => setLimit(Number(e.target.value))}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') (e.target as HTMLInputElement).blur()
+          }}
+        />
+      </div>
+      <p className="settings-section__hint">
+        Older messages are dropped past this. Turning the history off clears what is stored.
+      </p>
+      <button
+        type="button"
+        className="settings-shist__clear"
+        onClick={clear}
+        disabled={entries.length === 0}
+      >
+        Clear history now
+      </button>
+    </section>
   )
 }

--- a/src/renderer/src/components/StatusBar.css
+++ b/src/renderer/src/components/StatusBar.css
@@ -76,6 +76,22 @@
   text-overflow: ellipsis;
 }
 
+/* The message slot is a BUTTON since #953 — it opens the history — so it sheds
+   the browser's button chrome and keeps the bar's own type and colour. The hover
+   is the only new affordance: something here is now clickable, and nothing else
+   on the bar would say so. */
+.statusbar__plugin--history {
+  background: none;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+.statusbar__plugin--history:hover,
+.statusbar__plugin--history:focus-visible {
+  background: var(--bg-sunken);
+}
+
 /* Discovery tip (#434) — a 💡 hint filling the otherwise-empty message area.
  * Fades in/out over ~1s (opacity transition; TIP_FADE_MS in status-tips.ts
  * must match) so rotation is gentle rather than blinky. Linked tips read as

--- a/src/renderer/src/components/StatusBar.tsx
+++ b/src/renderer/src/components/StatusBar.tsx
@@ -4,6 +4,7 @@ import { useWorkspace } from '../store/workspace'
 import { useConsole } from '../store/console'
 import { useEditorSettings } from '../store/settings'
 import { FirmwareFlasher } from './FirmwareFlasher'
+import { StatusHistoryPopup, StatusHistoryView } from './StatusHistory'
 import { onOpenTool } from './tools-bus'
 import { CoffeeLink } from './CoffeeLink'
 import { updateButtonView } from './updateButton'
@@ -97,6 +98,11 @@ export function StatusBar({
   const activeFile = openFiles.find((f) => f.id === activeId) ?? null
 
   const [flasherOpen, setFlasherOpen] = useState(false)
+  // The status history (#953): the popup over the bar, and the full log. The bar
+  // shows one line and each message wipes the last, so what you did not happen
+  // to be looking at is otherwise gone.
+  const [historyOpen, setHistoryOpen] = useState(false)
+  const [historyFull, setHistoryFull] = useState(false)
   // Tools ▸ Firmware Flasher (#917). The status bar owns the dialog, so it opens
   // it; the menu only asks. It does NOT own the Board Finder — that stays inside
   // the dialog (#896) and, since #917, in the app frame for the standalone case.
@@ -455,12 +461,16 @@ export function StatusBar({
               {pluginMsg.text}
             </button>
           ) : (
-            <span
-              className="statusbar__item statusbar__plugin"
-              title={pluginMsg.tooltip ?? undefined}
+            // Clickable since #953: the bar keeps a history now, and the message
+            // itself is the obvious thing to click to see the ones before it.
+            <button
+              type="button"
+              className="statusbar__item statusbar__plugin statusbar__plugin--history"
+              title={pluginMsg.tooltip ?? 'Show recent messages'}
+              onClick={() => setHistoryOpen((v) => !v)}
             >
               {pluginMsg.text}
-            </span>
+            </button>
           ))}
 
         {/* Discovery tip (#434) — only rendered while the bar is otherwise
@@ -606,6 +616,17 @@ export function StatusBar({
         </div>
       </div>
 
+
+      {historyOpen && !historyFull && (
+        <StatusHistoryPopup
+          onClose={() => setHistoryOpen(false)}
+          onExpand={() => {
+            setHistoryOpen(false)
+            setHistoryFull(true)
+          }}
+        />
+      )}
+      {historyFull && <StatusHistoryView onClose={() => setHistoryFull(false)} />}
 
       {flasherOpen && (
         <FirmwareFlasher

--- a/src/renderer/src/components/StatusHistory.css
+++ b/src/renderer/src/components/StatusHistory.css
@@ -1,0 +1,201 @@
+/* --------------------------------------------------------------------------
+ * Status history (#953) — the popup over the bar, and the full-screen log.
+ *
+ * Unique `shist__` BEM prefix: this CSS is global, and a shared prefix is how
+ * two panels end up restyling each other.
+ *
+ * Both surfaces are themed through the app's tokens rather than a palette of
+ * their own, because unlike the Board Finder or the flasher these are not a
+ * world apart — they sit on the app's own chrome and should look it, in the
+ * skeuomorph skin as much as the dark one.
+ * ------------------------------------------------------------------------ */
+
+.shist__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+}
+
+.shist__row {
+  display: flex;
+  gap: 0.55rem;
+  padding: 0.2rem 0.1rem;
+  font-size: 0.74rem;
+  line-height: 1.35;
+  border-bottom: 1px solid var(--border);
+}
+.shist__row:last-child {
+  border-bottom: 0;
+}
+
+.shist__time {
+  flex: 0 0 auto;
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  /* The timestamps form a column; proportional digits would make it ragged. */
+  font-variant-numeric: tabular-nums;
+}
+
+.shist__text {
+  flex: 1 1 auto;
+  min-width: 0;
+  color: var(--text);
+  /* A long message wraps rather than being cut — the end of a path or an error
+     is usually the part worth reading. */
+  overflow-wrap: anywhere;
+}
+
+.shist__empty {
+  margin: 0;
+  padding: 0.5rem 0.2rem;
+  font-size: 0.74rem;
+  color: var(--text-muted);
+}
+
+/* --- the popup ------------------------------------------------------------ */
+
+.shist__popup {
+  /* Fixed, not absolute: the status bar sets `overflow: hidden`, which would
+     clip an absolutely-positioned child at the bar's own height — the same trap
+     the sync indicator's popup documents. */
+  position: fixed;
+  left: 8px;
+  bottom: 2.2rem;
+  z-index: 60;
+  width: max-content;
+  min-width: 20rem;
+  max-width: min(44rem, calc(100vw - 16px));
+  padding: 0.45rem 0.55rem;
+  background: var(--bg-elevated);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
+}
+
+.shist__popup-foot {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 0.35rem;
+  padding-top: 0.35rem;
+  border-top: 1px solid var(--border);
+}
+
+.shist__link {
+  padding: 0.1rem 0.3rem;
+  background: none;
+  border: 0;
+  color: var(--accent);
+  font: inherit;
+  font-size: 0.72rem;
+  cursor: pointer;
+}
+.shist__link:hover,
+.shist__link:focus-visible {
+  text-decoration: underline;
+}
+
+/* --- the full view -------------------------------------------------------- */
+
+.shist {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.shist__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+}
+
+.shist__panel {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: min(56rem, calc(100vw - 3rem));
+  height: min(40rem, calc(100vh - 4rem));
+  background: var(--bg-elevated);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.55);
+  overflow: hidden;
+}
+
+.shist__head {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 0.6rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.shist__title {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.shist__count {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.shist__spacer {
+  flex: 1 1 auto;
+}
+
+/* Confirmation for the two actions with no other visible result. */
+.shist__said {
+  font-size: 0.72rem;
+  color: var(--accent);
+}
+
+.shist__btn {
+  padding: 0.2rem 0.6rem;
+  background: var(--bg-sunken);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font: inherit;
+  font-size: 0.74rem;
+  cursor: pointer;
+}
+.shist__btn:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+.shist__btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.shist__btn--danger:hover:not(:disabled) {
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+.shist__close {
+  padding: 0.1rem 0.4rem;
+  background: none;
+  border: 0;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+.shist__close:hover {
+  color: var(--text);
+}
+
+.shist__body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0.4rem 0.6rem 0.7rem;
+}

--- a/src/renderer/src/components/StatusHistory.tsx
+++ b/src/renderer/src/components/StatusHistory.tsx
@@ -1,0 +1,204 @@
+import { useEffect, useMemo, useRef, useState, type JSX } from 'react'
+import {
+  formatHistoryText,
+  formatTime,
+  historyFileName,
+  type StatusEntry
+} from '../../../shared/status-history'
+import { useStatusHistory } from '../store/status-history'
+import './StatusHistory.css'
+
+/**
+ * WHAT THE STATUS BAR SAID (#953).
+ * =============================================================================
+ *
+ * Two surfaces over one log. The POPUP is the common case — click the bar, see
+ * the last handful, carry on — and the FULL VIEW is for the times you need to
+ * read, search or keep it: copy, save, clear.
+ *
+ * NEWEST FIRST on screen, oldest first in the file. The thing you just missed is
+ * the thing you clicked for, so it belongs at the top; a saved log is read by
+ * other tools and by future-you scrolling down, and those want time running
+ * forwards.
+ */
+
+const PEEK_ROWS = 8
+
+/** One row, in both views. */
+function Row({ entry }: { entry: StatusEntry }): JSX.Element {
+  return (
+    <li className="shist__row">
+      <span className="shist__time">{formatTime(entry.at)}</span>
+      <span className="shist__text">{entry.text}</span>
+    </li>
+  )
+}
+
+/** Nothing recorded yet — say which of the two reasons it is. */
+function Empty({ enabled }: { enabled: boolean }): JSX.Element {
+  return (
+    <p className="shist__empty">
+      {enabled
+        ? 'Nothing yet — messages appear here as they happen.'
+        : 'History is off. Turn it on in Settings ▸ Editor to start keeping messages.'}
+    </p>
+  )
+}
+
+export interface StatusHistoryPopupProps {
+  onClose: () => void
+  /** Open the full-screen view instead. */
+  onExpand: () => void
+}
+
+/** The click-the-bar popup: the most recent few, and a way to see the rest. */
+export function StatusHistoryPopup({ onClose, onExpand }: StatusHistoryPopupProps): JSX.Element {
+  const { entries, enabled } = useStatusHistory()
+  const recent = useMemo(() => [...entries].reverse().slice(0, PEEK_ROWS), [entries])
+  const box = useRef<HTMLDivElement>(null)
+
+  // Click-away and Esc, the two ways out of anything that hovers.
+  useEffect(() => {
+    const onDown = (e: MouseEvent): void => {
+      if (box.current && !box.current.contains(e.target as Node)) onClose()
+    }
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') onClose()
+    }
+    // Deferred: the click that OPENED this would otherwise close it again.
+    const id = setTimeout(() => document.addEventListener('mousedown', onDown), 0)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      clearTimeout(id)
+      document.removeEventListener('mousedown', onDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [onClose])
+
+  return (
+    <div className="shist__popup" ref={box} role="group" aria-label="Recent status messages">
+      {recent.length === 0 ? (
+        <Empty enabled={enabled} />
+      ) : (
+        <ul className="shist__list">
+          {recent.map((e) => (
+            <Row key={e.id} entry={e} />
+          ))}
+        </ul>
+      )}
+      <div className="shist__popup-foot">
+        <button type="button" className="shist__link" onClick={onExpand}>
+          Show all{entries.length > recent.length ? ` (${entries.length})` : ''}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+/** The full-screen log: read it, copy it, save it, clear it. */
+export function StatusHistoryView({ onClose }: { onClose: () => void }): JSX.Element {
+  const { entries, enabled, clear } = useStatusHistory()
+  const newestFirst = useMemo(() => [...entries].reverse(), [entries])
+  const [said, setSaid] = useState<string | null>(null)
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  // Confirmation lives on the button that did the thing, briefly. A copy has no
+  // other visible result, so without this it is indistinguishable from a no-op.
+  useEffect(() => {
+    if (!said) return
+    const id = setTimeout(() => setSaid(null), 2000)
+    return () => clearTimeout(id)
+  }, [said])
+
+  const copy = async (): Promise<void> => {
+    try {
+      await navigator.clipboard.writeText(formatHistoryText(entries))
+      setSaid('Copied')
+    } catch {
+      setSaid('Could not copy')
+    }
+  }
+
+  const save = async (): Promise<void> => {
+    const text = formatHistoryText(entries)
+    try {
+      const path = await window.api.fs.saveFileDialog(historyFileName())
+      if (!path) return
+      await window.api.fs.writeFile(path, text)
+      setSaid('Saved')
+    } catch {
+      setSaid('Could not save')
+    }
+  }
+
+  return (
+    <div className="shist" role="dialog" aria-modal="true" aria-label="Status history">
+      <div className="shist__backdrop" onClick={onClose} aria-hidden />
+      <div className="shist__panel">
+        <header className="shist__head">
+          <h2 className="shist__title">Status history</h2>
+          <span className="shist__count">
+            {entries.length} {entries.length === 1 ? 'message' : 'messages'}
+          </span>
+          <span className="shist__spacer" />
+          {said && (
+            <span className="shist__said" role="status">
+              {said}
+            </span>
+          )}
+          <button
+            type="button"
+            className="shist__btn"
+            onClick={() => void copy()}
+            disabled={entries.length === 0}
+          >
+            Copy
+          </button>
+          <button
+            type="button"
+            className="shist__btn"
+            onClick={() => void save()}
+            disabled={entries.length === 0}
+          >
+            Save…
+          </button>
+          <button
+            type="button"
+            className="shist__btn shist__btn--danger"
+            onClick={clear}
+            disabled={entries.length === 0}
+          >
+            Clear
+          </button>
+          <button
+            type="button"
+            className="shist__close"
+            onClick={onClose}
+            aria-label="Close status history"
+            title="Close (Esc)"
+          >
+            ✕
+          </button>
+        </header>
+        <div className="shist__body">
+          {newestFirst.length === 0 ? (
+            <Empty enabled={enabled} />
+          ) : (
+            <ul className="shist__list shist__list--full">
+              {newestFirst.map((e) => (
+                <Row key={e.id} entry={e} />
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/store/status-history.ts
+++ b/src/renderer/src/store/status-history.ts
@@ -1,0 +1,191 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  appendEntry,
+  clampHistoryLimit,
+  HISTORY_LIMIT_DEFAULT,
+  isRecordable,
+  parseHistory,
+  trimToLimit,
+  type StatusEntry
+} from '../../../shared/status-history'
+import { STATUS_EVENT } from '../lib/status-bar'
+
+/**
+ * KEEPING WHAT THE STATUS BAR SAID (#953).
+ * =============================================================================
+ *
+ * The bar holds one line and every message wipes the one before it. That is
+ * right for a status bar and wrong for the messages you want afterwards — which
+ * file failed to sync, what the compile said, why the install stopped.
+ *
+ * RECORDED AT THE EVENT, not in `showStatus`. Everything that reaches the bar
+ * goes through the `snakie:status` window event, but not everything goes through
+ * `showStatus`: a plugin can post to the bar directly. Listening to the event
+ * catches both, and means a future poster is recorded without knowing this
+ * module exists.
+ *
+ * ONE LISTENER for the whole renderer, attached at module load rather than by a
+ * component, so history accrues whether or not anything is watching it — the
+ * panel that reads it is opened *after* the message you wanted.
+ *
+ * Persisted to `localStorage` so it survives a reload. The cap is a ring buffer,
+ * so the stored value cannot grow without bound; turning history off clears what
+ * is there, because a switch labelled "don't keep a history" that leaves the old
+ * one on disk is not telling the truth.
+ */
+
+const ENTRIES_KEY = 'snakie.statusHistory'
+const LIMIT_KEY = 'snakie.statusHistoryLimit'
+const ENABLED_KEY = 'snakie.statusHistoryEnabled'
+
+let entries: StatusEntry[] = []
+let limit = HISTORY_LIMIT_DEFAULT
+let enabled = true
+let nextId = 1
+let loaded = false
+
+const listeners = new Set<() => void>()
+const notify = (): void => listeners.forEach((l) => l())
+
+/** Read persisted state once, tolerating anything the store holds. */
+function load(): void {
+  if (loaded) return
+  loaded = true
+  try {
+    limit = clampHistoryLimit(JSON.parse(window.localStorage.getItem(LIMIT_KEY) ?? 'null'))
+  } catch {
+    limit = HISTORY_LIMIT_DEFAULT
+  }
+  try {
+    enabled = window.localStorage.getItem(ENABLED_KEY) !== 'false'
+  } catch {
+    enabled = true
+  }
+  try {
+    entries = trimToLimit(
+      parseHistory(JSON.parse(window.localStorage.getItem(ENTRIES_KEY) ?? '[]')),
+      limit
+    )
+    nextId = entries.reduce((m, e) => Math.max(m, e.id), 0) + 1
+  } catch {
+    entries = []
+  }
+}
+
+/** Best-effort persist. Storage can be off, or full. */
+function save(): void {
+  try {
+    window.localStorage.setItem(ENTRIES_KEY, JSON.stringify(entries))
+  } catch {
+    // A log that cannot be written is not worth an error the user can do
+    // nothing about; it stays in memory for this session.
+  }
+}
+
+/** Record one message, if history is on. */
+export function recordStatus(text: string, priority = 0): void {
+  load()
+  if (!enabled || !isRecordable(text)) return
+  entries = appendEntry(entries, { id: nextId++, text, at: Date.now(), priority }, limit)
+  save()
+  notify()
+}
+
+/** Everything kept, oldest first. */
+export function statusHistory(): StatusEntry[] {
+  load()
+  return entries
+}
+
+export function clearStatusHistory(): void {
+  load()
+  entries = []
+  save()
+  notify()
+}
+
+export function statusHistoryLimit(): number {
+  load()
+  return limit
+}
+
+export function setStatusHistoryLimit(value: number): void {
+  load()
+  limit = clampHistoryLimit(value)
+  // Applied to what is ALREADY stored, or the number in Settings and the number
+  // of lines on screen disagree until enough new messages arrive.
+  entries = trimToLimit(entries, limit)
+  try {
+    window.localStorage.setItem(LIMIT_KEY, JSON.stringify(limit))
+  } catch {
+    /* keep the in-memory value */
+  }
+  save()
+  notify()
+}
+
+export function statusHistoryEnabled(): boolean {
+  load()
+  return enabled
+}
+
+export function setStatusHistoryEnabled(on: boolean): void {
+  load()
+  enabled = on
+  try {
+    window.localStorage.setItem(ENABLED_KEY, String(on))
+  } catch {
+    /* keep the in-memory value */
+  }
+  // Turning it off discards what was kept: a switch that says "do not keep a
+  // history" and leaves the old one on disk is not telling the truth.
+  if (!on) {
+    entries = []
+    save()
+  }
+  notify()
+}
+
+/** Module-level capture, so history accrues with nothing mounted. */
+if (typeof window !== 'undefined') {
+  window.addEventListener(STATUS_EVENT, (e: Event) => {
+    const detail = (e as CustomEvent<{ text?: unknown; priority?: number }>).detail
+    if (isRecordable(detail?.text)) recordStatus(detail.text, detail?.priority ?? 0)
+  })
+}
+
+/** React view of the log. */
+export function useStatusHistory(): {
+  entries: StatusEntry[]
+  limit: number
+  enabled: boolean
+  clear: () => void
+  setLimit: (n: number) => void
+  setEnabled: (on: boolean) => void
+} {
+  const [, bump] = useState(0)
+  useEffect(() => {
+    const l = (): void => bump((n) => n + 1)
+    listeners.add(l)
+    return () => {
+      listeners.delete(l)
+    }
+  }, [])
+  return {
+    entries: statusHistory(),
+    limit: statusHistoryLimit(),
+    enabled: statusHistoryEnabled(),
+    clear: useCallback(clearStatusHistory, []),
+    setLimit: useCallback(setStatusHistoryLimit, []),
+    setEnabled: useCallback(setStatusHistoryEnabled, [])
+  }
+}
+
+/** Test seam: forget everything, including what was loaded from storage. */
+export function resetStatusHistoryForTest(): void {
+  entries = []
+  limit = HISTORY_LIMIT_DEFAULT
+  enabled = true
+  nextId = 1
+  loaded = true
+}

--- a/src/shared/status-history.ts
+++ b/src/shared/status-history.ts
@@ -1,0 +1,130 @@
+/**
+ * THE STATUS BAR'S HISTORY, AS PURE DATA (#953).
+ * =============================================================================
+ *
+ * The bar shows one line at a time and each message wipes the one before it, so
+ * anything you did not happen to be looking at is simply gone — including the
+ * ones that matter afterwards, like which file failed to sync and why.
+ *
+ * This module is the rules, DOM-free: what gets recorded, how the ring buffer
+ * behaves at its limit, and how the log reads when copied out. The React store
+ * and the panels sit on top in the renderer.
+ */
+
+/** One recorded message. */
+export interface StatusEntry {
+  /** Monotonic within a session; the React key, and the sort order. */
+  id: number
+  text: string
+  /** `Date.now()` when it was recorded. */
+  at: number
+  /** What the sender claimed — kept so the log can show why one message won. */
+  priority: number
+}
+
+/** How many lines are kept when nobody has chosen. */
+export const HISTORY_LIMIT_DEFAULT = 200
+
+/**
+ * The bounds a stored or typed limit is held to.
+ *
+ * The floor is not zero: "keep none" is the `enabled` switch, and a limit of
+ * zero would be a second, silent way to express it that the UI could not show.
+ */
+export const HISTORY_LIMIT_MIN = 10
+export const HISTORY_LIMIT_MAX = 5000
+
+/** Hold a limit inside its bounds, whatever arrived. */
+export function clampHistoryLimit(value: unknown): number {
+  // `null` and `undefined` mean "nothing stored", which is the DEFAULT — not the
+  // minimum. Left to `Number()` they part company: `Number(undefined)` is NaN
+  // and lands on the default, but `Number(null)` is 0 and clamps to the floor,
+  // so an absent setting would silently become "keep 10".
+  if (value === null || value === undefined || value === '') return HISTORY_LIMIT_DEFAULT
+  const n = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(n)) return HISTORY_LIMIT_DEFAULT
+  return Math.min(HISTORY_LIMIT_MAX, Math.max(HISTORY_LIMIT_MIN, Math.floor(n)))
+}
+
+/**
+ * Is this message worth recording?
+ *
+ * An EMPTY text is how the bar is cleared, not something that was said — and a
+ * history full of blank lines would bury the messages it exists to keep.
+ */
+export function isRecordable(text: unknown): text is string {
+  return typeof text === 'string' && text.trim().length > 0
+}
+
+/**
+ * Append one entry, dropping the oldest past `limit`.
+ *
+ * NEWEST LAST, which is how a log reads and how it is written to a file. The
+ * popup reverses it for display; storing it reversed instead would mean every
+ * append rewrites the array's front.
+ */
+export function appendEntry(
+  entries: readonly StatusEntry[],
+  entry: StatusEntry,
+  limit: number
+): StatusEntry[] {
+  const next = [...entries, entry]
+  const cap = clampHistoryLimit(limit)
+  return next.length <= cap ? next : next.slice(next.length - cap)
+}
+
+/**
+ * Re-apply a limit to what is already stored.
+ *
+ * Lowering the limit in Settings has to take effect on the existing log, not
+ * just on what arrives next — otherwise the number in the box and the number of
+ * lines on screen disagree until enough new messages arrive to reconcile them.
+ */
+export function trimToLimit(entries: readonly StatusEntry[], limit: number): StatusEntry[] {
+  const cap = clampHistoryLimit(limit)
+  return entries.length <= cap ? [...entries] : entries.slice(entries.length - cap)
+}
+
+/** A local `HH:MM:SS` for one entry. */
+export function formatTime(at: number): string {
+  const d = new Date(at)
+  const p = (n: number): string => String(n).padStart(2, '0')
+  return `${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`
+}
+
+/**
+ * The log as text, for the clipboard and for a saved file.
+ *
+ * One line per message, timestamp first, oldest first — the shape anything else
+ * that reads logs expects, and the shape that diffs and greps usefully.
+ */
+export function formatHistoryText(entries: readonly StatusEntry[]): string {
+  return entries.map((e) => `${formatTime(e.at)}  ${e.text}`).join('\n')
+}
+
+/** What a saved log is called: unambiguous, sortable, no spaces. */
+export function historyFileName(now: Date = new Date()): string {
+  const p = (n: number): string => String(n).padStart(2, '0')
+  const stamp =
+    `${now.getFullYear()}${p(now.getMonth() + 1)}${p(now.getDate())}` +
+    `-${p(now.getHours())}${p(now.getMinutes())}${p(now.getSeconds())}`
+  return `snakie-status-${stamp}.txt`
+}
+
+/** Validate a stored log, dropping anything malformed rather than rendering it. */
+export function parseHistory(raw: unknown): StatusEntry[] {
+  if (!Array.isArray(raw)) return []
+  const out: StatusEntry[] = []
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue
+    const e = item as Record<string, unknown>
+    if (!isRecordable(e.text)) continue
+    out.push({
+      id: typeof e.id === 'number' ? e.id : out.length,
+      text: e.text,
+      at: typeof e.at === 'number' && Number.isFinite(e.at) ? e.at : 0,
+      priority: typeof e.priority === 'number' ? e.priority : 0
+    })
+  }
+  return out
+}

--- a/test/statusHistory.test.ts
+++ b/test/statusHistory.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import {
+  appendEntry,
+  clampHistoryLimit,
+  formatHistoryText,
+  formatTime,
+  HISTORY_LIMIT_DEFAULT,
+  HISTORY_LIMIT_MAX,
+  HISTORY_LIMIT_MIN,
+  historyFileName,
+  isRecordable,
+  parseHistory,
+  trimToLimit,
+  type StatusEntry
+} from '../src/shared/status-history'
+
+/**
+ * Keeping what the status bar said (#953).
+ *
+ * The bar holds one line and each message wipes the one before it, so anything
+ * you were not looking at is gone — including the messages that matter
+ * afterwards. The rules for what is kept, how many, and how it reads when copied
+ * out are here, DOM-free, because every one of them is a decision rather than a
+ * rendering detail.
+ */
+
+const at = (n: number): number => Date.UTC(2026, 8, 6, 12, 0, n)
+const entry = (id: number, text = `msg ${id}`): StatusEntry => ({
+  id,
+  text,
+  at: at(id),
+  priority: 2
+})
+
+describe('what gets recorded', () => {
+  it('ignores the empty text that CLEARS the bar', () => {
+    // An empty message is how the slot is emptied, not something that was said.
+    // Recorded, it would bury the log in blank lines.
+    expect(isRecordable('')).toBe(false)
+    expect(isRecordable('   ')).toBe(false)
+    expect(isRecordable('Synced')).toBe(true)
+  })
+
+  it('ignores anything that is not a string at all', () => {
+    // The detail crosses a window event and a plugin can post it.
+    for (const bad of [null, undefined, 42, {}, []]) expect(isRecordable(bad)).toBe(false)
+  })
+})
+
+describe('the ring buffer', () => {
+  it('keeps newest LAST, which is how a log reads', () => {
+    let list: StatusEntry[] = []
+    for (const i of [1, 2, 3]) list = appendEntry(list, entry(i), 10)
+    expect(list.map((e) => e.id)).toEqual([1, 2, 3])
+  })
+
+  it('drops the oldest past the limit', () => {
+    // The limit is clamped to its floor first, so a test below HISTORY_LIMIT_MIN
+    // would be testing the clamp instead of the buffer.
+    let list: StatusEntry[] = []
+    for (let i = 1; i <= 14; i++) list = appendEntry(list, entry(i), HISTORY_LIMIT_MIN)
+    expect(list.map((e) => e.id)).toEqual([5, 6, 7, 8, 9, 10, 11, 12, 13, 14])
+  })
+
+  it('never grows past the limit however many arrive', () => {
+    let list: StatusEntry[] = []
+    for (let i = 1; i <= 500; i++) list = appendEntry(list, entry(i), 25)
+    expect(list).toHaveLength(25)
+  })
+
+  it('applies a LOWERED limit to what is already stored', () => {
+    // Otherwise the number in Settings and the number of lines on screen
+    // disagree until enough new messages arrive to reconcile them.
+    const list = Array.from({ length: 30 }, (_, i) => entry(i + 1))
+    const trimmed = trimToLimit(list, HISTORY_LIMIT_MIN)
+    expect(trimmed).toHaveLength(HISTORY_LIMIT_MIN)
+    expect(trimmed[trimmed.length - 1].id, 'the newest survives').toBe(30)
+    expect(trimmed[0].id, 'the oldest goes').toBe(21)
+  })
+
+  it('does not mutate what it was given', () => {
+    const before = [entry(1)]
+    appendEntry(before, entry(2), 10)
+    trimToLimit(before, 10)
+    expect(before).toHaveLength(1)
+  })
+})
+
+describe('the limit is held to its bounds', () => {
+  it('clamps anything out of range', () => {
+    expect(clampHistoryLimit(1)).toBe(HISTORY_LIMIT_MIN)
+    expect(clampHistoryLimit(999999)).toBe(HISTORY_LIMIT_MAX)
+    expect(clampHistoryLimit(250)).toBe(250)
+  })
+
+  it('falls back to the default on nonsense, rather than to zero', () => {
+    // A zero limit would be a second, silent way to say "keep none" that the UI
+    // could not show — that is what the enabled switch is for.
+    for (const bad of [NaN, Infinity, 'abc', null, undefined, '', {}]) {
+      expect(clampHistoryLimit(bad), String(bad)).toBe(HISTORY_LIMIT_DEFAULT)
+    }
+    // A real zero is a real answer — the floor — because "keep none" is the
+    // enabled switch, not a limit of nothing.
+    expect(clampHistoryLimit(0)).toBe(HISTORY_LIMIT_MIN)
+  })
+
+  it('floors a fraction rather than storing one', () => {
+    expect(clampHistoryLimit(200.7)).toBe(200)
+  })
+})
+
+describe('the log as text', () => {
+  it('is one line per message, timestamped, oldest first', () => {
+    // Oldest first in the FILE even though the screen shows newest first: a
+    // saved log is read by other tools and by scrolling down, and both want
+    // time running forwards.
+    const text = formatHistoryText([entry(1, 'first'), entry(2, 'second')])
+    const lines = text.split('\n')
+    expect(lines).toHaveLength(2)
+    expect(lines[0]).toContain('first')
+    expect(lines[1]).toContain('second')
+    expect(lines[0]).toMatch(/^\d\d:\d\d:\d\d {2}first$/)
+  })
+
+  it('is empty for an empty log, not a stray newline', () => {
+    expect(formatHistoryText([])).toBe('')
+  })
+
+  it('pads the clock so the times form a column', () => {
+    expect(formatTime(Date.UTC(2026, 0, 1, 0, 0, 0))).toMatch(/^\d\d:\d\d:\d\d$/)
+  })
+})
+
+describe('the saved file is named usefully', () => {
+  it('sorts by name and has no spaces', () => {
+    const name = historyFileName(new Date(2026, 8, 6, 9, 5, 3))
+    expect(name).toBe('snakie-status-20260906-090503.txt')
+    expect(name).not.toContain(' ')
+  })
+})
+
+describe('a stored log is untrusted', () => {
+  it('drops malformed rows rather than rendering them', () => {
+    const parsed = parseHistory([
+      { id: 1, text: 'good', at: 123, priority: 2 },
+      { id: 2, text: '' },
+      null,
+      'nope',
+      { id: 3, at: 5 },
+      { id: 4, text: 'also good', at: 9, priority: 0 }
+    ])
+    expect(parsed.map((e) => e.text)).toEqual(['good', 'also good'])
+  })
+
+  it('survives a value that is not an array at all', () => {
+    for (const bad of [null, undefined, 'x', 42, {}]) expect(parseHistory(bad)).toEqual([])
+  })
+
+  it('repairs a missing timestamp instead of rendering NaN', () => {
+    const [e] = parseHistory([{ text: 'x' }])
+    expect(Number.isFinite(e.at)).toBe(true)
+  })
+})
+
+describe('the wiring is where it has to be', () => {
+  const store = readFileSync('src/renderer/src/store/status-history.ts', 'utf8')
+
+  it('records at the EVENT, so a plugin posting directly is kept too', () => {
+    // Not everything reaching the bar goes through `showStatus` — a plugin can
+    // dispatch `snakie:status` itself, and those messages are worth keeping.
+    expect(store).toContain('window.addEventListener(STATUS_EVENT')
+  })
+
+  it('listens at module load, not from a component', () => {
+    // The panel that reads the history is opened AFTER the message you wanted,
+    // so capture cannot depend on anything being mounted.
+    expect(store).toMatch(/if \(typeof window !== 'undefined'\) \{\s*window\.addEventListener/)
+  })
+
+  it('turning history off actually discards it', () => {
+    // A switch that says "do not keep a history" and leaves the old one on disk
+    // is not telling the truth.
+    const fn = store.slice(store.indexOf('export function setStatusHistoryEnabled'))
+    expect(fn.slice(0, 600)).toContain('entries = []')
+  })
+})
+
+describe('the status bar offers the way in', () => {
+  const bar = readFileSync('src/renderer/src/components/StatusBar.tsx', 'utf8')
+
+  it('makes the message itself clickable', () => {
+    // The obvious thing to click to see the messages before it.
+    expect(bar).toContain('statusbar__plugin--history')
+    expect(bar).toContain('setHistoryOpen')
+  })
+
+  it('offers both the popup and the full view', () => {
+    expect(bar).toContain('<StatusHistoryPopup')
+    expect(bar).toContain('<StatusHistoryView')
+  })
+})


### PR DESCRIPTION
Closes #953.

The bar shows one line and every message wipes the one before it — right for a status bar, wrong for the messages you want *afterwards*: which file failed to sync, what the compile said, why an install stopped.

- **Click the message** → popup with the recent few
- **Show all** → full log: copy to clipboard, save as a text file, clear
- **Settings ▸ Editor** → keep a history at all, how many lines, clear now

## Decisions worth naming

**Newest first on screen, oldest first in the file.** The thing you just missed is the thing you clicked for, so it belongs at the top. A saved log is read by other tools and by scrolling down, and those want time running forwards.

**Recorded from the event, not from `showStatus`.** Everything reaching the bar goes through `snakie:status`, but not everything goes through `showStatus` — a plugin can post directly, and those are worth keeping. The listener attaches at **module load** rather than from a component, because the panel that reads the history is opened *after* the message you wanted; capture can't depend on anything being mounted.

**Lowering the limit applies to what's already stored**, not just to what arrives — otherwise the number in Settings and the number of lines on screen disagree until enough new messages reconcile them.

**Turning history off discards it.** A switch saying "don't keep a history" that leaves the old one on disk isn't telling the truth.

## Two edges the tests caught rather than I did

- A stored `null` limit clamped to the **floor** instead of the default, because `Number(null)` is `0` while `Number(undefined)` is `NaN`. An absent setting silently became "keep 10".
- The Settings number field is **uncontrolled**, committed on blur. Controlled, typing `500` over `200` passes through `5` — which trims the log to its floor one character into an edit.

The theme-token test also caught a `--border-subtle` I'd invented; it's `--border` now, which is exactly what that guard is for.

## Gates

lint (pre-existing `DriverInstallBanner.tsx` warning only) · typecheck · **6,656 tests in 321 files** · build — green. Ring buffer and the null case both mutation-checked.

**Not verified on screen** — the rules are tested DOM-free, but I haven't clicked the bar in a running app.

Next in the queue: #955 (file size column) and #956.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe