### PR TITLE
Stop embossing the app's own text (#960)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **The app no longer embosses its own text** (#960). `text-shadow: 0 1px 0
+  #fff` under dark text on grey, and the dark-above inverse on the dark skin —
+  a letterpress effect on 32 rules across buttons, the toolbar, the status bar,
+  panel headers, the activity bar, Find & Replace and the plugin rack. At body
+  size it reads as a blur: every glyph carries a white ghost a pixel below it,
+  which is the opposite of what a shadow is meant to do for contrast.
+
+  **The instrument glows stay.** Forty-one rules use `0 0 6px` in the accent on
+  LED readouts, meters and scope traces — that is those panels' whole look, and
+  nobody is reading a paragraph through it. The distinction drawn is between a
+  shadow *offset under* a glyph and a halo *around* one, which is exactly the
+  difference between the effect that hurt and the effect that was wanted. A test
+  guards it in both directions, so neither the letterpress returns nor a later
+  sweep strips the instruments.
+
+  Four `text-shadow: none` overrides went with it — each was unsetting a rule
+  that no longer exists, and an override of nothing reads as a deliberate
+  exception to someone later.
+
+### Fixed
+
 - **Sending a binary file to the board no longer corrupts it** (#959). Compiling
   a `.mpy` and uploading it produced *"This does not look like a readable .mpy —
   the file is truncated."* The viewer was right: the file on the board really was

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snakie",
-  "version": "0.54.1",
+  "version": "0.54.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "snakie",
-      "version": "0.54.1",
+      "version": "0.54.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snakie",
-  "version": "0.54.1",
+  "version": "0.54.2",
   "description": "A modern, cross-platform MicroPython editor.",
   "productName": "Snakie",
   "main": "./out/main/index.js",

--- a/src/renderer/src/components/DataLoggerInstrument.css
+++ b/src/renderer/src/components/DataLoggerInstrument.css
@@ -160,7 +160,6 @@
   color: #33301f;
   white-space: pre;
   /* Faint ink-ribbon inconsistency + the dotty impression. */
-  text-shadow: 0.4px 0 rgba(0, 0, 0, 0.18);
   letter-spacing: 0.02em;
 }
 

--- a/src/renderer/src/components/FindReplace.css
+++ b/src/renderer/src/components/FindReplace.css
@@ -283,14 +283,12 @@
   font-family: 'Helvetica Neue', Helvetica, Arial, system-ui, sans-serif;
   font-weight: 600;
   color: #5a5e66;
-  text-shadow: 0 1px 0 #fff;
 }
 
 :root[data-theme='skeuomorph'] .find-replace__close {
   background: linear-gradient(180deg, #fbfbfd, #cdd1d8);
   border: 1px solid #9498a1;
   color: #5a5e66;
-  text-shadow: 0 1px 0 #fff;
   box-shadow:
     inset 0 1px 0 #fff,
     0 1px 2px rgba(0, 0, 0, 0.22);
@@ -319,7 +317,6 @@
   background: linear-gradient(180deg, #fbfbfd, #cdd1d8);
   border: 1px solid #9498a1;
   color: #4a4e56;
-  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
   box-shadow:
     inset 0 1px 0 #fff,
     0 1px 2px rgba(0, 0, 0, 0.22);
@@ -342,7 +339,6 @@
   background: linear-gradient(180deg, #9fb6cf, #c2d2e2);
   border-color: #6e87a3;
   color: #1d3a5b;
-  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.4);
   box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.35);
 }
 
@@ -351,7 +347,6 @@
   background: linear-gradient(180deg, #f3d488, #d6a23f 55%, #bd8526);
   border: 1px solid #9a6b1e;
   color: #4a3410;
-  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.4);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.6),
     0 1px 2px rgba(0, 0, 0, 0.3);
@@ -365,7 +360,6 @@
 :root[data-theme='skeuomorph'] .find-replace__option,
 :root[data-theme='skeuomorph'] .find-replace__status {
   color: #5a5e66;
-  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
 }
 
 :root[data-theme='skeuomorph'] .find-replace__count--empty {

--- a/src/renderer/src/components/GamepadInstrument.css
+++ b/src/renderer/src/components/GamepadInstrument.css
@@ -257,14 +257,12 @@
     0 3px 0 #4a0d07,
     inset 0 1px 0 rgba(255, 255, 255, 0.25);
   cursor: pointer;
-  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5);
 }
 
 .gp__estop--latched {
   background: radial-gradient(circle at 50% 35%, #ffd24a, #f0a81c 75%, #b87a08);
   border-color: #8a6206;
   color: #2a1c00;
-  text-shadow: none;
   box-shadow:
     inset 0 2px 5px rgba(0, 0, 0, 0.4),
     0 0 14px rgba(240, 168, 28, 0.6);

--- a/src/renderer/src/components/HelpPanel.css
+++ b/src/renderer/src/components/HelpPanel.css
@@ -41,7 +41,6 @@
   font-weight: 700;
   letter-spacing: 0.14em;
   color: #4a3410;
-  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.4);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/renderer/src/components/InstrumentWindow.css
+++ b/src/renderer/src/components/InstrumentWindow.css
@@ -323,7 +323,6 @@
   letter-spacing: 0.18em;
   /* Lightened from #4a4f57 for contrast on the dark dock (see __title). */
   color: #868c96;
-  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.6);
 }
 /* The icon-only toggles wrap so 13+ instruments stay readable in the narrow dock. */
 .instr-dock__group-row {

--- a/src/renderer/src/components/PluginsPanel.css
+++ b/src/renderer/src/components/PluginsPanel.css
@@ -48,7 +48,6 @@
   font-size: 0.74rem;
   letter-spacing: 0.18em;
   color: #cfd3d8;
-  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.8);
 }
 
 .rack__header-spacer {
@@ -99,7 +98,6 @@
   font-weight: 700;
   letter-spacing: 0.14em;
   color: #7c818a;
-  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.8);
 }
 
 .rack__pwr-led {
@@ -182,7 +180,6 @@
   font-weight: 700;
   letter-spacing: 0.16em;
   color: #7c818a;
-  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.8);
 }
 
 /* --- Module list ----------------------------------------------------------- */
@@ -333,7 +330,6 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.7);
 }
 
 .rack__desc {

--- a/src/renderer/src/components/ShellPanel.css
+++ b/src/renderer/src/components/ShellPanel.css
@@ -154,7 +154,6 @@
 :root[data-theme='skeuomorph'] .shell-actions .shell-toggle__btn {
   background: var(--panel2);
   color: var(--txt3);
-  text-shadow: none;
 }
 
 :root[data-theme='skeuomorph'] .shell-actions .shell-toggle__btn:hover {

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -296,7 +296,6 @@
 }
 
 :root[data-theme='skeuomorph'] .toolbar__wordmark {
-  text-shadow: 0 1px 0 #fff;
 }
 
 /* New / Save fuse into one brushed-metal segmented control (the internal
@@ -340,7 +339,6 @@
   border: 1px solid #9498a1;
   background: linear-gradient(180deg, #fbfbfd, #cdd1d8);
   color: #4a4e56;
-  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
   box-shadow:
     inset 0 1px 0 #fff,
     0 1px 2px rgba(0, 0, 0, 0.22);
@@ -360,7 +358,6 @@
   background: linear-gradient(180deg, #8fe49a, #34ad4f 52%, #218c39);
   border: 1px solid #1c7a34;
   color: #fff;
-  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.3);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.75),
     inset 0 -3px 5px rgba(0, 0, 0, 0.22),
@@ -372,7 +369,6 @@
   background: linear-gradient(180deg, #ff9d8e, #e34f3d 52%, #c4301f);
   border: 1px solid #aa2a1c;
   color: #fff;
-  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.3);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.6),
     inset 0 -3px 5px rgba(0, 0, 0, 0.22),
@@ -395,7 +391,6 @@
  * read dark exactly like its sibling ghost buttons instead. */
 :root[data-theme='skeuomorph'] .btn--ghost.btn--danger {
   color: #4a4e56;
-  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
 }
 
 :root[data-theme='skeuomorph'] .btn--ghost.is-active {
@@ -452,7 +447,6 @@
   border-radius: 10px;
   background: transparent;
   color: #9498a1;
-  text-shadow: 0 1px 0 #000;
   box-shadow: none;
 }
 
@@ -481,7 +475,6 @@
   background: linear-gradient(180deg, #dfe2e7, #c9cdd4);
   border-bottom: 1px solid #9498a1;
   color: #43474f;
-  text-shadow: 0 1px 0 #fff;
   box-shadow: inset 0 1px 0 #fff;
 }
 
@@ -608,7 +601,6 @@
 
 :root[data-theme='skeuomorph'] .pkgs__title {
   color: #eef6f0;
-  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.3);
 }
 
 /* Engraved felt labels. */
@@ -772,7 +764,6 @@
   border-color: transparent;
   box-shadow: none;
   color: #6a6450;
-  text-shadow: none;
 }
 
 :root[data-theme='skeuomorph'] .editor-header__actions .btn:hover {
@@ -911,7 +902,6 @@
 :root[data-theme='skeuomorph'] .shell-toggle__btn {
   background: linear-gradient(180deg, #fbfbfd, #cdd1d8);
   color: #5a5e66;
-  text-shadow: 0 1px 0 #fff;
 }
 
 :root[data-theme='skeuomorph'] .shell-toggle__btn + .shell-toggle__btn {
@@ -944,7 +934,6 @@
   background: linear-gradient(180deg, #c9cdd4, #a9aeb8);
   border-top: 1px solid #fff;
   color: #3a3d44;
-  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
 }
 
 :root[data-theme='skeuomorph'] .statusbar__conn--connected .statusbar__dot {
@@ -1016,7 +1005,6 @@
 }
 
 :root[data-theme='dark'] .toolbar__wordmark {
-  text-shadow: 0 1px 0 #000;
 }
 
 /* New / Save: one dark brushed-metal segmented control. */
@@ -1059,7 +1047,6 @@
   border: 1px solid #15171b;
   background: linear-gradient(180deg, #3a3d44, #25272c);
   color: #d2d6dd;
-  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.5);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.08),
     0 1px 2px rgba(0, 0, 0, 0.5);
@@ -1079,7 +1066,6 @@
   background: linear-gradient(180deg, #4fce6e, #2f9a48 52%, #1f7a38);
   border: 1px solid #14512a;
   color: #f3fff5;
-  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.45);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.4),
     inset 0 -3px 5px rgba(0, 0, 0, 0.35),
@@ -1091,7 +1077,6 @@
   background: linear-gradient(180deg, #ef7e6c, #cf4434 52%, #a8301f);
   border: 1px solid #7a2316;
   color: #fff;
-  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.45);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.28),
     inset 0 -3px 5px rgba(0, 0, 0, 0.35),
@@ -1125,7 +1110,6 @@
   border: 1px solid #7a531a;
   background: radial-gradient(circle at 50% 30%, #f7e6a8, #e2bd6a 40%, #c4881d 72%, #9a6716);
   color: #4a3209;
-  text-shadow: none;
   box-shadow:
     inset 0 2px 1px rgba(255, 255, 255, 0.65),
     inset 0 -4px 6px rgba(60, 38, 6, 0.6),
@@ -1162,7 +1146,6 @@
   border-radius: 10px;
   background: transparent;
   color: #8a8f98;
-  text-shadow: 0 1px 0 #000;
   box-shadow: none;
 }
 
@@ -1191,7 +1174,6 @@
   background: linear-gradient(180deg, #313439, #23252a);
   border-bottom: 1px solid #15171b;
   color: #b6bbc3;
-  text-shadow: 0 -1px 0 #000;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
 
@@ -1578,7 +1560,6 @@
 :root[data-theme='dark'] .shell-toggle__btn {
   background: linear-gradient(180deg, #34373d, #25272c);
   color: #c2c6cd;
-  text-shadow: 0 -1px 0 #000;
 }
 
 :root[data-theme='dark'] .shell-toggle__btn + .shell-toggle__btn {
@@ -1611,7 +1592,6 @@
   background: linear-gradient(180deg, #2c2f35, #1c1e22);
   border-top: 1px solid rgba(255, 255, 255, 0.07);
   color: #c2c6cd;
-  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.5);
 }
 
 :root[data-theme='dark'] .statusbar__conn--connected .statusbar__dot {

--- a/test/noTextEmboss.test.ts
+++ b/test/noTextEmboss.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * No letterpress on text (#960).
+ *
+ * The app was embossing its own type — `text-shadow: 0 1px 0 #fff` under dark
+ * text on grey, and the dark-above inverse on the dark skin. At body size on a
+ * settings dialog it reads as a blur: every glyph carries a white ghost a pixel
+ * below it, which is the opposite of what a shadow is meant to do for contrast.
+ *
+ * WHAT IS NOT A LETTERPRESS. The instrument panels glow — `0 0 6px` in the
+ * accent, on LED readouts, meters and scope traces. That is the panels' whole
+ * look and nobody is trying to read a 0.7rem paragraph through it, so those
+ * stay. The distinction this file draws is therefore between a shadow OFFSET
+ * under the glyph and a halo AROUND it, which is exactly the distinction
+ * between the effect that hurt and the one that was wanted.
+ */
+
+/** Every stylesheet the renderer ships. */
+function stylesheets(dir = 'src/renderer/src'): string[] {
+  const out: string[] = []
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name)
+    if (statSync(p).isDirectory()) out.push(...stylesheets(p))
+    else if (name.endsWith('.css')) out.push(p)
+  }
+  return out
+}
+
+interface Shadow {
+  file: string
+  line: number
+  value: string
+}
+
+function shadows(): Shadow[] {
+  const found: Shadow[] = []
+  for (const file of stylesheets()) {
+    readFileSync(file, 'utf8')
+      .split('\n')
+      .forEach((line, i) => {
+        const m = /text-shadow:\s*([^;]+);/.exec(line)
+        if (m) found.push({ file, line: i + 1, value: m[1].trim() })
+      })
+  }
+  return found
+}
+
+/** A halo: no offset, just a blur radius. `0 0 6px …` */
+const isGlow = (value: string): boolean => /^0\s+0\s+\d/.test(value)
+
+describe('the app does not emboss its own text', () => {
+  it('has no offset text-shadow left anywhere', () => {
+    const offenders = shadows().filter((s) => s.value !== 'none' && !isGlow(s.value))
+    expect(
+      offenders.map((s) => `${s.file}:${s.line}  ${s.value}`),
+      'text-shadow with an offset is the letterpress effect #960 removed — a glow (`0 0 Npx`) is fine'
+    ).toEqual([])
+  })
+
+  it('kept the instrument glows, which are a different thing', () => {
+    // A guard in both directions: a later sweep that deleted these would strip
+    // the LED readouts, meters and scope traces of the look they exist to have.
+    const glows = shadows().filter((s) => isGlow(s.value))
+    expect(glows.length).toBeGreaterThan(30)
+    expect(glows.some((s) => s.file.includes('Oscilloscope'))).toBe(true)
+    expect(glows.some((s) => s.file.includes('Multimeter'))).toBe(true)
+  })
+
+  it('keeps only the `none` overrides that still turn something off', () => {
+    // An override of a rule that no longer exists is dead code that reads as a
+    // deliberate exception. Each remaining one must sit in a file that still
+    // sets a glow.
+    for (const s of shadows().filter((s) => s.value === 'none')) {
+      const sameFile = shadows().filter((o) => o.file === s.file && isGlow(o.value))
+      expect(sameFile.length, `${s.file}:${s.line} overrides nothing`).toBeGreaterThan(0)
+    }
+  })
+})


### PR DESCRIPTION
Closes #960.

`text-shadow: 0 1px 0 #fff` under dark text on grey — plus the dark-above inverse on the dark skin — across **32 rules**: buttons, the toolbar, the status bar, panel headers, the activity bar, Find & Replace and the plugin rack.

At body size it reads as a blur. Every glyph carries a white ghost a pixel below it, which is the opposite of what a shadow is meant to do for contrast — exactly what your screenshot shows.

## The instrument glows stay

There were 83 `text-shadow` rules in total, and they are not one effect. **41** are `0 0 6px` in the accent, on LED readouts, meters and scope traces — that's those panels' whole look, and nobody is reading a 0.7rem paragraph through one.

So the line I drew is between a shadow **offset under** a glyph and a halo **around** one. That's the difference between the effect that hurt and the effect that was wanted, and it's what the test encodes — in both directions, so neither the letterpress returns nor a later sweep strips the instruments.

## Two judgement calls, named so you can reverse them

Both removed for consistency rather than kept as favourites:

- **The E-STOP button's** `0 1px 1px` — a real drop shadow, but white-on-red at that size needs no help.
- **The data logger's** `0.4px 0` ink-spread — a faux-bold evoking a printer ribbon on a simulated printout, not a drop shadow. It was still muddying 0.66rem type, so it went too.

Say the word and either comes back.

## Also removed: four dead overrides

Four `text-shadow: none` rules were unsetting rules that no longer exist. An override of nothing reads as a deliberate exception to whoever meets it next. The four that remain each turn off a *glow* and are still doing work — the test checks that too, so dead ones can't accumulate again.

## Gates

lint (pre-existing `DriverInstallBanner.tsx` warning only) · typecheck · **6,693 tests in 324 files** · build — green. Mutation-checked by putting one emboss back.

**Not verified on screen** — this is a subtractive CSS change across two skins, so it's worth a look at the skeuomorph skin in particular, where the emboss was doing the most work.

Also filed: **#962**, the docs and screenshots audit you asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe