### PR TITLE
fix(web): pick up a new deploy without a hard reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+
 - **Compile to `.mpy` in the browser** (#970). On app.snakie.org the file tree's
   context menu read **"Compile to .mpy (unavailable)"**, greyed out. Nothing was
   stopping it: `mpy-cross` is already WebAssembly, and a browser tab runs
@@ -40,6 +41,43 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   mangle every byte above 0x7F.
 
 ### Fixed
+
+
+- **The browser build picks up a new deploy on its own** (#971). app.snakie.org
+  could keep serving an older build until you hard-reloaded the tab. Not HTTP
+  caching — the **service worker** (#464), and two halves of one mistake.
+
+  `registerType: 'autoUpdate'` was silently inert. vite-plugin-pwa only turns it
+  into `skipWaiting` + `clientsClaim` when `injectRegister` is `'auto'` or absent,
+  and we set `'script'` — chosen so the registration wasn't an inline script the
+  strict CSP rejects. So Workbox shipped a worker that calls `skipWaiting()` only
+  when the page posts it a `SKIP_WAITING` message, and never calls
+  `clients.claim()`. Nothing ever posted that message, because the registration the
+  plugin injected was a bare `navigator.serviceWorker.register(…)` with no update
+  handling at all.
+
+  A new deploy therefore installed and then sat in `waiting` until every tab of the
+  origin closed — which, for the tab you keep the IDE open in, is never — while
+  each navigation kept being answered from the **old** precache. A hard reload
+  worked because it is the one thing that bypasses the worker. The config read as
+  if it auto-updated; the build disagreed, with no warning.
+
+  Both flags are now set **explicitly**, so the behaviour can't hinge on a plugin
+  inference again, and the app registers the worker itself — our bundle is
+  `'self'`, so the CSP reason for `injectRegister: 'script'` still holds without
+  its side effect.
+
+  When a new build lands the page **reloads itself** — but only when nothing is
+  unsaved. Snakie is an editor, and reloading over an unsaved buffer would be a
+  worse bug than the stale build. With work in progress it says so instead, through
+  the same notifier the desktop app uses, and waits for you; the notice says
+  *reload*, not *restart*, because a browser tab has no restart. The check assumes
+  there IS unsaved work until the UI says otherwise — a needless prompt is an
+  annoyance, a discarded buffer is not.
+
+  A `version.json` stamp ships beside the bundle and is fetched `no-store`, so the
+  staleness check can't itself be answered from a cache. It names the new version
+  in the notice, and covers contexts with no service worker at all.
 
 - **macOS releases no longer fail at random** (#968). Signing died with
   `security set-key-partition-list … SecKeychainUnlock: The user name or passphrase

--- a/src/renderer/src/components/UpdateNotifier.tsx
+++ b/src/renderer/src/components/UpdateNotifier.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react'
 import type { UpdateStatus } from '../../../preload/index.d'
 import { friendlyUpdateError, RELEASES_URL } from './updateButton'
+import { setUnsavedWorkProbe } from '../lib/unsaved-work'
+import { useWorkspaceOptional } from '../store/workspace'
 import './UpdateNotifier.css'
 
 /**
@@ -20,9 +22,20 @@ import './UpdateNotifier.css'
  * Nothing renders until a status arrives, so in development / unpackaged runs
  * (where the main process never pushes a status) the banner stays hidden.
  */
+/** The browser build applies an update by reloading, not by relaunching (#971). */
+const isWeb = !!import.meta.env.VITE_SNAKIE_WEB
+
 export function UpdateNotifier(): JSX.Element | null {
   const [status, setStatus] = useState<UpdateStatus | null>(null)
   const [dismissed, setDismissed] = useState(false)
+  const workspace = useWorkspaceOptional()
+
+  // Tell the web updater whether a reload would cost the user anything (#971).
+  // Only the web build reloads itself, but registering unconditionally keeps the
+  // seam honest and costs a closure. `openFiles` is a new array on every store
+  // change, so the probe is always reading current state.
+  const openFiles = workspace?.openFiles
+  useEffect(() => setUnsavedWorkProbe(() => !!openFiles?.some((f) => f.dirty)), [openFiles])
 
   useEffect(() => {
     const unsubscribe = window.api.updates.onStatus((next) => {
@@ -67,9 +80,18 @@ export function UpdateNotifier(): JSX.Element | null {
           : 'Downloading update…'
       break
     case 'downloaded':
-      message = status.version
-        ? `Update ready (v${status.version}) — restart to update`
-        : 'Update ready — restart to update'
+      // Same lifecycle state, two different acts. The desktop app relaunches into
+      // a downloaded installer; the web build has nothing to install — the new
+      // code is already served and precached, and applying it is a reload. Saying
+      // "restart" in a browser tab would send the reader looking for a menu item
+      // that isn't there (#971).
+      message = isWeb
+        ? status.version
+          ? `New version available (v${status.version}) — reload to update`
+          : 'New version available — reload to update'
+        : status.version
+          ? `Update ready (v${status.version}) — restart to update`
+          : 'Update ready — restart to update'
       action = (
         <button
           type="button"
@@ -78,7 +100,7 @@ export function UpdateNotifier(): JSX.Element | null {
             void window.api.updates.quitAndInstall()
           }}
         >
-          Restart
+          {isWeb ? 'Reload' : 'Restart'}
         </button>
       )
       break

--- a/src/renderer/src/lib/unsaved-work.ts
+++ b/src/renderer/src/lib/unsaved-work.ts
@@ -1,0 +1,39 @@
+/**
+ * "Is there work a reload would destroy?" (#971)
+ * =============================================================================
+ *
+ * The browser build applies an update by reloading the page, and on a fresh
+ * visit that should just happen — that is the whole point of #971. But Snakie is
+ * an editor, and reloading over an unsaved buffer would be a worse bug than the
+ * stale build it fixes. So the reload asks first.
+ *
+ * The question is asked from outside React (`web/web-updates.ts`, driven by a
+ * service-worker event), and only React knows the answer. This is the seam: the
+ * UI registers a probe, the updater consults it. It lives here rather than in
+ * `web/` so the Electron bundle can import the registration side without pulling
+ * in the browser's service-worker code.
+ */
+
+let probe: (() => boolean) | null = null
+
+/**
+ * Register the probe the updater consults. Returns an unregister function, so a
+ * component can hand it straight back from `useEffect`.
+ */
+export function setUnsavedWorkProbe(next: () => boolean): () => void {
+  probe = next
+  return () => {
+    if (probe === next) probe = null
+  }
+}
+
+/**
+ * Whether a reload right now would lose something.
+ *
+ * Defaults to TRUE with no probe registered, deliberately: before the UI has
+ * mounted we cannot know, and the cost of being wrong is asymmetric — a
+ * needless prompt is a small annoyance, a silently discarded buffer is not.
+ */
+export function hasUnsavedWork(): boolean {
+  return probe ? probe() : true
+}

--- a/src/renderer/src/web/install-web-api.ts
+++ b/src/renderer/src/web/install-web-api.ts
@@ -16,6 +16,7 @@ import { createWebDeviceRouter } from './web-device-router'
 import { createWebFsApi, opfsFallbackAvailable } from './web-fs'
 import { createWebMpyApi, type WebMpyFs } from './web-mpy'
 import { createWebRobotApi, type WebRobotFs } from './web-robot'
+import { createWebUpdatesApi } from './web-updates'
 import { createWebPartsApi } from './web-parts'
 import { INSTRUMENTS_PY, SNAKIE_PY } from './web-lib-sources'
 import { createWebFeedbackApi, captureTabScreenshot } from './web-feedback'
@@ -96,6 +97,13 @@ export function installWebApi(kind: WebWindowKind = 'main'): boolean {
   w.api.openExternal = (async (url: string) => {
     window.open(url, '_blank', 'noopener,noreferrer')
   }) as unknown as Window['api']['openExternal']
+  // Keep the page on the deployed build (#971). This also REGISTERS the service
+  // worker: vite-plugin-pwa no longer injects a registration script, because the
+  // one it injected had no update handling and its presence disabled
+  // `registerType: 'autoUpdate'` outright. Main window only — the worker's scope
+  // is the whole origin, so the pop-out windows are covered by this one
+  // registration and would only duplicate it.
+  w.api.updates = createWebUpdatesApi(version) as unknown as Window['api']['updates']
   // The device namespace multiplexes the WASM simulator + real Web Serial boards.
   w.api.device = createWebDeviceRouter() as unknown as Window['api']['device']
   // Serve the bundled MicroPython library sources so the "Install library" banner

--- a/src/renderer/src/web/web-updates.ts
+++ b/src/renderer/src/web/web-updates.ts
@@ -1,0 +1,209 @@
+/**
+ * Keeping the browser build up to date (#971).
+ * =============================================================================
+ *
+ * app.snakie.org could keep serving an older build until you hard-reloaded it.
+ * The cause was not HTTP caching — it was the service worker (#464), and two
+ * halves of the same mistake:
+ *
+ *  1. `registerType: 'autoUpdate'` was silently inert. vite-plugin-pwa only
+ *     turns it into `skipWaiting` + `clientsClaim` when `injectRegister` is
+ *     `'auto'` or absent, and we set `'script'` (to keep the registration out of
+ *     an inline script the strict CSP rejects). So Workbox emitted a worker that
+ *     activates only when the page posts it `SKIP_WAITING`, and never claims.
+ *  2. Nothing ever posted that message, because the injected registration was a
+ *     bare `navigator.serviceWorker.register(…)` with no update handling.
+ *
+ * A new deploy therefore installed and then sat in `waiting` until every tab of
+ * the origin closed — which, for the tab you keep the IDE open in, is never —
+ * while each navigation kept being answered from the OLD precache. A hard reload
+ * worked because it is the one thing that bypasses the worker.
+ *
+ * The config now sets both flags explicitly, so a new worker activates and takes
+ * over. This module does the other half: it registers the worker (from our own
+ * bundle, which IS `'self'`, so the CSP reason for `injectRegister: 'script'`
+ * still holds) and reacts when a new build lands.
+ *
+ * WHAT IT DOES WHEN A NEW BUILD LANDS. It reloads — but only when nothing is
+ * unsaved. Snakie is an editor; silently reloading over someone's unsaved buffer
+ * would be a worse bug than the one being fixed. With work in progress it says
+ * so instead, through the same `UpdateNotifier` the desktop app uses, and the
+ * reload waits for the user. On a fresh visit there is nothing unsaved, which is
+ * the case the report was actually about: open the site, get the current build.
+ */
+import type { UpdateStatus } from '../../../preload/index.d'
+import { hasUnsavedWork } from '../lib/unsaved-work'
+
+/** Where the build stamps its version. Emitted by `vite.web.config.ts`. */
+export const VERSION_URL = '/version.json'
+
+/** The service worker vite-plugin-pwa generates, at the scope it claims. */
+export const SW_URL = '/sw.js'
+export const SW_SCOPE = '/'
+
+/** How often to ask whether a new build has been deployed. */
+export const POLL_INTERVAL_MS = 30 * 60 * 1000
+
+/** What `version.json` holds. */
+export interface VersionStamp {
+  version: string
+  builtAt: string
+}
+
+type Listener = (status: UpdateStatus) => void
+
+/**
+ * Compare the running build against a deployed one. A pure string compare, not a
+ * semver ordering: any difference means the server is serving something else,
+ * and rolling BACK a bad deploy has to reach people just as fast as rolling out.
+ */
+export function isDifferentBuild(running: string, deployed: string | undefined): boolean {
+  return !!deployed && !!running && deployed !== running
+}
+
+/**
+ * Read the deployed version stamp, bypassing every cache.
+ *
+ * `cache: 'no-store'` is the point of the request: the whole failure mode being
+ * fixed is a stale copy of something, so a check that can itself be answered
+ * from cache would report "up to date" forever.
+ */
+export async function fetchDeployedVersion(
+  fetchImpl: typeof fetch = fetch,
+  url = VERSION_URL
+): Promise<string | undefined> {
+  try {
+    const res = await fetchImpl(url, { cache: 'no-store' })
+    if (!res.ok) return undefined
+    const stamp = (await res.json()) as Partial<VersionStamp>
+    return typeof stamp.version === 'string' ? stamp.version : undefined
+  } catch {
+    // Offline, or the file isn't deployed yet. Not knowing is not an error —
+    // the service worker is the primary signal; this is the belt to its braces.
+    return undefined
+  }
+}
+
+/**
+ * The web `updates` namespace, matching the preload contract the UI already
+ * speaks so `UpdateNotifier` and the status bar need no web-specific wiring.
+ *
+ * `download` resolves immediately and does nothing: on the web the new build is
+ * already on the server and, by the time we say anything, already precached.
+ * There is no download step to opt into — only a reload to apply.
+ */
+export function createWebUpdatesApi(runningVersion: string): {
+  check(): Promise<void>
+  download(): Promise<void>
+  quitAndInstall(): Promise<void>
+  onStatus(cb: Listener): () => void
+} {
+  const listeners = new Set<Listener>()
+  let registration: ServiceWorkerRegistration | null = null
+  /** At most one reload per page load, whatever fires first. */
+  let applied = false
+  /** Don't nag: once announced, later signals about the same build are quiet. */
+  let announced = false
+
+  const emit = (status: UpdateStatus): void => {
+    for (const l of listeners) l(status)
+  }
+
+  const apply = (): void => {
+    if (applied) return
+    applied = true
+    // A normal reload revalidates the top-level document, and the newly
+    // activated worker answers it from the NEW precache. No cache-busting query
+    // is needed, and adding one would leave a junk URL in the address bar.
+    window.location.reload()
+  }
+
+  /** A newer build is ready to run. Take it now, or offer it. */
+  const onNewBuild = (version?: string): void => {
+    if (applied) return
+    if (!hasUnsavedWork()) {
+      apply()
+      return
+    }
+    if (announced) return
+    announced = true
+    // 'downloaded' is the lifecycle state that means "ready, apply when you
+    // like" — exactly where a claimed worker leaves us. UpdateNotifier words it
+    // for the web (reload, not restart) off the same status.
+    emit({ state: 'downloaded', version })
+  }
+
+  const watchInstalling = (worker: ServiceWorker | null): void => {
+    if (!worker) return
+    worker.addEventListener('statechange', () => {
+      // `controller` is null on the very FIRST install, when there is no older
+      // build to replace — that is a new visitor, not an update, and reloading
+      // them would be a gratuitous flash.
+      if (worker.state === 'installed' && navigator.serviceWorker.controller) {
+        void fetchDeployedVersion().then(onNewBuild)
+      }
+    })
+  }
+
+  const poll = async (): Promise<void> => {
+    // Ask the worker to re-check first: it is the authoritative signal, and it
+    // also refreshes the precache so a reload has something to land on.
+    try {
+      await registration?.update()
+    } catch {
+      // A failed update check is a network problem, not ours to report.
+    }
+    const deployed = await fetchDeployedVersion()
+    if (isDifferentBuild(runningVersion, deployed)) onNewBuild(deployed)
+  }
+
+  const start = (): void => {
+    if (!('serviceWorker' in navigator) || !window.isSecureContext) {
+      // No worker (Safari private browsing, an insecure origin): the version
+      // poll alone still notices a deploy and offers the reload.
+      window.setInterval(() => void poll(), POLL_INTERVAL_MS)
+      return
+    }
+    void navigator.serviceWorker
+      .register(SW_URL, { scope: SW_SCOPE })
+      .then((reg) => {
+        registration = reg
+        // Already waiting when we arrived — installed during a previous visit
+        // that never applied it.
+        if (reg.waiting && navigator.serviceWorker.controller) {
+          void fetchDeployedVersion().then(onNewBuild)
+        }
+        watchInstalling(reg.installing)
+        reg.addEventListener('updatefound', () => watchInstalling(reg.installing))
+      })
+      .catch(() => {
+        // Registration can fail outright (storage blocked, an unsupported
+        // context). The poll below still covers the "am I stale?" question.
+      })
+    window.setInterval(() => void poll(), POLL_INTERVAL_MS)
+    // Coming back to a tab left open for days is exactly when the running build
+    // is most likely to be old, and is a moment the user is already looking.
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'visible') void poll()
+    })
+  }
+
+  start()
+
+  return {
+    check: async (): Promise<void> => {
+      await poll()
+    },
+    download: async (): Promise<void> => {
+      // Nothing to download — see the note above.
+    },
+    quitAndInstall: async (): Promise<void> => {
+      applied = false // an explicit request always applies
+      apply()
+    },
+    onStatus: (cb: Listener): (() => void) => {
+      listeners.add(cb)
+      return () => listeners.delete(cb)
+    }
+  }
+}

--- a/test/webAutoUpdate.test.ts
+++ b/test/webAutoUpdate.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import {
+  fetchDeployedVersion,
+  isDifferentBuild,
+  POLL_INTERVAL_MS,
+  SW_SCOPE,
+  SW_URL,
+  VERSION_URL
+} from '../src/renderer/src/web/web-updates'
+import { hasUnsavedWork, setUnsavedWorkProbe } from '../src/renderer/src/lib/unsaved-work'
+
+/**
+ * The browser build picks up a new deploy (#971).
+ *
+ * app.snakie.org kept serving an older build until you hard-reloaded. Not HTTP
+ * caching — the service worker (#464). `registerType: 'autoUpdate'` was silently
+ * inert, because vite-plugin-pwa only honours it when `injectRegister` is
+ * `'auto'` or absent:
+ *
+ *   // vite-plugin-pwa/dist/index.js
+ *   if ((injectRegister === "auto" || injectRegister == null) && registerType === "autoUpdate") {
+ *     workbox.skipWaiting = true
+ *     workbox.clientsClaim = true
+ *   }
+ *
+ * We set `'script'`, so Workbox shipped a worker that only calls `skipWaiting()`
+ * on a `SKIP_WAITING` message — which nothing sent — and never calls
+ * `clients.claim()`. A deploy installed, then waited for every tab of the origin
+ * to close, while navigations kept being served the OLD precached `index.html`.
+ */
+
+const webConfigRaw = readFileSync('vite.web.config.ts', 'utf8')
+/** Comments here QUOTE the setting they warn about, so match on code only. */
+const webConfig = webConfigRaw.replace(/\/\*[\s\S]*?\*\/|\/\/[^\n]*/g, '')
+const notifier = readFileSync('src/renderer/src/components/UpdateNotifier.tsx', 'utf8')
+
+describe('the service worker is configured to actually take over', () => {
+  it('sets skipWaiting AND clientsClaim explicitly, not by inference', () => {
+    // Explicitly, because the inference is what failed: the config *said*
+    // autoUpdate and the build disagreed, with no warning. Stating both here
+    // means the behaviour cannot depend on a plugin internal again.
+    expect(webConfig).toMatch(/^\s*skipWaiting: true,$/m)
+    expect(webConfig).toMatch(/^\s*clientsClaim: true,$/m)
+  })
+
+  it('never sets injectRegister to the value that disables autoUpdate', () => {
+    // 'script' is the exact value that silently switched autoUpdate off. It was
+    // chosen so the registration was not an inline script the strict CSP
+    // rejects — our own bundle is `'self'`, so registering from app code keeps
+    // that property without the side effect.
+    const setting = /injectRegister:\s*([^,\n]+)/.exec(webConfig)?.[1]?.trim()
+    expect(setting, 'injectRegister should be null — we register from app code').toBe('null')
+  })
+
+  it('registers the worker itself, since the plugin no longer injects one', () => {
+    // With injectRegister null nothing emits registerSW.js. If this registration
+    // ever went away the PWA would silently stop existing: no offline, no
+    // updates, and no error either.
+    const updates = readFileSync('src/renderer/src/web/web-updates.ts', 'utf8')
+    expect(updates).toContain('navigator.serviceWorker')
+    expect(updates).toMatch(/\.register\(\s*SW_URL/)
+    const install = readFileSync('src/renderer/src/web/install-web-api.ts', 'utf8')
+    expect(install).toContain('createWebUpdatesApi')
+  })
+
+  it('points at the worker the plugin generates, at the whole origin', () => {
+    expect(SW_URL).toBe('/sw.js')
+    expect(SW_SCOPE).toBe('/')
+  })
+})
+
+describe('the version stamp is emitted and always fetched fresh', () => {
+  it('writes version.json next to the bundle', () => {
+    expect(webConfig).toContain("fileName: 'version.json'")
+    expect(webConfig).toContain('version: pkgVersion')
+  })
+
+  it('leaves it OUT of the precache, or the check would answer itself', () => {
+    // A staleness check served from the cache reports "up to date" forever.
+    const glob = /globPatterns:\s*\[([^\]]*)\]/.exec(webConfig)?.[1] ?? ''
+    expect(glob).not.toContain('json')
+  })
+
+  it('asks for it with no-store', async () => {
+    let seen: RequestInit | undefined
+    const fake = (async (_url: string | URL | Request, init?: RequestInit) => {
+      seen = init
+      return { ok: true, json: async () => ({ version: '9.9.9' }) } as unknown as Response
+    }) as unknown as typeof fetch
+
+    await fetchDeployedVersion(fake, VERSION_URL)
+    expect(seen?.cache).toBe('no-store')
+  })
+
+  it('reads the deployed version out of it', async () => {
+    const fake = (async () =>
+      ({ ok: true, json: async () => ({ version: '0.57.0' }) }) as unknown as Response) as typeof fetch
+    await expect(fetchDeployedVersion(fake)).resolves.toBe('0.57.0')
+  })
+
+  it('treats every failure as "I do not know", never as an update', async () => {
+    const notFound = (async () => ({ ok: false }) as unknown as Response) as typeof fetch
+    const garbage = (async () =>
+      ({
+        ok: true,
+        json: async () => ({ nope: 1 })
+      }) as unknown as Response) as typeof fetch
+    const offline = (async () => {
+      throw new Error('offline')
+    }) as unknown as typeof fetch
+
+    await expect(fetchDeployedVersion(notFound)).resolves.toBeUndefined()
+    await expect(fetchDeployedVersion(garbage)).resolves.toBeUndefined()
+    await expect(fetchDeployedVersion(offline)).resolves.toBeUndefined()
+  })
+})
+
+describe('deciding whether the server is serving something else', () => {
+  it('is a difference, not an ordering — a rollback must reach people too', () => {
+    expect(isDifferentBuild('0.55.0', '0.56.0')).toBe(true)
+    expect(isDifferentBuild('0.56.0', '0.55.0')).toBe(true)
+  })
+
+  it('says no when they match', () => {
+    expect(isDifferentBuild('0.56.0', '0.56.0')).toBe(false)
+  })
+
+  it('says no when either side is unknown', () => {
+    expect(isDifferentBuild('0.56.0', undefined)).toBe(false)
+    expect(isDifferentBuild('', '0.56.0')).toBe(false)
+  })
+
+  it('polls on a human timescale, not a busy one', () => {
+    expect(POLL_INTERVAL_MS).toBeGreaterThanOrEqual(5 * 60 * 1000)
+  })
+})
+
+describe('a reload never discards unsaved work', () => {
+  it('assumes there IS unsaved work until the UI says otherwise', () => {
+    // Before the app mounts nobody can answer, and the costs are asymmetric: a
+    // needless prompt is an annoyance, a discarded buffer is not.
+    expect(hasUnsavedWork()).toBe(true)
+  })
+
+  it('answers from the registered probe', () => {
+    let dirty = false
+    const off = setUnsavedWorkProbe(() => dirty)
+    expect(hasUnsavedWork()).toBe(false)
+    dirty = true
+    expect(hasUnsavedWork()).toBe(true)
+    off()
+  })
+
+  it('goes back to assuming the worst once unregistered', () => {
+    const off = setUnsavedWorkProbe(() => false)
+    expect(hasUnsavedWork()).toBe(false)
+    off()
+    expect(hasUnsavedWork()).toBe(true)
+  })
+
+  it('does not let a stale unregister clobber a newer probe', () => {
+    const offOld = setUnsavedWorkProbe(() => false)
+    setUnsavedWorkProbe(() => true)
+    offOld() // the old component unmounting must not remove the new probe
+    expect(hasUnsavedWork()).toBe(true)
+    setUnsavedWorkProbe(() => false)() // reset
+  })
+
+  it('is what the updater consults before reloading', () => {
+    const updates = readFileSync('src/renderer/src/web/web-updates.ts', 'utf8')
+    expect(updates).toContain('hasUnsavedWork()')
+    // and the UI is what supplies the answer
+    expect(notifier).toContain('setUnsavedWorkProbe')
+    expect(notifier).toContain('f.dirty')
+  })
+})
+
+describe('the notice says what a browser can actually do', () => {
+  it('offers Reload on the web and Restart on the desktop', () => {
+    // Same 'downloaded' lifecycle state, two different acts: the desktop
+    // relaunches into an installer, the web build reloads. Telling a browser
+    // user to "restart" sends them looking for a menu item that isn't there.
+    expect(notifier).toContain("isWeb ? 'Reload' : 'Restart'")
+    expect(notifier).toContain('reload to update')
+    expect(notifier).toContain('restart to update')
+  })
+})

--- a/vite.web.config.ts
+++ b/vite.web.config.ts
@@ -96,13 +96,46 @@ export default defineConfig({
     // PWA (#464): installable to the ChromeOS shelf + offline via a Workbox
     // precache of the built app shell (incl. the MicroPython WASM). Web build
     // only — the plugin lives here, so the Electron build is untouched.
-    // `injectRegister: 'script'` emits an external registerSW.js (no inline
-    // script) so it passes the strict web CSP (`script-src 'self' …`).
+    // The registration is NOT injected by the plugin; `web-updates.ts` does it,
+    // which keeps it out of an inline script the strict CSP would reject
+    // (`script-src 'self' …`) just as the old `injectRegister: 'script'` did —
+    // see the note on `injectRegister` below for why that value had to go.
     VitePWA({
       registerType: 'autoUpdate',
-      injectRegister: 'script',
+      // WE register the worker, from `web-updates.ts` (#971). The plugin's own
+      // injected script is a bare `navigator.serviceWorker.register(…)` with no
+      // update handling at all — and `injectRegister: 'script'`, which we used to
+      // set to keep the registration out of an inline script the strict CSP would
+      // reject, ALSO silently disables `registerType: 'autoUpdate'`:
+      //
+      //   // vite-plugin-pwa/dist/index.js
+      //   if ((injectRegister === "auto" || injectRegister == null) && registerType === "autoUpdate") {
+      //     workbox.skipWaiting = true
+      //     workbox.clientsClaim = true
+      //   }
+      //
+      // So the config read as if it auto-updated while the build shipped a worker
+      // that waited forever — see the skipWaiting/clientsClaim note below.
+      // Registering from app code satisfies the CSP just as well (our bundle IS
+      // `'self'`) and lets us react to an update instead of only publishing one.
+      injectRegister: null,
       includeAssets: ['favicon.svg', 'apple-touch-icon.png'],
       workbox: {
+        // BOTH SET EXPLICITLY, not left to the plugin to infer (#971). Without
+        // them Workbox emits a worker that calls `skipWaiting()` only when the
+        // page posts it a `SKIP_WAITING` message — which nothing did — and never
+        // calls `clients.claim()`. A new deploy therefore installed and then sat
+        // in `waiting` until every tab of the origin closed, while each
+        // navigation kept being answered from the OLD precache. That is the
+        // "app.snakie.org needs a hard reload" bug: a hard reload was the one
+        // thing that bypassed the worker.
+        //
+        // `clientsClaim` matters as much as `skipWaiting`: activating without
+        // claiming leaves the open page on the previous worker, whose precache
+        // the new one has already cleaned up — the classic post-deploy failure
+        // to lazy-load a chunk.
+        skipWaiting: true,
+        clientsClaim: true,
         globPatterns: ['**/*.{js,css,html,svg,png,woff,woff2,wasm}'],
         // The MicroPython WASM + Monaco chunks are large; precache them so the
         // classroom app truly works offline after the first visit.
@@ -136,6 +169,21 @@ export default defineConfig({
         ]
       }
     }),
+    {
+      // A version stamp the running page can check itself against (#971).
+      // The service worker is the primary "you are stale" signal; this is the
+      // fallback for contexts that have no worker (Safari private browsing, a
+      // blocked-storage profile) and what lets the notice name the new version.
+      // Written by the build so it cannot drift from what actually shipped.
+      name: 'snakie-web-version-stamp',
+      generateBundle(): void {
+        this.emitFile({
+          type: 'asset',
+          fileName: 'version.json',
+          source: JSON.stringify({ version: pkgVersion, builtAt: new Date().toISOString() }, null, 2)
+        })
+      }
+    },
     {
       // Relax the renderer CSP for the WEB build ONLY (Electron keeps its strict
       // one): `'wasm-unsafe-eval'` lets the MicroPython WASM instantiate, and


### PR DESCRIPTION
Closes #971.

app.snakie.org could keep serving an older build until you hard-reloaded the tab.

**I filed the issue on a wrong premise** — I'd claimed there was no service worker,
on the strength of `grep -rn 'serviceWorker' src` finding nothing. There is one;
`vite-plugin-pwa` generates it at build time (#464), so it never appears in `src`.
HTTP caching was not the cause.

## The actual cause

`registerType: 'autoUpdate'` was **silently inert**. vite-plugin-pwa only honours it
under one condition:

```js
// vite-plugin-pwa/dist/index.js:874
if ((injectRegister === "auto" || injectRegister == null) && registerType === "autoUpdate") {
  workbox.skipWaiting = true
  workbox.clientsClaim = true
}
```

We set `injectRegister: 'script'` — deliberately, so the registration was an external
file rather than an inline script the strict CSP rejects. That choice silently turned
`autoUpdate` off. The deployed worker (confirmed by fetching it from production, and
reproduced from `master`) therefore had:

- `NavigationRoute` + `createHandlerBoundToURL("index.html")` — navigations answered
  from the **precache**, not the network;
- `self.skipWaiting()` only inside a `SKIP_WAITING` message handler;
- **no `clients.claim()` at all**.

And nothing ever posted that message, because the registration the plugin injected was
a bare `navigator.serviceWorker.register('/sw.js')` with no update handling.

So a new deploy installed and then sat in `waiting` until every tab of the origin
closed — which, for the tab you keep the IDE open in, is never — while each navigation
kept being served the old precached `index.html`. A hard reload worked because it is
the one thing that bypasses the worker. The config read as if it auto-updated; the
build disagreed, with no warning.

## The fix

- **`skipWaiting` and `clientsClaim` set explicitly.** Not left to an inference that
  has already misfired once. `clientsClaim` matters as much as `skipWaiting`:
  activating without claiming leaves the open page on the previous worker, whose
  precache the new one has already cleaned up — the classic post-deploy failure to
  lazy-load a chunk.
- **`injectRegister: null`; we register from `web-updates.ts`.** Our bundle *is*
  `'self'`, so the CSP property that motivated `'script'` still holds — and this
  restores the plugin's `autoUpdate` inference as well as letting the app react to an
  update rather than only publish one.
- **A new build reloads the page — but only when nothing is unsaved.** Snakie is an
  editor; reloading over an unsaved buffer would be a worse bug than the stale build.
  With work in progress it says so through the existing `UpdateNotifier` and waits.
  The probe defaults to "there IS unsaved work" until the UI registers an answer: a
  needless prompt is an annoyance, a discarded buffer is not.
- **Worded for a browser.** Same `downloaded` lifecycle state, two different acts —
  the desktop relaunches into an installer, the web build reloads. "Restart" would
  send a browser user looking for a menu item that doesn't exist.
- **A `version.json` stamp**, fetched `no-store` so the staleness check can't itself
  be answered from a cache. It names the new version in the notice and covers
  contexts with no worker at all (Safari private browsing, blocked storage).

## Verified on the built artifacts, not just the source

```
$ grep -oE 'clientsClaim\(\)|self\.skipWaiting\(\)' dist-web/sw.js | sort | uniq -c
   1 clientsClaim()
   1 self.skipWaiting()
$ cat dist-web/version.json
{ "version": "0.56.0", "builtAt": "…" }
$ grep -c version.json dist-web/sw.js      # must be 0 — a precached check answers itself
0
$ ls dist-web/registerSW.js                # gone; the app registers instead
```

`test/webAutoUpdate.test.ts` (19 tests) guards the config settings, the `no-store`
fetch, the version comparison (a *difference*, not an ordering — a rollback has to
reach people as fast as a rollout), the unsaved-work probe including the
stale-unregister case, and the browser wording. Mutation-checked: restoring
`injectRegister: 'script'` and dropping the two flags fails two tests.

## Checks

`lint` (0 errors, 1 pre-existing warning), `typecheck`, `test` (**6,753 passing**
across 330 files), `build` and `build:web` all green.

Not verified: the end-to-end reload against a live deploy — that needs two successive
deploys of app.snakie.org, so the real confirmation is the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDF5L8njCWc5AJdRAZ1ERe