### PR TITLE
An empty .mpy buffer is never written back as the file (#964)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Copying a `.mpy` to the board no longer produces a 0-byte file — and ⌘S no
+  longer destroys it** (#964). A `.mpy` opens with no text on purpose: it is
+  bytecode, reading it as UTF-8 would mangle it, and the Bytecode view fetches
+  the real bytes itself (#875). The empty string in the buffer is a placeholder,
+  not the file.
+
+  Three writers treated it as the file. Uploading wrote it to the board, giving
+  the reported 0-byte file. And `saveFile` — which has **no dirty check**, so it
+  writes whether or not anything changed — wrote it back over the `.mpy` **on
+  disk**. #915 made that far easier to reach by moving ⌘S out of the editor onto
+  the menu, where it fires with a Bytecode tab focused: compile with #949, glance
+  at the bytecode, press ⌘S out of habit, and the file was gone.
+
+  The open file now says its buffer is not the file, and the writers respect it —
+  one fact on the file rather than three writers each re-deriving it from the
+  extension, because the writer that forgets to re-derive it is the one that
+  deletes somebody's work. Saving such a file does nothing; uploading it sends
+  the file from disk, as bytes, all-or-nothing. A text buffer still uploads as it
+  stands, unsaved edits and all, which is what that control is for.
+
+### Fixed
+
 - **The gold buttons are readable in dark mode** (#956). The active Electronics
   tab, Breadboard, "+ New part", the Help pill and eleven other gold controls
   painted pale text on a pale gold background.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snakie",
-  "version": "0.54.3",
+  "version": "0.54.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "snakie",
-      "version": "0.54.3",
+      "version": "0.54.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snakie",
-  "version": "0.54.3",
+  "version": "0.54.4",
   "description": "A modern, cross-platform MicroPython editor.",
   "productName": "Snakie",
   "main": "./out/main/index.js",

--- a/src/renderer/src/components/UploadControls.tsx
+++ b/src/renderer/src/components/UploadControls.tsx
@@ -4,7 +4,8 @@ import { IS_WEB } from '../lib/env'
 import { useDeviceStatus } from '../hooks/useDeviceStatus'
 import { usePrompt } from './PromptModal'
 import { useFileSelection } from '../store/file-selection'
-import { planUploadOf, runFolderUpload } from '../lib/folder-transfer'
+import { deviceAtomicOps, planUploadOf, runFolderUpload } from '../lib/folder-transfer'
+import { writeAtomically } from '../../../shared/atomic-write'
 import { enqueueDeviceTask } from '../lib/device-queue'
 import { hostBaseName } from '../../../shared/transfer-plan'
 import './UploadControls.css'
@@ -175,7 +176,22 @@ export function UploadControls(): JSX.Element {
       await enqueueDeviceTask({
         key: `write:${dest}`,
         label: `Uploading ${activeFile.name} → ${dest}`,
-        run: () => window.api.device.writeFile(dest, activeFile.content)
+        run: async () => {
+          // A BINARY buffer holds no text — a `.mpy` opens empty on purpose
+          // (#875/#964) — so uploading `content` put a 0-byte file on the board.
+          // Send the file itself instead, as bytes and all-or-nothing, the way
+          // every other copy to the board goes (#959).
+          if (activeFile.binary && activeFile.source === 'local' && activeFile.path) {
+            const bytes = await window.api.fs.readFileBytes(activeFile.path)
+            await writeAtomically(deviceAtomicOps, dest, bytes.length, (tmp) =>
+              window.api.device.writeFileBytes(tmp, bytes)
+            )
+            return
+          }
+          // A text buffer is uploaded as it stands, INCLUDING unsaved edits —
+          // that is the point of this control, and it has always worked that way.
+          await window.api.device.writeFile(dest, activeFile.content)
+        }
       })
       setFeedback({
         kind: 'success',

--- a/src/renderer/src/store/workspace.ts
+++ b/src/renderer/src/store/workspace.ts
@@ -149,6 +149,21 @@ export interface OpenFile {
   content: string
   /** True when the buffer has unsaved edits. */
   dirty: boolean
+  /**
+   * The buffer does NOT hold this file's content (#964).
+   *
+   * A `.mpy` opens with no text on purpose: it is bytecode, reading it as UTF-8
+   * would mangle it, and the Bytecode view fetches the real bytes itself (#875).
+   * The empty string in `content` is therefore a placeholder, not the file — and
+   * anything that writes `content` back would replace the file with nothing.
+   *
+   * Three writers did. Uploading gave a 0-byte file on the board, and ⌘S — which
+   * #915 made work outside the editor — destroyed the `.mpy` on disk. So the
+   * fact lives on the file itself rather than being re-derived from the
+   * extension by each writer, because the writer that forgets to re-derive it is
+   * the one that deletes somebody's work.
+   */
+  binary?: boolean
 }
 
 /**
@@ -369,7 +384,15 @@ export function WorkspaceProvider({ children }: { children: ReactNode }): JSX.El
         : await window.api.device.readFile(path)
     dispatch({
       type: 'open',
-      file: { id, source, path, name: baseName(path), content, dirty: false }
+      file: {
+        id,
+        source,
+        path,
+        name: baseName(path),
+        content,
+        dirty: false,
+        binary: isMpyFile(path)
+      }
     })
   }, [])
 
@@ -395,6 +418,12 @@ export function WorkspaceProvider({ children }: { children: ReactNode }): JSX.El
     async (id: string): Promise<void> => {
       const file = state.openFiles.find((f) => f.id === id)
       if (!file) return
+      // Nothing to save, and saving would DESTROY it (#964): the buffer is a
+      // placeholder, so writing it back replaces the file with nothing. There is
+      // no dirty check above this — `saveFile` writes whether or not anything
+      // changed — so this is the only thing standing between ⌘S on a Bytecode
+      // tab and an empty file.
+      if (file.binary) return
       if (file.source === 'local' && !file.path) {
         // Untitled local buffer: "Save As" — pick a destination, write it, and
         // promote the buffer to a real saved file (path/name updated, dirty

--- a/test/binaryBufferWriteback.test.ts
+++ b/test/binaryBufferWriteback.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+
+/**
+ * An empty buffer must never be written back as if it were the file (#964).
+ *
+ * A `.mpy` opens with no text on purpose: it is bytecode, reading it as UTF-8
+ * would mangle it, and the Bytecode view (#875) fetches the real bytes itself.
+ * The empty string in `content` is a PLACEHOLDER, not the file.
+ *
+ * Three writers treated it as the file. Uploading produced a 0-byte file on the
+ * board — the reported symptom — and `saveFile`, which has no dirty check,
+ * replaced the `.mpy` ON DISK with nothing. #915 made that far easier to reach
+ * by moving ⌘S out of the editor and onto the menu, where it fires with a
+ * Bytecode tab focused.
+ *
+ * So the fact lives on the open file rather than being re-derived from the
+ * extension by each writer: the writer that forgets to re-derive it is the one
+ * that deletes somebody's work.
+ */
+
+const store = readFileSync('src/renderer/src/store/workspace.ts', 'utf8')
+const upload = readFileSync('src/renderer/src/components/UploadControls.tsx', 'utf8')
+
+/** The body of the single-file upload task — the one that writes `dest`. */
+const uploadRun = ((): string => {
+  const at = upload.indexOf('run: async () =>')
+  expect(at, 'the single-file upload task moved').toBeGreaterThan(-1)
+  return upload.slice(at, at + 1400)
+})()
+
+describe('the file itself says its buffer is not the file', () => {
+  it('carries a `binary` flag rather than leaving each writer to guess', () => {
+    expect(store).toMatch(/binary\?: boolean/)
+    expect(store).toContain('binary: isMpyFile(path)')
+  })
+
+  it('sets it from the same rule that empties the buffer', () => {
+    // If these two ever disagree, a file opens empty and nothing knows it.
+    const open = store.slice(store.indexOf('const openFile = useCallback'))
+    const head = open.slice(0, 1200)
+    expect(head).toContain("isMpyFile(path)\n      ? ''")
+    expect(head).toContain('binary: isMpyFile(path)')
+  })
+})
+
+describe('saving refuses', () => {
+  it('returns before writing anything', () => {
+    const fn = store.slice(store.indexOf('const saveFile = useCallback'))
+    const guard = fn.indexOf('if (file.binary) return')
+    expect(guard, 'no binary guard in saveFile').toBeGreaterThan(-1)
+    // BEFORE both write paths, not after one of them.
+    expect(guard).toBeLessThan(fn.indexOf('fs.writeFile'))
+    expect(guard).toBeLessThan(fn.indexOf('device.writeFile'))
+  })
+
+  it('is the only thing stopping it, because there is no dirty check', () => {
+    // Worth pinning: `saveFile` writes whether or not anything changed, so the
+    // Bytecode view being read-only does not protect the file — only this does.
+    const fn = store.slice(
+      store.indexOf('const saveFile = useCallback'),
+      store.indexOf('const saveFileAs')
+    )
+    expect(fn).not.toMatch(/if \(!file\.dirty\)\s*return/)
+  })
+})
+
+describe('uploading sends the file, not the placeholder', () => {
+  it('reads a binary file from disk and writes bytes', () => {
+    const run = uploadRun
+    expect(run).toContain('activeFile.binary')
+    expect(run).toContain('readFileBytes')
+    expect(run).toContain('writeFileBytes')
+  })
+
+  it('does it atomically, like every other copy to the board', () => {
+    expect(upload).toContain('writeAtomically(deviceAtomicOps')
+  })
+
+  it('still uploads a TEXT buffer as it stands, unsaved edits and all', () => {
+    // That is the point of this control and has always been how it works — the
+    // fix must not quietly turn it into "upload what is on disk".
+    const run = uploadRun
+    expect(run).toContain('window.api.device.writeFile(dest, activeFile.content)')
+  })
+})


### PR DESCRIPTION
Closes #964. Fixes the 0-byte file you hit — and two worse ones it led me to.

## The root

A `.mpy` opens with **no text**, on purpose: it's bytecode, reading it as UTF-8 would mangle it, and the Bytecode view fetches the real bytes itself (#875). The empty string in `content` is a **placeholder, not the file**.

Three writers treated it as the file:

| writer | result |
|---|---|
| `UploadControls` (the ⇄ bridge) | **0-byte file on the board** ← what you reported |
| `saveFile` local | **destroyed the `.mpy` on disk** |
| `saveFile` device | destroyed a `.mpy` opened from the board |

`saveFile` has **no dirty check** — it writes whether or not anything changed — so the Bytecode view being read-only never protected the file.

**And #915 made that far easier to reach.** ⌘S used to live inside Monaco and fire only with the editor focused; as a menu accelerator it fires wherever you are, including on a Bytecode tab. Compile with #949, glance at the bytecode, press ⌘S out of habit, and the file was gone. That one's on me — it was a consequence of moving the shortcut that I didn't think through.

## The fix

The fact goes on the **open file** — `binary`, set from the same rule that empties the buffer — rather than each writer re-deriving it from the extension. There were three writers, and the one that forgets to re-derive it is the one that deletes somebody's work.

- **Saving** such a file returns before either write path.
- **Uploading** reads the file from disk and sends bytes, atomically, like every other copy to the board (#959).
- **A text buffer still uploads as it stands**, unsaved edits and all — that's the point of that control, and a test pins it so the fix can't quietly turn it into "upload what's on disk".

Both guards mutation-checked: removing either fails.

## Gates

lint (pre-existing `DriverInstallBanner.tsx` warning only) · typecheck · **6,705 tests in 326 files** · build — green.

**Worth knowing:** if you already pressed ⌘S on a `.mpy` tab, that file on disk is empty and needs recompiling. The size column from #955 will show it as `0 B`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe