### PR TITLE
Readable text on the gold buttons in dark mode (#956)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **The gold buttons are readable in dark mode** (#956). The active Electronics
+  tab, Breadboard, "+ New part", the Help pill and eleven other gold controls
+  painted pale text on a pale gold background.
+
+  One token, misused. `--goldink` means gold-*coloured* ink, for text on the
+  dark chrome — but it reads like "the ink for gold", so it was used for both.
+  The gold *surfaces* do not flip with the skin: `--grad-gold` and `--gold` are
+  byte-identical in both. So on the dark skin it painted `#f0dca6` on a gradient
+  whose top stop **is** `#f0dca6` — a contrast ratio of **1.00**, which is why
+  these read perfectly in skeuomorph and not at all in dark.
+
+  There is now `--ongold` for text on those surfaces, defined once in the shared
+  `:root` because a value that must not differ between skins should not live
+  somewhere it could. Thirteen rules moved to it; the rest kept `--goldink`,
+  which was never wrong where it pairs with `--goldbg` or sits on a dark panel.
+
+  The ink is a shade deeper than the Board Finder's own local answer to this: at
+  4.43:1 that one cleared the gradient but not the solid gold, which also carries
+  text. This clears 4.5 on all three surfaces, and the test computes the ratios
+  rather than trusting a comment.
+
+### Fixed
+
 - **The app no longer embosses its own text** (#960). `text-shadow: 0 1px 0
   #fff` under dark text on grey, and the dark-above inverse on the dark skin —
   a letterpress effect on 32 rules across buttons, the toolbar, the status bar,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snakie",
-  "version": "0.54.2",
+  "version": "0.54.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "snakie",
-      "version": "0.54.2",
+      "version": "0.54.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snakie",
-  "version": "0.54.2",
+  "version": "0.54.3",
   "description": "A modern, cross-platform MicroPython editor.",
   "productName": "Snakie",
   "main": "./out/main/index.js",

--- a/src/renderer/src/components/BoardGraph.css
+++ b/src/renderer/src/components/BoardGraph.css
@@ -96,7 +96,7 @@
 }
 
 .boardgraph__viewtab.is-active {
-  color: var(--goldink, #fff);
+  color: var(--ongold);
   font-weight: 700;
   background: var(--grad-gold, #2f5f8c);
   box-shadow: inset 0 1px 0 var(--pillinset, rgba(255, 255, 255, 0.4));
@@ -372,7 +372,7 @@
   font-family: var(--font-ui), inherit;
   font-size: 12.5px;
   font-weight: 700;
-  color: var(--goldink, #6b4e17);
+  color: var(--ongold);
   background: var(--grad-gold, #e6ab30);
   border: none;
   border-radius: 999px;
@@ -400,7 +400,7 @@
   font-size: 10.5px;
   font-weight: 700;
   line-height: 1;
-  color: var(--goldink, #6b4e17);
+  color: var(--ongold);
   background: rgba(255, 255, 255, 0.5);
   border-radius: 999px;
 }
@@ -994,7 +994,7 @@
   font-size: 10.5px;
   font-weight: 700;
   letter-spacing: 0.04em;
-  color: var(--goldink, #4a3a12);
+  color: var(--ongold);
   background: var(--gold, #e8b34a);
   border: 1px solid #c79a3a;
   border-radius: 4px;
@@ -1010,7 +1010,7 @@
   font-size: 8.5px;
   font-weight: 700;
   letter-spacing: 0.06em;
-  color: var(--goldink, #4a3a12);
+  color: var(--ongold);
   background: var(--gold, #e8b34a);
   border-radius: 3px;
   padding: 1px 4px;

--- a/src/renderer/src/components/MiniViewer.css
+++ b/src/renderer/src/components/MiniViewer.css
@@ -44,7 +44,7 @@
 }
 .miniviewer__seg-btn.is-active {
   background: var(--grad-gold, var(--accent));
-  color: var(--goldink, var(--accent-contrast));
+  color: var(--ongold);
   font-weight: 700;
 }
 

--- a/src/renderer/src/components/PartsPanel.css
+++ b/src/renderer/src/components/PartsPanel.css
@@ -47,7 +47,7 @@
 .pl__btn--primary {
   background: var(--grad-gold, #2f6b2a);
   border: none;
-  color: var(--goldink, #fff);
+  color: var(--ongold);
   box-shadow: inset 0 1px 0 var(--pillinset, rgba(255, 255, 255, 0.5));
 }
 
@@ -278,7 +278,7 @@
 }
 
 .pl__badge--update {
-  color: var(--goldink, #5a3d0e);
+  color: var(--ongold);
   background: var(--grad-gold, #e6ab30);
   border-color: transparent;
 }
@@ -539,7 +539,7 @@
 }
 
 .pl__seg-btn.is-active {
-  color: var(--goldink, #fff);
+  color: var(--ongold);
   background: var(--grad-gold, var(--accent, #2f6b2a));
 }
 

--- a/src/renderer/src/components/RobotDockPanel.css
+++ b/src/renderer/src/components/RobotDockPanel.css
@@ -24,7 +24,7 @@
 .robotdock .robotdock__btn--cta:hover,
 :root[data-theme='skeuomorph'] .robotdock .robotdock__btn--cta,
 :root[data-theme='skeuomorph'] .robotdock .robotdock__btn--cta:hover {
-  color: var(--goldink, #191a1d);
+  color: var(--ongold);
   background: var(--grad-gold, var(--accent, #c8a24a));
   border: 1px solid var(--gold, var(--accent, #c8a24a));
   font-weight: 700;

--- a/src/renderer/src/components/Tutorials.css
+++ b/src/renderer/src/components/Tutorials.css
@@ -383,7 +383,7 @@
   font-family: var(--font-ui), sans-serif;
   font-size: 0.74rem;
   font-weight: 600;
-  color: var(--goldink, #fff);
+  color: var(--ongold);
   background: var(--grad-gold, #2f6b2a);
   border: none;
   border-radius: var(--radius);

--- a/src/renderer/src/components/WorkspaceSwitcher.css
+++ b/src/renderer/src/components/WorkspaceSwitcher.css
@@ -45,10 +45,10 @@
 
 .ws-switcher__btn.is-active {
   background: var(--grad-gold, var(--accent));
-  color: var(--goldink, var(--accent-contrast));
+  color: var(--ongold);
   font-weight: 750;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.22);
 }
 .ws-switcher__btn.is-active:hover {
-  color: var(--goldink, var(--accent-contrast));
+  color: var(--ongold);
 }

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -11,6 +11,29 @@
  * textures tokens can't express (mirrored skeuomorph ⇄ dark).
  * ------------------------------------------------------------------------- */
 :root {
+  /**
+   * The ink that goes ON the gold gradient (#956).
+   *
+   * `--grad-gold` is IDENTICAL in both skins, so the text on it cannot come from
+   * a token that flips: `--goldink` is pale gold on the dark skin, which painted
+   * #f0dca6 on a gradient whose top stop IS #f0dca6 — a contrast ratio of 1.00,
+   * i.e. invisible. That is why the active Electronics tab, "+ New part" and the
+   * Help pill were unreadable in dark mode and fine in skeuomorph.
+   *
+   * Defined HERE, in the shared block, rather than twice: a value that must not
+   * differ between skins should not be somewhere it could.
+   *
+   * Dark brass, a shade deeper than the Board Finder's own `--bf-gold-ink`
+   * (#5a3d0e). That one clears AA comfortably on the GRADIENT but lands at
+   * 4.43:1 on the solid `--gold` (#d9a441), which is also identical across
+   * skins and also carries text. This value clears 4.5 on all three surfaces —
+   * 8.85:1, 6.87:1 and 5.33:1 — and the test computes those rather than
+   * trusting this comment.
+   *
+   * NOT to be confused with `--goldink`, which is gold-COLOURED ink for text on
+   * the dark chrome, and is correct wherever it pairs with `--goldbg`.
+   */
+  --ongold: #4a3209;
   /* Base/shared chrome metrics — overridden per skin below where they differ. */
   --radius: 8px;
   --border-w: 1px;

--- a/test/goldInk.test.ts
+++ b/test/goldInk.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Readable text on the gold controls (#956).
+ *
+ * `--goldink` means gold-COLOURED ink, for text on the dark chrome. It reads
+ * like "the ink for gold", so it was used for both — and the gold SURFACES do
+ * not flip with the skin:
+ *
+ *     --grad-gold  linear-gradient(#f0dca6, #e7bf62)   identical in both skins
+ *     --gold       #d9a441                             identical in both skins
+ *     --goldink    #f0dca6 (dark) / #6b4e17 (skeuo)    flips
+ *
+ * So on the dark skin it painted #f0dca6 on a gradient whose top stop IS
+ * #f0dca6 — a contrast ratio of 1.00. The active Electronics tab, "+ New part"
+ * and the Help pill were invisible in one skin and fine in the other.
+ *
+ * `--ongold` is the ink for those surfaces, defined once in the shared `:root`
+ * because a value that must not differ between skins should not live somewhere
+ * it could.
+ */
+
+function stylesheets(dir = 'src/renderer/src'): string[] {
+  const out: string[] = []
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name)
+    if (statSync(p).isDirectory()) out.push(...stylesheets(p))
+    else if (name.endsWith('.css')) out.push(p)
+  }
+  return out
+}
+
+/** Rules that paint a gold SURFACE, with whatever colour they set on it. */
+function goldSurfaceRules(): { file: string; line: number; selector: string; color: string }[] {
+  const out: { file: string; line: number; selector: string; color: string }[] = []
+  for (const file of stylesheets()) {
+    const lines = readFileSync(file, 'utf8').split('\n')
+    lines.forEach((l, i) => {
+      const paintsGold = /background[^;]*var\(--(grad-gold|gold)\b/.test(l)
+      if (!paintsGold) return
+      let start = i
+      while (start > 0 && !lines[start].includes('{')) start--
+      let end = i
+      while (end < lines.length - 1 && !lines[end].includes('}')) end++
+      const body = lines.slice(start, end + 1)
+      const colour = body.find((b) => /^\s*color:/.test(b))
+      out.push({
+        file,
+        line: start + 1,
+        selector: lines[start].split('{')[0].trim(),
+        color: colour?.trim() ?? '(inherits)'
+      })
+    })
+  }
+  return out
+}
+
+describe('nothing paints gold ink on a gold surface', () => {
+  it('no rule with a gold background sets --goldink', () => {
+    const bad = goldSurfaceRules().filter((r) => r.color.includes('--goldink'))
+    expect(
+      bad.map((r) => `${r.file}:${r.line}  ${r.selector}  ${r.color}`),
+      '--goldink is pale on the dark skin, and the gold surfaces are the same in both — use --ongold'
+    ).toEqual([])
+  })
+
+  it('the gold controls actually use --ongold', () => {
+    // Both directions: a later change that dropped the token would leave the
+    // controls inheriting whatever, which is how this started.
+    const users = goldSurfaceRules().filter((r) => r.color.includes('--ongold'))
+    expect(users.length).toBeGreaterThan(8)
+    expect(users.some((r) => r.file.includes('WorkspaceSwitcher'))).toBe(true)
+    expect(users.some((r) => r.file.includes('PartsPanel'))).toBe(true)
+  })
+})
+
+describe('the token is defined where it cannot diverge', () => {
+  const css = readFileSync('src/renderer/src/index.css', 'utf8')
+
+  it('lives in the shared :root, not once per skin', () => {
+    // The surfaces it sits on are identical across skins, so its ink must be
+    // too — defining it twice is an invitation for them to drift apart.
+    const shared = css.slice(css.indexOf(':root {'), css.indexOf(":root[data-theme='dark']"))
+    expect(shared).toContain('--ongold:')
+    for (const skin of ['dark', 'skeuomorph']) {
+      const at = css.indexOf(`:root[data-theme='${skin}'] {`)
+      const block = css.slice(at, css.indexOf('\n}', at))
+      expect(block, `${skin} must not redefine it`).not.toContain('--ongold:')
+    }
+  })
+
+  it('is dark enough to read on both ends of the gradient', () => {
+    const m = /--ongold:\s*(#[0-9a-f]{6})/i.exec(css)
+    expect(m).toBeTruthy()
+    const ratio = (a: string, b: string): number => {
+      const lum = (h: string): number => {
+        const v = [1, 3, 5].map((i) => {
+          const c = parseInt(h.slice(i, i + 2), 16) / 255
+          return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
+        })
+        return 0.2126 * v[0] + 0.7152 * v[1] + 0.0722 * v[2]
+      }
+      const [x, y] = [lum(a), lum(b)].sort((p, q) => q - p)
+      return (x + 0.05) / (y + 0.05)
+    }
+    // The gradient's two stops, and the solid gold.
+    for (const bg of ['#f0dca6', '#e7bf62', '#d9a441']) {
+      expect(ratio(m![1], bg), `${m![1]} on ${bg}`).toBeGreaterThan(4.5)
+    }
+  })
+})
+
+describe('--goldink keeps the job it was named for', () => {
+  it('is still used for gold text on dark surfaces', () => {
+    // The fix is a split, not a rename: gold-coloured text on the dark chrome
+    // is exactly what this token is for, and those uses were never wrong.
+    const remaining = stylesheets().filter((f) =>
+      readFileSync(f, 'utf8').includes('var(--goldink')
+    )
+    expect(remaining.length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
Closes #956.

The active Electronics tab, Breadboard, "+ New part", the Help pill and eleven other gold controls painted pale text on a pale gold background.

## One token, misused

`--goldink` means gold-**coloured** ink, for text on the dark chrome. It reads like "the ink for gold", so it got used for both — and the gold *surfaces* don't flip with the skin:

```
--grad-gold  linear-gradient(#f0dca6, #e7bf62)   identical in both skins
--gold       #d9a441                             identical in both skins
--goldink    #f0dca6 (dark) / #6b4e17 (skeuo)    flips
```

So on the dark skin it painted `#f0dca6` on a gradient whose top stop **is** `#f0dca6` — contrast ratio **1.00**. That's why it read perfectly in skeuomorph and not at all in dark, and why it looked like a dark-mode bug rather than a token bug.

## The fix is a split, not a rename

`--ongold` is the ink for those surfaces, defined once in the **shared `:root`** — a value that must not differ between skins shouldn't live somewhere it could. Thirteen rules moved to it.

The rest keep `--goldink`, which was never wrong where it pairs with `--goldbg` or sits on a dark panel. A blanket replace would have broken the correct half.

## My own test caught the value

I started with the Board Finder's local answer (`--bf-gold-ink: #5a3d0e`). It clears AA on the gradient — but lands at **4.43:1** on the solid `--gold`, which also carries text. `#4a3209` clears 4.5 on all three surfaces (8.85 / 6.87 / 5.33), and the test **computes** those ratios rather than trusting the comment that states them.

lint · typecheck · **6,698 tests** · build — green. Mutation-checked by putting one control back on `--goldink`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe