### PR TITLE
Show file sizes in both file trees (#955)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **File sizes in both file trees** (#955). Neither the local nor the device tree
+  showed how big a file was, which hid the one case worth seeing: **a 0-byte file
+  looks exactly like a good one**. This repo has met that — a truncated
+  `lsm6dsox.py` on a board threw a `SyntaxError` at line 159 and cost real
+  diagnosis time, which is what #864's atomic writes exist to prevent.
+
+  Sizes read as `0 B`, `847 B`, `2 KB`, `1.4 MB`, `1 TB` — **plain bytes below a
+  kilobyte**, deliberately. The app's other formatter renders a 213-byte file as
+  `0.2 KB` and an empty one as `0 KB`, which is exactly the reading this exists
+  to replace.
+
+  An unknown size shows **nothing**, never `0 B`. A `stat` can fail — a broken
+  symlink, a file deleted between the listing and the stat — and a zero invented
+  there would manufacture the very problem the column was added to reveal.
+  Folders show nothing too: a folder is not an empty file.
+
+  The device tree had the number all along (`os.ilistdir` returns it); it was
+  simply never displayed. The local listing now stats each file, in parallel, and
+  a failure leaves the size absent rather than failing the listing.
+
+### Added
+
 - **The status bar keeps a history** (#953). It shows one line at a time and
   every message wipes the one before it, so anything you were not looking at was
   simply gone — including the ones that matter afterwards: which file failed to

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snakie",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "snakie",
-      "version": "0.53.0",
+      "version": "0.54.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snakie",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "description": "A modern, cross-platform MicroPython editor.",
   "productName": "Snakie",
   "main": "./out/main/index.js",

--- a/src/main/fs/ipc.ts
+++ b/src/main/fs/ipc.ts
@@ -20,11 +20,24 @@ async function wrap<T>(fn: () => Promise<T>): Promise<IpcResult<T>> {
 /** Read a directory and return its entries, directories first then files. */
 async function readDir(path: string): Promise<FsEntry[]> {
   const dirents = await fs.readdir(path, { withFileTypes: true })
-  const entries: FsEntry[] = dirents.map((d) => ({
-    name: d.name,
-    path: join(path, d.name),
-    isDir: d.isDirectory()
-  }))
+  // `readdir` knows the TYPE but not the size, so each file costs a stat (#955).
+  // In parallel, and a failure leaves `size` ABSENT rather than 0 — a listing is
+  // worth showing without a size, and a zero invented from a failed stat would
+  // read as "this file is empty", which is the one thing the column is for.
+  const entries: FsEntry[] = await Promise.all(
+    dirents.map(async (d) => {
+      const full = join(path, d.name)
+      const entry: FsEntry = { name: d.name, path: full, isDir: d.isDirectory() }
+      if (!entry.isDir) {
+        try {
+          entry.size = (await fs.stat(full)).size
+        } catch {
+          // Gone, or unreadable, between the listing and now.
+        }
+      }
+      return entry
+    })
+  )
   entries.sort((a, b) => {
     if (a.isDir !== b.isDir) return a.isDir ? -1 : 1
     return a.name.localeCompare(b.name)

--- a/src/main/fs/types.ts
+++ b/src/main/fs/types.ts
@@ -14,6 +14,17 @@ export interface FsEntry {
   path: string
   /** True when the entry is a directory. */
   isDir: boolean
+  /**
+   * Size in bytes, for files (#955).
+   *
+   * OPTIONAL, and absent rather than zero when it could not be read — a broken
+   * symlink, or a file deleted between the listing and the stat. The column
+   * exists to make a genuinely empty file visible, so a `0` invented from a
+   * failed stat would manufacture the exact problem it is there to reveal.
+   *
+   * Absent for directories too: a folder is not an empty file.
+   */
+  size?: number
 }
 
 /** Result of `fs.stat`, mirroring the essentials of Node's `fs.Stats`. */

--- a/src/renderer/src/components/DeviceFileTree.tsx
+++ b/src/renderer/src/components/DeviceFileTree.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef, useState,
-  useSyncExternalStore
-} from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
+import { rowSize } from '../../../shared/file-size'
 import type { DirEntry } from '../../../preload/index.d'
 import { useFileSelection } from '../store/file-selection'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
@@ -170,6 +169,9 @@ function DeviceRow({
         {entry.isDir ? (expanded ? '▼' : '▶') : '▤'}
       </span>
       <span className="tree-row__name">{entry.name}</span>
+      {/* The size (#955). The device listing has carried it all along —
+          `os.ilistdir` returns it — it was simply never shown. */}
+      {rowSize(entry) && <span className="tree-row__size">{rowSize(entry)}</span>}
       {/* Which files the board runs by itself (#755, #872). Two stages: the
           setup file (`boot.py`) and then the program — and CircuitPython tries
           code.py before main.py, so a board carrying both runs only the first
@@ -521,10 +523,7 @@ export function DeviceFileTree(): JSX.Element {
     (paths: string[]): void => {
       const roots = pruneNested(paths)
       if (roots.length === 0) return
-      const label =
-        roots.length === 1
-          ? `"${roots[0].split('/').pop()}"`
-          : `${roots.length} items`
+      const label = roots.length === 1 ? `"${roots[0].split('/').pop()}"` : `${roots.length} items`
       if (!window.confirm(`Delete ${label} from the device? This cannot be undone.`)) return
       void (async (): Promise<void> => {
         setBusy(true)
@@ -670,7 +669,16 @@ export function DeviceFileTree(): JSX.Element {
       }
       return items
     },
-    [deleteMany, deletePath, downloadToComputer, handleOpenFile, newFileIn, newFolderIn, renamePath, selection]
+    [
+      deleteMany,
+      deletePath,
+      downloadToComputer,
+      handleOpenFile,
+      newFileIn,
+      newFolderIn,
+      renamePath,
+      selection
+    ]
   )
 
   if (!connected) {
@@ -815,15 +823,20 @@ export function DeviceFileTree(): JSX.Element {
         )}
       </div>
 
-      {menu && (
-        <ContextMenu position={menu.position} items={menuItems(menu)} onClose={closeMenu} />
-      )}
+      {menu && <ContextMenu position={menu.position} items={menuItems(menu)} onClose={closeMenu} />}
 
       {/* Flash-usage gauge (#211): a slim used/total bar pinned at the bottom.
           Only shown when the board reported `statvfs` (else `disk` is null). */}
       {disk && disk.total > 0 && (
         <div className="devicetree__disk" title={`${usageLabel(disk)} used of flash`}>
-          <div className="devicetree__disk-bar" role="progressbar" aria-label="Device flash used" aria-valuenow={usedPct(disk)} aria-valuemin={0} aria-valuemax={100}>
+          <div
+            className="devicetree__disk-bar"
+            role="progressbar"
+            aria-label="Device flash used"
+            aria-valuenow={usedPct(disk)}
+            aria-valuemin={0}
+            aria-valuemax={100}
+          >
             <div
               className={`devicetree__disk-fill${usedPct(disk) >= 90 ? ' is-full' : usedPct(disk) >= 75 ? ' is-high' : ''}`}
               style={{ width: `${usedPct(disk)}%` }}

--- a/src/renderer/src/components/LocalFileTree.tsx
+++ b/src/renderer/src/components/LocalFileTree.tsx
@@ -4,6 +4,7 @@ import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { useWorkspace, FILE_SAVED_EVENT, type FileSavedDetail } from '../store/workspace'
 import { forgetTagsPrompt, useSync } from '../store/sync'
 import { useFileSelection } from '../store/file-selection'
+import { rowSize } from '../../../shared/file-size'
 import { showStatus } from '../lib/status-bar'
 import { ContextMenu, type ContextMenuItem, type ContextMenuPosition } from './ContextMenu'
 import { usePrompt } from './PromptModal'
@@ -128,6 +129,10 @@ function TreeNode({
           {entry.isDir ? (expanded ? '▼' : '▶') : '▤'}
         </span>
         <span className="tree-row__name">{entry.name}</span>
+        {/* The size, right-aligned (#955). Absent for folders, and absent when
+            the stat failed — never a fabricated `0 B`, which is the one reading
+            this column exists to make trustworthy. */}
+        {rowSize(entry) && <span className="tree-row__size">{rowSize(entry)}</span>}
         {/* Folders are taggable too (#848) — a whole folder is the unit people
             actually keep in sync, and tagging its files one by one both misses
             new files and is tedious. A tagged folder is pushed into whichever

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -2354,6 +2354,36 @@ body {
 .tree-row__name {
   overflow: hidden;
   text-overflow: ellipsis;
+  /* Takes the slack, so the size below keeps its place at the right rather than
+     being pushed off by a long filename. */
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+/* The file size (#955), right-aligned at the end of the row.
+ *
+ * `margin-left: auto` rather than a fixed column: these are trees, not tables,
+ * and every row is indented differently — a fixed column would either clip the
+ * deepest names or leave a gap at the shallowest.
+ *
+ * Quiet by default and NEVER hidden: it is scanned, not read, and the one
+ * reading that matters (`0 B`) has to survive being glanced at. Tabular figures
+ * so the numbers line up down the column despite the ragged left edge. */
+.tree-row__size {
+  flex: 0 0 auto;
+  margin-left: auto;
+  padding-left: 0.5rem;
+  color: var(--text-muted);
+  font-size: 0.68rem;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+/* On the row you are pointing at or have selected, it comes up with everything
+   else rather than staying muted against a changed background. */
+.tree-row:hover .tree-row__size,
+.tree-row.is-selected .tree-row__size {
+  color: inherit;
 }
 
 /* --------------------------------------------------------------------------

--- a/src/shared/file-size.ts
+++ b/src/shared/file-size.ts
@@ -1,0 +1,61 @@
+/**
+ * FILE SIZES, AS PEOPLE READ THEM (#955).
+ * =============================================================================
+ *
+ * The file trees show a name and nothing else, which hides the one case worth
+ * seeing: a 0-byte file looks exactly like a good one. This repo has met that —
+ * a truncated `lsm6dsox.py` on a board threw a `SyntaxError` at line 159 and
+ * cost real diagnosis time, which is what #864's atomic writes exist to stop
+ * happening again. A size column turns that into something you can see.
+ *
+ * PLAIN BYTES BELOW 1 KB, deliberately. `formatBytes` in `board-finder.ts` is
+ * the other formatter here and it is tuned for flash and RAM: it renders a
+ * 213-byte file as `0.2 KB` and a zero as `0 KB`, which is exactly the reading
+ * this column exists to prevent. Nothing under a kilobyte is rounded here.
+ *
+ * BINARY UNITS, labelled KB/MB/GB/TB, matching how the rest of the app counts.
+ */
+
+/** Units above bytes, each 1024 of the last. */
+const UNITS = ['KB', 'MB', 'GB', 'TB'] as const
+
+/**
+ * A byte count as a short, readable string: `0 B`, `847 B`, `2 KB`, `1.4 MB`.
+ *
+ * One decimal only where it says something — `2 KB` rather than `2.0 KB` — since
+ * a column of sizes is scanned, not compared digit by digit.
+ *
+ * Returns null for anything that is not a real, non-negative size. That is not
+ * the same as zero, and the difference matters more here than anywhere: a `stat`
+ * that failed must render as NOTHING, never as `0 B`, or the column invents the
+ * very problem it was added to reveal.
+ */
+export function formatFileSize(bytes: unknown): string | null {
+  if (typeof bytes !== 'number' || !Number.isFinite(bytes) || bytes < 0) return null
+
+  // Below a kilobyte, say the number. This is the whole point of the column.
+  if (bytes < 1024) return `${Math.round(bytes)} B`
+
+  let value = bytes / 1024
+  let unit = 0
+  while (value >= 1024 && unit < UNITS.length - 1) {
+    value /= 1024
+    unit += 1
+  }
+  // `.toFixed(1)` then trimming a trailing `.0` keeps 1023.6 KB from rounding up
+  // into a unit it has not reached.
+  const shown = value >= 100 ? Math.round(value).toString() : value.toFixed(1).replace(/\.0$/, '')
+  return `${shown} ${UNITS[unit]}`
+}
+
+/**
+ * What a tree row shows for an entry.
+ *
+ * Directories get nothing rather than `0 B` — a folder is not an empty file, and
+ * saying so in the column that means "this file is empty" would be a lie in the
+ * one place it is expensive.
+ */
+export function rowSize(entry: { isDir?: boolean; size?: number | null }): string | null {
+  if (entry.isDir) return null
+  return formatFileSize(entry.size ?? undefined)
+}

--- a/test/fileSize.test.ts
+++ b/test/fileSize.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { formatFileSize, rowSize } from '../src/shared/file-size'
+
+/**
+ * File sizes in the trees (#955).
+ *
+ * Neither tree showed how big a file was, which hid the case that matters: a
+ * 0-byte file looks exactly like a good one. This repo has met that — a
+ * truncated `lsm6dsox.py` on a board threw a `SyntaxError` at line 159 and cost
+ * real diagnosis time, which is what #864's atomic writes exist to prevent.
+ *
+ * So most of what is tested here is about the two readings that must never be
+ * confused: a file that really is empty, and a size we could not read.
+ */
+
+describe('the reading this column exists for', () => {
+  it('says 0 B for an empty file, in bytes, unrounded', () => {
+    // `formatBytes` in board-finder.ts — the app's other formatter — renders
+    // this as "0 KB", which is exactly the reading this replaces.
+    expect(formatFileSize(0)).toBe('0 B')
+  })
+
+  it('never rounds a small file away to zero', () => {
+    expect(formatFileSize(1)).toBe('1 B')
+    expect(formatFileSize(213)).toBe('213 B')
+    expect(formatFileSize(1023)).toBe('1023 B')
+  })
+
+  it('is null — not "0 B" — when the size is unknown', () => {
+    // A failed stat must render as NOTHING. A zero invented here would
+    // manufacture the exact problem the column was added to reveal.
+    for (const bad of [undefined, null, NaN, Infinity, -1, '512', {}]) {
+      expect(formatFileSize(bad), String(bad)).toBeNull()
+    }
+  })
+})
+
+describe('the units people expect', () => {
+  it('climbs B → KB → MB → GB → TB', () => {
+    expect(formatFileSize(1024)).toBe('1 KB')
+    expect(formatFileSize(1024 ** 2)).toBe('1 MB')
+    expect(formatFileSize(1024 ** 3)).toBe('1 GB')
+    expect(formatFileSize(1024 ** 4)).toBe('1 TB')
+  })
+
+  it('shows one decimal only where it says something', () => {
+    // A column of sizes is scanned, not compared digit by digit, so "2 KB"
+    // beats "2.0 KB" — but 1.5 MB is a different number from 1 MB.
+    expect(formatFileSize(1536)).toBe('1.5 KB')
+    expect(formatFileSize(2048)).toBe('2 KB')
+    expect(formatFileSize(Math.round(1.4 * 1024 ** 3))).toBe('1.4 GB')
+  })
+
+  it('does not round up into a unit it has not reached', () => {
+    // 1023.6 KB is not 1 MB. `.toFixed(1)` on the value keeps it in KB.
+    expect(formatFileSize(1024 * 1023.6)).toContain('KB')
+  })
+
+  it('drops the decimal once the number is big enough not to need it', () => {
+    expect(formatFileSize(1024 * 500)).toBe('500 KB')
+  })
+
+  it('stops at TB rather than inventing a unit above it', () => {
+    expect(formatFileSize(1024 ** 5)).toBe('1024 TB')
+  })
+})
+
+describe('what a tree row shows', () => {
+  it('shows nothing for a folder', () => {
+    // A folder is not an empty file, and saying "0 B" in the column that means
+    // "this file is empty" would be a lie in the one place it is expensive.
+    expect(rowSize({ isDir: true, size: 0 })).toBeNull()
+    expect(rowSize({ isDir: true })).toBeNull()
+  })
+
+  it('shows the size for a file', () => {
+    expect(rowSize({ isDir: false, size: 5157 })).toBe('5 KB')
+    expect(rowSize({ isDir: false, size: 0 })).toBe('0 B')
+  })
+
+  it('shows nothing for a file whose size never arrived', () => {
+    expect(rowSize({ isDir: false })).toBeNull()
+    expect(rowSize({ isDir: false, size: null })).toBeNull()
+  })
+})
+
+describe('both trees show it, and the local one has the data to', () => {
+  it('the local listing stats each file', () => {
+    // `readdir` knows the type but not the size.
+    const ipc = readFileSync('src/main/fs/ipc.ts', 'utf8')
+    expect(ipc).toContain('entry.size = (await fs.stat(full)).size')
+  })
+
+  it('a failed stat leaves the size ABSENT, not zero', () => {
+    const ipc = readFileSync('src/main/fs/ipc.ts', 'utf8')
+    const fn = ipc.slice(ipc.indexOf('async function readDir'), ipc.indexOf('async function stat'))
+    // No fallback that would turn an unreadable file into an empty one.
+    expect(fn).not.toMatch(/size:\s*0/)
+    expect(fn).not.toMatch(/\?\?\s*0/)
+  })
+
+  it('is optional on the type, so "unknown" is expressible at all', () => {
+    expect(readFileSync('src/main/fs/types.ts', 'utf8')).toContain('size?: number')
+  })
+
+  it('appears in both trees', () => {
+    for (const f of [
+      'src/renderer/src/components/LocalFileTree.tsx',
+      'src/renderer/src/components/DeviceFileTree.tsx'
+    ]) {
+      expect(readFileSync(f, 'utf8'), f).toContain('tree-row__size')
+    }
+  })
+
+  it('does not squeeze the name out to make room', () => {
+    // The name takes the slack and ellipsizes; the size keeps its place.
+    const css = readFileSync('src/renderer/src/index.css', 'utf8')
+    const rule = css.slice(css.indexOf('.tree-row__size {'), css.indexOf('}', css.indexOf('.tree-row__size {')))
+    expect(rule).toContain('margin-left: auto')
+    expect(rule).toContain('flex: 0 0 auto')
+    expect(rule).toContain('tabular-nums')
+  })
+})


### PR DESCRIPTION
Closes #955.

Neither tree showed how big a file was, which hid the case that matters: **a 0-byte file looks exactly like a good one**. This repo has met that — a truncated `lsm6dsox.py` on a board threw a `SyntaxError` at line 159 and cost real diagnosis time, which is what #864's atomic writes exist to prevent.

`0 B` · `847 B` · `2 KB` · `1.4 MB` · `1 TB`

## Plain bytes below a kilobyte, deliberately

The app's other formatter (`formatBytes`, for board flash and RAM) renders a 213-byte file as `0.2 KB` and an empty one as **`0 KB`** — exactly the reading this exists to replace. Nothing under a kilobyte is rounded here.

One decimal only where it says something (`2 KB`, not `2.0 KB`), since a column of sizes is scanned rather than compared digit by digit — and never rounding up into a unit it hasn't reached.

## An unknown size shows nothing, never `0 B`

This is the part that mattered most to get right. A `stat` can fail — a broken symlink, a file deleted between the listing and the stat — and **a zero invented there would manufacture the very problem the column was added to reveal**.

So `size` is optional on `FsEntry` rather than defaulted, `formatFileSize` returns `null` for anything that isn't a real non-negative number, and a mutation check confirms that defaulting it to `0` fails the tests. Folders show nothing for the same reason: a folder is not an empty file.

## The two sides needed different work

- **Device tree** — had the number all along. `os.ilistdir` returns it and `DirEntry.size` has carried it since the listing was written; it was simply never displayed.
- **Local tree** — didn't. `readdir` knows the type but not the size, so each file now costs a `stat`, run in parallel, with a failure leaving the size absent rather than failing the listing.

## Layout

Right-aligned with `margin-left: auto` rather than a fixed column — these are trees, every row is indented differently, and a fixed column would either clip the deepest names or leave a gap at the shallowest. Tabular figures so the numbers line up down a ragged left edge, and the name takes the slack so a long filename ellipsizes rather than pushing the size off the row.

## Gates

lint (pre-existing `DriverInstallBanner.tsx` warning only) · typecheck · **6,672 tests in 322 files** · build — green.

**Not verified on screen.** Still queued: #956 (gold buttons — root cause posted on the issue) and making the Settings window wider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe