### PR TITLE
Describe the app that ships, and generate the board catalogue (#962)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **The docs describe the app that ships** (#962). The README announced
+  "v0.13.0 released" at v0.54.x, and `docs/micropython-boards.md` claimed 219
+  boards from a July snapshot while the shipped index held 225 from MicroPython
+  v1.29.0. Nothing from this run of releases appeared anywhere: not the Board
+  Finder, not the File / Device / Tools menus, not the shortcut sheet, not
+  `.py` → `.mpy`, not the status history, not file sizes.
+
+  The board catalogue is **generated** now, by `scripts/build-boards-doc.mjs`
+  from the same index the app ships, and a test holds its total, its MicroPython
+  release and every one of its rows to that source. It drifted because it had to
+  be retyped, and a reference that is quietly wrong is worse than none — the
+  reader trusts it.
+
+  The README's Status section no longer names a version at all. A number there
+  has to be maintained to stay true, and Releases already has it; what belongs in
+  a README is what the app does.
+
+  **No screenshots were audited: the repository contains none.** Any that exist
+  live outside it, and are still worth a pass against the current UI.
+
 ### Fixed
 
 - **Copying a `.mpy` to the board no longer produces a 0-byte file — and ⌘S no

--- a/README.md
+++ b/README.md
@@ -56,19 +56,38 @@ Re-run it after updating to a new version, or pass `--uninstall` to remove it.
 ### Device & REPL
 
 - 🔌 Connect to a MicroPython device over serial (raw-REPL protocol)
-- ▶️ **Run** and **Stop** — Stop also **soft-resets** the board when nothing's
-  running
+- ▶️ **Run** (⌘R) and **Stop** (⌘.) — Stop also **soft-resets** the board when
+  nothing's running
 - 🐚 Interactive shell (REPL) with a live serial **Plotter** alongside the console
 - 🗂️ Browse / create / rename / delete files locally and on the device
-  (Thonny-style)
-- 📦 Install MicroPython packages (`mip`) and 📡 flash firmware (built-in board
-  catalog)
+  (Thonny-style), each tree showing **file sizes** — so an empty file is visible
+- ⚙️ **Compile `.py` to `.mpy`** from the file tree's context menu, using
+  MicroPython's own `mpy-cross` built to WebAssembly from the same release the
+  firmware catalogue offers
+- 📦 Install MicroPython packages (`mip`)
+
+### Board Finder & firmware
+
+- 🔎 A **Board Finder** covering **237 boards** — all 225 MicroPython publishes a
+  `board.json` for, plus 12 it builds nothing for but that people actually own
+  (the Adafruit ESP32 Feather V2, Pimoroni's Tiny 2350 and Servo 2040, the
+  micro:bit v2 …), each with the build it really flashes and why
+- 📇 Filter by maker, chip, runtime and features; every board carries its flash,
+  RAM and PSRAM **with the page each figure was read from**, because MicroPython's
+  index publishes no sizes
+- 🔬 Eighteen of them open with their **own hardware**: the board photographed,
+  turned over where there is a back, its 3-D model where there is one, and every
+  pad readable by name — `GP4 · Pin 6 · I/O · I2C0 SDA · SPI0 RX · PWM 2A`
+- 📡 A **firmware flasher** that offers the *right* build — including the variants
+  that are easy to miss, like the SPIRAM build a Feather V2 needs to see its PSRAM
 
 ### Board View & Instruments
 
 - 🔭 A live **Board View** window that parses your code for pin usage and draws the
-  **actual board** — Raspberry Pi Pico 2 W, ESP32, Pimoroni Pico Plus 2 / Tiny 2040
-  / Tiny 2350, plus your own board definitions
+  **actual board** — any microcontroller in the Parts Library (Pico / Pico W /
+  Pico 2 W, ESP32 and ESP32-S3 Feathers, XIAO RP2040 / RP2350, Pimoroni's Tiny
+  2350, Servo 2040 and Pico LiPo 2, Arduino Nano ESP32 …), plus your own board
+  definitions
 - 🕸️ A **node graph** of every connection by type (input / output / PWM / I²C / SPI
   / PIO / ADC) with live pin values, **zoom / rotate / export** (SVG · PNG · PDF),
   and a visual **Board Creator** for custom boards
@@ -93,6 +112,15 @@ Re-run it after updating to a new version, or pass `--uninstall` to remove it.
 
 ### Workflow
 
+- ⌨️ **Application menus** — File (New, Open File/Folder, Open Recent, Save,
+  Save As, Close Tab), Device (Connect, Run, Stop, Soft Reset, Sync), Tools
+  (Firmware Flasher, Board Finder, Parts Catalog, Sprite Editor, Find & Replace,
+  Settings) and View ▸ Workspace — so nothing is reachable only by knowing which
+  panel hides the button
+- 🔑 A **keyboard shortcut sheet** (Help ▸ Keyboard Shortcuts) generated from the
+  menu itself, so it cannot drift from the real bindings
+- 🧾 A **status history** — the bar keeps what it said; click it for the recent
+  messages, or open the full log to copy, save or clear it
 - 🌳 Built-in version control (Git, VS Code-style)
 - 🤖 Integrated LLM chat pane
 - 🔔 In-app update notifications when a new version is ready
@@ -180,19 +208,25 @@ Notes on arch coverage:
 
 ## Status
 
-🚀 **v0.13.0 released** — signed + notarized macOS builds alongside Windows and
-Linux. On top of the original editor / REPL / device tooling, recent releases added
-the **Skeuomorph** redesign, the **Board View** (node-graph pinout, multi-board +
-custom boards, viewport + export, Board Creator), the **Oscilloscope / Multimeter /
-Plotter** instruments, and the **MicroPython instruments telemetry library** that
-feeds them live from a running program. See
-[`CHANGELOG.md`](CHANGELOG.md) for the full history and
-[`docs/`](docs/) for the design + plugin + board + instruments guides.
+🚀 **Released and updating.** Grab the current build from
+[Releases](https://github.com/kevinmcaleer/Snakie/releases/latest); macOS builds
+are signed and notarized, and the in-app updater takes it from there.
 
-> ⚠️ Many features are build-, type- and unit-test-verified but the **on-device**
-> paths (live values, the instruments, firmware flashing, package install) need a
-> real MicroPython board to fully validate. The LLM chat needs an Anthropic API
-> key; the package installer needs network access.
+The foundations — the editor, the REPL, the device tooling, the Skeuomorph
+redesign, the Board View and the Oscilloscope / Multimeter / Plotter instruments
+— have been in for a while. More recently: the **Board Finder** and a firmware
+catalogue that knows the sizes and the variants, a **Parts Library** of 59
+standard parts with a visual Part Editor, **application menus** with a generated
+shortcut sheet, and `.py` → `.mpy` compilation with MicroPython's own compiler
+built to WebAssembly.
+
+See [`CHANGELOG.md`](CHANGELOG.md) for the full history and [`docs/`](docs/) for
+the design, plugin, board, parts and instruments guides.
+
+> ⚠️ Much is verified by build, type-check and ~6,700 unit tests, but the
+> **on-device** paths — live instrument values, firmware flashing, package
+> install — need a real MicroPython board to validate fully. The LLM chat needs
+> an Anthropic API key; the package installer needs network access.
 
 ## License
 

--- a/docs/board.md
+++ b/docs/board.md
@@ -2,7 +2,8 @@
 
 The **Board View** is a separate, always-on-top window that visualises the pin
 wiring of the Python file you're editing. Open it from the toolbar's **board**
-button; it streams live, so the picture updates as you type.
+button or from **View ▸ Board View** (⇧⌘B); it streams live, so the picture
+updates as you type.
 
 It works by parsing your MicroPython source for the common `machine` constructors
 (`Pin`, `PWM`, `I2C`, `SPI`, `StateMachine`) and drawing a coloured wire from

--- a/docs/micropython-boards.md
+++ b/docs/micropython-boards.md
@@ -5,11 +5,17 @@ ships a `board.json` in the mainline [micropython/micropython](https://github.co
 tree. For each board: **supplier** (vendor), **board name** (product), **model**
 (the MicroPython build-target / board id you flash), and **chip type** (MCU).
 
-- **Total boards:** 219 across 10 MCU ports.
-- **Source:** mainline `ports/*/boards/*/board.json` (authoritative, machine-generated).
-- **Snapshot:** July 2026 (mainline `master`).
+- **Total boards:** 225 across 11 MCU ports.
+- **MicroPython:** `v1.29.0`.
+- **Source:** `src/renderer/public/boards/boards.json`, generated from mainline `ports/*/boards/*/board.json`.
+- **Generated:** 2026-09-05 — **do not edit by hand**, run `node scripts/build-boards-doc.mjs`.
 
 > Notes
+> - Snakie’s **Board Finder** shows these plus 12 more that MicroPython
+>   builds nothing for but people own anyway — the Adafruit ESP32 Feather V2, the
+>   micro:bit v2, Pimoroni’s Tiny 2350 and Servo 2040 and others. They are not in
+>   this table because the one column it exists to give — the build target you
+>   flash — is precisely what they do not have. See `src/shared/board-overlay.ts`.
 > - The `ESP32_GENERIC*` and `ESP8266_GENERIC` targets cover the countless
 >   third-party ESP dev boards (NodeMCU, DOIT, HiLetgo, etc.) that share a chip.
 > - Some vendors (e.g. Pimoroni, Arduino, LEGO) also ship **extra** boards in their
@@ -22,16 +28,17 @@ tree. For each board: **supplier** (vendor), **board name** (product), **model**
 | Port | MCU family | Boards |
 |------|-----------|-------:|
 | `rp2` | Raspberry Pi RP2 — RP2040 / RP2350 | 38 |
-| `esp32` | Espressif ESP32 family | 42 |
+| `esp32` | Espressif ESP32 family | 45 |
 | `esp8266` | Espressif ESP8266 | 1 |
-| `stm32` | STMicroelectronics STM32 | 74 |
+| `stm32` | STMicroelectronics STM32 | 76 |
 | `samd` | Microchip SAMD (SAM D21 / D51) | 18 |
 | `nrf` | Nordic Semiconductor nRF | 23 |
 | `mimxrt` | NXP i.MX RT | 14 |
 | `renesas-ra` | Renesas RA | 7 |
 | `alif` | Alif Ensemble | 1 |
+| `psoc-edge` | Infineon PSoC Edge | 1 |
 | `cc3200` | Texas Instruments CC3200 | 1 |
-| | **Total** | **219** |
+| | **Total** | **225** |
 
 ## Raspberry Pi RP2 — RP2040 / RP2350
 
@@ -39,93 +46,96 @@ Port: `rp2` — 38 boards.
 
 | Supplier | Board name | Model (build target) | Chip |
 |----------|-----------|----------------------|------|
-| Adafruit | Feather RP2040 | `ADAFRUIT_FEATHER_RP2040` | RP2040 |
-| Adafruit | Feather RP2350 | `ADAFRUIT_FEATHER_RP2350` | RP2350 |
-| Adafruit | ItsyBitsy RP2040 | `ADAFRUIT_ITSYBITSY_RP2040` | RP2040 |
-| Adafruit | QT Py RP2040 | `ADAFRUIT_QTPY_RP2040` | RP2040 |
-| Arduino | Nano RP2040 Connect | `ARDUINO_NANO_RP2040_CONNECT` | RP2040 |
-| Cytron | MOTION 2350 Pro | `CYTRON_MOTION_2350_PRO` | RP2350 |
-| Cytron | NanoXRP Controller | `CYTRON_NANOXRP_CONTROLLER` | RP2040 |
-| Machdyne | Werkzeug | `MACHDYNE_WERKZEUG` | RP2040 |
-| McHobby | RP2040 PYBStick | `GARATRONIC_PYBSTICK26_RP2040` | RP2040 |
-| nullbits | Bit-C PRO | `NULLBITS_BIT_C_PRO` | RP2040 |
-| Pimoroni | Pico LiPo | `PIMORONI_PICOLIPO` | RP2040 |
-| Pimoroni | Tiny2040 | `PIMORONI_TINY2040` | RP2040 |
-| Pololu | 3pi+ 2040 Robot | `POLOLU_3PI_2040_ROBOT` | RP2040 |
-| Pololu | Zumo 2040 Robot | `POLOLU_ZUMO_2040_ROBOT` | RP2040 |
-| Raspberry Pi | Pico | `RPI_PICO` | RP2040 |
-| Raspberry Pi | Pico 2 | `RPI_PICO2` | RP2350 |
-| Raspberry Pi | Pico 2 W | `RPI_PICO2_W` | RP2350 |
-| Raspberry Pi | Pico W | `RPI_PICO_W` | RP2040 |
-| Seeed Studio | XIAO RP2040 | `SEEED_XIAO_RP2040` | RP2040 |
-| Seeed Studio | XIAO RP2350 | `SEEED_XIAO_RP2350` | RP2350 |
-| Silicognition LLC | RP2040-Shim | `SIL_RP2040_SHIM` | RP2040 |
-| Soldered Electronics | NULA RP2350 | `SOLDERED_NULA_MAX_RP2350` | RP2350 |
-| SparkFun | IoT Node LoRaWAN RP2350 | `SPARKFUN_IOTNODE_LORAWAN_RP2350` | RP2350 |
-| SparkFun | Pro Micro - RP2040 | `SPARKFUN_PROMICRO` | RP2040 |
-| SparkFun | Pro Micro RP2350 | `SPARKFUN_PROMICRO_RP2350` | RP2350 |
-| SparkFun | SparkFun IoT RedBoard RP2350 | `SPARKFUN_IOTREDBOARD_RP2350` | RP2350 |
-| SparkFun | Thing Plus - RP2040 | `SPARKFUN_THINGPLUS` | RP2040 |
-| SparkFun | Thing Plus RP2350 | `SPARKFUN_THINGPLUS_RP2350` | RP2350 |
-| SparkFun | XRP Controller | `SPARKFUN_XRP_CONTROLLER` | RP2350 |
-| SparkFun | XRP Controller (Beta) | `SPARKFUN_XRP_CONTROLLER_BETA` | RP2040 |
-| Waveshare | RP2040-LCD-0.96 | `WAVESHARE_RP2040_LCD_0_96` | RP2040 |
-| Waveshare | RP2040-Plus | `WAVESHARE_RP2040_PLUS` | RP2040 |
-| Waveshare | RP2040-Zero | `WAVESHARE_RP2040_ZERO` | RP2040 |
-| Waveshare | RP2350B Core | `WAVESHARE_RP2350B_CORE` | RP2350 |
-| WeAct | Studio RP2040 | `WEACTSTUDIO` | RP2040 |
-| WeAct Studio | RP2350B Core | `WEACTSTUDIO_RP2350B_CORE` | RP2350 |
-| WIZnet | W5100S-EVB-Pico | `W5100S_EVB_PICO` | RP2040 |
-| WIZnet | W5500-EVB-Pico | `W5500_EVB_PICO` | RP2040 |
+| Adafruit | Feather RP2040 | `ADAFRUIT_FEATHER_RP2040` | rp2040 |
+| Adafruit | Feather RP2350 | `ADAFRUIT_FEATHER_RP2350` | rp2350 |
+| Adafruit | ItsyBitsy RP2040 | `ADAFRUIT_ITSYBITSY_RP2040` | rp2040 |
+| Adafruit | QT Py RP2040 | `ADAFRUIT_QTPY_RP2040` | rp2040 |
+| Arduino | Nano RP2040 Connect | `ARDUINO_NANO_RP2040_CONNECT` | rp2040 |
+| Cytron | MOTION 2350 Pro | `CYTRON_MOTION_2350_PRO` | rp2350 |
+| Cytron | NanoXRP Controller | `CYTRON_NANOXRP_CONTROLLER` | rp2040 |
+| Machdyne | Werkzeug | `MACHDYNE_WERKZEUG` | rp2040 |
+| McHobby | RP2040 PYBStick | `GARATRONIC_PYBSTICK26_RP2040` | rp2040 |
+| nullbits | Bit-C PRO | `NULLBITS_BIT_C_PRO` | rp2040 |
+| Pimoroni | Pico LiPo | `PIMORONI_PICOLIPO` | rp2040 |
+| Pimoroni | Tiny2040 | `PIMORONI_TINY2040` | rp2040 |
+| Pololu | 3pi+ 2040 Robot | `POLOLU_3PI_2040_ROBOT` | rp2040 |
+| Pololu | Zumo 2040 Robot | `POLOLU_ZUMO_2040_ROBOT` | rp2040 |
+| Raspberry Pi | Pico | `RPI_PICO` | rp2040 |
+| Raspberry Pi | Pico 2 | `RPI_PICO2` | rp2350 |
+| Raspberry Pi | Pico 2 W | `RPI_PICO2_W` | rp2350 |
+| Raspberry Pi | Pico W | `RPI_PICO_W` | rp2040 |
+| Seeed Studio | XIAO RP2040 | `SEEED_XIAO_RP2040` | rp2040 |
+| Seeed Studio | XIAO RP2350 | `SEEED_XIAO_RP2350` | rp2350 |
+| Silicognition LLC | RP2040-Shim | `SIL_RP2040_SHIM` | rp2040 |
+| Soldered Electronics | NULA RP2350 | `SOLDERED_NULA_MAX_RP2350` | rp2350 |
+| SparkFun | IoT Node LoRaWAN RP2350 | `SPARKFUN_IOTNODE_LORAWAN_RP2350` | rp2350 |
+| SparkFun | Pro Micro - RP2040 | `SPARKFUN_PROMICRO` | rp2040 |
+| SparkFun | Pro Micro RP2350 | `SPARKFUN_PROMICRO_RP2350` | rp2350 |
+| SparkFun | SparkFun IoT RedBoard RP2350 | `SPARKFUN_IOTREDBOARD_RP2350` | rp2350 |
+| SparkFun | Thing Plus - RP2040 | `SPARKFUN_THINGPLUS` | rp2040 |
+| SparkFun | Thing Plus RP2350 | `SPARKFUN_THINGPLUS_RP2350` | rp2350 |
+| SparkFun | XRP Controller | `SPARKFUN_XRP_CONTROLLER` | rp2350 |
+| SparkFun | XRP Controller (Beta) | `SPARKFUN_XRP_CONTROLLER_BETA` | rp2040 |
+| Waveshare | RP2040-LCD-0.96 | `WAVESHARE_RP2040_LCD_0_96` | rp2040 |
+| Waveshare | RP2040-Plus | `WAVESHARE_RP2040_PLUS` | rp2040 |
+| Waveshare | RP2040-Zero | `WAVESHARE_RP2040_ZERO` | rp2040 |
+| Waveshare | RP2350B Core | `WAVESHARE_RP2350B_CORE` | rp2350 |
+| WeAct Studio | RP2350B Core | `WEACTSTUDIO_RP2350B_CORE` | rp2350 |
+| WeAct | Studio RP2040 | `WEACTSTUDIO` | rp2040 |
+| WIZnet | W5100S-EVB-Pico | `W5100S_EVB_PICO` | rp2040 |
+| WIZnet | W5500-EVB-Pico | `W5500_EVB_PICO` | rp2040 |
 
 ## Espressif ESP32 family
 
-Port: `esp32` — 42 boards.
+Port: `esp32` — 45 boards.
 
 | Supplier | Board name | Model (build target) | Chip |
 |----------|-----------|----------------------|------|
-| Arduino | Nano ESP32 | `ARDUINO_NANO_ESP32` | ESP32-S3 |
-| Espressif | ESP32 / WROOM | `ESP32_GENERIC` | ESP32 |
-| Espressif | ESP32-C2 | `ESP32_GENERIC_C2` | ESP32-C2 |
-| Espressif | ESP32-C3 | `ESP32_GENERIC_C3` | ESP32-C3 |
-| Espressif | ESP32-C5 | `ESP32_GENERIC_C5` | ESP32-C5 |
-| Espressif | ESP32-C6 | `ESP32_GENERIC_C6` | ESP32-C6 |
-| Espressif | ESP32-P4 | `ESP32_GENERIC_P4` | ESP32-P4 |
-| Espressif | ESP32-S2 | `ESP32_GENERIC_S2` | ESP32-S2 |
-| Espressif | ESP32-S3 | `ESP32_GENERIC_S3` | ESP32-S3 |
-| LILYGO | T3-S3 | `LILYGO_T3_S3` | ESP32-S3 |
-| LILYGO | TTGO LoRa32 | `LILYGO_TTGO_LORA32` | ESP32 |
-| M5Stack | Atom | `M5STACK_ATOM` | ESP32 |
-| M5Stack | AtomS3 Lite | `M5STACK_ATOMS3_LITE` | ESP32-S3 |
-| M5Stack | NanoC6 | `M5STACK_NANOC6` | ESP32-C6 |
-| McHobby | PYBSTICK26_ESP32C3 | `GARATRONIC_PYBSTICK26_ESP32C3` | ESP32-C3 |
-| Olimex | ESP32 EVB | `OLIMEX_ESP32_EVB` | ESP32 |
-| Olimex | ESP32 POE | `OLIMEX_ESP32_POE` | ESP32 |
-| Seeed Studio | XIAO ESP32C3 | `SEEED_XIAO_ESP32C3` | ESP32-C3 |
-| Seeed Studio | XIAO ESP32C5 | `SEEED_XIAO_ESP32C5` | ESP32-C5 |
-| Seeed Studio | XIAO ESP32C6 | `SEEED_XIAO_ESP32C6` | ESP32-C6 |
-| Seeed Studio | XIAO ESP32S3 | `SEEED_XIAO_ESP32S3` | ESP32-S3 |
-| Silicognition | wESP32 | `SIL_WESP32` | ESP32 |
-| Silicognition LLC | ManT1S | `SIL_MANT1S` | ESP32 |
-| Soldered Electronics | NULA Mini | `SOLDERED_NULA_MINI` | ESP32-C6 |
-| SparkFun | ESP32 / WROOM | `SPARKFUN_IOT_REDBOARD_ESP32` | ESP32 |
-| SparkFun | Thing Plus ESP32-C5 | `SPARKFUN_THINGPLUS_ESP32C5` | ESP32-C5 |
-| Unexpected Maker | FeatherS2 | `UM_FEATHERS2` | ESP32-S2 |
-| Unexpected Maker | FeatherS2 Neo | `UM_FEATHERS2NEO` | ESP32-S2 |
-| Unexpected Maker | FeatherS3 | `UM_FEATHERS3` | ESP32-S3 |
-| Unexpected Maker | FeatherS3 Neo | `UM_FEATHERS3NEO` | ESP32-S3 |
-| Unexpected Maker | NanoS3 | `UM_NANOS3` | ESP32-S3 |
-| Unexpected Maker | OMGS3 | `UM_OMGS3` | ESP32-S3 |
-| Unexpected Maker | ProS3 | `UM_PROS3` | ESP32-S3 |
-| Unexpected Maker | RGB Touch Mini | `UM_RGBTOUCH_MINI` | ESP32-S3 |
-| Unexpected Maker | TinyC6 | `UM_TINYC6` | ESP32-C6 |
-| Unexpected Maker | TinyPICO | `UM_TINYPICO` | ESP32 |
-| Unexpected Maker | TinyS2 | `UM_TINYS2` | ESP32-S2 |
-| Unexpected Maker | TinyS3 | `UM_TINYS3` | ESP32-S3 |
-| Unexpected Maker | TinyWATCH S3 | `UM_TINYWATCHS3` | ESP32-S3 |
-| Wemos | C3 mini | `LOLIN_C3_MINI` | ESP32-C3 |
-| Wemos | S2 mini | `LOLIN_S2_MINI` | ESP32-S2 |
-| Wemos | S2 pico | `LOLIN_S2_PICO` | ESP32-S2 |
+| Arduino | Nano ESP32 | `ARDUINO_NANO_ESP32` | esp32s3 |
+| Espressif | ESP32 / WROOM | `ESP32_GENERIC` | esp32 |
+| Espressif | ESP32-C2 | `ESP32_GENERIC_C2` | esp32c2 |
+| Espressif | ESP32-C3 | `ESP32_GENERIC_C3` | esp32c3 |
+| Espressif | ESP32-C5 | `ESP32_GENERIC_C5` | esp32c5 |
+| Espressif | ESP32-C6 | `ESP32_GENERIC_C6` | esp32c6 |
+| Espressif | ESP32-H2 | `ESP32_GENERIC_H2` | esp32h2 |
+| Espressif | ESP32-P4 | `ESP32_GENERIC_P4` | esp32p4 |
+| Espressif | ESP32-S2 | `ESP32_GENERIC_S2` | esp32s2 |
+| Espressif | ESP32-S3 | `ESP32_GENERIC_S3` | esp32s3 |
+| LILYGO | T3-S3 | `LILYGO_T3_S3` | esp32s3 |
+| LILYGO | TTGO LoRa32 | `LILYGO_TTGO_LORA32` | esp32 |
+| M5Stack | Atom | `M5STACK_ATOM` | esp32 |
+| M5Stack | AtomS3 Lite | `M5STACK_ATOMS3_LITE` | esp32s3 |
+| M5Stack | NanoC6 | `M5STACK_NANOC6` | esp32c6 |
+| M5Stack | NanoH2 | `M5STACK_NANOH2` | esp32h2 |
+| McHobby | PYBSTICK26_ESP32C3 | `GARATRONIC_PYBSTICK26_ESP32C3` | esp32c3 |
+| Olimex | ESP32 EVB | `OLIMEX_ESP32_EVB` | esp32 |
+| Olimex | ESP32 POE | `OLIMEX_ESP32_POE` | esp32 |
+| Seeed Studio | XIAO ESP32C3 | `SEEED_XIAO_ESP32C3` | esp32c3 |
+| Seeed Studio | XIAO ESP32C5 | `SEEED_XIAO_ESP32C5` | esp32c5 |
+| Seeed Studio | XIAO ESP32C6 | `SEEED_XIAO_ESP32C6` | esp32c6 |
+| Seeed Studio | XIAO ESP32S3 | `SEEED_XIAO_ESP32S3` | esp32s3 |
+| Silicognition LLC | ManT1S | `SIL_MANT1S` | esp32 |
+| Silicognition | wESP32 | `SIL_WESP32` | esp32 |
+| Soldered Electronics | NULA Mini | `SOLDERED_NULA_MINI` | esp32c6 |
+| SparkFun | ESP32 / WROOM | `SPARKFUN_IOT_REDBOARD_ESP32` | esp32 |
+| SparkFun | Thing Plus ESP32-C5 | `SPARKFUN_THINGPLUS_ESP32C5` | esp32c5 |
+| Unexpected Maker | FeatherS2 | `UM_FEATHERS2` | esp32s2 |
+| Unexpected Maker | FeatherS2 Neo | `UM_FEATHERS2NEO` | esp32s2 |
+| Unexpected Maker | FeatherS3 | `UM_FEATHERS3` | esp32s3 |
+| Unexpected Maker | FeatherS3 Neo | `UM_FEATHERS3NEO` | esp32s3 |
+| Unexpected Maker | NanoS3 | `UM_NANOS3` | esp32s3 |
+| Unexpected Maker | OMGS3 | `UM_OMGS3` | esp32s3 |
+| Unexpected Maker | ProS3 | `UM_PROS3` | esp32s3 |
+| Unexpected Maker | RGB Touch Mini | `UM_RGBTOUCH_MINI` | esp32s3 |
+| Unexpected Maker | TinyC6 | `UM_TINYC6` | esp32c6 |
+| Unexpected Maker | TinyPICO | `UM_TINYPICO` | esp32 |
+| Unexpected Maker | TinyS2 | `UM_TINYS2` | esp32s2 |
+| Unexpected Maker | TinyS3 | `UM_TINYS3` | esp32s3 |
+| Unexpected Maker | TinyWATCH S3 | `UM_TINYWATCHS3` | esp32s3 |
+| Waveshare | Waveshare ESP32-S3-Pico | `WAVESHARE_ESP32_S3_PICO` | esp32s3 |
+| Wemos | C3 mini | `LOLIN_C3_MINI` | esp32c3 |
+| Wemos | S2 mini | `LOLIN_S2_MINI` | esp32s2 |
+| Wemos | S2 pico | `LOLIN_S2_PICO` | esp32s2 |
 
 ## Espressif ESP8266
 
@@ -133,88 +143,90 @@ Port: `esp8266` — 1 board.
 
 | Supplier | Board name | Model (build target) | Chip |
 |----------|-----------|----------------------|------|
-| Espressif | ESP8266 | `ESP8266_GENERIC` | ESP8266 |
+| Espressif | ESP8266 | `ESP8266_GENERIC` | esp8266 |
 
 ## STMicroelectronics STM32
 
-Port: `stm32` — 74 boards.
+Port: `stm32` — 76 boards.
 
 | Supplier | Board name | Model (build target) | Chip |
 |----------|-----------|----------------------|------|
-| Adafruit | F405 Express | `ADAFRUIT_F405_EXPRESS` | STM32F4 |
-| Arduino | Giga | `ARDUINO_GIGA` | STM32H7 |
-| Arduino | Nicla Vision | `ARDUINO_NICLA_VISION` | STM32H7 |
-| Arduino | Opta WiFi | `ARDUINO_OPTA` | STM32H7 |
-| Arduino | Portenta H7 | `ARDUINO_PORTENTA_H7` | STM32H7 |
-| Espruino | Pico | `ESPRUINO_PICO` | STM32F4 |
-| Fez | Cerb40 | `CERB40` | STM32F4 |
-| George Robotics | Pyboard D-series SF2 | `PYBD_SF2` | STM32F7 |
-| George Robotics | Pyboard D-series SF3 | `PYBD_SF3` | STM32F7 |
-| George Robotics | Pyboard D-series SF6 | `PYBD_SF6` | STM32F7 |
-| George Robotics | Pyboard Lite v1.0 | `PYBLITEV10` | STM32F4 |
-| George Robotics | Pyboard v1.0 | `PYBV10` | STM32F4 |
-| George Robotics | Pyboard v1.1 | `PYBV11` | STM32F4 |
-| HydraBus | HydraBus v1.0 | `HYDRABUS` | STM32F4 |
-| LEGO | Hub No.6 | `LEGO_HUB_NO6` | STM32F4 |
-| LEGO | Hub No.7 | `LEGO_HUB_NO7` | STM32F4 |
-| LimiFrog | LimiFrog | `LIMIFROG` | STM32L4 |
-| McHobby | GARATRONIC_NADHAT_F405 | `GARATRONIC_NADHAT_F405` | STM32F4 |
-| McHobby | GARATRONIC_PYBSTICK26_F411 | `GARATRONIC_PYBSTICK26_F411` | STM32F4 |
-| MikroElektronika | MikroE Clicker 2 for STM32 | `MIKROE_CLICKER2_STM32` | STM32F4 |
-| MikroElektronika | MikroE Quail | `MIKROE_QUAIL` | STM32F4 |
-| Netduino | Netduino Plus 2 | `NETDUINO_PLUS_2` | STM32F4 |
-| Olimex | STM32-E407 | `OLIMEX_E407` | STM32F4 |
-| Olimex | STM32-H407 | `OLIMEX_H407` | STM32F4 |
-| SparkFun | MicroMod STM32 | `SPARKFUN_MICROMOD_STM32` | STM32F4 |
-| ST Microelectronics | B_L072Z_LRWAN1 | `B_L072Z_LRWAN1` | STM32L0 |
-| ST Microelectronics | B_L475E_IOT01A | `B_L475E_IOT01A` | STM32L4 |
-| ST Microelectronics | Discovery F4 | `STM32F4DISC` | STM32F4 |
-| ST Microelectronics | Discovery F411 | `STM32F411DISC` | STM32F4 |
-| ST Microelectronics | Discovery F429 | `STM32F429DISC` | STM32F4 |
-| ST Microelectronics | Discovery F469 | `STM32F469DISC` | STM32F4 |
-| ST Microelectronics | Discovery F7 | `STM32F7DISC` | STM32F7 |
-| ST Microelectronics | Discovery F769 | `STM32F769DISC` | STM32F7 |
-| ST Microelectronics | Discovery Kit H7 | `STM32H7B3I_DK` | STM32H7 |
-| ST Microelectronics | Discovery Kit H747I | `STM32H747I_DISCO` | STM32H7 |
-| ST Microelectronics | Discovery L476 | `STM32L476DISC` | STM32L4 |
-| ST Microelectronics | Discovery L496G | `STM32L496GDISC` | STM32L4 |
-| ST Microelectronics | Nucleo F091RC | `NUCLEO_F091RC` | STM32F0 |
-| ST Microelectronics | Nucleo F401RE | `NUCLEO_F401RE` | STM32F4 |
-| ST Microelectronics | Nucleo F411RE | `NUCLEO_F411RE` | STM32F4 |
-| ST Microelectronics | Nucleo F412ZG | `NUCLEO_F412ZG` | STM32F4 |
-| ST Microelectronics | Nucleo F413ZH | `NUCLEO_F413ZH` | STM32F4 |
-| ST Microelectronics | Nucleo F429ZI | `NUCLEO_F429ZI` | STM32F4 |
-| ST Microelectronics | Nucleo F439ZI | `NUCLEO_F439ZI` | STM32F4 |
-| ST Microelectronics | Nucleo F446RE | `NUCLEO_F446RE` | STM32F4 |
-| ST Microelectronics | Nucleo F722ZE | `NUCLEO_F722ZE` | STM32F7 |
-| ST Microelectronics | Nucleo F746ZG | `NUCLEO_F746ZG` | STM32F7 |
-| ST Microelectronics | Nucleo F756ZG | `NUCLEO_F756ZG` | STM32F7 |
-| ST Microelectronics | Nucleo F767ZI | `NUCLEO_F767ZI` | STM32F7 |
-| ST Microelectronics | Nucleo G0B1RE | `NUCLEO_G0B1RE` | STM32G0 |
-| ST Microelectronics | Nucleo G474RE | `NUCLEO_G474RE` | STM32G4 |
-| ST Microelectronics | Nucleo H563ZI | `NUCLEO_H563ZI` | STM32H5 |
-| ST Microelectronics | Nucleo H723ZG | `NUCLEO_H723ZG` | STM32H7 |
-| ST Microelectronics | Nucleo H743ZI | `NUCLEO_H743ZI` | STM32H7 |
-| ST Microelectronics | Nucleo H743ZI2 | `NUCLEO_H743ZI2` | STM32H7 |
-| ST Microelectronics | Nucleo H753ZI | `NUCLEO_H753ZI` | STM32H7 |
-| ST Microelectronics | Nucleo H7A3ZI-Q | `NUCLEO_H7A3ZI_Q` | STM32H7 |
-| ST Microelectronics | Nucleo L073RZ | `NUCLEO_L073RZ` | STM32L0 |
-| ST Microelectronics | Nucleo L152RE | `NUCLEO_L152RE` | STM32L1 |
-| ST Microelectronics | Nucleo L432KC | `NUCLEO_L432KC` | STM32L4 |
-| ST Microelectronics | Nucleo L452RE | `NUCLEO_L452RE` | STM32L4 |
-| ST Microelectronics | Nucleo L476RG | `NUCLEO_L476RG` | STM32L4 |
-| ST Microelectronics | Nucleo L4A6ZG | `NUCLEO_L4A6ZG` | STM32L4 |
-| ST Microelectronics | Nucleo U5A5ZJ_Q | `NUCLEO_U5A5ZJ_Q` | STM32U5 |
-| ST Microelectronics | Nucleo WB55 | `NUCLEO_WB55` | STM32WB |
-| ST Microelectronics | Nucleo WL55 | `NUCLEO_WL55` | STM32WL |
-| ST Microelectronics | STM32F439 | `STM32F439` | STM32F4 |
-| ST Microelectronics | USBDONGLE_WB55 | `USBDONGLE_WB55` | STM32WB |
-| VCC-GND Studio | F407VE | `VCC_GND_F407VE` | STM32F4 |
-| VCC-GND Studio | F407ZG | `VCC_GND_F407ZG` | STM32F4 |
-| VCC-GND Studio | H743VI | `VCC_GND_H743VI` | STM32H7 |
-| WeAct Studio | Mini STM32H743 | `WEACTSTUDIO_MINI_STM32H743` | STM32H7 |
-| WeAct Studio | Mini STM32U585 | `WEACTSTUDIO_MINI_STM32U585` | STM32U5 |
-| WeAct Studio | WeAct F411 'blackpill'. Default variant is v3.1 with no SPI Flash. | `WEACT_F411_BLACKPILL` | STM32F411 |
+| Adafruit | F405 Express | `ADAFRUIT_F405_EXPRESS` | stm32f4 |
+| Arduino | Giga | `ARDUINO_GIGA` | stm32h7 |
+| Arduino | Nicla Vision | `ARDUINO_NICLA_VISION` | stm32h7 |
+| Arduino | Opta WiFi | `ARDUINO_OPTA` | stm32h7 |
+| Arduino | Portenta H7 | `ARDUINO_PORTENTA_H7` | stm32h7 |
+| Espruino | Pico | `ESPRUINO_PICO` | stm32f4 |
+| Fez | Cerb40 | `CERB40` | stm32f4 |
+| George Robotics | Pyboard D-series SF2 | `PYBD_SF2` | stm32f7 |
+| George Robotics | Pyboard D-series SF3 | `PYBD_SF3` | stm32f7 |
+| George Robotics | Pyboard D-series SF6 | `PYBD_SF6` | stm32f7 |
+| George Robotics | Pyboard Lite v1.0 | `PYBLITEV10` | stm32f4 |
+| George Robotics | Pyboard v1.0 | `PYBV10` | stm32f4 |
+| George Robotics | Pyboard v1.1 | `PYBV11` | stm32f4 |
+| HydraBus | HydraBus v1.0 | `HYDRABUS` | stm32f4 |
+| LEGO | Hub No.6 | `LEGO_HUB_NO6` | stm32f4 |
+| LEGO | Hub No.7 | `LEGO_HUB_NO7` | stm32f4 |
+| LimiFrog | LimiFrog | `LIMIFROG` | stm32l4 |
+| McHobby | GARATRONIC_NADHAT_F405 | `GARATRONIC_NADHAT_F405` | stm32f4 |
+| McHobby | GARATRONIC_PYBSTICK26_F411 | `GARATRONIC_PYBSTICK26_F411` | stm32f4 |
+| MikroElektronika | MikroE Clicker 2 for STM32 | `MIKROE_CLICKER2_STM32` | stm32f4 |
+| MikroElektronika | MikroE Quail | `MIKROE_QUAIL` | stm32f4 |
+| Netduino | Netduino Plus 2 | `NETDUINO_PLUS_2` | stm32f4 |
+| Olimex | STM32-E407 | `OLIMEX_E407` | stm32f4 |
+| Olimex | STM32-H407 | `OLIMEX_H407` | stm32f4 |
+| PyMateIO | GARATRONIC_PYMATE_CORE8ADI8DOSC | `GARATRONIC_PYMATE_CORE8ADI8DOSC` | stm32f4 |
+| SparkFun | MicroMod STM32 | `SPARKFUN_MICROMOD_STM32` | stm32f4 |
+| ST Microelectronics | B_L072Z_LRWAN1 | `B_L072Z_LRWAN1` | stm32l0 |
+| ST Microelectronics | B_L475E_IOT01A | `B_L475E_IOT01A` | stm32l4 |
+| ST Microelectronics | Discovery F4 | `STM32F4DISC` | stm32f4 |
+| ST Microelectronics | Discovery F411 | `STM32F411DISC` | stm32f4 |
+| ST Microelectronics | Discovery F429 | `STM32F429DISC` | stm32f4 |
+| ST Microelectronics | Discovery F469 | `STM32F469DISC` | stm32f4 |
+| ST Microelectronics | Discovery F7 | `STM32F7DISC` | stm32f7 |
+| ST Microelectronics | Discovery F769 | `STM32F769DISC` | stm32f7 |
+| ST Microelectronics | Discovery Kit H7 | `STM32H7B3I_DK` | stm32h7 |
+| ST Microelectronics | Discovery Kit H747I | `STM32H747I_DISCO` | stm32h7 |
+| ST Microelectronics | Discovery L476 | `STM32L476DISC` | stm32l4 |
+| ST Microelectronics | Discovery L496G | `STM32L496GDISC` | stm32l4 |
+| ST Microelectronics | Nucleo F091RC | `NUCLEO_F091RC` | stm32f0 |
+| ST Microelectronics | Nucleo F401RE | `NUCLEO_F401RE` | stm32f4 |
+| ST Microelectronics | Nucleo F411RE | `NUCLEO_F411RE` | stm32f4 |
+| ST Microelectronics | Nucleo F412ZG | `NUCLEO_F412ZG` | stm32f4 |
+| ST Microelectronics | Nucleo F413ZH | `NUCLEO_F413ZH` | stm32f4 |
+| ST Microelectronics | Nucleo F429ZI | `NUCLEO_F429ZI` | stm32f4 |
+| ST Microelectronics | Nucleo F439ZI | `NUCLEO_F439ZI` | stm32f4 |
+| ST Microelectronics | Nucleo F446RE | `NUCLEO_F446RE` | stm32f4 |
+| ST Microelectronics | Nucleo F722ZE | `NUCLEO_F722ZE` | stm32f7 |
+| ST Microelectronics | Nucleo F746ZG | `NUCLEO_F746ZG` | stm32f7 |
+| ST Microelectronics | Nucleo F756ZG | `NUCLEO_F756ZG` | stm32f7 |
+| ST Microelectronics | Nucleo F767ZI | `NUCLEO_F767ZI` | stm32f7 |
+| ST Microelectronics | Nucleo G0B1RE | `NUCLEO_G0B1RE` | stm32g0 |
+| ST Microelectronics | Nucleo G474RE | `NUCLEO_G474RE` | stm32g4 |
+| ST Microelectronics | Nucleo H563ZI | `NUCLEO_H563ZI` | stm32h5 |
+| ST Microelectronics | Nucleo H723ZG | `NUCLEO_H723ZG` | stm32h7 |
+| ST Microelectronics | Nucleo H743ZI | `NUCLEO_H743ZI` | stm32h7 |
+| ST Microelectronics | Nucleo H743ZI2 | `NUCLEO_H743ZI2` | stm32h7 |
+| ST Microelectronics | Nucleo H753ZI | `NUCLEO_H753ZI` | stm32h7 |
+| ST Microelectronics | Nucleo H7A3ZI-Q | `NUCLEO_H7A3ZI_Q` | stm32h7 |
+| ST Microelectronics | Nucleo L073RZ | `NUCLEO_L073RZ` | stm32l0 |
+| ST Microelectronics | Nucleo L152RE | `NUCLEO_L152RE` | stm32l1 |
+| ST Microelectronics | Nucleo L432KC | `NUCLEO_L432KC` | stm32l4 |
+| ST Microelectronics | Nucleo L452RE | `NUCLEO_L452RE` | stm32l4 |
+| ST Microelectronics | Nucleo L476RG | `NUCLEO_L476RG` | stm32l4 |
+| ST Microelectronics | Nucleo L4A6ZG | `NUCLEO_L4A6ZG` | stm32l4 |
+| ST Microelectronics | Nucleo U5A5ZJ_Q | `NUCLEO_U5A5ZJ_Q` | stm32u5 |
+| ST Microelectronics | Nucleo WB55 | `NUCLEO_WB55` | stm32wb |
+| ST Microelectronics | Nucleo WL55 | `NUCLEO_WL55` | stm32wl |
+| ST Microelectronics | STM32F439 | `STM32F439` | stm32f4 |
+| ST Microelectronics | USBDONGLE_WB55 | `USBDONGLE_WB55` | stm32wb |
+| VCC-GND Studio | F407VE | `VCC_GND_F407VE` | stm32f4 |
+| VCC-GND Studio | F407ZG | `VCC_GND_F407ZG` | stm32f4 |
+| VCC-GND Studio | H743VI | `VCC_GND_H743VI` | stm32h7 |
+| WeAct Studio | Mini STM32H723 | `WEACTSTUDIO_MINI_STM32H723` | stm32h7 |
+| WeAct Studio | Mini STM32H743 | `WEACTSTUDIO_MINI_STM32H743` | stm32h7 |
+| WeAct Studio | Mini STM32U585 | `WEACTSTUDIO_MINI_STM32U585` | stm32u5 |
+| WeAct Studio | WeAct F411 'blackpill'. Default variant is v3.1 with no SPI Flash. | `WEACT_F411_BLACKPILL` | stm32f411 |
 
 ## Microchip SAMD (SAM D21 / D51)
 
@@ -222,24 +234,24 @@ Port: `samd` — 18 boards.
 
 | Supplier | Board name | Model (build target) | Chip |
 |----------|-----------|----------------------|------|
-| Adafruit | Feather M0 Express | `ADAFRUIT_FEATHER_M0_EXPRESS` | SAMD21 |
-| Adafruit | Feather M4 Express | `ADAFRUIT_FEATHER_M4_EXPRESS` | SAMD51 |
-| Adafruit | ItsyBitsy M0 Express | `ADAFRUIT_ITSYBITSY_M0_EXPRESS` | SAMD21 |
-| Adafruit | ItsyBitsy M4 Express | `ADAFRUIT_ITSYBITSY_M4_EXPRESS` | SAMD51 |
-| Adafruit | Metro M4 Express Airlift | `ADAFRUIT_METRO_M4_EXPRESS` | SAMD51 |
-| Adafruit | NeoKey Trinkey | `ADAFRUIT_NEOKEY_TRINKEY` | SAMD21 |
-| Adafruit | QT Py - SAMD21 | `ADAFRUIT_QTPY_SAMD21` | SAMD21 |
-| Adafruit | Trinket M0 | `ADAFRUIT_TRINKET_M0` | SAMD21 |
-| Microchip | Generic SAMD21J18 | `SAMD_GENERIC_D21X18` | SAMD21 |
-| Microchip | Generic SAMD51P19 | `SAMD_GENERIC_D51X19` | SAMD51 |
-| Microchip | Generic SAMD51P20 | `SAMD_GENERIC_D51X20` | SAMD51 |
-| Microchip | SAMD21 Xplained Pro | `SAMD21_XPLAINED_PRO` | SAMD21 |
-| MiniFig Boards | Mini SAM M4 | `MINISAM_M4` | SAMD51 |
-| Seeed Studio | Wio Terminal D51R | `SEEED_WIO_TERMINAL` | SAMD51 |
-| Seeed Studio | XIAO SAMD21 | `SEEED_XIAO_SAMD21` | SAMD21 |
-| SparkFun | SAMD51 Thing Plus | `SPARKFUN_SAMD51_THING_PLUS` | SAMD51 |
-| SparkFun | SparkFun RedBoard Turbo | `SPARKFUN_REDBOARD_TURBO` | SAMD21 |
-| SparkFun | SparkFun SAMD21 Dev Breakout | `SPARKFUN_SAMD21_DEV_BREAKOUT` | SAMD21 |
+| Adafruit | Feather M0 Express | `ADAFRUIT_FEATHER_M0_EXPRESS` | samd21 |
+| Adafruit | Feather M4 Express | `ADAFRUIT_FEATHER_M4_EXPRESS` | samd51 |
+| Adafruit | ItsyBitsy M0 Express | `ADAFRUIT_ITSYBITSY_M0_EXPRESS` | samd21 |
+| Adafruit | ItsyBitsy M4 Express | `ADAFRUIT_ITSYBITSY_M4_EXPRESS` | samd51 |
+| Adafruit | Metro M4 Express Airlift | `ADAFRUIT_METRO_M4_EXPRESS` | samd51 |
+| Adafruit | NeoKey Trinkey | `ADAFRUIT_NEOKEY_TRINKEY` | samd21 |
+| Adafruit | QT Py - SAMD21 | `ADAFRUIT_QTPY_SAMD21` | samd21 |
+| Adafruit | Trinket M0 | `ADAFRUIT_TRINKET_M0` | samd21 |
+| Microchip | Generic SAMD21J18 | `SAMD_GENERIC_D21X18` | samd21 |
+| Microchip | Generic SAMD51P19 | `SAMD_GENERIC_D51X19` | samd51 |
+| Microchip | Generic SAMD51P20 | `SAMD_GENERIC_D51X20` | samd51 |
+| Microchip | SAMD21 Xplained Pro | `SAMD21_XPLAINED_PRO` | samd21 |
+| MiniFig Boards | Mini SAM M4 | `MINISAM_M4` | samd51 |
+| Seeed Studio | Wio Terminal D51R | `SEEED_WIO_TERMINAL` | samd51 |
+| Seeed Studio | XIAO SAMD21 | `SEEED_XIAO_SAMD21` | samd21 |
+| SparkFun | SAMD51 Thing Plus | `SPARKFUN_SAMD51_THING_PLUS` | samd51 |
+| SparkFun | SparkFun RedBoard Turbo | `SPARKFUN_REDBOARD_TURBO` | samd21 |
+| SparkFun | SparkFun SAMD21 Dev Breakout | `SPARKFUN_SAMD21_DEV_BREAKOUT` | samd21 |
 
 ## Nordic Semiconductor nRF
 
@@ -247,29 +259,29 @@ Port: `nrf` — 23 boards.
 
 | Supplier | Board name | Model (build target) | Chip |
 |----------|-----------|----------------------|------|
-| Actinius | Icarus | `ACTINIUS_ICARUS` | nRF91 |
-| Adafruit | Feather nRF52840 Express | `FEATHER52` | nRF52 |
-| Arduino | Nano 33 BLE Sense | `ARDUINO_NANO_33_BLE_SENSE` | nRF52 |
-| Arduino | Primo | `ARDUINO_PRIMO` | nRF52 |
-| BBC | micro:bit v1 | `MICROBIT` | nRF51 |
-| Ezurio | DVK-BL652 | `DVK_BL652` | nRF52 |
-| I-SYST | BLUEIO Tag EVIM | `BLUEIO_TAG_EVIM` | nRF52 |
-| I-SYST | IBK BLYST Nano | `IBK_BLYST_NANO` | nRF52 |
-| I-SYST | IDK BLYST Nano | `IDK_BLYST_NANO` | nRF52 |
-| Makerdiary | nrf52840 MDK USB Dongle | `NRF52840_MDK_USB_DONGLE` | nRF52 |
-| Nordic Semiconductor | pca10000 | `PCA10000` | nRF51 |
-| Nordic Semiconductor | pca10001 | `PCA10001` | nRF51 |
-| Nordic Semiconductor | pca10028 | `PCA10028` | nRF51 |
-| Nordic Semiconductor | pca10031 | `PCA10031` | nRF51 |
-| Nordic Semiconductor | pca10040 | `PCA10040` | nRF52 |
-| Nordic Semiconductor | pca10056 | `PCA10056` | nRF52 |
-| Nordic Semiconductor | pca10059 | `PCA10059` | nRF52 |
-| Nordic Semiconductor | pca10090 | `PCA10090` | nRF91 |
-| Particle | Xenon | `PARTICLE_XENON` | nRF52 |
-| Seeed Studio | XIAO nRF52840 Sense | `SEEED_XIAO_NRF52` | nRF52 |
-| u-blox | EVK-NINA-B1 | `EVK_NINA_B1` | nRF52 |
-| u-blox | EVK-NINA-B3 | `EVK_NINA_B3` | nRF52 |
-| Wireless-Tag | WT51822-S4AT | `WT51822_S4AT` | nRF51 |
+| Actinius | Icarus | `ACTINIUS_ICARUS` | nrf91 |
+| Adafruit | Feather nRF52840 Express | `FEATHER52` | nrf52 |
+| Arduino | Nano 33 BLE Sense | `ARDUINO_NANO_33_BLE_SENSE` | nrf52 |
+| Arduino | Primo | `ARDUINO_PRIMO` | nrf52 |
+| BBC | micro:bit v1 | `MICROBIT` | nrf51 |
+| Ezurio | DVK-BL652 | `DVK_BL652` | nrf52 |
+| I-SYST | BLUEIO Tag EVIM | `BLUEIO_TAG_EVIM` | nrf52 |
+| I-SYST | IBK BLYST Nano | `IBK_BLYST_NANO` | nrf52 |
+| I-SYST | IDK BLYST Nano | `IDK_BLYST_NANO` | nrf52 |
+| Makerdiary | nrf52840 MDK USB Dongle | `NRF52840_MDK_USB_DONGLE` | nrf52 |
+| Nordic Semiconductor | pca10000 | `PCA10000` | nrf51 |
+| Nordic Semiconductor | pca10001 | `PCA10001` | nrf51 |
+| Nordic Semiconductor | pca10028 | `PCA10028` | nrf51 |
+| Nordic Semiconductor | pca10031 | `PCA10031` | nrf51 |
+| Nordic Semiconductor | pca10040 | `PCA10040` | nrf52 |
+| Nordic Semiconductor | pca10056 | `PCA10056` | nrf52 |
+| Nordic Semiconductor | pca10059 | `PCA10059` | nrf52 |
+| Nordic Semiconductor | pca10090 | `PCA10090` | nrf91 |
+| Particle | Xenon | `PARTICLE_XENON` | nrf52 |
+| Seeed Studio | XIAO nRF52840 Sense | `SEEED_XIAO_NRF52` | nrf52 |
+| u-blox | EVK-NINA-B1 | `EVK_NINA_B1` | nrf52 |
+| u-blox | EVK-NINA-B3 | `EVK_NINA_B3` | nrf52 |
+| Wireless-Tag | WT51822-S4AT | `WT51822_S4AT` | nrf51 |
 
 ## NXP i.MX RT
 
@@ -277,20 +289,20 @@ Port: `mimxrt` — 14 boards.
 
 | Supplier | Board name | Model (build target) | Chip |
 |----------|-----------|----------------------|------|
-| Adafruit | Metro M7 | `ADAFRUIT_METRO_M7` | i.MX RT |
-| Makerdiary | iMX RT1011 Nano Kit | `MAKERDIARY_RT1011_NANO_KIT` | i.MX RT |
-| NXP | MIMXRT1010_EVK | `MIMXRT1010_EVK` | i.MX RT |
-| NXP | MIMXRT1015_EVK | `MIMXRT1015_EVK` | i.MX RT |
-| NXP | MIMXRT1020_EVK | `MIMXRT1020_EVK` | i.MX RT |
-| NXP | MIMXRT1050_EVK | `MIMXRT1050_EVK` | i.MX RT |
-| NXP | MIMXRT1060_EVK | `MIMXRT1060_EVK` | i.MX RT |
-| NXP | MIMXRT1064_EVK | `MIMXRT1064_EVK` | i.MX RT |
-| NXP | MIMXRT1170_EVK | `MIMXRT1170_EVK` | i.MX RT |
-| Olimex | RT1010-Py | `OLIMEX_RT1010` | i.MX RT |
-| PHYTEC | phyBOARD-RT1170 Development Kit | `PHYBOARD_RT1170` | i.MX RT |
-| PJRC | Teensy 4.0 | `TEENSY40` | i.MX RT |
-| PJRC | Teensy 4.1 | `TEENSY41` | i.MX RT |
-| Seeed Studio | Arch Mix | `SEEED_ARCH_MIX` | i.MX RT |
+| Adafruit | Metro M7 | `ADAFRUIT_METRO_M7` | mimxrt |
+| Makerdiary | iMX RT1011 Nano Kit | `MAKERDIARY_RT1011_NANO_KIT` | mimxrt |
+| NXP | MIMXRT1010_EVK | `MIMXRT1010_EVK` | mimxrt |
+| NXP | MIMXRT1015_EVK | `MIMXRT1015_EVK` | mimxrt |
+| NXP | MIMXRT1020_EVK | `MIMXRT1020_EVK` | mimxrt |
+| NXP | MIMXRT1050_EVK | `MIMXRT1050_EVK` | mimxrt |
+| NXP | MIMXRT1060_EVK | `MIMXRT1060_EVK` | mimxrt |
+| NXP | MIMXRT1064_EVK | `MIMXRT1064_EVK` | mimxrt |
+| NXP | MIMXRT1170_EVK | `MIMXRT1170_EVK` | mimxrt |
+| Olimex | RT1010-Py | `OLIMEX_RT1010` | mimxrt |
+| PHYTEC | phyBOARD-RT1170 Development Kit | `PHYBOARD_RT1170` | mimxrt |
+| PJRC | Teensy 4.0 | `TEENSY40` | mimxrt |
+| PJRC | Teensy 4.1 | `TEENSY41` | mimxrt |
+| Seeed Studio | Arch Mix | `SEEED_ARCH_MIX` | mimxrt |
 
 ## Renesas RA
 
@@ -299,12 +311,12 @@ Port: `renesas-ra` — 7 boards.
 | Supplier | Board name | Model (build target) | Chip |
 |----------|-----------|----------------------|------|
 | Arduino | Portenta C33 | `ARDUINO_PORTENTA_C33` | RA6M5 |
-| MikroElektronika | Mikroe RA4M1 Clicker | `RA4M1_CLICKER` | RA4M1 |
-| Renesas Electronics | EK-RA4M1 | `EK_RA4M1` | RA4M1 |
-| Renesas Electronics | EK-RA4W1 | `EK_RA4W1` | RA4W1 |
-| Renesas Electronics | EK-RA6M1 | `EK_RA6M1` | RA6M1 |
-| Renesas Electronics | EK-RA6M2 | `EK_RA6M2` | RA6M2 |
-| Vekatech | VK-RA6M5 | `VK_RA6M5` | RA6M5 |
+| MikroElektronika | Mikroe RA4M1 Clicker | `RA4M1_CLICKER` | ra4m1 |
+| Renesas Electronics | EK-RA4M1 | `EK_RA4M1` | ra4m1 |
+| Renesas Electronics | EK-RA4W1 | `EK_RA4W1` | ra4w1 |
+| Renesas Electronics | EK-RA6M1 | `EK_RA6M1` | ra6m1 |
+| Renesas Electronics | EK-RA6M2 | `EK_RA6M2` | ra6m2 |
+| Vekatech | VK-RA6M5 | `VK_RA6M5` | ra6m5 |
 
 ## Alif Ensemble
 
@@ -312,7 +324,15 @@ Port: `alif` — 1 board.
 
 | Supplier | Board name | Model (build target) | Chip |
 |----------|-----------|----------------------|------|
-| Alif Semiconductor | Ensemble E7 DevKit | `ALIF_ENSEMBLE` | Alif Ensemble E7 (AE722F80F55D5XX) |
+| Alif Semiconductor | Ensemble E7 DevKit | `ALIF_ENSEMBLE` | AE722F80F55D5XX |
+
+## Infineon PSoC Edge
+
+Port: `psoc-edge` — 1 board.
+
+| Supplier | Board name | Model (build target) | Chip |
+|----------|-----------|----------------------|------|
+| Infineon Technologies | KIT_PSE84_AI | `KIT_PSE84_AI` | PSE846GPS2DBZC4 |
 
 ## Texas Instruments CC3200
 
@@ -320,5 +340,4 @@ Port: `cc3200` — 1 board.
 
 | Supplier | Board name | Model (build target) | Chip |
 |----------|-----------|----------------------|------|
-| Pycom | WiPy Module | `WIPY` | CC3200 |
-
+| Pycom | WiPy Module | `WIPY` | cc3200 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snakie",
-  "version": "0.54.4",
+  "version": "0.54.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "snakie",
-      "version": "0.54.4",
+      "version": "0.54.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snakie",
-  "version": "0.54.4",
+  "version": "0.54.5",
   "description": "A modern, cross-platform MicroPython editor.",
   "productName": "Snakie",
   "main": "./out/main/index.js",

--- a/scripts/build-boards-doc.mjs
+++ b/scripts/build-boards-doc.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * REGENERATE docs/micropython-boards.md FROM THE BOARD INDEX (#962).
+ * =============================================================================
+ *
+ * The doc was hand-typed, and it drifted — it claimed 219 boards from a July
+ * snapshot while the shipped index had 225 from MicroPython v1.29.0. That is
+ * the whole reason to generate it: a catalogue somebody has to retype is a
+ * catalogue that goes quietly wrong, and a reference that is quietly wrong is
+ * worse than none, because the reader trusts it.
+ *
+ * Source of truth is `src/renderer/public/boards/boards.json`, itself generated
+ * by `build-board-index.mjs` from upstream's own `board.json` files — so this
+ * doc is now two steps from MicroPython's tree and no steps from anybody's
+ * memory. The curated overlay (`board-overlay.ts`) is SUMMARISED rather than
+ * tabled: those boards have no upstream build target, which is the one column
+ * this table exists to give.
+ *
+ *     node scripts/build-boards-doc.mjs
+ *
+ * Run it after refreshing the board index, and commit the result.
+ */
+import { readFileSync, writeFileSync } from 'node:fs'
+
+const INDEX = 'src/renderer/public/boards/boards.json'
+const OVERLAY = 'src/shared/board-overlay.ts'
+const OUT = 'docs/micropython-boards.md'
+
+/** Friendly names for the ports, in the order the doc has always used them. */
+const PORTS = [
+  ['rp2', 'Raspberry Pi RP2 — RP2040 / RP2350'],
+  ['esp32', 'Espressif ESP32 family'],
+  ['esp8266', 'Espressif ESP8266'],
+  ['stm32', 'STMicroelectronics STM32'],
+  ['samd', 'Microchip SAMD (SAM D21 / D51)'],
+  ['nrf', 'Nordic Semiconductor nRF'],
+  ['mimxrt', 'NXP i.MX RT'],
+  ['renesas-ra', 'Renesas RA'],
+  ['alif', 'Alif Ensemble'],
+  ['psoc-edge', 'Infineon PSoC Edge'],
+  ['cc3200', 'Texas Instruments CC3200']
+]
+
+/** Escape a cell so a stray pipe in a vendor string cannot break the table. */
+const cell = (s) => String(s ?? '').replace(/\|/g, '\\|')
+
+const index = JSON.parse(readFileSync(INDEX, 'utf8'))
+const boards = index.boards
+const overlayCount = (readFileSync(OVERLAY, 'utf8').match(/^ {4}id: '/gm) ?? []).length
+
+const byPort = new Map()
+for (const b of boards) {
+  if (!byPort.has(b.port)) byPort.set(b.port, [])
+  byPort.get(b.port).push(b)
+}
+// Any port the list above has not been told about still gets a section, rather
+// than being silently dropped from a document that claims to be complete.
+for (const port of byPort.keys()) {
+  if (!PORTS.some(([p]) => p === port)) PORTS.push([port, port])
+}
+
+const plural = (n, word) => `${n} ${word}${n === 1 ? '' : 's'}`
+const out = []
+
+out.push('# MicroPython-compatible boards')
+out.push('')
+out.push('A catalogue of boards with an official MicroPython build, i.e. every board that')
+out.push('ships a `board.json` in the mainline [micropython/micropython](https://github.com/micropython/micropython)')
+out.push('tree. For each board: **supplier** (vendor), **board name** (product), **model**')
+out.push('(the MicroPython build-target / board id you flash), and **chip type** (MCU).')
+out.push('')
+out.push(`- **Total boards:** ${boards.length} across ${plural(byPort.size, 'MCU port')}.`)
+out.push(`- **MicroPython:** \`${index.micropython}\`.`)
+out.push(`- **Source:** \`${INDEX}\`, generated from mainline \`ports/*/boards/*/board.json\`.`)
+out.push(`- **Generated:** ${index.generated} — **do not edit by hand**, run \`node scripts/build-boards-doc.mjs\`.`)
+out.push('')
+out.push('> Notes')
+out.push('> - Snakie’s **Board Finder** shows these plus ' + overlayCount + ' more that MicroPython')
+out.push('>   builds nothing for but people own anyway — the Adafruit ESP32 Feather V2, the')
+out.push('>   micro:bit v2, Pimoroni’s Tiny 2350 and Servo 2040 and others. They are not in')
+out.push('>   this table because the one column it exists to give — the build target you')
+out.push('>   flash — is precisely what they do not have. See `src/shared/board-overlay.ts`.')
+out.push('> - The `ESP32_GENERIC*` and `ESP8266_GENERIC` targets cover the countless')
+out.push('>   third-party ESP dev boards (NodeMCU, DOIT, HiLetgo, etc.) that share a chip.')
+out.push('> - Some vendors (e.g. Pimoroni, Arduino, LEGO) also ship **extra** boards in their')
+out.push('>   own MicroPython forks that are not in mainline and so are not listed here.')
+out.push('> - Vendor strings are reproduced verbatim from upstream, so minor naming variants')
+out.push('>   exist (e.g. "WeAct" vs "WeAct Studio").')
+out.push('')
+out.push('## Summary by port')
+out.push('')
+out.push('| Port | MCU family | Boards |')
+out.push('|------|-----------|-------:|')
+for (const [port, name] of PORTS) {
+  const list = byPort.get(port)
+  if (!list) continue
+  out.push(`| \`${port}\` | ${cell(name)} | ${list.length} |`)
+}
+out.push(`| | **Total** | **${boards.length}** |`)
+out.push('')
+
+for (const [port, name] of PORTS) {
+  const list = byPort.get(port)
+  if (!list) continue
+  list.sort((a, b) => (a.vendor + a.product).localeCompare(b.vendor + b.product))
+  out.push(`## ${name}`)
+  out.push('')
+  out.push(`Port: \`${port}\` — ${plural(list.length, 'board')}.`)
+  out.push('')
+  out.push('| Supplier | Board name | Model (build target) | Chip |')
+  out.push('|----------|-----------|----------------------|------|')
+  for (const b of list) {
+    out.push(`| ${cell(b.vendor)} | ${cell(b.product)} | \`${cell(b.id)}\` | ${cell(b.mcu)} |`)
+  }
+  out.push('')
+}
+
+writeFileSync(OUT, out.join('\n'))
+console.log(`→ ${OUT}: ${boards.length} boards across ${byPort.size} ports (MicroPython ${index.micropython})`)

--- a/test/docsCurrent.test.ts
+++ b/test/docsCurrent.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+
+/**
+ * The docs still describe the app that ships (#962).
+ *
+ * `docs/micropython-boards.md` claimed 219 boards from a July snapshot while the
+ * shipped index held 225 from MicroPython v1.29.0, and the README announced
+ * "v0.13.0 released" at v0.54.x. Both drifted for the same reason: a fact that
+ * has to be retyped is a fact that goes quietly wrong, and a reference that is
+ * quietly wrong is worse than none because the reader trusts it.
+ *
+ * So the catalogue is generated now, and this checks it still matches its
+ * source. Prose cannot be tested and is not the target here — the numbers are.
+ */
+
+const index = JSON.parse(readFileSync('src/renderer/public/boards/boards.json', 'utf8'))
+const boardsDoc = readFileSync('docs/micropython-boards.md', 'utf8')
+const readme = readFileSync('README.md', 'utf8')
+
+describe('the board catalogue matches the index it came from', () => {
+  it('states the same total', () => {
+    const m = /\*\*Total boards:\*\* (\d+)/.exec(boardsDoc)
+    expect(m, 'the doc no longer states a total').toBeTruthy()
+    expect(Number(m![1])).toBe(index.boards.length)
+  })
+
+  it('names the MicroPython release it was built from', () => {
+    expect(boardsDoc).toContain(`\`${index.micropython}\``)
+  })
+
+  it('has a row per board', () => {
+    // Every board reachable in the table, not just a plausible-looking count in
+    // the header — the two drifting apart is how it went wrong before.
+    for (const b of index.boards) {
+      expect(boardsDoc, `${b.id} is missing from the table`).toContain(`\`${b.id}\``)
+    }
+  })
+
+  it('says how to regenerate it, and not to edit it by hand', () => {
+    expect(boardsDoc).toContain('do not edit by hand')
+    expect(boardsDoc).toContain('scripts/build-boards-doc.mjs')
+  })
+})
+
+describe('the README does not pin a version that will rot', () => {
+  it('announces no specific released version', () => {
+    // It said "v0.13.0 released" for forty-one minor versions. The fix is not a
+    // newer number — it is not having one here at all, since Releases has it.
+    expect(readme).not.toMatch(/\*\*v\d+\.\d+\.\d+ released\*\*/)
+  })
+
+  it('describes what the app can actually do now', () => {
+    // None of this run's work appeared anywhere in the docs.
+    for (const feature of ['Board Finder', 'Application menus', '.mpy']) {
+      expect(readme, `README never mentions ${feature}`).toContain(feature)
+    }
+  })
+})


### PR DESCRIPTION
Closes #962.

## What was wrong

- The README announced **"v0.13.0 released"** — at v0.54.x. Forty-one minor versions stale, on the front door.
- `docs/micropython-boards.md` claimed **219 boards** from a July snapshot; the shipped index holds **225** from MicroPython v1.29.0.
- **Nothing from this run appeared anywhere.** I checked rather than assumed: "Board Finder", "Tools menu", "Compile to", "status history" and "cheatsheet" each matched **zero** documents.

## The catalogue is generated now

`scripts/build-boards-doc.mjs` rebuilds `docs/micropython-boards.md` from the index the app ships — so the doc is two steps from MicroPython's own tree and no steps from anybody's memory. A test holds its stated total, its MicroPython release and **every one of its 225 rows** to that source.

It drifted *because* it had to be retyped. Regenerating the numbers without fixing that would only have reset the clock.

The 12 overlay boards are summarised rather than tabled: they have no upstream build target, which is the one column that table exists to give.

## The README

Features now cover the Board Finder, the menus and shortcut sheet, `.py` → `.mpy`, file sizes and the status history — and the board list under Board View, which still named Tiny 2040 as if the Parts Library hadn't grown to 59 parts.

**The Status section no longer names a version at all.** A number there has to be maintained to stay true, Releases already has it, and what belongs in a README is what the app does. A test asserts no `**vX.Y.Z released**` creeps back.

Also: `docs/board.md` said the Board View opens from the toolbar, which was the only route before #916 added View ▸ Board View (⇧⌘B).

## What I could not audit

**Screenshots — the repository contains none.** No image is referenced from any doc, and none exists under `docs/`, `assets/` or `images/`. Any screenshots that exist live outside this repo (the site, the Releases pages), and they're still worth a pass against the current UI — that half of the issue isn't something I can close from here.

## Gates

lint (pre-existing `DriverInstallBanner.tsx` warning only) · typecheck · **6,711 tests in 327 files** · build — green. The drift guard is mutation-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe