### PR TITLE
fix(ci,ui): stop the macOS signing flake and the modal colour bleed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,23 +70,112 @@ jobs:
       # arches (universal serialport prebuild); each Linux job is pinned to its
       # native arch to avoid cross-arch native rebuild failures.
       #
-      # The build is split into a macOS step (with the signing + notarization env
-      # from secrets) and a Windows/Linux step with NO signing env at all. This
-      # avoids two traps:
-      #   1. CSC_LINK leaking to Windows makes electron-builder sign the .exe with
-      #      the macOS Developer ID cert (wrong);
-      #   2. setting CSC_LINK to an *empty string* on Windows FAILS the build
-      #      ("Env WIN_CSC_LINK ... not a file") — the var must be ABSENT, not
-      #      empty. A per-key `… || ''` env can't omit a key, hence two steps.
+      # The build is split into a macOS step (with the notarization env from
+      # secrets) and a Windows/Linux step with no signing env at all.
+      #
+      # It used to be split because CSC_LINK had to reach macOS and be ABSENT on
+      # Windows — present, it signed the .exe with the macOS Developer ID cert;
+      # empty, it failed the build outright ("Env WIN_CSC_LINK … not a file"), and a
+      # per-key `… || ''` cannot omit a key. Since #968 the cert never goes through
+      # the environment at all (see the keychain step below), so that trap is gone —
+      # but APPLE_ID / APPLE_APP_SPECIFIC_PASSWORD are still macOS-only, and the
+      # split keeps them there.
+      #
       # Do NOT add CSC_IDENTITY_AUTO_DISCOVERY=false: it *disables* macOS code
       # signing outright (electron-builder logs "skipped … code signing"), which
-      # previously shipped signed builds unsigned. See docs/macos-signing.md.
+      # previously shipped signed builds unsigned — and since #968 auto-discovery is
+      # precisely how the identity is found in the keychain we prepare.
+      # See docs/macos-signing.md.
+      # --- The signing keychain, built by us and not by electron-builder (#968) --
+      #
+      # macOS releases failed INTERMITTENTLY — v0.51.1 and v0.55.0 each needed three
+      # attempts — always on the same command, with:
+      #
+      #   security set-key-partition-list … SecKeychainUnlock:
+      #     The user name or passphrase you entered is not correct.
+      #
+      # Not the credentials (those would fail every time) and not the runner image
+      # (byte-identical across the passing and failing runs of one release). It is a
+      # bug in electron-builder's own keychain setup —
+      # app-builder-lib/out/codeSign/macCodeSign.js, `importCerts`:
+      #
+      #   security import                 … -P <p12 password>
+      #   security set-key-partition-list … -k <p12 password>    ← wants the KEYCHAIN's
+      #
+      # `-k` is the password `security` falls back to when it has to unlock the
+      # keychain itself, so the wrong one is harmless *while the keychain happens to
+      # still be unlocked* by createKeychain's earlier `unlock-keychain`, and fatal
+      # the moment anything has relocked it. That is the whole shape of the flake:
+      # a latent defect that only bites when lock state goes the wrong way. What
+      # relocks it on the runner is NOT established — the error message is the only
+      # evidence, and it names the unlock, not the cause. The fix does not depend on
+      # knowing: passing the keychain's real password makes the command correct
+      # whether it is locked or not.
+      #
+      # macPackager.js:26 — when CSC_LINK is ABSENT, electron-builder skips
+      # createKeychain entirely and signs against `process.env.CSC_KEYCHAIN`. So we
+      # import the cert once, in a fixed order, with the right password, and hand it
+      # a keychain that is already set up. The buggy path is never taken.
+      #
+      # With no cert (a fork, or secrets unset) this is a no-op: CSC_KEYCHAIN stays
+      # unset and the build below runs unsigned, exactly as it did before.
+      - name: Prepare signing keychain — macOS
+        if: matrix.os == 'macos-latest'
+        env:
+          MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+          MAC_CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if [ -z "${MAC_CSC_LINK:-}" ]; then
+            echo "No signing certificate — building unsigned."
+            exit 0
+          fi
+
+          KEYCHAIN="$RUNNER_TEMP/snakie-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
+          CERT="$RUNNER_TEMP/certificate.p12"
+          printf '%s' "$MAC_CSC_LINK" | base64 --decode > "$CERT"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          # No flags = no lock on sleep and no lock on timeout. The default is a
+          # five-minute idle lock, and notarizing four artifacts takes far longer.
+          security set-keychain-settings "$KEYCHAIN"
+
+          # Prepend to the user search list — codesign only looks at keychains on it
+          # — KEEPING the existing entries so nothing else on the runner breaks.
+          # Done BEFORE the unlock, because `list-keychains -s` resets lock state;
+          # doing it after is what leaves electron-builder signing into a locked
+          # keychain.
+          security list-keychains -d user -s "$KEYCHAIN" \
+            $(security list-keychains -d user | sed -e 's/[" ]//g')
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+
+          # -P is the .p12's password; -k below is the KEYCHAIN's. Conflating the
+          # two is the whole bug. Without the partition list, codesign blocks on a
+          # UI authorisation prompt that no one is there to answer.
+          security import "$CERT" -k "$KEYCHAIN" -P "$MAC_CSC_KEY_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" > /dev/null
+          rm -f "$CERT"
+
+          # Fail here, loudly, if the identity did not land — rather than 20 minutes
+          # later inside electron-builder, or worse, as a silently unsigned build.
+          # `-v` needs the chain to validate: Developer ID Certification Authority
+          # is in macOS's SystemRootCertificates, so this does not need
+          # electron-builder's bundled root_certs.keychain (which carries WWDR, the
+          # App Store / development intermediate, not the Developer ID one).
+          security find-identity -v -p codesigning "$KEYCHAIN"
+          security find-identity -v -p codesigning "$KEYCHAIN" | grep -q "Developer ID Application"
+          echo "CSC_KEYCHAIN=$KEYCHAIN" >> "$GITHUB_ENV"
+
       - name: Build installers — macOS (signed + notarized)
         if: matrix.os == 'macos-latest'
         run: npm run dist -- ${{ matrix.platform_flag }} --publish never
         env:
-          CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+          # No CSC_LINK / CSC_KEY_PASSWORD: their presence is what makes
+          # electron-builder build its own keychain. CSC_KEYCHAIN is exported by the
+          # step above (empty when there is no cert, which signs nothing).
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **macOS releases no longer fail at random** (#968). Signing died with
+  `security set-key-partition-list … SecKeychainUnlock: The user name or passphrase
+  you entered is not correct` — v0.51.1 and v0.55.0 each needed three attempts.
+  It is a defect in electron-builder's own keychain setup: `importCerts` passes the
+  **.p12's** password to `set-key-partition-list -k`, which wants the **keychain's**.
+  `security` only consults `-k` when it has to unlock the keychain, so the wrong
+  password is invisible while the keychain happens to still be unlocked and fatal
+  once anything has relocked it — a latent bug that shows up as a coin toss.
+
+  `release.yml` now builds and unlocks the signing keychain itself, imports the
+  certificate with the right password in each place, asserts the identity landed,
+  and hands electron-builder the keychain via `CSC_KEYCHAIN`. With `CSC_LINK`
+  absent, electron-builder skips its own keychain code entirely, so the broken path
+  is never taken. Unsigned builds (a fork, secrets unset) are unaffected — the step
+  is a no-op without a certificate. Background in `docs/macos-signing.md`.
+
+  Failures here were also **silent**: the tag pushed, master claimed a release, and
+  no release existed. The identity check now fails in seconds with a clear message
+  rather than twenty minutes in.
+
+- **The Cancel button is readable in the Simulated device memory dialog** (#969).
+  It was near-white at rest and pure white on hover, over the dialog's light card.
+  `ConnectionControl` renders the dialog inline, so it is a DOM descendant of
+  `.conn-control` — and the shell header's chip rules, whose colours are chosen for
+  a dark green bar, reached it through a descendant combinator and painted a modal
+  button as if it sat on the header. Every real header control is a direct child, so
+  those rules are now scoped with `>`; the header is unchanged. The Save button had
+  quietly been picking up the header's green gradient for the same reason.
+
 ## [0.55.0] - 2026-09-06
 
 ### Added

--- a/docs/macos-signing.md
+++ b/docs/macos-signing.md
@@ -32,11 +32,60 @@ Settings → Secrets and variables → Actions → **New repository secret**:
 | `APPLE_APP_SPECIFIC_PASSWORD` | app-specific password for that Apple ID | appleid.apple.com → App-Specific Passwords |
 | `APPLE_TEAM_ID` | your 10-char Team ID | Apple Developer → Membership |
 
-That's it — `release.yml` passes these to electron-builder
-(`CSC_LINK`/`CSC_KEY_PASSWORD` for signing; `APPLE_ID`/
-`APPLE_APP_SPECIFIC_PASSWORD`/`APPLE_TEAM_ID` for notarization via
-`mac.notarize: true` in `electron-builder.yml`). The entitlements live in
-`build/entitlements.mac.plist`.
+That's it — `release.yml` takes it from there. The notarization secrets
+(`APPLE_ID`/`APPLE_APP_SPECIFIC_PASSWORD`/`APPLE_TEAM_ID`) go straight to
+electron-builder as env, for `mac.notarize` in `electron-builder.yml`. The
+entitlements live in `build/entitlements.mac.plist`.
+
+The **certificate** does not: it goes into a keychain the workflow builds itself,
+in the *Prepare signing keychain* step, which then exports `CSC_KEYCHAIN`. That is
+deliberate, and worth knowing before you change it.
+
+## Why the workflow builds its own keychain (#968)
+
+Left to itself, electron-builder creates a temp keychain and imports the cert —
+and macOS releases then failed **intermittently**. v0.51.1 and v0.55.0 each needed
+three attempts, always dying on the same command:
+
+```
+security set-key-partition-list … SecKeychainUnlock:
+  The user name or passphrase you entered is not correct.
+```
+
+Not the credentials (they would fail every time) and not the runner image (identical
+across the passing and failing runs of a single release). It is a defect in
+`app-builder-lib/out/codeSign/macCodeSign.js`, `importCerts`:
+
+```js
+security import                 … -P <p12 password>
+security set-key-partition-list … -k <p12 password>   // wants the KEYCHAIN's password
+```
+
+`-k` is the password `security` falls back to when it has to unlock the keychain
+itself. So the wrong one is invisible while the keychain is still unlocked from
+`createKeychain`'s earlier `unlock-keychain`, and fatal once anything has relocked
+it. What does the relocking on a hosted runner was never established — but it does
+not need to be, because passing the keychain's *real* password is correct either
+way.
+
+`macPackager.js` only calls `createKeychain` when `CSC_LINK` is set; with it absent
+it signs against `process.env.CSC_KEYCHAIN` instead. So the workflow imports the
+cert once, in a fixed order, with the right password, and hands electron-builder a
+keychain that is already correct. The buggy path is never entered.
+
+Consequences to keep in mind:
+
+- **`CSC_LINK` / `CSC_KEY_PASSWORD` must NOT be set on the build step.** Setting
+  either puts electron-builder back on its own keychain path — the bug returns
+  silently, as a flake.
+- `CSC_IDENTITY_AUTO_DISCOVERY=false` stays off, as before: it disables signing
+  outright, and auto-discovery is now exactly how the identity is found.
+- With no cert (a fork, secrets unset) the step is a no-op, `CSC_KEYCHAIN` stays
+  unset, and the build is unsigned — as it was before.
+- The identity is asserted at the end of the step, so a broken cert fails in
+  seconds with a clear message instead of twenty minutes later. `-v` requires the
+  chain to validate; *Developer ID Certification Authority* ships in macOS's
+  `SystemRootCertificates.keychain`, so nothing extra is imported for it.
 
 ## Verifying a release is signed & notarized
 

--- a/src/renderer/src/components/ShellPanel.css
+++ b/src/renderer/src/components/ShellPanel.css
@@ -117,27 +117,38 @@
 }
 
 /* Clear + the connect/disconnect + device dropdown — subtle green chips on the
-   green header (no alarming red). */
+   green header (no alarming red).
+
+   DIRECT CHILDREN ONLY (`>`), deliberately. These colours are chosen for the
+   dark green header bar: near-white text on a translucent white fill. But
+   `.conn-control` also hosts the Simulated-device memory dialog
+   (ConnectionControl.tsx renders <SimMemoryDialog> as a sibling of the header
+   controls, not through a portal), and a modal's buttons are plain
+   `.btn--ghost` / `.btn--primary` too. With a descendant combinator these rules
+   reached into that dialog and painted its Cancel button #eafff2 — then #fff on
+   hover — over the dialog's parchment card, i.e. invisible (#969). Every real
+   header control is a direct child of `.conn-control`, so `>` keeps the header
+   identical and stops the bleed. */
 .region--shell .shell-actions__clear,
-.region--shell .conn-control .btn--ghost,
+.region--shell .conn-control > .btn--ghost,
 .region--shell .conn-control__select {
   color: #eafff2;
   background: rgba(255, 255, 255, 0.14);
   border-color: rgba(255, 255, 255, 0.24);
 }
 .region--shell .shell-actions__clear:hover,
-.region--shell .conn-control .btn--ghost:hover {
+.region--shell .conn-control > .btn--ghost:hover {
   background: rgba(255, 255, 255, 0.22);
   color: #fff;
 }
-.region--shell .conn-control .btn--danger,
-.region--shell .conn-control .btn--primary {
+.region--shell .conn-control > .btn--danger,
+.region--shell .conn-control > .btn--primary {
   background: linear-gradient(180deg, #3fa06a, #2c7d4e);
   border-color: rgba(0, 0, 0, 0.22);
   color: #fff;
 }
-.region--shell .conn-control .btn--danger:hover,
-.region--shell .conn-control .btn--primary:hover {
+.region--shell .conn-control > .btn--danger:hover,
+.region--shell .conn-control > .btn--primary:hover {
   background: linear-gradient(180deg, #46ac73, #327f52);
 }
 

--- a/test/modalStyleBleed.test.ts
+++ b/test/modalStyleBleed.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * A region's chrome must not bleed into a modal rendered inside it (#969).
+ *
+ * The shell header is a dark green bar, so its controls are painted near-white:
+ *
+ *     .region--shell .conn-control .btn--ghost       color: #eafff2
+ *     .region--shell .conn-control .btn--ghost:hover color: #fff
+ *
+ * But `ConnectionControl` renders the Simulated-device memory dialog INLINE —
+ * `{memOpen && <SimMemoryDialog …/>}` is a sibling of the header controls, not a
+ * portal — so the dialog is a DOM descendant of `.conn-control`. Its Cancel
+ * button is a plain `.btn--ghost` too, so a *descendant* combinator reached it
+ * and painted white text on the dialog's parchment card. Invisible; worse on
+ * hover, which is where the user first noticed it.
+ *
+ * Every real header control is a direct child of `.conn-control`, so the child
+ * combinator keeps the header identical and stops the bleed.
+ */
+
+function stylesheets(dir = 'src/renderer/src'): string[] {
+  const out: string[] = []
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name)
+    if (statSync(p).isDirectory()) out.push(...stylesheets(p))
+    else if (name.endsWith('.css')) out.push(p)
+  }
+  return out
+}
+
+/** `.btn`, `.btn--ghost`, … — the classes ANY button in the app wears, modals included. */
+const GENERIC_BTN = /(^|[\s>+~])\.btn(--[a-z-]+)?(?=$|[\s>+~:.[])/
+
+type Rule = { file: string; line: number; selector: string }
+
+/** Repaints the button — the bleed that makes a modal's control unreadable. */
+const PAINTS = /(?<!-)\b(color|background(-color|-image)?)\s*:/
+
+/** Every selector that reaches a generic `.btn` from an ancestor, split by combinator. */
+function rulesReachingAButton(): { descendant: Rule[]; child: Rule[] } {
+  const descendant: Rule[] = []
+  const child: Rule[] = []
+  for (const file of stylesheets()) {
+    const text = readFileSync(file, 'utf8')
+    // Strip comments so a selector quoted in prose isn't mistaken for a rule.
+    const clean = text.replace(/\/\*[\s\S]*?\*\//g, (c) => c.replace(/[^\n]/g, ' '))
+    for (const m of clean.matchAll(/([^{}]+)\{[^{}]*\}/g)) {
+      const line = clean.slice(0, m.index).split('\n').length
+      if (!PAINTS.test(m[0].slice(m[0].indexOf('{')))) continue
+      for (const raw of m[1].split(',')) {
+        const selector = raw.trim().replace(/\s+/g, ' ')
+        if (!selector || !GENERIC_BTN.test(selector)) continue
+        // Only compound selectors — a bare `.btn--ghost { … }` is the button's own rule.
+        const btnAt = selector.search(GENERIC_BTN)
+        const prefix = selector.slice(0, btnAt).trim()
+        if (!prefix) continue
+        // The skins legitimately theme every button: `:root[data-theme='x'] .btn`.
+        if (/^:root\[data-theme=/.test(prefix)) continue
+        const combinator = selector.slice(btnAt, btnAt + 1)
+        ;(combinator === '>' || / > $/.test(selector.slice(0, btnAt + 1))
+          ? child
+          : descendant
+        ).push({ file, line, selector })
+      }
+    }
+  }
+  return { descendant, child }
+}
+
+describe('the shell header does not paint the dialog inside it (#969)', () => {
+  const shellCss = 'src/renderer/src/components/ShellPanel.css'
+
+  it('scopes every .conn-control button rule to direct children', () => {
+    const { descendant } = rulesReachingAButton()
+    const leaks = descendant.filter((r) => r.selector.includes('.conn-control'))
+    expect(
+      leaks.map((r) => `${r.file}:${r.line}  ${r.selector}`),
+      'a descendant combinator here reaches into SimMemoryDialog — use `>`'
+    ).toEqual([])
+  })
+
+  it('still styles the header chips it is there to style', () => {
+    // The fix must not have deleted the green-bar treatment along the way.
+    const css = readFileSync(shellCss, 'utf8')
+    for (const sel of [
+      '.region--shell .conn-control > .btn--ghost',
+      '.region--shell .conn-control > .btn--danger',
+      '.region--shell .conn-control > .btn--primary'
+    ]) {
+      expect(css, `${sel} should still exist`).toContain(sel)
+    }
+  })
+
+  it('is guarding a dialog that really is nested inside .conn-control', () => {
+    // If SimMemoryDialog is ever moved to a portal the bleed goes away on its
+    // own — but until then this is why the child combinator above matters.
+    const tsx = readFileSync('src/renderer/src/components/ConnectionControl.tsx', 'utf8')
+    const open = tsx.indexOf('<div className="conn-control"')
+    expect(open, 'ConnectionControl should still render a .conn-control container').toBeGreaterThan(-1)
+    expect(tsx.indexOf('<SimMemoryDialog'), 'dialog is rendered inline, inside that container').toBeGreaterThan(open)
+  })
+})
+
+describe('no new region chrome can reach a modal button unnoticed', () => {
+  /**
+   * A tripwire, not a ban. Each of these reaches a generic `.btn` through a
+   * descendant combinator, which is fine ONLY while no fixed-position overlay is
+   * rendered inside that container. Both entries below were checked (#969):
+   *
+   *   .editor-header__actions  — two plain buttons, Chat and Find. No overlay.
+   *   .btn-seg                 — the fused icon toolbars in the file trees. No overlay.
+   *
+   * Rules that only set geometry (the file trees' compact `.btn` padding) are not
+   * listed: they cannot make a control unreadable, which is the failure guarded here.
+   *
+   * Adding a row means confirming the same thing for the new container: does any
+   * component render a dialog, popup or context menu inside it? If so, use `>`.
+   */
+  const REVIEWED = ['.editor-header__actions .btn', '.btn-seg .btn']
+
+  it('has only reviewed descendant rules over a generic .btn', () => {
+    const { descendant } = rulesReachingAButton()
+    const unreviewed = descendant.filter(
+      (r) => !REVIEWED.some((known) => r.selector.startsWith(known))
+    )
+    expect(
+      unreviewed.map((r) => `${r.file}:${r.line}  ${r.selector}`),
+      'new descendant rule over a generic .btn — check nothing modal renders inside, then add it to REVIEWED'
+    ).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #968. Closes #969.

## #968 — macOS releases failed at random

Every macOS release job died on the same command, roughly two runs in three:

```
security set-key-partition-list … SecKeychainUnlock:
  The user name or passphrase you entered is not correct.
```

v0.51.1 needed three attempts; v0.55.0 needed three. Not the credentials — those
would fail every time. Not the runner image — byte-identical (`20260828.587`)
across the failing and passing runs of a single release.

It's a defect in `app-builder-lib/out/codeSign/macCodeSign.js`, `importCerts`:

```js
security import                 … -P <p12 password>
security set-key-partition-list … -k <p12 password>   // wants the KEYCHAIN's password
```

`-k` is the password `security` falls back to when it has to unlock the keychain
itself. So the wrong one is **invisible** while the keychain is still unlocked from
`createKeychain`'s earlier `unlock-keychain`, and **fatal** once anything has
relocked it. A latent bug that presents as a coin toss. What does the relocking on a
hosted runner I could not establish — and deliberately did not guess at in the
comments — because the fix doesn't depend on it: the keychain's real password is
correct whether it's locked or not.

### The fix

`macPackager.js:26` — when `CSC_LINK` is **absent**, electron-builder skips
`createKeychain` entirely and signs against `process.env.CSC_KEYCHAIN`. So a new
step prepares the keychain itself: create, disable auto-lock, put it on the user
search list *keeping* the existing entries, unlock, import, `set-key-partition-list`
with the right password, assert the identity landed, export `CSC_KEYCHAIN`.

- **`CSC_LINK` / `CSC_KEY_PASSWORD` are gone from the build step.** Either one puts
  electron-builder back on its own keychain path and the flake returns silently.
- No cert (a fork, secrets unset) ⇒ the step is a no-op, `CSC_KEYCHAIN` stays unset,
  the build is unsigned exactly as before.
- The identity assertion means a broken cert fails in seconds with a clear message
  instead of twenty minutes in. These failures were also *silent*: the tag pushed,
  master said released, and no release existed.
- `-v` needs the chain to validate; *Developer ID Certification Authority* is in
  macOS's `SystemRootCertificates.keychain`, so nothing extra is imported.
  electron-builder's bundled `root_certs.keychain` carries WWDR — the App Store /
  development intermediate, not the Developer ID one — so skipping it costs nothing.

### Verified

The `security` sequence was run end to end on macOS against a throwaway self-signed
Developer ID-named cert, with the machine's keychain search list saved and restored:

- every command exits 0 through `set-key-partition-list`;
- the search list ends up `[new keychain, login.keychain-db]` — the quoting handling
  is right and nothing existing is dropped;
- `show-keychain-info` reports `no-timeout`, so auto-lock is off;
- the identity is present in the keychain.

The one thing that can't be checked locally is that a *real* Developer ID cert
validates under `-v`, since that needs the actual certificate. The next tagged
release is the real test.

## #969 — Cancel unreadable in the Simulated device memory dialog

Near-white at rest, pure white on hover, on the dialog's light card.

`ConnectionControl` renders the dialog **inline** — `{memOpen && <SimMemoryDialog …/>}`
is a sibling of the header controls, not a portal — so it is a DOM descendant of
`.conn-control`. The shell header is a dark green bar, so `ShellPanel.css` gives its
chips near-white text through a *descendant* combinator, and a modal's buttons are
plain `.btn--ghost` / `.btn--primary` too. The Save button had been quietly picking
up the header's green gradient for the same reason.

Every real header control is a **direct child** of `.conn-control`; only the dialog
is nested deeper. Scoping the three rules with `>` leaves the header pixel-identical
and stops the bleed.

Swept the rest of the codebase for the same shape — a fixed-position overlay
rendered as a DOM descendant of a container that repaints generic `.btn`s. The only
other descendant rules over a generic `.btn` are `.editor-header__actions .btn` and
`.btn-seg .btn`; neither container hosts an overlay.

`test/modalStyleBleed.test.ts` guards both: the specific fix, and a tripwire that
fails when a *new* descendant rule repaints a generic `.btn`, so the next one has to
be checked for a nested modal rather than discovered in a screenshot. Mutation-checked
— reverting the `>` fails three of the four tests.

## Checks

`lint` (0 errors, 1 pre-existing warning), `typecheck`, `test` (6,715 passing across
328 files) and `build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe